### PR TITLE
F.efficient language filter

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -36,6 +36,10 @@ static const char INTERNAL_TEXT_MATCH_PREDICATE[] =
 static const char HAS_PREDICATE_PREDICATE[] =
     "<QLever-internal-function/has-predicate>";
 
+static const std::string URI_PREFIX = "<QLever-internal-function/";
+
+static const std::string LANGUAGE_PREDICATE = URI_PREFIX + "langtag>";
+
 static const char VALUE_PREFIX[] = ":v:";
 static const char VALUE_DATE_PREFIX[] = ":v:date:";
 static const char VALUE_FLOAT_PREFIX[] = ":v:float:";
@@ -66,3 +70,7 @@ static constexpr uint8_t NUM_COMPRESSION_PREFIXES = 127;
 // compression has been applied to  a word
 static const uint8_t NO_PREFIX_CHAR =
     MIN_COMPRESSION_PREFIX + NUM_COMPRESSION_PREFIXES;
+
+// Prefixing strings with this char will put them to the beginning of the
+// Vocabulary. Necessary for language filter, because the languages have to be
+// known during the merge process

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -32,6 +32,7 @@ using std::vector;
 
 using json = nlohmann::json;
 
+using IdPairMMapVec = ad_utility::MmapVector<std::array<Id, 2>>;
 // a simple struct for better naming
 struct LinesAndWords {
   size_t nofLines;
@@ -545,7 +546,11 @@ class Index {
   bool isLiteral(const string& object);
 
   bool shouldBeExternalized(const string& object);
-  void tripleToInternalRepresentation(array<string, 3>* spo);
+  // convert value literals to internal representation
+  // and add externalization characters if necessary.
+  // Returns the language tag of spo[2] (the object) or ""
+  // if there is none.
+  string tripleToInternalRepresentation(array<string, 3>* spo);
 
   /**
    * @brief Throws an exception if no patterns are loaded. Should be called from

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -148,7 +148,9 @@ class MetaDataWrapperDense {
 
   // ____________________________________________________________
   void set(Id id, const FullRelationMetaData& value) {
-    AD_CHECK(id < _vec.size());
+    if (id >= _vec.size()) {
+      AD_CHECK(id < _vec.size());
+    }
     bool previouslyEmpty = _vec[id] == emptyMetaData;
 
     // check that we never insert the empty key

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -265,6 +265,7 @@ class Vocabulary {
   google::sparse_hash_map<string, Id> asMap();
 
   static bool isLiteral(const string& word);
+  static bool isExternalizedLiteral(const string& word);
 
   template <bool isEntity = false>
   bool shouldBeExternalized(const string& word) const;

--- a/src/index/VocabularyGenerator.cpp
+++ b/src/index/VocabularyGenerator.cpp
@@ -11,9 +11,12 @@
 #include <utility>
 #include <vector>
 
+#include "../util/Conversions.h"
 #include "../util/Exception.h"
+#include "../util/HashMap.h"
 #include "../util/Log.h"
 #include "./ConstantsIndexCreation.h"
+#include "./Vocabulary.h"
 
 class PairCompare {
  public:
@@ -31,6 +34,8 @@ size_t mergeVocabulary(const std::string& basename, size_t numFiles) {
   std::ofstream outfileExternal(basename + EXTERNAL_LITS_TEXT_FILE_NAME);
   AD_CHECK(outfileExternal.is_open());
   std::vector<bool> endOfFile(numFiles, false);
+
+  ad_utility::HashMap<string, Id> langtagMap;
 
   using pair_T = std::pair<string, size_t>;
   std::priority_queue<pair_T, std::vector<pair_T>, PairCompare> queue;
@@ -65,7 +70,8 @@ size_t mergeVocabulary(const std::string& basename, size_t numFiles) {
       if (top.first < string({EXTERNALIZED_LITERALS_PREFIX})) {
         outfile << top.first << std::endl;
       } else {
-        outfileExternal << top.first << std::endl;
+        // we have to strip the externalization character again
+        outfileExternal << top.first.substr(1) << std::endl;
       }
 
       // according to the standard, flush() or seek() must be called before
@@ -108,11 +114,11 @@ size_t mergeVocabulary(const std::string& basename, size_t numFiles) {
 }
 
 // ____________________________________________________________________________________________
-google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(
+ad_utility::HashMap<string, Id> vocabMapFromPartialIndexedFile(
     const string& partialFile) {
   std::ifstream file(partialFile, std::ios_base::binary);
   AD_CHECK(file.is_open());
-  google::sparse_hash_map<string, Id> vocabMap;
+  ad_utility::HashMap<string, Id> vocabMap;
   uint32_t len;
   while (file.read((char*)&len, sizeof(len))) {
     std::string word(len, '\0');

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -3,11 +3,13 @@
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
 #pragma once
 
-#include <google/sparse_hash_map>
 #include <string>
+#include <utility>
 
 #include "../global/Constants.h"
 #include "../global/Id.h"
+#include "../util/HashMap.h"
+#include "../util/MmapVector.h"
 
 using std::string;
 // _______________________________________________________________
@@ -23,5 +25,5 @@ size_t mergeVocabulary(const std::string& basename, size_t numFiles);
 
 // __________________________________________________________________________________________
 // read the words and indices from the file and create hash map from it.
-google::sparse_hash_map<string, Id> vocabMapFromPartialIndexedFile(
+ad_utility::HashMap<string, Id> vocabMapFromPartialIndexedFile(
     const string& partialFile);

--- a/src/index/VocabularyImpl.h
+++ b/src/index/VocabularyImpl.h
@@ -139,6 +139,13 @@ bool Vocabulary<S>::isLiteral(const string& word) {
 
 // _____________________________________________________________________________
 template <class S>
+bool Vocabulary<S>::isExternalizedLiteral(const string& word) {
+  return word.size() > 1 && word[0] == EXTERNALIZED_LITERALS_PREFIX &&
+         word[1] == '\"';
+}
+
+// _____________________________________________________________________________
+template <class S>
 template <bool isEntity>
 bool Vocabulary<S>::shouldBeExternalized(const string& word) const {
   if constexpr (isEntity) {

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -2,10 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include "../util/Conversions.h"
 #include "../util/StringUtils.h"
 #include "ParseException.h"
 #include "ParsedQuery.h"
@@ -158,6 +160,19 @@ void ParsedQuery::expandPrefix(
     string& item, const ad_utility::HashMap<string, string>& prefixMap) {
   if (!ad_utility::startsWith(item, "?") &&
       !ad_utility::startsWith(item, "<")) {
+    std::optional<string> langtag = std::nullopt;
+    if (ad_utility::startsWith(item, "@")) {
+      auto secondPos = item.find("@", 1);
+      if (secondPos == string::npos) {
+        throw ParseException(
+            "langtaged predicates must have form @lang@ActualPredicate. Second "
+            "@ is missing in " +
+            item);
+      }
+      langtag = item.substr(1, secondPos - 1);
+      item = item.substr(secondPos + 1);
+    }
+
     size_t i = item.find(':');
     size_t from = item.find("^^");
     if (from == string::npos) {
@@ -176,6 +191,10 @@ void ParsedQuery::expandPrefix(
                prefixUri.substr(0, prefixUri.size() - 1) + item.substr(i + 1) +
                '>';
       }
+    }
+    if (langtag) {
+      item =
+          ad_utility::convertToLanguageTaggedPredicate(item, langtag.value());
     }
   }
 }

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -4,6 +4,7 @@
 
 #include "./SparqlParser.h"
 #include "../global/Constants.h"
+#include "../util/Conversions.h"
 #include "../util/Exception.h"
 #include "../util/Log.h"
 #include "../util/StringUtils.h"
@@ -290,7 +291,7 @@ void SparqlParser::parseWhere(const string& str, ParsedQuery& query,
     }
   }
   for (const string& filter : filters) {
-    addFilter(filter, &currentPattern->_filters);
+    addFilter(filter, currentPattern);
   }
 }
 
@@ -429,7 +430,8 @@ void SparqlParser::parseSolutionModifiers(const string& str,
 
 // _____________________________________________________________________________
 void SparqlParser::addFilter(const string& str,
-                             vector<SparqlFilter>* _filters) {
+                             vector<SparqlFilter>* _filters,
+                             ParsedQuery::GraphPattern* pattern) {
   size_t i = str.find('(');
   AD_CHECK(i != string::npos);
   size_t j = str.rfind(')');
@@ -455,11 +457,43 @@ void SparqlParser::addFilter(const string& str,
         }
         std::string lvar = lhs.substr(5, lhs.size() - 6);
         std::cout << "lvar:" << lvar << std::endl;
-        SparqlFilter f;
-        f._type = SparqlFilter::LANG_MATCHES;
-        f._lhs = lvar;
-        f._rhs = rhs.substr(1, rhs.size() - 2);
-        _filters->emplace_back(f);
+
+        auto langTag = rhs.substr(1, rhs.size() - 2);
+        // first find a predicate for the given variable
+        auto it =
+            std::find_if(pattern->_whereClauseTriples.begin(),
+                         pattern->_whereClauseTriples.end(),
+                         [&lvar](const auto& tr) { return tr._o == lvar; });
+        while (it != pattern->_whereClauseTriples.end() &&
+               ad_utility::startsWith(it->_p, "?")) {
+          it = std::find_if(it + 1, pattern->_whereClauseTriples.end(),
+                            [&lvar](const auto& tr) { return tr._o == lvar; });
+        }
+        if (it == pattern->_whereClauseTriples.end()) {
+          LOG(INFO)
+              << "language filter variable " + rhs +
+                     "that did not appear as object in any suitable triple. "
+                     "using special literal-to-language triple instead.\n";
+          auto langEntity = ad_utility::convertLangtagToEntityUri(langTag);
+          SparqlTriple triple(lvar, LANGUAGE_PREDICATE, langEntity);
+          // Quadratic in number of triples in query.
+          // Shouldn't be a problem here, though.
+          // Could use a (hash)-set instead of vector.
+          if (std::find(pattern->_whereClauseTriples.begin(),
+                        pattern->_whereClauseTriples.end(),
+                        triple) != pattern->_whereClauseTriples.end()) {
+            LOG(INFO) << "Ignoring duplicate triple: " << str << std::endl;
+          } else {
+            pattern->_whereClauseTriples.push_back(triple);
+          }
+        } else {
+          // replace the triple
+          string taggedPredicate = '@' + langTag + '@' + it->_p;
+          *it = SparqlTriple(it->_s, taggedPredicate, it->_o);
+        }
+
+        // Convert the language filter to a special triple
+        // to make it more efficient (no need for string resolution)
         return;
       }
       if (pred == "regex") {

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -23,7 +23,8 @@ class SparqlParser {
   static void addPrefix(const string& str, ParsedQuery& query);
   static void addWhereTriple(const string& str,
                              ParsedQuery::GraphPattern* pattern);
-  static void addFilter(const string& str, vector<SparqlFilter>* _filters);
+  static void addFilter(const string& str, vector<SparqlFilter>* _filters,
+                        ParsedQuery::GraphPattern* pattern = nullptr);
 
   static string stripAndLowercaseKeywordLiteral(const string& lit);
 };

--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -85,6 +85,13 @@ inline bool isNumeric(const string& val);
 //! Converts numeric strings (as determined by isNumeric()) into index words
 inline string convertNumericToIndexWord(const string& val);
 
+//! Convert a language tag like "@en" to the corresponding entity uri
+//! for the efficient language filter
+inline string convertLangtagToEntityUri(const string& tag);
+inline std::optional<string> convertEntityUriToLangtag(const string& word);
+inline std::string convertToLanguageTaggedPredicate(const string& pred,
+                                                    const string& langtag);
+
 // _____________________________________________________________________________
 string convertValueLiteralToIndexWord(const string& orig) {
   /*
@@ -603,5 +610,25 @@ string convertNumericToIndexWord(const string& val) {
     wasInt = true;
   }
   return convertFloatToIndexWord(tmp) + ((wasInt) ? 'I' : 'F');
+}
+
+// _________________________________________________________
+string convertLangtagToEntityUri(const string& tag) {
+  return URI_PREFIX + "@" + tag + ">";
+}
+
+// _________________________________________________________
+std::optional<string> convertEntityUriToLangtag(const string& word) {
+  static const string prefix = URI_PREFIX + "@";
+  if (ad_utility::startsWith(word, prefix)) {
+    return word.substr(prefix.size(), word.size() - prefix.size() - 1);
+  } else {
+    return std::nullopt;
+  }
+}
+// _________________________________________________________
+std::string convertToLanguageTaggedPredicate(const string& pred,
+                                             const string& langtag) {
+  return '@' + langtag + '@' + pred;
 }
 }  // namespace ad_utility

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -58,20 +58,20 @@ TEST(IndexTest, createFromTsvTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
-    ASSERT_TRUE(index._psoMeta.relationExists(2));
     ASSERT_TRUE(index._psoMeta.relationExists(3));
+    ASSERT_TRUE(index._psoMeta.relationExists(4));
+    ASSERT_FALSE(index._psoMeta.relationExists(2));
     ASSERT_FALSE(index._psoMeta.relationExists(1));
-    ASSERT_FALSE(index._psoMeta.relationExists(4));
-    ASSERT_FALSE(index._psoMeta.getRmd(2).isFunctional());
-    ASSERT_TRUE(index._psoMeta.getRmd(3).isFunctional());
-    ASSERT_FALSE(index._psoMeta.getRmd(2).hasBlocks());
+    ASSERT_FALSE(index._psoMeta.getRmd(3).isFunctional());
+    ASSERT_TRUE(index._psoMeta.getRmd(4).isFunctional());
+    ASSERT_FALSE(index._psoMeta.getRmd(3).hasBlocks());
 
-    ASSERT_TRUE(index._posMeta.relationExists(2));
     ASSERT_TRUE(index._posMeta.relationExists(3));
-    ASSERT_FALSE(index._posMeta.relationExists(1));
-    ASSERT_FALSE(index._posMeta.relationExists(4));
-    ASSERT_TRUE(index._posMeta.getRmd(2).isFunctional());
+    ASSERT_TRUE(index._posMeta.relationExists(4));
+    ASSERT_FALSE(index._posMeta.relationExists(2));
+    ASSERT_FALSE(index._posMeta.relationExists(5));
     ASSERT_TRUE(index._posMeta.getRmd(3).isFunctional());
+    ASSERT_TRUE(index._posMeta.getRmd(4).isFunctional());
 
     ad_utility::File psoFile("_testindex.index.pso", "r");
     size_t nofbytes = static_cast<size_t>(index._psoMeta.getOffsetAfter());
@@ -81,13 +81,13 @@ TEST(IndexTest, createFromTsvTest) {
     off_t bytesDone = 0;
     // Relation b
     // Pair index
-    ASSERT_EQ(Id(0), *reinterpret_cast<Id*>(buf + bytesDone));
-    bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
-    bytesDone += sizeof(Id);
-    ASSERT_EQ(0u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(Id(1), *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
+    bytesDone += sizeof(Id);
+    ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
+    bytesDone += sizeof(Id);
+    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     // No (more) block info because of the change from Aug2016 and
     // due to the reasons that the test relation is very small.
@@ -103,13 +103,13 @@ TEST(IndexTest, createFromTsvTest) {
     //    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     //    bytesDone += sizeof(Id);
     // Relation b2
-    ASSERT_EQ(Id(0), *reinterpret_cast<Id*>(buf + bytesDone));
-    bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
-    bytesDone += sizeof(Id);
-    ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(Id(1), *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
+    bytesDone += sizeof(Id);
+    ASSERT_EQ(2u, *reinterpret_cast<Id*>(buf + bytesDone));
+    bytesDone += sizeof(Id);
+    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     // No LHS & RHS
     ASSERT_EQ(index._psoMeta.getOffsetAfter(), bytesDone);
@@ -137,10 +137,11 @@ TEST(IndexTest, createFromTsvTest) {
     // 1: 1
     // 2: 2
     // 3: 3
-    // 4: a
-    // 5: b
-    // 6: c
-    // 7: is-a
+    // 4: ql:langtag
+    // 5: a
+    // 6: b
+    // 7: c
+    // 8: is-a
     f << "a\tis-a\t1\t.\n"
          "a\tis-a\t2\t.\n"
          "a\tis-a\t0\t.\n"
@@ -158,14 +159,14 @@ TEST(IndexTest, createFromTsvTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
-    ASSERT_TRUE(index._psoMeta.relationExists(7));
-    ASSERT_FALSE(index._psoMeta.relationExists(1));
+    ASSERT_TRUE(index._psoMeta.relationExists(8));
+    ASSERT_FALSE(index._psoMeta.relationExists(2));
 
-    ASSERT_FALSE(index._psoMeta.getRmd(7).isFunctional());
-    ASSERT_FALSE(index._psoMeta.getRmd(7).hasBlocks());
+    ASSERT_FALSE(index._psoMeta.getRmd(8).isFunctional());
+    ASSERT_FALSE(index._psoMeta.getRmd(8).hasBlocks());
 
-    ASSERT_TRUE(index._posMeta.relationExists(7));
-    ASSERT_FALSE(index._posMeta.getRmd(7).isFunctional());
+    ASSERT_TRUE(index._posMeta.relationExists(8));
+    ASSERT_FALSE(index._posMeta.getRmd(8).isFunctional());
 
     ad_utility::File psoFile("_testindex.index.pso", "r");
     size_t nofbytes = static_cast<size_t>(index._psoMeta.getOffsetAfter());
@@ -175,31 +176,31 @@ TEST(IndexTest, createFromTsvTest) {
     off_t bytesDone = 0;
 
     // Pair index
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(0u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(2u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(0u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(3u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(7u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(7u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(2u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
@@ -256,31 +257,31 @@ TEST(IndexTest, createFromTsvTest) {
     // Pair index
     ASSERT_EQ(0u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(0u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
+    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
+    bytesDone += sizeof(Id);
+    ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
+    bytesDone += sizeof(Id);
     ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
-    bytesDone += sizeof(Id);
-    ASSERT_EQ(1u, *reinterpret_cast<Id*>(buf + bytesDone));
-    bytesDone += sizeof(Id);
-    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(7u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(2u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(4u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(2u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(7u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
     ASSERT_EQ(3u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
-    ASSERT_EQ(5u, *reinterpret_cast<Id*>(buf + bytesDone));
+    ASSERT_EQ(6u, *reinterpret_cast<Id*>(buf + bytesDone));
     bytesDone += sizeof(Id);
 
     // Lhs info
@@ -386,18 +387,20 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     index.setUsePatterns(true);
     index.createFromOnDiskIndex("_testindex");
 
-    ASSERT_EQ(2u, index.getHasPattern().size());
-    ASSERT_EQ(1u, index.getHasPredicate().size());
+    ASSERT_EQ(3u, index.getHasPattern().size());
+    ASSERT_EQ(2u, index.getHasPredicate().size());
     ASSERT_EQ(1u, index._patterns.size());
     Pattern p;
     p.push_back(3);
     p.push_back(6);
     std::pair<Id*, size_t> ip = index._patterns[0];
     for (size_t i = 0; i < ip.second; i++) {
-      ASSERT_EQ(p[i], ip.first[i]);
+      // add 1 because of special language filter predicate
+      // which is automatically inserted
+      ASSERT_EQ(p[i] + 1, ip.first[i]);
     }
-    ASSERT_EQ(0u, index.getHasPattern()[1]);
-    ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
+    ASSERT_EQ(0u, index.getHasPattern()[2]);
+    ASSERT_EQ(NO_PATTERN, index.getHasPattern()[1]);
 
     ASSERT_FLOAT_EQ(4.0 / 2, index.getHasPredicateMultiplicityEntities());
     ASSERT_FLOAT_EQ(4.0 / 3, index.getHasPredicateMultiplicityPredicates());
@@ -409,18 +412,18 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     index._maxNumPatterns = 1;
     index.createFromOnDiskIndex("_testindex");
 
-    ASSERT_EQ(2u, index.getHasPattern().size());
-    ASSERT_EQ(1u, index.getHasPredicate().size());
+    ASSERT_EQ(3u, index.getHasPattern().size());
+    ASSERT_EQ(2u, index.getHasPredicate().size());
     ASSERT_EQ(1u, index._patterns.size());
     Pattern p;
     p.push_back(3);
     p.push_back(6);
     std::pair<Id*, size_t> ip = index._patterns[0];
     for (size_t i = 0; i < ip.second; i++) {
-      ASSERT_EQ(p[i], ip.first[i]);
+      ASSERT_EQ(p[i] + 1, ip.first[i]);
     }
-    ASSERT_EQ(0u, index.getHasPattern()[1]);
-    ASSERT_EQ(NO_PATTERN, index.getHasPattern()[0]);
+    ASSERT_EQ(0u, index.getHasPattern()[2]);
+    ASSERT_EQ(NO_PATTERN, index.getHasPattern()[1]);
 
     ASSERT_FLOAT_EQ(4.0 / 2, index.getHasPredicateMultiplicityEntities());
     ASSERT_FLOAT_EQ(4.0 / 3, index.getHasPredicateMultiplicityPredicates());
@@ -457,21 +460,21 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
   Index index;
   index.createFromOnDiskIndex("_testindex2");
 
-  ASSERT_TRUE(index._psoMeta.relationExists(2));
   ASSERT_TRUE(index._psoMeta.relationExists(3));
-  ASSERT_FALSE(index._psoMeta.relationExists(1));
-  ASSERT_FALSE(index._psoMeta.relationExists(4));
-  ASSERT_FALSE(index._psoMeta.getRmd(2).isFunctional());
-  ASSERT_TRUE(index._psoMeta.getRmd(3).isFunctional());
-  ASSERT_FALSE(index._psoMeta.getRmd(2).hasBlocks());
+  ASSERT_TRUE(index._psoMeta.relationExists(4));
+  ASSERT_FALSE(index._psoMeta.relationExists(2));
+  ASSERT_FALSE(index._psoMeta.relationExists(5));
+  ASSERT_FALSE(index._psoMeta.getRmd(3).isFunctional());
+  ASSERT_TRUE(index._psoMeta.getRmd(4).isFunctional());
   ASSERT_FALSE(index._psoMeta.getRmd(3).hasBlocks());
+  ASSERT_FALSE(index._psoMeta.getRmd(4).hasBlocks());
 
-  ASSERT_TRUE(index._posMeta.relationExists(2));
   ASSERT_TRUE(index._posMeta.relationExists(3));
-  ASSERT_FALSE(index._posMeta.relationExists(1));
-  ASSERT_FALSE(index._posMeta.relationExists(4));
-  ASSERT_TRUE(index._posMeta.getRmd(2).isFunctional());
+  ASSERT_TRUE(index._posMeta.relationExists(4));
+  ASSERT_FALSE(index._posMeta.relationExists(2));
+  ASSERT_FALSE(index._posMeta.relationExists(5));
   ASSERT_TRUE(index._posMeta.getRmd(3).isFunctional());
+  ASSERT_TRUE(index._posMeta.getRmd(4).isFunctional());
 
   remove("_testtmp3.tsv");
   remove("_testindex2.index.pso");
@@ -514,10 +517,10 @@ TEST(IndexTest, scanTest) {
 
     index.scanPSO("b", &wtl);
     ASSERT_EQ(2u, wtl.size());
-    ASSERT_EQ(0u, wtl[0][0]);
-    ASSERT_EQ(4u, wtl[0][1]);
-    ASSERT_EQ(0u, wtl[1][0]);
-    ASSERT_EQ(5u, wtl[1][1]);
+    ASSERT_EQ(1u, wtl[0][0]);
+    ASSERT_EQ(5u, wtl[0][1]);
+    ASSERT_EQ(1u, wtl[1][0]);
+    ASSERT_EQ(6u, wtl[1][1]);
     wtl.clear();
     index.scanPSO("x", &wtl);
     ASSERT_EQ(0u, wtl.size());
@@ -527,10 +530,10 @@ TEST(IndexTest, scanTest) {
 
     index.scanPOS("b", &wtl);
     ASSERT_EQ(2u, wtl.size());
-    ASSERT_EQ(4u, wtl[0][0]);
-    ASSERT_EQ(0u, wtl[0][1]);
-    ASSERT_EQ(5u, wtl[1][0]);
-    ASSERT_EQ(0u, wtl[1][1]);
+    ASSERT_EQ(5u, wtl[0][0]);
+    ASSERT_EQ(1u, wtl[0][1]);
+    ASSERT_EQ(6u, wtl[1][0]);
+    ASSERT_EQ(1u, wtl[1][1]);
     wtl.clear();
     index.scanPOS("x", &wtl);
     ASSERT_EQ(0u, wtl.size());
@@ -540,15 +543,15 @@ TEST(IndexTest, scanTest) {
 
     index.scanPSO("b", "a", &wol);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(5u, wol[1][0]);
+    ASSERT_EQ(5u, wol[0][0]);
+    ASSERT_EQ(6u, wol[1][0]);
     wol.clear();
     index.scanPSO("b", "c", &wol);
     ASSERT_EQ(0u, wol.size());
 
     index.scanPOS("b2", "c2", &wol);
     ASSERT_EQ(1u, wol.size());
-    ASSERT_EQ(1u, wol[0][0]);
+    ASSERT_EQ(2u, wol[0][0]);
   }
 
   remove("_testtmp2.tsv");
@@ -570,10 +573,11 @@ TEST(IndexTest, scanTest) {
   // 1: 1
   // 2: 2
   // 3: 3
-  // 4: a
-  // 5: b
-  // 6: c
-  // 7: is-a
+  // 4: ql:langtag
+  // 5: a
+  // 6: b
+  // 7: c
+  // 8: is-a
   f2 << "a\tis-a\t1\t.\n"
         "a\tis-a\t2\t.\n"
         "a\tis-a\t0\t.\n"
@@ -597,59 +601,59 @@ TEST(IndexTest, scanTest) {
 
     index.scanPSO("is-a", &wtl);
     ASSERT_EQ(7u, wtl.size());
-    ASSERT_EQ(4u, wtl[0][0]);
+    ASSERT_EQ(5u, wtl[0][0]);
     ASSERT_EQ(0u, wtl[0][1]);
-    ASSERT_EQ(4u, wtl[1][0]);
+    ASSERT_EQ(5u, wtl[1][0]);
     ASSERT_EQ(1u, wtl[1][1]);
-    ASSERT_EQ(4u, wtl[2][0]);
+    ASSERT_EQ(5u, wtl[2][0]);
     ASSERT_EQ(2u, wtl[2][1]);
-    ASSERT_EQ(5u, wtl[3][0]);
+    ASSERT_EQ(6u, wtl[3][0]);
     ASSERT_EQ(0u, wtl[3][1]);
-    ASSERT_EQ(5u, wtl[4][0]);
+    ASSERT_EQ(6u, wtl[4][0]);
     ASSERT_EQ(3u, wtl[4][1]);
-    ASSERT_EQ(6u, wtl[5][0]);
+    ASSERT_EQ(7u, wtl[5][0]);
     ASSERT_EQ(1u, wtl[5][1]);
-    ASSERT_EQ(6u, wtl[6][0]);
+    ASSERT_EQ(7u, wtl[6][0]);
     ASSERT_EQ(2u, wtl[6][1]);
 
     index.scanPOS("is-a", &wtl);
     ASSERT_EQ(7u, wtl.size());
     ASSERT_EQ(0u, wtl[0][0]);
-    ASSERT_EQ(4u, wtl[0][1]);
+    ASSERT_EQ(5u, wtl[0][1]);
     ASSERT_EQ(0u, wtl[1][0]);
-    ASSERT_EQ(5u, wtl[1][1]);
+    ASSERT_EQ(6u, wtl[1][1]);
     ASSERT_EQ(1u, wtl[2][0]);
-    ASSERT_EQ(4u, wtl[2][1]);
+    ASSERT_EQ(5u, wtl[2][1]);
     ASSERT_EQ(1u, wtl[3][0]);
-    ASSERT_EQ(6u, wtl[3][1]);
+    ASSERT_EQ(7u, wtl[3][1]);
     ASSERT_EQ(2u, wtl[4][0]);
-    ASSERT_EQ(4u, wtl[4][1]);
+    ASSERT_EQ(5u, wtl[4][1]);
     ASSERT_EQ(2u, wtl[5][0]);
-    ASSERT_EQ(6u, wtl[5][1]);
+    ASSERT_EQ(7u, wtl[5][1]);
     ASSERT_EQ(3u, wtl[6][0]);
-    ASSERT_EQ(5u, wtl[6][1]);
+    ASSERT_EQ(6u, wtl[6][1]);
 
     index.scanPOS("is-a", "0", &wol);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(5u, wol[1][0]);
+    ASSERT_EQ(5u, wol[0][0]);
+    ASSERT_EQ(6u, wol[1][0]);
 
     wol.clear();
     index.scanPOS("is-a", "1", &wol);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(6u, wol[1][0]);
+    ASSERT_EQ(5u, wol[0][0]);
+    ASSERT_EQ(7u, wol[1][0]);
 
     wol.clear();
     index.scanPOS("is-a", "2", &wol);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(6u, wol[1][0]);
+    ASSERT_EQ(5u, wol[0][0]);
+    ASSERT_EQ(7u, wol[1][0]);
 
     wol.clear();
     index.scanPOS("is-a", "3", &wol);
     ASSERT_EQ(1u, wol.size());
-    ASSERT_EQ(5u, wol[0][0]);
+    ASSERT_EQ(6u, wol[0][0]);
 
     wol.clear();
     index.scanPSO("is-a", "a", &wol);

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -71,7 +71,7 @@ class MergeVocabularyTest : public ::testing::Test {
     std::ofstream expVoc(_pathVocabExp);
     std::ofstream expExtVoc(_pathExternalVocabExp);
     expVoc << "ape\nbear\ngorilla\nmonkey\nzebra\n";
-    expExtVoc << EXTERNALIZED_LITERALS_PREFIX << "bla\n";
+    expExtVoc << "bla\n";
 
     // open files for partial Vocabularies
     auto mode = std::ios_base::out | std::ios_base::binary;


### PR DESCRIPTION
Implemented efficient language filters using a special mediator predicate that maps a literal to its language.

Currently this is the only variant that is implemented as I see no reason to keep the old inefficient variation.

Disadvantage: The special predicate is always inserted at the beginning of the vocabulary and thus a lot of hardcoded IDs in the unit tests of the Index class have to be incremented by one.