### PR TITLE
Added a prefix filter and support for different column types to filters

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -399,3 +399,52 @@ queries:
           - selected: ["?scientist", "?height"]
           - contains_row: ["<Granville_Woods>", '2.1336']
           - contains_row: ["<Charles_Bradley_(Chemist)>", '1.98']
+  - query : having-avg-height
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?profession (AVG(?height) as ?avg) WHERE {
+            ?s <Profession> ?profession .
+            ?s <Height> ?height .
+          }
+          GROUP BY ?profession
+          HAVING (?avg > 1.9)
+          ORDER BY DESC(?avg)
+        checks:
+          - num_rows: 17
+          - num_cols: 2
+          - selected: ["?profession", "?avg"]
+          - contains_row: ["<Anatomist>", '1.94']
+          - contains_row: ["<Peace_activist>", '1.91']
+  - query : having-number-of-awards
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?profession (COUNT(DISTINCT ?s) as ?count) WHERE {
+            ?s <Profession> ?profession .
+            ?s <Award_Won> ?award .
+          }
+          GROUP BY ?profession
+          ORDER BY DESC(?count)
+          HAVING (?count > 300)
+        checks:
+          - num_rows: 6 
+          - num_cols: 2
+          - selected: ["?profession", "?count"]
+          - contains_row: ["<Chemist>", '603']
+          - contains_row: ["<Professor>", '352']
+  - query : having-group-concat
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?profession (GROUP_CONCAT(DISTINCT ?award) as ?awards) WHERE {
+            ?s <Profession> ?profession .
+            ?s <Award_Won> ?award .
+          }
+          GROUP BY ?profession
+          HAVING (?awards = <Victoria_Cross>)
+        checks:
+          - num_rows: 1 
+          - num_cols: 2
+          - selected: ["?profession", "?awards"]
+          - contains_row: ["<Apothecary>", '<Victoria_Cross>']

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -448,3 +448,19 @@ queries:
           - num_cols: 2
           - selected: ["?profession", "?awards"]
           - contains_row: ["<Apothecary>", '<Victoria_Cross>']
+  - query : prefix-filter-on-group-concat 
+    solutions:
+      - type: no-text
+        sparql: |
+          SELECT ?s (GROUP_CONCAT(?award) as ?awards) WHERE {
+            ?s <is-a> <Scientist> .
+            ?s <Award_Won> ?award .
+          }
+          GROUP BY ?s
+          HAVING regex(?awards, "^<Nobel_Prize")
+        checks:
+          - num_rows: 139 
+          - num_cols: 2
+          - selected: ["?s", "?awards"]
+          - contains_row: ['<Eric_Betzig>', '<Nobel_Prize_in_Chemistry>']
+          - contains_row: ['<Alan_MacDiarmid>', '<Nobel_Prize_in_Chemistry> <Rutherford_Medal>']

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -69,54 +69,54 @@ string Filter::asString(size_t indent) const {
 // _____________________________________________________________________________
 template <class RT, ResultTable::ResultType T>
 vector<RT>* Filter::computeFilterForResultType(
-    vector<RT>* res, size_t l, size_t r,
+    vector<RT>* res, size_t lhs, size_t rhs,
     shared_ptr<const ResultTable> subRes) const {
   switch (_type) {
     case SparqlFilter::EQ:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) ==
-                                  ValueReader<T>::get(e[r]);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) ==
+                                  ValueReader<T>::get(e[rhs]);
                          },
                          res);
       break;
     case SparqlFilter::NE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) !=
-                                  ValueReader<T>::get(e[r]);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) !=
+                                  ValueReader<T>::get(e[rhs]);
                          },
                          res);
       break;
     case SparqlFilter::LT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) <
-                                  ValueReader<T>::get(e[r]);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) <
+                                  ValueReader<T>::get(e[rhs]);
                          },
                          res);
       break;
     case SparqlFilter::LE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) <=
-                                  ValueReader<T>::get(e[r]);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) <=
+                                  ValueReader<T>::get(e[rhs]);
                          },
                          res);
       break;
     case SparqlFilter::GT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) >
-                                  ValueReader<T>::get(e[r]);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) >
+                                  ValueReader<T>::get(e[rhs]);
                          },
                          res);
       break;
     case SparqlFilter::GE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) >=
-                                  ValueReader<T>::get(e[r]);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) >=
+                                  ValueReader<T>::get(e[rhs]);
                          },
                          res);
       break;
@@ -140,29 +140,29 @@ vector<RT>* Filter::computeFilterForResultType(
 }
 
 template <class RT>
-vector<RT>* Filter::computeFilter(vector<RT>* res, size_t l, size_t r,
+vector<RT>* Filter::computeFilter(vector<RT>* res, size_t lhs, size_t rhs,
                                   shared_ptr<const ResultTable> subRes) const {
-  switch (subRes->getResultType(l)) {
+  switch (subRes->getResultType(lhs)) {
     case ResultTable::ResultType::KB:
       return computeFilterForResultType<RT, ResultTable::ResultType::KB>(
-          res, l, r, subRes);
+          res, lhs, rhs, subRes);
     case ResultTable::ResultType::VERBATIM:
       return computeFilterForResultType<RT, ResultTable::ResultType::VERBATIM>(
-          res, l, r, subRes);
+          res, lhs, rhs, subRes);
     case ResultTable::ResultType::FLOAT:
       return computeFilterForResultType<RT, ResultTable::ResultType::FLOAT>(
-          res, l, r, subRes);
+          res, lhs, rhs, subRes);
     case ResultTable::ResultType::LOCAL_VOCAB:
       return computeFilterForResultType<RT,
                                         ResultTable::ResultType::LOCAL_VOCAB>(
-          res, l, r, subRes);
+          res, lhs, rhs, subRes);
     case ResultTable::ResultType::TEXT:
       return computeFilterForResultType<RT, ResultTable::ResultType::TEXT>(
-          res, l, r, subRes);
+          res, lhs, rhs, subRes);
   }
   AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
            "Tried to compute a filter on an unknown result type " +
-               std::to_string(static_cast<int>(subRes->getResultType(l))));
+               std::to_string(static_cast<int>(subRes->getResultType(lhs))));
 }
 
 // _____________________________________________________________________________
@@ -225,62 +225,86 @@ void Filter::computeResult(ResultTable* result) const {
 
 template <class RT, ResultTable::ResultType T>
 vector<RT>* Filter::computeFilterFixedValueForResultType(
-    vector<RT>* res, size_t l, Id r,
+    vector<RT>* res, size_t lhs, Id rhs,
     shared_ptr<const ResultTable> subRes) const {
   switch (_type) {
     case SparqlFilter::EQ:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r, &subRes](const RT& e) { return e[l] == r; },
-                         res);
+      getEngine().filter(
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          [lhs, rhs, &subRes](const RT& e) { return e[lhs] == rhs; }, res);
       break;
     case SparqlFilter::NE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] != r; }, res);
+                         [lhs, rhs](const RT& e) { return e[lhs] != rhs; },
+                         res);
       break;
     case SparqlFilter::LT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) <
-                                  ValueReader<T>::get(r);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) <
+                                  ValueReader<T>::get(rhs);
                          },
                          res);
       break;
     case SparqlFilter::LE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) <=
-                                  ValueReader<T>::get(r);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) <=
+                                  ValueReader<T>::get(rhs);
                          },
                          res);
       break;
     case SparqlFilter::GT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) >
-                                  ValueReader<T>::get(r);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) >
+                                  ValueReader<T>::get(rhs);
                          },
                          res);
       break;
     case SparqlFilter::GE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) {
-                           return ValueReader<T>::get(e[l]) >=
-                                  ValueReader<T>::get(r);
+                         [lhs, rhs](const RT& e) {
+                           return ValueReader<T>::get(e[lhs]) >=
+                                  ValueReader<T>::get(rhs);
                          },
                          res);
       break;
     case SparqlFilter::LANG_MATCHES:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [this, l](const RT& e) {
-                           std::optional<string> entity =
-                               getIndex().idToOptionalString(e[l]);
-                           if (!entity) {
-                             return true;
-                           }
-                           return ad_utility::endsWith(entity.value(), _rhs);
-                         },
-                         res);
+      getEngine().filter(
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          [this, lhs, &subRes](const RT& e) {
+            std::optional<string> entity;
+            if constexpr (T == ResultTable::ResultType::KB) {
+              entity = getIndex().idToOptionalString(e[lhs]);
+            } else if (T == ResultTable::ResultType::LOCAL_VOCAB) {
+              entity = subRes->idToOptionalString(e[lhs]);
+            }
+            if (!entity) {
+              return true;
+            }
+            return ad_utility::endsWith(entity.value(), _rhs);
+          },
+          res);
       break;
+    case SparqlFilter::PREFIX:
+      // Check if the prefix filter can be applied. Use the regex filter
+      // otherwise.
+      if constexpr (T == ResultTable::ResultType::KB) {
+        // remove the leading '^' symbol
+        std::string rhs = _rhs.substr(1);
+        std::string upperBoundStr = rhs;
+        upperBoundStr[upperBoundStr.size() - 1]++;
+        size_t upperBound =
+            getIndex().getVocab().getValueIdForLT(upperBoundStr);
+        size_t lowerBound = getIndex().getVocab().getValueIdForGE(rhs);
+        getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                           [this, lhs, lowerBound, upperBound](const RT& e) {
+                             return lowerBound <= e[lhs] && e[lhs] < upperBound;
+                           },
+                           res);
+        break;
+      }
     case SparqlFilter::REGEX: {
       std::regex self_regex;
       if (_regexIgnoreCase) {
@@ -289,30 +313,21 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       } else {
         self_regex.assign(_rhs, std::regex_constants::ECMAScript);
       }
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [this, self_regex, &l](const RT& e) {
-                           std::optional<string> entity =
-                               getIndex().idToOptionalString(e[l]);
-                           if (!entity) {
-                             return true;
-                           }
-                           return std::regex_search(entity.value(), self_regex);
-                         },
-                         res);
-    } break;
-    case SparqlFilter::PREFIX: {
-      // remove the leading '^' symbol
-      std::string rhs = _rhs.substr(1);
-      size_t lowerBound = getIndex().getVocab().getValueIdForGE(rhs);
-      std::string upperBoundStr = rhs;
-      // TODO(florian): This only works for ascii but could break unicode
-      upperBoundStr[upperBoundStr.size() - 1]++;
-      size_t upperBound = getIndex().getVocab().getValueIdForLT(upperBoundStr);
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [this, l, lowerBound, upperBound](const RT& e) {
-                           return lowerBound <= e[l] && e[l] < upperBound;
-                         },
-                         res);
+      getEngine().filter(
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          [this, self_regex, &lhs, &subRes](const RT& e) {
+            std::optional<string> entity;
+            if constexpr (T == ResultTable::ResultType::KB) {
+              entity = getIndex().idToOptionalString(e[lhs]);
+            } else if (T == ResultTable::ResultType::LOCAL_VOCAB) {
+              entity = subRes->idToOptionalString(e[lhs]);
+            }
+            if (!entity) {
+              return true;
+            }
+            return std::regex_search(entity.value(), self_regex);
+          },
+          res);
     } break;
   }
   return res;
@@ -321,11 +336,12 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
 // _____________________________________________________________________________
 template <class RT>
 vector<RT>* Filter::computeFilterFixedValue(
-    vector<RT>* res, size_t l, Id r,
+    vector<RT>* res, size_t lhs, Id rhs,
     shared_ptr<const ResultTable> subRes) const {
-  ResultTable::ResultType resultType = subRes->getResultType(l);
+  ResultTable::ResultType resultType = subRes->getResultType(lhs);
   // Catch some unsupported combinations
   if (resultType != ResultTable::ResultType::KB &&
+      resultType != ResultTable::ResultType::LOCAL_VOCAB &&
       (_type == SparqlFilter::PREFIX || _type == SparqlFilter::LANG_MATCHES ||
        _type == SparqlFilter::REGEX)) {
     AD_THROW(
@@ -337,23 +353,23 @@ vector<RT>* Filter::computeFilterFixedValue(
     case ResultTable::ResultType::KB:
       return computeFilterFixedValueForResultType<RT,
                                                   ResultTable::ResultType::KB>(
-          res, l, r, subRes);
+          res, lhs, rhs, subRes);
     case ResultTable::ResultType::VERBATIM:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::VERBATIM>(res, l, r, subRes);
+          RT, ResultTable::ResultType::VERBATIM>(res, lhs, rhs, subRes);
     case ResultTable::ResultType::FLOAT:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::FLOAT>(res, l, r, subRes);
+          RT, ResultTable::ResultType::FLOAT>(res, lhs, rhs, subRes);
     case ResultTable::ResultType::LOCAL_VOCAB:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::LOCAL_VOCAB>(res, l, r, subRes);
+          RT, ResultTable::ResultType::LOCAL_VOCAB>(res, lhs, rhs, subRes);
     case ResultTable::ResultType::TEXT:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::TEXT>(res, l, r, subRes);
+          RT, ResultTable::ResultType::TEXT>(res, lhs, rhs, subRes);
   }
   AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
            "Tried to compute a filter on an unknown result type " +
-               std::to_string(static_cast<int>(subRes->getResultType(l))));
+               std::to_string(static_cast<int>(subRes->getResultType(lhs))));
 }
 
 // _____________________________________________________________________________
@@ -363,35 +379,35 @@ void Filter::computeResultFixedValue(
   LOG(DEBUG) << "Filter result computation..." << endl;
 
   // interpret the filters right hand side
-  size_t l = _subtree->getVariableColumn(_lhs);
-  Id r;
-  switch (subRes->getResultType(l)) {
+  size_t lhs = _subtree->getVariableColumn(_lhs);
+  Id rhs;
+  switch (subRes->getResultType(lhs)) {
     case ResultTable::ResultType::KB: {
-      std::string rhs = _rhs;
-      if (ad_utility::isXsdValue(rhs)) {
-        rhs = ad_utility::convertValueLiteralToIndexWord(rhs);
+      std::string rhs_string = _rhs;
+      if (ad_utility::isXsdValue(rhs_string)) {
+        rhs_string = ad_utility::convertValueLiteralToIndexWord(rhs_string);
       } else if (ad_utility::isNumeric(_rhs)) {
-        rhs = ad_utility::convertNumericToIndexWord(rhs);
+        rhs_string = ad_utility::convertNumericToIndexWord(rhs_string);
       }
       if (_type == SparqlFilter::EQ || _type == SparqlFilter::NE) {
-        if (!getIndex().getVocab().getId(_rhs, &r)) {
-          r = std::numeric_limits<size_t>::max() - 1;
+        if (!getIndex().getVocab().getId(_rhs, &rhs)) {
+          rhs = std::numeric_limits<size_t>::max() - 1;
         }
       } else if (_type == SparqlFilter::GE) {
-        r = getIndex().getVocab().getValueIdForGE(rhs);
+        rhs = getIndex().getVocab().getValueIdForGE(rhs_string);
       } else if (_type == SparqlFilter::GT) {
-        r = getIndex().getVocab().getValueIdForGT(rhs);
+        rhs = getIndex().getVocab().getValueIdForGT(rhs_string);
       } else if (_type == SparqlFilter::LT) {
-        r = getIndex().getVocab().getValueIdForLT(rhs);
+        rhs = getIndex().getVocab().getValueIdForLT(rhs_string);
       } else if (_type == SparqlFilter::LE) {
-        r = getIndex().getVocab().getValueIdForLE(rhs);
+        rhs = getIndex().getVocab().getValueIdForLE(rhs_string);
       }
       // All other types of filters do not use r and work on _rhs directly
       break;
     }
     case ResultTable::ResultType::VERBATIM:
       try {
-        r = std::stoull(_rhs);
+        rhs = std::stoull(_rhs);
       } catch (const std::logic_error& e) {
         AD_THROW(ad_semsearch::Exception::BAD_QUERY,
                  "A filter filters on an unsigned integer column, but its "
@@ -402,7 +418,7 @@ void Filter::computeResultFixedValue(
     case ResultTable::ResultType::FLOAT:
       try {
         float f = std::stof(_rhs);
-        std::memcpy(&r, &f, sizeof(float));
+        std::memcpy(&rhs, &f, sizeof(float));
       } catch (const std::logic_error& e) {
         AD_THROW(
             ad_semsearch::Exception::BAD_QUERY,
@@ -421,17 +437,22 @@ void Filter::computeResultFixedValue(
         // Find a matching entry in subRes' _localVocab. If _rhs is not in the
         // _localVocab of subRes r will be equal to  _localVocab.size() and
         // not match the index of any entry in _localVocab.
-        for (r = 0; r < subRes->_localVocab->size(); r++) {
-          if ((*subRes->_localVocab)[r] == _rhs) {
+        for (rhs = 0; rhs < subRes->_localVocab->size(); rhs++) {
+          if ((*subRes->_localVocab)[rhs] == _rhs) {
             break;
           }
         }
-      } else {
-        AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-                 "Only equality and inequality filters are allowed on "
-                 "dynamicaly assembled strings, but the following filter "
-                 "requires another type of filter operation:" +
-                     asString());
+      } else if (_type != SparqlFilter::LANG_MATCHES &&
+                 _type != SparqlFilter::PREFIX &&
+                 _type != SparqlFilter::REGEX) {
+        // Comparison based filters on the local vocab are hard, as the
+        // vocabularyis not sorted.
+        AD_THROW(
+            ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+            "Only equality, inequality and string based filters are allowed on "
+            "dynamicaly assembled strings, but the following filter "
+            "requires another type of filter operation:" +
+                asString());
       }
       break;
     default:
@@ -443,35 +464,35 @@ void Filter::computeResultFixedValue(
     case 1: {
       typedef array<Id, 1> RT;
       result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
+          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
       break;
     }
     case 2: {
       typedef array<Id, 2> RT;
       result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
+          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
       break;
     }
     case 3: {
       typedef array<Id, 3> RT;
       result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
+          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
       break;
     }
     case 4: {
       typedef array<Id, 4> RT;
       result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
+          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
       break;
     }
     case 5: {
       typedef array<Id, 5> RT;
       result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), l, r, subRes);
+          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
       break;
     }
     default: {
-      computeFilterFixedValue(&result->_varSizeData, l, r, subRes);
+      computeFilterFixedValue(&result->_varSizeData, lhs, rhs, subRes);
       break;
     }
   }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -16,17 +16,8 @@ size_t Filter::getResultWidth() const { return _subtree->getResultWidth(); }
 // _____________________________________________________________________________
 Filter::Filter(QueryExecutionContext* qec,
                std::shared_ptr<QueryExecutionTree> subtree,
-               SparqlFilter::FilterType type, size_t lhsInd, size_t rhsInd,
-               Id rhsId)
-    : Operation(qec),
-      _subtree(subtree),
-      _type(type),
-      _lhsInd(lhsInd),
-      _rhsInd(rhsInd),
-      _rhsId(rhsId) {
-  AD_CHECK(rhsId == std::numeric_limits<Id>::max() ||
-           rhsInd == std::numeric_limits<size_t>::max());
-}
+               SparqlFilter::FilterType type, string lhs, string rhs)
+    : Operation(qec), _subtree(subtree), _type(type), _lhs(lhs), _rhs(rhs) {}
 
 // _____________________________________________________________________________
 string Filter::asString(size_t indent) const {
@@ -38,7 +29,7 @@ string Filter::asString(size_t indent) const {
   for (size_t i = 0; i < indent; ++i) {
     os << " ";
   }
-  os << " with col " << _lhsInd;
+  os << " with " << _lhs;
   switch (_type) {
     case SparqlFilter::EQ:
       os << " == ";
@@ -59,59 +50,75 @@ string Filter::asString(size_t indent) const {
       os << " >= ";
       break;
     case SparqlFilter::LANG_MATCHES:
-      os << " LANG_MATCHES " << _rhsString;
+      os << " LANG_MATCHES ";
       break;
     case SparqlFilter::REGEX:
       os << " REGEX ";
       if (_regexIgnoreCase) {
         os << "ignoring case ";
-      }
-      os << _rhsString;
+      };
       break;
     case SparqlFilter::PREFIX:
-      os << " PREFIX " << _rhsString;
+      os << " PREFIX ";
       break;
   }
-  if (_type != SparqlFilter::LANG_MATCHES && _type != SparqlFilter::REGEX &&
-      _type != SparqlFilter::PREFIX) {
-    if (_rhsInd != std::numeric_limits<size_t>::max()) {
-      os << "col " << _rhsInd;
-    } else {
-      os << "entity Id " << _rhsId;
-    }
-  }
-
+  os << _rhs;
   return os.str();
 }
 
 // _____________________________________________________________________________
-template <class RT>
-vector<RT>* Filter::computeFilter(vector<RT>* res, size_t l, size_t r,
-                                  shared_ptr<const ResultTable> subRes) const {
+template <class RT, ResultTable::ResultType T>
+vector<RT>* Filter::computeFilterForResultType(
+    vector<RT>* res, size_t l, size_t r,
+    shared_ptr<const ResultTable> subRes) const {
   switch (_type) {
     case SparqlFilter::EQ:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] == e[r]; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) ==
+                                  ValueReader<T>::get(e[r]);
+                         },
+                         res);
       break;
     case SparqlFilter::NE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] != e[r]; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) !=
+                                  ValueReader<T>::get(e[r]);
+                         },
+                         res);
       break;
     case SparqlFilter::LT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] < e[r]; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) <
+                                  ValueReader<T>::get(e[r]);
+                         },
+                         res);
       break;
     case SparqlFilter::LE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] <= e[r]; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) <=
+                                  ValueReader<T>::get(e[r]);
+                         },
+                         res);
       break;
     case SparqlFilter::GT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] > e[r]; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) >
+                                  ValueReader<T>::get(e[r]);
+                         },
+                         res);
       break;
     case SparqlFilter::GE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] >= e[r]; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) >=
+                                  ValueReader<T>::get(e[r]);
+                         },
+                         res);
       break;
     case SparqlFilter::LANG_MATCHES:
       AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
@@ -132,6 +139,32 @@ vector<RT>* Filter::computeFilter(vector<RT>* res, size_t l, size_t r,
   return res;
 }
 
+template <class RT>
+vector<RT>* Filter::computeFilter(vector<RT>* res, size_t l, size_t r,
+                                  shared_ptr<const ResultTable> subRes) const {
+  switch (subRes->getResultType(l)) {
+    case ResultTable::ResultType::KB:
+      return computeFilterForResultType<RT, ResultTable::ResultType::KB>(
+          res, l, r, subRes);
+    case ResultTable::ResultType::VERBATIM:
+      return computeFilterForResultType<RT, ResultTable::ResultType::VERBATIM>(
+          res, l, r, subRes);
+    case ResultTable::ResultType::FLOAT:
+      return computeFilterForResultType<RT, ResultTable::ResultType::FLOAT>(
+          res, l, r, subRes);
+    case ResultTable::ResultType::LOCAL_VOCAB:
+      return computeFilterForResultType<RT,
+                                        ResultTable::ResultType::LOCAL_VOCAB>(
+          res, l, r, subRes);
+    case ResultTable::ResultType::TEXT:
+      return computeFilterForResultType<RT, ResultTable::ResultType::TEXT>(
+          res, l, r, subRes);
+  }
+  AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+           "Tried to compute a filter on an unknown result type " +
+               std::to_string(static_cast<int>(subRes->getResultType(l))));
+}
+
 // _____________________________________________________________________________
 void Filter::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
@@ -141,55 +174,64 @@ void Filter::computeResult(ResultTable* result) const {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  size_t l = _lhsInd;
-  size_t r = _rhsInd;
-  if (r == std::numeric_limits<size_t>::max()) {
-    AD_CHECK(_rhsId != std::numeric_limits<size_t>::max());
-    return computeResultFixedValue(result);
-  }
-  switch (subRes->_nofColumns) {
-    case 1: {
-      typedef array<Id, 1> RT;
-      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
-      break;
+  result->_localVocab = subRes->_localVocab;
+  size_t lhsInd = _subtree->getVariableColumn(_lhs);
+
+  if (_rhs[0] == '?') {
+    size_t rhsInd = _subtree->getVariableColumn(_rhs);
+    // compare two columns
+    switch (subRes->_nofColumns) {
+      case 1: {
+        typedef array<Id, 1> RT;
+        result->_fixedSizeData =
+            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        break;
+      }
+      case 2: {
+        typedef array<Id, 2> RT;
+        result->_fixedSizeData =
+            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        break;
+      }
+      case 3: {
+        typedef array<Id, 3> RT;
+        result->_fixedSizeData =
+            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        break;
+      }
+      case 4: {
+        typedef array<Id, 4> RT;
+        result->_fixedSizeData =
+            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        break;
+      }
+      case 5: {
+        typedef array<Id, 5> RT;
+        result->_fixedSizeData =
+            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        break;
+      }
+      default:
+        computeFilter(&result->_varSizeData, lhsInd, rhsInd, subRes);
+        break;
     }
-    case 2: {
-      typedef array<Id, 2> RT;
-      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
-      break;
-    }
-    case 3: {
-      typedef array<Id, 3> RT;
-      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
-      break;
-    }
-    case 4: {
-      typedef array<Id, 4> RT;
-      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
-      break;
-    }
-    case 5: {
-      typedef array<Id, 5> RT;
-      result->_fixedSizeData = computeFilter(new vector<RT>(), l, r, subRes);
-      break;
-    }
-    default:
-      computeFilter(&result->_varSizeData, l, r, subRes);
-      break;
+  } else {
+    // compare the left column to a fixed value
+    return computeResultFixedValue(result, subRes);
   }
   result->finish();
   LOG(DEBUG) << "Filter result computation done." << endl;
 }
 
-// _____________________________________________________________________________
-template <class RT>
-vector<RT>* Filter::computeFilterFixedValue(
+template <class RT, ResultTable::ResultType T>
+vector<RT>* Filter::computeFilterFixedValueForResultType(
     vector<RT>* res, size_t l, Id r,
     shared_ptr<const ResultTable> subRes) const {
   switch (_type) {
     case SparqlFilter::EQ:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] == r; }, res);
+                         [l, r, &subRes](const RT& e) { return e[l] == r; },
+                         res);
       break;
     case SparqlFilter::NE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
@@ -197,39 +239,55 @@ vector<RT>* Filter::computeFilterFixedValue(
       break;
     case SparqlFilter::LT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] < r; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) <
+                                  ValueReader<T>::get(r);
+                         },
+                         res);
       break;
     case SparqlFilter::LE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] <= r; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) <=
+                                  ValueReader<T>::get(r);
+                         },
+                         res);
       break;
     case SparqlFilter::GT:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] > r; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) >
+                                  ValueReader<T>::get(r);
+                         },
+                         res);
       break;
     case SparqlFilter::GE:
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                         [l, r](const RT& e) { return e[l] >= r; }, res);
+                         [l, r](const RT& e) {
+                           return ValueReader<T>::get(e[l]) >=
+                                  ValueReader<T>::get(r);
+                         },
+                         res);
       break;
     case SparqlFilter::LANG_MATCHES:
-      getEngine().filter(
-          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
-          [this, l](const RT& e) {
-            std::optional<string> entity = getIndex().idToOptionalString(e[l]);
-            if (!entity) {
-              return true;
-            }
-            return ad_utility::endsWith(entity.value(), this->_rhsString);
-          },
-          res);
+      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+                         [this, l](const RT& e) {
+                           std::optional<string> entity =
+                               getIndex().idToOptionalString(e[l]);
+                           if (!entity) {
+                             return true;
+                           }
+                           return ad_utility::endsWith(entity.value(), _rhs);
+                         },
+                         res);
       break;
     case SparqlFilter::REGEX: {
       std::regex self_regex;
       if (_regexIgnoreCase) {
-        self_regex.assign(this->_rhsString, std::regex_constants::ECMAScript |
-                                                std::regex_constants::icase);
+        self_regex.assign(_rhs, std::regex_constants::ECMAScript |
+                                    std::regex_constants::icase);
       } else {
-        self_regex.assign(this->_rhsString, std::regex_constants::ECMAScript);
+        self_regex.assign(_rhs, std::regex_constants::ECMAScript);
       }
       getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
                          [this, self_regex, &l](const RT& e) {
@@ -243,8 +301,10 @@ vector<RT>* Filter::computeFilterFixedValue(
                          res);
     } break;
     case SparqlFilter::PREFIX: {
-      size_t lowerBound = getIndex().getVocab().getValueIdForGE(_rhsString);
-      std::string upperBoundStr = _rhsString;
+      // remove the leading '^' symbol
+      std::string rhs = _rhs.substr(1);
+      size_t lowerBound = getIndex().getVocab().getValueIdForGE(rhs);
+      std::string upperBoundStr = rhs;
       // TODO(florian): This only works for ascii but could break unicode
       upperBoundStr[upperBoundStr.size() - 1]++;
       size_t upperBound = getIndex().getVocab().getValueIdForLT(upperBoundStr);
@@ -259,12 +319,126 @@ vector<RT>* Filter::computeFilterFixedValue(
 }
 
 // _____________________________________________________________________________
-void Filter::computeResultFixedValue(ResultTable* result) const {
+template <class RT>
+vector<RT>* Filter::computeFilterFixedValue(
+    vector<RT>* res, size_t l, Id r,
+    shared_ptr<const ResultTable> subRes) const {
+  ResultTable::ResultType resultType = subRes->getResultType(l);
+  // Catch some unsupported combinations
+  if (resultType != ResultTable::ResultType::KB &&
+      (_type == SparqlFilter::PREFIX || _type == SparqlFilter::LANG_MATCHES ||
+       _type == SparqlFilter::REGEX)) {
+    AD_THROW(
+        ad_semsearch::Exception::BAD_QUERY,
+        "Requested to apply a string based filter on a non string column: " +
+            asString());
+  }
+  switch (resultType) {
+    case ResultTable::ResultType::KB:
+      return computeFilterFixedValueForResultType<RT,
+                                                  ResultTable::ResultType::KB>(
+          res, l, r, subRes);
+    case ResultTable::ResultType::VERBATIM:
+      return computeFilterFixedValueForResultType<
+          RT, ResultTable::ResultType::VERBATIM>(res, l, r, subRes);
+    case ResultTable::ResultType::FLOAT:
+      return computeFilterFixedValueForResultType<
+          RT, ResultTable::ResultType::FLOAT>(res, l, r, subRes);
+    case ResultTable::ResultType::LOCAL_VOCAB:
+      return computeFilterFixedValueForResultType<
+          RT, ResultTable::ResultType::LOCAL_VOCAB>(res, l, r, subRes);
+    case ResultTable::ResultType::TEXT:
+      return computeFilterFixedValueForResultType<
+          RT, ResultTable::ResultType::TEXT>(res, l, r, subRes);
+  }
+  AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+           "Tried to compute a filter on an unknown result type " +
+               std::to_string(static_cast<int>(subRes->getResultType(l))));
+}
+
+// _____________________________________________________________________________
+void Filter::computeResultFixedValue(
+    ResultTable* result,
+    const std::shared_ptr<const ResultTable> subRes) const {
   LOG(DEBUG) << "Filter result computation..." << endl;
-  shared_ptr<const ResultTable> subRes = _subtree->getResult();
-  result->_nofColumns = subRes->_nofColumns;
-  size_t l = _lhsInd;
-  Id r = _rhsId;
+
+  // interpret the filters right hand side
+  size_t l = _subtree->getVariableColumn(_lhs);
+  Id r;
+  switch (subRes->getResultType(l)) {
+    case ResultTable::ResultType::KB: {
+      std::string rhs = _rhs;
+      if (ad_utility::isXsdValue(rhs)) {
+        rhs = ad_utility::convertValueLiteralToIndexWord(rhs);
+      } else if (ad_utility::isNumeric(_rhs)) {
+        rhs = ad_utility::convertNumericToIndexWord(rhs);
+      }
+      if (_type == SparqlFilter::EQ || _type == SparqlFilter::NE) {
+        if (!getIndex().getVocab().getId(_rhs, &r)) {
+          r = std::numeric_limits<size_t>::max() - 1;
+        }
+      } else if (_type == SparqlFilter::GE) {
+        r = getIndex().getVocab().getValueIdForGE(rhs);
+      } else if (_type == SparqlFilter::GT) {
+        r = getIndex().getVocab().getValueIdForGT(rhs);
+      } else if (_type == SparqlFilter::LT) {
+        r = getIndex().getVocab().getValueIdForLT(rhs);
+      } else if (_type == SparqlFilter::LE) {
+        r = getIndex().getVocab().getValueIdForLE(rhs);
+      }
+      // All other types of filters do not use r and work on _rhs directly
+      break;
+    }
+    case ResultTable::ResultType::VERBATIM:
+      try {
+        r = std::stoull(_rhs);
+      } catch (const std::logic_error& e) {
+        AD_THROW(ad_semsearch::Exception::BAD_QUERY,
+                 "A filter filters on an unsigned integer column, but its "
+                 "right hand side '" +
+                     _rhs + "' could not be parsed as an unsigned integer.");
+      }
+      break;
+    case ResultTable::ResultType::FLOAT:
+      try {
+        float f = std::stof(_rhs);
+        std::memcpy(&r, &f, sizeof(float));
+      } catch (const std::logic_error& e) {
+        AD_THROW(
+            ad_semsearch::Exception::BAD_QUERY,
+            "A filter filters on a float column, but its right hand side '" +
+                _rhs + "' could not be parsed as a float.");
+      }
+      break;
+    case ResultTable::ResultType::TEXT:
+      AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+               "Filtering on text type columns is not supported but required "
+               "by filter: " +
+                   asString());
+      break;
+    case ResultTable::ResultType::LOCAL_VOCAB:
+      if (_type == SparqlFilter::EQ || _type == SparqlFilter::NE) {
+        // Find a matching entry in subRes' _localVocab. If _rhs is not in the
+        // _localVocab of subRes r will be equal to  _localVocab.size() and
+        // not match the index of any entry in _localVocab.
+        for (r = 0; r < subRes->_localVocab->size(); r++) {
+          if ((*subRes->_localVocab)[r] == _rhs) {
+            break;
+          }
+        }
+      } else {
+        AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+                 "Only equality and inequality filters are allowed on "
+                 "dynamicaly assembled strings, but the following filter "
+                 "requires another type of filter operation:" +
+                     asString());
+      }
+      break;
+    default:
+      AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+               "Trying to filter on a not yet supported column type.");
+      break;
+  }
   switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -94,7 +94,7 @@ class Filter : public Operation {
    */
   template <class RT, ResultTable::ResultType T>
   vector<RT>* computeFilterForResultType(
-      vector<RT>* res, size_t l, size_t r,
+      vector<RT>* res, size_t lhs, size_t rhs,
       shared_ptr<const ResultTable> subRes) const;
 
   /**
@@ -102,7 +102,7 @@ class Filter : public Operation {
    *        arguments
    */
   template <class RT>
-  vector<RT>* computeFilter(vector<RT>* res, size_t l, size_t r,
+  vector<RT>* computeFilter(vector<RT>* res, size_t lhs, size_t rhs,
                             shared_ptr<const ResultTable> subRes) const;
   /**
    * @brief Uses the result type and the filter type (_type) to apply the filter
@@ -111,7 +111,7 @@ class Filter : public Operation {
    */
   template <class RT, ResultTable::ResultType T>
   vector<RT>* computeFilterFixedValueForResultType(
-      vector<RT>* res, size_t l, Id r,
+      vector<RT>* res, size_t lhs, Id rhs,
       shared_ptr<const ResultTable> subRes) const;
 
   /**
@@ -120,7 +120,7 @@ class Filter : public Operation {
    */
   template <class RT>
   vector<RT>* computeFilterFixedValue(
-      vector<RT>* res, size_t l, Id r,
+      vector<RT>* res, size_t lhs, Id rhs,
       shared_ptr<const ResultTable> subRes) const;
 
   void computeResultFixedValue(

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -21,8 +21,7 @@ class Filter : public Operation {
  public:
   Filter(QueryExecutionContext* qec,
          std::shared_ptr<QueryExecutionTree> subtree,
-         SparqlFilter::FilterType type, size_t var1Column, size_t var2Column,
-         Id rhsId = std::numeric_limits<Id>::max());
+         SparqlFilter::FilterType type, string lhs, string rhs);
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -40,7 +39,7 @@ class Filter : public Operation {
       return std::numeric_limits<Id>::max();
     }
     // TODO(schnelle): return a better estimate
-    if (_rhsId == std::numeric_limits<Id>::max()) {
+    if (_rhs[0] == '?') {
       if (_type == SparqlFilter::FilterType::EQ) {
         return _subtree->getSizeEstimate() / 1000;
       }
@@ -69,8 +68,6 @@ class Filter : public Operation {
            _subtree->getCostEstimate();
   }
 
-  void setRightHandSideString(std::string s) { _rhsString = s; }
-
   void setRegexIgnoreCase(bool i) { _regexIgnoreCase = i; }
 
   std::shared_ptr<QueryExecutionTree> getSubtree() const { return _subtree; };
@@ -86,21 +83,66 @@ class Filter : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   SparqlFilter::FilterType _type;
-  size_t _lhsInd;
-  size_t _rhsInd;
-  Id _rhsId;
-  std::string _rhsString;
+  string _lhs;
+  string _rhs;
   bool _regexIgnoreCase;
 
+  /**
+   * @brief Uses the result type and the filter type (_type) to apply the filter
+   * to subRes and store it in res.
+   * @return The pointer res.
+   */
+  template <class RT, ResultTable::ResultType T>
+  vector<RT>* computeFilterForResultType(
+      vector<RT>* res, size_t l, size_t r,
+      shared_ptr<const ResultTable> subRes) const;
+
+  /**
+   * @brief Calls computeFilterForResultType with the correct template
+   *        arguments
+   */
   template <class RT>
   vector<RT>* computeFilter(vector<RT>* res, size_t l, size_t r,
                             shared_ptr<const ResultTable> subRes) const;
-  virtual void computeResult(ResultTable* result) const override;
+  /**
+   * @brief Uses the result type and the filter type (_type) to apply the filter
+   * to subRes and store it in res.
+   * @return The pointer res.
+   */
+  template <class RT, ResultTable::ResultType T>
+  vector<RT>* computeFilterFixedValueForResultType(
+      vector<RT>* res, size_t l, Id r,
+      shared_ptr<const ResultTable> subRes) const;
 
+  /**
+   * @brief Calls computeFilterFixedValueForResultType with the correct template
+   *        arguments
+   */
   template <class RT>
   vector<RT>* computeFilterFixedValue(
       vector<RT>* res, size_t l, Id r,
       shared_ptr<const ResultTable> subRes) const;
 
-  void computeResultFixedValue(ResultTable* result) const;
+  void computeResultFixedValue(
+      ResultTable* result,
+      const std::shared_ptr<const ResultTable> subRes) const;
+  virtual void computeResult(ResultTable* result) const override;
+
+  /**
+   * @brief This struct handles the extraction of the data from an id based upon
+   *        the result type of the id's column.
+   */
+  template <ResultTable::ResultType T>
+  struct ValueReader {
+    static Id get(size_t in) { return in; }
+  };
+};
+
+template <>
+struct Filter::ValueReader<ResultTable::ResultType::FLOAT> {
+  static float get(size_t in) {
+    float f;
+    std::memcpy(&f, &in, sizeof(float));
+    return f;
+  }
 };

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -418,8 +418,8 @@ void processGroup(const GroupBy::Aggregate& a, size_t blockStart,
           }
         }
       }
-      resultRow[a._outCol] = outTable->_localVocab.size();
-      outTable->_localVocab.push_back(out.str());
+      resultRow[a._outCol] = outTable->_localVocab->size();
+      outTable->_localVocab->push_back(out.str());
       break;
     }
     case GroupBy::AggregateType::MAX: {

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -175,7 +175,7 @@ class QueryExecutionTree {
           case ResultTable::ResultType::LOCAL_VOCAB: {
             std::optional<string> entity =
                 res->idToOptionalString(row[validIndices[j].first]);
-            os << ad_utility::toJson(entity.value()) << ",";
+            os << ad_utility::toJson(entity) << ",";
             break;
           }
           default:
@@ -215,7 +215,7 @@ class QueryExecutionTree {
         case ResultTable::ResultType::LOCAL_VOCAB: {
           std::optional<string> entity = res->idToOptionalString(
               row[validIndices[validIndices.size() - 1].first]);
-          os << ad_utility::toJson(entity.value()) << "]";
+          os << ad_utility::toJson(entity) << "]";
           break;
         }
         default:

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1549,7 +1549,8 @@ std::shared_ptr<Operation> QueryPlanner::createFilterOperation(
       } else if (filter._type == SparqlFilter::LE) {
         entityId = _qec->getIndex().getVocab().getValueIdForLE(compWith);
       } else if (filter._type == SparqlFilter::LANG_MATCHES ||
-                 filter._type == SparqlFilter::REGEX) {
+                 filter._type == SparqlFilter::REGEX ||
+                 filter._type == SparqlFilter::PREFIX) {
         entityId = std::numeric_limits<size_t>::max() - 1;
       }
     }
@@ -1564,6 +1565,10 @@ std::shared_ptr<Operation> QueryPlanner::createFilterOperation(
         static_cast<Filter*>(filterOp.get())
             ->setRegexIgnoreCase(filter._regexIgnoreCase);
       }
+    }
+    if (_qec && (filter._type == SparqlFilter::PREFIX)) {
+      static_cast<Filter*>(filterOp.get())
+          ->setRightHandSideString(filter._rhs.substr(1));
     }
     return filterOp;
   }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1517,61 +1517,12 @@ void QueryPlanner::applyFiltersIfPossible(
 // _____________________________________________________________________________
 std::shared_ptr<Operation> QueryPlanner::createFilterOperation(
     const SparqlFilter& filter, const SubtreePlan& parent) const {
-  if (isVariable(filter._rhs)) {
-    std::shared_ptr<Operation> filterOp = std::make_shared<Filter>(
-        _qec, parent._qet, filter._type,
-        parent._qet.get()->getVariableColumn(filter._lhs),
-        parent._qet.get()->getVariableColumn(filter._rhs));
-    return filterOp;
-  } else {
-    string compWith = filter._rhs;
-    Id entityId = 0;
-    if (_qec) {
-      // TODO(schnelle): A proper SPARQL parser should have
-      // tagged/converted numeric values already. However our parser is
-      // currently far too crude for that
-      if (ad_utility::isXsdValue(compWith)) {
-        compWith = ad_utility::convertValueLiteralToIndexWord(compWith);
-      } else if (ad_utility::isNumeric(compWith)) {
-        compWith = ad_utility::convertNumericToIndexWord(compWith);
-      }
-      if (filter._type == SparqlFilter::EQ ||
-          filter._type == SparqlFilter::NE) {
-        if (!_qec->getIndex().getVocab().getId(compWith, &entityId)) {
-          entityId = std::numeric_limits<size_t>::max() - 1;
-        }
-      } else if (filter._type == SparqlFilter::GE) {
-        entityId = _qec->getIndex().getVocab().getValueIdForGE(compWith);
-      } else if (filter._type == SparqlFilter::GT) {
-        entityId = _qec->getIndex().getVocab().getValueIdForGT(compWith);
-      } else if (filter._type == SparqlFilter::LT) {
-        entityId = _qec->getIndex().getVocab().getValueIdForLT(compWith);
-      } else if (filter._type == SparqlFilter::LE) {
-        entityId = _qec->getIndex().getVocab().getValueIdForLE(compWith);
-      } else if (filter._type == SparqlFilter::LANG_MATCHES ||
-                 filter._type == SparqlFilter::REGEX ||
-                 filter._type == SparqlFilter::PREFIX) {
-        entityId = std::numeric_limits<size_t>::max() - 1;
-      }
-    }
-    std::shared_ptr<Operation> filterOp(
-        new Filter(_qec, parent._qet, filter._type,
-                   parent._qet.get()->getVariableColumn(filter._lhs),
-                   std::numeric_limits<size_t>::max(), entityId));
-    if (_qec && (filter._type == SparqlFilter::LANG_MATCHES ||
-                 filter._type == SparqlFilter::REGEX)) {
-      static_cast<Filter*>(filterOp.get())->setRightHandSideString(filter._rhs);
-      if (filter._type == SparqlFilter::REGEX) {
-        static_cast<Filter*>(filterOp.get())
-            ->setRegexIgnoreCase(filter._regexIgnoreCase);
-      }
-    }
-    if (_qec && (filter._type == SparqlFilter::PREFIX)) {
-      static_cast<Filter*>(filterOp.get())
-          ->setRightHandSideString(filter._rhs.substr(1));
-    }
-    return filterOp;
+  std::shared_ptr<Filter> op = std::make_shared<Filter>(
+      _qec, parent._qet, filter._type, filter._lhs, filter._rhs);
+  if (filter._type == SparqlFilter::REGEX) {
+    op->setRegexIgnoreCase(filter._regexIgnoreCase);
   }
+  return op;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -11,7 +11,8 @@ ResultTable::ResultTable()
       _sortedBy(0),
       _varSizeData(),
       _fixedSizeData(nullptr),
-      _status(ResultTable::OTHER) {}
+      _status(ResultTable::OTHER),
+      _localVocab(std::make_shared<std::vector<std::string>>()) {}
 
 // _____________________________________________________________________________
 void ResultTable::clear() {

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -47,8 +47,16 @@ class ResultTable {
   void* _fixedSizeData;
 
   vector<ResultType> _resultTypes;
+
   // This vector is used to store generated strings (such as the GROUP_CONCAT
   // results) which are used in the output with the ResultType::STRING type.
+  // A std::shared_ptr is used to allow for quickly passing the vocabulary
+  // from one result to the next, as any operation that occurs after one
+  // having added entries to the _localVocab needs to ensure its ResultTable
+  // has the same _localVocab. As currently entries in the _localVocab are not
+  // being moved or deleted having a single copy used by several operations
+  // should not lead to any references to the _localVocab being invalidated
+  // due to later use.
   // WARNING: Currently only operations that can run after a GroupBy copy
   //          the _localVocab of a subresult.
   std::shared_ptr<vector<string>> _localVocab;

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -51,7 +51,7 @@ class ResultTable {
   // results) which are used in the output with the ResultType::STRING type.
   // WARNING: Currently only operations that can run after a GroupBy copy
   //          the _localVocab of a subresult.
-  vector<string> _localVocab;
+  std::shared_ptr<vector<string>> _localVocab;
 
   ResultTable();
 
@@ -83,8 +83,8 @@ class ResultTable {
   }
 
   std::optional<std::string> idToOptionalString(Id id) const {
-    if (id < _localVocab.size()) {
-      return _localVocab[id];
+    if (id < _localVocab->size()) {
+      return (*_localVocab)[id];
     } else if (id == ID_NO_VALUE) {
       return std::nullopt;
     }

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -21,8 +21,7 @@ void IndexMetaData<MapType>::add(const FullRelationMetaData& rmd,
 
   off_t afterExpected =
       rmd.hasBlocks() ? bRmd._offsetAfter
-                      : static_cast<off_t>(rmd._startFullIndex +
-                                           rmd.getNofBytesForFulltextIndex());
+                      : static_cast<off_t>(rmd._startFullIndex + rmd.getNofBytesForFulltextIndex());
   if (rmd.hasBlocks()) {
     _blockData[rmd._relId] = bRmd;
   }
@@ -132,15 +131,12 @@ bool IndexMetaData<MapType>::relationExists(Id relId) const {
 
 // _____________________________________________________________________________
 template <class MapType>
-ad_utility::File& operator<<(ad_utility::File& f,
-                             const IndexMetaData<MapType>& imd) {
+ad_utility::File& operator<<(ad_utility::File& f, const IndexMetaData<MapType>& imd) {
   // first write magic number
   if constexpr (imd._isMmapBased) {
-    f.write(&MAGIC_NUMBER_MMAP_META_DATA_VERSION,
-            sizeof(MAGIC_NUMBER_MMAP_META_DATA_VERSION));
+    f.write(&MAGIC_NUMBER_MMAP_META_DATA_VERSION, sizeof(MAGIC_NUMBER_MMAP_META_DATA_VERSION));
   } else {
-    f.write(&MAGIC_NUMBER_SPARSE_META_DATA_VERSION,
-            sizeof(MAGIC_NUMBER_SPARSE_META_DATA_VERSION));
+    f.write(&MAGIC_NUMBER_SPARSE_META_DATA_VERSION, sizeof(MAGIC_NUMBER_SPARSE_META_DATA_VERSION));
   }
   // write version
   f.write(&V_CURRENT, sizeof(V_CURRENT));
@@ -235,10 +231,8 @@ string IndexMetaData<MapType>::statistics() const {
 
   os << "# Elements:  " << _totalElements << '\n';
   os << "# Blocks:    " << _totalBlocks << "\n\n";
-  os << "Theoretical size of Id triples: " << _totalElements * 3 * sizeof(Id)
-     << " bytes \n";
-  os << "Size of pair index:             " << totalPairIndexBytes
-     << " bytes \n";
+  os << "Theoretical size of Id triples: " << _totalElements * 3 * sizeof(Id) << " bytes \n";
+  os << "Size of pair index:             " << totalPairIndexBytes << " bytes \n";
   os << "Total Size:                     " << _totalBytes << " bytes \n";
   os << "-------------------------------------------------------------------\n";
   return os.str();
@@ -257,8 +251,7 @@ size_t IndexMetaData<MapType>::getNofBlocksForRelation(const Id id) const {
 
 // _____________________________________________________________________________
 template <class MapType>
-size_t IndexMetaData<MapType>::getTotalBytesForRelation(
-    const FullRelationMetaData& frmd) const {
+size_t IndexMetaData<MapType>::getTotalBytesForRelation(const FullRelationMetaData& frmd) const {
   auto it = _blockData.find(frmd._relId);
   if (it != _blockData.end()) {
     return static_cast<size_t>(it->second._offsetAfter - frmd._startFullIndex);
@@ -289,8 +282,7 @@ void IndexMetaData<MapType>::calculateExpensiveStatistics() {
 
 // ___________________________________________________________________
 template <class MapType>
-VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(
-    unsigned char* buf) {
+VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char* buf) {
   uint64_t magicNumber = *reinterpret_cast<uint64_t*>(buf);
   size_t nOfBytes = 0;
   bool hasVersion = false;
@@ -323,12 +315,11 @@ VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(
       hasVersion = true;
       nOfBytes = sizeof(uint64_t);
     } else {
-      throw WrongFormatException(
-          "ERROR: No or wrong magic number found in persistent "
-          "mmap-based meta data. "
-          "Please use ./MetaDataConverterMain "
-          "to convert old indices without rebuilding them (See "
-          "README.md).Terminating...\n");
+      throw WrongFormatException("ERROR: No or wrong magic number found in persistent "
+                                 "mmap-based meta data. "
+                                 "Please use ./MetaDataConverterMain "
+                                 "to convert old indices without rebuilding them (See "
+                                 "README.md).Terminating...\n");
     }
   }
 
@@ -341,10 +332,9 @@ VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(
     res._nOfBytes += sizeof(uint64_t);
   }
   if (res._version < V_CURRENT) {
-    LOG(INFO)
-        << "WARNING: your IndexMetaData seems to have an old format (version "
-           "tag < V_CURRENT). Please consider using ./MetaDataConverterMain to "
-           "benefit from improvements in the index structure.\n";
+    LOG(INFO) << "WARNING: your IndexMetaData seems to have an old format (version "
+                 "tag < V_CURRENT). Please consider using ./MetaDataConverterMain to "
+                 "benefit from improvements in the index structure.\n";
 
   } else if (res._version > V_CURRENT) {
     LOG(INFO) << "ERROR: version tag does not match any actual version (> "

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -21,7 +21,8 @@ void IndexMetaData<MapType>::add(const FullRelationMetaData& rmd,
 
   off_t afterExpected =
       rmd.hasBlocks() ? bRmd._offsetAfter
-                      : static_cast<off_t>(rmd._startFullIndex + rmd.getNofBytesForFulltextIndex());
+                      : static_cast<off_t>(rmd._startFullIndex +
+                                           rmd.getNofBytesForFulltextIndex());
   if (rmd.hasBlocks()) {
     _blockData[rmd._relId] = bRmd;
   }
@@ -131,12 +132,15 @@ bool IndexMetaData<MapType>::relationExists(Id relId) const {
 
 // _____________________________________________________________________________
 template <class MapType>
-ad_utility::File& operator<<(ad_utility::File& f, const IndexMetaData<MapType>& imd) {
+ad_utility::File& operator<<(ad_utility::File& f,
+                             const IndexMetaData<MapType>& imd) {
   // first write magic number
   if constexpr (imd._isMmapBased) {
-    f.write(&MAGIC_NUMBER_MMAP_META_DATA_VERSION, sizeof(MAGIC_NUMBER_MMAP_META_DATA_VERSION));
+    f.write(&MAGIC_NUMBER_MMAP_META_DATA_VERSION,
+            sizeof(MAGIC_NUMBER_MMAP_META_DATA_VERSION));
   } else {
-    f.write(&MAGIC_NUMBER_SPARSE_META_DATA_VERSION, sizeof(MAGIC_NUMBER_SPARSE_META_DATA_VERSION));
+    f.write(&MAGIC_NUMBER_SPARSE_META_DATA_VERSION,
+            sizeof(MAGIC_NUMBER_SPARSE_META_DATA_VERSION));
   }
   // write version
   f.write(&V_CURRENT, sizeof(V_CURRENT));
@@ -231,8 +235,10 @@ string IndexMetaData<MapType>::statistics() const {
 
   os << "# Elements:  " << _totalElements << '\n';
   os << "# Blocks:    " << _totalBlocks << "\n\n";
-  os << "Theoretical size of Id triples: " << _totalElements * 3 * sizeof(Id) << " bytes \n";
-  os << "Size of pair index:             " << totalPairIndexBytes << " bytes \n";
+  os << "Theoretical size of Id triples: " << _totalElements * 3 * sizeof(Id)
+     << " bytes \n";
+  os << "Size of pair index:             " << totalPairIndexBytes
+     << " bytes \n";
   os << "Total Size:                     " << _totalBytes << " bytes \n";
   os << "-------------------------------------------------------------------\n";
   return os.str();
@@ -251,7 +257,8 @@ size_t IndexMetaData<MapType>::getNofBlocksForRelation(const Id id) const {
 
 // _____________________________________________________________________________
 template <class MapType>
-size_t IndexMetaData<MapType>::getTotalBytesForRelation(const FullRelationMetaData& frmd) const {
+size_t IndexMetaData<MapType>::getTotalBytesForRelation(
+    const FullRelationMetaData& frmd) const {
   auto it = _blockData.find(frmd._relId);
   if (it != _blockData.end()) {
     return static_cast<size_t>(it->second._offsetAfter - frmd._startFullIndex);
@@ -282,7 +289,8 @@ void IndexMetaData<MapType>::calculateExpensiveStatistics() {
 
 // ___________________________________________________________________
 template <class MapType>
-VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char* buf) {
+VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(
+    unsigned char* buf) {
   uint64_t magicNumber = *reinterpret_cast<uint64_t*>(buf);
   size_t nOfBytes = 0;
   bool hasVersion = false;
@@ -315,11 +323,12 @@ VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char*
       hasVersion = true;
       nOfBytes = sizeof(uint64_t);
     } else {
-      throw WrongFormatException("ERROR: No or wrong magic number found in persistent "
-                                 "mmap-based meta data. "
-                                 "Please use ./MetaDataConverterMain "
-                                 "to convert old indices without rebuilding them (See "
-                                 "README.md).Terminating...\n");
+      throw WrongFormatException(
+          "ERROR: No or wrong magic number found in persistent "
+          "mmap-based meta data. "
+          "Please use ./MetaDataConverterMain "
+          "to convert old indices without rebuilding them (See "
+          "README.md).Terminating...\n");
     }
   }
 
@@ -332,9 +341,10 @@ VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char*
     res._nOfBytes += sizeof(uint64_t);
   }
   if (res._version < V_CURRENT) {
-    LOG(INFO) << "WARNING: your IndexMetaData seems to have an old format (version "
-                 "tag < V_CURRENT). Please consider using ./MetaDataConverterMain to "
-                 "benefit from improvements in the index structure.\n";
+    LOG(INFO)
+        << "WARNING: your IndexMetaData seems to have an old format (version "
+           "tag < V_CURRENT). Please consider using ./MetaDataConverterMain to "
+           "benefit from improvements in the index structure.\n";
 
   } else if (res._version > V_CURRENT) {
     LOG(INFO) << "ERROR: version tag does not match any actual version (> "

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -207,7 +207,7 @@ class Vocabulary {
 
   Id getValueIdForLE(const string& indexWord) const {
     Id lb = lower_bound(indexWord);
-    if ((lb < _words.size() && at(lb) != indexWord) && lb > 0) {
+    if ((lb < _words.size() && lb > 0) && at(lb) != indexWord) {
       // If indexWord is not in the vocab, it may be that
       // we ended up one too high. We don't want this to match in LE.
       // The one before is actually lower than index word but that's fine
@@ -219,7 +219,7 @@ class Vocabulary {
 
   Id getValueIdForGT(const string& indexWord) const {
     Id lb = lower_bound(indexWord);
-    if ((lb < _words.size() && at(lb) != indexWord) && lb > 0) {
+    if ((lb < _words.size() && lb > 0) && at(lb) != indexWord) {
       // If indexWord is not in the vocab, lb points to the next value.
       // But if this happened, we know that there is nothing in between and
       // it's

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -207,7 +207,7 @@ class Vocabulary {
 
   Id getValueIdForLE(const string& indexWord) const {
     Id lb = lower_bound(indexWord);
-    if (at(lb) != indexWord && lb > 0) {
+    if ((lb < _words.size() && at(lb) != indexWord) && lb > 0) {
       // If indexWord is not in the vocab, it may be that
       // we ended up one too high. We don't want this to match in LE.
       // The one before is actually lower than index word but that's fine
@@ -219,7 +219,7 @@ class Vocabulary {
 
   Id getValueIdForGT(const string& indexWord) const {
     Id lb = lower_bound(indexWord);
-    if (at(lb) != indexWord && lb > 0) {
+    if ((lb < _words.size() && at(lb) != indexWord) && lb > 0) {
       // If indexWord is not in the vocab, lb points to the next value.
       // But if this happened, we know that there is nothing in between and
       // it's

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -121,7 +121,8 @@ class SparqlFilter {
     GT = 5,
     GE = 6,
     LANG_MATCHES = 7,
-    REGEX = 8
+    REGEX = 8,
+    PREFIX = 9
   };
 
   string asString() const;

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -521,18 +521,9 @@ void SparqlParser::addFilter(const string& str, vector<SparqlFilter>* _filters,
           bool isSimple = true;
           bool escaped = false;
 
-          std::vector<bool> regexControlChars(sizeof(char), false);
-          regexControlChars['['] = true;
-          regexControlChars['^'] = true;
-          regexControlChars['$'] = true;
-          regexControlChars['.'] = true;
-          regexControlChars['|'] = true;
-          regexControlChars['?'] = true;
-          regexControlChars['*'] = true;
-          regexControlChars['+'] = true;
-          regexControlChars['('] = true;
-          regexControlChars[')'] = true;
-
+          // Check if the regex is only a prefix regex or also does
+          // anything else.
+          const static string regexControlChars = "[]^$.|?*+()";
           for (size_t i = 1; isSimple && i < f._rhs.size(); i++) {
             if (f._rhs[i] == '\\') {
               escaped = true;
@@ -540,7 +531,7 @@ void SparqlParser::addFilter(const string& str, vector<SparqlFilter>* _filters,
             }
             if (!escaped) {
               char c = f._rhs[i];
-              if (regexControlChars[c]) {
+              if (regexControlChars.find(c) != string::npos) {
                 isSimple = false;
               }
             }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -89,9 +89,9 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // create an input result table with a local vocabulary
   ResultTable inTable;
-  inTable._localVocab.push_back("<local1>");
-  inTable._localVocab.push_back("<local2>");
-  inTable._localVocab.push_back("<local3>");
+  inTable._localVocab->push_back("<local1>");
+  inTable._localVocab->push_back("<local2>");
+  inTable._localVocab->push_back("<local3>");
 
   vector<vector<Id>> inputData;
   // The input data types are
@@ -182,13 +182,13 @@ TEST_F(GroupByTest, doGroupBy) {
     ASSERT_EQ(0u + i + 10, outTable._varSizeData[2][2 + i]);
   }
   // check for a local vocab entry for each of the 5 input cols
-  ASSERT_EQ(std::string("<entity1>, <entity2>"), outTable._localVocab[0]);
-  ASSERT_EQ(std::string("123, 0"), outTable._localVocab[1]);
-  ASSERT_EQ(std::string("Exert 1, Exert 2"), outTable._localVocab[2]);
+  ASSERT_EQ(std::string("<entity1>, <entity2>"), (*outTable._localVocab)[0]);
+  ASSERT_EQ(std::string("123, 0"), (*outTable._localVocab)[1]);
+  ASSERT_EQ(std::string("Exert 1, Exert 2"), (*outTable._localVocab)[2]);
   std::ostringstream groupConcatFloatString;
   groupConcatFloatString << floatValues[0] << ", " << floatValues[1];
-  ASSERT_EQ(groupConcatFloatString.str(), outTable._localVocab[3]);
-  ASSERT_EQ(std::string("<local1>, <local2>"), outTable._localVocab[4]);
+  ASSERT_EQ(groupConcatFloatString.str(), (*outTable._localVocab)[3]);
+  ASSERT_EQ(std::string("<local1>, <local2>"), (*outTable._localVocab)[4]);
 
   // SAMPLE CHECKS
   ASSERT_EQ(4u, outTable._varSizeData[0][7]);

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -515,7 +515,7 @@ TEST(QueryPlannerTest, testFilterAfterSeed) {
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    FILTER     {\n      "
         "SCAN POS with P = \"<r>\"\n      qet-width: 2 \n   "
-        " }\n     with col 1 != col 0\n    qet-width: 2 \n  }"
+        " }\n     with ?x != ?y\n    qet-width: 2 \n  }"
         " join-column: [0]\n  |X|\n  {\n    SCAN PSO with P = \""
         "<r>\"\n    qet-width: 2 \n  } join-column: [0]\n "
         " qet-width: 3 \n}",
@@ -543,7 +543,7 @@ TEST(QueryPlannerTest, testFilterAfterJoin) {
         "    } join-column: [0]\n    |X|\n    {\n      "
         "SCAN PSO with P = \"<r>\"\n      qet-width: 2 \n"
         "    } join-column: [0]\n    qet-width: 3 \n  }\n"
-        "   with col 1 != col 2\n  qet-width: 3 \n}",
+        "   with ?x != ?z\n  qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;


### PR DESCRIPTION
This is a cleaner implementation of two features that were hacked together for the presentation builds.
The prefix filter handles regexes that do prefix checking efficiently while the changes to the way filters are created allow for filtering on a greater variety of ResultTypes. 