### PR TITLE
Improved the check that determines if the pattern trick should be used.

### DIFF
--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -201,4 +201,6 @@ class QueryPlanner {
   SubtreePlan getTextLeafPlan(const TripleGraph::Node& node) const;
 
   SubtreePlan optionalJoin(const SubtreePlan& a, const SubtreePlan& b) const;
+  bool checkUsePatternTrick(ParsedQuery& pq,
+                            SparqlTriple& patternTrickTriple) const;
 };

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -201,6 +201,18 @@ class QueryPlanner {
   SubtreePlan getTextLeafPlan(const TripleGraph::Node& node) const;
 
   SubtreePlan optionalJoin(const SubtreePlan& a, const SubtreePlan& b) const;
-  bool checkUsePatternTrick(ParsedQuery& pq,
-                            SparqlTriple& patternTrickTriple) const;
+
+  /**
+   * @brief Determines if the pattern trick (and in turn the
+   * CountAvailablePredicates operation) are applicable to the given
+   * parsed query. If a ql:has-predicate triple is found and
+   * CountAvailblePredicates can be used for it, the triple will be removed from
+   * the parsed query.
+   * @param pq The parsed query.
+   * @param patternTrickTriple An output parameter in which the triple that
+   * satisfies the requirements for the pattern trick is stored.
+   * @return True if the pattern trick should be used.
+   */
+  bool checkUsePatternTrick(ParsedQuery* pq,
+                            SparqlTriple* patternTrickTriple) const;
 };


### PR DESCRIPTION
This pr removes some bugs that occurred when triples restricted the object of a ql:has-predicate, when filters filter on any part of a ql:has-predicate triple or when optional parts of a query create results for the object of ql:has-predicate.
This also fixes a bug that caused the order by operation created when constructing the CountAvailablePredicates operation being setup wrongly, leading to a segfault. This may solve #84.