### PR TITLE
Travis: Install and use GCC 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,22 @@ language: c++
 sudo: false
 dist: trusty
 
-compiler:
-  - gcc
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
+      - gcc-5
+      - g++-5
       - libsparsehash-dev
       - cmake
 
+compiler:
+  - gcc-5
+
 before_script:
+  - $CXX --version
   - mkdir build
   - cd build
   - cmake ..


### PR DESCRIPTION
Travis' newest supported distribution is Ubuntu 14.04 LTS (not joking) but we
can use a more current compiler. To match internal infrastructure we choose GCC
5.x which is the default in Ubuntu 16.04 LTS