### PR TITLE
Don't force "en_US.utf8" locale

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -70,7 +70,7 @@ void printUsage(char* execName) {
 
 // Main function.
 int main(int argc, char** argv) {
-  char* locale = setlocale(LC_CTYPE, "en_US.utf8");
+  char* locale = setlocale(LC_CTYPE, "");
 
   std::locale loc;
   ad_utility::ReadableNumberFacet facet(1);

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -76,7 +76,7 @@ void printUsage(char* execName) {
 // Main function.
 int main(int argc, char** argv) {
   cout.sync_with_stdio(false);
-  char* locale = setlocale(LC_CTYPE, "en_US.utf8");
+  char* locale = setlocale(LC_CTYPE, "");
 
   // std::locale loc;
   // ad_utility::ReadableNumberFacet facet(1);

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv) {
             << __TIME__ << EMPH_OFF << std::endl
             << std::endl;
 
-  char* locale = setlocale(LC_CTYPE, "en_US.utf8");
+  char* locale = setlocale(LC_CTYPE, "");
   cout << "Set locale LC_CTYPE to: " << locale << endl;
 
   std::locale loc;

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -110,7 +110,7 @@ void printUsage(char* execName) {
 
 // Main function.
 int main(int argc, char** argv) {
-  char* locale = setlocale(LC_CTYPE, "en_US.utf8");
+  char* locale = setlocale(LC_CTYPE, "");
 
   std::locale loc;
   ad_utility::ReadableNumberFacet facet(1);

--- a/test/ContextFileParserTest.cpp
+++ b/test/ContextFileParserTest.cpp
@@ -8,7 +8,7 @@
 #include "../src/parser/ContextFileParser.h"
 
 TEST(ContextFileParserTest, getLineTest) {
-  char* locale = setlocale(LC_CTYPE, "en_US.utf8");
+  char* locale = setlocale(LC_CTYPE, "");
   std::cout << "Set locale LC_CTYPE to: " << locale << std::endl;
 
   std::fstream f("_testtmp.contexts.tsv", std::ios_base::out);

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -77,14 +77,14 @@ TEST(StringUtilsTest, endsWith) {
 }
 
 TEST(StringUtilsTest, getLowercaseUtf8) {
-  setlocale(LC_CTYPE, "en_US.utf8");
+  setlocale(LC_CTYPE, "");
   ASSERT_EQ("schindler's list", getLowercaseUtf8("Schindler's List"));
   ASSERT_EQ("#+-_foo__bar++", getLowercaseUtf8("#+-_foo__Bar++"));
   ASSERT_EQ(u8"fôéßaéé", getLowercaseUtf8(u8"FÔÉßaéÉ"));
 }
 
 TEST(StringUtilsTest, firstCharToUpperUtf8) {
-  setlocale(LC_CTYPE, "en_US.utf8");
+  setlocale(LC_CTYPE, "");
   ASSERT_EQ("Foo", firstCharToUpperUtf8("foo"));
   ASSERT_EQ("Foo", firstCharToUpperUtf8("Foo"));
   ASSERT_EQ("#foo", firstCharToUpperUtf8("#foo"));
@@ -213,7 +213,7 @@ TEST(StringUtilsTest, strip) {
 }
 
 TEST(StringUtilsTest, splitWs) {
-  setlocale(LC_CTYPE, "en_US.utf8");
+  setlocale(LC_CTYPE, "");
   string s1 = "  this\nis\t  \nit  ";
   string s2 = "\n   \t  \n \t";
   string s3 = "thisisit";


### PR DESCRIPTION
Instead of using `setlocale(LC_CTYPE, "en_US.utf8")` and thus forcing "en_US" we
now use `setlocale(LC_CTYPE, "")` which configures the program to use the default
locale's character set instead of defaulting to the uber-portable "C" or "POSIX"
locales.  (see "man 3 setlocale").

On a sane system this will use UTF-8, we do not care about insane systems.

The main advantage of this change is that it allows to use docker containers
without running "locale-gen" in the container thus making the image smaller
(~150 MB instead of ~220 MB using a Ubuntu 18.04 base)