### PR TITLE
Add GroupBy into the optimizer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ To obtain a list of available predicates and their counts `ql:has-predicate` can
 
 `ql:has-predicate` can also be used as a normal predicate in an arbitrary query.
 
-Group by is supported both for selecting as well as in ORDER BY clauses:
+Group by is supported, its aggregates can be used both for selecting as well as in ORDER BY clauses:
 
     SELECT ?profession (AVG(?height) as ?avg) WHERE {
       ?a <is-a> ?profession .

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -15,7 +15,7 @@ queries:
           - num_cols: 3
           - num_rows: 1653
           - selected: ["?x", "SCORE(?t)", "TEXT(?t)"]
-            # null cells are ignored
+#null cells are ignored
           - contains_row: ["<Albert_Einstein>", null, null]
           - contains_row: ["<Luís_Lindley_Cintra>", null, null] # Test Unicode
           - order_numeric: {"dir" : "DESC", "var": "SCORE(?t)"}
@@ -77,7 +77,7 @@ queries:
           ORDER BY DESC(?count)
         checks:
           - num_cols: 2
-          # -num_rows: 5295 # greater than current limit
+#- num_rows : 5295 #greater than current limit
           - selected: ["?count", "?place"]
           - contains_row: [280, "<New_York_City>"]
           - order_numeric: {"dir": "DESC", "var": "?count"}
@@ -93,8 +93,8 @@ queries:
           ORDER BY DESC((COUNT(?x) as ?count))
         checks:
           - num_cols: 2
-          # The query returns to many rows, the current limit is 4096
-          # - num_rows: 5295
+#The query returns to many rows, the current limit is 4096
+#- num_rows : 5295
           - selected: ["?place", "?count2"]
           - order_numeric: {"dir": "DESC", "var": "?count2"}
   - query: scientists-order-by-aggregate-avg
@@ -155,7 +155,7 @@ queries:
           - num_rows: 2
           - num_cols: 2
           - selected: ["?avg", "?gender"]
-          # Float values are only compared to limited precision
+#Float values are only compared to limited precision
           - res: [[1.8, "<Male>"], [1.7, "<Female>"]]
           - order_numeric: {"dir": "DESC", "var": "?avg"}
   - query : pattern-trick
@@ -182,8 +182,8 @@ queries:
             ?entity ql:has-predicate ?relation .
           }
         checks:
-          # The number o rows is greater than the current limit of 4096.
-          # - num_rows: 168444
+#The number o rows is greater than the current limit of 4096.
+#- num_rows : 168444
           - num_cols: 2
           - selected: ["?entity", "?relation"]
           - contains_row: ["<Alan_Fersht>", "<Leader_of>"]
@@ -383,3 +383,19 @@ queries:
           - num_cols: 2
           - selected: ["?predicate", "?count"]
           - contains_row: ["<Gender>", "18589"]
+  - query : distinct-order-by-check 
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT DISTINCT ?scientist ?height WHERE {
+            ?scientist <is-a> <Scientist> .
+            ?scientist <Height> ?height .
+          }
+          ORDER BY DESC(?height)
+          LIMIT 2
+        checks:
+          - num_rows: 2
+          - num_cols: 2
+          - selected: ["?scientist", "?height"]
+          - contains_row: ["<Granville_Woods>", '2.1336']
+          - contains_row: ["<Charles_Bradley_(Chemist)>", '1.98']

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -249,7 +249,7 @@ queries:
           - contains_row: ["<Aaron_Antonovsky>","<Helen_Antonovsky>"]
           - contains_row: ["<Abraham_Zelmanov>", ""]
           - contains_row: ["<Abraham_Pais>","<Ida_Nicolaisen>;<Lila_Lee_Pais>"]
-          - contains_row: ["<Aafia_Siddiqui>","<Ammar_al-Baluchi>;<Amjad_Mohammed_Khan>"]
+          - contains_row: ["<Aafia_Siddiqui>","<Amjad_Mohammed_Khan>;<Ammar_al-Baluchi>"]
   - query: giant-int-scientists
     solutions:
       - type: no-text

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -32,7 +32,6 @@ struct option options[] = {{"all-permutations", no_argument, NULL, 'a'},
                            {"port", required_argument, NULL, 'p'},
                            {"patterns", no_argument, NULL, 'P'},
                            {"text", no_argument, NULL, 't'},
-                           {"unopt-optional", no_argument, NULL, 'u'},
                            {NULL, 0, NULL, 0}};
 
 void printUsage(char* execName) {
@@ -58,9 +57,6 @@ void printUsage(char* execName) {
        << "Enables the usage of text." << endl;
   cout << "  " << std::setw(20) << "j, worker-threads" << std::setw(1) << "    "
        << "Sets the number of worker threads to use" << endl;
-  cout << "  " << std::setw(20) << "u, unopt-optional" << std::setw(1) << "    "
-       << "Always place optional joins at the root of the query execution tree."
-       << endl;
   cout.copyfmt(coutState);
 }
 
@@ -78,7 +74,6 @@ int main(int argc, char** argv) {
   string index = "";
   bool text = false;
   bool allPermutations = false;
-  bool optimizeOptionals = true;
   int port = -1;
   int numThreads = 1;
   bool usePatterns = false;
@@ -106,9 +101,6 @@ int main(int argc, char** argv) {
         break;
       case 'j':
         numThreads = atoi(optarg);
-        break;
-      case 'u':
-        optimizeOptionals = false;
         break;
       case 'h':
         printUsage(argv[0]);
@@ -149,8 +141,7 @@ int main(int argc, char** argv) {
 
   try {
     Server server(port, numThreads);
-    server.initialize(index, text, allPermutations, optimizeOptionals,
-                      usePatterns);
+    server.initialize(index, text, allPermutations, usePatterns);
     server.run();
   } catch (const ad_semsearch::Exception& e) {
     LOG(ERROR) << e.getFullErrorMessage() << '\n';

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -214,7 +214,7 @@ void processQuery(QueryExecutionContext& qec, const string& query,
   SparqlParser sp;
   ParsedQuery pq = sp.parse(query);
   pq.expandPrefixes();
-  QueryPlanner qp(&qec, optimizeOptionals);
+  QueryPlanner qp(&qec);
   ad_utility::Timer timer;
   timer.start();
   auto qet = qp.createExecutionTree(pq);

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -33,11 +33,9 @@ struct option options[] = {{"all-permutations", no_argument, NULL, 'a'},
                            {"patterns", no_argument, NULL, 'P'},
                            {"queryfile", required_argument, NULL, 'q'},
                            {"text", no_argument, NULL, 't'},
-                           {"unopt-optional", no_argument, NULL, 'u'},
                            {NULL, 0, NULL, 0}};
 
-void processQuery(QueryExecutionContext& qec, const string& query,
-                  bool optimizeOptionals);
+void processQuery(QueryExecutionContext& qec, const string& query);
 void printUsage(char* execName);
 
 void printUsage(char* execName) {
@@ -68,8 +66,6 @@ void printUsage(char* execName) {
        << "Path to a file containing one query per line." << endl;
   cout << "  " << std::setw(20) << "t, text" << std::setw(1) << "    "
        << "Enables the usage of text." << endl;
-  cout << "  " << std::setw(20) << "u, unopt-optional" << std::setw(1) << "    "
-       << "Always execute optional joins last." << endl;
   cout.copyfmt(coutState);
 }
 
@@ -90,7 +86,6 @@ int main(int argc, char** argv) {
   bool interactive = false;
   bool onDiskLiterals = false;
   bool allPermutations = false;
-  bool optimizeOptionals = true;
   bool usePatterns = false;
 
   optind = 1;
@@ -123,9 +118,6 @@ int main(int argc, char** argv) {
       case 'h':
         printUsage(argv[0]);
         exit(0);
-        break;
-      case 'u':
-        optimizeOptionals = false;
         break;
       case 'P':
         usePatterns = true;
@@ -188,13 +180,13 @@ int main(int argc, char** argv) {
         if (os.str() == "") {
           return 0;
         }
-        processQuery(qec, os.str(), optimizeOptionals);
+        processQuery(qec, os.str());
       }
     } else {
       std::ifstream qf(queryfile);
       string line;
       while (std::getline(qf, line)) {
-        processQuery(qec, line, optimizeOptionals);
+        processQuery(qec, line);
       }
     }
   } catch (const std::exception& e) {
@@ -207,8 +199,7 @@ int main(int argc, char** argv) {
   return 0;
 }
 
-void processQuery(QueryExecutionContext& qec, const string& query,
-                  bool optimizeOptionals) {
+void processQuery(QueryExecutionContext& qec, const string& query) {
   ad_utility::Timer t;
   t.start();
   SparqlParser sp;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -41,9 +41,9 @@ string CountAvailablePredicates::asString(size_t indent) const {
 size_t CountAvailablePredicates::getResultWidth() const { return 2; }
 
 // _____________________________________________________________________________
-size_t CountAvailablePredicates::resultSortedOn() const {
+vector<size_t> CountAvailablePredicates::resultSortedOn() const {
   // The result is not sorted on any column.
-  return std::numeric_limits<size_t>::max();
+  return {};
 }
 
 // _____________________________________________________________________________
@@ -100,7 +100,7 @@ size_t CountAvailablePredicates::getCostEstimate() {
 // _____________________________________________________________________________
 void CountAvailablePredicates::computeResult(ResultTable* result) const {
   result->_nofColumns = 2;
-  result->_sortedBy = 0;
+  result->_sortedBy = resultSortedOn();
   result->_fixedSizeData = new vector<array<Id, 2>>();
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -77,13 +77,17 @@ float CountAvailablePredicates::getMultiplicity(size_t col) {
 // _____________________________________________________________________________
 size_t CountAvailablePredicates::getSizeEstimate() {
   if (_subtree.get() != nullptr) {
+    // Predicates are only computed for entities in the subtrees result.
+
     // This estimate is probably wildly innacurrate, but as it does not
     // depend on the order of operations of the subtree should be sufficient
-    // for the type of optizations the optimizer can currently do.
+    // for the type of optimizations the optimizer can currently do.
     size_t num_distinct = _subtree->getSizeEstimate() /
                           _subtree->getMultiplicity(_subjectColumnIndex);
     return num_distinct / getIndex().getHasPredicateMultiplicityPredicates();
   } else {
+    // Predicates are counted for all entities. In this case the size estimate
+    // should be accurate.
     return getIndex().getHasPredicateFullSize() /
            getIndex().getHasPredicateMultiplicityPredicates();
   }

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -41,32 +41,32 @@ class CountAvailablePredicates : public Operation {
                            std::shared_ptr<QueryExecutionTree> subtree,
                            size_t subjectColumnIndex);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const;
+  virtual vector<size_t> resultSortedOn() const override;
 
   std::unordered_map<string, size_t> getVariableColumns() const;
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     if (_subtree != nullptr) {
       _subtree->setTextLimit(limit);
     }
   }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     if (_subtree != nullptr) {
       return _subtree->knownEmptyResult();
     }
     return false;
   }
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
-  virtual size_t getSizeEstimate();
+  virtual size_t getSizeEstimate() override;
 
-  virtual size_t getCostEstimate();
+  virtual size_t getCostEstimate() override;
 
   void setVarNames(const std::string& predicateVarName,
                    const std::string& countVarName);
@@ -103,5 +103,5 @@ class CountAvailablePredicates : public Operation {
   std::string _predicateVarName;
   std::string _countVarName;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -28,6 +28,19 @@ string Distinct::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
+std::unordered_map<string, size_t> Distinct::getVariableColumns() const {
+  std::unordered_map<string, size_t> map;
+  for (size_t index : _keepIndices) {
+    for (const auto& it : _subtree->getVariableColumnMap()) {
+      if (it.second == index) {
+        map.insert(it);
+      }
+    }
+  }
+  return map;
+}
+
+// _____________________________________________________________________________
 void Distinct::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -51,6 +51,8 @@ class Distinct : public Operation {
     return _subtree->knownEmptyResult();
   }
 
+  std::unordered_map<string, size_t> getVariableColumns() const;
+
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<size_t> _keepIndices;

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -25,27 +25,35 @@ class Distinct : public Operation {
            std::shared_ptr<QueryExecutionTree> subtree,
            const vector<size_t>& keepIndices);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t resultSortedOn() const { return _subtree->resultSortedOn(); }
+  virtual vector<size_t> resultSortedOn() const override {
+    return _subtree->resultSortedOn();
+  }
 
-  virtual void setTextLimit(size_t limit) { _subtree->setTextLimit(limit); }
+  virtual void setTextLimit(size_t limit) override {
+    _subtree->setTextLimit(limit);
+  }
 
-  virtual size_t getSizeEstimate() { return _subtree->getSizeEstimate(); }
+  virtual size_t getSizeEstimate() override {
+    return _subtree->getSizeEstimate();
+  }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     return getSizeEstimate() + _subtree->getCostEstimate();
   }
 
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     return _subtree->getMultiplicity(col);
   }
 
-  virtual bool knownEmptyResult() { return _subtree->knownEmptyResult(); }
+  virtual bool knownEmptyResult() override {
+    return _subtree->knownEmptyResult();
+  }
 
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<size_t> _keepIndices;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -24,13 +24,17 @@ class Filter : public Operation {
          SparqlFilter::FilterType type, size_t var1Column, size_t var2Column,
          Id rhsId = std::numeric_limits<Id>::max());
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t resultSortedOn() const { return _subtree->resultSortedOn(); }
+  virtual vector<size_t> resultSortedOn() const override {
+    return _subtree->resultSortedOn();
+  }
 
-  virtual void setTextLimit(size_t limit) { _subtree->setTextLimit(limit); }
+  virtual void setTextLimit(size_t limit) override {
+    _subtree->setTextLimit(limit);
+  }
 
-  virtual size_t getSizeEstimate() {
+  virtual size_t getSizeEstimate() override {
     if (_type == SparqlFilter::FilterType::REGEX) {
       // TODO(jbuerklin): return a better estimate
       return std::numeric_limits<Id>::max();
@@ -57,7 +61,7 @@ class Filter : public Operation {
     }
   }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     if (_type == SparqlFilter::FilterType::REGEX) {
       return std::numeric_limits<Id>::max();
     }
@@ -71,9 +75,11 @@ class Filter : public Operation {
 
   std::shared_ptr<QueryExecutionTree> getSubtree() const { return _subtree; };
 
-  virtual bool knownEmptyResult() { return _subtree->knownEmptyResult(); }
+  virtual bool knownEmptyResult() override {
+    return _subtree->knownEmptyResult();
+  }
 
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     return _subtree->getMultiplicity(col);
   }
 
@@ -89,7 +95,7 @@ class Filter : public Operation {
   template <class RT>
   vector<RT>* computeFilter(vector<RT>* res, size_t l, size_t r,
                             shared_ptr<const ResultTable> subRes) const;
-  void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 
   template <class RT>
   vector<RT>* computeFilterFixedValue(

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -107,17 +107,15 @@ float GroupBy::getMultiplicity(size_t col) {
 }
 
 size_t GroupBy::getSizeEstimate() {
-  // group by should currently not be used in the optimizer
-  AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-           "GroupBy does not yet compute size estimates.");
-  return 0;
+  // TODO: stub implementation of getSizeEstimate()
+  return _subtree->getSizeEstimate();
 }
 
 size_t GroupBy::getCostEstimate() {
-  // group by should currently not be used in the optimizer
-  AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-           "GroupBy does not yet compute cost estimates.");
-  return 0;
+  // TODO: add the cost of the actual group by operation to the cost.
+  // Currently group by is only added to the optimizer as a terminal operation
+  // and its cost should not affect the optimizers results.
+  return _subtree->getCostEstimate();
 }
 
 template <typename T, typename C>

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -67,6 +67,7 @@ vector<size_t> GroupBy::resultSortedOn() const {
   vector<size_t> sortedOn;
   std::unordered_map<string, size_t> subtreeVarCols =
       _subtree->getVariableColumnMap();
+  sortedOn.reserve(subtreeVarCols.size());
   for (std::string var : _groupByVariables) {
     sortedOn.push_back(subtreeVarCols[var]);
   }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -49,7 +49,7 @@ string GroupBy::asString(size_t indent) const {
   for (size_t i = 0; i < indent; ++i) {
     os << " ";
   }
-  os << "GROUP_BY" << std::endl;
+  os << "GROUP_BY ";
   for (const std::string var : _groupByVariables) {
     os << var << ", ";
   }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -84,12 +84,23 @@ vector<pair<size_t, bool>> GroupBy::computeSortColumns(
   std::unordered_map<string, size_t> inVarColMap =
       inputTree->getVariableColumnMap();
 
+  std::unordered_set<size_t> sortColSet;
+
   // The returned columns are all groupByVariables followed by aggregrates
   for (std::string var : _groupByVariables) {
-    cols.push_back({inVarColMap[var], false});
+    size_t col = inVarColMap[var];
+    // avoid sorting by a column twice
+    if (sortColSet.find(col) == sortColSet.end()) {
+      sortColSet.insert(col);
+      cols.push_back({col, false});
+    }
   }
   for (const ParsedQuery::Alias& a : _aliases) {
-    cols.push_back({inVarColMap[a._outVarName], false});
+    size_t col = inVarColMap[a._inVarName];
+    if (sortColSet.find(col) == sortColSet.end()) {
+      sortColSet.insert(col);
+      cols.push_back({inVarColMap[a._inVarName], false});
+    }
   }
   return cols;
 }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -63,7 +63,15 @@ string GroupBy::asString(size_t indent) const {
 
 size_t GroupBy::getResultWidth() const { return _varColMap.size(); }
 
-size_t GroupBy::resultSortedOn() const { return -1; }
+vector<size_t> GroupBy::resultSortedOn() const {
+  vector<size_t> sortedOn;
+  std::unordered_map<string, size_t> subtreeVarCols =
+      _subtree->getVariableColumnMap();
+  for (std::string var : _groupByVariables) {
+    sortedOn.push_back(subtreeVarCols[var]);
+  }
+  return sortedOn;
+}
 
 vector<pair<size_t, bool>> GroupBy::computeSortColumns(
     std::shared_ptr<QueryExecutionTree> inputTree) {

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -60,23 +60,27 @@ class GroupBy : public Operation {
   GroupBy(QueryExecutionContext* qec, const vector<string>& groupByVariables,
           const std::vector<ParsedQuery::Alias>& aliases);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const;
+  virtual vector<size_t> resultSortedOn() const override;
 
   std::unordered_map<string, size_t> getVariableColumns() const;
 
-  virtual void setTextLimit(size_t limit) { _subtree->setTextLimit(limit); }
+  virtual void setTextLimit(size_t limit) override {
+    _subtree->setTextLimit(limit);
+  }
 
-  virtual bool knownEmptyResult() { return _subtree->knownEmptyResult(); }
+  virtual bool knownEmptyResult() override {
+    return _subtree->knownEmptyResult();
+  }
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
-  virtual size_t getSizeEstimate();
+  virtual size_t getSizeEstimate() override;
 
-  virtual size_t getCostEstimate();
+  virtual size_t getCostEstimate() override;
 
   /**
    * @brief To allow for creating a OrderBy Operation after the GroupBy
@@ -102,7 +106,7 @@ class GroupBy : public Operation {
   std::vector<ParsedQuery::Alias> _aliases;
   std::unordered_map<string, size_t> _varColMap;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };
 
 // This method is declared here solely for unit testing purposes

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -55,19 +55,19 @@ size_t HasPredicateScan::getResultWidth() const {
   return -1;
 }
 
-size_t HasPredicateScan::resultSortedOn() const {
+vector<size_t> HasPredicateScan::resultSortedOn() const {
   switch (_type) {
     case ScanType::FREE_S:
       // is the lack of sorting here a problem?
-      return -1;
+      return {};
     case ScanType::FREE_O:
-      return 0;
+      return {0};
     case ScanType::FULL_SCAN:
-      return 0;
+      return {0};
     case ScanType::SUBQUERY_S:
       return _subtree->resultSortedOn();
   }
-  return -1;
+  return {};
 }
 
 std::unordered_map<string, size_t> HasPredicateScan::getVariableColumns()

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -28,23 +28,23 @@ class HasPredicateScan : public Operation {
 
   HasPredicateScan(QueryExecutionContext* qec, ScanType type);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const;
+  virtual vector<size_t> resultSortedOn() const override;
 
   std::unordered_map<string, size_t> getVariableColumns() const;
 
-  virtual void setTextLimit(size_t limit);
+  virtual void setTextLimit(size_t limit) override;
 
-  virtual bool knownEmptyResult();
+  virtual bool knownEmptyResult() override;
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
-  virtual size_t getSizeEstimate();
+  virtual size_t getSizeEstimate() override;
 
-  virtual size_t getCostEstimate();
+  virtual size_t getCostEstimate() override;
 
   void setSubject(const std::string& subject);
   void setObject(const std::string& object);
@@ -85,5 +85,5 @@ class HasPredicateScan : public Operation {
   std::string _subject;
   std::string _object;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -94,6 +94,32 @@ size_t IndexScan::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
+vector<size_t> IndexScan::resultSortedOn() const {
+  switch (_type) {
+    case PSO_BOUND_S:
+    case POS_BOUND_O:
+    case SOP_BOUND_O:
+      return {0};
+    case PSO_FREE_S:
+    case POS_FREE_O:
+    case SPO_FREE_P:
+    case SOP_FREE_O:
+    case OSP_FREE_S:
+    case OPS_FREE_P:
+      return {0, 1};
+    case FULL_INDEX_SCAN_SPO:
+    case FULL_INDEX_SCAN_SOP:
+    case FULL_INDEX_SCAN_PSO:
+    case FULL_INDEX_SCAN_POS:
+    case FULL_INDEX_SCAN_OSP:
+    case FULL_INDEX_SCAN_OPS:
+      return {0, 1, 2};
+    default:
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED, "Should be unreachable.");
+  }
+}
+
+// _____________________________________________________________________________
 void IndexScan::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "IndexScan result computation...\n";
   switch (_type) {
@@ -141,7 +167,7 @@ void IndexScan::computeResult(ResultTable* result) const {
 void IndexScan::computePSOboundS(ResultTable* result) const {
   result->_nofColumns = 1;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0};
   result->_fixedSizeData = new vector<array<Id, 1>>();
   _executionContext->getIndex().scanPSO(
       _predicate, _subject,
@@ -154,7 +180,7 @@ void IndexScan::computePSOfreeS(ResultTable* result) const {
   result->_nofColumns = 2;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0, 1};
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanPSO(
       _predicate, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
@@ -165,7 +191,7 @@ void IndexScan::computePSOfreeS(ResultTable* result) const {
 void IndexScan::computePOSboundO(ResultTable* result) const {
   result->_nofColumns = 1;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0};
   result->_fixedSizeData = new vector<array<Id, 1>>();
   _executionContext->getIndex().scanPOS(
       _predicate, _object,
@@ -178,7 +204,7 @@ void IndexScan::computePOSfreeO(ResultTable* result) const {
   result->_nofColumns = 2;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0, 1};
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanPOS(
       _predicate, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
@@ -205,7 +231,7 @@ void IndexScan::computeSPOfreeP(ResultTable* result) const {
   result->_nofColumns = 2;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0, 1};
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanSPO(
       _subject, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
@@ -216,7 +242,7 @@ void IndexScan::computeSPOfreeP(ResultTable* result) const {
 void IndexScan::computeSOPboundO(ResultTable* result) const {
   result->_nofColumns = 1;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0};
   result->_fixedSizeData = new vector<array<Id, 1>>();
   _executionContext->getIndex().scanSOP(
       _subject, _object,
@@ -229,7 +255,7 @@ void IndexScan::computeSOPfreeO(ResultTable* result) const {
   result->_nofColumns = 2;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0, 1};
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanSOP(
       _subject, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
@@ -241,7 +267,7 @@ void IndexScan::computeOPSfreeP(ResultTable* result) const {
   result->_nofColumns = 2;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0, 1};
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanOPS(
       _object, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
@@ -253,7 +279,7 @@ void IndexScan::computeOSPfreeS(ResultTable* result) const {
   result->_nofColumns = 2;
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  result->_sortedBy = 0;
+  result->_sortedBy = {0, 1};
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanOSP(
       _object, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -29,7 +29,7 @@ class IndexScan : public Operation {
     FULL_INDEX_SCAN_OPS = 14
   };
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
   IndexScan(QueryExecutionContext* qec, ScanType type)
       : Operation(qec),
@@ -50,26 +50,26 @@ class IndexScan : public Operation {
     }
   }
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const { return 0; }
+  virtual vector<size_t> resultSortedOn() const override;
 
-  virtual void setTextLimit(size_t) {
+  virtual void setTextLimit(size_t) override {
     // Do nothing.
   }
 
-  virtual size_t getSizeEstimate() {
+  virtual size_t getSizeEstimate() override {
     if (_sizeEstimate == std::numeric_limits<size_t>::max()) {
       _sizeEstimate = computeSizeEstimate();
     }
     return _sizeEstimate;
   }
 
-  virtual size_t getCostEstimate() { return getSizeEstimate(); }
+  virtual size_t getCostEstimate() override { return getSizeEstimate(); }
 
   void determineMultiplicities();
 
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     if (_multiplicity.size() == 0) {
       determineMultiplicities();
     }
@@ -79,7 +79,7 @@ class IndexScan : public Operation {
 
   void precomputeSizeEstimate() { _sizeEstimate = computeSizeEstimate(); }
 
-  virtual bool knownEmptyResult() { return getSizeEstimate() == 0; }
+  virtual bool knownEmptyResult() override { return getSizeEstimate() == 0; }
 
   ScanType getType() const { return _type; }
 
@@ -91,7 +91,7 @@ class IndexScan : public Operation {
   size_t _sizeEstimate;
   vector<float> _multiplicity;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 
   void computePSOboundS(ResultTable* result) const;
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -61,7 +61,7 @@ void Join::computeResult(ResultTable* result) const {
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_resultTypes.resize(result->_nofColumns);
-    result->_sortedBy = _leftJoinCol;
+    result->_sortedBy = {_leftJoinCol};
     if (resWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 1>>();
     } else if (resWidth == 2) {
@@ -93,7 +93,7 @@ void Join::computeResult(ResultTable* result) const {
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_resultTypes.resize(result->_nofColumns);
-    result->_sortedBy = _leftJoinCol;
+    result->_sortedBy = {_leftJoinCol};
     if (resWidth == 1) {
       result->_fixedSizeData = new vector<array<Id, 1>>();
     } else if (resWidth == 2) {
@@ -127,7 +127,7 @@ void Join::computeResult(ResultTable* result) const {
       result->_resultTypes.push_back(rightRes->_resultTypes[i]);
     }
   }
-  result->_sortedBy = _leftJoinCol;
+  result->_sortedBy = {_leftJoinCol};
 
   if (leftWidth == 1) {
     if (rightWidth == 1) {
@@ -433,11 +433,11 @@ size_t Join::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-size_t Join::resultSortedOn() const {
+vector<size_t> Join::resultSortedOn() const {
   if (!isFullScanDummy(_left)) {
-    return _leftJoinCol;
+    return {_leftJoinCol};
   } else {
-    return 2 + _rightJoinCol;
+    return {2 + _rightJoinCol};
   }
 }
 
@@ -492,7 +492,7 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
   if (isFullScanDummy(_left)) {
     AD_CHECK(!isFullScanDummy(_right))
     result->_nofColumns = _right->getResultWidth() + 2;
-    result->_sortedBy = 2 + _rightJoinCol;
+    result->_sortedBy = {2 + _rightJoinCol};
     shared_ptr<const ResultTable> nonDummyRes = _right->getResult();
     result->_resultTypes.reserve(result->_nofColumns);
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
@@ -534,7 +534,7 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
   } else {
     AD_CHECK(!isFullScanDummy(_left))
     result->_nofColumns = _left->getResultWidth() + 2;
-    result->_sortedBy = _leftJoinCol;
+    result->_sortedBy = {_leftJoinCol};
 
     shared_ptr<const ResultTable> nonDummyRes = _left->getResult();
     result->_resultTypes.reserve(result->_nofColumns);

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -18,23 +18,23 @@ class Join : public Operation {
        std::shared_ptr<QueryExecutionTree> t2, size_t t1JoinCol,
        size_t t2JoinCol, bool keepJoinColumn = true);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const;
+  virtual vector<size_t> resultSortedOn() const override;
 
   std::unordered_map<string, size_t> getVariableColumns() const;
 
   std::unordered_set<string> getContextVars() const;
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);
     _right->setTextLimit(limit);
     _sizeEstimateComputed = false;
   }
 
-  virtual size_t getSizeEstimate() {
+  virtual size_t getSizeEstimate() override {
     if (!_sizeEstimateComputed) {
       computeSizeEstimateAndMultiplicities();
       _sizeEstimateComputed = true;
@@ -42,15 +42,15 @@ class Join : public Operation {
     return _sizeEstimate;
   }
 
-  virtual size_t getCostEstimate();
+  virtual size_t getCostEstimate() override;
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     return _left->knownEmptyResult() || _right->knownEmptyResult();
   }
 
   void computeSizeEstimateAndMultiplicities();
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
  private:
   std::shared_ptr<QueryExecutionTree> _left;
@@ -66,7 +66,7 @@ class Join : public Operation {
 
   vector<float> _multiplicities;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 
   static bool isFullScanDummy(std::shared_ptr<QueryExecutionTree> tree) {
     return tree->getType() == QueryExecutionTree::SCAN &&

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -18,7 +18,7 @@ using std::shared_ptr;
 class Operation {
  public:
   // Default Constructor.
-  Operation() : _executionContext(NULL) {}
+  Operation() : _executionContext(NULL), _hasComputedSortColumns(false) {}
 
   // Typical Constructor.
   explicit Operation(QueryExecutionContext* executionContext)
@@ -56,6 +56,17 @@ class Operation {
     _executionContext = executionContext;
   }
 
+  /**
+   * @return A list of columns on which the result of this operation is sorted.
+   */
+  const vector<size_t>& getResultSortedOn() {
+    if (!_hasComputedSortColumns) {
+      _hasComputedSortColumns = true;
+      _resultSortedColumns = resultSortedOn();
+    }
+    return _resultSortedColumns;
+  }
+
   const Index& getIndex() const { return _executionContext->getIndex(); }
 
   const Engine& getEngine() const { return _executionContext->getEngine(); }
@@ -64,7 +75,6 @@ class Operation {
   // This should possible act like an ID for each subtree.
   virtual string asString(size_t indent = 0) const = 0;
   virtual size_t getResultWidth() const = 0;
-  virtual size_t resultSortedOn() const = 0;
   virtual void setTextLimit(size_t limit) = 0;
   virtual size_t getCostEstimate() = 0;
   virtual size_t getSizeEstimate() = 0;
@@ -80,8 +90,26 @@ class Operation {
   // No ownership.
   QueryExecutionContext* _executionContext;
 
+  /**
+   * @brief Allows for updating of the sorted columns of an operation. This
+   *        has to be used by an operation if it's sort columns change during
+   *        the operations lifetime.
+   */
+  void setResultSortedOn(const vector<size_t>& sortedColumns) {
+    _resultSortedColumns = sortedColumns;
+  }
+
+  /**
+   * @brief Compute and return the columns un which the result will be sorted
+   * @return The columns on which the result will be sorted.
+   */
+  virtual vector<size_t> resultSortedOn() const = 0;
+
  private:
   //! Compute the result of the query-subtree rooted at this element..
   //! Computes both, an EntityList and a HitList.
   virtual void computeResult(ResultTable* result) const = 0;
+
+  vector<size_t> _resultSortedColumns;
+  bool _hasComputedSortColumns;
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -22,7 +22,7 @@ class Operation {
 
   // Typical Constructor.
   explicit Operation(QueryExecutionContext* executionContext)
-      : _executionContext(executionContext) {}
+      : _executionContext(executionContext), _hasComputedSortColumns(false) {}
 
   // Destructor.
   virtual ~Operation() {
@@ -100,7 +100,7 @@ class Operation {
   }
 
   /**
-   * @brief Compute and return the columns un which the result will be sorted
+   * @brief Compute and return the columns on which the result will be sorted
    * @return The columns on which the result will be sorted.
    */
   virtual vector<size_t> resultSortedOn() const = 0;

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -255,7 +255,14 @@ size_t OptionalJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-size_t OptionalJoin::resultSortedOn() const { return _joinColumns[0][0]; }
+vector<size_t> OptionalJoin::resultSortedOn() const {
+  std::vector<size_t> sortedOn;
+  // The result is sorted on all join columns from the left subtree.
+  for (const auto& a : _joinColumns) {
+    sortedOn.push_back(a[0]);
+  }
+  return sortedOn;
+}
 
 // _____________________________________________________________________________
 float OptionalJoin::getMultiplicity(size_t col) {

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -18,30 +18,30 @@ class OptionalJoin : public Operation {
                std::shared_ptr<QueryExecutionTree> t2, bool t2Optional,
                const std::vector<array<Id, 2>>& joinCols);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const;
+  virtual vector<size_t> resultSortedOn() const override;
 
   std::unordered_map<string, size_t> getVariableColumns() const;
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);
     _right->setTextLimit(limit);
   }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     return (_left->knownEmptyResult() && !_leftOptional) ||
            (_right->knownEmptyResult() && !_rightOptional) ||
            (_left->knownEmptyResult() && _right->knownEmptyResult());
   }
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
-  virtual size_t getSizeEstimate();
+  virtual size_t getSizeEstimate() override;
 
-  virtual size_t getCostEstimate();
+  virtual size_t getCostEstimate() override;
 
  private:
   void computeSizeEstimateAndMultiplicities();
@@ -57,5 +57,5 @@ class OptionalJoin : public Operation {
   size_t _sizeEstimate;
   bool _multiplicitiesComputed;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -34,6 +34,19 @@ string OrderBy::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
+vector<size_t> OrderBy::resultSortedOn() const {
+  std::vector<size_t> sortedOn;
+  sortedOn.resize(_sortIndices.size());
+  for (const pair<size_t, bool>& p : _sortIndices) {
+    if (!p.second) {
+      // Only ascending columns count as sorted.
+      sortedOn.push_back(p.first);
+    }
+  }
+  return sortedOn;
+}
+
+// _____________________________________________________________________________
 void OrderBy::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Gettign sub-result for OrderBy result computation..." << endl;
   AD_CHECK(_sortIndices.size() > 0);
@@ -85,8 +98,7 @@ void OrderBy::computeResult(ResultTable* result) const {
       break;
     }
   }
-  result->_sortedBy = (_sortIndices[0].second ? result->_nofColumns + 1
-                                              : _sortIndices[0].first);
+  result->_sortedBy = resultSortedOn();
   result->finish();
   LOG(DEBUG) << "OrderBy result computation done." << endl;
 }

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -18,28 +18,27 @@ using std::vector;
 
 class OrderBy : public Operation {
  public:
-  virtual size_t getResultWidth() const;
-
- public:
   OrderBy(QueryExecutionContext* qec,
           std::shared_ptr<QueryExecutionTree> subtree,
           const vector<pair<size_t, bool>>& sortIndices);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t resultSortedOn() const {
-    return std::numeric_limits<size_t>::max();
+  virtual vector<size_t> resultSortedOn() const override;
+
+  virtual void setTextLimit(size_t limit) override {
+    _subtree->setTextLimit(limit);
   }
 
-  virtual void setTextLimit(size_t limit) { _subtree->setTextLimit(limit); }
+  virtual size_t getSizeEstimate() override {
+    return _subtree->getSizeEstimate();
+  }
 
-  virtual size_t getSizeEstimate() { return _subtree->getSizeEstimate(); }
-
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     return _subtree->getMultiplicity(col);
   }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     size_t size = getSizeEstimate();
     size_t logSize = std::max(
         size_t(1),
@@ -49,11 +48,15 @@ class OrderBy : public Operation {
     return nlogn + subcost;
   }
 
-  virtual bool knownEmptyResult() { return _subtree->knownEmptyResult(); }
+  virtual bool knownEmptyResult() override {
+    return _subtree->knownEmptyResult();
+  }
+
+  virtual size_t getResultWidth() const override;
 
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<pair<size_t, bool>> _sortIndices;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -89,7 +89,9 @@ class QueryExecutionTree {
                                  size_t offset = 0,
                                  size_t maxSend = MAX_NOF_ROWS_IN_RESULT) const;
 
-  size_t resultSortedOn() const { return _rootOperation->resultSortedOn(); }
+  const std::vector<size_t>& resultSortedOn() const {
+    return _rootOperation->getResultSortedOn();
+  }
 
   bool isContextvar(const string& var) const {
     return _contextVars.count(var) > 0;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -419,10 +419,9 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
           std::make_pair(subjectColumn, false)};
 
       SubtreePlan orderByPlan(_qec);
-      std::shared_ptr<Operation> orderByOp(
-          new OrderBy(_qec, parent._qet, sortIndices));
-
       if (!isSorted) {
+        std::shared_ptr<Operation> orderByOp =
+            std::make_shared<OrderBy>(_qec, parent._qet, sortIndices);
         orderByPlan._qet->setVariableColumns(
             parent._qet->getVariableColumnMap());
         orderByPlan._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByOp);

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -131,212 +131,53 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) const {
     // as a filter later on).
     finalTab = fillDpTab(tg, pattern->_filters, childPlans);
 
-    if (pattern == &pq._rootGraphPattern && doGrouping && !usePatternTrick) {
-      finalTab.emplace_back(getGroupByRow(pq, finalTab));
-    }
+    if (pattern == &pq._rootGraphPattern) {
+      // GROUP BY
+      if (doGrouping && !usePatternTrick) {
+        finalTab.emplace_back(getGroupByRow(pq, finalTab));
+      } else if (usePatternTrick) {
+        finalTab.emplace_back(
+            getPatternTrickRow(pq, finalTab, patternTrickTriple));
+      }
 
-    // If the pattern trick is used sorting has to be done after the grouping.
-    if (pattern == &pq._rootGraphPattern && pq._orderBy.size() > 0 &&
-        !usePatternTrick) {
-      // If there is an order by clause, add another row to the table and
-      // just add an order by / sort to every previous result if needed.
-      // If the ordering is perfect already, just copy the plan.
-      finalTab.emplace_back(getOrderByRow(pq, finalTab));
+      // HAVING
+      if (pq._havingClauses.size() > 0) {
+        finalTab.emplace_back(getHavingRow(pq, finalTab));
+      }
+
+      // DISTINCT
+      if (pq._distinct) {
+        finalTab.emplace_back(getDistinctRow(pq, finalTab));
+      }
+
+      // ORDER BY
+      if (pq._orderBy.size() > 0) {
+        // If there is an order by clause, add another row to the table and
+        // just add an order by / sort to every previous result if needed.
+        // If the ordering is perfect already, just copy the plan.
+        finalTab.emplace_back(getOrderByRow(pq, finalTab));
+      }
     }
 
     vector<SubtreePlan>& lastRow = finalTab.back();
-    if (!usePatternTrick) {
-      // when the pattern trick is in use there is one triple that is not
-      // part of the triple graph, so the lastRow can be empty
-      AD_CHECK_GT(lastRow.size(), 0);
-    }
-    if (lastRow.size() > 0) {
-      size_t minCost = lastRow[0].getCostEstimate();
-      size_t minInd = 0;
 
-      for (size_t i = 1; i < lastRow.size(); ++i) {
-        size_t thisCost = lastRow[i].getCostEstimate();
-        if (thisCost < minCost) {
-          minCost = lastRow[i].getCostEstimate();
-          minInd = i;
-        }
+    AD_CHECK_GT(lastRow.size(), 0);
+
+    size_t minCost = lastRow[0].getCostEstimate();
+    size_t minInd = 0;
+
+    for (size_t i = 1; i < lastRow.size(); ++i) {
+      size_t thisCost = lastRow[i].getCostEstimate();
+      if (thisCost < minCost) {
+        minCost = lastRow[i].getCostEstimate();
+        minInd = i;
       }
-      lastRow[minInd]._isOptional = pattern->_optional;
-      patternPlans[pattern->_id] = lastRow[minInd];
     }
+    lastRow[minInd]._isOptional = pattern->_optional;
+    patternPlans[pattern->_id] = lastRow[minInd];
   }
 
   SubtreePlan final = patternPlans[0];
-
-  if (usePatternTrick) {
-    if (final._qet->getRootOperation() != nullptr) {
-      // Determine the column containing the subjects for which we are
-      // interested in their predicates.
-      auto it =
-          final._qet.get()->getVariableColumnMap().find(patternTrickTriple._s);
-      if (it == final._qet.get()->getVariableColumnMap().end()) {
-        AD_THROW(ad_semsearch::Exception::BAD_QUERY,
-                 "The root operation of the "
-                 "query excecution tree does "
-                 "not contain a column for "
-                 "variable " +
-                     patternTrickTriple._s +
-                     " required by the pattern "
-                     "trick.");
-      }
-      size_t subjectColumn = it->second;
-      const std::vector<size_t>& resultSortedOn =
-          final._qet->getRootOperation()->getResultSortedOn();
-      bool isSorted =
-          resultSortedOn.size() > 0 && resultSortedOn[0] == subjectColumn;
-      // a and b need to be ordered properly first
-      vector<pair<size_t, bool>> sortIndices = {
-          std::make_pair(subjectColumn, false)};
-
-      SubtreePlan orderByPlan(_qec);
-      std::shared_ptr<Operation> orderByOp(
-          new OrderBy(_qec, final._qet, sortIndices));
-
-      if (!isSorted) {
-        orderByPlan._qet->setVariableColumns(
-            final._qet->getVariableColumnMap());
-        orderByPlan._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByOp);
-      }
-      SubtreePlan patternTrickPlan(_qec);
-      std::shared_ptr<Operation> countPred(new CountAvailablePredicates(
-          _qec, isSorted ? final._qet : orderByPlan._qet, subjectColumn));
-
-      static_cast<CountAvailablePredicates*>(countPred.get())
-          ->setVarNames(patternTrickTriple._o, pq._aliases[0]._outVarName);
-      QueryExecutionTree& tree = *patternTrickPlan._qet.get();
-      tree.setVariableColumns(
-          static_cast<CountAvailablePredicates*>(countPred.get())
-              ->getVariableColumns());
-      tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
-                        countPred);
-
-      final = patternTrickPlan;
-      LOG(DEBUG) << "Plan after pattern trick: " << endl
-                 << final._qet->asString() << endl;
-    } else {
-      // Use the pattern trick without a subtree
-      SubtreePlan patternTrickPlan(_qec);
-      std::shared_ptr<Operation> countPred(new CountAvailablePredicates(_qec));
-
-      static_cast<CountAvailablePredicates*>(countPred.get())
-          ->setVarNames(patternTrickTriple._o, pq._aliases[0]._outVarName);
-      QueryExecutionTree& tree = *patternTrickPlan._qet.get();
-      tree.setVariableColumns(
-          static_cast<CountAvailablePredicates*>(countPred.get())
-              ->getVariableColumns());
-      tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
-                        countPred);
-
-      final = patternTrickPlan;
-    }
-  }
-
-  // create filter operations for the having clauses
-  for (const SparqlFilter& filter : pq._havingClauses) {
-    SubtreePlan plan(_qec);
-    auto& tree = *plan._qet.get();
-    tree.setVariableColumns(final._qet.get()->getVariableColumnMap());
-    tree.setOperation(QueryExecutionTree::FILTER,
-                      createFilterOperation(filter, final));
-    tree.setContextVars(final._qet.get()->getContextVars());
-    final = plan;
-  }
-
-  if (usePatternTrick) {
-    // OrderBy for the pattern trick has to be added after the pattern trick
-    if (pq._orderBy.size() > 0) {
-      SubtreePlan plan(_qec);
-      auto& tree = *plan._qet.get();
-      vector<pair<size_t, bool>> sortIndices;
-      for (auto& ord : pq._orderBy) {
-        sortIndices.emplace_back(pair<size_t, bool>{
-            final._qet.get()->getVariableColumn(ord._key), ord._desc});
-      }
-      std::shared_ptr<Operation> ob(new OrderBy(_qec, final._qet, sortIndices));
-      tree.setVariableColumns(final._qet.get()->getVariableColumnMap());
-      tree.setOperation(QueryExecutionTree::ORDER_BY, ob);
-      tree.setContextVars(final._qet.get()->getContextVars());
-      final = plan;
-    }
-  }
-
-  // A distinct modifier is applied in the end. This is very easy
-  // but not necessarily optimal.
-  // TODO: Adjust so that the optimal place for the operation is found.
-  if (pq._distinct) {
-    QueryExecutionTree distinctTree(*final._qet.get());
-    vector<size_t> keepIndices;
-    ad_utility::HashSet<size_t> indDone;
-    for (const auto& var : pq._selectedVariables) {
-      if (final._qet.get()->getVariableColumnMap().find(var) !=
-          final._qet.get()->getVariableColumnMap().end()) {
-        auto ind = final._qet.get()->getVariableColumnMap().find(var)->second;
-        if (indDone.count(ind) == 0) {
-          keepIndices.push_back(ind);
-          indDone.insert(ind);
-        }
-      } else if (ad_utility::startsWith(var, "SCORE(") ||
-                 ad_utility::startsWith(var, "TEXT(")) {
-        auto varInd = var.find('?');
-        auto cVar = var.substr(varInd, var.rfind(')') - varInd);
-        if (final._qet.get()->getVariableColumnMap().find(cVar) !=
-            final._qet.get()->getVariableColumnMap().end()) {
-          auto ind =
-              final._qet.get()->getVariableColumnMap().find(cVar)->second;
-          if (indDone.count(ind) == 0) {
-            keepIndices.push_back(ind);
-            indDone.insert(ind);
-          }
-        }
-      }
-    }
-    const std::vector<size_t>& resultSortedOn =
-        final._qet->getRootOperation()->getResultSortedOn();
-    // check if the current result is sorted on all columns of the distinct
-    // with the order of the sorting
-    bool isSorted = resultSortedOn.size() >= keepIndices.size();
-    size_t lastSortedOnIndex = 0;
-    for (size_t i = 0; isSorted && i < keepIndices.size(); i++) {
-      isSorted = isSorted && resultSortedOn[i] == keepIndices[i];
-    }
-    if (isSorted) {
-      std::shared_ptr<Operation> distinct(
-          new Distinct(_qec, final._qet, keepIndices));
-      distinctTree.setOperation(QueryExecutionTree::DISTINCT, distinct);
-    } else {
-      if (keepIndices.size() == 1) {
-        std::shared_ptr<QueryExecutionTree> tree(new QueryExecutionTree(_qec));
-        std::shared_ptr<Operation> sort(
-            new Sort(_qec, final._qet, keepIndices[0]));
-        tree->setVariableColumns(final._qet.get()->getVariableColumnMap());
-        tree->setOperation(QueryExecutionTree::SORT, sort);
-        tree->setContextVars(final._qet.get()->getContextVars());
-        std::shared_ptr<Operation> distinct(
-            new Distinct(_qec, tree, keepIndices));
-        distinctTree.setOperation(QueryExecutionTree::DISTINCT, distinct);
-      } else {
-        std::shared_ptr<QueryExecutionTree> tree(new QueryExecutionTree(_qec));
-        vector<pair<size_t, bool>> obCols;
-        for (auto& i : keepIndices) {
-          obCols.emplace_back(std::make_pair(i, false));
-        }
-        std::shared_ptr<Operation> ob(new OrderBy(_qec, final._qet, obCols));
-        tree->setVariableColumns(final._qet.get()->getVariableColumnMap());
-        tree->setOperation(QueryExecutionTree::ORDER_BY, ob);
-        tree->setContextVars(final._qet.get()->getContextVars());
-        std::shared_ptr<Operation> distinct(
-            new Distinct(_qec, tree, keepIndices));
-        distinctTree.setOperation(QueryExecutionTree::DISTINCT, distinct);
-      }
-    }
-    distinctTree.setTextLimit(getTextLimit(pq._textLimit));
-    return distinctTree;
-  }
 
   final._qet.get()->setTextLimit(getTextLimit(pq._textLimit));
   LOG(DEBUG) << "Done creating execution plan.\n";
@@ -456,6 +297,189 @@ bool QueryPlanner::checkUsePatternTrick(
     }
   }
   return usePatternTrick;
+}
+
+// _____________________________________________________________________________
+vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
+    const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
+  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
+  vector<SubtreePlan> added;
+  added.reserve(previous.size());
+  for (size_t i = 0; i < previous.size(); ++i) {
+    const SubtreePlan& parent = previous[i];
+    SubtreePlan distinctPlan(_qec);
+    vector<size_t> keepIndices;
+    ad_utility::HashSet<size_t> indDone;
+    for (const auto& var : pq._selectedVariables) {
+      if (parent._qet.get()->getVariableColumnMap().find(var) !=
+          parent._qet.get()->getVariableColumnMap().end()) {
+        auto ind = parent._qet.get()->getVariableColumnMap().find(var)->second;
+        if (indDone.count(ind) == 0) {
+          keepIndices.push_back(ind);
+          indDone.insert(ind);
+        }
+      } else if (ad_utility::startsWith(var, "SCORE(") ||
+                 ad_utility::startsWith(var, "TEXT(")) {
+        auto varInd = var.find('?');
+        auto cVar = var.substr(varInd, var.rfind(')') - varInd);
+        if (parent._qet.get()->getVariableColumnMap().find(cVar) !=
+            parent._qet.get()->getVariableColumnMap().end()) {
+          auto ind =
+              parent._qet.get()->getVariableColumnMap().find(cVar)->second;
+          if (indDone.count(ind) == 0) {
+            keepIndices.push_back(ind);
+            indDone.insert(ind);
+          }
+        }
+      }
+    }
+    const std::vector<size_t>& resultSortedOn =
+        parent._qet->getRootOperation()->getResultSortedOn();
+    // check if the current result is sorted on all columns of the distinct
+    // with the order of the sorting
+    bool isSorted = resultSortedOn.size() >= keepIndices.size();
+    for (size_t i = 0; isSorted && i < keepIndices.size(); i++) {
+      isSorted = isSorted && resultSortedOn[i] == keepIndices[i];
+    }
+    if (isSorted) {
+      std::shared_ptr<Operation> distinct(
+          new Distinct(_qec, parent._qet, keepIndices));
+      distinctPlan._qet->setOperation(QueryExecutionTree::DISTINCT, distinct);
+      distinctPlan._qet->setVariableColumns(
+          static_cast<Distinct*>(distinct.get())->getVariableColumns());
+      distinctPlan._qet->setContextVars(parent._qet.get()->getContextVars());
+    } else {
+      if (keepIndices.size() == 1) {
+        std::shared_ptr<QueryExecutionTree> tree(new QueryExecutionTree(_qec));
+        std::shared_ptr<Operation> sort(
+            new Sort(_qec, parent._qet, keepIndices[0]));
+        tree->setVariableColumns(parent._qet->getVariableColumnMap());
+        tree->setOperation(QueryExecutionTree::SORT, sort);
+        tree->setContextVars(parent._qet.get()->getContextVars());
+        std::shared_ptr<Operation> distinct(
+            new Distinct(_qec, tree, keepIndices));
+        distinctPlan._qet->setOperation(QueryExecutionTree::DISTINCT, distinct);
+        distinctPlan._qet->setVariableColumns(
+            static_cast<Distinct*>(distinct.get())->getVariableColumns());
+        distinctPlan._qet->setContextVars(parent._qet.get()->getContextVars());
+      } else {
+        std::shared_ptr<QueryExecutionTree> tree(new QueryExecutionTree(_qec));
+        vector<pair<size_t, bool>> obCols;
+        for (auto& i : keepIndices) {
+          obCols.emplace_back(std::make_pair(i, false));
+        }
+        std::shared_ptr<Operation> ob(new OrderBy(_qec, parent._qet, obCols));
+        tree->setVariableColumns(parent._qet->getVariableColumnMap());
+        tree->setOperation(QueryExecutionTree::ORDER_BY, ob);
+        tree->setContextVars(parent._qet.get()->getContextVars());
+        std::shared_ptr<Operation> distinct(
+            new Distinct(_qec, tree, keepIndices));
+        distinctPlan._qet->setOperation(QueryExecutionTree::DISTINCT, distinct);
+        distinctPlan._qet->setVariableColumns(
+            static_cast<Distinct*>(distinct.get())->getVariableColumns());
+        distinctPlan._qet->setContextVars(parent._qet.get()->getContextVars());
+      }
+    }
+    added.push_back(distinctPlan);
+  }
+  return added;
+}
+
+// _____________________________________________________________________________
+vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
+    const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab,
+    const SparqlTriple& patternTrickTriple) const {
+  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
+  vector<SubtreePlan> added;
+  if (previous.size() > 0) {
+    added.reserve(previous.size());
+    for (size_t i = 0; i < previous.size(); ++i) {
+      const SubtreePlan& parent = previous[i];
+      // Determine the column containing the subjects for which we are
+      // interested in their predicates.
+      auto it =
+          parent._qet.get()->getVariableColumnMap().find(patternTrickTriple._s);
+      if (it == parent._qet.get()->getVariableColumnMap().end()) {
+        AD_THROW(ad_semsearch::Exception::BAD_QUERY,
+                 "The root operation of the "
+                 "query excecution tree does "
+                 "not contain a column for "
+                 "variable " +
+                     patternTrickTriple._s +
+                     " required by the pattern "
+                     "trick.");
+      }
+      size_t subjectColumn = it->second;
+      const std::vector<size_t>& resultSortedOn =
+          parent._qet->getRootOperation()->getResultSortedOn();
+      bool isSorted =
+          resultSortedOn.size() > 0 && resultSortedOn[0] == subjectColumn;
+      // a and b need to be ordered properly first
+      vector<pair<size_t, bool>> sortIndices = {
+          std::make_pair(subjectColumn, false)};
+
+      SubtreePlan orderByPlan(_qec);
+      std::shared_ptr<Operation> orderByOp(
+          new OrderBy(_qec, parent._qet, sortIndices));
+
+      if (!isSorted) {
+        orderByPlan._qet->setVariableColumns(
+            parent._qet->getVariableColumnMap());
+        orderByPlan._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByOp);
+      }
+      SubtreePlan patternTrickPlan(_qec);
+      std::shared_ptr<Operation> countPred(new CountAvailablePredicates(
+          _qec, isSorted ? parent._qet : orderByPlan._qet, subjectColumn));
+
+      static_cast<CountAvailablePredicates*>(countPred.get())
+          ->setVarNames(patternTrickTriple._o, pq._aliases[0]._outVarName);
+      QueryExecutionTree& tree = *patternTrickPlan._qet.get();
+      tree.setVariableColumns(
+          static_cast<CountAvailablePredicates*>(countPred.get())
+              ->getVariableColumns());
+      tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
+                        countPred);
+      added.push_back(patternTrickPlan);
+    }
+  } else {
+    // Use the pattern trick without a subtree
+    SubtreePlan patternTrickPlan(_qec);
+    std::shared_ptr<Operation> countPred(new CountAvailablePredicates(_qec));
+
+    static_cast<CountAvailablePredicates*>(countPred.get())
+        ->setVarNames(patternTrickTriple._o, pq._aliases[0]._outVarName);
+    QueryExecutionTree& tree = *patternTrickPlan._qet.get();
+    tree.setVariableColumns(
+        static_cast<CountAvailablePredicates*>(countPred.get())
+            ->getVariableColumns());
+    tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
+                      countPred);
+    added.push_back(patternTrickPlan);
+  }
+  return added;
+}
+
+// _____________________________________________________________________________
+vector<QueryPlanner::SubtreePlan> QueryPlanner::getHavingRow(
+    const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const {
+  const vector<SubtreePlan>& previous = dpTab[dpTab.size() - 1];
+  vector<SubtreePlan> added;
+  added.reserve(previous.size());
+  for (size_t i = 0; i < previous.size(); ++i) {
+    const SubtreePlan& parent = previous[i];
+    SubtreePlan filtered = parent;
+    for (const SparqlFilter& filter : pq._havingClauses) {
+      SubtreePlan plan(_qec);
+      auto& tree = *plan._qet.get();
+      tree.setVariableColumns(parent._qet.get()->getVariableColumnMap());
+      tree.setOperation(QueryExecutionTree::FILTER,
+                        createFilterOperation(filter, parent));
+      tree.setContextVars(parent._qet.get()->getContextVars());
+      filtered = plan;
+    }
+    added.push_back(filtered);
+  }
+  return added;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -175,6 +175,16 @@ class QueryPlanner {
   vector<SubtreePlan> getGroupByRow(
       const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
 
+  vector<SubtreePlan> getDistinctRow(
+      const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
+
+  vector<SubtreePlan> getPatternTrickRow(
+      const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab,
+      const SparqlTriple& patternTrickTriple) const;
+
+  vector<SubtreePlan> getHavingRow(
+      const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
+
   bool connected(const SubtreePlan& a, const SubtreePlan& b,
                  const TripleGraph& graph) const;
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -11,8 +11,7 @@ using std::vector;
 
 class QueryPlanner {
  public:
-  explicit QueryPlanner(QueryExecutionContext* qec,
-                        bool optimizeOptionals = true);
+  explicit QueryPlanner(QueryExecutionContext* qec);
 
   QueryExecutionTree createExecutionTree(ParsedQuery& pq) const;
 
@@ -154,11 +153,6 @@ class QueryPlanner {
 
  private:
   QueryExecutionContext* _qec;
-  /**
-   * @brief Controls if optional joins are added to the optimizer or always
-   *        done last.
-   */
-  bool _optimizeOptionals;
 
   static bool isVariable(const string& elem);
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -178,6 +178,9 @@ class QueryPlanner {
   vector<SubtreePlan> getOrderByRow(
       const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
 
+  vector<SubtreePlan> getGroupByRow(
+      const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
+
   bool connected(const SubtreePlan& a, const SubtreePlan& b,
                  const TripleGraph& graph) const;
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -184,7 +184,8 @@ class QueryPlanner {
   vector<array<Id, 2>> getJoinColumns(const SubtreePlan& a,
                                       const SubtreePlan& b) const;
 
-  string getPruningKey(const SubtreePlan& plan, size_t orderedOnCol) const;
+  string getPruningKey(const SubtreePlan& plan,
+                       const vector<size_t>& orderedOnColumns) const;
 
   void applyFiltersIfPossible(vector<SubtreePlan>& row,
                               const vector<SparqlFilter>& filters,

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -41,7 +41,7 @@ class ResultTable {
 
   size_t _nofColumns;
   // A value >= _nofColumns indicates unsorted data
-  size_t _sortedBy;
+  vector<size_t> _sortedBy;
 
   vector<vector<Id>> _varSizeData;
   void* _fixedSizeData;

--- a/src/engine/ScanningJoin.cpp
+++ b/src/engine/ScanningJoin.cpp
@@ -36,10 +36,11 @@ ScanningJoin& ScanningJoin::operator=(const ScanningJoin& other) {
 ScanningJoin::~ScanningJoin() { delete _subtree; }
 
 // _____________________________________________________________________________
-string ScanningJoin::asString() const {
+string ScanningJoin::asString(size_t indent) const {
   std::ostringstream os;
   os << "SCANNING JOIN for the result of " << _subtree << " on col "
-     << _subtreeJoinCol << " and the equivalent of: " << IndexScan::asString();
+     << _subtreeJoinCol
+     << " and the equivalent of: " << IndexScan::asString(indent);
   return os.str();
 }
 

--- a/src/engine/ScanningJoin.h
+++ b/src/engine/ScanningJoin.h
@@ -24,30 +24,32 @@ class ScanningJoin : public IndexScan {
 
   virtual ~ScanningJoin();
 
-  virtual string asString() const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const { return _subtreeJoinCol; }
+  virtual vector<size_t> resultSortedOn() const override {
+    return {_subtreeJoinCol};
+  }
 
   virtual void setTextLimit(size_t limit) { _subtree->setTextLimit(limit); }
 
   virtual size_t getSizeEstimate() { return _subtree->getSizeEstimate(); }
 
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     return _subtree->getMultiplicity(col);
   }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     return _subtree->getSizeEstimate() + getSizeEstimate() * 10;
   }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     return _subtree->knownEmptyResult() || IndexScan::knownEmptyResult();
   }
 
  private:
   QueryExecutionTree* _subtree;
   size_t _subtreeJoinCol;
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -17,11 +17,8 @@
 
 // _____________________________________________________________________________
 void Server::initialize(const string& ontologyBaseName, bool useText,
-                        bool allPermutations, bool optimizeOptionals,
-                        bool usePatterns) {
+                        bool allPermutations, bool usePatterns) {
   LOG(INFO) << "Initializing server..." << std::endl;
-
-  _optimizeOptionals = optimizeOptionals;
 
   _index.setUsePatterns(usePatterns);
 
@@ -164,7 +161,7 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
       // QueryGraph qg(qec);
       // qg.createFromParsedQuery(pq);
       // const QueryExecutionTree& qet = qg.getExecutionTree();
-      QueryPlanner qp(qec, _optimizeOptionals);
+      QueryPlanner qp(qec);
       QueryExecutionTree qet = qp.createExecutionTree(pq);
       LOG(INFO) << qet.asString() << std::endl;
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -36,8 +36,7 @@ class Server {
 
   // Initialize the server.
   void initialize(const string& ontologyBaseName, bool useText,
-                  bool allPermutations = false, bool optimizeOptionals = true,
-                  bool usePatterns = false);
+                  bool allPermutations = false, bool usePatterns = false);
 
   //! Loop, wait for requests and trigger processing.
   void run();
@@ -48,7 +47,6 @@ class Server {
   int _port;
   Index _index;
   Engine _engine;
-  bool _optimizeOptionals;
 
   bool _initialized;
 

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -77,7 +77,7 @@ void Sort::computeResult(ResultTable* result) const {
       break;
     }
   }
-  result->_sortedBy = _sortCol;
+  result->_sortedBy = resultSortedOn();
   result->finish();
   LOG(DEBUG) << "Sort result computation done." << endl;
 }

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -12,27 +12,28 @@ using std::list;
 
 class Sort : public Operation {
  public:
-  virtual size_t getResultWidth() const;
-
- public:
   Sort(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> subtree,
        size_t sortCol);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t resultSortedOn() const { return _sortCol; }
+  virtual vector<size_t> resultSortedOn() const override { return {_sortCol}; }
 
-  virtual void setTextLimit(size_t limit) { _subtree->setTextLimit(limit); }
+  virtual void setTextLimit(size_t limit) override {
+    _subtree->setTextLimit(limit);
+  }
 
-  virtual size_t getSizeEstimate() { return _subtree->getSizeEstimate(); }
+  virtual size_t getSizeEstimate() override {
+    return _subtree->getSizeEstimate();
+  }
 
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     return _subtree->getMultiplicity(col);
   }
 
   std::shared_ptr<QueryExecutionTree> getSubtree() const { return _subtree; }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     size_t size = getSizeEstimate();
     size_t logSize = std::max(
         size_t(2), static_cast<size_t>(logb(static_cast<double>(size))));
@@ -41,11 +42,15 @@ class Sort : public Operation {
     return nlogn + subcost;
   }
 
-  virtual bool knownEmptyResult() { return _subtree->knownEmptyResult(); }
+  virtual bool knownEmptyResult() override {
+    return _subtree->knownEmptyResult();
+  }
+
+  virtual size_t getResultWidth() const;
 
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   size_t _sortCol;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/TextOperationForContexts.h
+++ b/src/engine/TextOperationForContexts.h
@@ -29,29 +29,27 @@ class TextOperationForContexts : public Operation {
             vector<pair<std::shared_ptr<QueryExecutionTree>, size_t>>(),
             textLimit) {}
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const {
-    return std::numeric_limits<size_t>::max();
-  }
+  virtual vector<size_t> resultSortedOn() const override { return {}; }
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     _textLimit = limit;
     for (auto& st : _subtrees) {
       st.first->setTextLimit(limit);
     }
   }
 
-  virtual size_t getSizeEstimate() {
+  virtual size_t getSizeEstimate() override {
     if (_executionContext) {
       // TODO: return a better estimate!
     }
     return 10000;
   }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     size_t sum = 10000;
     for (auto& pair : _subtrees) {
       sum += pair.first->getCostEstimate();
@@ -59,12 +57,12 @@ class TextOperationForContexts : public Operation {
     return sum;
   }
 
-  virtual float getMultiplicity(size_t col) {
+  virtual float getMultiplicity(size_t col) override {
     // TODO: return a better estimate!
     return col;
   }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     // TODO: return a better estimate!
     return false;
   }
@@ -74,5 +72,5 @@ class TextOperationForContexts : public Operation {
   vector<pair<std::shared_ptr<QueryExecutionTree>, size_t>> _subtrees;
   size_t _textLimit;
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/TextOperationWithFilter.h
+++ b/src/engine/TextOperationWithFilter.h
@@ -22,36 +22,36 @@ class TextOperationWithFilter : public Operation {
                           std::shared_ptr<QueryExecutionTree> filterResult,
                           size_t filterColumn, size_t textLimit = 1);
 
-  virtual string asString(size_t indent) const;
+  virtual string asString(size_t indent) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const {
+  virtual vector<size_t> resultSortedOn() const override {
     // unsorted, obtained from iterating over a hash map.
-    return std::numeric_limits<size_t>::max();
+    return {};
   }
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     _textLimit = limit;
     _filterResult->setTextLimit(limit);
     _sizeEstimate = std::numeric_limits<size_t>::max();
     _multiplicities.clear();
   }
 
-  virtual size_t getSizeEstimate();
-  virtual size_t getCostEstimate();
+  virtual size_t getSizeEstimate() override;
+  virtual size_t getCostEstimate() override;
 
   const string& getWordPart() const { return _words; }
 
   size_t getNofVars() const { return _nofVars; }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     return _filterResult->knownEmptyResult() ||
            (_executionContext &&
             _executionContext->getIndex().getSizeEstimate(_words) == 0);
   }
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
  private:
   string _words;
@@ -66,5 +66,5 @@ class TextOperationWithFilter : public Operation {
 
   void computeMultiplicities();
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/engine/TextOperationWithoutFilter.h
+++ b/src/engine/TextOperationWithoutFilter.h
@@ -20,32 +20,32 @@ class TextOperationWithoutFilter : public Operation {
   TextOperationWithoutFilter(QueryExecutionContext* qec, const string& words,
                              size_t nofVars, size_t textLimit = 1);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const {
+  virtual vector<size_t> resultSortedOn() const override {
     // unsorted, obtained from iterating over a hash map.
-    return std::numeric_limits<size_t>::max();
+    return {};
   }
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     _textLimit = limit;
     _multiplicities.clear();
     _sizeEstimate = std::numeric_limits<size_t>::max();
   }
 
-  virtual size_t getSizeEstimate();
+  virtual size_t getSizeEstimate() override;
 
-  virtual size_t getCostEstimate();
+  virtual size_t getCostEstimate() override;
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
   const string& getWordPart() const { return _words; }
 
   size_t getNofVars() const { return _nofVars; }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     return _executionContext &&
            _executionContext->getIndex().getSizeEstimate(_words) == 0;
   }
@@ -60,7 +60,7 @@ class TextOperationWithoutFilter : public Operation {
 
   void computeMultiplicities();
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 
   void computeResultNoVar(ResultTable* result) const;
 

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -95,7 +95,7 @@ void TwoColumnJoin::computeResult(ResultTable* result) const {
         rightFilter ? rightResult->_fixedSizeData : leftResult->_fixedSizeData);
     size_t jc1 = rightFilter ? _jc1Left : _jc1Right;
     size_t jc2 = rightFilter ? _jc2Left : _jc2Right;
-    result->_sortedBy = jc1;
+    result->_sortedBy = {jc1};
     result->_nofColumns = v->getResultWidth();
     result->_resultTypes.reserve(result->_nofColumns);
     result->_resultTypes.insert(result->_resultTypes.end(),
@@ -181,7 +181,9 @@ size_t TwoColumnJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-size_t TwoColumnJoin::resultSortedOn() const { return _jc1Left; }
+vector<size_t> TwoColumnJoin::resultSortedOn() const {
+  return {_jc1Left, _jc2Left};
+}
 
 // _____________________________________________________________________________
 float TwoColumnJoin::getMultiplicity(size_t col) {

--- a/src/engine/TwoColumnJoin.h
+++ b/src/engine/TwoColumnJoin.h
@@ -17,24 +17,24 @@ class TwoColumnJoin : public Operation {
                 std::shared_ptr<QueryExecutionTree> t2,
                 const std::vector<array<Id, 2>>& joinCols);
 
-  virtual string asString(size_t indent = 0) const;
+  virtual string asString(size_t indent = 0) const override;
 
-  virtual size_t getResultWidth() const;
+  virtual size_t getResultWidth() const override;
 
-  virtual size_t resultSortedOn() const;
+  virtual vector<size_t> resultSortedOn() const override;
 
   std::unordered_map<string, size_t> getVariableColumns() const;
 
-  virtual void setTextLimit(size_t limit) {
+  virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);
     _right->setTextLimit(limit);
   }
 
-  virtual size_t getSizeEstimate() {
+  virtual size_t getSizeEstimate() override {
     return (_left->getSizeEstimate() + _right->getSizeEstimate()) / 10;
   }
 
-  virtual size_t getCostEstimate() {
+  virtual size_t getCostEstimate() override {
     if ((_left->getResultWidth() == 2 && _jc1Left == 0 && _jc2Left == 1) ||
         (_right->getResultWidth() == 2 && _jc1Right == 0 && _jc2Right == 1)) {
       return _left->getSizeEstimate() + _left->getCostEstimate() +
@@ -44,11 +44,11 @@ class TwoColumnJoin : public Operation {
     return std::numeric_limits<size_t>::max() / 1000000;
   }
 
-  virtual bool knownEmptyResult() {
+  virtual bool knownEmptyResult() override {
     return _left->knownEmptyResult() || _right->knownEmptyResult();
   }
 
-  virtual float getMultiplicity(size_t col);
+  virtual float getMultiplicity(size_t col) override;
 
  private:
   std::shared_ptr<QueryExecutionTree> _left;
@@ -63,5 +63,5 @@ class TwoColumnJoin : public Operation {
 
   void computeMultiplicities();
 
-  virtual void computeResult(ResultTable* result) const;
+  virtual void computeResult(ResultTable* result) const override;
 };

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -297,6 +297,9 @@ ParsedQuery::GraphPattern& ParsedQuery::GraphPattern::operator=(
   _whereClauseTriples = std::vector<SparqlTriple>(other._whereClauseTriples);
   _filters = std::vector<SparqlFilter>(other._filters);
   _optional = other._optional;
+  for (GraphPattern* child : _children) {
+    delete child;
+  }
   _children.clear();
   _children.reserve(other._children.size());
   for (const GraphPattern* g : other._children) {

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -140,7 +140,7 @@ class ParsedQuery {
   class GraphPattern {
    public:
     // deletes the patterns children.
-    GraphPattern() {}
+    GraphPattern() : _optional(false) {}
     // Move and copyconstructors to avoid double deletes on the trees children
     GraphPattern(GraphPattern&& other);
     GraphPattern(const GraphPattern& other);

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -31,7 +31,7 @@ class DummyOperation : public Operation {
 
   virtual size_t getResultWidth() const { return 2; }
 
-  virtual size_t resultSortedOn() const { return 1; }
+  virtual vector<size_t> resultSortedOn() const { return {1}; }
 
   virtual void setTextLimit(size_t limit) { (void)limit; }
 

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -987,64 +987,61 @@ TEST(QueryExecutionTreeTest, testFormerSegfaultTriFilter) {
 }
 
 TEST(QueryPlannerTest, testSimpleOptional) {
-  for (bool optimizeOptionals = true; optimizeOptionals;
-       optimizeOptionals = false) {
-    try {
-      QueryPlanner qp(nullptr, optimizeOptionals);
+  try {
+    QueryPlanner qp(nullptr);
 
-      ParsedQuery pq = SparqlParser::parse(
-          "SELECT ?a ?b \n "
-          "WHERE  {?a <rel1> ?b . OPTIONAL { ?a <rel2> ?c }}");
-      pq.expandPrefixes();
-      QueryExecutionTree qet = qp.createExecutionTree(pq);
-      ASSERT_EQ(
-          "{\n"
-          "  OPTIONAL_JOIN\n"
-          "  {\n"
-          "    SCAN PSO with P = \"<rel1>\"\n"
-          "    qet-width: 2 \n"
-          "  } join-columns: [0]\n"
-          "  |X|\n"
-          "  {\n"
-          "    SCAN PSO with P = \"<rel2>\"\n"
-          "    qet-width: 2 \n"
-          "  } join-columns: [0]\n"
-          "  qet-width: 3 \n"
-          "}",
-          qet.asString());
+    ParsedQuery pq = SparqlParser::parse(
+        "SELECT ?a ?b \n "
+        "WHERE  {?a <rel1> ?b . OPTIONAL { ?a <rel2> ?c }}");
+    pq.expandPrefixes();
+    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    ASSERT_EQ(
+        "{\n"
+        "  OPTIONAL_JOIN\n"
+        "  {\n"
+        "    SCAN PSO with P = \"<rel1>\"\n"
+        "    qet-width: 2 \n"
+        "  } join-columns: [0]\n"
+        "  |X|\n"
+        "  {\n"
+        "    SCAN PSO with P = \"<rel2>\"\n"
+        "    qet-width: 2 \n"
+        "  } join-columns: [0]\n"
+        "  qet-width: 3 \n"
+        "}",
+        qet.asString());
 
-      ParsedQuery pq2 = SparqlParser::parse(
-          "SELECT ?a ?b \n "
-          "WHERE  {?a <rel1> ?b . "
-          "OPTIONAL { ?a <rel2> ?c }} ORDER BY ?b");
-      pq2.expandPrefixes();
-      QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
-      ASSERT_EQ(
-          "{\n"
-          "  SORT on column:1\n"
-          "  {\n"
-          "    OPTIONAL_JOIN\n"
-          "    {\n"
-          "      SCAN PSO with P = \"<rel1>\"\n"
-          "      qet-width: 2 \n"
-          "    } join-columns: [0]\n"
-          "    |X|\n"
-          "    {\n"
-          "      SCAN PSO with P = \"<rel2>\"\n"
-          "      qet-width: 2 \n"
-          "    } join-columns: [0]\n"
-          "    qet-width: 3 \n"
-          "  }\n"
-          "  qet-width: 3 \n"
-          "}",
-          qet2.asString());
-    } catch (const ad_semsearch::Exception& e) {
-      std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
-      FAIL() << e.getFullErrorMessage();
-    } catch (const std::exception& e) {
-      std::cout << "Caught: " << e.what() << std::endl;
-      FAIL() << e.what();
-    }
+    ParsedQuery pq2 = SparqlParser::parse(
+        "SELECT ?a ?b \n "
+        "WHERE  {?a <rel1> ?b . "
+        "OPTIONAL { ?a <rel2> ?c }} ORDER BY ?b");
+    pq2.expandPrefixes();
+    QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
+    ASSERT_EQ(
+        "{\n"
+        "  SORT on column:1\n"
+        "  {\n"
+        "    OPTIONAL_JOIN\n"
+        "    {\n"
+        "      SCAN PSO with P = \"<rel1>\"\n"
+        "      qet-width: 2 \n"
+        "    } join-columns: [0]\n"
+        "    |X|\n"
+        "    {\n"
+        "      SCAN PSO with P = \"<rel2>\"\n"
+        "      qet-width: 2 \n"
+        "    } join-columns: [0]\n"
+        "    qet-width: 3 \n"
+        "  }\n"
+        "  qet-width: 3 \n"
+        "}",
+        qet2.asString());
+  } catch (const ad_semsearch::Exception& e) {
+    std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
+    FAIL() << e.getFullErrorMessage();
+  } catch (const std::exception& e) {
+    std::cout << "Caught: " << e.what() << std::endl;
+    FAIL() << e.what();
   }
 }
 


### PR DESCRIPTION
This pr changes two things:
First all information for ResultTable sorting is now stored as a vector instead of a single column id. This allows for checking if a result is sorted on multiple columns and prevents the creation of some redundant OrderBy operations.
The group by and accompanying OrderBy operations are now added as a last row to the optimizer, which allows for selecting execution plans that do not require an OrderBy operation for the group by if they are cheaper. This fixes #129 as the planner can now detect that using a different scan makes the OrderBy unnecessary and thus the plan cheaper.
