### PR TITLE
Disambiguate non-existing optional value and ""

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -217,3 +217,36 @@ queries:
           - contains_row: ["<Named_after>"]
           - contains_row: ["<Influenced_By>"]
           - contains_row: ["<Production_staff>"]
+  - query : optional-spouse
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?x ?y WHERE {
+              ?x <is-a> <Scientist> .
+              OPTIONAL { ?x <Spouse_(or_domestic_partner)> ?y } .
+              FILTER (?x < <Ada_Lovelace>)
+          }
+        checks:
+          - num_rows: 126
+          - num_cols: 2
+          - selected: ["?x", "?y"]
+          - contains_row: ["<Aaron_Antonovsky>","<Helen_Antonovsky>"]
+          - contains_row: ["<Abraham_Zelmanov>", null]
+  - query : optional-spouse-group-concat
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?x (GROUP_CONCAT(?y; separator=";") AS ?partners) WHERE {
+              ?x <is-a> <Scientist> .
+              OPTIONAL {?x <Spouse_(or_domestic_partner)> ?y .}
+              FILTER (?x < <Ada_Lovelace>)
+          }
+          GROUP BY ?x
+        checks:
+          - num_rows: 124
+          - num_cols: 2
+          - selected: ["?x", "?partners"]
+          - contains_row: ["<Aaron_Antonovsky>","<Helen_Antonovsky>"]
+          - contains_row: ["<Abraham_Zelmanov>", ""]
+          - contains_row: ["<Abraham_Pais>","<Ida_Nicolaisen>;<Lila_Lee_Pais>"]
+          - contains_row: ["<Aafia_Siddiqui>","<Ammar_al-Baluchi>;<Amjad_Mohammed_Khan>"]

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -73,6 +73,44 @@ string Filter::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
+template <class RT>
+vector<RT>* Filter::computeFilter(vector<RT>* res, size_t l, size_t r,
+                                  shared_ptr<const ResultTable> subRes) const {
+  switch (_type) {
+    case SparqlFilter::EQ:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] == e[r]; }, res);
+      break;
+    case SparqlFilter::NE:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] != e[r]; }, res);
+      break;
+    case SparqlFilter::LT:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] < e[r]; }, res);
+      break;
+    case SparqlFilter::LE:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] <= e[r]; }, res);
+      break;
+    case SparqlFilter::GT:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] > e[r]; }, res);
+      break;
+    case SparqlFilter::GE:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] >= e[r]; }, res);
+      break;
+    case SparqlFilter::LANG_MATCHES:
+      AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+               "Language filtering with a dynamic right side has not yet "
+               "been implemented.");
+      break;
+  }
+  return res;
+}
+
+// _____________________________________________________________________________
 void Filter::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
@@ -90,263 +128,81 @@ void Filter::computeResult(ResultTable* result) const {
   switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == e[r]; },
-                             res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                   "Language filtering with a dynamic right side has not yet "
-                   "been implemented.");
-          break;
-      }
+      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
       break;
     }
     case 2: {
       typedef array<Id, 2> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == e[r]; },
-                             res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                   "Language filtering with a dynamic right side has not yet "
-                   "been implemented.");
-          break;
-      }
+      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
       break;
     }
     case 3: {
       typedef array<Id, 3> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == e[r]; },
-                             res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                   "Language filtering with a dynamic right side has not yet "
-                   "been implemented.");
-          break;
-      }
+      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
       break;
     }
     case 4: {
       typedef array<Id, 4> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == e[r]; },
-                             res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                   "Language filtering with a dynamic right side has not yet "
-                   "been implemented.");
-          break;
-      }
+      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
       break;
     }
     case 5: {
       typedef array<Id, 5> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == e[r]; },
-                             res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > e[r]; },
-                             res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= e[r]; },
-                             res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                   "Language filtering with a dynamic right side has not yet "
-                   "been implemented.");
-          break;
-      }
+      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
       break;
     }
-    default: {
-      typedef vector<Id> RT;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] == e[r]; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] != e[r]; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] < e[r]; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] <= e[r]; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] > e[r]; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] >= e[r]; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                   "Language filtering with a dynamic right side has not yet "
-                   "been implemented.");
-          break;
-      }
+    default:
+      computeFilter(&result->_varSizeData, l, r, subRes);
       break;
-    }
   }
   result->finish();
   LOG(DEBUG) << "Filter result computation done." << endl;
+}
+
+// _____________________________________________________________________________
+template <class RT>
+vector<RT>* Filter::computeFilterFixedValue(
+    vector<RT>* res, size_t l, Id r,
+    shared_ptr<const ResultTable> subRes) const {
+  switch (_type) {
+    case SparqlFilter::EQ:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] == r; }, res);
+      break;
+    case SparqlFilter::NE:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] != r; }, res);
+      break;
+    case SparqlFilter::LT:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] < r; }, res);
+      break;
+    case SparqlFilter::LE:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] <= r; }, res);
+      break;
+    case SparqlFilter::GT:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] > r; }, res);
+      break;
+    case SparqlFilter::GE:
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [l, r](const RT& e) { return e[l] >= r; }, res);
+      break;
+    case SparqlFilter::LANG_MATCHES:
+      getEngine().filter(
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          [this, l](const RT& e) {
+            std::optional<string> entity = getIndex().idToOptionalString(e[l]);
+            if (!entity) {
+              return true;
+            }
+            return ad_utility::endsWith(entity.value(), this->_rhsString);
+          },
+          res);
+      break;
+  }
+  return res;
 }
 
 // _____________________________________________________________________________
@@ -359,276 +215,36 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
   switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == r; }, res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != r; }, res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < r; }, res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= r; }, res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > r; }, res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= r; }, res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [this, &l](const RT& e) {
-                               std::optional<string> entity =
-                                   getIndex().idToOptionalString(e[l]);
-                               if (!entity) {
-                                 return true;
-                               }
-                               return ad_utility::endsWith(entity.value(),
-                                                           this->_rhsString);
-                             },
-                             res);
-          break;
-      }
+      result->_fixedSizeData =
+          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
       break;
     }
     case 2: {
       typedef array<Id, 2> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == r; }, res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != r; }, res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < r; }, res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= r; }, res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > r; }, res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= r; }, res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [this, &l](const RT& e) {
-                               std::optional<string> entity =
-                                   getIndex().idToOptionalString(e[l]);
-                               if (!entity) {
-                                 return true;
-                               }
-                               return ad_utility::endsWith(entity.value(),
-                                                           this->_rhsString);
-                             },
-                             res);
-          break;
-      }
+      result->_fixedSizeData =
+          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
       break;
     }
     case 3: {
       typedef array<Id, 3> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == r; }, res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != r; }, res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < r; }, res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= r; }, res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > r; }, res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= r; }, res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [this, &l](const RT& e) {
-                               std::optional<string> entity =
-                                   getIndex().idToOptionalString(e[l]);
-                               if (!entity) {
-                                 return true;
-                               }
-                               return ad_utility::endsWith(entity.value(),
-                                                           this->_rhsString);
-                             },
-                             res);
-          break;
-      }
+      result->_fixedSizeData =
+          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
       break;
     }
     case 4: {
       typedef array<Id, 4> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == r; }, res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != r; }, res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < r; }, res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= r; }, res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > r; }, res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= r; }, res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [this, &l](const RT& e) {
-                               std::optional<string> entity =
-                                   getIndex().idToOptionalString(e[l]);
-                               if (!entity) {
-                                 return true;
-                               }
-                               return ad_utility::endsWith(entity.value(),
-                                                           this->_rhsString);
-                             },
-                             res);
-          break;
-      }
+      result->_fixedSizeData =
+          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
       break;
     }
     case 5: {
       typedef array<Id, 5> RT;
-      auto res = new vector<RT>();
-      result->_fixedSizeData = res;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] == r; }, res);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] != r; }, res);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] < r; }, res);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] <= r; }, res);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] > r; }, res);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [&l, &r](const RT& e) { return e[l] >= r; }, res);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                             [this, &l](const RT& e) {
-                               std::optional<string> entity =
-                                   getIndex().idToOptionalString(e[l]);
-                               if (!entity) {
-                                 return true;
-                               }
-                               return ad_utility::endsWith(entity.value(),
-                                                           this->_rhsString);
-                             },
-                             res);
-          break;
-      }
+      result->_fixedSizeData =
+          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
       break;
     }
     default: {
-      typedef vector<Id> RT;
-      switch (_type) {
-        case SparqlFilter::EQ:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] == r; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::NE:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] != r; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::LT:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] < r; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::LE:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] <= r; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::GT:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] > r; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::GE:
-          getEngine().filter(subRes->_varSizeData,
-                             [&l, &r](const RT& e) { return e[l] >= r; },
-                             &result->_varSizeData);
-          break;
-        case SparqlFilter::LANG_MATCHES:
-          getEngine().filter(subRes->_varSizeData,
-                             [this, &l](const RT& e) {
-                               std::optional<string> entity =
-                                   getIndex().idToOptionalString(e[l]);
-                               if (!entity) {
-                                 return true;
-                               }
-                               return ad_utility::endsWith(entity.value(),
-                                                           this->_rhsString);
-                             },
-                             &result->_varSizeData);
-          break;
-      }
+      computeFilterFixedValue(&result->_varSizeData, l, r, subRes);
       break;
     }
   }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./Filter.h"
+#include <optional>
 #include <sstream>
 #include "./QueryExecutionTree.h"
 
@@ -388,9 +389,13 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LANG_MATCHES:
           getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                              [this, &l](const RT& e) {
-                               return ad_utility::endsWith(
-                                   getIndex().idToString(e[l]),
-                                   this->_rhsString);
+                               std::optional<string> entity =
+                                   getIndex().idToOptionalString(e[l]);
+                               if (!entity) {
+                                 return true;
+                               }
+                               return ad_utility::endsWith(entity.value(),
+                                                           this->_rhsString);
                              },
                              res);
           break;
@@ -429,9 +434,13 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LANG_MATCHES:
           getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                              [this, &l](const RT& e) {
-                               return ad_utility::endsWith(
-                                   getIndex().idToString(e[l]),
-                                   this->_rhsString);
+                               std::optional<string> entity =
+                                   getIndex().idToOptionalString(e[l]);
+                               if (!entity) {
+                                 return true;
+                               }
+                               return ad_utility::endsWith(entity.value(),
+                                                           this->_rhsString);
                              },
                              res);
           break;
@@ -470,9 +479,13 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LANG_MATCHES:
           getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                              [this, &l](const RT& e) {
-                               return ad_utility::endsWith(
-                                   getIndex().idToString(e[l]),
-                                   this->_rhsString);
+                               std::optional<string> entity =
+                                   getIndex().idToOptionalString(e[l]);
+                               if (!entity) {
+                                 return true;
+                               }
+                               return ad_utility::endsWith(entity.value(),
+                                                           this->_rhsString);
                              },
                              res);
           break;
@@ -511,9 +524,13 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LANG_MATCHES:
           getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                              [this, &l](const RT& e) {
-                               return ad_utility::endsWith(
-                                   getIndex().idToString(e[l]),
-                                   this->_rhsString);
+                               std::optional<string> entity =
+                                   getIndex().idToOptionalString(e[l]);
+                               if (!entity) {
+                                 return true;
+                               }
+                               return ad_utility::endsWith(entity.value(),
+                                                           this->_rhsString);
                              },
                              res);
           break;
@@ -552,9 +569,13 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LANG_MATCHES:
           getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                              [this, &l](const RT& e) {
-                               return ad_utility::endsWith(
-                                   getIndex().idToString(e[l]),
-                                   this->_rhsString);
+                               std::optional<string> entity =
+                                   getIndex().idToOptionalString(e[l]);
+                               if (!entity) {
+                                 return true;
+                               }
+                               return ad_utility::endsWith(entity.value(),
+                                                           this->_rhsString);
                              },
                              res);
           break;
@@ -597,9 +618,13 @@ void Filter::computeResultFixedValue(ResultTable* result) const {
         case SparqlFilter::LANG_MATCHES:
           getEngine().filter(subRes->_varSizeData,
                              [this, &l](const RT& e) {
-                               return ad_utility::endsWith(
-                                   getIndex().idToString(e[l]),
-                                   this->_rhsString);
+                               std::optional<string> entity =
+                                   getIndex().idToOptionalString(e[l]);
+                               if (!entity) {
+                                 return true;
+                               }
+                               return ad_utility::endsWith(entity.value(),
+                                                           this->_rhsString);
                              },
                              &result->_varSizeData);
           break;

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -76,7 +76,15 @@ class Filter : public Operation {
   Id _rhsId;
   std::string _rhsString;
 
-  virtual void computeResult(ResultTable* result) const;
+  template <class RT>
+  vector<RT>* computeFilter(vector<RT>* res, size_t l, size_t r,
+                            shared_ptr<const ResultTable> subRes) const;
+  void computeResult(ResultTable* result) const;
+
+  template <class RT>
+  vector<RT>* computeFilterFixedValue(
+      vector<RT>* res, size_t l, Id r,
+      shared_ptr<const ResultTable> subRes) const;
 
   void computeResultFixedValue(ResultTable* result) const;
 };

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -196,8 +196,10 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
             const auto it = distinctHashSet.find((*input)[i][a._inCol]);
             if (it == distinctHashSet.end()) {
               distinctHashSet.insert((*input)[i][a._inCol]);
+              // TODO(schnelle): What's the correct way to handle OPTIONAL here
               // load the string, parse it as an xsd::int or float
-              std::string entity = index.idToString((*input)[i][a._inCol]);
+              std::string entity =
+                  index.idToOptionalString((*input)[i][a._inCol]).value_or("");
               if (!ad_utility::startsWith(entity, VALUE_FLOAT_PREFIX)) {
                 res = std::numeric_limits<float>::quiet_NaN();
                 break;
@@ -213,7 +215,9 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
         } else {
           for (size_t i = blockStart; i <= blockEnd; i++) {
             // load the string, parse it as an xsd::int or float
-            std::string entity = index.idToString((*input)[i][a._inCol]);
+            // TODO(schnelle): What's the correct way to handle OPTIONAL here
+            std::string entity =
+                index.idToOptionalString((*input)[i][a._inCol]).value_or("");
             if (!ad_utility::startsWith(entity, VALUE_FLOAT_PREFIX)) {
               res = std::numeric_limits<float>::quiet_NaN();
               break;
@@ -320,19 +324,28 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
             const auto it = distinctHashSet.find((*input)[i][a._inCol]);
             if (it == distinctHashSet.end()) {
               distinctHashSet.insert((*input)[i][a._inCol]);
-              out << inTable->idToString((*input)[i][a._inCol]) << *delim;
+              // TODO(schnelle): What's the correct way to handle OPTIONAL here
+              out << inTable->idToOptionalString((*input)[i][a._inCol])
+                         .value_or("")
+                  << *delim;
             }
           }
           const auto it = distinctHashSet.find((*input)[blockEnd][a._inCol]);
           if (it == distinctHashSet.end()) {
-            out << inTable->idToString((*input)[blockEnd][a._inCol]);
+            // TODO(schnelle): What's the correct way to handle OPTIONAL here
+            out << inTable->idToOptionalString((*input)[blockEnd][a._inCol])
+                       .value_or("");
           }
           distinctHashSet.clear();
         } else {
           for (size_t i = blockStart; i + 1 <= blockEnd; i++) {
-            out << inTable->idToString((*input)[i][a._inCol]) << *delim;
+            // TODO(schnelle): What's the correct way to handle OPTIONAL here
+            out << inTable->idToOptionalString((*input)[i][a._inCol])
+                       .value_or("")
+                << *delim;
           }
-          out << inTable->idToString((*input)[blockEnd][a._inCol]);
+          out << inTable->idToOptionalString((*input)[blockEnd][a._inCol])
+                     .value_or("");
         }
       } else {
         if (a._distinct) {
@@ -340,7 +353,9 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
             const auto it = distinctHashSet.find((*input)[i][a._inCol]);
             if (it == distinctHashSet.end()) {
               distinctHashSet.insert((*input)[i][a._inCol]);
-              std::string entity = index.idToString((*input)[i][a._inCol]);
+              // TODO(schnelle): What's the correct way to handle OPTIONAL here
+              std::string entity =
+                  index.idToOptionalString((*input)[i][a._inCol]).value_or("");
               if (ad_utility::startsWith(entity, VALUE_PREFIX)) {
                 out << ad_utility::convertIndexWordToValueLiteral(entity)
                     << *delim;
@@ -351,7 +366,10 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
           }
           const auto it = distinctHashSet.find((*input)[blockEnd][a._inCol]);
           if (it == distinctHashSet.end()) {
-            std::string entity = index.idToString((*input)[blockEnd][a._inCol]);
+            // TODO(schnelle): What's the correct way to handle OPTIONAL here
+            std::string entity =
+                index.idToOptionalString((*input)[blockEnd][a._inCol])
+                    .value_or("");
             if (ad_utility::startsWith(entity, VALUE_PREFIX)) {
               out << ad_utility::convertIndexWordToValueLiteral(entity);
             } else {
@@ -361,7 +379,9 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
           distinctHashSet.clear();
         } else {
           for (size_t i = blockStart; i + 1 <= blockEnd; i++) {
-            std::string entity = index.idToString((*input)[i][a._inCol]);
+            // TODO(schnelle): What's the correct way to handle OPTIONAL here
+            std::string entity =
+                index.idToOptionalString((*input)[i][a._inCol]).value_or("");
             if (ad_utility::startsWith(entity, VALUE_PREFIX)) {
               out << ad_utility::convertIndexWordToValueLiteral(entity)
                   << *delim;
@@ -369,7 +389,10 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
               out << entity << *delim;
             }
           }
-          std::string entity = index.idToString((*input)[blockEnd][a._inCol]);
+          // TODO(schnelle): What's the correct way to handle OPTIONAL here
+          std::string entity =
+              index.idToOptionalString((*input)[blockEnd][a._inCol])
+                  .value_or("");
           if (ad_utility::startsWith(entity, VALUE_PREFIX)) {
             out << ad_utility::convertIndexWordToValueLiteral(entity);
           } else {
@@ -490,7 +513,9 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
             if (it == distinctHashSet.end()) {
               distinctHashSet.insert((*input)[i][a._inCol]);
               // load the string, parse it as an xsd::int or float
-              std::string entity = index.idToString((*input)[i][a._inCol]);
+              // TODO(schnelle): What's the correct way to handle OPTIONAL here
+              std::string entity =
+                  index.idToOptionalString((*input)[i][a._inCol]).value_or("");
               if (!ad_utility::startsWith(entity, VALUE_FLOAT_PREFIX)) {
                 res = std::numeric_limits<float>::quiet_NaN();
                 break;
@@ -504,7 +529,9 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
         } else {
           for (size_t i = blockStart; i <= blockEnd; i++) {
             // load the string, parse it as an xsd::int or float
-            std::string entity = index.idToString((*input)[i][a._inCol]);
+            // TODO(schnelle): What's the correct way to handle OPTIONAL here
+            std::string entity =
+                index.idToOptionalString((*input)[i][a._inCol]).value_or("");
             if (!ad_utility::startsWith(entity, VALUE_FLOAT_PREFIX)) {
               res = std::numeric_limits<float>::quiet_NaN();
               break;

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <vector>
 #include "../global/Id.h"
 #include "../util/Exception.h"
@@ -81,13 +82,13 @@ class ResultTable {
     _cond_var.wait(lk, [&] { return _status == ResultTable::FINISHED; });
   }
 
-  std::string idToString(Id id) const {
+  std::optional<std::string> idToOptionalString(Id id) const {
     if (id < _localVocab.size()) {
       return _localVocab[id];
     } else if (id == ID_NO_VALUE) {
-      return "";
+      return std::nullopt;
     }
-    return "ID OUT OF RANGE";
+    return std::nullopt;
   }
 
   size_t size() const;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -328,8 +328,7 @@ string Server::composeResponseJson(const ParsedQuery& query,
 
   std::ostringstream os;
   os << "{\n"
-     << "\"query\": \"" << ad_utility::escapeForJson(query._originalString)
-     << "\",\n"
+     << "\"query\": " << ad_utility::toJson(query._originalString) << ",\n"
      << "\"status\": \"OK\",\n"
      << "\"resultsize\": \"" << resultSize << "\",\n";
 
@@ -390,7 +389,7 @@ string Server::composeResponseJson(
   _requestProcessingTimer.stop();
 
   os << "{\n"
-     << "\"query\": \"" << ad_utility::escapeForJson(query) << "\",\n"
+     << "\"query\": " << ad_utility::toJson(query) << ",\n"
      << "\"status\": \"ERROR\",\n"
      << "\"resultsize\": \"0\",\n"
      << "\"time\": {\n"
@@ -399,9 +398,9 @@ string Server::composeResponseJson(
      << "ms\"\n"
      << "},\n";
 
-  string msg = ad_utility::escapeForJson(exception.getFullErrorMessage());
+  string msg = ad_utility::toJson(exception.getFullErrorMessage());
 
-  os << "\"exception\": \"" << msg << "\"\n"
+  os << "\"exception\": " << msg << "\n"
      << "}\n";
 
   return os.str();
@@ -414,7 +413,7 @@ string Server::composeResponseJson(const string& query,
   _requestProcessingTimer.stop();
 
   os << "{\n"
-     << "\"query\": \"" << ad_utility::escapeForJson(query) << "\",\n"
+     << "\"query\": " << ad_utility::toJson(query) << ",\n"
      << "\"status\": \"ERROR\",\n"
      << "\"resultsize\": \"0\",\n"
      << "\"time\": {\n"
@@ -422,9 +421,9 @@ string Server::composeResponseJson(const string& query,
      << "\"computeResult\": \"" << _requestProcessingTimer.msecs() << "ms\"\n"
      << "},\n";
 
-  string msg = ad_utility::escapeForJson(exception.what());
+  string msg = ad_utility::toJson(exception.what());
 
-  os << "\"exception\": \"" << msg << "\"\n"
+  os << "\"exception\": " << msg << "\n"
      << "}\n";
 
   return os.str();

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -388,10 +388,13 @@ void Index::calculateBlockBoundaries() {
   // A block boundary is always the last WordId in the block.
   // this way std::lower_bound will point to the correct bracket.
   for (size_t i = 0; i < _textVocab.size() - 1; ++i) {
-    if (_textVocab[i].size() < MIN_WORD_PREFIX_SIZE ||
-        (_textVocab[i + 1].size() < MIN_WORD_PREFIX_SIZE) ||
-        _textVocab[i].substr(0, MIN_WORD_PREFIX_SIZE) !=
-            _textVocab[i + 1].substr(0, MIN_WORD_PREFIX_SIZE)) {
+    // we need foo.value().get() because the vocab returns
+    // a std::optional<std::reference_wrapper<string>> and the "." currently
+    // doesn't implicitly convert to a true reference (unlike function calls)
+    if (_textVocab[i].value().get().size() < MIN_WORD_PREFIX_SIZE ||
+        (_textVocab[i + 1].value().get().size() < MIN_WORD_PREFIX_SIZE) ||
+        _textVocab[i].value().get().substr(0, MIN_WORD_PREFIX_SIZE) !=
+            _textVocab[i + 1].value().get().substr(0, MIN_WORD_PREFIX_SIZE)) {
       _blockBoundaries.push_back(i);
     }
   }
@@ -501,7 +504,9 @@ void Index::openTextFileHandle() {
 }
 
 // _____________________________________________________________________________
-const string& Index::wordIdToString(Id id) const { return _textVocab[id]; }
+const string& Index::wordIdToString(Id id) const {
+  return _textVocab[id].value();
+}
 
 // _____________________________________________________________________________
 void Index::getContextListForWords(const string& words,

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -5,6 +5,7 @@
 #include "./Index.h"
 #include <algorithm>
 #include <cmath>
+#include <optional>
 #include <stxxl/algorithm>
 #include <stxxl/map>
 #include <unordered_set>
@@ -1283,20 +1284,6 @@ double Index::getHasPredicateMultiplicityPredicates() const {
 size_t Index::getHasPredicateFullSize() const {
   throwExceptionIfNoPatterns();
   return _fullHasPredicateSize;
-}
-
-// _____________________________________________________________________________
-string Index::idToString(Id id) const {
-  if (id < _vocab.size()) {
-    return _vocab[id];
-  } else if (id == ID_NO_VALUE) {
-    return "";
-  } else {
-    id -= _vocab.size();
-    AD_CHECK(id < _vocab.getExternalVocab().size()) {
-      return _vocab.getExternalVocab()[id];
-    }
-  }
 }
 
 // _____________________________________________________________________________

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <stxxl/vector>
 #include <vector>
@@ -100,7 +101,9 @@ class Index {
   size_t sizeEstimate(const string& sub, const string& pred,
                       const string& obj) const;
 
-  string idToString(Id id) const;
+  std::optional<string> idToOptionalString(Id id) const {
+    return _vocab.idToOptionalString(id);
+  }
 
   void scanPSO(const string& predicate, WidthTwoList* result) const;
 

--- a/src/web/script.js
+++ b/src/web/script.js
@@ -183,8 +183,12 @@ function processQuery(query) {
         for (var i = 0; i < result.res.length; i++) {
             res += "<tr>"
             for (var j = 0; j < result.res[i].length; ++j) {
-                res += "<td title=\"" + htmlEscape(result.res[i][j]).replace(/\"/g, "&quot;") + "\">"
-                    + htmlEscape(getShortStr(result.res[i][j], 26))
+                var value = result.res[i][j];
+                if (!value) {
+                  value = "";
+                }
+                res += "<td title=\"" + htmlEscape(value.replace(/\"/g, "&quot;")) + "\">"
+                    + htmlEscape(getShortStr(value, 26))
                     + "</td>";
             }
             res += "</tr>";

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -92,8 +92,24 @@ TEST(StringUtilsTest, firstCharToUpperUtf8) {
   // that use different specifications for unicode chars.
   // In one, the capital ß exists, in others it doesn't.
   //  ASSERT_EQ("ẞfoo", firstCharToUpperUtf8("ßfoo"));
-  ASSERT_EQ("Éfoo", firstCharToUpperUtf8("éfoo"));
-  ASSERT_EQ("Éfoo", firstCharToUpperUtf8("Éfoo"));
+  ASSERT_EQ(u8"Éfoo", firstCharToUpperUtf8(u8"éfoo"));
+  ASSERT_EQ(u8"Éfoo", firstCharToUpperUtf8(u8"Éfoo"));
+}
+
+TEST(StringUtilsTest, toJson) {
+  setlocale(LC_CTYPE, "");
+  ASSERT_EQ("\"nothing special\"", toJson("nothing special"));
+  // We can pass an optional without value to get JSON null
+  ASSERT_EQ("null", toJson(std::nullopt));
+  ASSERT_EQ(u8"\"2 byte unicode: äöüß\"", toJson(u8"2 byte unicode: äöüß"));
+  ASSERT_EQ(u8"\"Chinese: 漢字\"", toJson(u8"Chinese: 漢字"));
+
+  ASSERT_EQ("\"embedded \\\"quotes\\\" should work\"",
+            toJson("embedded \"quotes\" should work"));
+  ASSERT_EQ("\"quoteception: \\\"\\\\\\\"\\\"\"",
+            toJson("quoteception: \"\\\"\""));
+  ASSERT_EQ("\"tabs\\tare nice\"", toJson("tabs\tare nice"));
+  ASSERT_EQ("\"multi\\nline\"", toJson("multi\nline"));
 }
 
 TEST(StringUtilsTest, split) {


### PR DESCRIPTION
Until now non existing values from an `OPTIONAL` were handled as `ID_NO_VALUE` only up to the point where they get turned into strings via `idToString()` (in `Index` and `ResultTable`). There they just become `""`.

This has several problems, for one it makes it impossible to disambiguate between a value that is the empty string and one that is missing (see #106). It turns out, this is not only true when using the API but also inside QLever e.g. during `FILTER` when matching the language tag and during `GROUP BY` when doing `GROUP_CONCAT()`.

Sadly the fix is quite intrusive. So I want to get some eyes on the basic concept which is using `std::optional` (how fitting) when turning Ids into strings.

At the moment this PR uses `null` instead of `""` in the JSON output and let's non-existing values through the language `FILTER`. For `GROUP_CONCAT` I still just convert to `""`. Will have to figure out what the correct behavior is here. Also while we are there it might make sense to clean up the `FILTER` code and remove a lot of code duplication.