### PR TITLE
Add a Google + left aligned pointer .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Left
+...


### PR DESCRIPTION
As discussed in a recent review we should follow a common code style. At
the chair we mostly use Google style and left aligned pointers so lets
stick with that. I tested reformatting everything but it's a huge change
and even breaks the build due to bad header dependencies (which we
should fix separately).

So the next plan is to reformat all new and significantly changed files
as well as fixing the headers. The first step of this is adding
a `.clang-format` file for automatic formatting.

Since the file is in the project root `clang-format -i foo.cpp`
automatically picks it up when executed within the project tree.