### PR TITLE
Prevent copying/assigning to ResultTable + format

### DIFF
--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -14,45 +14,6 @@ ResultTable::ResultTable()
       _status(ResultTable::OTHER) {}
 
 // _____________________________________________________________________________
-ResultTable::ResultTable(const ResultTable& other)
-    : _nofColumns(other._nofColumns),
-      _sortedBy(other._sortedBy),
-      _varSizeData(other._varSizeData),
-      _fixedSizeData(nullptr),
-      _status(other._status) {
-  if (other._nofColumns <= 5) {
-    if (other._nofColumns == 1) {
-      _fixedSizeData = new vector<array<Id, 1>>;
-      *static_cast<vector<array<Id, 1>>*>(_fixedSizeData) =
-          *static_cast<vector<array<Id, 1>>*>(other._fixedSizeData);
-    }
-    if (other._nofColumns == 2) {
-      _fixedSizeData = new vector<array<Id, 2>>;
-      *static_cast<vector<array<Id, 2>>*>(_fixedSizeData) =
-          *static_cast<vector<array<Id, 2>>*>(other._fixedSizeData);
-    }
-    if (other._nofColumns == 3) {
-      _fixedSizeData = new vector<array<Id, 3>>;
-      *static_cast<vector<array<Id, 3>>*>(_fixedSizeData) =
-          *static_cast<vector<array<Id, 3>>*>(other._fixedSizeData);
-    }
-    if (other._nofColumns == 4) {
-      _fixedSizeData = new vector<array<Id, 4>>;
-      *static_cast<vector<array<Id, 4>>*>(_fixedSizeData) =
-          *static_cast<vector<array<Id, 4>>*>(other._fixedSizeData);
-    }
-    if (other._nofColumns == 5) {
-      _fixedSizeData = new vector<array<Id, 5>>;
-      *static_cast<vector<array<Id, 5>>*>(_fixedSizeData) =
-          *static_cast<vector<array<Id, 5>>*>(other._fixedSizeData);
-    }
-  } else {
-    assert(!other._fixedSizeData);
-    _fixedSizeData = nullptr;
-  }
-}
-
-// _____________________________________________________________________________
 void ResultTable::clear() {
   if (_fixedSizeData) {
     if (_nofColumns == 1) {

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -34,35 +34,13 @@ class ResultTable {
 
   ResultTable();
 
-  ResultTable(const ResultTable&);
+  ResultTable(const ResultTable& other) = delete;
 
-  ResultTable(ResultTable&& other) noexcept
-      : _nofColumns(0),
-        _sortedBy(0),
-        _varSizeData(),
-        _fixedSizeData(nullptr),
-        _status(ResultTable::OTHER) {
-    swap(*this, other);
-  }
+  ResultTable(ResultTable&& other) = delete;
 
-  ResultTable& operator=(ResultTable other) {
-    swap(*this, other);
-    return *this;
-  }
+  ResultTable& operator=(ResultTable other) = delete;
 
-  ResultTable& operator=(ResultTable&& other) noexcept {
-    swap(*this, other);
-    return *this;
-  }
-
-  friend void swap(ResultTable& a, ResultTable& b) noexcept {
-    using std::swap;
-    swap(a._status, b._status);
-    swap(a._nofColumns, b._nofColumns);
-    swap(a._sortedBy, b._sortedBy);
-    swap(a._varSizeData, b._varSizeData);
-    swap(a._fixedSizeData, b._fixedSizeData);
-  }
+  ResultTable& operator=(ResultTable&& other) = delete;
 
   virtual ~ResultTable();
 

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -105,7 +105,7 @@ void TextOperationWithoutFilter::computeResultMultVars(
     result->_resultTypes.reserve(result->_nofColumns);
     result->_resultTypes.push_back(ResultTable::ResultType::TEXT);
     result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);
-    for (int i = 2; i < result->_nofColumns; i++) {
+    for (size_t i = 2; i < result->_nofColumns; i++) {
       result->_resultTypes.push_back(ResultTable::ResultType::KB);
     }
     getExecutionContext()->getIndex().getECListForWords(

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -380,7 +380,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     for (size_t i = 0; i < ip.second; i++) {
       ASSERT_EQ(p[i], ip.first[i]);
     }
-    ASSERT_EQ(0, index.getHasPattern()[1]);
+    ASSERT_EQ(0u, index.getHasPattern()[1]);
     ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
   }
   {
@@ -400,7 +400,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     for (size_t i = 0; i < ip.second; i++) {
       ASSERT_EQ(p[i], ip.first[i]);
     }
-    ASSERT_EQ(0, index.getHasPattern()[1]);
+    ASSERT_EQ(0u, index.getHasPattern()[1]);
     ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
   }
 }


### PR DESCRIPTION
with ResulTable(s) being used for waiting on a result copying or assigning them
becomes difficult to handle. Thankfully we don't actually do that so delete the
copy and assignment constructors/operator=s and thus make sure it never
happens. While we are here format it and also fix some signed-unsigned
comparisons in IndexTest