### PR TITLE
Improved ql:has-relation versatility.

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -109,3 +109,44 @@ queries:
           - selected: ["?avg", "?gender"]
           # Float values are only compared to limited precision
           - res: [[1.8, "<Male>"], [1.7, "<Female>"]]
+  - query : pattern-trick
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?r (COUNT(?r) as ?count) WHERE {
+            ?a <is-a> <Scientist> .
+            ?a ql:has-relation ?r .
+          }
+          GROUP BY ?r
+          ORDER BY DESC(?count)
+        checks:
+          - num_rows: 156
+          - num_cols: 2
+          - selected: ["?r", "?count"]
+          - contains_row: ["<Religion>", 1185]
+  - query : has-relation-full 
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?entity ?relation WHERE {
+            ?entity ql:has-relation ?relation .
+          }
+        checks:
+          # The number o rows is greater than the current limit of 4096.
+          # - num_rows: 168444 
+          - num_cols: 2
+          - selected: ["?entity", "?relation"]
+          - contains_row: ["<Alan_Fersht>", "<Leader_of>"]
+  - query : has-relation-subquery-subject
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?entity ?r WHERE {
+            ?entity <is-a> <Profession> .
+            ?entity ql:has-relation ?r.
+          }
+        checks:
+          - num_rows: 760
+          - num_cols: 2
+          - selected: ["?entity", "?r"]
+          - contains_row: ["<Geographer>", "<Profession>"]

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(engine
         OptionalJoin.cpp OptionalJoin.h
         CountAvailablePredicates.cpp CountAvailablePredicates.h
         GroupBy.cpp GroupBy.h
+        HasRelationScan.cpp HasRelationScan.h
 )
 
 target_link_libraries(engine index parser)

--- a/src/engine/HasRelationScan.cpp
+++ b/src/engine/HasRelationScan.cpp
@@ -1,0 +1,436 @@
+// Copyright 2018, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+
+#include "HasRelationScan.h"
+
+HasRelationScan::HasRelationScan(QueryExecutionContext* qec, ScanType type)
+  : Operation(qec),
+    _type(type),
+    _subtree(nullptr),
+    _subtreeColIndex(-1),
+    _subject(),
+    _object() {}
+
+string HasRelationScan::asString(size_t indent) const {
+  std::ostringstream os;
+  for (size_t i = 0; i < indent; ++i) {
+    os << " ";
+  }
+  switch (_type) {
+  case ScanType::FREE_S:
+    os << "HAS_RELATION_SCAN with S = " << _subject << " O = " << _object;
+    break;
+  case ScanType::FREE_O:
+    os << "HAS_RELATION_SCAN with S = " << _subject << " O = " << _object;
+    break;
+  case ScanType::FULL_SCAN:
+    os << "HAS_RELATION_SCAN with S = " << _subject << " O = " << _object;
+    break;
+  case ScanType::SUBQUERY_S:
+    os << "HAS_RELATION_SCAN with S = " << _subtree->asString(indent)
+       << " O = " << _object;
+    break;
+  }
+  return os.str();
+}
+
+size_t HasRelationScan::getResultWidth() const {
+  switch (_type) {
+  case ScanType::FREE_S:
+    return 1;
+  case ScanType::FREE_O:
+    return 1;
+  case ScanType::FULL_SCAN:
+    return 2;
+  case ScanType::SUBQUERY_S:
+    return _subtree->getResultWidth() + 1;
+  }
+  return -1;
+}
+
+size_t HasRelationScan::resultSortedOn() const {
+  switch (_type) {
+  case ScanType::FREE_S:
+    // is the lack of sorting here a problem?
+    return -1;
+  case ScanType::FREE_O:
+    return 0;
+  case ScanType::FULL_SCAN:
+    return 0;
+  case ScanType::SUBQUERY_S:
+    return _subtree->resultSortedOn();
+  }
+  return -1;
+}
+
+std::unordered_map<string, size_t> HasRelationScan::getVariableColumns() const {
+  std::unordered_map<string, size_t> varCols;
+  switch (_type) {
+  case ScanType::FREE_S:
+    varCols.insert(std::make_pair(_subject, 0));
+    break;
+  case ScanType::FREE_O:
+    varCols.insert(std::make_pair(_object, 0));
+    break;
+  case ScanType::FULL_SCAN:
+    varCols.insert(std::make_pair(_subject, 0));
+    varCols.insert(std::make_pair(_object, 1));
+    break;
+  case ScanType::SUBQUERY_S:
+    varCols = _subtree->getVariableColumnMap();
+    varCols.insert(std::make_pair(_object, getResultWidth() - 1));
+    break;
+  }
+  return varCols;
+}
+
+void HasRelationScan::setTextLimit(size_t limit) {
+  if (_type == ScanType::SUBQUERY_S) {
+    _subtree->setTextLimit(limit);
+  }
+}
+
+bool HasRelationScan::knownEmptyResult() {
+  if (_type == ScanType::SUBQUERY_S) {
+    return _subtree->knownEmptyResult();
+  } else {
+    return false;
+  }
+}
+
+float HasRelationScan::getMultiplicity(size_t col) {
+  switch (_type) {
+  case ScanType::FREE_S:
+    // TODO track multiplicity
+    return 1;
+  case ScanType::FREE_O:
+    return 1;
+  case ScanType::FULL_SCAN:
+    return 1;
+  case ScanType::SUBQUERY_S:
+    if (col < getResultWidth() - 1) {
+      return _subtree->getMultiplicity(col);
+    } else {
+      // TODO track multiplicity
+      return _subtree->getMultiplicity(_subtreeColIndex);
+    }
+    break;
+  }
+  return 1;
+}
+
+size_t HasRelationScan::getSizeEstimate() {
+  // TODO: these size estimates only owrk if all predicates are functional
+  switch (_type) {
+  case ScanType::FREE_S:
+    return getIndex().getHasPattern().size() + getIndex().getHasRelation().size();
+  case ScanType::FREE_O:
+    return getIndex().getHasPattern().size() + getIndex().getHasRelation().size();
+  case ScanType::FULL_SCAN:
+    return getIndex().getHasPattern().size() + getIndex().getHasRelation().size();
+  case ScanType::SUBQUERY_S:
+    return _subtree->getSizeEstimate();
+  }
+  return 0;
+}
+
+size_t HasRelationScan::getCostEstimate() {
+  // TODO: these size estimates only owrk if all predicates are functional
+  switch (_type) {
+  case ScanType::FREE_S:
+    return getSizeEstimate();
+  case ScanType::FREE_O:
+    return getSizeEstimate();
+  case ScanType::FULL_SCAN:
+    return getSizeEstimate();
+  case ScanType::SUBQUERY_S:
+    return _subtree->getCostEstimate() + getSizeEstimate();
+  }
+  return 0;
+}
+
+void HasRelationScan::computeResult(ResultTable* result) const {
+  result->_nofColumns = getResultWidth();
+  result->_sortedBy = resultSortedOn();
+  switch (_type) {
+  case ScanType::FREE_S:
+    computeFreeS(result);
+    break;
+  case ScanType::FREE_O:
+    computeFreeO(result);
+    break;
+  case ScanType::FULL_SCAN:
+    computeFullScan(result);
+    break;
+  case ScanType::SUBQUERY_S:
+    computeSubqueryS(result);
+    break;
+  }
+  result->finish();
+}
+
+
+void HasRelationScan::computeFreeS(ResultTable* result) const {
+  Id objectId;
+  if (!getIndex().getVocab().getId(_object, &objectId)) {
+    AD_THROW(ad_semsearch::Exception::BAD_INPUT,
+             "The predicate '" + _object + "' is not in the vocabulary.");
+  }
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+  std::vector<std::array<Id, 1>>* fixedSizeData = new std::vector<std::array<Id, 1>>();
+  result->_fixedSizeData = fixedSizeData;
+
+  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
+  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
+  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
+
+  size_t id = 0;
+  while (id < hasPattern.size() || id < hasRelation.size()) {
+    if (id < hasPattern.size() && hasPattern[id] != NO_PATTERN) {
+      // add the pattern
+      size_t numPredicates;
+      Id* patternData;
+      std::tie(patternData, numPredicates) = patterns[hasPattern[id]];
+      for (size_t i = 0; i < numPredicates; i++) {
+        if (patternData[i] == objectId) {
+          fixedSizeData->push_back({{id}});
+        }
+      }
+    } else if (id < hasRelation.size()) {
+      // add the relations
+      size_t numPredicates;
+      Id* predicateData;
+      std::tie(predicateData, numPredicates) = hasRelation[id];
+      for (size_t i = 0; i < numPredicates; i++) {
+        if (predicateData[i] == objectId) {
+          fixedSizeData->push_back({{id}});
+        }
+      }
+    }
+    id++;
+  }
+}
+
+void HasRelationScan::computeFreeO(ResultTable* result) const {
+  Id subjectId;
+  if (!getIndex().getVocab().getId(_subject, &subjectId)) {
+    AD_THROW(ad_semsearch::Exception::BAD_INPUT,
+             "The subject " + _subject + " is not in the vocabulary.");
+  }
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+  std::vector<std::array<Id, 1>>* fixedSizeData = new std::vector<std::array<Id, 1>>();
+  result->_fixedSizeData = fixedSizeData;
+
+  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
+  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
+  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
+
+  if (subjectId < hasPattern.size() && hasPattern[subjectId] != NO_PATTERN) {
+    // add the pattern
+    size_t numPredicates;
+    Id* patternData;
+    std::tie(patternData, numPredicates) = patterns[hasPattern[subjectId]];
+    for (size_t i = 0; i < numPredicates; i++) {
+      fixedSizeData->push_back({{patternData[i]}});
+    }
+  } else if (subjectId < hasRelation.size()) {
+    // add the relations
+    size_t numPredicates;
+    Id* predicateData;
+    std::tie(predicateData, numPredicates) = hasRelation[subjectId];
+    for (size_t i = 0; i < numPredicates; i++) {
+      fixedSizeData->push_back({{predicateData[i]}});
+    }
+  }
+}
+
+void HasRelationScan::computeFullScan(ResultTable* result) const {
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+  std::vector<std::array<Id, 2>>* fixedSizeData = new std::vector<std::array<Id, 2>>();
+  result->_fixedSizeData = fixedSizeData;
+
+  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
+  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
+  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
+
+  size_t id = 0;
+  while (id < hasPattern.size() || id < hasRelation.size()) {
+    if (id < hasPattern.size() && hasPattern[id] != NO_PATTERN) {
+      // add the pattern
+      size_t numPredicates;
+      Id* patternData;
+      std::tie(patternData, numPredicates) = patterns[hasPattern[id]];
+      for (size_t i = 0; i < numPredicates; i++) {
+        fixedSizeData->push_back({{id, patternData[i]}});
+      }
+    } else if (id < hasRelation.size()) {
+      // add the relations
+      size_t numPredicates;
+      Id* predicateData;
+      std::tie(predicateData, numPredicates) = hasRelation[id];
+      for (size_t i = 0; i < numPredicates; i++) {
+        fixedSizeData->push_back({{id, predicateData[i]}});
+      }
+    }
+    id++;
+  }
+}
+
+template <typename T, typename C>
+struct resizeIfVec {
+  static void resize(T& t, int size) {
+    (void)t;
+    (void)size;
+  }
+};
+
+template <typename C>
+struct resizeIfVec<vector<C>, C> {
+  static void resize(vector<C>& t, int size) { t.resize(size); }
+};
+
+template <typename A, typename R>
+void doComputeSubqueryS(const std::vector<A>* input,
+                        const size_t inputSubjectColumn,
+                        std::vector<R>* result,
+                        const std::vector<PatternID>& hasPattern,
+                        const CompactStringVector<Id, Id>& hasRelation,
+                        const CompactStringVector<size_t, Id>& patterns) {
+  for (size_t i = 0; i < input->size(); i++) {
+    const A& inputRow = (*input)[i];
+    size_t id = inputRow[inputSubjectColumn];
+    if (id < hasPattern.size() && hasPattern[id] != NO_PATTERN) {
+      // add the pattern
+      size_t numPredicates;
+      Id* patternData;
+      std::tie(patternData, numPredicates) = patterns[hasPattern[id]];
+      for (size_t i = 0; i < numPredicates; i++) {
+        R row;
+        resizeIfVec<R, Id>::resize(row, inputRow.size() + 1);
+        for (size_t j = 0; j < inputRow.size(); j++) {
+          row[j] = inputRow[j];
+        }
+        row[inputRow.size()] = patternData[i];
+        result->push_back(row);
+      }
+    } else if (id < hasRelation.size()) {
+      // add the relations
+      size_t numPredicates;
+      Id* predicateData;
+      std::tie(predicateData, numPredicates) = hasRelation[id];
+      for (size_t i = 0; i < numPredicates; i++) {
+        R row;
+        resizeIfVec<R, Id>::resize(row, inputRow.size() + 1);
+        for (size_t j = 0; j < inputRow.size(); j++) {
+          row[j] = inputRow[j];
+        }
+        row[inputRow.size()] = predicateData[i];
+        result->push_back(row);
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+
+/**
+ * @brief  This struct is used to call doComputeSubqueryS with the correct template
+ * parameters. Using it is equivalent to a structure of nested if clauses,
+ * checking if the inputColCount and resultColCount are of a certain value, and
+ * then calling doGroupBy.
+ */
+template <int InputColCount>
+struct CallComputeSubqueryS {
+  static void call(int inputColCount,
+                   const ResultTable* input,
+                   const size_t inputSubjectColumn,
+                   ResultTable* result,
+                   const std::vector<PatternID>& hasPattern,
+                   const CompactStringVector<Id, Id>& hasRelation,
+                   const CompactStringVector<size_t, Id>& patterns) {
+    if (InputColCount == inputColCount) {
+      if (InputColCount < 5) {
+        result->_fixedSizeData = new vector<array<Id, InputColCount + 1>>();
+        doComputeSubqueryS<std::array<Id, InputColCount>, std::array<Id, InputColCount + 1>>(
+              static_cast<vector<array<Id, InputColCount>>*>(input->_fixedSizeData),
+              inputSubjectColumn,
+              static_cast<vector<array<Id, InputColCount + 1>>*>(result->_fixedSizeData),
+              hasPattern, hasRelation, patterns);
+      } else {
+        doComputeSubqueryS<std::array<Id, InputColCount>, std::vector<Id>>(
+              static_cast<vector<array<Id, InputColCount>>*>(input->_fixedSizeData),
+              inputSubjectColumn,
+              &result->_varSizeData,
+              hasPattern, hasRelation, patterns);
+      }
+    } else {
+      CallComputeSubqueryS<InputColCount + 1>::call(
+            inputColCount, input, inputSubjectColumn, result, hasPattern, hasRelation, patterns);
+    }
+  }
+};
+
+template <>
+struct CallComputeSubqueryS<6> {
+  static void call(int inputColCount,
+                   const ResultTable* input,
+                   const size_t inputSubjectColumn,
+                   ResultTable* result,
+                   const std::vector<PatternID>& hasPattern,
+                   const CompactStringVector<Id, Id>& hasRelation,
+                   const CompactStringVector<size_t, Id>& patterns) {
+    // avoid unused warnings from the compiler
+    (void) inputColCount;
+    // call doComputeSubqueryS with variable sized data
+    doComputeSubqueryS<std::vector<Id>, std::vector<Id>>(
+          &input->_varSizeData,
+          inputSubjectColumn,
+          &result->_varSizeData,
+          hasPattern, hasRelation, patterns);
+  }
+};
+
+
+void HasRelationScan::computeSubqueryS(ResultTable* result) const {
+
+  std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
+
+  result->_resultTypes.insert(result->_resultTypes.begin(), subresult->_resultTypes.begin(), subresult->_resultTypes.end());
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+
+  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
+  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
+  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
+  CallComputeSubqueryS<1>::call(subresult->_nofColumns,
+                                subresult.get(),
+                                _subtreeColIndex,
+                                result,
+                                hasPattern,
+                                hasRelation,
+                                patterns);
+}
+
+
+void HasRelationScan::setSubject(const std::string& subject) {
+  _subject = subject;
+}
+
+void HasRelationScan::setObject(const std::string& object) {
+  _object = object;
+}
+
+void HasRelationScan::setSubtree(std::shared_ptr<QueryExecutionTree> subtree) {
+  _subtree = subtree;
+}
+
+void HasRelationScan::setSubtreeSubjectColumn(size_t colIndex) {
+  _subtreeColIndex = colIndex;
+}
+
+
+HasRelationScan::ScanType HasRelationScan::getType() const {
+  return _type;
+}

--- a/src/engine/HasRelationScan.cpp
+++ b/src/engine/HasRelationScan.cpp
@@ -4,13 +4,20 @@
 
 #include "HasRelationScan.h"
 
+template <typename A, typename R>
+void doComputeSubqueryS(const std::vector<A>* input,
+                        const size_t inputSubjectColumn, std::vector<R>* result,
+                        const std::vector<PatternID>& hasPattern,
+                        const CompactStringVector<Id, Id>& hasRelation,
+                        const CompactStringVector<size_t, Id>& patterns);
+
 HasRelationScan::HasRelationScan(QueryExecutionContext* qec, ScanType type)
-  : Operation(qec),
-    _type(type),
-    _subtree(nullptr),
-    _subtreeColIndex(-1),
-    _subject(),
-    _object() {}
+    : Operation(qec),
+      _type(type),
+      _subtree(nullptr),
+      _subtreeColIndex(-1),
+      _subject(),
+      _object() {}
 
 string HasRelationScan::asString(size_t indent) const {
   std::ostringstream os;
@@ -18,48 +25,48 @@ string HasRelationScan::asString(size_t indent) const {
     os << " ";
   }
   switch (_type) {
-  case ScanType::FREE_S:
-    os << "HAS_RELATION_SCAN with S = " << _subject << " O = " << _object;
-    break;
-  case ScanType::FREE_O:
-    os << "HAS_RELATION_SCAN with S = " << _subject << " O = " << _object;
-    break;
-  case ScanType::FULL_SCAN:
-    os << "HAS_RELATION_SCAN with S = " << _subject << " O = " << _object;
-    break;
-  case ScanType::SUBQUERY_S:
-    os << "HAS_RELATION_SCAN with S = " << _subtree->asString(indent)
-       << " O = " << _object;
-    break;
+    // TODO(florian): these are not good cache keys
+    case ScanType::FREE_S:
+      os << "HAS_RELATION_SCAN with O = " << _object;
+      break;
+    case ScanType::FREE_O:
+      os << "HAS_RELATION_SCAN with S = " << _subject;
+      break;
+    case ScanType::FULL_SCAN:
+      os << "HAS_RELATION_SCAN for the full relation";
+      break;
+    case ScanType::SUBQUERY_S:
+      os << "HAS_RELATION_SCAN with S = " << _subtree->asString(indent);
+      break;
   }
   return os.str();
 }
 
 size_t HasRelationScan::getResultWidth() const {
   switch (_type) {
-  case ScanType::FREE_S:
-    return 1;
-  case ScanType::FREE_O:
-    return 1;
-  case ScanType::FULL_SCAN:
-    return 2;
-  case ScanType::SUBQUERY_S:
-    return _subtree->getResultWidth() + 1;
+    case ScanType::FREE_S:
+      return 1;
+    case ScanType::FREE_O:
+      return 1;
+    case ScanType::FULL_SCAN:
+      return 2;
+    case ScanType::SUBQUERY_S:
+      return _subtree->getResultWidth() + 1;
   }
   return -1;
 }
 
 size_t HasRelationScan::resultSortedOn() const {
   switch (_type) {
-  case ScanType::FREE_S:
-    // is the lack of sorting here a problem?
-    return -1;
-  case ScanType::FREE_O:
-    return 0;
-  case ScanType::FULL_SCAN:
-    return 0;
-  case ScanType::SUBQUERY_S:
-    return _subtree->resultSortedOn();
+    case ScanType::FREE_S:
+      // is the lack of sorting here a problem?
+      return -1;
+    case ScanType::FREE_O:
+      return 0;
+    case ScanType::FULL_SCAN:
+      return 0;
+    case ScanType::SUBQUERY_S:
+      return _subtree->resultSortedOn();
   }
   return -1;
 }
@@ -67,20 +74,20 @@ size_t HasRelationScan::resultSortedOn() const {
 std::unordered_map<string, size_t> HasRelationScan::getVariableColumns() const {
   std::unordered_map<string, size_t> varCols;
   switch (_type) {
-  case ScanType::FREE_S:
-    varCols.insert(std::make_pair(_subject, 0));
-    break;
-  case ScanType::FREE_O:
-    varCols.insert(std::make_pair(_object, 0));
-    break;
-  case ScanType::FULL_SCAN:
-    varCols.insert(std::make_pair(_subject, 0));
-    varCols.insert(std::make_pair(_object, 1));
-    break;
-  case ScanType::SUBQUERY_S:
-    varCols = _subtree->getVariableColumnMap();
-    varCols.insert(std::make_pair(_object, getResultWidth() - 1));
-    break;
+    case ScanType::FREE_S:
+      varCols.insert(std::make_pair(_subject, 0));
+      break;
+    case ScanType::FREE_O:
+      varCols.insert(std::make_pair(_object, 0));
+      break;
+    case ScanType::FULL_SCAN:
+      varCols.insert(std::make_pair(_subject, 0));
+      varCols.insert(std::make_pair(_object, 1));
+      break;
+    case ScanType::SUBQUERY_S:
+      varCols = _subtree->getVariableColumnMap();
+      varCols.insert(std::make_pair(_object, getResultWidth() - 1));
+      break;
   }
   return varCols;
 }
@@ -101,51 +108,54 @@ bool HasRelationScan::knownEmptyResult() {
 
 float HasRelationScan::getMultiplicity(size_t col) {
   switch (_type) {
-  case ScanType::FREE_S:
-    // TODO track multiplicity
-    return 1;
-  case ScanType::FREE_O:
-    return 1;
-  case ScanType::FULL_SCAN:
-    return 1;
-  case ScanType::SUBQUERY_S:
-    if (col < getResultWidth() - 1) {
-      return _subtree->getMultiplicity(col);
-    } else {
+    case ScanType::FREE_S:
       // TODO track multiplicity
-      return _subtree->getMultiplicity(_subtreeColIndex);
-    }
-    break;
+      return 1;
+    case ScanType::FREE_O:
+      return 1;
+    case ScanType::FULL_SCAN:
+      return 1;
+    case ScanType::SUBQUERY_S:
+      if (col < getResultWidth() - 1) {
+        return _subtree->getMultiplicity(col);
+      } else {
+        // TODO track multiplicity
+        return _subtree->getMultiplicity(_subtreeColIndex);
+      }
+      break;
   }
   return 1;
 }
 
 size_t HasRelationScan::getSizeEstimate() {
-  // TODO: these size estimates only owrk if all predicates are functional
+  // TODO: these size estimates only work if all predicates are functional
   switch (_type) {
-  case ScanType::FREE_S:
-    return getIndex().getHasPattern().size() + getIndex().getHasRelation().size();
-  case ScanType::FREE_O:
-    return getIndex().getHasPattern().size() + getIndex().getHasRelation().size();
-  case ScanType::FULL_SCAN:
-    return getIndex().getHasPattern().size() + getIndex().getHasRelation().size();
-  case ScanType::SUBQUERY_S:
-    return _subtree->getSizeEstimate();
+    case ScanType::FREE_S:
+      return getIndex().getHasPattern().size() +
+             getIndex().getHasRelation().size();
+    case ScanType::FREE_O:
+      return getIndex().getHasPattern().size() +
+             getIndex().getHasRelation().size();
+    case ScanType::FULL_SCAN:
+      return getIndex().getHasPattern().size() +
+             getIndex().getHasRelation().size();
+    case ScanType::SUBQUERY_S:
+      return _subtree->getSizeEstimate();
   }
   return 0;
 }
 
 size_t HasRelationScan::getCostEstimate() {
-  // TODO: these size estimates only owrk if all predicates are functional
+  // TODO: these size estimates only work if all predicates are functional
   switch (_type) {
-  case ScanType::FREE_S:
-    return getSizeEstimate();
-  case ScanType::FREE_O:
-    return getSizeEstimate();
-  case ScanType::FULL_SCAN:
-    return getSizeEstimate();
-  case ScanType::SUBQUERY_S:
-    return _subtree->getCostEstimate() + getSizeEstimate();
+    case ScanType::FREE_S:
+      return getSizeEstimate();
+    case ScanType::FREE_O:
+      return getSizeEstimate();
+    case ScanType::FULL_SCAN:
+      return getSizeEstimate();
+    case ScanType::SUBQUERY_S:
+      return _subtree->getCostEstimate() + getSizeEstimate();
   }
   return 0;
 }
@@ -153,37 +163,51 @@ size_t HasRelationScan::getCostEstimate() {
 void HasRelationScan::computeResult(ResultTable* result) const {
   result->_nofColumns = getResultWidth();
   result->_sortedBy = resultSortedOn();
-  switch (_type) {
-  case ScanType::FREE_S:
-    computeFreeS(result);
-    break;
-  case ScanType::FREE_O:
-    computeFreeO(result);
-    break;
-  case ScanType::FULL_SCAN:
-    computeFullScan(result);
-    break;
-  case ScanType::SUBQUERY_S:
-    computeSubqueryS(result);
-    break;
-  }
-  result->finish();
-}
-
-
-void HasRelationScan::computeFreeS(ResultTable* result) const {
-  Id objectId;
-  if (!getIndex().getVocab().getId(_object, &objectId)) {
-    AD_THROW(ad_semsearch::Exception::BAD_INPUT,
-             "The predicate '" + _object + "' is not in the vocabulary.");
-  }
-  result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  std::vector<std::array<Id, 1>>* fixedSizeData = new std::vector<std::array<Id, 1>>();
-  result->_fixedSizeData = fixedSizeData;
 
   const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
   const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
   const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
+
+  switch (_type) {
+    case ScanType::FREE_S: {
+      Id objectId;
+      if (!getIndex().getVocab().getId(_object, &objectId)) {
+        AD_THROW(ad_semsearch::Exception::BAD_INPUT,
+                 "The predicate '" + _object + "' is not in the vocabulary.");
+      }
+      HasRelationScan::computeFreeS(result, objectId, hasPattern, hasRelation,
+                                    patterns);
+    } break;
+    case ScanType::FREE_O: {
+      Id subjectId;
+      if (!getIndex().getVocab().getId(_subject, &subjectId)) {
+        AD_THROW(ad_semsearch::Exception::BAD_INPUT,
+                 "The subject " + _subject + " is not in the vocabulary.");
+      }
+      HasRelationScan::computeFreeO(result, subjectId, hasPattern, hasRelation,
+                                    patterns);
+    } break;
+    case ScanType::FULL_SCAN:
+      HasRelationScan::computeFullScan(result, hasPattern, hasRelation,
+                                       patterns);
+      break;
+    case ScanType::SUBQUERY_S:
+      HasRelationScan::computeSubqueryS(result, _subtree, _subtreeColIndex,
+                                        hasPattern, hasRelation, patterns);
+      break;
+  }
+  result->finish();
+}
+
+void HasRelationScan::computeFreeS(
+    ResultTable* result, size_t objectId,
+    const std::vector<PatternID>& hasPattern,
+    const CompactStringVector<Id, Id>& hasRelation,
+    const CompactStringVector<size_t, Id>& patterns) {
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+  std::vector<std::array<Id, 1>>* fixedSizeData =
+      new std::vector<std::array<Id, 1>>();
+  result->_fixedSizeData = fixedSizeData;
 
   size_t id = 0;
   while (id < hasPattern.size() || id < hasRelation.size()) {
@@ -212,19 +236,15 @@ void HasRelationScan::computeFreeS(ResultTable* result) const {
   }
 }
 
-void HasRelationScan::computeFreeO(ResultTable* result) const {
-  Id subjectId;
-  if (!getIndex().getVocab().getId(_subject, &subjectId)) {
-    AD_THROW(ad_semsearch::Exception::BAD_INPUT,
-             "The subject " + _subject + " is not in the vocabulary.");
-  }
+void HasRelationScan::computeFreeO(
+    ResultTable* result, size_t subjectId,
+    const std::vector<PatternID>& hasPattern,
+    const CompactStringVector<Id, Id>& hasRelation,
+    const CompactStringVector<size_t, Id>& patterns) {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  std::vector<std::array<Id, 1>>* fixedSizeData = new std::vector<std::array<Id, 1>>();
+  std::vector<std::array<Id, 1>>* fixedSizeData =
+      new std::vector<std::array<Id, 1>>();
   result->_fixedSizeData = fixedSizeData;
-
-  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
-  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
-  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
 
   if (subjectId < hasPattern.size() && hasPattern[subjectId] != NO_PATTERN) {
     // add the pattern
@@ -245,15 +265,15 @@ void HasRelationScan::computeFreeO(ResultTable* result) const {
   }
 }
 
-void HasRelationScan::computeFullScan(ResultTable* result) const {
+void HasRelationScan::computeFullScan(
+    ResultTable* result, const std::vector<PatternID>& hasPattern,
+    const CompactStringVector<Id, Id>& hasRelation,
+    const CompactStringVector<size_t, Id>& patterns) {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  std::vector<std::array<Id, 2>>* fixedSizeData = new std::vector<std::array<Id, 2>>();
+  std::vector<std::array<Id, 2>>* fixedSizeData =
+      new std::vector<std::array<Id, 2>>();
   result->_fixedSizeData = fixedSizeData;
-
-  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
-  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
-  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
 
   size_t id = 0;
   while (id < hasPattern.size() || id < hasRelation.size()) {
@@ -293,8 +313,7 @@ struct resizeIfVec<vector<C>, C> {
 
 template <typename A, typename R>
 void doComputeSubqueryS(const std::vector<A>* input,
-                        const size_t inputSubjectColumn,
-                        std::vector<R>* result,
+                        const size_t inputSubjectColumn, std::vector<R>* result,
                         const std::vector<PatternID>& hasPattern,
                         const CompactStringVector<Id, Id>& hasRelation,
                         const CompactStringVector<size_t, Id>& patterns) {
@@ -335,92 +354,85 @@ void doComputeSubqueryS(const std::vector<A>* input,
   }
 }
 
-
 /**
- * @brief  This struct is used to call doComputeSubqueryS with the correct template
- * parameters. Using it is equivalent to a structure of nested if clauses,
- * checking if the inputColCount and resultColCount are of a certain value, and
- * then calling doGroupBy.
+ * @brief  This struct is used to call doComputeSubqueryS with the correct
+ * template parameters. Using it is equivalent to a structure of nested if
+ * clauses, checking if the inputColCount and resultColCount are of a certain
+ * value, and then calling doGroupBy.
  */
 template <int InputColCount>
 struct CallComputeSubqueryS {
-  static void call(int inputColCount,
-                   const ResultTable* input,
-                   const size_t inputSubjectColumn,
-                   ResultTable* result,
+  static void call(int inputColCount, const ResultTable* input,
+                   const size_t inputSubjectColumn, ResultTable* result,
                    const std::vector<PatternID>& hasPattern,
                    const CompactStringVector<Id, Id>& hasRelation,
                    const CompactStringVector<size_t, Id>& patterns) {
     if (InputColCount == inputColCount) {
       if (InputColCount < 5) {
         result->_fixedSizeData = new vector<array<Id, InputColCount + 1>>();
-        doComputeSubqueryS<std::array<Id, InputColCount>, std::array<Id, InputColCount + 1>>(
-              static_cast<vector<array<Id, InputColCount>>*>(input->_fixedSizeData),
-              inputSubjectColumn,
-              static_cast<vector<array<Id, InputColCount + 1>>*>(result->_fixedSizeData),
-              hasPattern, hasRelation, patterns);
+        doComputeSubqueryS<std::array<Id, InputColCount>,
+                           std::array<Id, InputColCount + 1>>(
+            static_cast<vector<array<Id, InputColCount>>*>(
+                input->_fixedSizeData),
+            inputSubjectColumn,
+            static_cast<vector<array<Id, InputColCount + 1>>*>(
+                result->_fixedSizeData),
+            hasPattern, hasRelation, patterns);
       } else {
         doComputeSubqueryS<std::array<Id, InputColCount>, std::vector<Id>>(
-              static_cast<vector<array<Id, InputColCount>>*>(input->_fixedSizeData),
-              inputSubjectColumn,
-              &result->_varSizeData,
-              hasPattern, hasRelation, patterns);
+            static_cast<vector<array<Id, InputColCount>>*>(
+                input->_fixedSizeData),
+            inputSubjectColumn, &result->_varSizeData, hasPattern, hasRelation,
+            patterns);
       }
     } else {
       CallComputeSubqueryS<InputColCount + 1>::call(
-            inputColCount, input, inputSubjectColumn, result, hasPattern, hasRelation, patterns);
+          inputColCount, input, inputSubjectColumn, result, hasPattern,
+          hasRelation, patterns);
     }
   }
 };
 
 template <>
 struct CallComputeSubqueryS<6> {
-  static void call(int inputColCount,
-                   const ResultTable* input,
-                   const size_t inputSubjectColumn,
-                   ResultTable* result,
+  static void call(int inputColCount, const ResultTable* input,
+                   const size_t inputSubjectColumn, ResultTable* result,
                    const std::vector<PatternID>& hasPattern,
                    const CompactStringVector<Id, Id>& hasRelation,
                    const CompactStringVector<size_t, Id>& patterns) {
     // avoid unused warnings from the compiler
-    (void) inputColCount;
+    (void)inputColCount;
     // call doComputeSubqueryS with variable sized data
     doComputeSubqueryS<std::vector<Id>, std::vector<Id>>(
-          &input->_varSizeData,
-          inputSubjectColumn,
-          &result->_varSizeData,
-          hasPattern, hasRelation, patterns);
+        &input->_varSizeData, inputSubjectColumn, &result->_varSizeData,
+        hasPattern, hasRelation, patterns);
   }
 };
 
+void HasRelationScan::computeSubqueryS(
+    ResultTable* result, const std::shared_ptr<QueryExecutionTree> subtree,
+    const size_t subtreeColIndex, const std::vector<PatternID>& hasPattern,
+    const CompactStringVector<Id, Id>& hasRelation,
+    const CompactStringVector<size_t, Id>& patterns) {
+  std::shared_ptr<const ResultTable> subresult = subtree->getResult();
 
-void HasRelationScan::computeSubqueryS(ResultTable* result) const {
-
-  std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-
-  result->_resultTypes.insert(result->_resultTypes.begin(), subresult->_resultTypes.begin(), subresult->_resultTypes.end());
+  result->_resultTypes.insert(result->_resultTypes.begin(),
+                              subresult->_resultTypes.begin(),
+                              subresult->_resultTypes.end());
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
 
-  const std::vector<PatternID>& hasPattern = getIndex().getHasPattern();
-  const CompactStringVector<Id, Id>& hasRelation = getIndex().getHasRelation();
-  const CompactStringVector<size_t, Id>& patterns = getIndex().getPatterns();
-  CallComputeSubqueryS<1>::call(subresult->_nofColumns,
-                                subresult.get(),
-                                _subtreeColIndex,
-                                result,
-                                hasPattern,
-                                hasRelation,
-                                patterns);
+  CallComputeSubqueryS<1>::call(subresult->_nofColumns, subresult.get(),
+                                subtreeColIndex, result, hasPattern,
+                                hasRelation, patterns);
 }
-
 
 void HasRelationScan::setSubject(const std::string& subject) {
   _subject = subject;
 }
 
-void HasRelationScan::setObject(const std::string& object) {
-  _object = object;
-}
+void HasRelationScan::setObject(const std::string& object) { _object = object; }
+
+const std::string& HasRelationScan::getObject() const { return _object; }
 
 void HasRelationScan::setSubtree(std::shared_ptr<QueryExecutionTree> subtree) {
   _subtree = subtree;
@@ -430,7 +442,4 @@ void HasRelationScan::setSubtreeSubjectColumn(size_t colIndex) {
   _subtreeColIndex = colIndex;
 }
 
-
-HasRelationScan::ScanType HasRelationScan::getType() const {
-  return _type;
-}
+HasRelationScan::ScanType HasRelationScan::getType() const { return _type; }

--- a/src/engine/HasRelationScan.h
+++ b/src/engine/HasRelationScan.h
@@ -68,7 +68,8 @@ class HasRelationScan : public Operation {
   static void computeFullScan(ResultTable* result,
                               const std::vector<PatternID>& hasPattern,
                               const CompactStringVector<Id, Id>& hasRelation,
-                              const CompactStringVector<size_t, Id>& patterns);
+                              const CompactStringVector<size_t, Id>& patterns,
+                              size_t resultSize);
 
   static void computeSubqueryS(
       ResultTable* result, const std::shared_ptr<QueryExecutionTree> _subtree,

--- a/src/engine/HasRelationScan.h
+++ b/src/engine/HasRelationScan.h
@@ -1,0 +1,68 @@
+// Copyright 2018, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../global/Pattern.h"
+#include "../parser/ParsedQuery.h"
+#include "./Operation.h"
+#include "./QueryExecutionTree.h"
+
+class HasRelationScan : public Operation {
+ public:
+  enum class ScanType {
+    // Given a constant predicate, return all subjects
+    FREE_S,
+    // Given a constant subject, return all predicates
+    FREE_O,
+    // For all subjects return their predicates
+    FULL_SCAN,
+    // For a given subset of subjects return their predicates
+    SUBQUERY_S
+  };
+
+  HasRelationScan(QueryExecutionContext* qec, ScanType type);
+
+  virtual string asString(size_t indent = 0) const;
+
+  virtual size_t getResultWidth() const;
+
+  virtual size_t resultSortedOn() const;
+
+  std::unordered_map<string, size_t> getVariableColumns() const;
+
+  virtual void setTextLimit(size_t limit);
+
+  virtual bool knownEmptyResult();
+
+  virtual float getMultiplicity(size_t col);
+
+  virtual size_t getSizeEstimate();
+
+  virtual size_t getCostEstimate();
+
+  void setSubject(const std::string& subject);
+  void setObject(const std::string& object);
+  void setSubtree(std::shared_ptr<QueryExecutionTree> subtree);
+  void setSubtreeSubjectColumn(size_t colIndex);
+  ScanType getType() const;
+
+ private:
+  ScanType _type;
+  std::shared_ptr<QueryExecutionTree> _subtree;
+  size_t _subtreeColIndex;
+
+  std::string _subject;
+  std::string _object;
+
+  virtual void computeResult(ResultTable* result) const;
+  void computeFreeS(ResultTable* result) const;
+  void computeFreeO(ResultTable* result) const;
+  void computeFullScan(ResultTable* result) const;
+  void computeSubqueryS(ResultTable* result) const;
+};

--- a/src/engine/HasRelationScan.h
+++ b/src/engine/HasRelationScan.h
@@ -52,6 +52,30 @@ class HasRelationScan : public Operation {
   void setSubtreeSubjectColumn(size_t colIndex);
   ScanType getType() const;
 
+  const std::string& getObject() const;
+
+  // These are made static and public mainly for easier testing
+  static void computeFreeS(ResultTable* result, size_t objectId,
+                           const std::vector<PatternID>& hasPattern,
+                           const CompactStringVector<Id, Id>& hasRelation,
+                           const CompactStringVector<size_t, Id>& patterns);
+
+  static void computeFreeO(ResultTable* result, size_t subjectId,
+                           const std::vector<PatternID>& hasPattern,
+                           const CompactStringVector<Id, Id>& hasRelation,
+                           const CompactStringVector<size_t, Id>& patterns);
+
+  static void computeFullScan(ResultTable* result,
+                              const std::vector<PatternID>& hasPattern,
+                              const CompactStringVector<Id, Id>& hasRelation,
+                              const CompactStringVector<size_t, Id>& patterns);
+
+  static void computeSubqueryS(
+      ResultTable* result, const std::shared_ptr<QueryExecutionTree> _subtree,
+      const size_t subtreeColIndex, const std::vector<PatternID>& hasPattern,
+      const CompactStringVector<Id, Id>& hasRelation,
+      const CompactStringVector<size_t, Id>& patterns);
+
  private:
   ScanType _type;
   std::shared_ptr<QueryExecutionTree> _subtree;
@@ -61,8 +85,4 @@ class HasRelationScan : public Operation {
   std::string _object;
 
   virtual void computeResult(ResultTable* result) const;
-  void computeFreeS(ResultTable* result) const;
-  void computeFreeO(ResultTable* result) const;
-  void computeFullScan(ResultTable* result) const;
-  void computeSubqueryS(ResultTable* result) const;
 };

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -36,7 +36,8 @@ class QueryExecutionTree {
     TWO_COL_JOIN = 10,
     OPTIONAL_JOIN = 11,
     COUNT_AVAILABLE_PREDICATES = 12,
-    GROUP_BY = 13
+    GROUP_BY = 13,
+    HAS_RELATION_SCAN = 14
   };
 
   void setOperation(OperationType type, std::shared_ptr<Operation> op);

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -9,6 +9,7 @@
 #include "Distinct.h"
 #include "Filter.h"
 #include "GroupBy.h"
+#include "HasRelationScan.h"
 #include "IndexScan.h"
 #include "Join.h"
 #include "OptionalJoin.h"
@@ -17,7 +18,6 @@
 #include "TextOperationWithFilter.h"
 #include "TextOperationWithoutFilter.h"
 #include "TwoColumnJoin.h"
-#include "HasRelationScan.h"
 
 // _____________________________________________________________________________
 QueryPlanner::QueryPlanner(QueryExecutionContext* qec, bool optimizeOptionals)
@@ -553,17 +553,25 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
           if (isVariable(node._triple._s)) {
             std::shared_ptr<Operation> scan(
                 new HasRelationScan(_qec, HasRelationScan::ScanType::FREE_S));
-            static_cast<HasRelationScan*>(scan.get())->setSubject(node._triple._s);
-            static_cast<HasRelationScan*>(scan.get())->setObject(node._triple._o);
-            tree.setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
-            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+            static_cast<HasRelationScan*>(scan.get())
+                ->setSubject(node._triple._s);
+            static_cast<HasRelationScan*>(scan.get())
+                ->setObject(node._triple._o);
+            tree.setOperation(
+                QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
+            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())
+                                        ->getVariableColumns());
           } else if (isVariable(node._triple._o)) {
             std::shared_ptr<Operation> scan(
                 new HasRelationScan(_qec, HasRelationScan::ScanType::FREE_O));
-            static_cast<HasRelationScan*>(scan.get())->setSubject(node._triple._s);
-            static_cast<HasRelationScan*>(scan.get())->setObject(node._triple._o);
-            tree.setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
-            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+            static_cast<HasRelationScan*>(scan.get())
+                ->setSubject(node._triple._s);
+            static_cast<HasRelationScan*>(scan.get())
+                ->setObject(node._triple._o);
+            tree.setOperation(
+                QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
+            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())
+                                        ->getVariableColumns());
           }
         } else if (isVariable(node._triple._s)) {
           std::shared_ptr<Operation> scan(
@@ -596,11 +604,14 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
           plan._idsOfIncludedNodes |= (1 << i);
           auto& tree = *plan._qet.get();
           std::shared_ptr<Operation> scan(
-                new HasRelationScan(_qec, HasRelationScan::ScanType::FULL_SCAN));
-          static_cast<HasRelationScan*>(scan.get())->setSubject(node._triple._s);
+              new HasRelationScan(_qec, HasRelationScan::ScanType::FULL_SCAN));
+          static_cast<HasRelationScan*>(scan.get())
+              ->setSubject(node._triple._s);
           static_cast<HasRelationScan*>(scan.get())->setObject(node._triple._o);
-          tree.setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
-          tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+          tree.setOperation(
+              QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
+          tree.setVariableColumns(
+              static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
           seeds.push_back(plan);
         } else if (!isVariable(node._triple._p)) {
           {
@@ -1005,27 +1016,31 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
         // If the join column correspods the the has-relation scans
         // subject column we can use a specialized join that avoids
         // loading the full has-relation predicate.
-        /*if (a[i]._qet.get()->getType() ==
+        if (a[i]._qet.get()->getType() ==
                 QueryExecutionTree::OperationType::HAS_RELATION_SCAN ||
             b[j]._qet.get()->getType() ==
                 QueryExecutionTree::OperationType::HAS_RELATION_SCAN) {
           bool replaceJoin = false;
 
-          std::shared_ptr<QueryExecutionTree> hasRelationScan(new QueryExecutionTree(_qec));
-          std::shared_ptr<QueryExecutionTree> other(new QueryExecutionTree(_qec));
+          std::shared_ptr<QueryExecutionTree> hasRelationScan(
+              new QueryExecutionTree(_qec));
+          std::shared_ptr<QueryExecutionTree> other(
+              new QueryExecutionTree(_qec));
           if (a[i]._qet.get()->getType() ==
-              QueryExecutionTree::OperationType::HAS_RELATION_SCAN
-              && jcs[0][0] == 0) {
-            const HasRelationScan* op = static_cast<HasRelationScan*>(a[i]._qet->getRootOperation().get());
+                  QueryExecutionTree::OperationType::HAS_RELATION_SCAN &&
+              jcs[0][0] == 0) {
+            const HasRelationScan* op = static_cast<HasRelationScan*>(
+                a[i]._qet->getRootOperation().get());
             if (op->getType() == HasRelationScan::ScanType::FULL_SCAN) {
               hasRelationScan = a[i]._qet;
               other = b[j]._qet;
               replaceJoin = true;
             }
           } else if (b[j]._qet.get()->getType() ==
-                     QueryExecutionTree::OperationType::HAS_RELATION_SCAN
-                     && jcs[0][1] == 0) {
-            const HasRelationScan* op = static_cast<HasRelationScan*>(b[j]._qet->getRootOperation().get());
+                         QueryExecutionTree::OperationType::HAS_RELATION_SCAN &&
+                     jcs[0][1] == 0) {
+            const HasRelationScan* op = static_cast<HasRelationScan*>(
+                b[j]._qet->getRootOperation().get());
             if (op->getType() == HasRelationScan::ScanType::FULL_SCAN) {
               other = a[i]._qet;
               hasRelationScan = b[j]._qet;
@@ -1035,23 +1050,31 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
           if (replaceJoin) {
             SubtreePlan plan(_qec);
             auto& tree = *plan._qet.get();
-            std::shared_ptr<Operation> scan(
-                new HasRelationScan(_qec, HasRelationScan::ScanType::SUBQUERY_S));
-            tree.setVariableColumns(
-                static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+            std::shared_ptr<Operation> scan(new HasRelationScan(
+                _qec, HasRelationScan::ScanType::SUBQUERY_S));
             // TODO(florian): this still crashes when used
             static_cast<HasRelationScan*>(scan.get())->setSubtree(other);
-            static_cast<HasRelationScan*>(scan.get())->setSubtreeSubjectColumn(jcs[0][1]);
+            static_cast<HasRelationScan*>(scan.get())
+                ->setSubtreeSubjectColumn(jcs[0][1]);
+            static_cast<HasRelationScan*>(scan.get())
+                ->setObject(static_cast<HasRelationScan*>(
+                                hasRelationScan->getRootOperation().get())
+                                ->getObject());
+            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())
+                                        ->getVariableColumns());
             // tree.setContextVars(static_cast<HasRelationScan*>(scan.get())->getContextVars());
             tree.setOperation(QueryExecutionTree::HAS_RELATION_SCAN, scan);
             plan._idsOfIncludedNodes = a[i]._idsOfIncludedNodes;
             plan.addAllNodes(b[j]._idsOfIncludedNodes);
             plan._idsOfIncludedFilters = a[i]._idsOfIncludedFilters;
             plan._idsOfIncludedFilters |= b[j]._idsOfIncludedFilters;
-            candidates[getPruningKey(plan, static_cast<HasRelationScan*>(scan.get())->resultSortedOn())].emplace_back(plan);
+            candidates[getPruningKey(plan,
+                                     static_cast<HasRelationScan*>(scan.get())
+                                         ->resultSortedOn())]
+                .emplace_back(plan);
             continue;
           }
-        }*/
+        }
 
         // "NORMAL" CASE:
         // Check if a sub-result has to be re-sorted

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -17,6 +17,7 @@
 #include "TextOperationWithFilter.h"
 #include "TextOperationWithoutFilter.h"
 #include "TwoColumnJoin.h"
+#include "HasRelationScan.h"
 
 // _____________________________________________________________________________
 QueryPlanner::QueryPlanner(QueryExecutionContext* qec, bool optimizeOptionals)
@@ -51,7 +52,6 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) const {
   SparqlTriple patternTrickTriple("", "", "");
   for (size_t i = 0; i < pq._rootGraphPattern._whereClauseTriples.size(); i++) {
     const SparqlTriple& t = pq._rootGraphPattern._whereClauseTriples[i];
-    LOG(DEBUG) << "_p: " << t._p << endl;
     if (t._p == HAS_RELATION_PREDIACTE) {
       const ParsedQuery::Alias* countAlias = nullptr;
       for (const ParsedQuery::Alias& a : pq._aliases) {
@@ -72,10 +72,6 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) const {
         // remove the triple from the graph
         pq._rootGraphPattern._whereClauseTriples.erase(
             pq._rootGraphPattern._whereClauseTriples.begin() + i);
-      } else {
-        throw ParseException(
-            "ql:has-relation may currently only be used when "
-            "grouping by its object and counting the same.");
       }
     }
   }
@@ -144,7 +140,6 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) const {
     // edges to connected variables.
 
     LOG(TRACE) << "Collapse text cliques..." << std::endl;
-    ;
     tg.collapseTextCliques();
     LOG(TRACE) << "Collapse text cliques done." << std::endl;
     vector<vector<SubtreePlan>> finalTab;
@@ -548,13 +543,29 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             ad_semsearch::Exception::BAD_QUERY,
             "Triples should have at least one variable. Not the case in: " +
                 node._triple.asString());
-      }
-      if (node._variables.size() == 1) {
+      } else if (node._variables.size() == 1) {
         // Just pick one direction, they should be equivalent.
         SubtreePlan plan(_qec);
         plan._idsOfIncludedNodes |= (1 << i);
         auto& tree = *plan._qet.get();
-        if (isVariable(node._triple._s)) {
+        if (node._triple._p == HAS_RELATION_PREDIACTE) {
+          // Add a has relation scan instead of a normal IndexScan
+          if (isVariable(node._triple._s)) {
+            std::shared_ptr<Operation> scan(
+                new HasRelationScan(_qec, HasRelationScan::ScanType::FREE_S));
+            static_cast<HasRelationScan*>(scan.get())->setSubject(node._triple._s);
+            static_cast<HasRelationScan*>(scan.get())->setObject(node._triple._o);
+            tree.setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
+            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+          } else if (isVariable(node._triple._o)) {
+            std::shared_ptr<Operation> scan(
+                new HasRelationScan(_qec, HasRelationScan::ScanType::FREE_O));
+            static_cast<HasRelationScan*>(scan.get())->setSubject(node._triple._s);
+            static_cast<HasRelationScan*>(scan.get())->setObject(node._triple._o);
+            tree.setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
+            tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+          }
+        } else if (isVariable(node._triple._s)) {
           std::shared_ptr<Operation> scan(
               new IndexScan(_qec, IndexScan::ScanType::POS_BOUND_O));
           static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
@@ -579,7 +590,19 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
         seeds.push_back(plan);
       } else if (node._variables.size() == 2) {
         // Add plans for both possible scan directions.
-        if (!isVariable(node._triple._p)) {
+        if (node._triple._p == HAS_RELATION_PREDIACTE) {
+          // Add a has relation scan instead of a normal IndexScan
+          SubtreePlan plan(_qec);
+          plan._idsOfIncludedNodes |= (1 << i);
+          auto& tree = *plan._qet.get();
+          std::shared_ptr<Operation> scan(
+                new HasRelationScan(_qec, HasRelationScan::ScanType::FULL_SCAN));
+          static_cast<HasRelationScan*>(scan.get())->setSubject(node._triple._s);
+          static_cast<HasRelationScan*>(scan.get())->setObject(node._triple._o);
+          tree.setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
+          tree.setVariableColumns(static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+          seeds.push_back(plan);
+        } else if (!isVariable(node._triple._p)) {
           {
             SubtreePlan plan(_qec);
             plan._idsOfIncludedNodes |= (1 << i);
@@ -977,6 +1000,58 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
             b[j]._qet->getResultWidth() == 3) {
           continue;
         }
+
+        // Check if one of the two operations is a HAS_RELATION_SCAN .
+        // If the join column correspods the the has-relation scans
+        // subject column we can use a specialized join that avoids
+        // loading the full has-relation predicate.
+        /*if (a[i]._qet.get()->getType() ==
+                QueryExecutionTree::OperationType::HAS_RELATION_SCAN ||
+            b[j]._qet.get()->getType() ==
+                QueryExecutionTree::OperationType::HAS_RELATION_SCAN) {
+          bool replaceJoin = false;
+
+          std::shared_ptr<QueryExecutionTree> hasRelationScan(new QueryExecutionTree(_qec));
+          std::shared_ptr<QueryExecutionTree> other(new QueryExecutionTree(_qec));
+          if (a[i]._qet.get()->getType() ==
+              QueryExecutionTree::OperationType::HAS_RELATION_SCAN
+              && jcs[0][0] == 0) {
+            const HasRelationScan* op = static_cast<HasRelationScan*>(a[i]._qet->getRootOperation().get());
+            if (op->getType() == HasRelationScan::ScanType::FULL_SCAN) {
+              hasRelationScan = a[i]._qet;
+              other = b[j]._qet;
+              replaceJoin = true;
+            }
+          } else if (b[j]._qet.get()->getType() ==
+                     QueryExecutionTree::OperationType::HAS_RELATION_SCAN
+                     && jcs[0][1] == 0) {
+            const HasRelationScan* op = static_cast<HasRelationScan*>(b[j]._qet->getRootOperation().get());
+            if (op->getType() == HasRelationScan::ScanType::FULL_SCAN) {
+              other = a[i]._qet;
+              hasRelationScan = b[j]._qet;
+              replaceJoin = true;
+            }
+          }
+          if (replaceJoin) {
+            SubtreePlan plan(_qec);
+            auto& tree = *plan._qet.get();
+            std::shared_ptr<Operation> scan(
+                new HasRelationScan(_qec, HasRelationScan::ScanType::SUBQUERY_S));
+            tree.setVariableColumns(
+                static_cast<HasRelationScan*>(scan.get())->getVariableColumns());
+            // TODO(florian): this still crashes when used
+            static_cast<HasRelationScan*>(scan.get())->setSubtree(other);
+            static_cast<HasRelationScan*>(scan.get())->setSubtreeSubjectColumn(jcs[0][1]);
+            // tree.setContextVars(static_cast<HasRelationScan*>(scan.get())->getContextVars());
+            tree.setOperation(QueryExecutionTree::HAS_RELATION_SCAN, scan);
+            plan._idsOfIncludedNodes = a[i]._idsOfIncludedNodes;
+            plan.addAllNodes(b[j]._idsOfIncludedNodes);
+            plan._idsOfIncludedFilters = a[i]._idsOfIncludedFilters;
+            plan._idsOfIncludedFilters |= b[j]._idsOfIncludedFilters;
+            candidates[getPruningKey(plan, static_cast<HasRelationScan*>(scan.get())->resultSortedOn())].emplace_back(plan);
+            continue;
+          }
+        }*/
 
         // "NORMAL" CASE:
         // Check if a sub-result has to be re-sorted

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -424,7 +424,7 @@ string Server::composeResponseJson(const string& query,
 
   string msg = ad_utility::escapeForJson(exception.what());
 
-  os << "\"Exception-Error-Message\": \"" << msg << "\"\n"
+  os << "\"exception\": \"" << msg << "\"\n"
      << "}\n";
 
   return os.str();

--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -7,9 +7,9 @@
 
 // Constants which are only used during index creation
 
-// here we store all the literals in a text file, which will be externalized. This file is only
-// temporary since the final extneralized literals format is binary and will be
-// created from this file
+// here we store all the literals in a text file, which will be externalized.
+// This file is only temporary since the final extneralized literals format is
+// binary and will be created from this file
 const std::string EXTERNAL_LITS_TEXT_FILE_NAME = ".externalized-text";
 
 // How many lines are parsed at once during index creation.

--- a/src/index/ExternalVocabulary.cpp
+++ b/src/index/ExternalVocabulary.cpp
@@ -61,7 +61,7 @@ void ExternalVocabulary::buildFromVector(const vector<string>& v,
 
 // _____________________________________________________________________________
 void ExternalVocabulary::buildFromTextFile(const string& textFileName,
-                                         const string& outFileName) {
+                                           const string& outFileName) {
   _file.open(outFileName.c_str(), "w");
   std::ifstream infile(textFileName);
   AD_CHECK(infile.is_open());

--- a/src/index/ExternalVocabulary.h
+++ b/src/index/ExternalVocabulary.h
@@ -23,7 +23,7 @@ using std::vector;
 class ExternalVocabulary {
  public:
   void buildFromVector(const vector<string>& v, const string& fileName);
-  void buildFromTextFile(const string& textFileName, const string& outFileName); 
+  void buildFromTextFile(const string& textFileName, const string& outFileName);
 
   void initFromFile(const string& file);
 

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -123,10 +123,10 @@ void Index::passContextFileIntoVector(const string& contextFile,
   size_t i = 0;
   // write using vector_bufwriter
 
-
-  // we have deleted the vocabulary during the index creation to save ram, so now we have
-  // to reload it,
-  LOG(INFO) << "Loading vocabulary from disk (needed for correct Ids in text index)\n";
+  // we have deleted the vocabulary during the index creation to save ram, so
+  // now we have to reload it,
+  LOG(INFO) << "Loading vocabulary from disk (needed for correct Ids in text "
+               "index)\n";
   _vocab = Vocabulary();
   _vocab.readFromFile(_onDiskBase + ".vocabulary",
                       _onDiskLiterals ? _onDiskBase + ".literals-index" : "");

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -675,6 +675,8 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
   LOG(DEBUG) << "Number of entity-has-relation entries: "
              << entityHasRelation.size() << std::endl;
 
+  LOG(INFO) << "Found " << patterns.size() << " distinct patterns."
+            << std::endl;
   LOG(INFO) << numEntitiesWithPatterns
             << " of the databases entities have been assigned a pattern."
             << std::endl;
@@ -714,9 +716,9 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
   file.write(entityHasPattern.data(), sizeof(Id) * numHasPatterns * 2);
 
   // write the entityHasRelation vector
-  size_t numHasRelation = entityHasRelation.size();
-  file.write(&numHasRelation, sizeof(size_t));
-  file.write(entityHasRelation.data(), sizeof(Id) * numHasRelation * 2);
+  size_t numHasRelations = entityHasRelation.size();
+  file.write(&numHasRelations, sizeof(size_t));
+  file.write(entityHasRelation.data(), sizeof(Id) * numHasRelations * 2);
 
   // write the patterns
   patterns.write(file);
@@ -945,7 +947,7 @@ void Index::createFromOnDiskIndex(const string& onDiskBase,
               << std::endl;
   }
   if (_usePatterns) {
-    // Store all data in the file
+    // Read the pattern info from the patterns file
     std::string patternsFilePath = _onDiskBase + ".index.patterns";
     ad_utility::File patternsFile;
     patternsFile.open(patternsFilePath.c_str(), "r");

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -420,13 +420,10 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
   bool isValidPattern = true;
   size_t numInvalidPatterns = 0;
   size_t numValidPatterns = 0;
-  // DEGBUG CODE
-  std::map<size_t, size_t> predicateCounts;
 
   for (ExtVec::bufreader_type reader(vec); !reader.empty(); ++reader) {
     if ((*reader)[0] != currentRel) {
       currentRel = (*reader)[0];
-      predicateCounts[patternIndex]++;
       if (isValidPattern) {
         numValidPatterns++;
         auto it = patternCounts.find(pattern);
@@ -465,16 +462,6 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
             << " entities"
                " because they were to large."
             << std::endl;
-
-  // DEBUG CODE
-  // write out the mapping from predicate counts to number of occurences
-  ad_utility::File df((fileName + ".debug").c_str(), "w");
-  for (auto it : predicateCounts) {
-    string s =
-        std::to_string(it.first) + "\t" + std::to_string(it.second) + "\n";
-    df.write(s.c_str(), s.size());
-  }
-  df.close();
 
   // stores patterns sorted by their number of occurences
   size_t actualNumPatterns = patternCounts.size() < maxNumPatterns

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -15,14 +15,15 @@
 
 using std::array;
 
+const uint32_t Index::PATTERNS_FILE_VERSION = 0;
+
 // _____________________________________________________________________________
 Index::Index()
     : _usePatterns(false),
       _maxNumPatterns(std::numeric_limits<PatternID>::max() - 2) {}
 
 // _____________________________________________________________________________
-void Index::createFromTsvFile(const string& tsvFile,
-                              bool allPermutations) {
+void Index::createFromTsvFile(const string& tsvFile, bool allPermutations) {
   string indexFilename = _onDiskBase + ".index";
   size_t nofLines = passTsvFileForVocabulary(tsvFile);
   ExtVec v(nofLines);
@@ -57,7 +58,9 @@ void Index::createFromTsvFile(const string& tsvFile,
     if (_usePatterns) {
       LOG(INFO) << "Vector already sorted for pattern creation." << std::endl;
       createPatterns(indexFilename + ".patterns", v, _hasRelation, _hasPattern,
-                     _patterns, _maxNumPatterns);
+                     _patterns, _fullHasRelationMultiplicityEntities,
+                     _fullHasRelationMultiplicityPredicates,
+                     _fullHasRelationSize, _maxNumPatterns);
     }
     // SOP permutation
     LOG(INFO) << "Sorting for SOP permutation..." << std::endl;
@@ -79,47 +82,56 @@ void Index::createFromTsvFile(const string& tsvFile,
     stxxl::sort(begin(v), end(v), SortBySPO(), STXXL_MEMORY_TO_USE);
     LOG(INFO) << "Sort done." << std::endl;
     createPatterns(indexFilename + ".patterns", v, _hasRelation, _hasPattern,
-                   _patterns, _maxNumPatterns);
+                   _patterns, _fullHasRelationMultiplicityEntities,
+                   _fullHasRelationMultiplicityPredicates, _fullHasRelationSize,
+                   _maxNumPatterns);
   }
   openFileHandles();
 }
 
 // _____________________________________________________________________________________________
 Index::ExtVec Index::createExtVecAndVocabFromNTriples(const string& ntFile) {
-  size_t nofLines = passNTriplesFileForVocabulary(ntFile, NUM_TRIPLES_PER_PARTIAL_VOCAB);
+  size_t nofLines =
+      passNTriplesFileForVocabulary(ntFile, NUM_TRIPLES_PER_PARTIAL_VOCAB);
   if (_onDiskLiterals) {
-    _vocab.externalizeLiteralsFromTextFile(_onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME, 
-	                                   _onDiskBase + ".literals-index");
+    _vocab.externalizeLiteralsFromTextFile(
+        _onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME,
+        _onDiskBase + ".literals-index");
   }
-  // clear vocabulary to save ram (only information from partial binary files used from now on).
+  // clear vocabulary to save ram (only information from partial binary files
+  // used from now on).
   _vocab = Vocabulary();
   ExtVec v(nofLines);
   passNTriplesFileIntoIdVector(ntFile, v, NUM_TRIPLES_PER_PARTIAL_VOCAB);
 
   if (!_keepTempFiles) {
     // remove temporary files only used during index creation
-    LOG(INFO) << "Removing temporary files (partial vocabulary and external text file...\n";
+    LOG(INFO) << "Removing temporary files (partial vocabulary and external "
+                 "text file...\n";
 
     // TODO: using system and rm is not really elegant nor portable.
     // use std::filesystem as soon as QLever is ported to C++17
-    string removeCommand1 = "rm -- " + _onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME;
+    string removeCommand1 =
+        "rm -- " + _onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME;
     bool w1 = system(removeCommand1.c_str());
-    string removeCommand2 = "rm -- " + _onDiskBase + PARTIAL_VOCAB_FILE_NAME + "*";
+    string removeCommand2 =
+        "rm -- " + _onDiskBase + PARTIAL_VOCAB_FILE_NAME + "*";
     bool w2 = system(removeCommand2.c_str());
     if (w1 || w2) {
-      LOG(INFO) << "Warning. Deleting of temporary files probably not successful\n";
+      LOG(INFO)
+          << "Warning. Deleting of temporary files probably not successful\n";
     } else {
       LOG(INFO) << "Done.\n";
     }
   } else {
-    LOG(INFO) << "Keeping temporary files (partial vocabulary and external text file...\n";
+    LOG(INFO) << "Keeping temporary files (partial vocabulary and external "
+                 "text file...\n";
   }
   return v;
 }
-   							
+
 // _____________________________________________________________________________
-void Index::createFromNTriplesFile(const string& ntFile,
-                                   bool allPermutations) {
+void Index::createFromNTriplesFile(const string& ntFile, bool allPermutations) {
   string indexFilename = _onDiskBase + ".index";
 
   ExtVec v = createExtVecAndVocabFromNTriples(ntFile);
@@ -148,7 +160,9 @@ void Index::createFromNTriplesFile(const string& ntFile,
     if (_usePatterns) {
       LOG(INFO) << "Vector already sorted for pattern creation." << std::endl;
       createPatterns(indexFilename + ".patterns", v, _hasRelation, _hasPattern,
-                     _patterns, _maxNumPatterns);
+                     _patterns, _fullHasRelationMultiplicityEntities,
+                     _fullHasRelationMultiplicityPredicates,
+                     _fullHasRelationSize, _maxNumPatterns);
     }
     // SOP permutation
     LOG(INFO) << "Sorting for SOP permutation..." << std::endl;
@@ -170,7 +184,9 @@ void Index::createFromNTriplesFile(const string& ntFile,
     stxxl::sort(begin(v), end(v), SortBySPO(), STXXL_MEMORY_TO_USE);
     LOG(INFO) << "Sort done." << std::endl;
     createPatterns(indexFilename + ".patterns", v, _hasRelation, _hasPattern,
-                   _patterns, _maxNumPatterns);
+                   _patterns, _fullHasRelationMultiplicityEntities,
+                   _fullHasRelationMultiplicityPredicates, _fullHasRelationSize,
+                   _maxNumPatterns);
   }
   openFileHandles();
 }
@@ -235,19 +251,19 @@ void Index::passTsvFileIntoIdVector(const string& tsvFile, ExtVec& data) {
 // _____________________________________________________________________________
 size_t Index::passNTriplesFileForVocabulary(const string& ntFile,
                                             size_t linesPerPartial) {
-  array<string, 3> spo; 
+  array<string, 3> spo;
   NTriplesParser p(ntFile);
   ad_utility::HashSet<string> items;
-  size_t i = 0; 
-  size_t numFiles = 0; 
+  size_t i = 0;
+  size_t numFiles = 0;
   while (p.getLine(spo)) {
     if (ad_utility::isXsdValue(spo[2])) {
       spo[2] = ad_utility::convertValueLiteralToIndexWord(spo[2]);
     }
     if (_onDiskLiterals && isLiteral(spo[2]) && shouldBeExternalized(spo[2])) {
       spo[2] = string({EXTERNALIZED_LITERALS_PREFIX}) + spo[2];
-    }    
-    
+    }
+
     // Duplicated in pass for Id Vector, externalize to function
     for (size_t k = 0; k < 3; ++k) {
       items.insert(spo[k]);
@@ -260,10 +276,12 @@ size_t Index::passNTriplesFileForVocabulary(const string& ntFile,
 
     if (i % linesPerPartial == 0) {
       LOG(INFO) << "Lines processed: " << i << '\n';
-      string partialFilename = _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
+      string partialFilename =
+          _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
       Vocabulary vocab;
       vocab.createFromSet(items);
-      LOG(INFO) << "writing partial vocabular to " << partialFilename << std::endl;
+      LOG(INFO) << "writing partial vocabular to " << partialFilename
+                << std::endl;
       vocab.writeToBinaryFileForMerging(partialFilename);
       LOG(INFO) << "Done\n";
       items.clear();
@@ -275,8 +293,10 @@ size_t Index::passNTriplesFileForVocabulary(const string& ntFile,
   LOG(INFO) << "Lines processed: " << i << '\n';
   if (items.size() > 0) {
     // write remainder
-    string partialFilename = _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
-    LOG(INFO) << "writing partial vocabular to " << partialFilename << std::endl;
+    string partialFilename =
+        _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
+    LOG(INFO) << "writing partial vocabular to " << partialFilename
+              << std::endl;
     Vocabulary vocab;
     vocab.createFromSet(items);
     vocab.writeToBinaryFileForMerging(partialFilename);
@@ -296,10 +316,12 @@ void Index::passNTriplesFileIntoIdVector(const string& ntFile, ExtVec& data,
             << " and creating stxxl vector.\n";
   array<string, 3> spo;
   NTriplesParser p(ntFile);
-  std::string vocabFilename(_onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(0));
+  std::string vocabFilename(_onDiskBase + PARTIAL_VOCAB_FILE_NAME +
+                            std::to_string(0));
   LOG(INFO) << "Reading partial vocab from " << vocabFilename << " ...\n";
-  google::sparse_hash_map<string, Id> vocabMap = vocabMapFromPartialIndexedFile(vocabFilename);
-  LOG(INFO) << "done reading partial vocab\n"; 
+  google::sparse_hash_map<string, Id> vocabMap =
+      vocabMapFromPartialIndexedFile(vocabFilename);
+  LOG(INFO) << "done reading partial vocab\n";
   size_t i = 0;
   size_t numFiles = 0;
   // write using vector_bufwriter
@@ -321,11 +343,9 @@ void Index::passNTriplesFileIntoIdVector(const string& ntFile, ExtVec& data,
       }
     }
     if (broken) continue;
-    writer << array<Id, 3>{{
-                               vocabMap.find(spo[0])->second,
-                               vocabMap.find(spo[1])->second,
-                               vocabMap.find(spo[2])->second
-                           }};
+    writer << array<Id, 3>{{vocabMap.find(spo[0])->second,
+                            vocabMap.find(spo[1])->second,
+                            vocabMap.find(spo[2])->second}};
     ++i;
     if (i % 100000 == 0) {
       LOG(INFO) << "Lines processed: " << i << '\n';
@@ -334,7 +354,8 @@ void Index::passNTriplesFileIntoIdVector(const string& ntFile, ExtVec& data,
     if (i % linesPerPartial == 0) {
       numFiles++;
       LOG(INFO) << "Lines processed: " << i << '\n';
-      vocabFilename = _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
+      vocabFilename =
+          _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
       LOG(INFO) << "Reading partial vocab from " << vocabFilename << " ...\n";
       vocabMap = vocabMapFromPartialIndexedFile(vocabFilename);
       LOG(INFO) << "done reading partial vocab\n";
@@ -400,7 +421,9 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
                            CompactStringVector<Id, Id>& hasRelation,
                            std::vector<PatternID>& hasPattern,
                            CompactStringVector<size_t, Id>& patterns,
-                           size_t maxNumPatterns) {
+                           double& fullHasRelationMultiplicityEntities,
+                           double& fullHasRelationMultiplicityPredicates,
+                           size_t& fullHasRelationSize, size_t maxNumPatterns) {
   if (vec.size() == 0) {
     LOG(WARN) << "Attempt to write an empty index!" << std::endl;
     return;
@@ -538,12 +561,29 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
   size_t numEntitiesWithPatterns = 0;
   size_t numEntitiesWithoutPatterns = 0;
   size_t numInvalidEntities = 0;
+
+  // store how many entries there are in the full has-relation relation (after
+  // resolving all patterns) and how may distinct elements there are (for the
+  // multiplicity;
+  fullHasRelationSize = 0;
+  size_t fullHasRelationEntitiesDistinctSize = 0;
+  size_t fullHasRelationPredicatesDistinctSize = 0;
+  // This vector stores if the pattern was already counted toward the distinct
+  // has relation predicates size.
+  std::vector<bool> haveCountedPattern(patternSet.size());
+
+  // the input triple list is in spo order, we only need a hash map for
+  // predicates
+  ad_utility::HashSet<Id> predicateHashSet;
+
   pattern.clear();
   currentRel = vec[0][0];
   patternIndex = 0;
   // Create the has-relation and has-pattern predicates
   for (ExtVec::bufreader_type reader2(vec); !reader2.empty(); ++reader2) {
     if ((*reader2)[0] != currentRel) {
+      // we have arrived at a new entity;
+      fullHasRelationEntitiesDistinctSize++;
       std::unordered_map<Pattern, Id>::iterator it;
       if (isValidPattern) {
         it = patternSet.find(pattern);
@@ -551,10 +591,18 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
         it = patternSet.end();
         numInvalidEntities++;
       }
+      // increase the hasrelationsize here as every predicate is only
+      // listed once per entity (otherwise it woul always be the same as
+      // vec.size()
+      fullHasRelationSize += pattern.size();
       if (it == patternSet.end()) {
         numEntitiesWithoutPatterns++;
         // The pattern does not exist, use the has-relation predicate instead
         for (size_t i = 0; i < patternIndex; i++) {
+          if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+            predicateHashSet.insert(pattern[i]);
+            fullHasRelationPredicatesDistinctSize++;
+          }
           entityHasRelation.push_back(
               std::array<Id, 2>{currentRel, pattern[i]});
         }
@@ -562,6 +610,16 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
         numEntitiesWithPatterns++;
         // The pattern does exist, add an entry to the has-pattern predicate
         entityHasPattern.push_back(std::array<Id, 2>{currentRel, it->second});
+        if (!haveCountedPattern[it->second]) {
+          haveCountedPattern[it->second] = true;
+          // iterate over the pattern once to
+          for (size_t i = 0; i < patternIndex; i++) {
+            if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+              predicateHashSet.insert(pattern[i]);
+              fullHasRelationPredicatesDistinctSize++;
+            }
+          }
+        }
       }
       pattern.clear();
       currentRel = (*reader2)[0];
@@ -575,6 +633,8 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
     }
   }
   // process the last element
+  fullHasRelationSize += pattern.size();
+  fullHasRelationEntitiesDistinctSize++;
   std::unordered_map<Pattern, Id>::iterator it;
   if (isValidPattern) {
     it = patternSet.find(pattern);
@@ -586,12 +646,29 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
     // The pattern does not exist, use the has-relation predicate instead
     for (size_t i = 0; i < patternIndex; i++) {
       entityHasRelation.push_back(std::array<Id, 2>{currentRel, pattern[i]});
+      if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+        predicateHashSet.insert(pattern[i]);
+        fullHasRelationPredicatesDistinctSize++;
+      }
     }
   } else {
     numEntitiesWithPatterns++;
     // The pattern does exist, add an entry to the has-pattern predicate
     entityHasPattern.push_back(std::array<Id, 2>{currentRel, it->second});
+    for (size_t i = 0; i < patternIndex; i++) {
+      if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+        predicateHashSet.insert(pattern[i]);
+        fullHasRelationPredicatesDistinctSize++;
+      }
+    }
   }
+
+  fullHasRelationMultiplicityEntities =
+      fullHasRelationSize /
+      static_cast<double>(fullHasRelationEntitiesDistinctSize);
+  fullHasRelationMultiplicityPredicates =
+      fullHasRelationSize /
+      static_cast<double>(fullHasRelationPredicatesDistinctSize);
 
   LOG(DEBUG) << "Number of entity-has-pattern entries: "
              << entityHasPattern.size() << std::endl;
@@ -606,66 +683,70 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
             << std::endl;
   LOG(INFO) << "Of these " << numInvalidEntities
             << " would have to large a pattern." << std::endl;
+
   LOG(DEBUG) << "Total number of entities: "
              << (numEntitiesWithoutPatterns + numEntitiesWithPatterns)
              << std::endl;
 
-  // ensure neither of the relations is empty
-  if (entityHasPattern.size() == 0) {
-    entityHasPattern.push_back(std::array<Id, 2>{ID_NO_VALUE, ID_NO_VALUE});
-  }
-  if (entityHasRelation.size() == 0) {
-    entityHasRelation.push_back(std::array<Id, 2>{ID_NO_VALUE, ID_NO_VALUE});
-  }
+  LOG(DEBUG) << "Full has relation size: " << fullHasRelationSize << std::endl;
+  LOG(DEBUG) << "Full has relation entity multiplicity: "
+             << fullHasRelationMultiplicityEntities << std::endl;
+  LOG(DEBUG) << "Full has relation predicate multiplicity: "
+             << fullHasRelationMultiplicityPredicates << std::endl;
 
   // Store all data in the file
   ad_utility::File file(fileName.c_str(), "w");
-  off_t afterRelations = 0;
-  off_t afterPatterns = 0;
-  // write the has-pattern and has-relation relations into the file
-  auto md1 = writeRel(file, afterRelations, Id(0), entityHasPattern, true);
-  meta.add(md1.first, md1.second);
-  afterRelations = meta.getOffsetAfter();
-  auto md2 = writeRel(file, afterRelations, Id(1), entityHasRelation, false);
-  meta.add(md2.first, md2.second);
-  afterRelations = meta.getOffsetAfter();
 
-  size_t patternsPartSize = patterns.write(file);
-  afterPatterns = afterRelations + patternsPartSize;
+  // Write a byte of ones to make it less likely that an unversioned file is
+  // read as a versioned one (unversioned files begin with the id of the lowest
+  // entity that has a pattern).
+  // Then write the version, both multiplicitires and the full size.
+  unsigned char firstByte = 255;
+  file.write(&firstByte, sizeof(char));
+  file.write(&PATTERNS_FILE_VERSION, sizeof(uint32_t));
+  file.write(&fullHasRelationMultiplicityEntities, sizeof(double));
+  file.write(&fullHasRelationMultiplicityPredicates, sizeof(double));
+  file.write(&fullHasRelationSize, sizeof(size_t));
 
-  // write the meta data into the file
-  file << meta;
+  // write the entityHasPatterns vector
+  size_t numHasPatterns = entityHasPattern.size();
+  file.write(&numHasPatterns, sizeof(size_t));
+  file.write(entityHasPattern.data(), sizeof(Id) * numHasPatterns * 2);
 
-  // the last part of the file contains offset information for the varius parts
-  file.write(&afterRelations, sizeof(off_t));
-  file.write(&afterPatterns, sizeof(off_t));
+  // write the entityHasRelation vector
+  size_t numHasRelation = entityHasRelation.size();
+  file.write(&numHasRelation, sizeof(size_t));
+  file.write(entityHasRelation.data(), sizeof(Id) * numHasRelation * 2);
+
+  // write the patterns
+  patterns.write(file);
   file.close();
 
-  hasPattern.resize(entityHasPattern.back()[0] + 1);
-  // hasRelation.resize(entityHasRelation.back()[0] + 1);
+  LOG(INFO) << "Done creating patterns file." << std::endl;
 
   // create the has-relation and has-pattern lookup vectors
-  size_t pos = 0;
-  for (size_t i = 0; i < entityHasPattern.size(); i++) {
-    while (entityHasPattern[i][0] > pos) {
-      hasPattern[pos] = NO_PATTERN;
+  if (entityHasPattern.size() > 0) {
+    hasPattern.resize(entityHasPattern.back()[0] + 1);
+    size_t pos = 0;
+    for (size_t i = 0; i < entityHasPattern.size(); i++) {
+      while (entityHasPattern[i][0] > pos) {
+        hasPattern[pos] = NO_PATTERN;
+        pos++;
+      }
+      hasPattern[pos] = entityHasPattern[i][1];
       pos++;
     }
-    hasPattern[pos] = entityHasPattern[i][1];
-    pos++;
   }
 
-  pos = 0;
   vector<vector<Id>> hasRelationTmp;
-  if (!(entityHasRelation.size() == 1 &&
-        entityHasRelation[0][0] == ID_NO_VALUE)) {
+  if (entityHasRelation.size() > 0) {
+    hasRelationTmp.resize(entityHasRelation.back()[0] + 1);
+    size_t pos = 0;
     for (size_t i = 0; i < entityHasRelation.size(); i++) {
       Id current = entityHasRelation[i][0];
       while (current > pos) {
-        hasRelationTmp.emplace_back();
         pos++;
       }
-      hasRelationTmp.emplace_back();
       while (i < entityHasRelation.size() &&
              entityHasRelation[i][0] == current) {
         hasRelationTmp.back().push_back(entityHasRelation[i][1]);
@@ -675,8 +756,6 @@ void Index::createPatterns(const string& fileName, const ExtVec& vec,
     }
   }
   hasRelation.build(hasRelationTmp);
-
-  LOG(INFO) << "Done creating patterns file." << std::endl;
 }
 
 // _____________________________________________________________________________
@@ -800,7 +879,8 @@ void Index::writeNonFunctionalRelation(
 }
 
 // _____________________________________________________________________________
-void Index::createFromOnDiskIndex(const string& onDiskBase, bool allPermutations) {
+void Index::createFromOnDiskIndex(const string& onDiskBase,
+                                  bool allPermutations) {
   setOnDiskBase(onDiskBase);
   _vocab.readFromFile(_onDiskBase + ".vocabulary",
                       _onDiskLiterals ? _onDiskBase + ".literals-index" : "");
@@ -865,78 +945,92 @@ void Index::createFromOnDiskIndex(const string& onDiskBase, bool allPermutations
               << std::endl;
   }
   if (_usePatterns) {
-    IndexMetaData _patternsMeta;
-    ad_utility::File _patternsFile;
+    // Store all data in the file
+    std::string patternsFilePath = _onDiskBase + ".index.patterns";
+    ad_utility::File patternsFile;
+    patternsFile.open(patternsFilePath.c_str(), "r");
+    AD_CHECK(patternsFile.isOpen());
+    off_t off = 0;
+    unsigned char firstByte;
+    patternsFile.read(&firstByte, sizeof(char), off);
+    off++;
+    uint32_t version;
+    patternsFile.read(&version, sizeof(uint32_t), off);
+    off += sizeof(uint32_t);
+    if (version != PATTERNS_FILE_VERSION || firstByte != 255) {
+      version = firstByte == 255 ? version : -1;
+      _usePatterns = false;
+      patternsFile.close();
+      std::ostringstream oss;
+      oss << "The patterns file " << patternsFilePath << " version of "
+          << version << " does not match the programs pattern file "
+          << "version of " << PATTERNS_FILE_VERSION << ". Rebuild the index"
+          << " or start the query engine without pattern support." << std::endl;
+      throw std::runtime_error(oss.str());
+    } else {
+      patternsFile.read(&_fullHasRelationMultiplicityEntities, sizeof(double),
+                        off);
+      off += sizeof(double);
+      patternsFile.read(&_fullHasRelationMultiplicityPredicates, sizeof(double),
+                        off);
+      off += sizeof(double);
+      patternsFile.read(&_fullHasRelationSize, sizeof(size_t), off);
+      off += sizeof(size_t);
 
-    // patterns
-    _patternsFile.open(string(_onDiskBase + ".index.patterns").c_str(), "r");
-    AD_CHECK(_patternsFile.isOpen());
-    metaTo = _patternsFile.getLastOffset(&metaFrom);
-    // A second offset is stored at the end of the file
-    metaTo -= sizeof(off_t);
-    buf = new unsigned char[metaTo - metaFrom];
-    _patternsFile.read(buf, static_cast<size_t>(metaTo - metaFrom), metaFrom);
-    _patternsMeta.createFromByteBuffer(buf);
-    delete[] buf;
-    // read the offset of the patterns beginnig
-    off_t patternsFrom;
-    _patternsFile.read(&patternsFrom, sizeof(off_t), metaTo);
-    _patterns.load(_patternsFile, patternsFrom);
-    // load the has pattern and has relation relations
-    const FullRelationMetaData& rmdP = _patternsMeta.getRmd(0)._rmdPairs;
-    const FullRelationMetaData& rmdR = _patternsMeta.getRmd(1)._rmdPairs;
-    WidthTwoList buffer;
+      // read the entity has patterns vector
+      size_t hasPatternSize;
+      patternsFile.read(&hasPatternSize, sizeof(size_t), off);
+      off += sizeof(size_t);
+      std::vector<array<Id, 2>> entityHasPattern(hasPatternSize);
+      patternsFile.read(entityHasPattern.data(),
+                        hasPatternSize * sizeof(Id) * 2, off);
+      off += hasPatternSize * sizeof(Id) * 2;
 
-    size_t numElems = std::max(rmdR.getNofElements(), rmdP.getNofElements());
-    buffer.resize(numElems);
-    // determine the highest entity id
-    size_t maxIdRel = 0, maxIdPat = 0;
-    if (rmdR.getNofElements() > 0) {
-      _patternsFile.read(&maxIdRel, sizeof(Id),
-                         rmdR._startFullIndex +
-                             ((rmdR.getNofElements() - 1) * 2 * sizeof(Id)));
-    }
-    if (rmdP.getNofElements() > 0) {
-      _patternsFile.read(&maxIdPat, sizeof(Id),
-                         rmdP._startFullIndex +
-                             ((rmdP.getNofElements() - 1) * 2 * sizeof(Id)));
-    }
+      // read the entity has relation vector
+      size_t hasRelationSize;
+      patternsFile.read(&hasRelationSize, sizeof(size_t), off);
+      off += sizeof(size_t);
+      std::vector<array<Id, 2>> entityHasRelation(hasRelationSize);
+      patternsFile.read(entityHasRelation.data(),
+                        hasRelationSize * sizeof(Id) * 2, off);
+      off += hasRelationSize * sizeof(Id) * 2;
 
-    _patternsFile.read(buffer.data(), rmdP.getNofElements() * 2 * sizeof(Id),
-                       rmdP._startFullIndex);
-    _hasPattern.resize(maxIdPat + 1);
-    size_t pos = 0;
-    for (size_t i = 0; i < rmdP.getNofElements(); i++) {
-      while (buffer[i][0] > pos) {
-        _hasPattern[pos] = NO_PATTERN;
-        pos++;
-      }
-      _hasPattern[pos] = buffer[i][1];
-      pos++;
-    }
+      // read the patterns
+      _patterns.load(patternsFile, off);
 
-    _patternsFile.read(buffer.data(), rmdR.getNofElements() * 2 * sizeof(Id),
-                       rmdR._startFullIndex);
-
-    pos = 0;
-    vector<vector<Id>> hasRelationTmp;
-
-    if (!(rmdR.getNofElements() == 1 && buffer[0][0] == ID_NO_VALUE)) {
-      for (size_t i = 0; i < rmdR.getNofElements(); i++) {
-        Id current = buffer[i][0];
-        while (current > pos) {
-          hasRelationTmp.emplace_back();
+      // create the has-relation and has-pattern lookup vectors
+      if (entityHasPattern.size() > 0) {
+        _hasPattern.resize(entityHasPattern.back()[0] + 1);
+        size_t pos = 0;
+        for (size_t i = 0; i < entityHasPattern.size(); i++) {
+          while (entityHasPattern[i][0] > pos) {
+            _hasPattern[pos] = NO_PATTERN;
+            pos++;
+          }
+          _hasPattern[pos] = entityHasPattern[i][1];
           pos++;
         }
-        hasRelationTmp.emplace_back();
-        while (i < rmdR.getNofElements() && buffer[i][0] == current) {
-          hasRelationTmp.back().push_back(buffer[i][1]);
-          i++;
-        }
-        pos++;
       }
+
+      vector<vector<Id>> hasRelationTmp;
+      if (entityHasRelation.size() > 0) {
+        hasRelationTmp.resize(entityHasRelation.back()[0] + 1);
+        size_t pos = 0;
+        for (size_t i = 0; i < entityHasRelation.size(); i++) {
+          Id current = entityHasRelation[i][0];
+          while (current > pos) {
+            pos++;
+          }
+          while (i < entityHasRelation.size() &&
+                 entityHasRelation[i][0] == current) {
+            hasRelationTmp.back().push_back(entityHasRelation[i][1]);
+            i++;
+          }
+          pos++;
+        }
+      }
+      _hasRelation.build(hasRelationTmp);
     }
-    _hasRelation.build(hasRelationTmp);
   }
 }
 
@@ -1264,6 +1358,19 @@ const CompactStringVector<Id, Id>& Index::getHasRelation() const {
 const CompactStringVector<size_t, Id>& Index::getPatterns() const {
   return _patterns;
 }
+
+// _____________________________________________________________________________
+double Index::getHasRelationMultiplicityEntities() const {
+  return _fullHasRelationMultiplicityEntities;
+}
+
+// _____________________________________________________________________________
+double Index::getHasRelationMultiplicityPredicates() const {
+  return _fullHasRelationMultiplicityPredicates;
+}
+
+// _____________________________________________________________________________
+size_t Index::getHasRelationFullSize() const { return _fullHasRelationSize; }
 
 // _____________________________________________________________________________
 string Index::idToString(Id id) const {

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -127,6 +127,23 @@ class Index {
   const vector<PatternID>& getHasPattern() const;
   const CompactStringVector<Id, Id>& getHasRelation() const;
   const CompactStringVector<size_t, Id>& getPatterns() const;
+  /**
+   * @return The multiplicity of the Entites column (0) of the full has-relation
+   *         relation after unrolling the patterns.
+   */
+  double getHasRelationMultiplicityEntities() const;
+
+  /**
+   * @return The multiplicity of the Predicates column (0) of the full
+   * has-relation relation after unrolling the patterns.
+   */
+  double getHasRelationMultiplicityPredicates() const;
+
+  /**
+   * @return The size of the full has-relation relation after unrolling the
+   *         patterns.
+   */
+  size_t getHasRelationFullSize() const;
 
   // Get multiplicities with given var (SCAN for 2 cols)
   vector<float> getPSOMultiplicities(const string& key) const;
@@ -293,10 +310,25 @@ class Index {
   mutable ad_utility::File _ospFile;
   mutable ad_utility::File _opsFile;
   mutable ad_utility::File _textIndexFile;
+
+  // Pattern trick data
+  static const uint32_t PATTERNS_FILE_VERSION;
   bool _usePatterns;
   size_t _maxNumPatterns;
+  double _fullHasRelationMultiplicityEntities;
+  double _fullHasRelationMultiplicityPredicates;
+  size_t _fullHasRelationSize;
+  /**
+   * @brief Maps pattern ids to sets of predicate ids.
+   */
   CompactStringVector<size_t, Id> _patterns;
+  /**
+   * @brief Maps entity ids to pattern ids.
+   */
   std::vector<PatternID> _hasPattern;
+  /**
+   * @brief Maps entity ids to sets of predicate ids
+   */
   CompactStringVector<Id, Id> _hasRelation;
 
   size_t passTsvFileForVocabulary(const string& tsvFile);
@@ -334,6 +366,9 @@ class Index {
                              CompactStringVector<Id, Id>& hasRelation,
                              std::vector<PatternID>& hasPattern,
                              CompactStringVector<size_t, Id>& patterns,
+                             double& fullHasRelationMultiplicityEntities,
+                             double& fullHasRelationMultiplicityPredicates,
+                             size_t& fullHasRelationSize,
                              size_t maxNumPatterns);
 
   void createTextIndex(const string& filename, const TextVec& vec);

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -11,11 +11,11 @@
 #include "../engine/ResultTable.h"
 #include "../global/Pattern.h"
 #include "../util/File.h"
+#include "./ConstantsIndexCreation.h"
 #include "./DocsDB.h"
 #include "./IndexMetaData.h"
 #include "./StxxlSortFunctors.h"
 #include "./TextMetaData.h"
-#include "./ConstantsIndexCreation.h"
 #include "./Vocabulary.h"
 
 using std::array;
@@ -41,19 +41,18 @@ class Index {
   // Creates an index from a TSV file.
   // Will write vocabulary and on-disk index data.
   // Also ends up with fully functional in-memory metadata.
-  void createFromTsvFile(const string& tsvFile,
-                         bool allPermutations);
+  void createFromTsvFile(const string& tsvFile, bool allPermutations);
 
   // Creates an index from a file in NTriples format.
   // Will write vocabulary and on-disk index data.
   // Also ends up with fully functional in-memory metadata.
-  void createFromNTriplesFile(const string& ntFile,
-                              bool allPermutations);
+  void createFromNTriplesFile(const string& ntFile, bool allPermutations);
 
   // Creates an index object from an on disk index
   // that has previously been constructed.
   // Read necessary meta data into memory and opens file handles.
-  void createFromOnDiskIndex(const string& onDiskBase, bool allPermutations = false);
+  void createFromOnDiskIndex(const string& onDiskBase,
+                             bool allPermutations = false);
 
   // Adds a text index to a fully initialized KB index.
   // Reads a context file and builds the index for the first time.
@@ -242,7 +241,7 @@ class Index {
   void setTextName(const string& name);
 
   void setUsePatterns(bool usePatterns);
-  
+
   void setOnDiskLiterals(bool onDiskLiterals);
 
   void setKeepTempFiles(bool keepTempFiles);

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -37,7 +37,7 @@ struct option options[] = {{"all-permutations", no_argument, NULL, 'a'},
                            {"text-index-name", required_argument, NULL, 'T'},
                            {"words-by-contexts", required_argument, NULL, 'w'},
                            {"add-text-index", no_argument, NULL, 'A'},
-			   {"keep-temporary-files", no_argument, NULL, 'k'},
+                           {"keep-temporary-files", no_argument, NULL, 'k'},
                            {NULL, 0, NULL, 0}};
 
 string getStxxlDiskFileName(const string& location, const string& tail) {
@@ -98,13 +98,13 @@ void printUsage(char* execName) {
   cout << "  " << std::setw(20) << "w, words-by-contexts" << std::setw(1)
        << "    "
        << "words-file to build text index from." << endl;
-  cout << "  " << std::setw(20) << "A, add-text-index" << std::setw(1)
-       << "    "
+  cout << "  " << std::setw(20) << "A, add-text-index" << std::setw(1) << "    "
        << "Add text index to already existing kb-index" << endl;
-  cout << "  " << std::setw(20) << "k, keep-temporary-files" << std::setw(1)
-       << "    "
-       << "Keep Temporary Files from IndexCreation (normally only for debugging)" 
-       << endl;
+  cout
+      << "  " << std::setw(20) << "k, keep-temporary-files" << std::setw(1)
+      << "    "
+      << "Keep Temporary Files from IndexCreation (normally only for debugging)"
+      << endl;
   cout.copyfmt(coutState);
 }
 
@@ -234,8 +234,8 @@ int main(int argc, char** argv) {
     index.setKbName(kbIndexName);
     index.setTextName(textIndexName);
     index.setUsePatterns(usePatterns);
-    // TODO(j.kalmbach): onDiskLiterals is now  redundant in all other functions, probably
-    // remove it, same for onDiskBase
+    // TODO(j.kalmbach): onDiskLiterals is now  redundant in all other
+    // functions, probably remove it, same for onDiskBase
     index.setOnDiskLiterals(onDiskLiterals);
     index.setOnDiskBase(baseName);
     index.setKeepTempFiles(keepTemporaryFiles);
@@ -245,11 +245,11 @@ int main(int argc, char** argv) {
       // for  text  index  creation)
 
       if (ntFile.size() > 0) {
-	index.createFromNTriplesFile(ntFile, allPermutations);
+        index.createFromNTriplesFile(ntFile, allPermutations);
       } else if (tsvFile.size() > 0) {
-	index.createFromTsvFile(tsvFile, allPermutations);
+        index.createFromTsvFile(tsvFile, allPermutations);
       } else {
-	index.createFromOnDiskIndex(baseName, allPermutations);
+        index.createFromOnDiskIndex(baseName, allPermutations);
       }
     }
 

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -54,7 +54,8 @@ void Vocabulary::writeToFile(const string& fileName) const {
 // _____________________________________________________________________________
 void Vocabulary::writeToBinaryFileForMerging(const string& fileName) const {
   LOG(INFO) << "Writing vocabulary to binary file " << fileName << "\n";
-  std::ofstream out(fileName.c_str(), std::ios_base::out | std::ios_base::binary);
+  std::ofstream out(fileName.c_str(),
+                    std::ios_base::out | std::ios_base::binary);
   AD_CHECK(out.is_open());
   for (size_t i = 0; i < _words.size(); ++i) {
     // 32 bits should be enough for len of string

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -153,7 +153,8 @@ class Vocabulary {
   google::sparse_hash_map<string, Id> asMap();
 
   void externalizeLiterals(const string& fileName);
-  void externalizeLiteralsFromTextFile(const string& textFileName, const string& outFileName) {
+  void externalizeLiteralsFromTextFile(const string& textFileName,
+                                       const string& outFileName) {
     _externalLiterals.buildFromTextFile(textFileName, outFileName);
   }
 

--- a/src/index/VocabularyGenerator.cpp
+++ b/src/index/VocabularyGenerator.cpp
@@ -3,26 +3,27 @@
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
 
 #include "./VocabularyGenerator.h"
-#include <unordered_set>
-#include <vector>
-#include <queue>
-#include <string>
-#include <utility>
 #include <fstream>
 #include <iostream>
+#include <queue>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
-#include "./ConstantsIndexCreation.h"
-#include "../util/Log.h"
 #include "../util/Exception.h"
+#include "../util/Log.h"
+#include "./ConstantsIndexCreation.h"
 
 class PairCompare {
  public:
-  bool operator()(const std::pair<std::string, size_t>& p1, const std::pair<std::string, size_t>& p2) {
-    return p1.first > p2.first;}
+  bool operator()(const std::pair<std::string, size_t>& p1,
+                  const std::pair<std::string, size_t>& p2) {
+    return p1.first > p2.first;
+  }
 };
 // ___________________________________________________________________
 void mergeVocabulary(const std::string& basename, size_t numFiles) {
-  
   std::vector<std::fstream> infiles;
   std::ofstream outfile(basename + ".vocabulary");
   AD_CHECK(outfile.is_open());
@@ -34,7 +35,8 @@ void mergeVocabulary(const std::string& basename, size_t numFiles) {
   std::priority_queue<pair_T, std::vector<pair_T>, PairCompare> queue;
 
   for (size_t i = 0; i < numFiles; i++) {
-    infiles.emplace_back(basename + PARTIAL_VOCAB_FILE_NAME + std::to_string(i), std::ios_base::in | std::ios_base::out);
+    infiles.emplace_back(basename + PARTIAL_VOCAB_FILE_NAME + std::to_string(i),
+                         std::ios_base::in | std::ios_base::out);
     AD_CHECK(infiles.back().is_open());
     endOfFile[i] = true;
 
@@ -46,7 +48,6 @@ void mergeVocabulary(const std::string& basename, size_t numFiles) {
       endOfFile[i] = false;
     }
   }
-
 
   std::string lastWritten = "";
   size_t totalWritten = 0;
@@ -68,7 +69,7 @@ void mergeVocabulary(const std::string& basename, size_t numFiles) {
 
       // according to the standard, flush() or seek() must be called before
       // switching from read to write. And this is indeed necessary for gcc to
-      // avoid nasty bugs. 
+      // avoid nasty bugs.
       // We seek to the current position to avoid them
       infiles[top.second].seekp(infiles[top.second].tellp());
       // write id to partial vocabulary
@@ -86,7 +87,9 @@ void mergeVocabulary(const std::string& basename, size_t numFiles) {
     }
 
     // add next word from the same infile to the priority queue
-    if (endOfFile[top.second]) { continue;} // file is exhausted, nothing to add
+    if (endOfFile[top.second]) {
+      continue;
+    }  // file is exhausted, nothing to add
 
     size_t i = top.second;
     endOfFile[top.second] = true;
@@ -103,7 +106,8 @@ void mergeVocabulary(const std::string& basename, size_t numFiles) {
 }
 
 // ____________________________________________________________________________________________
-google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(const string& partialFile) {
+google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(
+    const string& partialFile) {
   std::ifstream file(partialFile, std::ios_base::binary);
   AD_CHECK(file.is_open());
   google::sparse_hash_map<string, Id> vocabMap;
@@ -117,4 +121,3 @@ google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(const string&
   }
   return vocabMap;
 }
-

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -3,18 +3,18 @@
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
 #pragma once
 
-#include <string>
 #include <google/sparse_hash_map>
+#include <string>
 
-#include "../global/Id.h"
 #include "../global/Constants.h"
+#include "../global/Id.h"
 
 using std::string;
 // _______________________________________________________________
-// merge the partial vocabularies at  binary files 
+// merge the partial vocabularies at  binary files
 // basename + PARTIAL_VOCAB_FILE_NAME + to_string(i)
 // where 0 <= i < numFiles
-// Directly Writes .vocabulary file at basename (no more need to pass 
+// Directly Writes .vocabulary file at basename (no more need to pass
 // through Vocabulary class
 // Writes file "externalTextFile" which can be used to directly write external
 // Literals
@@ -22,4 +22,5 @@ void mergeVocabulary(const std::string& basename, size_t numFiles);
 
 // __________________________________________________________________________________________
 // read the words and indices from the file and create hash map from it.
-google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(const string& partialFile);
+google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(
+    const string& partialFile);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,8 +53,10 @@ add_executable(GroupByTest GroupByTest.cpp)
 target_link_libraries(GroupByTest gtest_main engine -pthread)
 
 add_executable(VocabularyGeneratorTest VocabularyGeneratorTest.cpp)
-target_link_libraries(VocabularyGeneratorTest gtest_main index 
-                      -pthread)
+target_link_libraries(VocabularyGeneratorTest gtest_main index -pthread)
+
+add_executable(HasRelationScanTest HasRelationScanTest.cpp)
+target_link_libraries(HasRelationScanTest gtest_main engine -pthread)
 
 add_library(tests
             SparqlParserTest
@@ -74,4 +76,5 @@ add_library(tests
             SparsehashTest
             GroupByTest
             VocabularyGeneratorTest
-)
+            HasRelationScanTest
+            )

--- a/test/HasRelationScanTest.cpp
+++ b/test/HasRelationScanTest.cpp
@@ -147,7 +147,7 @@ TEST(HasRelationScan, fullScan) {
 
   // Query for all relations
   HasRelationScan::computeFullScan(&resultTable, hasPattern, hasRelation,
-                                   patterns);
+                                   patterns, 16);
   std::vector<array<Id, 2>> result =
       *static_cast<vector<array<Id, 2>>*>(resultTable._fixedSizeData);
 

--- a/test/HasRelationScanTest.cpp
+++ b/test/HasRelationScanTest.cpp
@@ -1,0 +1,269 @@
+// Copyright 2018, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <cstdio>
+#include "../src/engine/HasRelationScan.h"
+
+// used to test HasRelationScan with a subtree
+class DummyOperation : public Operation {
+ public:
+  DummyOperation(QueryExecutionContext* ctx) : Operation(ctx) {}
+  virtual void computeResult(ResultTable* result) const {
+    result->_nofColumns = 2;
+    result->_resultTypes.push_back(ResultTable::ResultType::KB);
+    result->_resultTypes.push_back(ResultTable::ResultType::KB);
+    result->_fixedSizeData = new vector<array<Id, 2>>();
+    for (size_t i = 0; i < 10; i++) {
+      static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData)
+          ->push_back({{10 - i, 2 * i}});
+    }
+    result->finish();
+  }
+
+  virtual string asString(size_t indent = 0) const {
+    (void)indent;
+    return "dummy";
+  }
+
+  virtual size_t getResultWidth() const { return 2; }
+
+  virtual size_t resultSortedOn() const { return 1; }
+
+  virtual void setTextLimit(size_t limit) { (void)limit; }
+
+  virtual size_t getCostEstimate() { return 10; }
+
+  virtual size_t getSizeEstimate() { return 10; }
+
+  virtual float getMultiplicity(size_t col) {
+    (void)col;
+    return 1;
+  }
+
+  virtual bool knownEmptyResult() { return false; }
+};
+
+TEST(HasRelationScan, freeS) {
+  // Used to store the result.
+  ResultTable resultTable;
+  // Maps entities to their patterns. If an entity id is higher than the lists
+  // length the hasRelation relation is used instead.
+  vector<PatternID> hasPattern = {0, NO_PATTERN, NO_PATTERN, 1, 0};
+  // The has relation relation, which is used when an entity does not have a
+  // pattern
+  vector<vector<Id>> hasRelationSrc = {{},     {0, 3}, {0},    {}, {},
+                                       {0, 3}, {3, 4}, {2, 4}, {3}};
+  // Maps pattern ids to patterns
+  vector<vector<Id>> patternsSrc = {{0, 2, 3}, {1, 3, 4, 2, 0}};
+
+  // These are used to store the relations and patterns in contiguous blocks
+  // of memory.
+  CompactStringVector<Id, Id> hasRelation(hasRelationSrc);
+  CompactStringVector<size_t, Id> patterns(patternsSrc);
+
+  // Find all entities that are in a triple with predicate 3
+  HasRelationScan::computeFreeS(&resultTable, 3, hasPattern, hasRelation,
+                                patterns);
+  std::vector<array<Id, 1>> result =
+      *static_cast<vector<array<Id, 1>>*>(resultTable._fixedSizeData);
+
+  // the result set does not guarantee any sorting so we have to sort manually
+  std::sort(
+      result.begin(), result.end(),
+      [](const array<Id, 1>& a, const array<Id, 1>& b) { return a[0] < b[0]; });
+
+  // three entties with a pattern and four entities without one are in the
+  // relation
+  ASSERT_EQ(7u, result.size());
+  ASSERT_EQ(0u, result[0][0]);
+  ASSERT_EQ(1u, result[1][0]);
+  ASSERT_EQ(3u, result[2][0]);
+  ASSERT_EQ(4u, result[3][0]);
+  ASSERT_EQ(5u, result[4][0]);
+  ASSERT_EQ(6u, result[5][0]);
+  ASSERT_EQ(8u, result[6][0]);
+}
+
+TEST(HasRelationScan, freeO) {
+  // Used to store the result.
+  ResultTable resultTable;
+  // Maps entities to their patterns. If an entity id is higher than the lists
+  // length the hasRelation relation is used instead.
+  vector<PatternID> hasPattern = {0, NO_PATTERN, NO_PATTERN, 1, 0};
+  // The has relation relation, which is used when an entity does not have a
+  // pattern
+  vector<vector<Id>> hasRelationSrc = {{},     {0, 3}, {0},    {}, {},
+                                       {0, 3}, {3, 4}, {2, 4}, {3}};
+  // Maps pattern ids to patterns
+  vector<vector<Id>> patternsSrc = {{0, 2, 3}, {1, 3, 4, 2, 0}};
+
+  // These are used to store the relations and patterns in contiguous blocks
+  // of memory.
+  CompactStringVector<Id, Id> hasRelation(hasRelationSrc);
+  CompactStringVector<size_t, Id> patterns(patternsSrc);
+
+  // Find all predicates for entity 3 (pattern 1)
+  HasRelationScan::computeFreeO(&resultTable, 3, hasPattern, hasRelation,
+                                patterns);
+  std::vector<array<Id, 1>> result =
+      *static_cast<vector<array<Id, 1>>*>(resultTable._fixedSizeData);
+
+  ASSERT_EQ(5u, result.size());
+  ASSERT_EQ(1u, result[0][0]);
+  ASSERT_EQ(3u, result[1][0]);
+  ASSERT_EQ(4u, result[2][0]);
+  ASSERT_EQ(2u, result[3][0]);
+  ASSERT_EQ(0u, result[4][0]);
+
+  // Find all predicates for entity 6 (has-relation entry 6)
+  HasRelationScan::computeFreeO(&resultTable, 6, hasPattern, hasRelation,
+                                patterns);
+  result = *static_cast<vector<array<Id, 1>>*>(resultTable._fixedSizeData);
+
+  ASSERT_EQ(2u, result.size());
+  ASSERT_EQ(3u, result[0][0]);
+  ASSERT_EQ(4u, result[1][0]);
+}
+
+TEST(HasRelationScan, fullScan) {
+  // Used to store the result.
+  ResultTable resultTable;
+  // Maps entities to their patterns. If an entity id is higher than the lists
+  // length the hasRelation relation is used instead.
+  vector<PatternID> hasPattern = {0, NO_PATTERN, NO_PATTERN, 1, 0};
+  // The has relation relation, which is used when an entity does not have a
+  // pattern
+  vector<vector<Id>> hasRelationSrc = {{}, {0, 3}, {0}, {}, {}, {0, 3}};
+  // Maps pattern ids to patterns
+  vector<vector<Id>> patternsSrc = {{0, 2, 3}, {1, 3, 4, 2, 0}};
+
+  // These are used to store the relations and patterns in contiguous blocks
+  // of memory.
+  CompactStringVector<Id, Id> hasRelation(hasRelationSrc);
+  CompactStringVector<size_t, Id> patterns(patternsSrc);
+
+  // Query for all relations
+  HasRelationScan::computeFullScan(&resultTable, hasPattern, hasRelation,
+                                   patterns);
+  std::vector<array<Id, 2>> result =
+      *static_cast<vector<array<Id, 2>>*>(resultTable._fixedSizeData);
+
+  ASSERT_EQ(16u, result.size());
+
+  // check the entity ids
+  ASSERT_EQ(0u, result[0][0]);
+  ASSERT_EQ(0u, result[1][0]);
+  ASSERT_EQ(0u, result[2][0]);
+  ASSERT_EQ(1u, result[3][0]);
+  ASSERT_EQ(1u, result[4][0]);
+  ASSERT_EQ(2u, result[5][0]);
+  ASSERT_EQ(3u, result[6][0]);
+  ASSERT_EQ(3u, result[7][0]);
+  ASSERT_EQ(3u, result[8][0]);
+  ASSERT_EQ(3u, result[9][0]);
+  ASSERT_EQ(3u, result[10][0]);
+  ASSERT_EQ(4u, result[11][0]);
+  ASSERT_EQ(4u, result[12][0]);
+  ASSERT_EQ(4u, result[13][0]);
+  ASSERT_EQ(5u, result[14][0]);
+  ASSERT_EQ(5u, result[15][0]);
+
+  // check the predicate ids
+  ASSERT_EQ(0u, result[0][1]);
+  ASSERT_EQ(2u, result[1][1]);
+  ASSERT_EQ(3u, result[2][1]);
+  ASSERT_EQ(0u, result[3][1]);
+  ASSERT_EQ(3u, result[4][1]);
+  ASSERT_EQ(0u, result[5][1]);
+  ASSERT_EQ(1u, result[6][1]);
+  ASSERT_EQ(3u, result[7][1]);
+  ASSERT_EQ(4u, result[8][1]);
+  ASSERT_EQ(2u, result[9][1]);
+  ASSERT_EQ(0u, result[10][1]);
+  ASSERT_EQ(0u, result[11][1]);
+  ASSERT_EQ(2u, result[12][1]);
+  ASSERT_EQ(3u, result[13][1]);
+  ASSERT_EQ(0u, result[14][1]);
+  ASSERT_EQ(3u, result[15][1]);
+}
+
+TEST(HasRelationScan, subtreeS) {
+  // Used to store the result.
+  ResultTable resultTable;
+  // Maps entities to their patterns. If an entity id is higher than the lists
+  // length the hasRelation relation is used instead.
+  vector<PatternID> hasPattern = {0, NO_PATTERN, NO_PATTERN, 1, 0};
+  // The has relation relation, which is used when an entity does not have a
+  // pattern
+  vector<vector<Id>> hasRelationSrc = {{},     {0, 3}, {0},    {}, {},
+                                       {0, 3}, {3, 4}, {2, 4}, {3}};
+  // Maps pattern ids to patterns
+  vector<vector<Id>> patternsSrc = {{0, 2, 3}, {1, 3, 4, 2, 0}};
+
+  // These are used to store the relations and patterns in contiguous blocks
+  // of memory.
+  CompactStringVector<Id, Id> hasRelation(hasRelationSrc);
+  CompactStringVector<size_t, Id> patterns(patternsSrc);
+
+  Index index;
+  Engine engine;
+  QueryExecutionContext ctx(index, engine);
+
+  // create the subtree operation
+  std::shared_ptr<QueryExecutionTree> subtree =
+      std::make_shared<QueryExecutionTree>(&ctx);
+  std::shared_ptr<Operation> operation = std::make_shared<DummyOperation>(&ctx);
+
+  subtree->setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN,
+                        operation);
+
+  HasRelationScan::computeSubqueryS(&resultTable, subtree, 1, hasPattern,
+                                    hasRelation, patterns);
+
+  std::vector<array<Id, 3>> result =
+      *static_cast<vector<array<Id, 3>>*>(resultTable._fixedSizeData);
+
+  // the sum of the count of every second entities relations
+  ASSERT_EQ(10u, result.size());
+
+  // check for the first column
+
+  // check for the entity ids
+  ASSERT_EQ(10u, result[0][0]);
+  ASSERT_EQ(10u, result[1][0]);
+  ASSERT_EQ(10u, result[2][0]);
+  ASSERT_EQ(9u, result[3][0]);
+  ASSERT_EQ(8u, result[4][0]);
+  ASSERT_EQ(8u, result[5][0]);
+  ASSERT_EQ(8u, result[6][0]);
+  ASSERT_EQ(7u, result[7][0]);
+  ASSERT_EQ(7u, result[8][0]);
+  ASSERT_EQ(6u, result[9][0]);
+
+  // check for the entity ids
+  ASSERT_EQ(0u, result[0][1]);
+  ASSERT_EQ(0u, result[1][1]);
+  ASSERT_EQ(0u, result[2][1]);
+  ASSERT_EQ(2u, result[3][1]);
+  ASSERT_EQ(4u, result[4][1]);
+  ASSERT_EQ(4u, result[5][1]);
+  ASSERT_EQ(4u, result[6][1]);
+  ASSERT_EQ(6u, result[7][1]);
+  ASSERT_EQ(6u, result[8][1]);
+  ASSERT_EQ(8u, result[9][1]);
+
+  // check for the predicate ids
+  ASSERT_EQ(0u, result[0][2]);
+  ASSERT_EQ(2u, result[1][2]);
+  ASSERT_EQ(3u, result[2][2]);
+  ASSERT_EQ(0u, result[3][2]);
+  ASSERT_EQ(0u, result[4][2]);
+  ASSERT_EQ(2u, result[5][2]);
+  ASSERT_EQ(3u, result[6][2]);
+  ASSERT_EQ(3u, result[7][2]);
+  ASSERT_EQ(4u, result[8][2]);
+  ASSERT_EQ(3u, result[9][2]);
+}

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -385,6 +385,9 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     }
     ASSERT_EQ(0u, index.getHasPattern()[1]);
     ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
+
+    ASSERT_FLOAT_EQ(4.0 / 2, index.getHasRelationMultiplicityEntities());
+    ASSERT_FLOAT_EQ(4.0 / 3, index.getHasRelationMultiplicityPredicates());
   }
   {
     LOG(DEBUG) << "Testing createPatterns with existing index..." << std::endl;
@@ -405,6 +408,9 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     }
     ASSERT_EQ(0u, index.getHasPattern()[1]);
     ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
+
+    ASSERT_FLOAT_EQ(4.0 / 2, index.getHasRelationMultiplicityEntities());
+    ASSERT_FLOAT_EQ(4.0 / 3, index.getHasRelationMultiplicityPredicates());
   }
 }
 

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -1,19 +1,18 @@
 #include <gtest/gtest.h>
-#include <string>
-#include <fstream>
 #include <cstdlib>
-#include <iostream>
 #include <ctime>
+#include <fstream>
+#include <iostream>
+#include <string>
 
+#include "../src/global/Constants.h"
 #include "../src/index/ConstantsIndexCreation.h"
 #include "../src/index/VocabularyGenerator.h"
-#include "../src/global/Constants.h"
 
 // Test fixture that sets up the binary files vor partial vocabulary and
 // everything else connected with vocabulary merging.
 class MergeVocabularyTest : public ::testing::Test {
-protected:
-
+ protected:
   // path of the 2 partial Vocabularies that are used by mergeVocabulary
   std::string _path0;
   std::string _path1;
@@ -36,17 +35,18 @@ protected:
     _basePath = std::string("qleverVocTest-") + std::to_string(std::rand());
     // those names are required by mergeVocabulary
     _path0 = std::string(PARTIAL_VOCAB_FILE_NAME + std::to_string(0));
-    _path1 =  std::string(PARTIAL_VOCAB_FILE_NAME + std::to_string(1));
+    _path1 = std::string(PARTIAL_VOCAB_FILE_NAME + std::to_string(1));
     // those names can be random
     _pathExp0 = std::string(".partial-vocabulary-expected0");
-    _pathExp1  = std::string(".partial-vocabulary-expected1");
+    _pathExp1 = std::string(".partial-vocabulary-expected1");
 
     // create random subdirectory in /tmp
     std::string tempPath = "/tmp/";
     _basePath = tempPath + _basePath + "/";
     if (system(("mkdir -p " + _basePath).c_str())) {
       // system should return 0 on success
-      std::cerr << "Could not create subfolder of tmp for test. this might lead to test failures\n";
+      std::cerr << "Could not create subfolder of tmp for test. this might "
+                   "lead to test failures\n";
     }
 
     // make paths abolute under created tmp directory
@@ -54,21 +54,24 @@ protected:
     _path1 = _basePath + _path1;
     _pathExp0 = _basePath + _pathExp0;
     _pathExp1 = _basePath + _pathExp1;
-    _pathVocabExp  = _basePath + std::string(".vocabExp");
+    _pathVocabExp = _basePath + std::string(".vocabExp");
     _pathExternalVocabExp = _basePath + std::string("externalTextFileExp");
-
 
     // these will be the contents of partial vocabularies, second element of
     // pair is the correct Id which is expected from mergeVocabulary
-    std::vector<std::pair<std::string, size_t>> words1{{"ape", 0}, {"gorilla", 2}, {"monkey", 3}, {std::string{EXTERNALIZED_LITERALS_PREFIX} + "bla", 5}};
-    std::vector<std::pair<std::string, size_t>> words2{{"bear", 1}, {"monkey", 3}, {"zebra", 4}};
+    std::vector<std::pair<std::string, size_t>> words1{
+        {"ape", 0},
+        {"gorilla", 2},
+        {"monkey", 3},
+        {std::string{EXTERNALIZED_LITERALS_PREFIX} + "bla", 5}};
+    std::vector<std::pair<std::string, size_t>> words2{
+        {"bear", 1}, {"monkey", 3}, {"zebra", 4}};
 
     // write expected vocabulary files
     std::ofstream expVoc(_pathVocabExp);
     std::ofstream expExtVoc(_pathExternalVocabExp);
     expVoc << "ape\nbear\ngorilla\nmonkey\nzebra\n";
     expExtVoc << EXTERNALIZED_LITERALS_PREFIX << "bla\n";
-   
 
     // open files for partial Vocabularies
     auto mode = std::ios_base::out | std::ios_base::binary;
@@ -77,11 +80,14 @@ protected:
     std::ofstream partialExp0(_pathExp0, mode);
     std::ofstream partialExp1(_pathExp1, mode);
 
-    if (! partial0.is_open()) std::cerr << "could not open temp file at" << _path0 << '\n';
-    if (! partial1.is_open()) std::cerr << "could not open temp file at" << _path1 << '\n';
-    if (! partialExp0.is_open()) std::cerr << "could not open temp file at" << _pathExp0 << '\n';
-    if (! partialExp1.is_open()) std::cerr << "could not open temp file at" << _pathExp1 << '\n';
-
+    if (!partial0.is_open())
+      std::cerr << "could not open temp file at" << _path0 << '\n';
+    if (!partial1.is_open())
+      std::cerr << "could not open temp file at" << _path1 << '\n';
+    if (!partialExp0.is_open())
+      std::cerr << "could not open temp file at" << _pathExp0 << '\n';
+    if (!partialExp1.is_open())
+      std::cerr << "could not open temp file at" << _pathExp1 << '\n';
 
     // write first partial vocabulary
     for (const auto& w : words1) {
@@ -91,8 +97,8 @@ protected:
       std::tie(word, id) = w;
       uint32_t len = word.size();
       // write 4 Bytes of string length
-      partial0.write((char*) &len, sizeof(uint32_t));
-      partialExp0.write((char*) &len, sizeof(uint32_t));
+      partial0.write((char*)&len, sizeof(uint32_t));
+      partialExp0.write((char*)&len, sizeof(uint32_t));
 
       // write the word
       partial0.write(word.c_str(), len);
@@ -100,9 +106,9 @@ protected:
 
       // zero for the file on which mergeVocabulary will work (that's how
       // they are created in index.cpp
-      partial0.write((char*) &zeros, sizeof(size_t));
+      partial0.write((char*)&zeros, sizeof(size_t));
       // valid Id for the expected partial vocab
-      partialExp0.write((char*) &id, sizeof(size_t));
+      partialExp0.write((char*)&id, sizeof(size_t));
     }
 
     // write second partialVocabulary
@@ -112,14 +118,14 @@ protected:
       size_t zeros = 0;
       std::tie(word, id) = w;
       uint32_t len = word.size();
-      partial1.write((char*) &len, sizeof(uint32_t));
-      partialExp1.write((char*) &len, sizeof(uint32_t));
+      partial1.write((char*)&len, sizeof(uint32_t));
+      partialExp1.write((char*)&len, sizeof(uint32_t));
 
       partial1.write(word.c_str(), len);
       partialExp1.write(word.c_str(), len);
 
-      partial1.write((char*) &zeros, sizeof(size_t));
-      partialExp1.write((char*) &id, sizeof(size_t));
+      partial1.write((char*)&zeros, sizeof(size_t));
+      partialExp1.write((char*)&id, sizeof(size_t));
     }
   }
 
@@ -139,37 +145,38 @@ protected:
     auto& f1 = p1.second;
     auto& f2 = p2.second;
 
-    return (s1 && s2 && f1.size() == f2.size() && std::equal(f1.begin(), f1.end() , f2.begin()));
+    return (s1 && s2 && f1.size() == f2.size() &&
+            std::equal(f1.begin(), f1.end(), f2.begin()));
   }
 
   // read all bytes from a file (e.g. to check equality of small test files)
-  static std::pair<bool, std::vector<char>> readAllBytes(const std::string& filename)
-  {
-      using std::ifstream;
-      ifstream ifs(filename, std::ios::binary | std::ios::ate);
-      if (!ifs.is_open()) {
-	return std::make_pair(false, std::vector<char>());
-      }
-      ifstream::pos_type pos = ifs.tellg();
+  static std::pair<bool, std::vector<char>> readAllBytes(
+      const std::string& filename) {
+    using std::ifstream;
+    ifstream ifs(filename, std::ios::binary | std::ios::ate);
+    if (!ifs.is_open()) {
+      return std::make_pair(false, std::vector<char>());
+    }
+    ifstream::pos_type pos = ifs.tellg();
 
-      std::vector<char>  result(pos);
+    std::vector<char> result(pos);
 
-      ifs.seekg(0, std::ios::beg);
-      ifs.read(&result[0], pos);
+    ifs.seekg(0, std::ios::beg);
+    ifs.read(&result[0], pos);
 
-      return std::make_pair(true, result);
+    return std::make_pair(true, result);
   }
 };
 
 // Test for merge Vocabulary
 TEST_F(MergeVocabularyTest, bla) {
-
   // mergeVocabulary only gets name of directory and number of files.
-  mergeVocabulary(_basePath , 2);
+  mergeVocabulary(_basePath, 2);
   // Assert that partial vocabularies have the expected ids
   ASSERT_TRUE(areBinaryFilesEqual(_path0, _pathExp0));
   ASSERT_TRUE(areBinaryFilesEqual(_path1, _pathExp1));
   // check that (external) vocabulary has the right form.
   ASSERT_TRUE(areBinaryFilesEqual(_pathVocabExp, _basePath + ".vocabulary"));
-  ASSERT_TRUE(areBinaryFilesEqual(_pathExternalVocabExp, _basePath + EXTERNAL_LITS_TEXT_FILE_NAME));
+  ASSERT_TRUE(areBinaryFilesEqual(_pathExternalVocabExp,
+                                  _basePath + EXTERNAL_LITS_TEXT_FILE_NAME));
 }


### PR DESCRIPTION
ql:has-relation can now be used like any other predicate, with the pattern trick still being used to answer queries matching its specific requirements.

I also ran clang-format on the entire repository which changed a handful of files and added those in the last commit of this pr.