### PR TITLE
C++17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
       - deadsnakes
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-5
-      - g++-5
+      - gcc-7
+      - g++-7
       - libsparsehash-dev
       - python3.6
       - python3-yaml
@@ -21,7 +21,7 @@ cache:
     - e2e_data/scientist-collection/
 
 env:
-  - CC=gcc-5 CXX=g++-5
+  - CC=gcc-7 CXX=g++-7
 
 before_script:
   - $CXX --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(QLever C CXX)
 # C/C++ Versions
 set (CMAKE_C_STANDARD 11)
 set (CMAKE_C_STANDARD_REQUIRED ON)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Check compiler versions:

--- a/src/index/DocsDB.cpp
+++ b/src/index/DocsDB.cpp
@@ -30,7 +30,6 @@ string DocsDB::getTextExcerpt(Id cid) const {
   assert(to > from);
   size_t nofBytes = static_cast<size_t>(to - from);
   string line(nofBytes, '\0');
-  // TODO in C++17 we'll get non-const pointer std::string::data() use it the
-  _dbFile.read(&line.front(), nofBytes, from);
+  _dbFile.read(line.data(), nofBytes, from);
   return line;
 }

--- a/src/index/ExternalVocabulary.cpp
+++ b/src/index/ExternalVocabulary.cpp
@@ -18,8 +18,7 @@ string ExternalVocabulary::operator[](Id id) const {
   assert(to > from);
   size_t nofBytes = static_cast<size_t>(to - from);
   string word(nofBytes, '\0');
-  // TODO in C++17 we'll get non-const pointer std::string::data() use it then
-  _file.read(&word.front(), nofBytes, from);
+  _file.read(word.data(), nofBytes, from);
   return word;
 }
 

--- a/src/util/LRUCache.h
+++ b/src/util/LRUCache.h
@@ -163,8 +163,11 @@ class LRUCache {
   size_t _capacity;
   EntryList _data;
   AccessMap _accessMap;
-  // TODO(schnelle): Once we switch to C++17
-  // this should be a shared_mutex
+  // TODO(schnelle): It would be nice to use std::shared_mutex to only exclude
+  // multiple writers.
+  // Sadly there is currently no easy way to upgrade a shared_lock to an
+  // exclusive lock. Thus using a shared_lock here would conflict with moving to
+  // the front of the queue in operator[]
   std::mutex _lock;
 };
 }  // namespace ad_utility


### PR DESCRIPTION
Now that Ubuntu 18.04.1 is out with a non-ancient GCC, we enable C++17.
We also need to update Travis' compiler to GCC 7 so as not to break builds there.

We also address some of the TODOs for stuff that's in C++14/17

We do keep our own IndexSequence.h instead of switching to std::integer
sequence for now as the former supports a leave-one-out feature. This
should likely be ported later.