### PR TITLE
Fix #56: `pread()` has a smaller size limit than `read()` on Linux

### DIFF
--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -150,12 +150,6 @@ TEST_F(FileTest, testReadIntoVector) {
   ASSERT_EQ("line2", lines2[1]);
 }
 
-TEST_F(FileTest, testGetTrailingOffT) {
-  File objUnderTest("_tmp_testFileBinary", "r");
-  off_t off = objUnderTest.getTrailingOffT();
-  ASSERT_EQ(off_t(3), off);
-}
-
 }  // namespace ad_utility
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
`pread()` has a size limit around 2.5 GB on Linux see
[here](https://stackoverflow.com/questions/36565209/pread-for-very-large-files)

While a bit weird on 64 bit systems checking the actually read number of bytes
is probably a good idea anyway. While we are here clean up `getLastOffset()`
and remove unused (except for its test) `getTrailingOffT()` which did pretty
much the same with a copy of the code but returning the read offset
directly. This also gets rid of a two more `seek()` (except for getting the
file size). More cleanup is likely needed.