### PR TITLE
Increase QET cache and STXXL memory size

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -5,11 +5,11 @@
 
 #include <string>
 
-static const int STXXL_MEMORY_TO_USE = 1024 * 1024 * 1024;
-static const int STXXL_DISK_SIZE_INDEX_BUILDER = 500 * 1000;
-static const int STXXL_DISK_SIZE_INDEX_TEST = 10;
+static const size_t STXXL_MEMORY_TO_USE = 1024L * 1024L * 1024L * 2L;
+static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 500 * 1000;
+static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 
-static const size_t NOF_SUBTREES_TO_CACHE = 100;
+static const size_t NOF_SUBTREES_TO_CACHE = 1000;
 static const size_t MAX_NOF_ROWS_IN_RESULT = 100000;
 static const size_t MIN_WORD_PREFIX_SIZE = 4;
 static const char PREFIX_CHAR = '*';


### PR DESCRIPTION
We're saving a lot of RAM with more efficient storage of the OPS/OSP
meta data and soon with vocabulary improvements. So we should put some
of that saved memory to good use.

Thus this commit increases the size of the query execution tree (QET)
cache ten fold. It also doubles the amount of memory STXXL may use.

When testing with Aqqu with a pure QLever backend this increases query
performance by at least an order of magnitude with minimal increase im
RAM use.

That said the 10-fold is currently quite arbitrary and likely still orders of magnitude less than what our virtuoso instance for Freebase has when combined with the varnish cache in front. Especially since we're caching just subtrees.