### PR TITLE
Fix Travis overriding the gcc-5 directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-language: c++
+language: generic
 sudo: false
 dist: trusty
-
 
 addons:
   apt:
@@ -13,8 +12,8 @@ addons:
       - libsparsehash-dev
       - cmake
 
-compiler:
-  - gcc-5
+env:
+  - CC=gcc-5 CXX=g++-5
 
 before_script:
   - $CXX --version


### PR DESCRIPTION
According to
https://stackoverflow.com/questions/35110123/travis-ci-with-c14-and-linux
Travis tends to override this when using language: c++