### PR TITLE
Run unit tests during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM base as builder
 RUN apt-get update && apt-get install -y build-essential cmake libsparsehash-dev
 COPY . /app/
 WORKDIR /app/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc)
+RUN cmake -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc) && make test
 
 FROM base as runtime
 WORKDIR /app


### PR DESCRIPTION
This makes sure that the Docker Cloud auto build doesn't override the `:latest` Image if unit tests fail. It of course also works locally