### PR TITLE
Enable End-to-End test during docker build

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -e
-PROJECT_DIR="$(dirname ${BASH_SOURCE[0]})/.."
+PROJECT_DIR=$(realpath "$(dirname ${BASH_SOURCE[0]})/..")
 # Change to the project directory so we can use simple relative paths
-cd "$PROJECT_DIR"
+pushd $PROJECT_DIR
+BINARY_DIR=$(realpath ./build)
+if [ ! -e $BINARY_DIR ]; then
+	BINARY_DIR=$(realpath .)
+fi
 function bail {
 	echo "$*"
 	exit 1
@@ -10,7 +14,7 @@ function bail {
 
 function cleanup_server {
 	echo "The Server Log follows:"
-	cat "build/server_log.txt"
+	cat "$BINARY_DIR/server_log.txt"
 	# Killing 0 sends the signal to all processes in the current
 	# process group
 	kill $SERVER_PID
@@ -25,34 +29,43 @@ else
 	export PYTHON_BINARY=`which python3`
 fi
 
-mkdir -p "e2e_data"
+INDEX_DIR="$PROJECT_DIR/e2e_data"
+INPUT_DIR="$INDEX_DIR/scientist-collection"
+INPUT_PREFIX="scientists"
+INPUT="$INPUT_DIR/$INPUT_PREFIX"
+mkdir -p "$INDEX_DIR"
 # Can't check for the scientist-collection directory because
 # Travis' caching creates it
-if [ ! -e "e2e_data/scientist-collection/scientists.nt" ]; then
+if [ ! -e "$INPUT.nt" ]; then
 	# Why the hell is this a ZIP that can't easily be decompressed from stdin?!?
-	wget -O "e2e_data/scientist-collection.zip" \
+	wget -O "$INDEX_DIR/scientist-collection.zip" \
 		"http://filicudi.informatik.uni-freiburg.de/bjoern-data/scientist-collection.zip"
-	unzip "e2e_data/scientist-collection.zip" -d "e2e_data"
+	unzip -j "$INDEX_DIR/scientist-collection.zip" -d "$INPUT_DIR/"
+	rm "$INDEX_DIR/scientist-collection.zip"
 fi;
 
-INDEX="e2e_data/scientists-index"
+
+INDEX_PREFIX="scientists-index"
+INDEX="$INDEX_DIR/$INDEX_PREFIX"
 
 # Delete and rebuild the index
 if [ "$1" != "no-index" ]; then
 	rm -f "$INDEX.*"
-	pushd "./build"
-	./IndexBuilderMain -a -l -i "../$INDEX" \
-		-n "../e2e_data/scientist-collection/scientists.nt" \
-		-w "../e2e_data/scientist-collection/scientists.wordsfile.tsv" \
-		-d "../e2e_data/scientist-collection/scientists.docsfile.tsv" \
+	pushd "$BINARY_DIR"
+	echo "Building index $INDEX"
+	./IndexBuilderMain -a -l -i "$INDEX" \
+		-n "$INPUT.nt" \
+		-w "$INPUT.wordsfile.tsv" \
+		-d "$INPUT.docsfile.tsv" \
 		--patterns || bail "Building Index failed"
 	popd
 fi
 
 # Launch the Server using the freshly baked index. Can't simply use a subshell here because
 # then we can't easily get the SERVER_PID out of that subshell
-pushd "./build"
-./ServerMain -i "../$INDEX" -p 9099 -t -a --patterns &> server_log.txt &
+pushd "$BINARY_DIR"
+echo "Launching server from path $(pwd)"
+./ServerMain -i "$INDEX" -p 9099 -t -a --patterns &> server_log.txt &
 SERVER_PID=$!
 popd
 
@@ -62,4 +75,5 @@ echo "Waiting for ServerMain to launch and open port"
 while ! curl --max-time 1 --output /dev/null --silent http://localhost:9099/; do
 	sleep 1
 done
-$PYTHON_BINARY e2e/queryit.py "e2e/scientists_queries.yaml" "http://localhost:9099" || bail "Querying Server failed"
+$PYTHON_BINARY "$PROJECT_DIR/e2e/queryit.py" "$PROJECT_DIR/e2e/scientists_queries.yaml" "http://localhost:9099" || bail "Querying Server failed"
+popd


### PR DESCRIPTION
This enables testing using our e2e/e2e.sh script during `docker build`.
The tests are executed in the final runtime stage of the multi stage
Dockerfile which makes sure that we are testing the final configuration.
This also makes sure that images build automatically in the docker
cloud are tested.

This also leaves the queryit.py tool as well as the example queries in
/app/e2e_data in the final container. While these are not strictly
needed they offer useful examples.

In a later step we may replace the Travis CI build with just building
the docker container there as well. This would get rid of the version
hacks