### PR TITLE
Run clang-format before we check in Travis

### DIFF
--- a/src/MetaDataConverterMain.cpp
+++ b/src/MetaDataConverterMain.cpp
@@ -2,14 +2,14 @@
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (johannes.kalmbach@gmail.com)
 //
-#include "./index/MetaDataConverter.h"
 #include <array>
 #include <iostream>
 #include "./global/Constants.h"
+#include "./index/MetaDataConverter.h"
 #include "./util/File.h"
 
 // _________________________________________________________
-int main (int argc, char** argv) {
+int main(int argc, char** argv) {
   if (argc != 2) {
     std::cerr << "Usage: ./MetaDataConverterMain <indexPrefix>\n";
     exit(1);

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -2,13 +2,13 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
-#include "./Index.h"
 #include <stxxl/algorithm>
 #include <tuple>
 #include <utility>
 #include "../parser/ContextFileParser.h"
 #include "../util/Simple8bCode.h"
 #include "./FTSAlgorithms.h"
+#include "./Index.h"
 
 // _____________________________________________________________________________
 void Index::addTextFromContextFile(const string& contextFile) {
@@ -469,10 +469,11 @@ void Index::createCodebooks(const vector<Index::Posting>& postings,
             [](const std::pair<Id, size_t>& a, const std::pair<Id, size_t>& b) {
               return a.second > b.second;
             });
-  std::sort(sfVec.begin(), sfVec.end(), [](const std::pair<Score, size_t>& a,
-                                           const std::pair<Score, size_t>& b) {
-    return a.second > b.second;
-  });
+  std::sort(
+      sfVec.begin(), sfVec.end(),
+      [](const std::pair<Score, size_t>& a, const std::pair<Score, size_t>& b) {
+        return a.second > b.second;
+      });
   for (size_t j = 0; j < wfVec.size(); ++j) {
     wordCodebook.push_back(wfVec[j].first);
     wordCodemap[wfVec[j].first] = j;
@@ -572,9 +573,8 @@ void Index::getWordPostingsForTerm(const string& term, vector<Id>& cids,
       entityTerm
           ? _textMeta.getBlockInfoByEntityId(idRange._first)
           : _textMeta.getBlockInfoByWordRange(idRange._first, idRange._last);
-  if (tbmd._cl.hasMultipleWords() &&
-      !(tbmd._firstWordId == idRange._first &&
-        tbmd._lastWordId == idRange._last)) {
+  if (tbmd._cl.hasMultipleWords() && !(tbmd._firstWordId == idRange._first &&
+                                       tbmd._lastWordId == idRange._last)) {
     vector<Id> blockCids;
     vector<Id> blockWids;
     vector<Score> blockScores;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -22,7 +22,6 @@ Index::Index()
     : _usePatterns(false),
       _maxNumPatterns(std::numeric_limits<PatternID>::max() - 2) {}
 
-
 // _____________________________________________________________________________________________
 template <class Parser>
 Index::ExtVec Index::createExtVecAndVocab(const string& filename) {
@@ -324,13 +323,13 @@ void Index::createPatterns(bool vecAlreadySorted, ExtVec* idTriples) {
 
 // _____________________________________________________________________________
 void Index::createPatternsImpl(const string& fileName, const ExtVec& vec,
-                           CompactStringVector<Id, Id>& hasPredicate,
-                           std::vector<PatternID>& hasPattern,
-                           CompactStringVector<size_t, Id>& patterns,
-                           double& fullHasPredicateMultiplicityEntities,
-                           double& fullHasPredicateMultiplicityPredicates,
-                           size_t& fullHasPredicateSize,
-                           size_t maxNumPatterns) {
+                               CompactStringVector<Id, Id>& hasPredicate,
+                               std::vector<PatternID>& hasPattern,
+                               CompactStringVector<size_t, Id>& patterns,
+                               double& fullHasPredicateMultiplicityEntities,
+                               double& fullHasPredicateMultiplicityPredicates,
+                               size_t& fullHasPredicateSize,
+                               size_t maxNumPatterns) {
   if (vec.size() == 0) {
     LOG(WARN) << "Attempt to write an empty index!" << std::endl;
     return;
@@ -831,11 +830,11 @@ void Index::createFromOnDiskIndex(const string& onDiskBase,
     LOG(INFO) << "Registered SOP permutation: " << _sopMeta.statistics()
               << std::endl;
     // OSP
-      _ospMeta.readFromFile(&_ospFile);
+    _ospMeta.readFromFile(&_ospFile);
     LOG(INFO) << "Registered OSP permutation: " << _ospMeta.statistics()
               << std::endl;
     // OPS
-      _opsMeta.readFromFile(&_opsFile);
+    _opsMeta.readFromFile(&_opsFile);
     LOG(INFO) << "Registered OPS permutation: " << _opsMeta.statistics()
               << std::endl;
   }

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -47,7 +47,7 @@ class IndexMetaData {
   // metaData implementations. Must be a compile time parameter because we have
   // to avoid instantation of member function set() for readonly MapTypes (e.g.
   // based on MmapVectorView
-  template<bool persistentRMD = false>
+  template <bool persistentRMD = false>
   void add(const FullRelationMetaData& rmd,
            const BlockBasedRelationMetaData& bRmd);
 
@@ -129,7 +129,7 @@ class IndexMetaData {
   // but this should not be an issue.
   template <class U>
   friend inline ad_utility::File& operator<<(ad_utility::File& f,
-                                      const IndexMetaData<U>& rmd);
+                                             const IndexMetaData<U>& rmd);
 
   size_t getNofBlocksForRelation(const Id relId) const;
 

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "./IndexMetaData.h"
 #include "../util/File.h"
 #include "./IndexMetaData.h"
 #include "./MetaDataHandler.h"
@@ -86,7 +85,7 @@ void IndexMetaData<MapType>::createFromByteBufferSparse(unsigned char* buf) {
     } else {
       add(rmd, BlockBasedRelationMetaData());
     }
-    }
+  }
 }
 
 // _____________________________________________________________________________

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -87,7 +87,7 @@ class Iterator {
 
   const FullRelationMetaData emptyMetaData = FullRelationMetaData::empty;
 };
-}
+}  // namespace VecWrapperImpl
 
 // _____________________________________________________________________
 template <class M>

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -34,15 +34,14 @@ class PermutationImpl {
   // sorted. Needed for the createPermutation function in the Index class
   // e.g. {1, 0, 2} for PsO
   const array<unsigned short, 3> _keyOrder;
-  };
+};
 
-  // instantiations for the 6 Permutations used in QLever
-  // They simplify the creation of permutations in the index class
-  const PermutationImpl<SortByPOS> Pos(SortByPOS(), "POS", ".pos", {1, 2, 0});
-  const PermutationImpl<SortByPSO> Pso(SortByPSO(), "PSO", ".pso", {1, 0, 2});
-  const PermutationImpl<SortBySOP> Sop(SortBySOP(), "SOP", ".sop", {0, 2, 1});
-  const PermutationImpl<SortBySPO> Spo(SortBySPO(), "SPO", ".spo", {0, 1, 2});
-  const PermutationImpl<SortByOPS> Ops(SortByOPS(), "OPS", ".ops", {2, 1, 0});
-  const PermutationImpl<SortByOSP> Osp(SortByOSP(), "OSP", ".osp", {2, 0, 1});
-}
-
+// instantiations for the 6 Permutations used in QLever
+// They simplify the creation of permutations in the index class
+const PermutationImpl<SortByPOS> Pos(SortByPOS(), "POS", ".pos", {1, 2, 0});
+const PermutationImpl<SortByPSO> Pso(SortByPSO(), "PSO", ".pso", {1, 0, 2});
+const PermutationImpl<SortBySOP> Sop(SortBySOP(), "SOP", ".sop", {0, 2, 1});
+const PermutationImpl<SortBySPO> Spo(SortBySPO(), "SPO", ".spo", {0, 1, 2});
+const PermutationImpl<SortByOPS> Ops(SortByOPS(), "OPS", ".ops", {2, 1, 0});
+const PermutationImpl<SortByOSP> Osp(SortByOSP(), "OSP", ".osp", {2, 0, 1});
+}  // namespace Permutation

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -30,7 +30,6 @@ class InvalidFileException : public std::exception {
   }
 };
 
-
 // _________________________________________________________________________
 class TruncateException : public std::exception {
  public:
@@ -65,7 +64,6 @@ class ReuseTag {};
 // Enum that specifies access patterns to this array
 enum class AccessPattern { None, Random, Sequential };
 
-
 // STL-like class which implements a dynamic array (similar to std::vector)
 // whose contents are stored persistently in a file on memory and are accessed
 // using memory mapping
@@ -79,18 +77,14 @@ class MmapVector {
   size_t size() const { return _size; }
 
   // __________________________________________________________________
-  size_t capacity() const {return _capacity; }
+  size_t capacity() const { return _capacity; }
 
   // standard iterator functions, each in a const and non-const version
   // begin
-  T* begin() {
-    return _ptr;
-  }
+  T* begin() { return _ptr; }
   const T* begin() const { return _ptr; }
   // end
-  T* end() {
-    return _ptr + _size;
-  }
+  T* end() { return _ptr + _size; }
   const T* end() const { return _ptr + _size; }
   // cbegin and cend
   const T* cbegin() const { return _ptr; }
@@ -163,7 +157,8 @@ class MmapVector {
 
   // create from given Iterator range
   // It must be an iterator type whose value Type must be convertible to T
-  // TODO<joka921>: use enable_if or constexpr if or concepts/ranges one they're out
+  // TODO<joka921>: use enable_if or constexpr if or concepts/ranges one they're
+  // out
   template <class It>
   void open(It begin, It end, const string& filename,
             AccessPattern pattern = AccessPattern::None);
@@ -210,7 +205,6 @@ class MmapVector {
     }
   }
 
-
   // truncate the underlying file to _bytesize and write meta data (_size,
   // _capacity, etc) for this
   // array to the end. new size of file will be _bytesize + sizeof(meta data)
@@ -251,7 +245,6 @@ class MmapVector {
   // advise the kernel to use a certain access pattern
   void advise(AccessPattern pattern);
 
-
   T* _ptr = nullptr;
   size_t _size = 0;
   size_t _capacity = 0;
@@ -268,7 +261,6 @@ class MmapVector {
 template <class T>
 class MmapVectorView : private MmapVector<T> {
  public:
-
   using const_iterator = const T*;
   using iterator = T*;
   // const access and iteration methods, directly map to the MmapVector-Variants
@@ -327,5 +319,5 @@ class MmapVectorView : private MmapVector<T> {
   // destructor
   ~MmapVectorView() { close(); }
 };
-}
+}  // namespace ad_utility
 #include "./MmapVectorImpl.h"

--- a/test/MmapVectorTest.cpp
+++ b/test/MmapVectorTest.cpp
@@ -2,11 +2,11 @@
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
 //
-#include "../src/util/MmapVector.h"
 #include <gtest/gtest.h>
 #include <unistd.h>
 #include <stdexcept>
 #include <vector>
+#include "../src/util/MmapVector.h"
 
 using ad_utility::MmapVector;
 using ad_utility::MmapVectorView;
@@ -27,7 +27,7 @@ TEST(MmapVectorTest, DefaultConstructor) {
 
 // ___________________________________________________________________
 TEST(MmapVectorTest, NewEmptyFileConstructor) {
-  MmapVector<int> v("_test.mmap", ad_utility::CreateTag()) ;
+  MmapVector<int> v("_test.mmap", ad_utility::CreateTag());
   ASSERT_EQ(size_t(0), v.size());
   ASSERT_NE(nullptr, v.begin());
   ASSERT_EQ(v.begin(), v.end());
@@ -91,8 +91,8 @@ TEST(MmapVectorTest, At) {
   ASSERT_EQ(v.begin() + s, v.end());
   for (int i = 0; i < 5000; i++) {
     ASSERT_EQ(v.at(i), 5000 - i);
-    }
-    ASSERT_THROW(v.at(5000), std::out_of_range);
+  }
+  ASSERT_THROW(v.at(5000), std::out_of_range);
 }
 
 // ___________________________________________________________________
@@ -291,7 +291,6 @@ TEST(MmapVectorTest, Reuse) {
   }
 }
 
-
 // ____________________________________________________________________
 TEST(MmapVectorTest, MoveConstructor) {
   // make sure that we get a unsignned 5000 to prevent compiler warnings
@@ -337,7 +336,6 @@ TEST(MmapVectorTest, MoveConstructor) {
     ASSERT_EQ(v2[i], i);
   }
 }
-
 
 // ____________________________________________________________________
 TEST(MmapVectorTest, MoveAssignment) {


### PR DESCRIPTION
Before we merge the `clang-format` code style check for Travis we need another round of formatting fixes because master is currently in violation.