### PR TITLE
Correct some uses of wrong variable types preventing QLever from running on ARM

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -208,7 +208,7 @@ void CountAvailablePredicates::computePatternTrick(
   ad_utility::HashMap<Id, size_t> predicateCounts;
   ad_utility::HashMap<size_t, size_t> patternCounts;
   size_t posInput = 0;
-  size_t lastSubject = ID_NO_VALUE;
+  Id lastSubject = ID_NO_VALUE;
   while (posInput < input->size()) {
     while ((*input)[posInput][subjectColumn] == lastSubject &&
            posInput < input->size()) {

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -745,7 +745,7 @@ void GroupBy::computeResult(ResultTable* result) const {
   aggregates.reserve(_aliases.size() + _groupByVariables.size());
 
   // parse the group by columns
-  std::unordered_map<string, Id> subtreeVarCols =
+  std::unordered_map<string, size_t> subtreeVarCols =
       _subtree->getVariableColumnMap();
   for (const string& var : _groupByVariables) {
     auto it = subtreeVarCols.find(var);

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -16,7 +16,7 @@ class OptionalJoin : public Operation {
   OptionalJoin(QueryExecutionContext* qec,
                std::shared_ptr<QueryExecutionTree> t1, bool t1Optional,
                std::shared_ptr<QueryExecutionTree> t2, bool t2Optional,
-               const std::vector<array<size_t, 2>>& joinCols);
+               const std::vector<array<Id, 2>>& joinCols);
 
   virtual string asString(size_t indent = 0) const;
 
@@ -51,7 +51,7 @@ class OptionalJoin : public Operation {
   bool _leftOptional;
   bool _rightOptional;
 
-  std::vector<std::array<size_t, 2>> _joinColumns;
+  std::vector<std::array<Id, 2>> _joinColumns;
 
   vector<float> _multiplicities;
   size_t _sizeEstimate;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1298,15 +1298,15 @@ bool QueryPlanner::connected(const QueryPlanner::SubtreePlan& a,
 }
 
 // _____________________________________________________________________________
-vector<array<size_t, 2>> QueryPlanner::getJoinColumns(
+vector<array<Id, 2>> QueryPlanner::getJoinColumns(
     const QueryPlanner::SubtreePlan& a,
     const QueryPlanner::SubtreePlan& b) const {
-  vector<array<size_t, 2>> jcs;
+  vector<array<Id, 2>> jcs;
   for (auto it = a._qet.get()->getVariableColumnMap().begin();
        it != a._qet.get()->getVariableColumnMap().end(); ++it) {
     auto itt = b._qet.get()->getVariableColumnMap().find(it->first);
     if (itt != b._qet.get()->getVariableColumnMap().end()) {
-      jcs.push_back(array<size_t, 2>{{it->second, itt->second}});
+      jcs.push_back(array<Id, 2>{{it->second, itt->second}});
     }
   }
   return jcs;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -183,8 +183,8 @@ class QueryPlanner {
   bool connected(const SubtreePlan& a, const SubtreePlan& b,
                  const TripleGraph& graph) const;
 
-  vector<array<size_t, 2>> getJoinColumns(const SubtreePlan& a,
-                                          const SubtreePlan& b) const;
+  vector<array<Id, 2>> getJoinColumns(const SubtreePlan& a,
+                                      const SubtreePlan& b) const;
 
   string getPruningKey(const SubtreePlan& plan, size_t orderedOnCol) const;
 

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -10,7 +10,7 @@ using std::string;
 TwoColumnJoin::TwoColumnJoin(QueryExecutionContext* qec,
                              std::shared_ptr<QueryExecutionTree> t1,
                              std::shared_ptr<QueryExecutionTree> t2,
-                             const vector<array<size_t, 2>>& jcs)
+                             const vector<array<Id, 2>>& jcs)
     : Operation(qec) {
   // Make sure subtrees are ordered so that identical queries can be identified.
   AD_CHECK_EQ(jcs.size(), 2);

--- a/src/engine/TwoColumnJoin.h
+++ b/src/engine/TwoColumnJoin.h
@@ -15,7 +15,7 @@ class TwoColumnJoin : public Operation {
   TwoColumnJoin(QueryExecutionContext* qec,
                 std::shared_ptr<QueryExecutionTree> t1,
                 std::shared_ptr<QueryExecutionTree> t2,
-                const std::vector<array<size_t, 2>>& joinCols);
+                const std::vector<array<Id, 2>>& joinCols);
 
   virtual string asString(size_t indent = 0) const;
 

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <array>
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -153,7 +154,9 @@ using IndexMetaDataMmapView = IndexMetaData<
     MetaDataWrapperDense<ad_utility::MmapVectorView<FullRelationMetaData>>>;
 
 // constants for Magic Numbers to separate different types of MetaData;
-const size_t MAGIC_NUMBER_MMAP_META_DATA = static_cast<size_t>(-1);
-const size_t MAGIC_NUMBER_SPARSE_META_DATA = static_cast<size_t>(-2);
+const uint64_t MAGIC_NUMBER_MMAP_META_DATA =
+    std::numeric_limits<uint64_t>::max();
+const uint64_t MAGIC_NUMBER_SPARSE_META_DATA =
+    std::numeric_limits<uint64_t>::max() - 1;
 
 #include "./IndexMetaDataImpl.h"

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -42,7 +42,7 @@ template <class MapType>
 void IndexMetaData<MapType>::createFromByteBufferSparse(unsigned char* buf) {
   size_t nofBytesDone = 0;
   // read magic number
-  size_t magicNumber = *reinterpret_cast<size_t*>(buf);
+  uint64_t magicNumber = *reinterpret_cast<uint64_t*>(buf);
   if (magicNumber == MAGIC_NUMBER_MMAP_META_DATA) {
     LOG(INFO)
         << "ERROR: magic number of MetaData indicates that we are trying "
@@ -94,7 +94,7 @@ void IndexMetaData<MapType>::createFromByteBufferSparse(unsigned char* buf) {
 template <class MapType>
 void IndexMetaData<MapType>::createFromByteBufferMmap(unsigned char* buf) {
   // read magic number
-  size_t magicNumber = *reinterpret_cast<size_t*>(buf);
+  uint64_t magicNumber = *reinterpret_cast<uint64_t*>(buf);
   if (magicNumber != MAGIC_NUMBER_MMAP_META_DATA) {
     LOG(INFO) << "ERROR: No or wrong magic number found in persistent "
                  "mmap-based meta data. "

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -252,8 +252,8 @@ class MmapVector {
   std::string _filename = "";
   AccessPattern _pattern = AccessPattern::None;
   static constexpr float ResizeFactor = 1.5;
-  static constexpr int MagicNumber = 7601577;
-  static constexpr int Version = 0;
+  static constexpr uint32_t MagicNumber = 7601577;
+  static constexpr uint32_t Version = 0;
 };
 
 // MmapVector variation that only supports read-access to a previously created

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -43,7 +43,6 @@ void MmapVector<T>::writeMetaDataToEnd() {
   ofs.write((char*)&_bytesize, sizeof(_bytesize));
   ofs.write((char*)&MagicNumber, sizeof(MagicNumber));
   ofs.write((char*)&Version, sizeof(Version));
-  ofs.flush();
   ofs.close();
 }
 
@@ -227,8 +226,6 @@ void MmapVector<T>::open(size_t size, string filename, AccessPattern pattern) {
   {
     std::ofstream ofs(_filename);
     AD_CHECK(ofs.is_open());
-    ofs << "bla";
-    // ofs.flush();
   }
   auto info = convertArraySizeToFileSize(std::max(size, MinCapacity));
   _bytesize = info._bytesize;

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -20,10 +20,10 @@ template <class T>
 constexpr float MmapVector<T>::ResizeFactor;
 
 template <class T>
-constexpr int MmapVector<T>::MagicNumber;
+constexpr uint32_t MmapVector<T>::MagicNumber;
 
 template <class T>
-constexpr int MmapVector<T>::Version;
+constexpr uint32_t MmapVector<T>::Version;
 
 // __________________________________________________________________________
 template <class T>
@@ -43,6 +43,8 @@ void MmapVector<T>::writeMetaDataToEnd() {
   ofs.write((char*)&_bytesize, sizeof(_bytesize));
   ofs.write((char*)&MagicNumber, sizeof(MagicNumber));
   ofs.write((char*)&Version, sizeof(Version));
+  ofs.flush();
+  ofs.close();
 }
 
 // __________________________________________________________________________
@@ -51,9 +53,9 @@ void MmapVector<T>::readMetaDataFromEnd() {
   std::ifstream fs(_filename, std::ios::binary | std::ios::ate);
   // since we do not know _bytesize yet we have to seek from the end
   AD_CHECK(fs.is_open());
-  static constexpr auto metaDataSize = sizeof(_size) + sizeof(_capacity) +
-                                       sizeof(_bytesize) + sizeof(MagicNumber) +
-                                       sizeof(Version);
+  static constexpr off_t metaDataSize = sizeof(_size) + sizeof(_capacity) +
+                                        sizeof(_bytesize) +
+                                        sizeof(MagicNumber) + sizeof(Version);
   if (fs.tellg() == -1 || static_cast<size_t>(fs.tellg()) < metaDataSize) {
     throw InvalidFileException();
   }
@@ -68,6 +70,7 @@ void MmapVector<T>::readMetaDataFromEnd() {
   auto tmpVersion = Version;
   fs.read((char*)&tmpMagic, sizeof(tmpMagic));
   fs.read((char*)&tmpVersion, sizeof(tmpVersion));
+  fs.close();
   if (tmpMagic != MagicNumber || tmpVersion != Version) {
     throw InvalidFileException();
   }
@@ -77,14 +80,14 @@ void MmapVector<T>::readMetaDataFromEnd() {
 template <class T>
 void MmapVector<T>::mapForReading() {
   // open to get valid file descriptor
-  FILE* fp = fopen(_filename.c_str(), "r");
+  int orig_fd = ::open(_filename.c_str(), O_RDONLY);
   // TODO: check if MAP_SHARED is necessary/usefule
-  void* ptr = mmap(0, _bytesize, PROT_READ, MAP_SHARED, fileno(fp), 0);
+  void* ptr = mmap(nullptr, _bytesize, PROT_READ, MAP_SHARED, orig_fd, 0);
   AD_CHECK(ptr != MAP_FAILED);
 
   // the filedescriptor and thus our mapping will still be valid
   // after closing, because mmap increases the count by one
-  fclose(fp);
+  ::close(orig_fd);
   _ptr = static_cast<T*>(ptr);
   advise(_pattern);
 }
@@ -96,7 +99,7 @@ void MmapVector<T>::mapForWriting() {
   int orig_fd = ::open(_filename.c_str(), O_RDWR);
   // map_shared because we need our updates in the original file
   void* ptr =
-      mmap(0, _bytesize, PROT_WRITE | PROT_READ, MAP_SHARED, orig_fd, 0);
+      mmap(nullptr, _bytesize, PROT_WRITE | PROT_READ, MAP_SHARED, orig_fd, 0);
   AD_CHECK(ptr != MAP_FAILED);
   // the filedescriptor and thus our mapping will still be valid
   // after closing, because mmap increases the count by one

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -588,7 +588,8 @@ string decodeUrl(const string& url) {
       } else if (h1 >= 'a' && h1 <= 'f') {
         h1 = h1 - 'a' + 10;
       } else {
-        h1 = -1;
+        decoded += '%';
+        continue;
       }
       char h2 = tolower(url[i + 2]);
       if (h2 >= '0' && h2 <= '9') {
@@ -596,14 +597,11 @@ string decodeUrl(const string& url) {
       } else if (h2 >= 'a' && h2 <= 'f') {
         h2 = h2 - 'a' + 10;
       } else {
-        h2 = -1;
-      }
-      if (h1 != -1 && h2 != -1) {
-        decoded += static_cast<char>(h1 * 16 + h2);
-        i += 2;
-      } else {
         decoded += '%';
+        continue;
       }
+      decoded += static_cast<char>(h1 * 16 + h2);
+      i += 2;
     } else {
       decoded += url[i];
     }

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -87,14 +87,14 @@ TEST(EngineTest, optionalJoinTest) {
   b.push_back(array<Id, 3>{{4, 2, 2}});
   b.push_back(array<Id, 3>{{1, 1, 3}});
   vector<array<Id, 4>> res;
-  vector<array<size_t, 2>> jcls;
-  jcls.push_back(array<size_t, 2>{{1, 2}});
-  jcls.push_back(array<size_t, 2>{{2, 1}});
+  vector<array<Id, 2>> jcls;
+  jcls.push_back(array<Id, 2>{{1, 2}});
+  jcls.push_back(array<Id, 2>{{2, 1}});
 
   // Join a and b on the column pairs 1,2 and 2,1 (entries from columns 1 of
   // a have to equal those of column 2 of b and vice versa).
   e.optionalJoin<vector<array<Id, 3>>, vector<array<Id, 3>>, array<Id, 4>, 4>(
-      a, b, false, true, jcls, &res, 4);
+      a, b, false, true, jcls, &res, 4u);
 
   ASSERT_EQ(5u, res.size());
 
@@ -136,13 +136,13 @@ TEST(EngineTest, optionalJoinTest) {
 
   vector<vector<Id>> vres;
   jcls.clear();
-  jcls.push_back(array<size_t, 2>{{1, 0}});
-  jcls.push_back(array<size_t, 2>{{2, 1}});
+  jcls.push_back(array<Id, 2>{{1, 0}});
+  jcls.push_back(array<Id, 2>{{2, 1}});
 
   // The template size parameter can be at most 6 (the maximum number
   // of fixed size columns plus one).
   e.optionalJoin<vector<vector<Id>>, vector<array<Id, 3>>, vector<Id>, 6>(
-      va, vb, true, false, jcls, &vres, 7);
+      va, vb, true, false, jcls, &vres, 7u);
 
   ASSERT_EQ(5u, vres.size());
   ASSERT_EQ(7u, vres[0].size());


### PR DESCRIPTION
To improve the portability and type correctness of the QLever code base I'm trying to get it running on my Raspberry Pi (ARM) as well as an Odroid C1 (ARM64). I find that most issues this uncovers look like they are worth doing right even on x86_64

**Note:** With the current state of this PR everything compiles and it can built some kind of index. However there are still problems with SCANs which break most queries (at least on ARM, haven't tested ARM64 yet). Also `convertIndexWordToFloat()` seems to be broken on 32 bit ARM.

* Most are uses of size_t where we really want Id (uint64_t) which on ARM are incompatible
* Also use explicitly sized types for versions and magic numbers
* In MmapVector we were also using -someSizeT as an off_t which somehow
  doesn't work on ARM. I guess the compiler tries to do it as an unary
  minus before converting to off_t