### PR TITLE
Fix FILTER with numeric constants

### DIFF
--- a/e2e/queryit.py
+++ b/e2e/queryit.py
@@ -69,6 +69,11 @@ def test_row(gold_row: List[Any],
         if gold is None:
             continue
         actual = actual_row[i]
+        # from literals only take the part in quotes stripping
+        # the quotes and any "^^xsd:type hints.
+        # This allows us to ignore double quoting trouble in checks
+        if actual and actual[0] == '"':
+            actual = actual[1:actual.rfind('"')]
         matches = False
         if isinstance(gold, int):
             matches = int(actual) == gold
@@ -118,6 +123,11 @@ def test_check(check_dict: Dict[str, Any], result: Dict[str, Any]) -> bool:
                 return False
         elif check == 'res':
             gold_res = value
+            if len(gold_res) != len(res):
+                eprint("res check failed:\n"+
+                       "\texpected number of rows: %r" % len(gold_res) +
+                       "\tdoes not match actual: %r" % len(value))
+                return False
             for i, gold_row in enumerate(gold_res):
                 actual_row = res[i]
                 if not test_row(gold_row, actual_row):

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -250,3 +250,41 @@ queries:
           - contains_row: ["<Abraham_Zelmanov>", ""]
           - contains_row: ["<Abraham_Pais>","<Ida_Nicolaisen>;<Lila_Lee_Pais>"]
           - contains_row: ["<Aafia_Siddiqui>","<Ammar_al-Baluchi>;<Amjad_Mohammed_Khan>"]
+  - query: giant-int-scientists
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?person ?height WHERE  {
+            ?person <is-a> <Scientist> .
+            ?person <Height> ?height .
+            FILTER(?height > 2)
+          }
+        checks:
+          - res: [["<Granville_Woods>", 2.134]]
+          - num_rows: 1
+  - query: tall-float-scientists
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?person ?height WHERE  {
+            ?person <is-a> <Scientist> .
+            ?person <Height> ?height .
+            FILTER(?height > 1.8)
+          }
+        checks:
+          - contains_row: ["<Granville_Woods>", 2.134]
+          - contains_row: ["<Andrew_Hogue>", 1.956]
+          - num_rows: 52
+          - num_cols: 2
+  - query: dwarf-float-scientists
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?person ?height WHERE  {
+            ?person <is-a> <Scientist> .
+            ?person <Height> ?height .
+            FILTER(?height < 1.47)
+          }
+        checks:
+          - res: [["<Zelda_Rubinstein>", 1.29]]
+          - num_rows: 1

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -327,7 +327,7 @@ void OptionalJoin::computeSizeEstimateAndMultiplicities() {
   } else {
     _sizeEstimate = multResult * numDistinctResult;
   }
-  // Don't estimate 0 since then some parent operations 
+  // Don't estimate 0 since then some parent operations
   // (in particular joins) using isKnownEmpty() will
   // will assume the size to be exactly zero
   _sizeEstimate += 1;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -507,11 +507,6 @@ bool QueryPlanner::isVariable(const string& elem) {
 }
 
 // _____________________________________________________________________________
-bool QueryPlanner::isWords(const string& elem) {
-  return !isVariable(elem) && elem.size() > 0 && elem[0] != '<';
-}
-
-// _____________________________________________________________________________
 QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
     const ParsedQuery::GraphPattern* pattern) const {
   TripleGraph tg;
@@ -1362,7 +1357,7 @@ void QueryPlanner::applyFiltersIfPossible(
       continue;
     }
     for (size_t i = 0; i < filters.size(); ++i) {
-      LOG(DEBUG) << "filter type: " << filters[i]._type << std::endl;
+      LOG(TRACE) << "filter type: " << filters[i]._type << std::endl;
       if (((row[n]._idsOfIncludedFilters >> i) & 1) != 0) {
         continue;
       }
@@ -1386,8 +1381,13 @@ void QueryPlanner::applyFiltersIfPossible(
           string compWith = filters[i]._rhs;
           Id entityId = 0;
           if (_qec) {
-            if (ad_utility::isXsdValue(filters[i]._rhs)) {
+            // TODO(schnelle): A proper SPARQL parser should have
+            // tagged/converted numeric values already. However our parser is
+            // currently far too crude for that
+            if (ad_utility::isXsdValue(compWith)) {
               compWith = ad_utility::convertValueLiteralToIndexWord(compWith);
+            } else if (ad_utility::isNumeric(compWith)) {
+              compWith = ad_utility::convertNumericToIndexWord(compWith);
             }
             if (filters[i]._type == SparqlFilter::EQ ||
                 filters[i]._type == SparqlFilter::NE) {

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -162,8 +162,6 @@ class QueryPlanner {
 
   static bool isVariable(const string& elem);
 
-  static bool isWords(const string& elem);
-
   void getVarTripleMap(
       const ParsedQuery& pq,
       ad_utility::HashMap<string, vector<SparqlTriple>>& varToTrip,

--- a/test/ConversionsTest.cpp
+++ b/test/ConversionsTest.cpp
@@ -25,6 +25,7 @@ TEST(ConversionsTest, convertFloatToIndexWord) {
   string pos4 = "2.0000009999";
   string pos5 = "2.9999";
   string pos6 = "111000.05";
+  string pos7 = "+111000.05";
   string neg = "-0.0005002";
   string neg2 = "-0.005002";
   string neg3 = "-2023.414";
@@ -46,6 +47,7 @@ TEST(ConversionsTest, convertFloatToIndexWord) {
   indexWords.push_back(convertFloatToIndexWord(pos4, 10, 20));
   indexWords.push_back(convertFloatToIndexWord(pos5, 10, 20));
   indexWords.push_back(convertFloatToIndexWord(pos6, 10, 20));
+  indexWords.push_back(convertFloatToIndexWord(pos7, 10, 20));
   indexWords.push_back(convertFloatToIndexWord(extra, 10, 20));
   indexWords.push_back(convertFloatToIndexWord(extra2, 10, 20));
   indexWords.push_back(convertFloatToIndexWord(extra3, 10, 20));
@@ -68,6 +70,7 @@ TEST(ConversionsTest, convertFloatToIndexWord) {
   ASSERT_EQ(pos4, convertIndexWordToFloatString(indexWords[12]));
   ASSERT_EQ(pos5, convertIndexWordToFloatString(indexWords[13]));
   ASSERT_EQ(pos6, convertIndexWordToFloatString(indexWords[14]));
+  ASSERT_EQ(pos6, convertIndexWordToFloatString(indexWords[15]));
 
   ASSERT_EQ("0.0",
             convertIndexWordToFloatString(convertFloatToIndexWord("0", 5, 5)));
@@ -290,6 +293,53 @@ TEST(ConversionsTest, convertIndexWordToFloat) {
                   convertIndexWordToFloat(convertFloatToIndexWord("1", 5, 5)));
   ASSERT_FLOAT_EQ(-1,
                   convertIndexWordToFloat(convertFloatToIndexWord("-1", 5, 5)));
+}
+
+TEST(ConversionsTest, isNumeric) {
+  ASSERT_TRUE(isNumeric("42"));
+  ASSERT_TRUE(isNumeric("42.3"));
+  ASSERT_TRUE(isNumeric("12345678"));
+  ASSERT_TRUE(isNumeric(".4"));
+  ASSERT_TRUE(isNumeric("-12.4"));
+  ASSERT_TRUE(isNumeric("+12.4"));
+  ASSERT_TRUE(isNumeric("-2"));
+  ASSERT_TRUE(isNumeric("0"));
+  ASSERT_TRUE(isNumeric("0.0"));
+  ASSERT_TRUE(isNumeric("0123"));
+
+  ASSERT_FALSE(isNumeric("a"));
+  // no automatic stripping
+  ASSERT_FALSE(isNumeric(" 123 "));
+  ASSERT_FALSE(isNumeric(" 123"));
+  ASSERT_FALSE(isNumeric("123 "));
+
+  ASSERT_FALSE(isNumeric("xyz"));
+  ASSERT_FALSE(isNumeric("0a"));
+  // Oh how awesome it were, if we Germans could just stop
+  // this comma as a decimal separator nonesense
+  ASSERT_FALSE(isNumeric("0,023"));
+}
+
+TEST(ConversionsTest, convertNumericToIndexWordEndToEnd) {
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("42")),
+                  "\"42\"^^<http://www.w3.org/2001/XMLSchema#int>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("42.3")),
+                  "\"42.3\"^^<http://www.w3.org/2001/XMLSchema#float>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("12345678")),
+                  "\"12345678\"^^<http://www.w3.org/2001/XMLSchema#int>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord(".4")),
+                  "\"0.4\"^^<http://www.w3.org/2001/XMLSchema#float>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("-12.3")),
+                  "\"-12.3\"^^<http://www.w3.org/2001/XMLSchema#float>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("-2")),
+                  "\"-2\"^^<http://www.w3.org/2001/XMLSchema#int>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("0")),
+                  "\"0\"^^<http://www.w3.org/2001/XMLSchema#int>");
+  ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("0.0")),
+                  "\"0.0\"^^<http://www.w3.org/2001/XMLSchema#float>");
+  // TODO(schnelle) for whatever reason the actual result becomes 1230
+  //ASSERT_EQ(convertIndexWordToValueLiteral(convertNumericToIndexWord("0123")),
+  //                "\"123\"^^<http://www.w3.org/2001/XMLSchema#int>");
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
This addresses #114. This is somewhat of a workaround as handling different types of literals and turning them into the appropriate type (i.e. float/int) would normally be done in the SPARQL parser.

**Note:** The first commit separately adds the end-to-end test cases so it is supposed to break the build. Also I'm still missing unit tests. And forgot about `'-'` (yay Unit tests)