### PR TITLE
E2E: Add order_numeric, and order_string checks

### DIFF
--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -81,6 +81,16 @@ def test_row(gold_row: List[Any],
             return False
     return True
 
+def quotes_inner(quoted: str) -> str:
+    """
+    For a string containing a quoted part returns the inner part
+    """
+    left_quote = quoted.find('"')
+    right_quote = quoted.rfind('"')
+    if right_quote < 0:
+        right_quote = len(quoted)
+    return quoted[left_quote+1:right_quote]
+
 def test_check(check_dict: Dict[str, Any], result: Dict[str, Any]) -> bool:
     """
     Test if the named result check holds. Returns True if it does
@@ -136,8 +146,8 @@ def test_check(check_dict: Dict[str, Any], result: Dict[str, Any]) -> bool:
                     previous = res[row_idx - 1][col_idx]
                     current = res[row_idx][col_idx]
                     if col_type == 'numeric':
-                        previous_value = float(previous)
-                        current_value = float(current)
+                        previous_value = float(quotes_inner(previous))
+                        current_value = float(quotes_inner(current))
                     elif col_type == 'string':
                         previous_value = previous
                         current_value = current

--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -127,6 +127,30 @@ def test_check(check_dict: Dict[str, Any], result: Dict[str, Any]) -> bool:
                 eprint("contains_row check failed:\n" +
                        "\tdid not find %r" % gold_row)
                 return False
+        elif check.startswith('order_'):
+            try:
+                direction, var = value['dir'], value['var']
+                col_type = check.split('_')[1]
+                col_idx = result['selected'].index(var)
+                for row_idx in range(1, len(res)):
+                    previous = res[row_idx - 1][col_idx]
+                    current = res[row_idx][col_idx]
+                    if col_type == 'numeric':
+                        previous_value = float(previous)
+                        current_value = float(current)
+                    elif col_type == 'string':
+                        previous_value = previous
+                        current_value = current
+                    if direction.lower() == 'asc' and previous_value > current_value:
+                        eprint('order_numeric check failed:\n\tnot ascending')
+                        return False
+                    if direction.lower() == 'desc' and previous_value < current_value:
+                        eprint('order_numeric check failed:\n\tnot descending')
+                        return False
+            except ValueError as ex:
+                eprint('order_numeric check failed:\n\t' + str(ex))
+                return False
+
 
 
     return True

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -18,11 +18,12 @@ queries:
             # null cells are ignored
           - contains_row: ["<Albert_Einstein>", null, null]
           - contains_row: ["<Luís_Lindley_Cintra>", null, null] # Test Unicode
+          - order_numeric: {"dir" : "DESC", "var": "SCORE(?t)"}
   - query: algo-star-female-scientists
     solutions:
       - type: text
         sparql: |
-          SELECT ?x WHERE {
+          SELECT ?x SCORE(?t) WHERE {
               ?x <is-a> <Scientist> .
               ?x <Gender> <Female> .
               ?t ql:contains-entity ?x .
@@ -30,10 +31,11 @@ queries:
           }
           ORDER BY DESC(SCORE(?t))
         checks:
-          - num_cols: 1
+          - num_cols: 2
           - num_rows: 11
-          - selected: ["?x"]
+          - selected: ["?x", "SCORE(?t)"]
           - contains_row: ["<Grete_Hermann>"]
+          - order_numeric: {"dir": "DESC", "var" : "SCORE(?t)"}
   - query: scientists-from-new-york
     solutions:
       - type: no-text
@@ -62,6 +64,7 @@ queries:
           - num_rows: 97
           - selected: ["?x", "?y"]
           - contains_row: ["<Albert_Einstein>", "<Mileva_Marić>"]
+          - order_string: {"dir": "ASC", "var": "?x"}
   - query: scientists-count-group-by-place-of-birth
     solutions:
       - type: no-text
@@ -77,6 +80,7 @@ queries:
           # -num_rows: 5295 # greater than current limit
           - selected: ["?count", "?place"]
           - contains_row: [280, "<New_York_City>"]
+          - order_numeric: {"dir": "DESC", "var": "?count"}
   - query: group-by-profession-average-height
     solutions:
       - type: no-text
@@ -92,6 +96,7 @@ queries:
           - num_rows: 312
           - selected: ["?avg", "?profession"]
           - contains_row: [null, "<Architect>"]
+          - order_numeric: {"dir": "DESC", "var": "?avg"}
   - query: group-by-gender-average-height
     solutions:
       - type: no-text
@@ -109,6 +114,7 @@ queries:
           - selected: ["?avg", "?gender"]
           # Float values are only compared to limited precision
           - res: [[1.8, "<Male>"], [1.7, "<Female>"]]
+          - order_numeric: {"dir": "DESC", "var": "?avg"}
   - query : pattern-trick
     solutions:
       - type: no-text
@@ -124,7 +130,8 @@ queries:
           - num_cols: 2
           - selected: ["?r", "?count"]
           - contains_row: ["<Religion>", 1185]
-  - query : has-relation-full 
+          - order_numeric: {"dir": "DESC", "var": "?count"}
+  - query : has-relation-full
     solutions:
       - type: no-text
         sparql: |
@@ -133,7 +140,7 @@ queries:
           }
         checks:
           # The number o rows is greater than the current limit of 4096.
-          # - num_rows: 168444 
+          # - num_rows: 168444
           - num_cols: 2
           - selected: ["?entity", "?relation"]
           - contains_row: ["<Alan_Fersht>", "<Leader_of>"]

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -97,6 +97,17 @@ queries:
           - selected: ["?avg", "?profession"]
           - contains_row: [null, "<Architect>"]
           - order_numeric: {"dir": "DESC", "var": "?avg"}
+  - query: person-order-by-height
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?person ?height WHERE {
+              ?person <is-a> <Person> .
+              ?person <Height> ?height .
+          }
+          ORDER BY DESC(?height)
+        checks:
+          - order_numeric: {"dir": "DESC", "var": "?height"}
   - query: group-by-gender-average-height
     solutions:
       - type: no-text


### PR DESCRIPTION
Adds simple checks for numeric and string order. Currently I just take the whole string ignoring the `"` and `"^^xxxx` but I think it's okay because all the values in an ordered column should all have the same format. What do you think?