### PR TITLE
Don't estimate OPTIONAL_JOIN size as 0 fixes #108

### DIFF
--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -57,6 +57,7 @@ void Join::computeResult(ResultTable* result) const {
   // Checking this before calling getResult on the subtrees can
   // avoid the computation of an non-empty subtree.
   if (_left->knownEmptyResult() || _right->knownEmptyResult()) {
+    LOG(TRACE) << "Either side is empty thus join result is empty" << endl;
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_resultTypes.resize(result->_nofColumns);
@@ -78,15 +79,17 @@ void Join::computeResult(ResultTable* result) const {
 
   // Check for joins with dummy
   if (isFullScanDummy(_left) || isFullScanDummy(_right)) {
+    LOG(TRACE) << "Either side is Full Scan Dummy" << endl;
     computeResultForJoinWithFullScanDummy(result);
     return;
   }
 
-  shared_ptr<const ResultTable> leftRes =
-      _left->getRootOperation()->getResult();
+  LOG(TRACE) << "Computing left side..." << endl;
+  shared_ptr<const ResultTable> leftRes = _left->getResult();
 
   // Check if we can stop early.
   if (leftRes->size() == 0) {
+    LOG(TRACE) << "Left side empty thus join result is empty" << endl;
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_resultTypes.resize(result->_nofColumns);
@@ -106,10 +109,10 @@ void Join::computeResult(ResultTable* result) const {
     return;
   }
 
-  shared_ptr<const ResultTable> rightRes =
-      _right->getRootOperation()->getResult();
+  LOG(TRACE) << "Computing right side..." << endl;
+  shared_ptr<const ResultTable> rightRes = _right->getResult();
 
-  LOG(DEBUG) << "Join result computation..." << endl;
+  LOG(DEBUG) << "Computing Join result..." << endl;
 
   AD_CHECK(result);
   AD_CHECK(!result->_fixedSizeData);
@@ -490,8 +493,7 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
     AD_CHECK(!isFullScanDummy(_right))
     result->_nofColumns = _right->getResultWidth() + 2;
     result->_sortedBy = 2 + _rightJoinCol;
-    shared_ptr<const ResultTable> nonDummyRes =
-        _right->getRootOperation()->getResult();
+    shared_ptr<const ResultTable> nonDummyRes = _right->getResult();
     result->_resultTypes.reserve(result->_nofColumns);
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
@@ -534,8 +536,7 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
     result->_nofColumns = _left->getResultWidth() + 2;
     result->_sortedBy = _leftJoinCol;
 
-    shared_ptr<const ResultTable> nonDummyRes =
-        _left->getRootOperation()->getResult();
+    shared_ptr<const ResultTable> nonDummyRes = _left->getResult();
     result->_resultTypes.reserve(result->_nofColumns);
     result->_resultTypes.insert(result->_resultTypes.end(),
                                 nonDummyRes->_resultTypes.begin(),

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -34,8 +34,8 @@ class Operation {
   // Use existing results if they are already available, otherwise
   // trigger computation.
   shared_ptr<const ResultTable> getResult() const {
-    LOG(TRACE) << "Try to atomically emplace a new empty ResultTable" << endl;
-    LOG(TRACE) << "Using key: \n" << asString() << endl;
+    LOG(DEBUG) << "Try to atomically emplace a new empty ResultTable" << endl;
+    LOG(DEBUG) << "Using key: \n" << asString() << endl;
     auto [newResult, existingResult] =
         _executionContext->getQueryTreeCache().tryEmplace(asString());
     if (newResult) {

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -327,7 +327,9 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
   } else {
     _sizeEstimate = multResult * numDistinctResult;
   }
-  // Don't estimate 0 since then upstream thinks we are sure it's zero
+  // Don't estimate 0 since then some parent operations 
+  // (in particular joins) using isKnownEmpty() will
+  // will assume the size to be exactly zero
   _sizeEstimate += 1;
 
   // compute estimates for the multiplicities of the result columns

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -327,6 +327,8 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
   } else {
     _sizeEstimate = multResult * numDistinctResult;
   }
+  // Don't estimate 0 since then upstream thinks we are sure it's zero
+  _sizeEstimate += 1;
 
   // compute estimates for the multiplicities of the result columns
   _multiplicities.clear();


### PR DESCRIPTION
When the OPTIONAL_JOIN has a an empty side it would estimate it's result
as empty. For estimates of size zero JOIN would then take the estimate
as exact and stop early.

The current fix is just incrementing the size estimate by one to make
sure it's never 0. @floriankramer do you know in which cases we are sure
that the size will be 0? Also I'm really not happy with `getKnownEmpty()`
being just a check for `getSizeEstimate() == 0` an **estimate** should
probably not be used as **known** even if it's exactly 0.

While we are here also remove redundant `getRootOperation()` calls in
Join.cpp (`getResult()` already uses the `_rootOperation`) and add some
useful `LOG(TRACE)`