### PR TITLE
Separate prefix file, fixing #141

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -56,6 +56,7 @@ static const int DEFAULT_NOF_DATE_YEAR_DIGITS = 19;
 
 static const std::string MMAP_FILE_SUFFIX = ".meta-mmap";
 static const std::string CONFIGURATION_FILE = ".meta-data.json";
+static const std::string PREFIX_FILE = ".prefixes";
 
 // Constants for the range of valid compression prefixes
 // all ASCII- printable characters are left out.

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -131,7 +131,7 @@ void Index::passContextFileIntoVector(const string& contextFile,
   // only add a text index. In that case the Vocabulary has never been
   // initialized before
   _vocab = Vocabulary<CompressedString>();
-  readConfigurationFile();
+  readConfiguration();
   _vocab.readFromFile(_onDiskBase + ".vocabulary",
                       _onDiskLiterals ? _onDiskBase + ".literals-index" : "");
 

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -95,9 +95,9 @@ void Index::createFromFile(const string& filename, bool allPermutations) {
   if (_vocabPrefixCompressed) {
     prefixes = calculatePrefixes(vocabFile, NUM_COMPRESSION_PREFIXES, 1, true);
   }
-  _configurationJson["prefixes"] =
-      Vocabulary<CompressedString>::prefixCompressFile(vocabFile, vocabFileTmp,
-                                                       prefixes);
+  _configurationJson["prefixes"] = prefixes;
+  Vocabulary<CompressedString>::prefixCompressFile(vocabFile, vocabFileTmp,
+                                                   prefixes);
   // TODO<joka921> maybe move this to its own function
   if (std::rename(vocabFileTmp.c_str(), vocabFile.c_str())) {
     LOG(INFO) << "Error: Rename the prefixed vocab file " << vocabFileTmp
@@ -1753,7 +1753,7 @@ void Index::readConfigurationFile() {
   }
 
   if (_configurationJson.find("prefixes") != _configurationJson.end()) {
-    _vocab.initializeRestartPrefixes(_configurationJson["prefixes"]);
+    _vocab.initializePrefixes(_configurationJson["prefixes"]);
   }
 
   if (_configurationJson.find("prefixes-external") !=

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -558,9 +558,8 @@ class Index {
    */
   void throwExceptionIfNoPatterns() const;
 
-  // TODO<joka921> better names
-  void writeConfigurationFile() const;
-  void readConfigurationFile();
+  void writeConfiguration() const;
+  void readConfiguration();
 
   // initialize the index-build-time settings for the vocabulary
   void initializeVocabularySettingsBuild();

--- a/src/index/MetaDataConverter.cpp
+++ b/src/index/MetaDataConverter.cpp
@@ -187,7 +187,8 @@ void CompressVocabAndCreateConfigurationFile(const string& indexPrefix) {
         ad_utility::File::exists(indexPrefix + ".literals-index");
     auto prefixes =
         calculatePrefixes(vocabFilename, NUM_COMPRESSION_PREFIXES, 1);
-    j["prefixes"] = Vocabulary<CompressedString>::prefixCompressFile(
+    j["prefixes"] = prefixes;
+    Vocabulary<CompressedString>::prefixCompressFile(
         vocabFilename, vocabFilename + ".converted", prefixes);
     notifyCreated(vocabFilename, true);
     std::ofstream f(confFilename);

--- a/src/index/MetaDataConverter.cpp
+++ b/src/index/MetaDataConverter.cpp
@@ -201,6 +201,10 @@ void CompressVocabAndCreateConfigurationFile(const string& indexPrefix) {
       for (const string& prefix : prefixes) {
         prefixFile << prefix << '\n';
       }
+      std::ofstream f(confFilename + ".converted");
+      AD_CHECK(f.is_open());
+      f << config;
+      notifyCreated(confFilename, true);
     } else {
       std::cout << "The configuration file " << confFilename
                 << " has an unrecoverably broken \"prefixes\" field"

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -318,7 +318,7 @@ class Vocabulary {
   //   prefixes - a list of prefixes which we will compress
   template <typename = std::enable_if_t<_isCompressed>>
   static void prefixCompressFile(const string& infile, const string& outfile,
-                          const vector<string>& prefixes);
+                                 const vector<string>& prefixes);
 
  private:
   // Wraps std::lower_bound and returns an index instead of an iterator

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -12,10 +12,10 @@
 #include <google/sparse_hash_map>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
-#include <nlohmann/json.hpp>
 #include "../global/Constants.h"
 #include "../global/Id.h"
 #include "../util/Exception.h"
@@ -28,7 +28,6 @@
 
 using std::string;
 using std::vector;
-using json = nlohmann::json;
 
 template <class StringType>
 struct AccessReturnTypeGetter {};
@@ -96,10 +95,6 @@ class PrefixComparator {
 template <class StringType>
 class Vocabulary {
  public:
-  // TODO<joka921, niklas> It would be cleaner to put the enable_if into the
-  // class declaration but this would need a lot of code restructuring.
-  // Can I leave it like this, the compiler errors are as decent as they become
-  // with templates
   template <
       typename = std::enable_if_t<std::is_same_v<StringType, string> ||
                                   std::is_same_v<StringType, CompressedString>>>
@@ -296,14 +291,13 @@ class Vocabulary {
   CompressedString compressPrefix(const string& word) const;
 
   // initialize compression with a list of prefixes
-  // can only be called on an empty array.
   // The prefixes do not have to be in any specific order
   //
   // StringRange prefixes can be of any type where
   // for (const string& el : prefixes {}
   // works
   template <class StringRange, typename = std::enable_if_t<_isCompressed>>
-  void initializeNewPrefixes(const StringRange& prefixes);
+  void initializePrefixes(const StringRange& prefixes);
 
   // set the list of prefixes for words which will become part of the
   // externalized vocabulary. Good for entity names that normally don't appear
@@ -315,17 +309,6 @@ class Vocabulary {
   template <class StringRange>
   void initializeExternalizePrefixes(const StringRange& prefixes);
 
-  // ______________________________________________________
-  // set the prefixes used for compression
-  // These have to have the exact same format returned by
-  // getJsonForPrefixes (serialization of the compression information)
-  template <typename = std::enable_if_t<_isCompressed>>
-  void initializeRestartPrefixes(const json& j);
-
-  // needed by function prefixCompressFile
-  template <typename = std::enable_if_t<_isCompressed>>
-  json getJsonForPrefixes() const;
-
   // Compress the file at path infile, write to file at outfile using the
   // specified prefixes.
   // Arguments:
@@ -333,14 +316,9 @@ class Vocabulary {
   //   outfile- output path. Will be overwritten by also one word per line
   //            in the same order as the infile
   //   prefixes - a list of prefixes which we will compress
-  //
-  //   Returns: A json array with information about the prefixes,
-  //            j[2]="ablab" means, that the prefix "ablab" was encoded by the
-  //            byte \x02
   template <typename = std::enable_if_t<_isCompressed>>
-  static std::array<std::string, NUM_COMPRESSION_PREFIXES> prefixCompressFile(
-      const string& infile, const string& outfile,
-      const vector<string>& prefixes);
+  static void prefixCompressFile(const string& infile, const string& outfile,
+                          const vector<string>& prefixes);
 
  private:
   // Wraps std::lower_bound and returns an index instead of an iterator

--- a/src/index/VocabularyImpl.h
+++ b/src/index/VocabularyImpl.h
@@ -239,7 +239,7 @@ void Vocabulary<S>::initializePrefixes(const StringRange& prefixes) {
     prefixIdx++;
   }
   if (prefixIdx != NUM_COMPRESSION_PREFIXES) {
-    LOG(INFO) << "WARNING: less than " << NUM_COMPRESSION_PREFIXES
+    LOG(WARN) << "less than " << NUM_COMPRESSION_PREFIXES
               << " prefixes specified.";
   }
   // if longest strings come first we correctly handle overlapping prefixes


### PR DESCRIPTION
This PR currently has two major commits. 

* The first one simplifies the old code without (hopefully) changing functionality, except for ignoring additional prefixes in the configuration file
* The second one moves the prefixes from the configuration file into a separate `.prefixes` file leaving only a boolean flag in the configuration file.

Sadly the `MetaDataConverter` seems to break on current indices instead of recognizing them as fine. I don't think that has anything to do with my new changes though. Until I figure that out it remains untested. Still I wanted to get this PR here so we don't get a duplication of work.

