### PR TITLE
End-to-End Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# End-to-End data
+e2e_data/*
 # Compiled Object files
 *.slo
 *.lo

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
       - cmake
       - netcat
 
+cache:
+  directories:
+    - e2e_data/scientist-collection/
+
 env:
   - CC=gcc-5 CXX=g++-5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,16 @@ dist: trusty
 addons:
   apt:
     sources:
+      - deadsnakes
       - ubuntu-toolchain-r-test
     packages:
       - gcc-5
       - g++-5
       - libsparsehash-dev
+      - python3.6
+      - python3-yaml
       - cmake
+      - netcat
 
 env:
   - CC=gcc-5 CXX=g++-5
@@ -21,9 +25,11 @@ before_script:
   - cd build
   - cmake ..
 
-script: 
-  - make -j 3 
+script:
+  - make -j 3
   - make test
+  - cd ..
+  - e2e/e2e.sh
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ quickly test if something is horribly broken.
 
 **Note**: This does not include compilation and unit tests, though these are
 also run on Travis CI. Refer to the previous section for Unit Tests and
-compilation. Also this does assume
+compilation. Also this does assume that the build uses the `./build` directory
+as described in the [Build](#1-build) section.
 
 To do a full End-to-End Test run *(from the project root)*
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Pure SPARQL is supported as well.
 With this, it is possible to answer queries like the following one for astronauts who walked on the moon:
 
     SELECT ?a TEXT(?t) SCORE(?t) WHERE {
-        ?a <is-a> <Astronaut> . 
+        ?a <is-a> <Astronaut> .
         ?t ql:contains-entity ?a .
         ?t ql:contains-word "walk* moon"
     } ORDER BY DESC(SCORE(?t))
-    
+
 This Readme sets you up to use the engine and to quickly build and query your own index.
 
 
@@ -28,8 +28,8 @@ To reproduce our experimental evaluation, best use the according release (git ta
 
 ## CAVEAT!
 
-The latest version changed the syntax for text queries from a universal (and symmetric) ``<in-text>`` predicate to two explicit predicates ``ql:contains-entity`` and ``ql:contains-word``. 
-We found this style more intuitive and also used it in the CIKM'17 research paper. 
+The latest version changed the syntax for text queries from a universal (and symmetric) ``<in-text>`` predicate to two explicit predicates ``ql:contains-entity`` and ``ql:contains-word``.
+We found this style more intuitive and also used it in the CIKM'17 research paper.
 Thus, old queries no longer work and need to be adjusted as described in this README.
 
 
@@ -45,9 +45,10 @@ Make sure you use a 64bit Linux with:
 * g++ 4.8 or higher
 * CMake 2.8.4 or higher
 * google-sparsehash
+* python3 + python3-yaml (for End-to-End Tests)
 
-Other compilers (and OS) are not supported, yet. 
-So far no major problems are known. 
+Other compilers (and OS) are not supported, yet.
+So far no major problems are known.
 Support for more platforms would be a highly appreciated contribution.
 
 You also have to have google sparsehash installed.
@@ -59,33 +60,54 @@ If this isn't the case on your system, run:
 
 ## 1. Build:
 
-
 a) Checkout this project:
 
     git clone https://github.com/Buchhold/QLever.git --recursive
 
-Don't forget --recursive so that submodules will be updated. 
+Don't forget --recursive so that submodules will be updated.
 For old versions of git, that do not support this parameter, you can do:
 
     git clone https://github.com/Buchhold/QLever.git
     cd QLever
     git submodule init
     git submodule update
-    
 
-b) Go to a folder where you want to build the binaries.
-Don't do this directly in QLever
 
-    cd /path/to/YOUR_FOLDER
+b) Go to a folder where you want to build the binaries.  Usually this is done
+with a separate `build` subfolder. This is also assumed by the `e2e/e2e.sh`
+script.
 
-c) Build the project (Optional: add -DPERFTOOLS_PROFILER=True/False and -DALLOW_SHUTDOWN=True/False)
+    mkdir build && cd build
 
-    cmake /path/to/QLever/ -DCMAKE_BUILD_TYPE=Release; make -j
+c) Build the project (Optional: add `-DPERFTOOLS_PROFILER=True/False` and `-DALLOW_SHUTDOWN=True/False`)
+
+    cmake -DCMAKE_BUILD_TYPE=Release .. && make -j
 
 d) Run ctest. All tests should pass:
 
     ctest
 
+### 1.1 Running End-to-End Tests
+
+QLever includes a simple mechanism for testing the entire system from
+from building an index to running queries in a single command.
+
+
+In fact this End-to-End Test is run on Travis CI for every commit and Pull
+Request. It is also useful for local development however since it allows you to
+quickly test if something is horribly broken.
+
+**Note**: This does not include compilation and unit tests, though these are
+also run on Travis CI. Refer to the previous section for Unit Tests and
+compilation. Also this does assume
+
+To do a full End-to-End Test run *(from the project root)*
+
+    e2e/e2e.sh
+
+If you want to skip creation of the index run
+
+    e2e/e2e.sh no-index
 
 ## 2. Creating an Index:
 
@@ -94,7 +116,7 @@ IMPORTANT:
 THERE HAS TO BE SUFFICIENT DISK SPACE UNDER THE PATH YOU CHOOSE FOR YOUR INDEX!
 FOR NOW - ALL FILES HAVE TO BE UTF-8 ENCODED!
 
-    You can use the files described and linked later in this document: 
+    You can use the files described and linked later in this document:
     "How to obtain data to play around with"
 
 a) from an NTriples file (currently no blank nodes allowed):
@@ -105,18 +127,18 @@ Note that the string passed to -i is the base name of various index files produc
 
 b) from a TSV File (no spaces / tabs in spo):
 
-    ./IndexBuilderMain -i /path/to/myindex -t /path/to/input.tsv 
+    ./IndexBuilderMain -i /path/to/myindex -t /path/to/input.tsv
 
 To include a text collection, the wordsfile (see below for the required format) has to be passed with -w.
 To support text snippets, a docsfile (see below for the required format)has to be passed with -d
 
 The full call will look like this:
 
-    ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt -w /path/to/wordsfile -d /path/to/docsfile 
-    
+    ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt -w /path/to/wordsfile -d /path/to/docsfile
+
 If you want support for SPARQL queries with predicate variables  (perfectly normal for SPARQL but rarely used in semantic text queries), use an optional argument -a to build all permutations:
 
-    ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt -a -w 
+    ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt -a -w
 
 To generate a patterns file and include support for ql:has-relations:
 
@@ -125,13 +147,13 @@ To generate a patterns file and include support for ql:has-relations:
 If you want some literals to be written to an on disk vocabulary (by default this concerns literals longer than 50 chars and literals in less frequent lagnuages), add an topional parameter -l. This is useful for large knowledge bases that included texts (descriptions etc) as literals and thus consume lots of memory on startup without this option.
 
     ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt -l
-    
+
 You can also add a text index to an existing knowledge base index by ommitting -n and -t parameters (for KB input)
 
     ./IndexBuilderMain -i /path/to/myindex -w /path/to/wordsfile -d /path/to/docsfile
-    
+
 All options can, of course, be combined. The full call with all permutations and literals on disk will look like this:
-                                         
+
     ./IndexBuilderMain -a -l -i /path/to/myindex -n /path/to/input.nt -w /path/to/wordsfile -d /path/to/docsfile
 
 ## 3. Starting a Sever:
@@ -158,7 +180,7 @@ If you built an index using the -l and/or -a options, make sure to include it at
 or visit:
 
     http://localhost:<PORT>/index.html
-    
+
 ## 5. Text Features
 
 ### 5.1 Input Data
@@ -170,7 +192,7 @@ The following two input files are needed for full feature support:
 A tab-separated file with one line per posting and following the format:
 
     word    isEntity    recordId   score
-        
+
 For example, for a sentence `He discovered penicillin, a drug.`, it could look like this:
 
     He                  0   0   1
@@ -191,14 +213,12 @@ This file is used to build the text index from.
 A tab-separated file with one line per original unit of text and following the format:
 
     max_record_id  text
-    
+
 For example, for the sentence above:
 
     1   He discovered penicillin, a drug.
-    
+
 Note that this file is only used to display proper excerpts as evidence for texttual matches.
-
-
 
 ### 5.2 Supported Queries
 
@@ -207,12 +227,12 @@ Typical SPARQL queries can then be augmented. The features are best explained us
 
 A query for plants with edible leaves:
 
-    SELECT ?plant WHERE { 
-        ?plant <is-a> <Plant> . 
-        ?t ql:contains-entity ?plant . 
+    SELECT ?plant WHERE {
+        ?plant <is-a> <Plant> .
+        ?t ql:contains-entity ?plant .
         ?t ql:contains-word "'edible' 'leaves'"
-    } 
-    
+    }
+
 The special predicate `ql:contains-entity` requires that results for `?plant` have to occur in a text record `?t`.
 In records matching `?t`, there also have to be both words `edible` and `leaves` as specified thorugh the `ql:contains-word` predicate.
 Note that the single quotes can also be omitted and will be in further examples.
@@ -221,12 +241,12 @@ Single quotes are necessary to mark phrases (which are not supported yet, but ma
 A query for Astronauts who walked on the moon:
 
     SELECT ?a TEXT(?t) SCORE(?t) WHERE {
-        ?a <is-a> <Astronaut> . 
+        ?a <is-a> <Astronaut> .
         ?t ql:contains-entity ?a .
         ?t ql:contains-word "walk* moon"
     } ORDER BY DESC(SCORE(?t))
     TEXTLIMIT 2
-    
+
 Note the following features:
 
 * A star `*` can be used to search for a prefix as done in the keyword `walk*`. Note that there is a min prefix size depending on settings at index build-time.
@@ -237,7 +257,7 @@ Note the following features:
 An alternative query for astronauts who walked on the moon:
 
         SELECT ?a TEXT(?t) SCORE(?t) WHERE {
-            ?a <is-a> <Astronaut> . 
+            ?a <is-a> <Astronaut> .
             ?t ql:contains-entity ?a .
             ?t ql:contains-word "walk*" .
             ?t ql:contains-entity <Moon> .
@@ -262,7 +282,7 @@ Text / Knowledge-base data can be nested in queries. This allows queries like on
     } ORDER BY DESC(SCORE(?t))
 
 
-For now, each text-record variable is required to have a triple `ql:contains-word/entity WORD/URI`. 
+For now, each text-record variable is required to have a triple `ql:contains-word/entity WORD/URI`.
 Pure connections to variables (e.g. "Books with a description that mentions a plant.") are planned for the future.
 
 To obtain a list of available relations and their counts `ql:has-relation` can be used if the index was build with the `--patterns` option, and the server was started with the `--patterns` option:
@@ -302,7 +322,7 @@ They are fine for setting up a working sever within seconds and getting comforta
     QLever/misc/tiny-example.kb.nt
     QLever/misc/tiny-example.wordsfile.tsv
     QLever/misc/tiny-example.docsfile.tsv
-    
+
 Note that we left out stopwords (unlike in the docsfile) to demonstrate how this can be done if desired.
 If you build an index using these files and ask the query:
 
@@ -311,7 +331,7 @@ If you build an index using these files and ask the query:
         ?t ql:contains-entity ?x .
         ?t ql:contains-word "penicillin"
     }  ORDER BY DESC(SCORE(?t))
-    
+
 You should find `<Alexander_Fleming>` and the textual evidence for that match.
 
 You can also display his awards or find `<Albert_Einstein>` and his awards with the following query:
@@ -327,17 +347,17 @@ have a look at the (really tiny) input files to get a feeling for how this works
 
 Curl-versions (ready for copy&paste) of the queries:
 
-    SELECT ?x TEXT(?t) WHERE \{ ?x <is-a> <Scientist> . ?t ql:contains-entity ?x . ?t ql:contains-word \"penicillin\" \} ORDER BY DESC(SCORE(?t))    
+    SELECT ?x TEXT(?t) WHERE \{ ?x <is-a> <Scientist> . ?t ql:contains-entity ?x . ?t ql:contains-word \"penicillin\" \} ORDER BY DESC(SCORE(?t))
 
     SELECT ?x ?award TEXT(?t) WHERE \{ ?x <is-a> <Scientist> . ?t ql:contains-entity ?x . ?t ql:contains-word \"theory rela*\" . ?x <Award_Won> ?award \}  ORDER BY DESC(SCORE(?t))
-    
+
 Again, there's not much to be done with this data.
 For a meaningful index, use the example data below.
 
 ## Download prepared input files for a collection about scientists
 
 These files are of medium size (facts about scientists - only one hop from a scientist in a knowledge graph. Text are Wikipedia articles about scientists.)
-Includes a knowledge base as nt file, and a words- and docsfile as tsv. 
+Includes a knowledge base as nt file, and a words- and docsfile as tsv.
 
 [scientist-collection.zip](http://filicudi.informatik.uni-freiburg.de/bjoern-data/scientist-collection.zip):
 
@@ -363,7 +383,7 @@ Curl-version (ready for copy&paste) of the query:
 
 
 Includes a knowledge base as nt file, and a words- and docsfile as tsv.
-Text and facts are basically equivalent to the [Broccoli](http://broccoli.cs.uni-freiburg.de) search engine. 
+Text and facts are basically equivalent to the [Broccoli](http://broccoli.cs.uni-freiburg.de) search engine.
 
 [wikipedia-freebase.zip](http://filicudi.informatik.uni-freiburg.de/bjoern-data/wikipedia-freebase.zip):
 
@@ -387,7 +407,7 @@ Curl-version (ready for copy&paste) of the query:
 
 ## Use any knowledge base and text collection of your choice
 
- 
+
 Create the files similar to the three files provided as sample downloads for other data sets.
 Usually, knowledge base files do not have to be changed. Only words- and docsfile have to be produced.
 
@@ -401,7 +421,7 @@ Usually, knowledge base files do not have to be changed. Only words- and docsfil
 You can get stats for the currently active index in the following way:
 
     <server>:<port>/?cmd=stats
-    
+
 This query will yield a JSON response that features:
 
 * The name of the KB index
@@ -426,15 +446,15 @@ Furthermore, in a UI, it is usually beneficial to get less than all result rows 
 
 While it is recommended for applications to specify a LIMIT, some experiments want to measure the time to produce the full result but not block the UI.
 Therefore an additional HTTP parameter "&send=<x>" can be used to only send x result rows but to compute the fully readable result for everything according to LIMIT.
- 
-**IMPORTANT: Unless you want to measure QLever's performance, using LIMIT (+ OFFSET for sequential loading) should be preferred in all applications. That way should be faster and standard SPARQL without downsides.** 
+
+**IMPORTANT: Unless you want to measure QLever's performance, using LIMIT (+ OFFSET for sequential loading) should be preferred in all applications. That way should be faster and standard SPARQL without downsides.**
 
 
 # Troubleshooting
 
 
 If you have problems, try to rebuild when compiling with -DCMAKE_BUILD_TYPE=Debug.
-In particular also rebuild the index. 
+In particular also rebuild the index.
 The release build assumes machine written words- and docsfiles and omits sanity checks for the sake of speed.
 
 ## Excessive RAM usage
@@ -451,7 +471,7 @@ this required memory is what is described below for runtime memory usage.
 However, in addition not all memory seems to be freed as soon as possible. This
 needs further investitation. For now, there is an easy workaround to build
 KB and text index in two steps (two calls of IndexBuilderMain) or to pre-build
-the index on a server with lots of available resources. 
+the index on a server with lots of available resources.
 
 In general, not building all 6 permutations helps a lot. If this is enough (e.g.
 for emulating the Brococli search engine), this reduces RAM very significantly.
@@ -478,7 +498,7 @@ different objects, especially string literals. As of now (release for CIKM
 2017), the index keeps some meta data in RAM for each main element of the
 permutation. For the two "main" permutation,  PSO and POS, this is very
 reasonnable and resembles what is done in the Broccoli search engine. Having a
-few bytes (32 + extra bytes for blocks inside relations, which aren't the main problem anymore) 
+few bytes (32 + extra bytes for blocks inside relations, which aren't the main problem anymore)
 for each of a few hundred thousand predicates is no problem, even for the largest KBs. However, having the same meta data for
 several hundreds of millions of objects (500M for Freebase, require twice, for
 OSP and OPS, plus 2 times 125M subjects) quickly adds up beyond acceptable numbers.
@@ -497,7 +517,7 @@ files.
   meta data within the on-disk index and make it configurable which lists to
   load into RAM on startup (PSO and POS probably being the sensible default, but
   sometimes also having SPO can be a nice addition). Whatever isn't loaded into
-  RAM has to be read form disk at query time if it is actually needed. 
+  RAM has to be read form disk at query time if it is actually needed.
   In particle, however, query planning has to respect which meta data is available in RAM and special care has to be taken for queries involving ?s ?p ?o triples. This is the reason why the change sn't trivial.
   The branch also adds another readme, PERFORMANCE\_TUNING.md with more
   detailed information about the trade-offs. However, this file also isn't finished,

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+function bail {
+	echo "$*"
+	exit 1
+}
+
+function cleanup {
+	echo "The Server Log follows:"
+	cat "build/server_log.txt"
+	# Killing 0 sends the signal to all processes in the current
+	# process group
+	kill $(jobs -p)
+}
+
+# Travis CI is super cool but also uses ancient OS images
+if [ -f "/usr/bin/python3.6" ]; then
+	export PYTHON_BINARY="/usr/bin/python3.6"
+else
+	export PYTHON_BINARY=`which python3`
+fi
+
+
+mkdir -p "e2e_data"
+if [ ! -e "e2e_data/scientists-collection.zip" ]; then
+	# Why the hell is this a ZIP that can't easily be decompressed from stdin?!?
+	wget -O "e2e_data/scientists-collection.zip" \
+		"http://filicudi.informatik.uni-freiburg.de/bjoern-data/scientist-collection.zip"
+	unzip "e2e_data/scientists-collection.zip" -d "e2e_data"
+fi;
+
+INDEX="e2e_data/scientists-index"
+
+# Delete and rebuild the index
+rm -f "$INDEX.*"
+(
+cd build && ./IndexBuilderMain -a -l -i "../$INDEX" \
+	-n "../e2e_data/scientist-collection/scientists.nt" \
+	-w "../e2e_data/scientist-collection/scientists.wordsfile.tsv" \
+	-d "../e2e_data/scientist-collection/scientists.docsfile.tsv"
+) || bail "Building Index failed"
+
+# Launch the Server using the freshly baked index
+(
+cd build && ./ServerMain -i "../$INDEX" -p 9099 -t -a -l &> server_log.txt
+) &
+
+# Setup the kill switch so it gets called whatever way we exit
+trap cleanup EXIT
+echo "Waiting for ServerMain to launch and open port"
+while ! curl --max-time 1 --output /dev/null --silent http://localhost:9099/; do
+	sleep 1
+done
+$PYTHON_BINARY e2e/queryit.py "e2e/scientists_queries.yaml" "http://localhost:9099" || bail "Querying Server failed"

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -32,13 +32,15 @@ fi;
 INDEX="e2e_data/scientists-index"
 
 # Delete and rebuild the index
-rm -f "$INDEX.*"
-(
-cd build && ./IndexBuilderMain -a -l -i "../$INDEX" \
-	-n "../e2e_data/scientist-collection/scientists.nt" \
-	-w "../e2e_data/scientist-collection/scientists.wordsfile.tsv" \
-	-d "../e2e_data/scientist-collection/scientists.docsfile.tsv"
-) || bail "Building Index failed"
+if [ "$1" != "no-index" ]; then
+	rm -f "$INDEX.*"
+	(
+	cd build && ./IndexBuilderMain -a -l -i "../$INDEX" \
+		-n "../e2e_data/scientist-collection/scientists.nt" \
+		-w "../e2e_data/scientist-collection/scientists.wordsfile.tsv" \
+		-d "../e2e_data/scientist-collection/scientists.docsfile.tsv"
+	) || bail "Building Index failed"
+fi
 
 # Launch the Server using the freshly baked index
 (

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -22,7 +22,9 @@ fi
 
 
 mkdir -p "e2e_data"
-if [ ! -d "e2e_data/scientist-collection/" ]; then
+# Can't check for the scientist-collection directory because
+# Travis' caching creates it
+if [ ! -e "e2e_data/scientist-collection/scientists.nt" ]; then
 	# Why the hell is this a ZIP that can't easily be decompressed from stdin?!?
 	wget -O "e2e_data/scientist-collection.zip" \
 		"http://filicudi.informatik.uni-freiburg.de/bjoern-data/scientist-collection.zip"

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -5,12 +5,12 @@ function bail {
 	exit 1
 }
 
-function cleanup {
+function cleanup_server {
 	echo "The Server Log follows:"
 	cat "build/server_log.txt"
 	# Killing 0 sends the signal to all processes in the current
 	# process group
-	kill $(jobs -p)
+	kill $SERVER_PID
 }
 
 # Travis CI is super cool but also uses ancient OS images
@@ -44,9 +44,10 @@ cd build && ./IndexBuilderMain -a -l -i "../$INDEX" \
 (
 cd build && ./ServerMain -i "../$INDEX" -p 9099 -t -a -l &> server_log.txt
 ) &
+SERVER_PID=$!
 
 # Setup the kill switch so it gets called whatever way we exit
-trap cleanup EXIT
+trap cleanup_server EXIT
 echo "Waiting for ServerMain to launch and open port"
 while ! curl --max-time 1 --output /dev/null --silent http://localhost:9099/; do
 	sleep 1

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -22,11 +22,11 @@ fi
 
 
 mkdir -p "e2e_data"
-if [ ! -e "e2e_data/scientists-collection.zip" ]; then
+if [ ! -d "e2e_data/scientist-collection/" ]; then
 	# Why the hell is this a ZIP that can't easily be decompressed from stdin?!?
-	wget -O "e2e_data/scientists-collection.zip" \
+	wget -O "e2e_data/scientist-collection.zip" \
 		"http://filicudi.informatik.uni-freiburg.de/bjoern-data/scientist-collection.zip"
-	unzip "e2e_data/scientists-collection.zip" -d "e2e_data"
+	unzip "e2e_data/scientist-collection.zip" -d "e2e_data"
 fi;
 
 INDEX="e2e_data/scientists-index"

--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -4,21 +4,29 @@ QLever Query Tool for End2End Testing
 """
 
 import sys
+import urllib.parse
 import urllib.request
-from typing import Dict, Any
+from typing import Dict, Any, List
 import json
 import yaml
 
-def exec_query(endpoint_url: str, sparql: str) -> Dict[str, Any]:
+def eprint(*args, **kwargs):
+    """
+    Like print but to stderr
+    """
+    print(*args, file=sys.stderr, **kwargs)
+
+def exec_query(endpoint_url: str, sparql: str,
+               max_send: int = 4096) -> Dict[str, Any]:
     """
     Execute a single SPARQL query against the given endpoint
     """
-    params = urllib.parse.urlencode({'query': sparql})
+    params = urllib.parse.urlencode({'query': sparql, 'send': max_send})
     url_suffix = '/?'+params
     request = urllib.request.Request(endpoint_url+url_suffix)
     conn = urllib.request.urlopen(request)
     if conn.status != 200:
-        print("Error executing SPARQL Query: ", sparql, file=sys.stderr)
+        eprint("Error executing SPARQL Query: ", sparql)
         return None
     return json.load(conn)
 
@@ -29,16 +37,104 @@ def is_result_sane(result: Dict[str, Any]) -> bool:
     required_fields = ['query', 'status', 'resultsize', 'selected', 'res']
     for field in required_fields:
         if field not in result:
-            print('QLever Result is missing "%s" field' % field,
-                  file=sys.stderr)
+            eprint('QLever Result is missing "%s" field' % field)
             return False
     return True
+
+def test_row(gold_row: List[Any],
+             actual_row: List[Any], epsilon=0.1) -> bool:
+    """
+    Test if gold_row and actual_row match. For floats we allow an epsilon
+    difference. If a gold_row cell is None it is ignored.
+    Returns True if they match
+    """
+    for i, gold in enumerate(gold_row):
+        if gold is None:
+            continue
+        actual = actual_row[i]
+        matches = False
+        if isinstance(gold, int):
+            matches = int(actual) == gold
+        elif isinstance(gold, float):
+            matches = abs(gold - float(actual)) <= epsilon
+        else:
+            matches = gold == actual
+
+        if not matches:
+            return False
+    return True
+
+def test_check(check_dict: Dict[str, Any], result: Dict[str, Any]) -> bool:
+    """
+    Test if the named result check holds. Returns True if it does
+    """
+    res = result['res']
+    for check, value in check_dict.items():
+        if check == 'num_rows':
+            if len(res) != int(value):
+                eprint("num_rows check failed:\n" +
+                       "\texpected %r, got %r" %
+                       (value, len(res)))
+                return False
+        elif check == 'num_cols':
+            for row in res:
+                if len(row) != int(value):
+                    eprint("num_cols check failed:\n" +
+                           "\texpected %r, got %r, row: %s" %
+                           (value, len(row), json.dumps(row)))
+                    return False
+        elif check == 'selected':
+            if value != result['selected']:
+                eprint("selected check failed:\n" +
+                       "\texpected %r, got %r" %
+                       (value, result['selected']))
+                return False
+        elif check == 'res':
+            gold_res = value
+            for i, gold_row in enumerate(gold_res):
+                actual_row = res[i]
+                if not test_row(gold_row, actual_row):
+                    eprint("res check failed:\n" +
+                           "\tat row %r" % i +
+                           "\texpected %r, got %r" %
+                           (gold_row, actual_row))
+                    return False
+        elif check == 'contains_row':
+            found = False
+            gold_row = value
+            for actual_row in res:
+                if test_row(gold_row, actual_row):
+                    found = True
+                    break
+            if not found:
+                eprint("contains_row check failed:\n" +
+                       "\tdid not find %r" % gold_row)
+                return False
+
+
+    return True
+
+
+
+def solution_checks(solution: Dict[str, Any],
+                    result: Dict[str, Any]) -> bool:
+    """
+    Tests the checks specified in the solution
+    """
+    if not 'checks' in solution:
+        return True
+    passed = True
+    checks = solution['checks']
+    for check in checks:
+        if not test_check(check, result):
+            passed = False
+    return passed
 
 def print_qlever_result(result: Dict[str, Any]) -> None:
     """
     Prints a QLever Result to stdout
     """
-    print(json.dumps(result), file=sys.stderr)
+    eprint(json.dumps(result))
 
 
 def main() -> None:
@@ -46,7 +142,7 @@ def main() -> None:
     Run QLever queries stored in a YAML file against a QLever instance
     """
     if len(sys.argv) != 3:
-        print("Usage: ", sys.argv[0], "<yaml_in> <qlever_endpoint_url>")
+        eprint("Usage: ", sys.argv[0], "<yaml_in> <qlever_endpoint_url>")
         sys.exit(1)
 
     inpath = sys.argv[1]
@@ -77,10 +173,14 @@ def main() -> None:
                     continue
 
                 if result['status'] != 'OK':
-                    print('QLever Result "status" is not "OK"',
-                          file=sys.stderr)
+                    eprint('QLever Result "status" is not "OK"')
                     error_detected = True
                     print_qlever_result(result)
+                    continue
+
+                if not solution_checks(solution, result):
+                    eprint('Solution checks failed')
+                    error_detected = True
                     continue
 
     if error_detected:

--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+QLever Query Tool for End2End Testing
+"""
+
+import sys
+import urllib.request
+from typing import Dict, Any
+import json
+import yaml
+
+def exec_query(endpoint_url: str, sparql: str) -> Dict[str, Any]:
+    """
+    Execute a single SPARQL query against the given endpoint
+    """
+    params = urllib.parse.urlencode({'query': sparql})
+    url_suffix = '/?'+params
+    request = urllib.request.Request(endpoint_url+url_suffix)
+    conn = urllib.request.urlopen(request)
+    if conn.status != 200:
+        print("Error executing SPARQL Query: ", sparql, file=sys.stderr)
+        return None
+    return json.load(conn)
+
+def is_result_sane(result: Dict[str, Any]) -> bool:
+    """
+    Checks a QLever Result object for sanity
+    """
+    required_fields = ['query', 'status', 'resultsize', 'selected', 'res']
+    for field in required_fields:
+        if field not in result:
+            print('QLever Result is missing "%s" field' % field,
+                  file=sys.stderr)
+            return False
+    return True
+
+def print_qlever_result(result: Dict[str, Any]) -> None:
+    """
+    Prints a QLever Result to stdout
+    """
+    print(json.dumps(result), file=sys.stderr)
+
+
+def main() -> None:
+    """
+    Run QLever queries stored in a YAML file against a QLever instance
+    """
+    if len(sys.argv) != 3:
+        print("Usage: ", sys.argv[0], "<yaml_in> <qlever_endpoint_url>")
+        sys.exit(1)
+
+    inpath = sys.argv[1]
+    endpoint_url = sys.argv[2]
+    error_detected = False
+    with open(inpath, 'rb') if inpath != '-' else sys.stdin as infile:
+        yaml_tree = yaml.load(infile)
+        queries = yaml_tree['queries']
+        for query in queries:
+            query_name = query['query']
+            solutions = query['solutions']
+            for solution in solutions:
+                solution_type = solution['type']
+                solution_sparql = solution['sparql']
+                print('Trying: ', query_name, '(%s)' % solution_type)
+                print('SPARQL:')
+                print(solution_sparql)
+                result = exec_query(endpoint_url, solution_sparql)
+                if not result:
+                    # A print was already done in exec_query()
+                    error_detected = True
+                    print_qlever_result(result)
+                    continue
+
+                if not is_result_sane(result):
+                    error_detected = True
+                    print_qlever_result(result)
+                    continue
+
+                if result['status'] != 'OK':
+                    print('QLever Result "status" is not "OK"',
+                          file=sys.stderr)
+                    error_detected = True
+                    print_qlever_result(result)
+                    continue
+
+    if error_detected:
+        sys.exit(2)
+
+
+
+if __name__ == '__main__':
+    main()

--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -7,12 +7,13 @@ import sys
 import urllib.parse
 import urllib.request
 from typing import Dict, Any, List
+from enum import Enum
 import json
 import yaml
 
-class BCol:
+class Color:
     """
-    Enum class for storing ANSI Color Codes
+    Enum-like class for storing ANSI Color Codes
     """
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -23,13 +24,14 @@ class BCol:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-def eprint(*args, color=BCol.FAIL, **kwargs):
+
+def eprint(*args, color=Color.FAIL, **kwargs):
     """
     Like print but to stderr
     """
     sys.stderr.write(color)
     print(*args, file=sys.stderr, **kwargs)
-    print(BCol.ENDC, file=sys.stderr)
+    print(Color.ENDC, file=sys.stderr)
 
 def exec_query(endpoint_url: str, sparql: str,
                max_send: int = 4096) -> Dict[str, Any]:
@@ -172,8 +174,8 @@ def main() -> None:
             for solution in solutions:
                 solution_type = solution['type']
                 solution_sparql = solution['sparql']
-                print(BCol.HEADER+'Trying: ', query_name,
-                      '(%s)' % solution_type + BCol.ENDC)
+                print(Color.HEADER+'Trying: ', query_name,
+                      '(%s)' % solution_type + Color.ENDC)
                 print('SPARQL:')
                 print(solution_sparql)
                 result = exec_query(endpoint_url, solution_sparql)
@@ -199,10 +201,10 @@ def main() -> None:
                     continue
 
     if error_detected:
-        print(BCol.FAIL+'Query tool found errors!'+BCol.ENDC)
+        print(Color.FAIL+'Query tool found errors!'+Color.ENDC)
         sys.exit(2)
 
-    print(BCol.OKGREEN+'Query tool did not find errors, search harder!'+BCol.ENDC)
+    print(Color.OKGREEN+'Query tool did not find errors, search harder!'+Color.ENDC)
 
 
 

--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -10,7 +10,10 @@ from typing import Dict, Any, List
 import json
 import yaml
 
-class bcol:
+class BCol:
+    """
+    Enum class for storing ANSI Color Codes
+    """
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
@@ -20,13 +23,13 @@ class bcol:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-def eprint(*args, col=bcol.FAIL, **kwargs):
+def eprint(*args, color=BCol.FAIL, **kwargs):
     """
     Like print but to stderr
     """
-    sys.stderr.write(col)
+    sys.stderr.write(color)
     print(*args, file=sys.stderr, **kwargs)
-    print(bcol.ENDC, file=sys.stderr)
+    print(BCol.ENDC, file=sys.stderr)
 
 def exec_query(endpoint_url: str, sparql: str,
                max_send: int = 4096) -> Dict[str, Any]:
@@ -169,7 +172,8 @@ def main() -> None:
             for solution in solutions:
                 solution_type = solution['type']
                 solution_sparql = solution['sparql']
-                print('Trying: ', query_name, '(%s)' % solution_type)
+                print(BCol.HEADER+'Trying: ', query_name,
+                      '(%s)' % solution_type + BCol.ENDC)
                 print('SPARQL:')
                 print(solution_sparql)
                 result = exec_query(endpoint_url, solution_sparql)
@@ -195,7 +199,10 @@ def main() -> None:
                     continue
 
     if error_detected:
+        print(BCol.FAIL+'Query tool found errors!'+BCol.ENDC)
         sys.exit(2)
+
+    print(BCol.OKGREEN+'Query tool did not find errors, search harder!'+BCol.ENDC)
 
 
 

--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -10,11 +10,23 @@ from typing import Dict, Any, List
 import json
 import yaml
 
-def eprint(*args, **kwargs):
+class bcol:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def eprint(*args, col=bcol.FAIL, **kwargs):
     """
     Like print but to stderr
     """
+    sys.stderr.write(col)
     print(*args, file=sys.stderr, **kwargs)
+    print(bcol.ENDC, file=sys.stderr)
 
 def exec_query(endpoint_url: str, sparql: str,
                max_send: int = 4096) -> Dict[str, Any]:
@@ -179,7 +191,6 @@ def main() -> None:
                     continue
 
                 if not solution_checks(solution, result):
-                    eprint('Solution checks failed')
                     error_detected = True
                     continue
 

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -50,16 +50,16 @@ queries:
   - query: scientists-married-to-scientists
     solutions:
       - type: no-text
-        # Note this has everyone?! twice, once for each direction
         sparql: |
           SELECT ?x ?y WHERE {
               ?x <is-a> <Scientist> .
               ?x <Spouse_(or_domestic_partner)> ?y .
               ?y <is-a> <Scientist> .
+              FILTER(?x < ?y) .
           } ORDER BY ASC(?x)
         checks:
           - num_cols: 2
-          - num_rows: 194
+          - num_rows: 97
           - selected: ["?x", "?y"]
           - contains_row: ["<Albert_Einstein>", "<Mileva_Marić>"]
   - query: scientists-count-group-by-place-of-birth

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -11,17 +11,29 @@ queries:
               ?t ql:contains-word "relati*"
           }
           ORDER BY DESC(SCORE(?t))
+        checks:
+          - num_cols: 3
+          - num_rows: 1653
+          - selected: ["?x", "SCORE(?t)", "TEXT(?t)"]
+            # null cells are ignored
+          - contains_row: ["<Albert_Einstein>", null, null]
+          - contains_row: ["<Luís_Lindley_Cintra>", null, null] # Test Unicode
   - query: algo-star-female-scientists
     solutions:
       - type: text
         sparql: |
-          SELECT ?x SCORE(?t) TEXT(?t) WHERE {
+          SELECT ?x WHERE {
               ?x <is-a> <Scientist> .
               ?x <Gender> <Female> .
               ?t ql:contains-entity ?x .
               ?t ql:contains-word "algo*"
           }
           ORDER BY DESC(SCORE(?t))
+        checks:
+          - num_cols: 1
+          - num_rows: 11
+          - selected: ["?x"]
+          - contains_row: ["<Grete_Hermann>"]
   - query: scientists-from-new-york
     solutions:
       - type: no-text
@@ -30,6 +42,11 @@ queries:
               ?x <is-a> <Scientist> .
               ?x <Place_of_birth> <New_York_City>
           }
+        checks:
+          - num_cols: 1
+          - num_rows: 280
+          - selected: ["?x"]
+          - contains_row: ["<Andrew_S._Tanenbaum>"]
   - query: scientists-married-to-scientists
     solutions:
       - type: no-text
@@ -40,6 +57,11 @@ queries:
               ?x <Spouse_(or_domestic_partner)> ?y .
               ?y <is-a> <Scientist> .
           } ORDER BY ASC(?x)
+        checks:
+          - num_cols: 2
+          - num_rows: 194
+          - selected: ["?x", "?y"]
+          - contains_row: ["<Albert_Einstein>", "<Mileva_Marić>"]
   - query: scientists-count-group-by-place-of-birth
     solutions:
       - type: no-text
@@ -50,6 +72,11 @@ queries:
           }
           GROUP BY ?place
           ORDER BY DESC(?count)
+        checks:
+          - num_cols: 2
+          # -num_rows: 5295 # greater than current limit
+          - selected: ["?count", "?place"]
+          - contains_row: [280, "<New_York_City>"]
   - query: group-by-profession-average-height
     solutions:
       - type: no-text
@@ -60,6 +87,11 @@ queries:
           }
           GROUP BY ?profession
           ORDER BY DESC(?avg)
+        checks:
+          - num_cols: 2
+          - num_rows: 312
+          - selected: ["?avg", "?profession"]
+          - contains_row: [null, "<Architect>"]
   - query: group-by-gender-average-height
     solutions:
       - type: no-text
@@ -71,3 +103,9 @@ queries:
           }
           GROUP BY ?gender
           ORDER BY DESC(?avg)
+        checks:
+          - num_rows: 2
+          - num_cols: 2
+          - selected: ["?avg", "?gender"]
+          # Float values are only compared to limited precision
+          - res: [[1.8, "<Male>"], [1.7, "<Female>"]]

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1,0 +1,73 @@
+---
+name: scientists
+queries:
+  - query: relativ-star-scientists
+    solutions:
+      - type: text
+        sparql: |
+          SELECT ?x SCORE(?t) TEXT(?t) WHERE {
+              ?x <is-a> <Scientist> .
+              ?t ql:contains-entity ?x .
+              ?t ql:contains-word "relati*"
+          }
+          ORDER BY DESC(SCORE(?t))
+  - query: algo-star-female-scientists
+    solutions:
+      - type: text
+        sparql: |
+          SELECT ?x SCORE(?t) TEXT(?t) WHERE {
+              ?x <is-a> <Scientist> .
+              ?x <Gender> <Female> .
+              ?t ql:contains-entity ?x .
+              ?t ql:contains-word "algo*"
+          }
+          ORDER BY DESC(SCORE(?t))
+  - query: scientists-from-new-york
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?x WHERE {
+              ?x <is-a> <Scientist> .
+              ?x <Place_of_birth> <New_York_City>
+          }
+  - query: scientists-married-to-scientists
+    solutions:
+      - type: no-text
+        # Note this has everyone?! twice, once for each direction
+        sparql: |
+          SELECT ?x ?y WHERE {
+              ?x <is-a> <Scientist> .
+              ?x <Spouse_(or_domestic_partner)> ?y .
+              ?y <is-a> <Scientist> .
+          } ORDER BY ASC(?x)
+  - query: scientists-count-group-by-place-of-birth
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT (COUNT(?x) as ?count) ?place WHERE {
+              ?x <is-a> <Scientist> .
+              ?x <Place_of_birth> ?place .
+          }
+          GROUP BY ?place
+          ORDER BY DESC(?count)
+  - query: group-by-profession-average-height
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT (AVG(?height) as ?avg) ?profession WHERE {
+              ?x <is-a> ?profession .
+              ?x <Height> ?height .
+          }
+          GROUP BY ?profession
+          ORDER BY DESC(?avg)
+  - query: group-by-gender-average-height
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT (AVG(?height) as ?avg) ?gender WHERE {
+              ?x <is-a> <Person> .
+              ?x <Gender> ?gender .
+              ?x <Height> ?height .
+          }
+          GROUP BY ?gender
+          ORDER BY DESC(?avg)


### PR DESCRIPTION
This PR adds a simple End-to-End testing mechanism to start tackling #68. Using a bash script as the test driver together with a simple query tool written in python. It tests the entire data set to query pipeline on the [scientist-collection](http://filicudi.informatik.uni-freiburg.de/bjoern-data/scientist-collection.zip)

The queries are stored in an easy to edit YAML file and include per query checks for the result. At the moment I have only added a small set of example queries. I plant to significantly expand these soon.

One particular check that is still missing is one that verifies order.