### PR TITLE
Order by aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Status](https://travis-ci.org/ad-freiburg/QLever.svg?branch=master)](https://travis-ci.org/ad-freiburg/QLever)
 
 QLever (pronounced "clever") is a query engine for efficient combined search on a knowledge base and a text corpus, in which named entities from the knowledge base have been identified.
-The query language is SPARQL extended by three QLever-specific predicates `ql:contains-entity`, `ql:contains-word` and `ql:has-relation`. `ql:contains-entity` and `ql:contains-word` can express the occurrence of an entity or word (the object of the predicate) in a text record (the subject of the predicate). `ql:has-relation` can be used to efficiently count available predicates for a set of entities.
+The query language is SPARQL extended by three QLever-specific predicates `ql:contains-entity`, `ql:contains-word` and `ql:has-predicate`. `ql:contains-entity` and `ql:contains-word` can express the occurrence of an entity or word (the object of the predicate) in a text record (the subject of the predicate). `ql:has-predicate` can be used to efficiently count available predicates for a set of entities.
 Pure SPARQL is supported as well.
 
 With this, it is possible to answer queries like the following one for astronauts who walked on the moon:
@@ -202,7 +202,7 @@ If you want support for SPARQL queries with predicate variables  (perfectly norm
 
     ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt -a -w
 
-To generate a patterns file and include support for ql:has-relations:
+To generate a patterns file and include support for ql:has-predicates:
 
     ./IndexBuilderMain -i /path/to/myindex -n /path/to/input.nt --patterns
 
@@ -347,19 +347,18 @@ Text / Knowledge-base data can be nested in queries. This allows queries like on
 For now, each text-record variable is required to have a triple `ql:contains-word/entity WORD/URI`.
 Pure connections to variables (e.g. "Books with a description that mentions a plant.") are planned for the future.
 
-To obtain a list of available relations and their counts `ql:has-relation` can be used if the index was build with the `--patterns` option, and the server was started with the `--patterns` option:
+To obtain a list of available predicates and their counts `ql:has-predicate` can be used if the index was build with the `--patterns` option, and the server was started with the `--patterns` option:
 
     SELECT ?relations (COUNT(?relations) as ?count) WHERE {
       ?s <is-a> <Scientist> .
       ?t2 ql:contains-entity ?s .
       ?t2 ql:contains-word "manhattan project" .
-      ?s ql:has-relation ?relations .
+      ?s ql:has-predicate ?relations .
     }
     GROUP BY ?relations
     ORDER BY DESC(?count)
 
-As of yet using ql:has-relation in any other form of query (apart from adding more triples in the WHERE part) ist not supported.
-In particular ql:has-relation can not be used as a normal predicate to add all available relations to the current solution.
+`ql:has-predicate` can also be used as a normal predicate in an arbitrary query. 
 
 Group by is supported, but aggregate aliases may currently only be used within the SELECT part of the query:
 

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -85,34 +85,34 @@ queries:
     solutions:
       - type: no-text
         sparql: |
-          SELECT ?place ?count WHERE {
+          SELECT ?place (COUNT(?x) as ?count2) WHERE {
               ?x <is-a> <Scientist> .
               ?x <Place_of_birth> ?place .
           }
           GROUP BY ?place
           ORDER BY DESC((COUNT(?x) as ?count))
         checks:
-          - num_cols: 1
-          - num_rows: 1 
-          - selected: ["?place"]
-          - order_numeric: {"dir": "DESC", "var": "?count"}
+          - num_cols: 2
+          # The query returns to many rows, the current limit is 4096
+          # - num_rows: 5295 
+          - selected: ["?place", "?count2"]
+          - order_numeric: {"dir": "DESC", "var": "?count2"}
   - query: scientists-order-by-aggregate-avg
     solutions:
       - type: no-text
         sparql: |
-          SELECT ?profession ?avg WHERE  {
+          SELECT ?profession (AVG(?height) as ?avg2) WHERE  {
             ?x <is-a> <Scientist> .
             ?x <Profession> ?profession .
             ?x <Height> ?height .
           }
           GROUP BY ?profession
           ORDER BY ASC((AVG(?height) as ?avg))
-          LIMIT 1
         checks:
-          - num_cols: 1 
-          - num_rows: 1 
-          - selected: ["?profession"]
-          - order_numeric: {"dir": "ASC", "var": "?count"}
+          - num_cols: 2 
+          - num_rows: 209 
+          - selected: ["?profession", "?avg2"]
+          - order_numeric: {"dir": "ASC", "var": "?avg2"}
   - query: group-by-profession-average-height
     solutions:
       - type: no-text

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -132,7 +132,7 @@ queries:
         sparql: |
           SELECT ?r (COUNT(?r) as ?count) WHERE {
             ?a <is-a> <Scientist> .
-            ?a ql:has-relation ?r .
+            ?a ql:has-predicate ?r .
           }
           GROUP BY ?r
           ORDER BY DESC(?count)
@@ -142,12 +142,12 @@ queries:
           - selected: ["?r", "?count"]
           - contains_row: ["<Religion>", 1185]
           - order_numeric: {"dir": "DESC", "var": "?count"}
-  - query : has-relation-full
+  - query : has-predicate-full 
     solutions:
       - type: no-text
         sparql: |
           SELECT ?entity ?relation WHERE {
-            ?entity ql:has-relation ?relation .
+            ?entity ql:has-predicate ?relation .
           }
         checks:
           # The number o rows is greater than the current limit of 4096.
@@ -155,13 +155,13 @@ queries:
           - num_cols: 2
           - selected: ["?entity", "?relation"]
           - contains_row: ["<Alan_Fersht>", "<Leader_of>"]
-  - query : has-relation-subquery-subject
+  - query : has-predicate-subquery-subject
     solutions:
       - type: no-text
         sparql: |
           SELECT ?entity ?r WHERE {
             ?entity <is-a> <Profession> .
-            ?entity ql:has-relation ?r.
+            ?entity ql:has-predicate ?r.
           }
         checks:
           - num_rows: 760

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -81,7 +81,7 @@ queries:
           - selected: ["?count", "?place"]
           - contains_row: [280, "<New_York_City>"]
           - order_numeric: {"dir": "DESC", "var": "?count"}
-  - query: scientists-order-by-aggregate
+  - query: scientists-order-by-aggregate-count
     solutions:
       - type: no-text
         sparql: |
@@ -93,10 +93,26 @@ queries:
           ORDER BY DESC((COUNT(?x) as ?count))
         checks:
           - num_cols: 1
-          # -num_rows: 5295 # greater than current limit
+          - num_rows: 1 
           - selected: ["?place"]
-          - res: [["<United_States_of_America>"]] 
           - order_numeric: {"dir": "DESC", "var": "?count"}
+  - query: scientists-order-by-aggregate-avg
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?profession ?avg WHERE  {
+            ?x <is-a> <Scientist> .
+            ?x <Profession> ?profession .
+            ?x <Height> ?height .
+          }
+          GROUP BY ?profession
+          ORDER BY ASC((AVG(?height) as ?avg))
+          LIMIT 1
+        checks:
+          - num_cols: 1 
+          - num_rows: 1 
+          - selected: ["?profession"]
+          - order_numeric: {"dir": "ASC", "var": "?count"}
   - query: group-by-profession-average-height
     solutions:
       - type: no-text

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -81,6 +81,22 @@ queries:
           - selected: ["?count", "?place"]
           - contains_row: [280, "<New_York_City>"]
           - order_numeric: {"dir": "DESC", "var": "?count"}
+  - query: scientists-order-by-aggregate
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?place ?count WHERE {
+              ?x <is-a> <Scientist> .
+              ?x <Place_of_birth> ?place .
+          }
+          GROUP BY ?place
+          ORDER BY DESC((COUNT(?x) as ?count))
+        checks:
+          - num_cols: 1
+          # -num_rows: 5295 # greater than current limit
+          - selected: ["?place"]
+          - res: [["<United_States_of_America>"]] 
+          - order_numeric: {"dir": "DESC", "var": "?count"}
   - query: group-by-profession-average-height
     solutions:
       - type: no-text

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -57,7 +57,7 @@ void printUsage(char* execName) {
   cout << "  " << std::setw(20) << "p, port" << std::setw(1) << "    "
        << "The port on which to run the web interface." << endl;
   cout << "  " << std::setw(20) << "P, patterns" << std::setw(1) << "    "
-       << "Use relation patterns for fast ql:has-relation queries." << endl;
+       << "Use predicate patterns to enable ql:has-predicate queries." << endl;
   cout << "  " << std::setw(20) << "t, text" << std::setw(1) << "    "
        << "Enables the usage of text." << endl;
   cout << "  " << std::setw(20) << "j, worker-threads" << std::setw(1) << "    "

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -26,7 +26,7 @@ add_library(engine
         OptionalJoin.cpp OptionalJoin.h
         CountAvailablePredicates.cpp CountAvailablePredicates.h
         GroupBy.cpp GroupBy.h
-        HasRelationScan.cpp HasRelationScan.h
+        HasPredicateScan.cpp HasPredicateScan.h
 )
 
 target_link_libraries(engine index parser)

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -92,8 +92,8 @@ void CountAvailablePredicates::computeResult(ResultTable* result) const {
 
   const std::vector<PatternID>& hasPattern =
       _executionContext->getIndex().getHasPattern();
-  const CompactStringVector<Id, Id>& hasRelation =
-      _executionContext->getIndex().getHasRelation();
+  const CompactStringVector<Id, Id>& hasPredicate =
+      _executionContext->getIndex().getHasPredicate();
   const CompactStringVector<size_t, Id>& patterns =
       _executionContext->getIndex().getPatterns();
 
@@ -103,33 +103,33 @@ void CountAvailablePredicates::computeResult(ResultTable* result) const {
     Engine::computePatternTrick<vector<Id>>(
         &subresult->_varSizeData,
         static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData), hasPattern,
-        hasRelation, patterns, _subjectColumnIndex);
+        hasPredicate, patterns, _subjectColumnIndex);
   } else {
     if (subresult->_nofColumns == 1) {
       Engine::computePatternTrick<array<Id, 1>>(
           static_cast<vector<array<Id, 1>>*>(subresult->_fixedSizeData),
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-          hasPattern, hasRelation, patterns, _subjectColumnIndex);
+          hasPattern, hasPredicate, patterns, _subjectColumnIndex);
     } else if (subresult->_nofColumns == 2) {
       Engine::computePatternTrick<array<Id, 2>>(
           static_cast<vector<array<Id, 2>>*>(subresult->_fixedSizeData),
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-          hasPattern, hasRelation, patterns, _subjectColumnIndex);
+          hasPattern, hasPredicate, patterns, _subjectColumnIndex);
     } else if (subresult->_nofColumns == 3) {
       Engine::computePatternTrick<array<Id, 3>>(
           static_cast<vector<array<Id, 3>>*>(subresult->_fixedSizeData),
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-          hasPattern, hasRelation, patterns, _subjectColumnIndex);
+          hasPattern, hasPredicate, patterns, _subjectColumnIndex);
     } else if (subresult->_nofColumns == 4) {
       Engine::computePatternTrick<array<Id, 4>>(
           static_cast<vector<array<Id, 4>>*>(subresult->_fixedSizeData),
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-          hasPattern, hasRelation, patterns, _subjectColumnIndex);
+          hasPattern, hasPredicate, patterns, _subjectColumnIndex);
     } else if (subresult->_nofColumns == 5) {
       Engine::computePatternTrick<array<Id, 5>>(
           static_cast<vector<array<Id, 5>>*>(subresult->_fixedSizeData),
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-          hasPattern, hasRelation, patterns, _subjectColumnIndex);
+          hasPattern, hasPredicate, patterns, _subjectColumnIndex);
     }
   }
   result->finish();

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -646,7 +646,7 @@ class Engine {
    * @param result A table with two columns, one for predicate ids,
    *               one for counts
    * @param hasPattern A mapping from entity ids to pattern ids (or NO_PATTERN)
-   * @param hasRelation A mapping from entity ids to sets of relations
+   * @param hasPredicate A mapping from entity ids to sets of relations
    * @param patterns A mapping from pattern ids to patterns
    * @param subjectColumn The column containing the entities for which the
    *                      relations should be counted.
@@ -655,7 +655,7 @@ class Engine {
   static void computePatternTrick(
       const vector<A>* input, vector<array<Id, 2>>* result,
       const vector<PatternID>& hasPattern,
-      const CompactStringVector<Id, Id>& hasRelation,
+      const CompactStringVector<Id, Id>& hasPredicate,
       const CompactStringVector<size_t, Id>& patterns,
       const size_t subjectColumn) {
     ad_utility::HashMap<Id, size_t> predicateCounts;
@@ -672,11 +672,11 @@ class Engine {
       if (subject < hasPattern.size() && hasPattern[subject] != NO_PATTERN) {
         // The subject matches a pattern
         patternCounts[hasPattern[subject]]++;
-      } else if (subject < hasRelation.size()) {
+      } else if (subject < hasPredicate.size()) {
         // The subject does not match a pattern
         size_t numPredicates;
         Id* predicateData;
-        std::tie(predicateData, numPredicates) = hasRelation[subject];
+        std::tie(predicateData, numPredicates) = hasPredicate[subject];
         if (numPredicates > 0) {
           for (size_t i = 0; i < numPredicates; i++) {
             auto it = predicateCounts.find(predicateData[i]);

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -13,7 +13,7 @@
 #include "./Operation.h"
 #include "./QueryExecutionTree.h"
 
-class HasRelationScan : public Operation {
+class HasPredicateScan : public Operation {
  public:
   enum class ScanType {
     // Given a constant predicate, return all subjects
@@ -26,7 +26,7 @@ class HasRelationScan : public Operation {
     SUBQUERY_S
   };
 
-  HasRelationScan(QueryExecutionContext* qec, ScanType type);
+  HasPredicateScan(QueryExecutionContext* qec, ScanType type);
 
   virtual string asString(size_t indent = 0) const;
 
@@ -57,24 +57,24 @@ class HasRelationScan : public Operation {
   // These are made static and public mainly for easier testing
   static void computeFreeS(ResultTable* result, size_t objectId,
                            const std::vector<PatternID>& hasPattern,
-                           const CompactStringVector<Id, Id>& hasRelation,
+                           const CompactStringVector<Id, Id>& hasPredicate,
                            const CompactStringVector<size_t, Id>& patterns);
 
   static void computeFreeO(ResultTable* result, size_t subjectId,
                            const std::vector<PatternID>& hasPattern,
-                           const CompactStringVector<Id, Id>& hasRelation,
+                           const CompactStringVector<Id, Id>& hasPredicate,
                            const CompactStringVector<size_t, Id>& patterns);
 
   static void computeFullScan(ResultTable* result,
                               const std::vector<PatternID>& hasPattern,
-                              const CompactStringVector<Id, Id>& hasRelation,
+                              const CompactStringVector<Id, Id>& hasPredicate,
                               const CompactStringVector<size_t, Id>& patterns,
                               size_t resultSize);
 
   static void computeSubqueryS(
       ResultTable* result, const std::shared_ptr<QueryExecutionTree> _subtree,
       const size_t subtreeColIndex, const std::vector<PatternID>& hasPattern,
-      const CompactStringVector<Id, Id>& hasRelation,
+      const CompactStringVector<Id, Id>& hasPredicate,
       const CompactStringVector<size_t, Id>& patterns);
 
  private:

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -32,7 +32,7 @@ static const char CONTAINS_WORD_PREDICATE_NS[] = "ql:contains-word";
 static const char INTERNAL_TEXT_MATCH_PREDICATE[] =
     "<QLever-internal-function/text>";
 static const char HAS_RELATION_PREDIACTE[] =
-    "<QLever-internal-function/has-relation>";
+    "<QLever-internal-function/has-predicate>";
 
 static const char VALUE_PREFIX[] = ":v:";
 static const char VALUE_DATE_PREFIX[] = ":v:date:";

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -124,25 +124,25 @@ class Index {
   void scanOSP(Id object, WidthTwoList* result) const;
 
   const vector<PatternID>& getHasPattern() const;
-  const CompactStringVector<Id, Id>& getHasRelation() const;
+  const CompactStringVector<Id, Id>& getHasPredicate() const;
   const CompactStringVector<size_t, Id>& getPatterns() const;
   /**
    * @return The multiplicity of the Entites column (0) of the full has-relation
    *         relation after unrolling the patterns.
    */
-  double getHasRelationMultiplicityEntities() const;
+  double getHasPredicateMultiplicityEntities() const;
 
   /**
    * @return The multiplicity of the Predicates column (0) of the full
    * has-relation relation after unrolling the patterns.
    */
-  double getHasRelationMultiplicityPredicates() const;
+  double getHasPredicateMultiplicityPredicates() const;
 
   /**
    * @return The size of the full has-relation relation after unrolling the
    *         patterns.
    */
-  size_t getHasRelationFullSize() const;
+  size_t getHasPredicateFullSize() const;
 
   // Get multiplicities with given var (SCAN for 2 cols)
   vector<float> getPSOMultiplicities(const string& key) const;
@@ -314,9 +314,9 @@ class Index {
   static const uint32_t PATTERNS_FILE_VERSION;
   bool _usePatterns;
   size_t _maxNumPatterns;
-  double _fullHasRelationMultiplicityEntities;
-  double _fullHasRelationMultiplicityPredicates;
-  size_t _fullHasRelationSize;
+  double _fullHasPredicateMultiplicityEntities;
+  double _fullHasPredicateMultiplicityPredicates;
+  size_t _fullHasPredicateSize;
   /**
    * @brief Maps pattern ids to sets of predicate ids.
    */
@@ -328,7 +328,7 @@ class Index {
   /**
    * @brief Maps entity ids to sets of predicate ids
    */
-  CompactStringVector<Id, Id> _hasRelation;
+  CompactStringVector<Id, Id> _hasPredicate;
 
   size_t passTsvFileForVocabulary(const string& tsvFile);
 
@@ -362,12 +362,12 @@ class Index {
    * @param vec The vectors of triples in spo order.
    */
   static void createPatterns(const string& fileName, const ExtVec& vec,
-                             CompactStringVector<Id, Id>& hasRelation,
+                             CompactStringVector<Id, Id>& hasPredicate,
                              std::vector<PatternID>& hasPattern,
                              CompactStringVector<size_t, Id>& patterns,
-                             double& fullHasRelationMultiplicityEntities,
-                             double& fullHasRelationMultiplicityPredicates,
-                             size_t& fullHasRelationSize,
+                             double& fullHasPredicateMultiplicityEntities,
+                             double& fullHasPredicateMultiplicityPredicates,
+                             size_t& fullHasPredicateSize,
                              size_t maxNumPatterns);
 
   void createTextIndex(const string& filename, const TextVec& vec);
@@ -457,4 +457,11 @@ class Index {
   bool isLiteral(const string& object);
 
   bool shouldBeExternalized(const string& object);
+
+  /**
+   * @brief Throws an exception if no patterns are loaded. Should be called from
+   *        whithin any index method that returns data requiring the patterns
+   *        file.
+   */
+  void throwExceptionIfNoPatterns() const;
 };

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -86,7 +86,8 @@ void printUsage(char* execName) {
   cout << "  " << std::setw(20) << "n, ntriples-file" << std::setw(1) << "    "
        << "NT file to build KB index from." << endl;
   cout << "  " << std::setw(20) << "P, patterns" << std::setw(1) << "    "
-       << "Detect and store relation patterns for fast ql:has-relation queries."
+       << "Detect and store prediate patterns to enable ql:has-predicate "
+          "queries."
        << endl;
   cout << "  " << std::setw(20) << "t, tsv-file" << std::setw(1) << "    "
        << "TSV file to build KB index from." << endl;

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -179,67 +179,82 @@ void ParsedQuery::parseAliases() {
     const std::string& var = _selectedVariables[i];
     if (var[0] == '(') {
       std::string inner = var.substr(1, var.size() - 2);
-      std::string lowerInner = ad_utility::getLowercaseUtf8(inner);
-      if (ad_utility::startsWith(lowerInner, "count") ||
-          ad_utility::startsWith(lowerInner, "group_concat") ||
-          ad_utility::startsWith(lowerInner, "first") ||
-          ad_utility::startsWith(lowerInner, "last") ||
-          ad_utility::startsWith(lowerInner, "sample") ||
-          ad_utility::startsWith(lowerInner, "min") ||
-          ad_utility::startsWith(lowerInner, "max") ||
-          ad_utility::startsWith(lowerInner, "sum") ||
-          ad_utility::startsWith(lowerInner, "avg")) {
-        Alias a;
-        a._isAggregate = true;
-        size_t pos = lowerInner.find(" as ");
-        if (pos == std::string::npos) {
-          throw ParseException("Alias " + var +
-                               " is malformed: keyword 'as' is missing or not "
-                               "surrounded by spaces.");
-        }
-        // skip the leading space of the 'as'
-        pos++;
-        std::string newVarName = inner.substr(pos + 2, var.size() - pos - 2);
-        newVarName = ad_utility::strip(newVarName, " \t\n");
-        a._outVarName = newVarName;
-        a._function = inner;
 
-        // find the second opening bracket
-        pos = inner.find('(', 1);
-        pos++;
-        while (pos < inner.size() &&
-               ::std::isspace(static_cast<unsigned char>(inner[pos]))) {
-          pos++;
-        }
-        if (lowerInner.compare(pos, 8, "distinct") == 0) {
-          // skip the distinct and any space after it
-          pos += 8;
-          while (pos < inner.size() &&
-                 ::std::isspace(static_cast<unsigned char>(inner[pos]))) {
-            pos++;
-          }
-        }
-        size_t start = pos;
-        while (pos < inner.size() &&
-               !::std::isspace(static_cast<unsigned char>(inner[pos]))) {
-          pos++;
-        }
-        if (pos == start || pos >= inner.size()) {
-          throw ParseException(
-              "Alias " + var +
-              " is malformed: no input variable given (e.g. COUNT(?a))");
-        }
-
-        a._inVarName = inner.substr(start, pos - start - 1);
-        _aliases.push_back(a);
-        // Replace the variable in the selected variables array with the aliased
-        // name.
-        _selectedVariables[i] = newVarName;
-      } else {
-        throw ParseException("Unknown or malformed alias: " + var);
-      }
+      // Replace the variable in the selected variables array with the aliased
+      // name.
+      _selectedVariables[i] = parseAlias(inner);
     }
   }
+  for (size_t i = 0; i < _orderBy.size(); i++) {
+    OrderKey& key = _orderBy[i];
+    if (key._key[0] == '(') {
+      std::string inner = key._key.substr(1, key._key.size() - 2);
+      // Preserve the descending or ascending order but change the key name.
+      key._key = parseAlias(inner);
+    }
+  }
+}
+
+// _____________________________________________________________________________
+std::string ParsedQuery::parseAlias(const std::string& alias) {
+  std::string newVarName = "";
+  std::string lowerInner = ad_utility::getLowercaseUtf8(alias);
+  if (ad_utility::startsWith(lowerInner, "count") ||
+      ad_utility::startsWith(lowerInner, "group_concat") ||
+      ad_utility::startsWith(lowerInner, "first") ||
+      ad_utility::startsWith(lowerInner, "last") ||
+      ad_utility::startsWith(lowerInner, "sample") ||
+      ad_utility::startsWith(lowerInner, "min") ||
+      ad_utility::startsWith(lowerInner, "max") ||
+      ad_utility::startsWith(lowerInner, "sum") ||
+      ad_utility::startsWith(lowerInner, "avg")) {
+    Alias a;
+    a._isAggregate = true;
+    size_t pos = lowerInner.find(" as ");
+    if (pos == std::string::npos) {
+      throw ParseException("Alias (" + alias +
+                           ") is malformed: keyword 'as' is missing or not "
+                           "surrounded by spaces.");
+    }
+    // skip the leading space of the 'as'
+    pos++;
+    newVarName = alias.substr(pos + 2);
+    newVarName = ad_utility::strip(newVarName, " \t\n");
+    a._outVarName = newVarName;
+    a._function = alias;
+
+    // find the second opening bracket
+    pos = alias.find('(', 1);
+    pos++;
+    while (pos < alias.size() &&
+           ::std::isspace(static_cast<unsigned char>(alias[pos]))) {
+      pos++;
+    }
+    if (lowerInner.compare(pos, 8, "distinct") == 0) {
+      // skip the distinct and any space after it
+      pos += 8;
+      while (pos < alias.size() &&
+             ::std::isspace(static_cast<unsigned char>(alias[pos]))) {
+        pos++;
+      }
+    }
+    size_t start = pos;
+    while (pos < alias.size() &&
+           !::std::isspace(static_cast<unsigned char>(alias[pos]))) {
+      pos++;
+    }
+    if (pos == start || pos >= alias.size()) {
+      throw ParseException(
+          "Alias (" + alias +
+          ") is malformed: no input variable given (e.g. COUNT(?a))");
+    }
+
+    a._inVarName = alias.substr(start, pos - start - 1);
+    _aliases.push_back(a);
+  } else {
+    throw ParseException("Unknown or malformed alias: (" + alias + ")");
+  }
+  return newVarName;
 }
 
 // _____________________________________________________________________________

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -178,8 +178,8 @@ void ParsedQuery::parseAliases() {
   for (size_t i = 0; i < _selectedVariables.size(); i++) {
     const std::string& var = _selectedVariables[i];
     if (var[0] == '(') {
+      // remove the leading and trailing bracket
       std::string inner = var.substr(1, var.size() - 2);
-
       // Replace the variable in the selected variables array with the aliased
       // name.
       _selectedVariables[i] = parseAlias(inner);
@@ -188,6 +188,7 @@ void ParsedQuery::parseAliases() {
   for (size_t i = 0; i < _orderBy.size(); i++) {
     OrderKey& key = _orderBy[i];
     if (key._key[0] == '(') {
+      // remove the leading and trailing bracket
       std::string inner = key._key.substr(1, key._key.size() - 2);
       // Preserve the descending or ascending order but change the key name.
       key._key = parseAlias(inner);

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -185,7 +185,6 @@ void SparqlParser::parseWhere(const string& str, ParsedQuery& query,
     if (inner[k] == 'O' || inner[k] == 'o') {
       if (inner.substr(k, 8) == "OPTIONAL" ||
           inner.substr(k, 8) == "optional") {
-        LOG(DEBUG) << "Found optional part\n";
         // find opening and closing brackets of optional part
         size_t ob = inner.find('{', k);
         size_t cb = ob;
@@ -383,7 +382,9 @@ void SparqlParser::addWhereTriple(const string& str,
 // _____________________________________________________________________________
 void SparqlParser::parseSolutionModifiers(const string& str,
                                           ParsedQuery& query) {
-  auto tokens = ad_utility::splitWs(str);
+  // Split the string at any whitespace but ignoe whitespace inside brackets
+  // to allow for alias parsing.
+  auto tokens = ad_utility::splitWsWithEscape(str, '(', ')');
   for (size_t i = 0; i < tokens.size(); ++i) {
     if (tokens[i] == "ORDER" && i < tokens.size() - 2 &&
         tokens[i + 1] == "BY") {

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -111,7 +111,7 @@ inline vector<string> split(const string& orig, const char sep);
 inline vector<string> splitWs(const string& orig);
 
 //! Splits a string at any maximum length sequence of whitespace, ignoring
-//! whitespace withing an escaped sequence. Left char begins an escaped
+//! whitespace within an escaped sequence. Left char begins an escaped
 //! sequence right ends it. If left == right the char toggles an escaped
 //! sequence, otherwise the depth of opening chars is tracked and whitespace
 //! is ignored as long as that depth is larger than 0.
@@ -412,7 +412,6 @@ vector<string> splitWs(const string& orig) {
       pos++;
     }
     // avoid adding whitespace at the back of the string
-    // if (!::isspace(static_cast<unsigned char>(orig[orig.size() - 1]))) {
     if (start != orig.size()) {
       result.emplace_back(orig.substr(start));
     }
@@ -451,7 +450,6 @@ inline vector<string> splitWsWithEscape(const string& orig, const char left,
       pos++;
     }
     // avoid adding whitespace at the back of the string
-    // if (!::isspace(static_cast<unsigned char>(orig[orig.size() - 1]))) {
     if (start != orig.size()) {
       result.emplace_back(orig.substr(start));
     }

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -110,6 +110,14 @@ inline vector<string> split(const string& orig, const char sep);
 //! Splits a string at any maximum length sequence of whitespace
 inline vector<string> splitWs(const string& orig);
 
+//! Splits a string at any maximum length sequence of whitespace, ignoring
+//! whitespace withing an escaped sequence. Left char begins an escaped
+//! sequence right ends it. If left == right the char toggles an escaped
+//! sequence, otherwise the depth of opening chars is tracked and whitespace
+//! is ignored as long as that depth is larger than 0.
+inline vector<string> splitWsWithEscape(const string& orig, const char left,
+                                        const char right);
+
 //! Splits a string a any character inside the seps string.
 inline vector<string> splitAny(const string& orig, const char* seps);
 
@@ -400,6 +408,45 @@ vector<string> splitWs(const string& orig) {
           pos++;
         }
         start = pos;
+      }
+      pos++;
+    }
+    // avoid adding whitespace at the back of the string
+    // if (!::isspace(static_cast<unsigned char>(orig[orig.size() - 1]))) {
+    if (start != orig.size()) {
+      result.emplace_back(orig.substr(start));
+    }
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
+inline vector<string> splitWsWithEscape(const string& orig, const char left,
+                                        const char right) {
+  vector<string> result;
+  if (orig.size() > 0) {
+    size_t start = 0;
+    size_t pos = 0;
+    int depth = 0;
+    while (pos < orig.size()) {
+      if (depth <= 0 && ::isspace(static_cast<unsigned char>(orig[pos]))) {
+        if (start != pos) {
+          result.emplace_back(orig.substr(start, pos - start));
+        }
+        // skip any whitespace
+        while (pos < orig.size() &&
+               ::isspace(static_cast<unsigned char>(orig[pos]))) {
+          pos++;
+        }
+        start = pos;
+      }
+      if (orig[pos] == left) {
+        depth++;
+        if (left == right) {
+          depth %= 2;
+        }
+      } else if (orig[pos] == right) {
+        depth--;
       }
       pos++;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,8 +55,8 @@ target_link_libraries(GroupByTest gtest_main engine -pthread)
 add_executable(VocabularyGeneratorTest VocabularyGeneratorTest.cpp)
 target_link_libraries(VocabularyGeneratorTest gtest_main index -pthread)
 
-add_executable(HasRelationScanTest HasRelationScanTest.cpp)
-target_link_libraries(HasRelationScanTest gtest_main engine -pthread)
+add_executable(HasPredicateScanTest HasPredicateScanTest.cpp)
+target_link_libraries(HasPredicateScanTest gtest_main engine -pthread)
 
 add_library(tests
             SparqlParserTest
@@ -76,5 +76,5 @@ add_library(tests
             SparsehashTest
             GroupByTest
             VocabularyGeneratorTest
-            HasRelationScanTest
+            HasPredicateScanTest
             )

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -5,7 +5,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <cstdio>
-#include "../src/engine/HasRelationScan.h"
+#include "../src/engine/HasPredicateScan.h"
 
 // used to test HasRelationScan with a subtree
 class DummyOperation : public Operation {
@@ -46,7 +46,7 @@ class DummyOperation : public Operation {
   virtual bool knownEmptyResult() { return false; }
 };
 
-TEST(HasRelationScan, freeS) {
+TEST(HasPredicateScan, freeS) {
   // Used to store the result.
   ResultTable resultTable;
   // Maps entities to their patterns. If an entity id is higher than the lists
@@ -65,8 +65,8 @@ TEST(HasRelationScan, freeS) {
   CompactStringVector<size_t, Id> patterns(patternsSrc);
 
   // Find all entities that are in a triple with predicate 3
-  HasRelationScan::computeFreeS(&resultTable, 3, hasPattern, hasRelation,
-                                patterns);
+  HasPredicateScan::computeFreeS(&resultTable, 3, hasPattern, hasRelation,
+                                 patterns);
   std::vector<array<Id, 1>> result =
       *static_cast<vector<array<Id, 1>>*>(resultTable._fixedSizeData);
 
@@ -87,7 +87,7 @@ TEST(HasRelationScan, freeS) {
   ASSERT_EQ(8u, result[6][0]);
 }
 
-TEST(HasRelationScan, freeO) {
+TEST(HasPredicateScan, freeO) {
   // Used to store the result.
   ResultTable resultTable;
   // Maps entities to their patterns. If an entity id is higher than the lists
@@ -106,8 +106,8 @@ TEST(HasRelationScan, freeO) {
   CompactStringVector<size_t, Id> patterns(patternsSrc);
 
   // Find all predicates for entity 3 (pattern 1)
-  HasRelationScan::computeFreeO(&resultTable, 3, hasPattern, hasRelation,
-                                patterns);
+  HasPredicateScan::computeFreeO(&resultTable, 3, hasPattern, hasRelation,
+                                 patterns);
   std::vector<array<Id, 1>> result =
       *static_cast<vector<array<Id, 1>>*>(resultTable._fixedSizeData);
 
@@ -119,8 +119,8 @@ TEST(HasRelationScan, freeO) {
   ASSERT_EQ(0u, result[4][0]);
 
   // Find all predicates for entity 6 (has-relation entry 6)
-  HasRelationScan::computeFreeO(&resultTable, 6, hasPattern, hasRelation,
-                                patterns);
+  HasPredicateScan::computeFreeO(&resultTable, 6, hasPattern, hasRelation,
+                                 patterns);
   result = *static_cast<vector<array<Id, 1>>*>(resultTable._fixedSizeData);
 
   ASSERT_EQ(2u, result.size());
@@ -128,7 +128,7 @@ TEST(HasRelationScan, freeO) {
   ASSERT_EQ(4u, result[1][0]);
 }
 
-TEST(HasRelationScan, fullScan) {
+TEST(HasPredicateScan, fullScan) {
   // Used to store the result.
   ResultTable resultTable;
   // Maps entities to their patterns. If an entity id is higher than the lists
@@ -146,8 +146,8 @@ TEST(HasRelationScan, fullScan) {
   CompactStringVector<size_t, Id> patterns(patternsSrc);
 
   // Query for all relations
-  HasRelationScan::computeFullScan(&resultTable, hasPattern, hasRelation,
-                                   patterns, 16);
+  HasPredicateScan::computeFullScan(&resultTable, hasPattern, hasRelation,
+                                    patterns, 16);
   std::vector<array<Id, 2>> result =
       *static_cast<vector<array<Id, 2>>*>(resultTable._fixedSizeData);
 
@@ -190,7 +190,7 @@ TEST(HasRelationScan, fullScan) {
   ASSERT_EQ(3u, result[15][1]);
 }
 
-TEST(HasRelationScan, subtreeS) {
+TEST(HasPredicateScan, subtreeS) {
   // Used to store the result.
   ResultTable resultTable;
   // Maps entities to their patterns. If an entity id is higher than the lists
@@ -220,8 +220,8 @@ TEST(HasRelationScan, subtreeS) {
   subtree->setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN,
                         operation);
 
-  HasRelationScan::computeSubqueryS(&resultTable, subtree, 1, hasPattern,
-                                    hasRelation, patterns);
+  HasPredicateScan::computeSubqueryS(&resultTable, subtree, 1, hasPattern,
+                                     hasRelation, patterns);
 
   std::vector<array<Id, 3>> result =
       *static_cast<vector<array<Id, 3>>*>(resultTable._fixedSizeData);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -374,7 +374,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     index.createFromTsvFile("_testtmppatterns.tsv", false);
 
     ASSERT_EQ(2u, index.getHasPattern().size());
-    ASSERT_EQ(1u, index.getHasRelation().size());
+    ASSERT_EQ(1u, index.getHasPredicate().size());
     ASSERT_EQ(1u, index._patterns.size());
     Pattern p;
     p.push_back(3);
@@ -386,8 +386,8 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     ASSERT_EQ(0u, index.getHasPattern()[1]);
     ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
 
-    ASSERT_FLOAT_EQ(4.0 / 2, index.getHasRelationMultiplicityEntities());
-    ASSERT_FLOAT_EQ(4.0 / 3, index.getHasRelationMultiplicityPredicates());
+    ASSERT_FLOAT_EQ(4.0 / 2, index.getHasPredicateMultiplicityEntities());
+    ASSERT_FLOAT_EQ(4.0 / 3, index.getHasPredicateMultiplicityPredicates());
   }
   {
     LOG(DEBUG) << "Testing createPatterns with existing index..." << std::endl;
@@ -397,7 +397,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     index.createFromOnDiskIndex("_testindex");
 
     ASSERT_EQ(2u, index.getHasPattern().size());
-    ASSERT_EQ(1u, index.getHasRelation().size());
+    ASSERT_EQ(1u, index.getHasPredicate().size());
     ASSERT_EQ(1u, index._patterns.size());
     Pattern p;
     p.push_back(3);
@@ -409,8 +409,8 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     ASSERT_EQ(0u, index.getHasPattern()[1]);
     ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
 
-    ASSERT_FLOAT_EQ(4.0 / 2, index.getHasRelationMultiplicityEntities());
-    ASSERT_FLOAT_EQ(4.0 / 3, index.getHasRelationMultiplicityPredicates());
+    ASSERT_FLOAT_EQ(4.0 / 2, index.getHasPredicateMultiplicityEntities());
+    ASSERT_FLOAT_EQ(4.0 / 3, index.getHasPredicateMultiplicityPredicates());
   }
 }
 

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -430,6 +430,27 @@ TEST(ParserTest, testSolutionModifiers) {
   ASSERT_EQ("?r", pq._groupByVariables[0]);
   ASSERT_EQ("?count", pq._orderBy[0]._key);
   ASSERT_FALSE(pq._orderBy[0]._desc);
+
+  // Test for an alias in the order by statement
+  pq = SparqlParser::parse(
+      "SELECT DISTINCT ?x ?y WHERE \t {?x :myrel ?y}\n"
+      "ORDER BY DESC((COUNT(?x) as ?count)) LIMIT 10 OFFSET 15");
+  pq.expandPrefixes();
+  ASSERT_EQ(0u, pq._prefixes.size());
+  ASSERT_EQ(2u, pq._selectedVariables.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
+  ASSERT_EQ("10", pq._limit);
+  ASSERT_EQ("15", pq._offset);
+  ASSERT_EQ(1u, pq._orderBy.size());
+  ASSERT_EQ("?count", pq._orderBy[0]._key);
+  ASSERT_TRUE(pq._orderBy[0]._desc);
+  ASSERT_EQ(1u, pq._aliases.size());
+  ASSERT_TRUE(pq._aliases[0]._isAggregate);
+  ASSERT_EQ("?x", pq._aliases[0]._inVarName);
+  ASSERT_EQ("?count", pq._aliases[0]._outVarName);
+  ASSERT_EQ("COUNT(?x) as ?count", pq._aliases[0]._function);
+  ASSERT_TRUE(pq._distinct);
+  ASSERT_FALSE(pq._reduced);
 }
 
 TEST(ParserTest, testGroupByAndAlias) {

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -257,6 +257,18 @@ TEST(StringUtilsTest, splitWs) {
   ASSERT_EQ(1u, v7.size());
   ASSERT_EQ(s7, v7[0]);
 }
+
+TEST(StringUtilsTest, splitWsWithEscape) {
+  setlocale(LC_CTYPE, "");
+  string s1 = " a1 \t (this is() one) two (\t\na)()";
+  auto v1 = splitWsWithEscape(s1, '(', ')');
+  ASSERT_EQ(4u, v1.size());
+  ASSERT_EQ("a1", v1[0]);
+  ASSERT_EQ("(this is() one)", v1[1]);
+  ASSERT_EQ("two", v1[2]);
+  ASSERT_EQ("(\t\na)()", v1[3]);
+}
+
 }  // namespace ad_utility
 
 int main(int argc, char** argv) {

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -260,6 +260,7 @@ TEST(StringUtilsTest, splitWs) {
 
 TEST(StringUtilsTest, splitWsWithEscape) {
   setlocale(LC_CTYPE, "");
+  // Test for splitting with a different opening and closing character
   string s1 = " a1 \t (this is() one) two (\t\na)()";
   auto v1 = splitWsWithEscape(s1, '(', ')');
   ASSERT_EQ(4u, v1.size());
@@ -267,6 +268,16 @@ TEST(StringUtilsTest, splitWsWithEscape) {
   ASSERT_EQ("(this is() one)", v1[1]);
   ASSERT_EQ("two", v1[2]);
   ASSERT_EQ("(\t\na)()", v1[3]);
+
+  // Test for splitting with the same opening and closing character
+  string s2 = " a1 \t 'this is' ' two' three '\t\na'' a'";
+  auto v2 = splitWsWithEscape(s2, '\'', '\'');
+  ASSERT_EQ(5u, v2.size());
+  ASSERT_EQ("a1", v2[0]);
+  ASSERT_EQ("'this is'", v2[1]);
+  ASSERT_EQ("' two'", v2[2]);
+  ASSERT_EQ("three", v2[3]);
+  ASSERT_EQ("'\t\na'' a'", v2[4]);
 }
 
 }  // namespace ad_utility


### PR DESCRIPTION
This pr renames has-relation to has-predicate both when parsing sparql queries as well as in the code (e.g. in `HasRelationScan` which is now `HasPredicateScan`).
All index functions that require a loaded patterns file now throw an exception if no patterns file was loaded.
Aggregate aliases can now be used inside the ORDER BY clause without having to be selected, as the sparql standard demands.