### PR TITLE
Multithreaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c++
 sudo: false
+dist: trusty
 
 compiler:
   - gcc
@@ -8,13 +9,16 @@ addons:
   apt:
     packages:
       - libsparsehash-dev
+      - cmake
 
 before_script:
   - mkdir build
   - cd build
   - cmake ..
 
-script: make -j 3 && make test
+script: 
+  - make -j 3 
+  - make test
 
 notifications:
   email:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ set(CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
 
 
 ################################
+# Threading
+################################
+find_package (Threads)
+################################
 # GTEST
 ################################
 add_subdirectory(third_party/googletest/googletest)
@@ -80,16 +84,16 @@ configure_file(src/web/script.js script.js)
 
 
 add_executable(IndexBuilderMain src/index/IndexBuilderMain.cpp)
-target_link_libraries(IndexBuilderMain index)
+target_link_libraries(IndexBuilderMain index ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(SparqlEngineMain src/SparqlEngineMain.cpp)
-target_link_libraries (SparqlEngineMain engine)
+target_link_libraries (SparqlEngineMain engine ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(ServerMain src/ServerMain.cpp)
-target_link_libraries (ServerMain engine)
+target_link_libraries (ServerMain engine ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(WriteIndexListsMain src/WriteIndexListsMain.cpp)
-target_link_libraries (WriteIndexListsMain engine)
+target_link_libraries (WriteIndexListsMain engine ${CMAKE_THREAD_LIBS_INIT})
 
 
 #add_executable(TextFilterComparison src/experiments/TextFilterComparison.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.4)
-project(SparqlEngineDraft)
+project(QLever C CXX)
 
 # Check compiler versions:
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(SparqlEngineDraft)
 
-
-
 # Check compiler versions:
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # Check version. If empty, warn. If too old, error out:
@@ -39,8 +37,8 @@ set(LOG_LEVEL_DEBUG 4)
 set(LOG_LEVEL_TRACE 5)
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -DLOGLEVEL=${LOG_LEVEL_DEBUG}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DLOGLEVEL=${LOG_LEVEL_DEBUG}")
-
-
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DLOGLEVEL=${LOG_LEVEL_DEBUG}")
+set(CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
 
 
 ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(QLever C CXX)
 
+# C/C++ Versions
+set (CMAKE_C_STANDARD 11)
+set (CMAKE_C_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Check compiler versions:
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # Check version. If empty, warn. If too old, error out:
@@ -15,11 +21,16 @@ endif()
 ##### Essential settings #####
 ###############################################################################
 
+################################
+# Threading
+################################
+find_package (Threads REQUIRED)
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 # set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wno-missing-field-initializers -DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=0")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wall -Wextra -Wno-missing-field-initializers -DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=0")
 
 if (${PERFTOOLS_PROFILER})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lprofiler")
@@ -40,11 +51,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DLOGLEVEL=${LOG_LEVEL_DEBUG
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DLOGLEVEL=${LOG_LEVEL_DEBUG}")
 set(CMAKE_REQUIRED_FLAGS "-fsanitize=thread")
 
-
-################################
-# Threading
-################################
-find_package (Threads)
 ################################
 # GTEST
 ################################
@@ -53,6 +59,9 @@ include_directories(third_party/googletest/googletest/include)
 ################################
 # STXXL
 ################################
+# Disable GNU parallel as it prevents build on Ubuntu 14.04
+set(USE_GNU_PARALLEL OFF CACHE BOOL "Don't use gnu parallel" FORCE)
+set(USE_OPENMP OFF CACHE BOOL "Don't use OpenMP" FORCE)
 add_subdirectory(third_party/stxxl)
 # apply STXXL CXXFLAGS
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${STXXL_CXX_FLAGS}")

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -32,6 +32,7 @@ struct option options[] = {
   {"all-permutations", no_argument,       NULL, 'a'},
   {"unopt-optional",   no_argument,       NULL, 'u'},
   {"help",             no_argument,       NULL, 'h'},
+  {"worker-threads",   required_argument, NULL, 'j'},
   {NULL,               0,                 NULL, 0}
 };
 
@@ -58,6 +59,8 @@ void printUsage(char *execName) {
        << "The port on which to run the web interface." << endl;
   cout << "  " << std::setw(20) << "t, text" << std::setw(1) << "    "
        << "Enables the usage of text." << endl;
+  cout << "  " << std::setw(20) << "j, worker-threads" << std::setw(1) << "    "
+       << "Sets the number of worker threads to use" << endl;
   cout << "  " << std::setw(20) << "u, unopt-optional" << std::setw(1) << "    "
        << "Always place optional joins at the root of the query execution tree."
        << endl;
@@ -82,11 +85,12 @@ int main(int argc, char** argv) {
   bool allPermutations = false;
   bool optimizeOptionals = true;
   int port = -1;
+  int numThreads = 1;
 
   optind = 1;
   // Process command line arguments.
   while (true) {
-    int c = getopt_long(argc, argv, "i:p:tlauh", options, NULL);
+    int c = getopt_long(argc, argv, "i:p:j:tlauh", options, NULL);
     if (c == -1) break;
     switch (c) {
       case 'i':
@@ -103,6 +107,9 @@ int main(int argc, char** argv) {
         break;
       case 'a':
         allPermutations = true;
+        break;
+      case 'j':
+        numThreads = atoi(optarg);
         break;
       case 'u':
         optimizeOptionals = false;
@@ -137,7 +144,7 @@ int main(int argc, char** argv) {
   cout << "Set locale LC_CTYPE to: " << locale << endl;
 
   try {
-    Server server(port);
+    Server server(port, numThreads);
     server.initialize(index, text, allPermutations, onDiskLiterals,
                       optimizeOptionals);
     server.run();

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -227,10 +227,11 @@ void processQuery(QueryExecutionContext& qec, const string& query,
   qet.writeResultToStream(cout, pq._selectedVariables, limit, offset);
   t.stop();
   std::cout << "\nDone. Time: " << t.usecs() / 1000.0 << " ms\n";
-  std::cout << "\nNumber of matches (no limit): " << qet.getResult().size() <<
+  size_t numMatches = qet.getResult()->size();
+  std::cout << "\nNumber of matches (no limit): " << numMatches <<
   "\n";
   size_t effectiveLimit = atoi(pq._limit.c_str()) > 0 ? 
-    atoi(pq._limit.c_str()) : qet.getResult().size();
+    atoi(pq._limit.c_str()) : numMatches;
   std::cout << "\nNumber of matches (limit): " <<
-  std::min(qet.getResult().size(), effectiveLimit) << "\n";
+  std::min(numMatches, effectiveLimit) << "\n";
 }

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -99,12 +99,12 @@ int main(int argc, char** argv) {
     }
     QueryPlanner queryPlanner(&qec);
     auto qet = queryPlanner.createExecutionTree(q);
-    auto& res = qet.getResult();
-    AD_CHECK(res.size() > 0);
-    AD_CHECK(res._nofColumns == 1);
+    const auto res = qet.getResult();
+    AD_CHECK(res->size() > 0);
+    AD_CHECK(res->_nofColumns == 1);
     string personlistFile = indexName + ".list.scientists";
     std::vector<std::array<Id, 1>>& ids =
-        *static_cast<std::vector<std::array<Id, 1>>*>(res._fixedSizeData);
+        *static_cast<std::vector<std::array<Id, 1>>*>(res->_fixedSizeData);
     std::ofstream f(personlistFile.c_str());
     for (size_t i = 0; i < ids.size(); ++i) {
       f << ids[i][0] << ' ';

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -35,15 +35,15 @@ string Distinct::asString(size_t indent) const {
 // _____________________________________________________________________________
 void Distinct::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
-  const ResultTable& subRes = _subtree->getResult();
+  shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "Distinct result computation..." << endl;
-  result->_nofColumns = subRes._nofColumns;
-  switch (subRes._nofColumns) {
+  result->_nofColumns = subRes->_nofColumns;
+  switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;
       auto res = new vector<RT>();
       result->_fixedSizeData = res;
-      getEngine().distinct(*static_cast<vector<RT>*>(subRes._fixedSizeData),
+      getEngine().distinct(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                            _keepIndices, res);
       break;
     }
@@ -51,7 +51,7 @@ void Distinct::computeResult(ResultTable* result) const {
       typedef array<Id, 2> RT;
       auto res = new vector<RT>();
       result->_fixedSizeData = res;
-      getEngine().distinct(*static_cast<vector<RT>*>(subRes._fixedSizeData),
+      getEngine().distinct(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                            _keepIndices, res);
       break;
     }
@@ -59,7 +59,7 @@ void Distinct::computeResult(ResultTable* result) const {
       typedef array<Id, 3> RT;
       auto res = new vector<RT>();
       result->_fixedSizeData = res;
-      getEngine().distinct(*static_cast<vector<RT>*>(subRes._fixedSizeData),
+      getEngine().distinct(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                            _keepIndices, res);
       break;
     }
@@ -67,7 +67,7 @@ void Distinct::computeResult(ResultTable* result) const {
       typedef array<Id, 4> RT;
       auto res = new vector<RT>();
       result->_fixedSizeData = res;
-      getEngine().distinct(*static_cast<vector<RT>*>(subRes._fixedSizeData),
+      getEngine().distinct(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                            _keepIndices, res);
       break;
     }
@@ -75,12 +75,12 @@ void Distinct::computeResult(ResultTable* result) const {
       typedef array<Id, 5> RT;
       auto res = new vector<RT>();
       result->_fixedSizeData = res;
-      getEngine().distinct(*static_cast<vector<RT>*>(subRes._fixedSizeData),
+      getEngine().distinct(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                            _keepIndices, res);
       break;
     }
     default: {
-      getEngine().distinct(subRes._varSizeData, _keepIndices,
+      getEngine().distinct(subRes->_varSizeData, _keepIndices,
                            &result->_varSizeData);
       break;
     }

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -85,6 +85,6 @@ void Distinct::computeResult(ResultTable* result) const {
       break;
     }
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "Distinct result computation done." << endl;
 }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -62,16 +62,16 @@ string Filter::asString(size_t indent) const {
 // _____________________________________________________________________________
 void Filter::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
-  const ResultTable& subRes = _subtree->getResult();
+  shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "Filter result computation..." << endl;
-  result->_nofColumns = subRes._nofColumns;
+  result->_nofColumns = subRes->_nofColumns;
   size_t l = _lhsInd;
   size_t r = _rhsInd;
   if (r == std::numeric_limits<size_t>::max()) {
     AD_CHECK(_rhsId != std::numeric_limits<size_t>::max());
     return computeResultFixedValue(result);
   }
-  switch (subRes._nofColumns) {
+  switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;
       auto res = new vector<RT>();
@@ -80,7 +80,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == e[r];
                   }, res);
@@ -88,7 +88,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != e[r];
                   }, res);
@@ -96,7 +96,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < e[r];
                   }, res);
@@ -104,7 +104,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= e[r];
                   }, res);
@@ -112,7 +112,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > e[r];
                   }, res);
@@ -120,7 +120,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= e[r];
                   }, res);
@@ -136,7 +136,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == e[r];
                   }, res);
@@ -144,7 +144,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != e[r];
                   }, res);
@@ -152,7 +152,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < e[r];
                   }, res);
@@ -160,7 +160,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= e[r];
                   }, res);
@@ -168,7 +168,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > e[r];
                   }, res);
@@ -176,7 +176,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= e[r];
                   }, res);
@@ -192,7 +192,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == e[r];
                   }, res);
@@ -200,7 +200,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != e[r];
                   }, res);
@@ -208,7 +208,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < e[r];
                   }, res);
@@ -216,7 +216,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= e[r];
                   }, res);
@@ -224,7 +224,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > e[r];
                   }, res);
@@ -232,7 +232,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= e[r];
                   }, res);
@@ -248,7 +248,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == e[r];
                   }, res);
@@ -256,7 +256,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != e[r];
                   }, res);
@@ -264,7 +264,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < e[r];
                   }, res);
@@ -272,7 +272,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= e[r];
                   }, res);
@@ -280,7 +280,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > e[r];
                   }, res);
@@ -288,7 +288,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= e[r];
                   }, res);
@@ -304,7 +304,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == e[r];
                   }, res);
@@ -312,7 +312,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != e[r];
                   }, res);
@@ -320,7 +320,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < e[r];
                   }, res);
@@ -328,7 +328,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= e[r];
                   }, res);
@@ -336,7 +336,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > e[r];
                   }, res);
@@ -344,7 +344,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= e[r];
                   }, res);
@@ -358,7 +358,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] == e[r];
                   }, &result->_varSizeData);
@@ -366,7 +366,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] != e[r];
                   }, &result->_varSizeData);
@@ -374,7 +374,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] < e[r];
                   }, &result->_varSizeData);
@@ -382,7 +382,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] <= e[r];
                   }, &result->_varSizeData);
@@ -390,7 +390,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] > e[r];
                   }, &result->_varSizeData);
@@ -398,7 +398,7 @@ void Filter::computeResult(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] >= e[r];
                   }, &result->_varSizeData);
@@ -414,11 +414,11 @@ void Filter::computeResult(ResultTable* result) const {
 // _____________________________________________________________________________
 void Filter::computeResultFixedValue(ResultTable* result) const {
   LOG(DEBUG) << "Filter result computation..." << endl;
-  const ResultTable& subRes = _subtree->getResult();
-  result->_nofColumns = subRes._nofColumns;
+  shared_ptr<const ResultTable> subRes = _subtree->getResult();
+  result->_nofColumns = subRes->_nofColumns;
   size_t l = _lhsInd;
   Id r = _rhsId;
-  switch (subRes._nofColumns) {
+  switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;
       auto res = new vector<RT>();
@@ -427,7 +427,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == r;
                   }, res);
@@ -435,7 +435,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != r;
                   }, res);
@@ -443,7 +443,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < r;
                   }, res);
@@ -451,7 +451,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= r;
                   }, res);
@@ -459,7 +459,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > r;
                   }, res);
@@ -467,7 +467,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= r;
                   }, res);
@@ -483,7 +483,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == r;
                   }, res);
@@ -491,7 +491,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != r;
                   }, res);
@@ -499,7 +499,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < r;
                   }, res);
@@ -507,7 +507,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= r;
                   }, res);
@@ -515,7 +515,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > r;
                   }, res);
@@ -523,7 +523,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= r;
                   }, res);
@@ -539,7 +539,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == r;
                   }, res);
@@ -547,7 +547,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != r;
                   }, res);
@@ -555,7 +555,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < r;
                   }, res);
@@ -563,7 +563,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= r;
                   }, res);
@@ -571,7 +571,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > r;
                   }, res);
@@ -579,7 +579,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= r;
                   }, res);
@@ -595,7 +595,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == r;
                   }, res);
@@ -603,7 +603,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != r;
                   }, res);
@@ -611,7 +611,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < r;
                   }, res);
@@ -619,7 +619,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= r;
                   }, res);
@@ -627,7 +627,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > r;
                   }, res);
@@ -635,7 +635,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= r;
                   }, res);
@@ -651,7 +651,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] == r;
                   }, res);
@@ -659,7 +659,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] != r;
                   }, res);
@@ -667,7 +667,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] < r;
                   }, res);
@@ -675,7 +675,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] <= r;
                   }, res);
@@ -683,7 +683,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] > r;
                   }, res);
@@ -691,7 +691,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  *static_cast<vector<RT>*>(subRes._fixedSizeData),
+                  *static_cast<vector<RT>*>(subRes->_fixedSizeData),
                   [&l, &r](const RT& e) {
                     return e[l] >= r;
                   }, res);
@@ -705,7 +705,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::EQ:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] == r;
                   }, &result->_varSizeData);
@@ -713,7 +713,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::NE:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] != r;
                   }, &result->_varSizeData);
@@ -721,7 +721,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LT:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] < r;
                   }, &result->_varSizeData);
@@ -729,7 +729,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LE:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] <= r;
                   }, &result->_varSizeData);
@@ -737,7 +737,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GT:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] > r;
                   }, &result->_varSizeData);
@@ -745,7 +745,7 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::GE:
           getEngine()
               .filter(
-                  subRes._varSizeData,
+                  subRes->_varSizeData,
                   [&l, &r](const RT& e) {
                     return e[l] >= r;
                   }, &result->_varSizeData);

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -407,7 +407,7 @@ void Filter::computeResult(ResultTable* result) const {
       break;
     }
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "Filter result computation done." << endl;
 }
 
@@ -754,6 +754,6 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
       break;
     }
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "Filter result computation done." << endl;
 }

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -143,7 +143,7 @@ void IndexScan::computePSOboundS(ResultTable* result) const {
   _executionContext->getIndex().scanPSO(
       _predicate, _subject,
       static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -154,7 +154,7 @@ void IndexScan::computePSOfreeS(ResultTable* result) const {
   _executionContext->getIndex().scanPSO(
       _predicate,
       static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -165,7 +165,7 @@ void IndexScan::computePOSboundO(ResultTable* result) const {
   _executionContext->getIndex().scanPOS(
       _predicate, _object,
       static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -176,7 +176,7 @@ void IndexScan::computePOSfreeO(ResultTable* result) const {
   _executionContext->getIndex().scanPOS(
       _predicate,
       static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -197,7 +197,7 @@ void IndexScan::computeSPOfreeP(ResultTable* result) const {
   _executionContext->getIndex().scanSPO(
       _subject,
       static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -208,7 +208,7 @@ void IndexScan::computeSOPboundO(ResultTable* result) const {
   _executionContext->getIndex().scanSOP(
       _subject, _object,
       static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -219,7 +219,7 @@ void IndexScan::computeSOPfreeO(ResultTable* result) const {
   _executionContext->getIndex().scanSOP(
       _subject,
       static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -230,7 +230,7 @@ void IndexScan::computeOPSfreeP(ResultTable* result) const {
   _executionContext->getIndex().scanOPS(
       _object,
       static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -241,7 +241,7 @@ void IndexScan::computeOSPfreeS(ResultTable* result) const {
   _executionContext->getIndex().scanOSP(
       _object,
       static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->_status = ResultTable::FINISHED;
+  result->finish();
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -68,7 +68,7 @@ void Join::computeResult(ResultTable* result) const {
     } else if (resWidth == 5) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
     }
-    result->_status = ResultTable::FINISHED;
+    result->finish();
     return;
   }
 
@@ -96,7 +96,7 @@ void Join::computeResult(ResultTable* result) const {
     } else if (resWidth == 5) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
     }
-    result->_status = ResultTable::FINISHED;
+    result->finish();
     return;
   }
 
@@ -390,7 +390,7 @@ void Join::computeResult(ResultTable* result) const {
           &result->_varSizeData);
     }
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "Join result computation done." << endl;
 }
 
@@ -580,7 +580,7 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
       doComputeJoinWithFullScanDummyRight(r, &result->_varSizeData);
     }
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "Join (with dummy) done. Size: " << result->size() << endl;
 }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -78,10 +78,10 @@ void Join::computeResult(ResultTable* result) const {
     return;
   }
 
-  const ResultTable& leftRes = _left->getRootOperation()->getResult();
+  shared_ptr<const ResultTable> leftRes = _left->getRootOperation()->getResult();
 
   // Check if we can stop early.
-  if (leftRes.size() == 0) {
+  if (leftRes->size() == 0) {
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_sortedBy = _leftJoinCol;
@@ -100,7 +100,7 @@ void Join::computeResult(ResultTable* result) const {
     return;
   }
 
-  const ResultTable& rightRes = _right->getRootOperation()->getResult();
+  shared_ptr<const ResultTable> rightRes = _right->getRootOperation()->getResult();
 
   LOG(DEBUG) << "Join result computation..." << endl;
 
@@ -114,48 +114,48 @@ void Join::computeResult(ResultTable* result) const {
     if (rightWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 1>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 1>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 1>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
     } else if (rightWidth == 2) {
       result->_fixedSizeData = new vector<array<Id, 2>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 1>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 2>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
     } else if (rightWidth == 3) {
       result->_fixedSizeData = new vector<array<Id, 3>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 1>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 3>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 3>>*>(result->_fixedSizeData));
     } else if (rightWidth == 4) {
       result->_fixedSizeData = new vector<array<Id, 4>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 1>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 4>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 4>>*>(result->_fixedSizeData));
     } else if (rightWidth == 5) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 1>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 5>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 5>>*>(result->_fixedSizeData));
     } else {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 1>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          rightRes._varSizeData,
+          rightRes->_varSizeData,
           _rightJoinCol,
           &result->_varSizeData);
     }
@@ -163,47 +163,47 @@ void Join::computeResult(ResultTable* result) const {
     if (rightWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 2>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 2>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 1>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));;
     } else if (rightWidth == 2) {
       result->_fixedSizeData = new vector<array<Id, 3>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 2>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 2>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 3>>*>(result->_fixedSizeData));
     } else if (rightWidth == 3) {
       result->_fixedSizeData = new vector<array<Id, 4>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 2>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 3>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 4>>*>(result->_fixedSizeData));
     } else if (rightWidth == 4) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 2>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 4>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 5>>*>(result->_fixedSizeData));
     } else if (rightWidth == 5) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 2>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 5>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 2>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          rightRes._varSizeData,
+          rightRes->_varSizeData,
           _rightJoinCol,
           &result->_varSizeData);
     }
@@ -211,46 +211,46 @@ void Join::computeResult(ResultTable* result) const {
     if (rightWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 3>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 3>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 1>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 3>>*>(result->_fixedSizeData));
     } else if (rightWidth == 2) {
       result->_fixedSizeData = new vector<array<Id, 4>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 3>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 2>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 4>>*>(result->_fixedSizeData));
     } else if (rightWidth == 3) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 3>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 3>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 5>>*>(result->_fixedSizeData));
     } else if (rightWidth == 4) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 3>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 4>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 5) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 3>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 5>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 3>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          rightRes._varSizeData,
+          rightRes->_varSizeData,
           _rightJoinCol,
           &result->_varSizeData);
     }
@@ -258,45 +258,45 @@ void Join::computeResult(ResultTable* result) const {
     if (rightWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 4>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 4>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 1>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 4>>*>(result->_fixedSizeData));
     } else if (rightWidth == 2) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 4>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 2>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 5>>*>(result->_fixedSizeData));
     } else if (rightWidth == 3) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 4>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 3>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 4) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 4>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 4>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 5) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 4>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 5>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 4>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          rightRes._varSizeData,
+          rightRes->_varSizeData,
           _rightJoinCol,
           &result->_varSizeData);
     }
@@ -304,88 +304,88 @@ void Join::computeResult(ResultTable* result) const {
     if (rightWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 5>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 1>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           static_cast<vector<array<Id, 5>>*>(result->_fixedSizeData));
     } else if (rightWidth == 2) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 5>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 2>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 3) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 5>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 3>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 4) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 5>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 4>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 5) {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 5>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 5>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else {
       _executionContext->getEngine().join(
-          *static_cast<const vector<array<Id, 5>>*>(leftRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(leftRes->_fixedSizeData),
           _leftJoinCol,
-          rightRes._varSizeData,
+          rightRes->_varSizeData,
           _rightJoinCol,
           &result->_varSizeData);
     }
   } else {
     if (rightWidth == 1) {
       _executionContext->getEngine().join(
-          leftRes._varSizeData,
+          leftRes->_varSizeData,
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 1>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 1>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 2) {
       _executionContext->getEngine().join(
-          leftRes._varSizeData,
+          leftRes->_varSizeData,
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 2>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 2>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 3) {
       _executionContext->getEngine().join(
-          leftRes._varSizeData,
+          leftRes->_varSizeData,
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 3>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 3>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 4) {
       _executionContext->getEngine().join(
-          leftRes._varSizeData,
+          leftRes->_varSizeData,
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 4>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 4>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else if (rightWidth == 5) {
       _executionContext->getEngine().join(
-          leftRes._varSizeData,
+          leftRes->_varSizeData,
           _leftJoinCol,
-          *static_cast<const vector<array<Id, 5>>*>(rightRes._fixedSizeData),
+          *static_cast<const vector<array<Id, 5>>*>(rightRes->_fixedSizeData),
           _rightJoinCol,
           &result->_varSizeData);
     } else {
       _executionContext->getEngine().join(
-          leftRes._varSizeData,
+          leftRes->_varSizeData,
           _leftJoinCol,
-          rightRes._varSizeData,
+          rightRes->_varSizeData,
           _rightJoinCol,
           &result->_varSizeData);
     }
@@ -505,39 +505,39 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
     AD_CHECK(!isFullScanDummy(_right))
     result->_nofColumns = _right->getResultWidth() + 2;
     result->_sortedBy = 2 + _rightJoinCol;
-    const ResultTable& nonDummyRes = _right->getRootOperation()->getResult();
+    shared_ptr<const ResultTable> nonDummyRes = _right->getRootOperation()->getResult();
 
     if (_right->getResultWidth() == 1) {
       const Index::WidthOneList& r = *static_cast<Index::WidthOneList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       result->_fixedSizeData = new Index::WidthThreeList();
       doComputeJoinWithFullScanDummyLeft(
           r,
           static_cast<Index::WidthThreeList*>(result->_fixedSizeData));
     } else if (_right->getResultWidth() == 2) {
       const Index::WidthTwoList& r = *static_cast<Index::WidthTwoList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       result->_fixedSizeData = new Index::WidthFourList();
       doComputeJoinWithFullScanDummyLeft(
           r,
           static_cast<Index::WidthFourList*>(result->_fixedSizeData));
     } else if (_right->getResultWidth() == 3) {
       const Index::WidthThreeList& r = *static_cast<Index::WidthThreeList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       result->_fixedSizeData = new Index::WidthFiveList();
       doComputeJoinWithFullScanDummyLeft(
           r,
           static_cast<Index::WidthFiveList*>(result->_fixedSizeData));
     } else if (_right->getResultWidth() == 4) {
       const Index::WidthFourList& r = *static_cast<Index::WidthFourList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       doComputeJoinWithFullScanDummyLeft(r, &result->_varSizeData);
     } else if (_right->getResultWidth() == 5) {
       const Index::WidthFiveList& r = *static_cast<Index::WidthFiveList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       doComputeJoinWithFullScanDummyLeft(r, &result->_varSizeData);
     } else {
-      const Index::VarWidthList& r = nonDummyRes._varSizeData;
+      const Index::VarWidthList& r = nonDummyRes->_varSizeData;
       doComputeJoinWithFullScanDummyLeft(r, &result->_varSizeData);
     }
   } else {
@@ -545,38 +545,38 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
     result->_nofColumns = _left->getResultWidth() + 2;
     result->_sortedBy = _leftJoinCol;
 
-    const ResultTable& nonDummyRes = _left->getRootOperation()->getResult();
+    shared_ptr<const ResultTable> nonDummyRes = _left->getRootOperation()->getResult();
     if (_left->getResultWidth() == 1) {
       const Index::WidthOneList& r = *static_cast<Index::WidthOneList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       result->_fixedSizeData = new Index::WidthThreeList();
       doComputeJoinWithFullScanDummyRight(
           r,
           static_cast<Index::WidthThreeList*>(result->_fixedSizeData));
     } else if (_left->getResultWidth() == 2) {
       const Index::WidthTwoList& r = *static_cast<Index::WidthTwoList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       result->_fixedSizeData = new Index::WidthFourList();
       doComputeJoinWithFullScanDummyRight(
           r,
           static_cast<Index::WidthFourList*>(result->_fixedSizeData));
     } else if (_left->getResultWidth() == 3) {
       const Index::WidthThreeList& r = *static_cast<Index::WidthThreeList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       result->_fixedSizeData = new Index::WidthFiveList();
       doComputeJoinWithFullScanDummyRight(
           r,
           static_cast<Index::WidthFiveList*>(result->_fixedSizeData));
     } else if (_left->getResultWidth() == 4) {
       const Index::WidthFourList& r = *static_cast<Index::WidthFourList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       doComputeJoinWithFullScanDummyRight(r, &result->_varSizeData);
     } else if (_left->getResultWidth() == 5) {
       const Index::WidthFiveList& r = *static_cast<Index::WidthFiveList*>(
-          nonDummyRes._fixedSizeData);
+          nonDummyRes->_fixedSizeData);
       doComputeJoinWithFullScanDummyRight(r, &result->_varSizeData);
     } else {
-      const Index::VarWidthList& r = nonDummyRes._varSizeData;
+      const Index::VarWidthList& r = nonDummyRes->_varSizeData;
       doComputeJoinWithFullScanDummyRight(r, &result->_varSizeData);
     }
   }

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -83,5 +83,5 @@ protected:
 private:
   //! Compute the result of the query-subtree rooted at this element..
   //! Computes both, an EntityList and a HitList.
-  virtual void computeResult(ResultTable *result) const = 0;
+  virtual void computeResult(ResultTable* result) const = 0;
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -3,85 +3,82 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 #pragma once
 
-#include "../util/Log.h"
+#include <memory>
+
 #include "../util/Exception.h"
-#include "./ResultTable.h"
+#include "../util/Log.h"
 #include "./QueryExecutionContext.h"
+#include "./ResultTable.h"
 
 using std::endl;
+using std::shared_ptr;
 
 class Operation {
-  public:
+public:
+  // Default Constructor.
+  Operation() : _executionContext(NULL) {}
 
-    // Default Constructor.
-    Operation() : _executionContext(NULL) {
+  // Typical Constructor.
+  explicit Operation(QueryExecutionContext *executionContext)
+      : _executionContext(executionContext) {}
+
+  // Destructor.
+  virtual ~Operation() {
+    // Do NOT delete _executionContext, since
+    // there is no ownership.
+  }
+
+  // Get the result for the subtree rooted at this element.
+  // Use existing results if they are already available, otherwise
+  // trigger computation.
+  shared_ptr<const ResultTable> getResult() const {
+    LOG(TRACE) << "Get result from cache (possibly empty)" << endl;
+    LOG(TRACE) << "Using key: \n" << asString() << endl;
+    shared_ptr<const ResultTable> result =
+        _executionContext->getCachedResultForQueryTree(asString());
+    if (!result) {
+      LOG(TRACE) << "Result from cache is null. Compute it." << endl;
+      ResultTable computed;
+      computeResult(&computed);
+      result = _executionContext->setAndGetCachedResultForQueryTree(
+          asString(), std::move(computed));
     }
+    LOG(TRACE) << "Result should be filled." << endl;
+    AD_CHECK_EQ(ResultTable::FINISHED, result->_status);
+    return result;
+  }
 
-    // Typical Constructor.
-    explicit Operation(QueryExecutionContext *executionContext) :
-        _executionContext(executionContext) {
-    }
+  //! Set the QueryExecutionContext for this particular element.
+  void setQueryExecutionContext(QueryExecutionContext *executionContext) {
+    _executionContext = executionContext;
+  }
 
-    // Destructor.
-    virtual ~Operation() {
-      // Do NOT delete _executionContext, since
-      // there is no ownership.
-    }
+  const Index &getIndex() const { return _executionContext->getIndex(); }
 
-    // Get the result for the subtree rooted at this element.
-    // Use existing results if they are already available, otherwise
-    // trigger computation.
-    const ResultTable& getResult() const {
-      LOG(TRACE) << "Get result from cache (possibly empty)" << endl;
-      LOG(TRACE) << "Using key: \n" << asString() << endl;
-      ResultTable *result =
-          _executionContext->getCachedResultForQueryTree(asString());
-      if (result->_status != ResultTable::FINISHED) {
-        LOG(TRACE) << "Result from cache is empty. Compute it." << endl;
-        computeResult(result);
-      }
-      LOG(TRACE) << "Result should be filled." << endl;
-      AD_CHECK_EQ(ResultTable::FINISHED, result->_status);
-      return *result;
-    }
+  const Engine &getEngine() const { return _executionContext->getEngine(); }
 
-    //! Set the QueryExecutionContext for this particular element.
-    void setQueryExecutionContext(QueryExecutionContext *executionContext) {
-      _executionContext = executionContext;
-    }
+  // Get a unique, not ambiguous string representation for a subtree.
+  // This should possible act like an ID for each subtree.
+  virtual string asString(size_t indent = 0) const = 0;
+  virtual size_t getResultWidth() const = 0;
+  virtual size_t resultSortedOn() const = 0;
+  virtual void setTextLimit(size_t limit) = 0;
+  virtual size_t getCostEstimate() = 0;
+  virtual size_t getSizeEstimate() = 0;
+  virtual float getMultiplicity(size_t col) = 0;
+  virtual bool knownEmptyResult() = 0;
 
-    const Index& getIndex() const {
-      return _executionContext->getIndex();
-    }
+protected:
+  QueryExecutionContext *getExecutionContext() const {
+    return _executionContext;
+  }
 
-    const Engine& getEngine() const {
-      return _executionContext->getEngine();
-    }
+  // The QueryExecutionContext for this particular element.
+  // No ownership.
+  QueryExecutionContext *_executionContext;
 
-    // Get a unique, not ambiguous string representation for a subtree.
-    // This should possible act like an ID for each subtree.
-    virtual string asString(size_t indent=0) const = 0;
-    virtual size_t getResultWidth() const = 0;
-    virtual size_t resultSortedOn() const = 0;
-    virtual void setTextLimit(size_t limit) = 0;
-    virtual size_t getCostEstimate() = 0;
-    virtual size_t getSizeEstimate() = 0;
-    virtual float getMultiplicity(size_t col) = 0;
-    virtual bool knownEmptyResult() = 0;
-
-  protected:
-
-    QueryExecutionContext *getExecutionContext() const {
-      return _executionContext;
-    }
-
-    // The QueryExecutionContext for this particular element.
-    // No ownership.
-    QueryExecutionContext *_executionContext;
-
-  private:
-    //! Compute the result of the query-subtree rooted at this element..
-    //! Computes both, an EntityList and a HitList.
-    virtual void computeResult(ResultTable *result) const = 0;
+private:
+  //! Compute the result of the query-subtree rooted at this element..
+  //! Computes both, an EntityList and a HitList.
+  virtual void computeResult(ResultTable *result) const = 0;
 };
-

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -228,7 +228,7 @@ void OptionalJoin::computeResult(ResultTable* result) const {
                       _joinColumns,
                       result,
                       result->_nofColumns);
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "OptionalJoin result computation done." << endl;
 }
 

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -11,16 +11,12 @@
 
 using std::list;
 
-
 class OptionalJoin : public Operation {
 public:
-
-  OptionalJoin(QueryExecutionContext* qec,
-               std::shared_ptr<QueryExecutionTree> t1,
-               bool t1Optional,
-               std::shared_ptr<QueryExecutionTree> t2,
-               bool t2Optional,
-               const std::vector<array<size_t, 2>>& joinCols);
+  OptionalJoin(QueryExecutionContext *qec,
+               std::shared_ptr<QueryExecutionTree> t1, bool t1Optional,
+               std::shared_ptr<QueryExecutionTree> t2, bool t2Optional,
+               const std::vector<array<size_t, 2>> &joinCols);
 
   virtual string asString(size_t indent = 0) const;
 
@@ -36,9 +32,9 @@ public:
   }
 
   virtual bool knownEmptyResult() {
-    return (_left->knownEmptyResult() && !_leftOptional)
-        || (_right->knownEmptyResult() && !_rightOptional)
-        || (_left->knownEmptyResult() && _right->knownEmptyResult());
+    return (_left->knownEmptyResult() && !_leftOptional) ||
+           (_right->knownEmptyResult() && !_rightOptional) ||
+           (_left->knownEmptyResult() && _right->knownEmptyResult());
   }
 
   virtual float getMultiplicity(size_t col);

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -41,47 +41,47 @@ string OrderBy::asString(size_t indent) const {
 void OrderBy::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Gettign sub-result for OrderBy result computation..." << endl;
   AD_CHECK(_sortIndices.size() > 0);
-  const ResultTable& subRes = _subtree->getResult();
+  shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "OrderBy result computation..." << endl;
-  result->_nofColumns = subRes._nofColumns;
-  switch (subRes._nofColumns) {
+  result->_nofColumns = subRes->_nofColumns;
+  switch (subRes->_nofColumns) {
     case 1: {
       auto res = new vector<array<Id, 1>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 1>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 1>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, OBComp<array<Id, 1>>(_sortIndices));
     }
       break;
     case 2: {
       auto res = new vector<array<Id, 2>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 2>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 2>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, OBComp<array<Id, 2>>(_sortIndices));
       break;
     }
     case 3: {
       auto res = new vector<array<Id, 3>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 3>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 3>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, OBComp<array<Id, 3>>(_sortIndices));
       break;
     }
     case 4: {
       auto res = new vector<array<Id, 4>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 4>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 4>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, OBComp<array<Id, 4>>(_sortIndices));
       break;
     }
     case 5: {
       auto res = new vector<array<Id, 5>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 5>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 5>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, OBComp<array<Id, 5>>(_sortIndices));
       break;
     }
     default: {
-      result->_varSizeData = subRes._varSizeData;
+      result->_varSizeData = subRes->_varSizeData;
       getEngine().sort(result->_varSizeData,
                        OBComp<vector<Id>>(_sortIndices));
       break;

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -89,6 +89,6 @@ void OrderBy::computeResult(ResultTable* result) const {
   }
   result->_sortedBy = (_sortIndices[0].second ? result->_nofColumns + 1 :
                        _sortIndices[0].first);
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "OrderBy result computation done." << endl;
 }

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 #include "../util/LRUCache.h"
 #include "../util/Log.h"
 #include "./ResultTable.h"
@@ -16,6 +17,7 @@
 
 using std::string;
 using std::vector;
+using std::shared_ptr;
 
 typedef ad_utility::LRUCache<string, ResultTable> SubtreeCache;
 
@@ -29,9 +31,14 @@ public:
       _index(&index), _engine(&engine), _costFactors() {
   }
 
-  ResultTable* getCachedResultForQueryTree(
+  shared_ptr<const ResultTable> getCachedResultForQueryTree(
       const string& queryAsString) {
-    return &_subtreeCache[queryAsString];
+    return _subtreeCache[queryAsString];
+  }
+
+  shared_ptr<const ResultTable> setAndGetCachedResultForQueryTree(
+      const string& queryAsString, ResultTable result) {
+    return _subtreeCache.insert(queryAsString, std::move(result));
   }
 
   const Engine& getEngine() const {

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -31,14 +31,9 @@ public:
       _index(&index), _engine(&engine), _costFactors() {
   }
 
-  shared_ptr<const ResultTable> getCachedResultForQueryTree(
-      const string& queryAsString) {
-    return _subtreeCache[queryAsString];
-  }
-
-  shared_ptr<const ResultTable> setAndGetCachedResultForQueryTree(
-      const string& queryAsString, ResultTable result) {
-    return _subtreeCache.insert(queryAsString, std::move(result));
+  shared_ptr<ResultTable> getCachedResultForQueryTree(
+      const string& queryAsString, bool* uncomputed) {
+    return _subtreeCache.getOrCreate(queryAsString, uncomputed);
   }
 
   const Engine& getEngine() const {
@@ -62,7 +57,6 @@ public:
   };
 
  private:
-
   SubtreeCache _subtreeCache;
   const Index* _index;
   const Engine* _engine;

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -31,9 +31,8 @@ public:
       _index(&index), _engine(&engine), _costFactors() {
   }
 
-  shared_ptr<ResultTable> getCachedResultForQueryTree(
-      const string& queryAsString, bool* uncomputed) {
-    return _subtreeCache.getOrCreate(queryAsString, uncomputed);
+  SubtreeCache& getQueryTreeCache() {
+    return _subtreeCache;
   }
 
   const Engine& getEngine() const {

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -28,7 +28,7 @@ public:
 
   QueryExecutionContext(const Index& index, const Engine& engine) :
       _subtreeCache(NOF_SUBTREES_TO_CACHE),
-      _index(&index), _engine(&engine), _costFactors() {
+      _index(index), _engine(engine), _costFactors() {
   }
 
   SubtreeCache& getQueryTreeCache() {
@@ -36,11 +36,11 @@ public:
   }
 
   const Engine& getEngine() const {
-    return *_engine;
+    return _engine;
   }
 
   const Index& getIndex() const {
-    return *_index;
+    return _index;
   }
 
   void clearCache() {
@@ -57,8 +57,8 @@ public:
 
  private:
   SubtreeCache _subtreeCache;
-  const Index* _index;
-  const Engine* _engine;
+  const Index& _index;
+  const Engine& _engine;
   QueryPlanningCostFactors _costFactors;
 };
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -97,7 +97,7 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out,
                                              size_t offset,
                                              char sep) const {
   // They may trigger computation (but does not have to).
-  const ResultTable& res = getResult();
+  shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
   vector<pair<size_t, OutputType>> validIndices;
   for (auto var : selectVars) {
@@ -117,30 +117,30 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out,
     }
   }
   if (validIndices.size() == 0) { return; }
-  if (res._nofColumns == 1) {
-    auto data = static_cast<vector<array<Id, 1>>*>(res._fixedSizeData);
+  if (res->_nofColumns == 1) {
+    auto data = static_cast<vector<array<Id, 1>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeTable(*data, sep, offset, upperBound, validIndices, out);
-  } else if (res._nofColumns == 2) {
-    auto data = static_cast<vector<array<Id, 2>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 2) {
+    auto data = static_cast<vector<array<Id, 2>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeTable(*data, sep, offset, upperBound, validIndices, out);
-  } else if (res._nofColumns == 3) {
-    auto data = static_cast<vector<array<Id, 3>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 3) {
+    auto data = static_cast<vector<array<Id, 3>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeTable(*data, sep, offset, upperBound, validIndices, out);
-  } else if (res._nofColumns == 4) {
-    auto data = static_cast<vector<array<Id, 4>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 4) {
+    auto data = static_cast<vector<array<Id, 4>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeTable(*data, sep, offset, upperBound, validIndices, out);
-  } else if (res._nofColumns == 5) {
-    auto data = static_cast<vector<array<Id, 5>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 5) {
+    auto data = static_cast<vector<array<Id, 5>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeTable(*data, sep, offset, upperBound, validIndices, out);
   } else {
     size_t upperBound = std::min<size_t>(offset + limit,
-                                         res._varSizeData.size());
-    writeTable(res._varSizeData, sep, offset, upperBound, validIndices, out);
+                                         res->_varSizeData.size());
+    writeTable(res->_varSizeData, sep, offset, upperBound, validIndices, out);
   }
   LOG(DEBUG) << "Done creating readable result.\n";
 }
@@ -154,7 +154,7 @@ void QueryExecutionTree::writeResultToStreamAsJson(
     size_t maxSend) const {
   out << "[\r\n";
   // They may trigger computation (but does not have to).
-  const ResultTable& res = getResult();
+  shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
   vector<pair<size_t, OutputType>> validIndices;
   for (auto var : selectVars) {
@@ -177,30 +177,30 @@ void QueryExecutionTree::writeResultToStreamAsJson(
     out << "]";
     return;
   }
-  if (res._nofColumns == 1) {
-    auto data = static_cast<vector<array<Id, 1>>*>(res._fixedSizeData);
+  if (res->_nofColumns == 1) {
+    auto data = static_cast<vector<array<Id, 1>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeJsonTable(*data, offset, upperBound, validIndices, maxSend, out);
-  } else if (res._nofColumns == 2) {
-    auto data = static_cast<vector<array<Id, 2>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 2) {
+    auto data = static_cast<vector<array<Id, 2>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeJsonTable(*data, offset, upperBound, validIndices, maxSend, out);
-  } else if (res._nofColumns == 3) {
-    auto data = static_cast<vector<array<Id, 3>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 3) {
+    auto data = static_cast<vector<array<Id, 3>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeJsonTable(*data, offset, upperBound, validIndices, maxSend, out);
-  } else if (res._nofColumns == 4) {
-    auto data = static_cast<vector<array<Id, 4>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 4) {
+    auto data = static_cast<vector<array<Id, 4>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeJsonTable(*data, offset, upperBound, validIndices, maxSend, out);
-  } else if (res._nofColumns == 5) {
-    auto data = static_cast<vector<array<Id, 5>>*>(res._fixedSizeData);
+  } else if (res->_nofColumns == 5) {
+    auto data = static_cast<vector<array<Id, 5>>*>(res->_fixedSizeData);
     size_t upperBound = std::min<size_t>(offset + limit, data->size());
     writeJsonTable(*data, offset, upperBound, validIndices, maxSend, out);
   } else {
     size_t upperBound = std::min<size_t>(offset + limit,
-                                         res._varSizeData.size());
-    writeJsonTable(res._varSizeData, offset, upperBound, validIndices, maxSend,
+                                         res->_varSizeData.size());
+    writeJsonTable(res->_varSizeData, offset, upperBound, validIndices, maxSend,
                    out);
   }
   out << "]";
@@ -221,7 +221,7 @@ size_t QueryExecutionTree::getSizeEstimate() {
   if (_sizeEstimate == std::numeric_limits<size_t>::max()) {
     if (_qec) {
       if (_type == QueryExecutionTree::SCAN && getResultWidth() == 1) {
-        _sizeEstimate = getResult().size();
+        _sizeEstimate = getResult()->size();
       } else {
         _sizeEstimate = _rootOperation->getSizeEstimate();
       }

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <memory>
 #include <bits/unordered_set.h>
 #include "./QueryExecutionContext.h"
 #include "./Operation.h"
@@ -14,6 +15,7 @@
 
 
 using std::string;
+using std::shared_ptr;
 
 // A query execution tree.
 // Processed bottom up, this gives an ordering to the operations
@@ -86,7 +88,7 @@ public:
     return _rootOperation->getResultWidth();
   }
 
-  const ResultTable& getResult() const {
+  shared_ptr<const ResultTable> getResult() const {
     return _rootOperation->getResult();
   }
 

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -7,19 +7,19 @@
 
 // _____________________________________________________________________________
 ResultTable::ResultTable() :
-    _status(ResultTable::OTHER),
     _nofColumns(0),
     _sortedBy(0),
     _varSizeData(),
-    _fixedSizeData(nullptr) {}
+    _fixedSizeData(nullptr),
+    _status(ResultTable::OTHER){}
 
 // _____________________________________________________________________________
 ResultTable::ResultTable(const ResultTable& other) :
-    _status(other._status),
     _nofColumns(other._nofColumns),
     _sortedBy(other._sortedBy),
     _varSizeData(other._varSizeData),
-    _fixedSizeData(nullptr) {
+    _fixedSizeData(nullptr), 
+    _status(other._status) {
   if (other._nofColumns <= 5) {
     if (other._nofColumns == 1) {
       _fixedSizeData = new vector<array<Id, 1>>;

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -70,7 +70,8 @@ public:
 
   bool isFinished() const {
     lock_guard<mutex> lk(_cond_var_m);
-    return _status == ResultTable::FINISHED;
+    bool tmp = _status == ResultTable::FINISHED;
+    return tmp;
   }
 
   void awaitFinished() const {

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -3,23 +3,24 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 #pragma once
 
-#include <vector>
-#include <array>
 #include "../global/Id.h"
 #include "../util/Exception.h"
+#include <array>
+#include <condition_variable>
+#include <mutex>
+#include <vector>
 
 using std::vector;
 using std::array;
+using std::condition_variable;
+using std::mutex;
+using std::unique_lock;
+using std::lock_guard;
 
 class ResultTable {
 public:
+  enum Status { FINISHED = 0, OTHER = 1 };
 
-  enum Status {
-    FINISHED = 0,
-    OTHER = 1
-  };
-
-  Status _status;
   size_t _nofColumns;
   // A value >= _nofColumns indicates unsorted data
   size_t _sortedBy;
@@ -29,28 +30,27 @@ public:
 
   ResultTable();
 
-  ResultTable(const ResultTable&);
+  ResultTable(const ResultTable &);
 
-  ResultTable(ResultTable&& other) noexcept :
-      _status(ResultTable::OTHER),
-      _nofColumns(0),
-      _sortedBy(0),
-      _varSizeData(),
-      _fixedSizeData(nullptr){
+  ResultTable(ResultTable &&other) noexcept : _nofColumns(0),
+                                              _sortedBy(0),
+                                              _varSizeData(),
+                                              _fixedSizeData(nullptr),
+                                              _status(ResultTable::OTHER){
     swap(*this, other);
   }
 
-  ResultTable& operator=(ResultTable other) {
-    swap(*this, other);
-    return *this;
-  }
-
-  ResultTable& operator=(ResultTable&& other) noexcept {
+  ResultTable &operator=(ResultTable other) {
     swap(*this, other);
     return *this;
   }
 
-  friend void swap(ResultTable& a, ResultTable& b) noexcept {
+  ResultTable &operator=(ResultTable &&other) noexcept {
+    swap(*this, other);
+    return *this;
+  }
+
+  friend void swap(ResultTable &a, ResultTable &b) noexcept {
     using std::swap;
     swap(a._status, b._status);
     swap(a._nofColumns, b._nofColumns);
@@ -60,6 +60,22 @@ public:
   }
 
   virtual ~ResultTable();
+
+  bool isFinished() {
+    lock_guard<mutex> lk(_cond_var_m);
+    return _status == ResultTable::FINISHED;
+  }
+
+  void finish() {
+    lock_guard<mutex> lk(_cond_var_m);
+    _status = ResultTable::FINISHED;
+    _cond_var.notify_all();
+  }
+
+  void awaitFinished() {
+    unique_lock<mutex> lk(_cond_var_m);
+    _cond_var.wait(lk, [&] { return _status == ResultTable::FINISHED; });
+  }
 
   size_t size() const;
 
@@ -74,37 +90,38 @@ public:
 
     vector<vector<Id>> res;
     if (_nofColumns == 1) {
-      const auto& data = *static_cast<vector<array<Id, 1>> *>(_fixedSizeData);
+      const auto &data = *static_cast<vector<array<Id, 1>> *>(_fixedSizeData);
       for (size_t i = 0; i < data.size(); ++i) {
         res.emplace_back(vector<Id>{{data[i][0]}});
       }
     } else if (_nofColumns == 2) {
-      const auto& data = *static_cast<vector<array<Id, 2>> *>(_fixedSizeData);
+      const auto &data = *static_cast<vector<array<Id, 2>> *>(_fixedSizeData);
       for (size_t i = 0; i < data.size(); ++i) {
         res.emplace_back(vector<Id>{{data[i][0], data[i][1]}});
       }
     } else if (_nofColumns == 3) {
-      const auto& data = *static_cast<vector<array<Id, 3>> *>(_fixedSizeData);
+      const auto &data = *static_cast<vector<array<Id, 3>> *>(_fixedSizeData);
       for (size_t i = 0; i < data.size(); ++i) {
-        res.emplace_back(
-            vector<Id>{{data[i][0], data[i][1], data[i][2]}});
+        res.emplace_back(vector<Id>{{data[i][0], data[i][1], data[i][2]}});
       }
     } else if (_nofColumns == 4) {
-      const auto& data = *static_cast<vector<array<Id, 4>> *>(_fixedSizeData);
+      const auto &data = *static_cast<vector<array<Id, 4>> *>(_fixedSizeData);
       for (size_t i = 0; i < data.size(); ++i) {
         res.emplace_back(
             vector<Id>{{data[i][0], data[i][1], data[i][2], data[i][3]}});
       }
     } else if (_nofColumns == 5) {
-      const auto& data = *static_cast<vector<array<Id, 5>> *>(_fixedSizeData);
+      const auto &data = *static_cast<vector<array<Id, 5>> *>(_fixedSizeData);
       for (size_t i = 0; i < data.size(); ++i) {
-        res.emplace_back(
-            vector<Id>{{data[i][0], data[i][1], data[i][2],
-                           data[i][3], data[i][4]}});
+        res.emplace_back(vector<Id>{
+            {data[i][0], data[i][1], data[i][2], data[i][3], data[i][4]}});
       }
     }
     return res;
   }
 
+private:
+  condition_variable _cond_var;
+  mutex _cond_var_m;
+  Status _status;
 };
-

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -47,6 +47,10 @@ void Server::initialize(const string& ontologyBaseName, bool useText,
 
 // _____________________________________________________________________________
 void Server::run() {
+  if (!_initialized) {
+    LOG(ERROR) << "Cannot start an uninitialized server!" << std::endl;
+    exit(1);
+  }
   QueryExecutionContext qec(_index, _engine);
   std::vector<std::thread> threads;
   for(int i = 0; i < _numThreads; ++i) {
@@ -58,11 +62,6 @@ void Server::run() {
 }
 // _____________________________________________________________________________
 void Server::runAcceptLoop(QueryExecutionContext* qec) {
-  if (!_initialized) {
-    LOG(ERROR) << "Cannot start an uninitialized server!" << std::endl;
-    exit(1);
-  }
-
   // Loop and wait for queries. Run forever, for now.
   while (true) {
     // Wait for new query
@@ -78,6 +77,7 @@ void Server::runAcceptLoop(QueryExecutionContext* qec) {
       LOG(ERROR) << "Socket error in acceot" << std::strerror(errno) << std::endl;
       continue;
     }
+    client.setKeepAlive(true);
     LOG(INFO) << "Incoming connection, processing..." << std::endl;
     process(&client, qec);
     client.close();

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -306,10 +306,10 @@ string Server::composeResponseJson(const ParsedQuery& query,
 
   // TODO(schnelle) we really should use a json library
   // such as https://github.com/nlohmann/json
-  const ResultTable& rt = qet.getResult();
+  shared_ptr<const ResultTable> rt = qet.getResult();
   _requestProcessingTimer.stop();
   off_t compResultUsecs = _requestProcessingTimer.usecs();
-  size_t resultSize = rt.size();
+  size_t resultSize = rt->size();
 
 
   std::ostringstream os;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <algorithm>
 #include <thread>
+#include <cstring>
 
 #include "../util/StringUtils.h"
 #include "../util/Log.h"
@@ -74,7 +75,7 @@ void Server::runAcceptLoop(QueryExecutionContext* qec) {
     // problem but this should be fixed on modern OSs
     bool success = _serverSocket.acceptClient(&client);
     if (!success) {
-      LOG(ERROR) << "Socket error while trying to accept client" << std::endl;
+      LOG(ERROR) << "Socket error in acceot" << std::strerror(errno) << std::endl;
       continue;
     }
     LOG(INFO) << "Incoming connection, processing..." << std::endl;
@@ -458,6 +459,7 @@ void Server::serveFile(Socket* client, const string& requestedFile) const {
     } else if (ad_utility::endsWith(requestedFile, ".js")) {
       contentType = "application/javascript";
     }
+    in.close();
   }
 
   size_t contentLength = contentString.size();

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -24,10 +24,9 @@ using ad_utility::Socket;
 //! The HTTP Sever used.
 class Server {
 public:
-  explicit Server(const int port)
-      :
-      _serverSocket(), _port(port), _index(), _engine(), _initialized(false) {
-  }
+  explicit Server(const int port, const int numThreads)
+      : _numThreads(numThreads), _serverSocket(), _port(port), _index(),
+        _engine(), _initialized(false) {}
 
   typedef ad_utility::HashMap<string, string> ParamValueMap;
 
@@ -41,6 +40,7 @@ public:
   void run();
 
 private:
+  const int _numThreads;
   Socket _serverSocket;
   int _port;
   Index _index;
@@ -49,36 +49,37 @@ private:
 
   bool _initialized;
 
-  void process(Socket* client, QueryExecutionContext* qec) const;
+  void runAcceptLoop(QueryExecutionContext* qec);
 
-  void serveFile(Socket* client, const string& requestedFile) const;
+  void process(Socket *client, QueryExecutionContext *qec) const;
 
-  ParamValueMap parseHttpRequest(const string& request) const;
+  void serveFile(Socket *client, const string &requestedFile) const;
 
-  string createQueryFromHttpParams(const ParamValueMap& params) const;
+  ParamValueMap parseHttpRequest(const string &request) const;
 
-  string createHttpResponse(const string& content,
-                            const string& contentType) const;
+  string createQueryFromHttpParams(const ParamValueMap &params) const;
+
+  string createHttpResponse(const string &content,
+                            const string &contentType) const;
 
   string create404HttpResponse() const;
   string create400HttpResponse() const;
 
-  string composeResponseJson(const ParsedQuery& query,
-                             const QueryExecutionTree& qet,
+  string composeResponseJson(const ParsedQuery &query,
+                             const QueryExecutionTree &qet,
                              size_t sendMax = MAX_NOF_ROWS_IN_RESULT) const;
 
-  string composeResponseSepValues(const ParsedQuery& query,
-                                  const QueryExecutionTree& qet,
+  string composeResponseSepValues(const ParsedQuery &query,
+                                  const QueryExecutionTree &qet,
                                   char sep) const;
 
-  string composeResponseJson(const string& query,
-                             const ad_semsearch::Exception& e) const;
+  string composeResponseJson(const string &query,
+                             const ad_semsearch::Exception &e) const;
 
-  string composeResponseJson(const string& query,
-                             const ParseException& e) const;
+  string composeResponseJson(const string &query,
+                             const ParseException &e) const;
 
   string composeStatsJson() const;
-
 
   mutable ad_utility::Timer _requestProcessingTimer;
 };

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -80,6 +80,6 @@ void Sort::computeResult(ResultTable* result) const {
     }
   }
   result->_sortedBy = _sortCol;
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "Sort result computation done." << endl;
 }

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -34,27 +34,27 @@ string Sort::asString(size_t indent) const {
 // _____________________________________________________________________________
 void Sort::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
-  const ResultTable& subRes = _subtree->getResult();
+  shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "Sort result computation..." << endl;
-  result->_nofColumns = subRes._nofColumns;
-  switch (subRes._nofColumns) {
+  result->_nofColumns = subRes->_nofColumns;
+  switch (subRes->_nofColumns) {
     case 1: {
       auto res = new vector<array<Id, 1>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 1>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 1>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, _sortCol);
     }
       break;
     case 2: {
       auto res = new vector<array<Id, 2>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 2>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 2>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, _sortCol);
       break;
     }
     case 3: {
       auto res = new vector<array<Id, 3>>();
-      *res = *static_cast<vector<array<Id, 3>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 3>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, _sortCol);
       result->_fixedSizeData = res;
       break;
@@ -62,19 +62,19 @@ void Sort::computeResult(ResultTable* result) const {
     case 4: {
       auto res = new vector<array<Id, 4>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 4>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 4>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, _sortCol);
       break;
     }
     case 5: {
       auto res = new vector<array<Id, 5>>();
       result->_fixedSizeData = res;
-      *res = *static_cast<vector<array<Id, 5>>*>(subRes._fixedSizeData);
+      *res = *static_cast<vector<array<Id, 5>>*>(subRes->_fixedSizeData);
       getEngine().sort(*res, _sortCol);
       break;
     }
     default: {
-      result->_varSizeData = subRes._varSizeData;
+      result->_varSizeData = subRes->_varSizeData;
       getEngine().sort(result->_varSizeData, _sortCol);
       break;
     }

--- a/src/engine/TextOperationForContexts.cpp
+++ b/src/engine/TextOperationForContexts.cpp
@@ -58,6 +58,6 @@ void TextOperationForContexts::computeResult(ResultTable* result) const {
     AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
              "Complex text query is a todo for the future.");
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "TextOperationForContexts result computation done." << endl;
 }

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -43,14 +43,14 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "TextOperationWithFilter result computation..." << endl;
   AD_CHECK_GE(_nofVars, 1);
   result->_nofColumns = 1 + _filterResult->getResultWidth() + _nofVars;
+  shared_ptr<const ResultTable> filterResult = _filterResult->getResult();
   if (_filterResult->getResultWidth() == 1) {
     AD_CHECK_GE(result->_nofColumns, 3);
     if (result->_nofColumns == 3) {
       result->_fixedSizeData = new vector<array<Id, 3>>;
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    1>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 1>>*>(filterResult->_fixedSizeData),
           _nofVars,
           _textLimit,
           *reinterpret_cast<vector<array<Id, 3>>*>(result->_fixedSizeData));
@@ -58,8 +58,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
       result->_fixedSizeData = new vector<array<Id, 4>>;
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    1>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 1>>*>(filterResult->_fixedSizeData),
           _nofVars,
           _textLimit,
           *reinterpret_cast<vector<array<Id, 4>>*>(result->_fixedSizeData));
@@ -67,16 +66,14 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
       result->_fixedSizeData = new vector<array<Id, 5>>;
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    1>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 1>>*>(filterResult->_fixedSizeData),
           _nofVars,
           _textLimit,
           *reinterpret_cast<vector<array<Id, 5>>*>(result->_fixedSizeData));
     } else {
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    1>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 1>>*>(filterResult->_fixedSizeData),
           _nofVars,
           _textLimit,
           result->_varSizeData);
@@ -87,8 +84,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
       result->_fixedSizeData = new vector<array<Id, 4>>;
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    2>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 2>>*>(filterResult->_fixedSizeData),
           _filterColumn,
           _nofVars,
           _textLimit,
@@ -97,8 +93,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
       result->_fixedSizeData = new vector<array<Id, 5>>;
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    2>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 2>>*>(filterResult->_fixedSizeData),
           _filterColumn,
           _nofVars,
           _textLimit,
@@ -106,8 +101,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
     } else {
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    2>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 2>>*>(filterResult->_fixedSizeData),
           _filterColumn,
           _nofVars,
           _textLimit,
@@ -119,8 +113,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
       result->_fixedSizeData = new vector<array<Id, 5>>;
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    3>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 3>>*>(filterResult->_fixedSizeData),
           _filterColumn,
           _nofVars,
           _textLimit,
@@ -128,8 +121,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
     } else {
       getExecutionContext()->getIndex().getFilteredECListForWords(
           _words,
-          *static_cast<vector<array<Id,
-                                    3>>*>(_filterResult->getResult()._fixedSizeData),
+          *static_cast<vector<array<Id, 3>>*>(filterResult->_fixedSizeData),
           _filterColumn,
           _nofVars,
           _textLimit,
@@ -138,8 +130,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
   } else if (_filterResult->getResultWidth() == 4) {
     getExecutionContext()->getIndex().getFilteredECListForWords(
         _words,
-        *static_cast<vector<array<Id,
-                                  4>>*>(_filterResult->getResult()._fixedSizeData),
+        *static_cast<vector<array<Id, 4>>*>(filterResult->_fixedSizeData),
         _filterColumn,
         _nofVars,
         _textLimit,
@@ -147,8 +138,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
   } else if (_filterResult->getResultWidth() == 5) {
     getExecutionContext()->getIndex().getFilteredECListForWords(
         _words,
-        *static_cast<vector<array<Id,
-                                  5>>*>(_filterResult->getResult()._fixedSizeData),
+        *static_cast<vector<array<Id, 5>>*>(filterResult->_fixedSizeData),
         _filterColumn,
         _nofVars,
         _textLimit,
@@ -156,7 +146,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
   } else {
     getExecutionContext()->getIndex().getFilteredECListForWords(
         _words,
-        _filterResult->getResult()._varSizeData,
+        filterResult->_varSizeData,
         _filterColumn,
         _nofVars,
         _textLimit,

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -152,7 +152,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) const {
         _textLimit,
         result->_varSizeData);
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "TextOperationWithFilter result computation done." << endl;
 }
 

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -43,7 +43,7 @@ void TextOperationWithoutFilter::computeResult(ResultTable* result) const {
   } else {
     computeResultMultVars(result);
   }
-  result->_status = ResultTable::FINISHED;
+  result->finish();
   LOG(DEBUG) << "TextOperationWithoutFilter result computation done." << endl;
 }
 

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -119,7 +119,7 @@ void TwoColumnJoin::computeResult(ResultTable* result) const {
                          &result->_varSizeData);
     }
 
-    result->_status = ResultTable::FINISHED;
+    result->finish();
     LOG(DEBUG) << "TwoColumnJoin result computation done." << endl;
     return;
   }

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -71,8 +71,6 @@ void TwoColumnJoin::computeResult(ResultTable* result) const {
   AD_CHECK(!result->_fixedSizeData);
   LOG(DEBUG) << "TwoColumnJoin result computation..." << endl;
 
-
-
   // Deal with the case that one of the lists is width two and
   // with join columns 0 1. This means we can use the filter method.
   if ((_left->getResultWidth() == 2 && _jc1Left == 0 && _jc2Left == 1) ||
@@ -81,8 +79,8 @@ void TwoColumnJoin::computeResult(ResultTable* result) const {
                         _jc2Right == 1);
     const auto& v = rightFilter ? _left : _right;
     const auto& filter = *static_cast<vector<array<Id, 2>>*>(
-        rightFilter ? _right->getResult()._fixedSizeData
-                    : _left->getResult()._fixedSizeData);
+        rightFilter ? _right->getResult()->_fixedSizeData
+                    : _left->getResult()->_fixedSizeData);
     size_t jc1 = rightFilter ? _jc1Left : _jc1Right;
     size_t jc2 = rightFilter ? _jc2Left : _jc2Right;
     result->_sortedBy = jc1;
@@ -95,29 +93,29 @@ void TwoColumnJoin::computeResult(ResultTable* result) const {
     if (result->_nofColumns == 2) {
       using ResType = vector<array<Id, 2>>;
       result->_fixedSizeData = new ResType();
-      getEngine().filter(*static_cast<ResType*>(toFilter._fixedSizeData),
+      getEngine().filter(*static_cast<ResType*>(toFilter->_fixedSizeData),
                          jc1, jc2, filter,
                          static_cast<ResType*>(result->_fixedSizeData));
     } else if (result->_nofColumns == 3) {
       using ResType = vector<array<Id, 3>>;
       result->_fixedSizeData = new ResType();
-      getEngine().filter(*static_cast<ResType*>(toFilter._fixedSizeData),
+      getEngine().filter(*static_cast<ResType*>(toFilter->_fixedSizeData),
                          jc1, jc2, filter,
                          static_cast<ResType*>(result->_fixedSizeData));
     } else if (result->_nofColumns == 4) {
       using ResType = vector<array<Id, 4>>;
       result->_fixedSizeData = new ResType();
-      getEngine().filter(*static_cast<ResType*>(toFilter._fixedSizeData),
+      getEngine().filter(*static_cast<ResType*>(toFilter->_fixedSizeData),
                          jc1, jc2, filter,
                          static_cast<ResType*>(result->_fixedSizeData));
     } else if (result->_nofColumns == 5) {
       using ResType = vector<array<Id, 5>>;
       result->_fixedSizeData = new ResType();
-      getEngine().filter(*static_cast<ResType*>(toFilter._fixedSizeData),
+      getEngine().filter(*static_cast<ResType*>(toFilter->_fixedSizeData),
                          jc1, jc2, filter,
                          static_cast<ResType*>(result->_fixedSizeData));
     } else {
-      getEngine().filter(toFilter._varSizeData, jc1, jc2, filter,
+      getEngine().filter(toFilter->_varSizeData, jc1, jc2, filter,
                          &result->_varSizeData);
     }
 

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -983,11 +983,12 @@ void Index::readFreqComprList(size_t nofElements, off_t from, size_t nofBytes,
   AD_CHECK_EQ(sizeof(off_t), ret);
   current += ret;
   T* codebook = new T[nofCodebookBytes / sizeof(T)];
-  ret = _textIndexFile.read(codebook, nofCodebookBytes);
+  ret = _textIndexFile.read(codebook, nofCodebookBytes, current);
   current += ret;
   AD_CHECK_EQ(ret, size_t(nofCodebookBytes));
   ret = _textIndexFile.read(encoded,
-                            static_cast<size_t>(nofBytes - (current - from)));
+                            static_cast<size_t>(nofBytes - (current - from)),
+                            current);
   current += ret;
   AD_CHECK_EQ(size_t(current - from), nofBytes);
   LOG(DEBUG) << "Decoding Simple8b code...\n";
@@ -1093,12 +1094,13 @@ void Index::dumpAsciiLists(const TextBlockMetaData& tbmd) const {
       AD_CHECK_EQ(sizeof(off_t), ret);
       current += ret;
       Id* codebookW = new Id[nofCodebookBytes / sizeof(Id)];
-      ret = _textIndexFile.read(codebookW, nofCodebookBytes);
+      ret = _textIndexFile.read(codebookW, nofCodebookBytes, current);
       current += ret;
       AD_CHECK_EQ(ret, size_t(nofCodebookBytes));
       ret = _textIndexFile.read(encodedW,
                                 static_cast<size_t>(nofBytes -
-                                                    (current - from)));
+                                                    (current - from)),
+                                current);
       current += ret;
       AD_CHECK_EQ(size_t(current - from), nofBytes);
       LOG(DEBUG) << "Decoding Simple8b code...\n";
@@ -1122,12 +1124,13 @@ void Index::dumpAsciiLists(const TextBlockMetaData& tbmd) const {
     AD_CHECK_EQ(sizeof(off_t), ret);
     current += ret;
     Score* codebookS = new Score[nofCodebookBytes / sizeof(Score)];
-    ret = _textIndexFile.read(codebookS, nofCodebookBytes);
+    ret = _textIndexFile.read(codebookS, nofCodebookBytes, current);
     current += ret;
     AD_CHECK_EQ(ret, size_t(nofCodebookBytes));
     ret = _textIndexFile.read(encodedS,
                               static_cast<size_t>(nofBytes -
-                                                  (current - from)));
+                                                  (current - from)),
+                              current);
     current += ret;
     AD_CHECK_EQ(size_t(current - from), nofBytes);
     LOG(DEBUG) << "Decoding Simple8b code...\n";
@@ -1175,12 +1178,13 @@ void Index::dumpAsciiLists(const TextBlockMetaData& tbmd) const {
       AD_CHECK_EQ(sizeof(off_t), ret);
       current += ret;
       Id* codebookW = new Id[nofCodebookBytes / sizeof(Id)];
-      ret = _textIndexFile.read(codebookW, nofCodebookBytes);
+      ret = _textIndexFile.read(codebookW, nofCodebookBytes, current);
       current += ret;
       AD_CHECK_EQ(ret, size_t(nofCodebookBytes));
       ret = _textIndexFile.read(encodedW,
                                 static_cast<size_t>(nofBytes -
-                                                    (current - from)));
+                                                    (current - from)),
+                                current);
       current += ret;
       AD_CHECK_EQ(size_t(current - from), nofBytes);
       LOG(DEBUG) << "Decoding Simple8b code...\n";
@@ -1205,12 +1209,13 @@ void Index::dumpAsciiLists(const TextBlockMetaData& tbmd) const {
     AD_CHECK_EQ(sizeof(off_t), ret);
     current += ret;
     Score* codebookS = new Score[nofCodebookBytes / sizeof(Score)];
-    ret = _textIndexFile.read(codebookS, nofCodebookBytes);
+    ret = _textIndexFile.read(codebookS, nofCodebookBytes, current);
     current += ret;
     AD_CHECK_EQ(ret, size_t(nofCodebookBytes));
     ret = _textIndexFile.read(encodedS,
                               static_cast<size_t>(nofBytes -
-                                                  (current - from)));
+                                                  (current - from)),
+                              current);
     current += ret;
     AD_CHECK_EQ(size_t(current - from), nofBytes);
     LOG(DEBUG) << "Decoding Simple8b code...\n";

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -189,8 +189,8 @@ class File {
     size_t read(void* targetBuffer, size_t nofBytesToRead,
         off_t seekOffsetFromStart) {
       assert(_file);
-      if (!seek(seekOffsetFromStart, SEEK_SET)) return 0;
-      return read(targetBuffer, nofBytesToRead);
+      return pread(fileno(_file), targetBuffer,
+          nofBytesToRead, seekOffsetFromStart);
     }
 
     //! Returns the number of bytes from the beginning

--- a/src/util/LRUCache.h
+++ b/src/util/LRUCache.h
@@ -31,16 +31,15 @@ namespace ad_utility {
 //! as full-text-query cache where one might want to get the best fit of any
 //! entry that can be used to filter the desired result from.
 //!
-//! This implementation provides thread safety through the use of locking and
-//! only allowing access to cached values via read-only shared_ptr's which
-//! also guarantee that memory is not freed while some thread still has access
-//! to the cached data.
+//! This implementation provides thread safety for the cache itself but does
+//! not enforce read-only access to the cached values. This is so that the
+//! values may be used to block threads on their completion.
 template <class Key, class Value,
           class AccessMap = ad_utility::HashMap<
-              Key, typename list<pair<Key, shared_ptr<const Value>>>::iterator>>
+              Key, typename list<pair<Key, shared_ptr<Value>>>::iterator>>
 class LRUCache {
 private:
-  typedef pair<Key, shared_ptr<const Value>> Entry;
+  typedef pair<Key, shared_ptr<Value>> Entry;
   typedef list<Entry> EntryList;
 
 public:
@@ -48,18 +47,52 @@ public:
   explicit LRUCache(size_t capacity)
       : _capacity(capacity), _data(), _accessMap(), _lock() {}
 
-  //! Lookup operator. If the value does not exist in the cache, a
-  //! shared_ptr<const Value>(nullptr) is returned. Using a shared_ptr
-  //! to const prevents any modification of cached values which may be
-  //! shared across threads. The shared_ptr itself may however be copied
-  //! as it uses thread safe primitives internally
-  shared_ptr<const Value> operator[](const Key& key) {
+  //! Get a value or default construct a new one.
+  //! If the value does not exist in the cache, a
+  //! a default Value is constructed and created is set to true. 
+  //! otherwise created is set to false. Using a created paramter allows
+  //! a threaded call to check if it needs to initialize the value in a
+  //! race free way. If we didn't make that explicit a newly created value
+  //! by another thread could not be distinguished from one created by the
+  //! current thread.
+  //! TODO(schnelle) add test
+  shared_ptr<Value> getOrCreate(const Key &key, bool* created) {
+    lock_guard<mutex> lock(_lock);
+    typename AccessMap::const_iterator mapIt = _accessMap.find(key);
+    if (mapIt == _accessMap.end()) {
+      *created = true;
+      // Insert without taking mutex recursively
+      _data.push_front(Entry(key, make_shared<Value>()));
+      _accessMap[key] = _data.begin();
+      if (_data.size() > _capacity) {
+        // Remove the last element.
+        // Since we are using shared_ptr this does not free the underlying
+        // memory if it is still accessible through a previously returned
+        // shared_ptr
+        _accessMap.erase(_data.back().first);
+        _data.pop_back();
+      }
+      assert(_data.size() <= _capacity);
+    } else {
+      *created = false;
+      // Move it to the front.
+      typename EntryList::iterator listIt = mapIt->second;
+      _data.splice(_data.begin(), _data, listIt);
+      _accessMap[key] = _data.begin();
+    }
+    assert(_accessMap.find(key)->second == _data.begin());
+    return _data.begin()->second;
+  }
+
+  //! Lookup a read-only value without creating a new one if non exists
+  //! instead shared_ptr<const Value>(nullptr) is returned in that case
+  shared_ptr<const Value> operator[](const Key &key) {
     lock_guard<mutex> lock(_lock);
     typename AccessMap::const_iterator mapIt = _accessMap.find(key);
     if (mapIt == _accessMap.end()) {
       // Returning a null pointer allows to easily check if the element
       // existed and crash misuses.
-      return shared_ptr<const Value>(nullptr);
+      return shared_ptr<Value>(nullptr);
     }
 
     // Move it to the front.
@@ -71,9 +104,9 @@ public:
   }
 
   //! Insert a key value pair to the cache.
-  shared_ptr<const Value> insert(const Key& key, Value value) {
+  void insert(const Key &key, Value value) {
     lock_guard<mutex> lock(_lock);
-    _data.push_front(Entry(key, make_shared<const Value>(std::move(value))));
+    _data.push_front(Entry(key, make_shared<Value>(std::move(value))));
     _accessMap[key] = _data.begin();
     if (_data.size() > _capacity) {
       // Remove the last element.
@@ -84,7 +117,6 @@ public:
       _data.pop_back();
     }
     assert(_data.size() <= _capacity);
-    return _data.begin()->second;
   }
 
   //! Set the capacity.
@@ -103,7 +135,7 @@ public:
   }
 
   //! Checks if there is an entry with the given key.
-  bool contains(const Key& key) {
+  bool contains(const Key &key) {
     lock_guard<mutex> lock(_lock);
     return _accessMap.count(key) > 0;
   }

--- a/src/util/LRUCache.h
+++ b/src/util/LRUCache.h
@@ -4,14 +4,19 @@
 
 #pragma once
 
+#include "./HashMap.h"
 #include <assert.h>
 #include <list>
+#include <memory>
+#include <mutex>
 #include <utility>
-#include "./HashMap.h"
 
 using std::list;
 using std::pair;
-
+using std::mutex;
+using std::shared_ptr;
+using std::make_shared;
+using std::lock_guard;
 
 namespace ad_utility {
 //! Associative array for almost arbitrary keys and values that acts as a cache.
@@ -25,75 +30,100 @@ namespace ad_utility {
 //! exact matching. An example application for that is using the LRUCache
 //! as full-text-query cache where one might want to get the best fit of any
 //! entry that can be used to filter the desired result from.
-template<class Key, class Value,
-    class AccessMap = ad_utility::HashMap<Key,
-        typename list<pair<Key, Value>>::iterator>>
+//!
+//! This implementation provides thread safety through the use of locking and
+//! only allowing access to cached values via read-only shared_ptr's which
+//! also guarantee that memory is not freed while some thread still has access
+//! to the cached data.
+template <class Key, class Value,
+          class AccessMap = ad_utility::HashMap<
+              Key, typename list<pair<Key, shared_ptr<const Value>>>::iterator>>
 class LRUCache {
-  private:
-    typedef pair<Key, Value> Entry;
-    typedef list<Entry> EntryList;
+private:
+  typedef pair<Key, shared_ptr<const Value>> Entry;
+  typedef list<Entry> EntryList;
 
-  public:
-    //! Typical constructor. A default value may be added in time.
-    explicit LRUCache(size_t capacity) :
-        _capacity(capacity), _data(), _accessMap() {
+public:
+  //! Typical constructor. A default value may be added in time.
+  explicit LRUCache(size_t capacity)
+      : _capacity(capacity), _data(), _accessMap(), _lock() {}
+
+  //! Lookup operator. If the value does not exist in the cache, a
+  //! shared_ptr<const Value>(nullptr) is returned. Using a shared_ptr
+  //! to const prevents any modification of cached values which may be
+  //! shared across threads. The shared_ptr itself may however be copied
+  //! as it uses thread safe primitives internally
+  shared_ptr<const Value> operator[](const Key& key) {
+    lock_guard<mutex> lock(_lock);
+    typename AccessMap::const_iterator mapIt = _accessMap.find(key);
+    if (mapIt == _accessMap.end()) {
+      // Returning a null pointer allows to easily check if the element
+      // existed and crash misuses.
+      return shared_ptr<const Value>(nullptr);
     }
 
-    //! Lookup operator. Creates elements with default constructed
-    //! values for keys that currently are not in the cache.
-    Value& operator[](const Key& key) {
-      typename AccessMap::const_iterator mapIt = _accessMap.find(key);
-      if (mapIt == _accessMap.end()) {
-        // Insert a pair with a default constructed value.
-        insert(key, Value());
-      } else {
-        // Move it to the front.
-        typename EntryList::iterator listIt = mapIt->second;
-        _data.splice(_data.begin(), _data, listIt);
-        _accessMap[key] = _data.begin();
-      }
-      assert(_accessMap.find(key)->second == _data.begin());
-      return _data.begin()->second;
+    // Move it to the front.
+    typename EntryList::iterator listIt = mapIt->second;
+    _data.splice(_data.begin(), _data, listIt);
+    _accessMap[key] = _data.begin();
+    assert(_accessMap.find(key)->second == _data.begin());
+    return _data.begin()->second;
+  }
+
+  //! Insert a key value pair to the cache.
+  shared_ptr<const Value> insert(const Key& key, Value value) {
+    lock_guard<mutex> lock(_lock);
+    _data.push_front(Entry(key, make_shared<const Value>(std::move(value))));
+    _accessMap[key] = _data.begin();
+    if (_data.size() > _capacity) {
+      // Remove the last element.
+      // Since we are using shared_ptr this does not free the underlying
+      // memory if it is still accessible through a previously returned
+      // shared_ptr
+      _accessMap.erase(_data.back().first);
+      _data.pop_back();
     }
+    assert(_data.size() <= _capacity);
+    return _data.begin()->second;
+  }
 
-    //! Insert a key value pair to the cache.
-    void insert(const Key& key, const Value& value) {
-      _data.push_front(Entry(key, value));
-      _accessMap[key] = _data.begin();
-      if (_data.size() > _capacity) {
-        // Remove the last element.
-        _accessMap.erase(_data.back().first);
-        _data.pop_back();
-      }
-      assert(_data.size() <= _capacity);
+  //! Set the capacity.
+  void setCapacity(const size_t nofElements) {
+    lock_guard<mutex> lock(_lock);
+    _capacity = nofElements;
+    while (_data.size() > _capacity) {
+      // Remove the last element.
+      // Since we are using shared_ptr this does not free the underlying
+      // memory if it is still accessible through a previously returned
+      // shared_ptr
+      _accessMap.erase(_data.back().first);
+      _data.pop_back();
     }
+    assert(_data.size() <= _capacity);
+  }
 
+  //! Checks if there is an entry with the given key.
+  bool contains(const Key& key) {
+    lock_guard<mutex> lock(_lock);
+    return _accessMap.count(key) > 0;
+  }
 
-    //! Set the capacity.
-    void setCapacity(const size_t nofElements) {
-      _capacity = nofElements;
-      while (_data.size() > _capacity) {
-        // Remove the last element.
-        _accessMap.erase(_data.back().first);
-        _data.pop_back();
-      }
-      assert(_data.size() <= _capacity);
-    }
+  //! Clear the cache
+  void clear() {
+    lock_guard<mutex> lock(_lock);
+    // Since we are using shared_ptr this does not free the underlying
+    // memory if it is still accessible through a previously returned
+    // shared_ptr
+    _data.clear();
+    _accessMap.clear();
+  }
 
-    //! Checks if there is an entry with the given key.
-    bool contains(const Key& key) {
-      return _accessMap.count(key) > 0;
-    }
-
-    //! Clear the cache
-    void clear() {
-      _data.clear();
-      _accessMap.clear();
-    }
-
-  private:
-    size_t _capacity;
-    EntryList _data;
-    AccessMap _accessMap;
+private:
+  size_t _capacity;
+  EntryList _data;
+  AccessMap _accessMap;
+  // TODO(schnelle): Once we switch to C++17
+  // this should be a shared_mutex
+  mutex _lock;
 };
 }

--- a/test/LRUCacheTest.cpp
+++ b/test/LRUCacheTest.cpp
@@ -14,26 +14,21 @@ namespace ad_utility {
 TEST(LRUCacheTest, testTypicalusage) {
   LRUCache<string, string> cache(5);
   cache.insert("1", "x");
-  cache.insert("2", "x");
-  cache.insert("3", "x");
-  cache.insert("4", "x");
-  cache.insert("5", "x");
+  cache.insert("2", "xx");
+  cache.insert("3", "xxx");
+  cache.insert("4", "xxxx");
+  cache.insert("5", "xxxxx");
 
-  ASSERT_EQ(cache["1"], "x");
-  ASSERT_EQ(cache["2"], "x");
-  ASSERT_EQ(cache["3"], "x");
-  ASSERT_EQ(cache["4"], "x");
-  ASSERT_EQ(cache["5"], "x");
-  ASSERT_EQ(cache["6"], "");
-  ASSERT_EQ(cache["1"], "");
-  ASSERT_EQ(cache["2"], "");
-  ASSERT_EQ(cache["3"], "");
-  cache["3"] = "xxxx";
-  ASSERT_EQ(cache["3"], "xxxx");
-  ASSERT_EQ(cache["5"], "x");
-  cache["0"] = string("xxxx");
-  ASSERT_EQ(cache["0"], "xxxx");
-  ASSERT_EQ(cache["4"], "");
+  ASSERT_EQ(*cache["1"], "x");
+  ASSERT_EQ(*cache["2"], "xx");
+  ASSERT_EQ(*cache["3"], "xxx");
+  ASSERT_EQ(*cache["4"], "xxxx");
+  ASSERT_EQ(*cache["5"], "xxxxx");
+  // Non-existing elements must yield shared_ptr<const Value>(nullptr)
+  // this bool converts to false
+  ASSERT_FALSE(cache["non-existant"]);
+  // insert and immediate result retrieval
+  ASSERT_EQ(*cache.insert("new", "newvalue"), "newvalue");
 }
 
 // _____________________________________________________________________________
@@ -45,23 +40,20 @@ TEST(LRUCacheTest, testIncreasingCapacity) {
   cache.insert("4", "x");
   cache.insert("5", "x");
 
-  ASSERT_EQ(cache["1"], "x");
-  ASSERT_EQ(cache["2"], "x");
-  ASSERT_EQ(cache["3"], "x");
-  ASSERT_EQ(cache["4"], "x");
-  ASSERT_EQ(cache["5"], "x");
-  ASSERT_EQ(cache["6"], "");
-  ASSERT_EQ(cache["1"], "");
+  ASSERT_EQ(*cache["1"], "x");
+  ASSERT_EQ(*cache["2"], "x");
+  ASSERT_EQ(*cache["3"], "x");
+  ASSERT_EQ(*cache["4"], "x");
+  ASSERT_EQ(*cache["5"], "x");
   cache.setCapacity(10);
-  ASSERT_EQ(cache["2"], "");
-  ASSERT_EQ(cache["3"], "x");
-  cache["3"] = "xxxx";
-  ASSERT_EQ(cache["3"], "xxxx");
-  ASSERT_EQ(cache["5"], "x");
-  cache["0"] = string("xxxx");
-  ASSERT_EQ(cache["0"], "xxxx");
-  ASSERT_EQ(cache["4"], "x");
-  ASSERT_EQ(cache["5"], "x");
+  ASSERT_EQ(*cache["3"], "x");
+  cache.insert("3", "xxxx");
+  ASSERT_EQ(*cache["3"], "xxxx");
+  ASSERT_EQ(*cache["5"], "x");
+  cache.insert("0", "xxxx");
+  ASSERT_EQ(*cache["0"], "xxxx");
+  ASSERT_EQ(*cache["4"], "x");
+  ASSERT_EQ(*cache["5"], "x");
 }
 
 // _____________________________________________________________________________
@@ -72,22 +64,16 @@ TEST(LRUCacheTest, testDecreasingCapacity) {
   cache.insert("3", "x");
   cache.insert("4", "x");
   cache.insert("5", "x");
-  ASSERT_EQ(cache["1"], "x");
-  ASSERT_EQ(cache["2"], "x");
-  ASSERT_EQ(cache["3"], "x");
-  ASSERT_EQ(cache["4"], "x");
-  ASSERT_EQ(cache["5"], "x");
-  ASSERT_EQ(cache["6"], "");
-  ASSERT_EQ(cache["7"], "");
-  ASSERT_EQ(cache["8"], "");
-  cache["9"] = "x";
-  cache["10"] = "x";
+  ASSERT_EQ(*cache["1"], "x");
+  ASSERT_EQ(*cache["2"], "x");
+  ASSERT_EQ(*cache["3"], "x");
+  ASSERT_EQ(*cache["4"], "x");
+  ASSERT_EQ(*cache["5"], "x");
+  cache.insert("9", "x");
+  cache.insert("10", "x");
   cache.setCapacity(5);
-  ASSERT_EQ(cache["1"], "");
-  ASSERT_EQ(cache["2"], "");
-  ASSERT_EQ(cache["3"], "");
-  ASSERT_EQ(cache["9"], "x");
-  ASSERT_EQ(cache["10"], "x");
+  ASSERT_EQ(*cache["9"], "x");
+  ASSERT_EQ(*cache["10"], "x");
 }
 }
 

--- a/test/LRUCacheTest.cpp
+++ b/test/LRUCacheTest.cpp
@@ -11,7 +11,7 @@ using std::string;
 
 namespace ad_utility {
 // _____________________________________________________________________________
-TEST(LRUCacheTest, testTypicalusage) {
+TEST(LRUCacheTest, testTypicalUsage) {
   LRUCache<string, string> cache(5);
   cache.insert("1", "x");
   cache.insert("2", "xx");
@@ -29,19 +29,19 @@ TEST(LRUCacheTest, testTypicalusage) {
   ASSERT_FALSE(cache["non-existant"]);
 }
 // _____________________________________________________________________________
-TEST(LRUCacheTest, testGetOrCreate) {
+TEST(LRUCacheTest, testTryEmplace) {
   LRUCache<string, string> cache(5);
   cache.insert("1", "x");
   cache.insert("2", "xx");
-  bool created = false;
-  ASSERT_EQ(*cache.getOrCreate("2", &created), "xx");
-  ASSERT_FALSE(created);
-  ASSERT_EQ(*cache.getOrCreate("4", &created), "");
-  ASSERT_TRUE(created);
-  created = false;
-  *cache.getOrCreate("4", &created) += "foo";
-  ASSERT_EQ(*cache.getOrCreate("4", &created), "foo");
-  ASSERT_FALSE(created);
+  // tryEmplace returns a pair of shared_ptr where the first is non-const and
+  // only non-null if it was freshly inserted. That in turn converts to false
+  // in bool context
+  ASSERT_FALSE(cache.tryEmplace("2", "foo").first);
+  ASSERT_EQ(*cache.tryEmplace("4", "bar").first, "bar");
+  auto emplaced = cache.tryEmplace("5", "foo").first;
+  ASSERT_TRUE(emplaced);
+  *emplaced += "bar";
+  ASSERT_EQ(*cache["5"], "foobar");
 }
 
 // _____________________________________________________________________________

--- a/test/LRUCacheTest.cpp
+++ b/test/LRUCacheTest.cpp
@@ -27,8 +27,21 @@ TEST(LRUCacheTest, testTypicalusage) {
   // Non-existing elements must yield shared_ptr<const Value>(nullptr)
   // this bool converts to false
   ASSERT_FALSE(cache["non-existant"]);
-  // insert and immediate result retrieval
-  ASSERT_EQ(*cache.insert("new", "newvalue"), "newvalue");
+}
+// _____________________________________________________________________________
+TEST(LRUCacheTest, testGetOrCreate) {
+  LRUCache<string, string> cache(5);
+  cache.insert("1", "x");
+  cache.insert("2", "xx");
+  bool created = false;
+  ASSERT_EQ(*cache.getOrCreate("2", &created), "xx");
+  ASSERT_FALSE(created);
+  ASSERT_EQ(*cache.getOrCreate("4", &created), "");
+  ASSERT_TRUE(created);
+  created = false;
+  *cache.getOrCreate("4", &created) += "foo";
+  ASSERT_EQ(*cache.getOrCreate("4", &created), "foo");
+  ASSERT_FALSE(created);
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
This PR adds multi-threading for the QLever server including sharing of cached subquery results between threads.

Architecturally this is achieved with four primary changes
- Make `LRUCache` thread safe 
    - Values are read-only accessible via`std::shared_ptr<const ValueType> getResult()` 
    - Values are added using an atomic `tryEmplace()`
    - On its own this change would have multiple threads racily recompute subqueries
- Enable waiting for the completion of a subquery `ResultTable`
    - Using a `std::condition_variable` and a `std::mutex` built a blocking `ResultTable::awaitFinished()` method that allows threads tto wait for completion of in-flight `ResultTable`s they find in the LRUCache
    - Once the computing thread finishes the `ResultTable` it calls `ResultTable::finish()` signalling other threads the completion
    - Together with the thread safe `LRUCache` this allows threads to share the computation of subqueries without competing for recomputation of the same data (unless evicted from the cache)
- Make the HTTP Backend threaded
    - Use concurrent `accept` calls so that a fixed number of worker threads (adjustable on the CLI) can service HTTP requests.
- Don't use seeking for file access, instead use `read` with the offset parameter. Otherwise one thread would seek, screwing up another threads view of the file

Sadly we are still missing end-to-end tests that would show that we're still able to compute known queries. However, anecdotal evidence *aka manual testing* showed basic queries to work. That said further testing is definitely needed.