### PR TITLE
Added optimized handling of range filters on sorted data.

### DIFF
--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -227,9 +227,11 @@ template <class RT, ResultTable::ResultType T>
 vector<RT>* Filter::computeFilterFixedValueForResultType(
     vector<RT>* res, size_t lhs, Id rhs,
     shared_ptr<const ResultTable> subRes) const {
+  bool lhs_is_sorted =
+      subRes->_sortedBy.size() > 0 && subRes->_sortedBy[0] == lhs;
   switch (_type) {
     case SparqlFilter::EQ:
-      if (subRes->_sortedBy[lhs]) {
+      if (lhs_is_sorted) {
         // The input data is sorted, use binary search to locate the first
         // and last element that match rhs and copy the range.
         RT rhs_array;
@@ -252,7 +254,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       }
       break;
     case SparqlFilter::NE:
-      if (subRes->_sortedBy[lhs]) {
+      if (lhs_is_sorted) {
         // The input data is sorted, use binary search to locate the first
         // and last element that match rhs and copy the range.
         RT rhs_array;
@@ -279,7 +281,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       }
       break;
     case SparqlFilter::LT:
-      if (subRes->_sortedBy[lhs]) {
+      if (lhs_is_sorted) {
         // The input data is sorted, use binary search to locate the first
         // and last element that match rhs and copy the range.
         RT rhs_array;
@@ -299,7 +301,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       }
       break;
     case SparqlFilter::LE:
-      if (subRes->_sortedBy[lhs]) {
+      if (lhs_is_sorted) {
         // The input data is sorted, use binary search to locate the first
         // and last element that match rhs and copy the range.
         RT rhs_array;
@@ -319,7 +321,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       }
       break;
     case SparqlFilter::GT:
-      if (subRes->_sortedBy[lhs]) {
+      if (lhs_is_sorted) {
         // The input data is sorted, use binary search to locate the first
         // and last element that match rhs and copy the range.
         RT rhs_array;
@@ -340,7 +342,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       }
       break;
     case SparqlFilter::GE:
-      if (subRes->_sortedBy[lhs]) {
+      if (lhs_is_sorted) {
         // The input data is sorted, use binary search to locate the first
         // and last element that match rhs and copy the range.
         RT rhs_array;
@@ -388,7 +390,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         size_t upperBound =
             getIndex().getVocab().getValueIdForLT(upperBoundStr);
         size_t lowerBound = getIndex().getVocab().getValueIdForGE(rhs);
-        if (subRes->_sortedBy[lhs]) {
+        if (lhs_is_sorted) {
           // The input data is sorted, use binary search to locate the first
           // and last element that match rhs and copy the range.
           RT rhs_array;

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -239,12 +239,16 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
         const typename vector<RT>::iterator& lower = std::lower_bound(
             data->begin(), data->end(), rhs_array,
-            [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+            [lhs](const RT& l, const RT& r) {
+              return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
+            });
         if (lower != data->end() && (*lower)[lhs] == rhs) {
           // an element equal to rhs exists in the vector
           const auto& upper = std::upper_bound(
-              lower, data->end(), rhs_array,
-              [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+              lower, data->end(), rhs_array, [lhs](const RT& l, const RT& r) {
+                return ValueReader<T>::get(l[lhs]) <
+                       ValueReader<T>::get(r[lhs]);
+              });
           res->insert(res->end(), lower, upper);
         }
       } else {
@@ -262,12 +266,16 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
         const typename vector<RT>::iterator& lower = std::lower_bound(
             data->begin(), data->end(), rhs_array,
-            [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+            [lhs](const RT& l, const RT& r) {
+              return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
+            });
         if (lower != data->end() && (*lower)[lhs] == rhs) {
           // rhs appears within the data, take all elements before and after it
           const typename vector<RT>::iterator& upper = std::upper_bound(
-              lower, data->end(), rhs_array,
-              [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+              lower, data->end(), rhs_array, [lhs](const RT& l, const RT& r) {
+                return ValueReader<T>::get(l[lhs]) <
+                       ValueReader<T>::get(r[lhs]);
+              });
           res->insert(res->end(), data->begin(), lower);
           res->insert(res->end(), upper, data->end());
         } else {
@@ -289,7 +297,9 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
         const typename vector<RT>::iterator& lower = std::lower_bound(
             data->begin(), data->end(), rhs_array,
-            [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+            [lhs](const RT& l, const RT& r) {
+              return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
+            });
         res->insert(res->end(), data->begin(), lower);
       } else {
         getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
@@ -309,7 +319,9 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
         const typename vector<RT>::iterator& upper = std::upper_bound(
             data->begin(), data->end(), rhs_array,
-            [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+            [lhs](const RT& l, const RT& r) {
+              return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
+            });
         res->insert(res->end(), data->begin(), upper);
       } else {
         getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
@@ -329,7 +341,9 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
         const typename vector<RT>::iterator& upper = std::upper_bound(
             data->begin(), data->end(), rhs_array,
-            [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+            [lhs](const RT& l, const RT& r) {
+              return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
+            });
         // an element equal to rhs exists in the vector
         res->insert(res->end(), upper, data->end());
       } else {
@@ -350,7 +364,9 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
         const typename vector<RT>::iterator& lower = std::lower_bound(
             data->begin(), data->end(), rhs_array,
-            [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
+            [lhs](const RT& l, const RT& r) {
+              return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
+            });
         // an element equal to rhs exists in the vector
         res->insert(res->end(), lower, data->end());
       } else {
@@ -400,8 +416,9 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
               data->begin(), data->end(), rhs_array,
               [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
           if (lower != data->end()) {
-            // rhs appears within the data, take all elements before and after
-            // it
+            // There is at least one element in the data that is also within the
+            // range, look for the upper boundary and then copy all elements
+            // within the range.
             rhs_array[lhs] = upperBound;
             const typename vector<RT>::iterator& upper = std::upper_bound(
                 lower, data->end(), rhs_array,

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -8,11 +8,12 @@
 // _____________________________________________________________________________
 ResultTable::ResultTable()
     : _nofColumns(0),
-      _sortedBy(0),
+      _sortedBy(),
       _varSizeData(),
       _fixedSizeData(nullptr),
-      _status(ResultTable::OTHER),
-      _localVocab(std::make_shared<std::vector<std::string>>()) {}
+      _resultTypes(),
+      _localVocab(std::make_shared<std::vector<std::string>>()),
+      _status(ResultTable::OTHER) {}
 
 // _____________________________________________________________________________
 void ResultTable::clear() {

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -40,7 +40,13 @@ class ResultTable {
   };
 
   size_t _nofColumns;
-  // A value >= _nofColumns indicates unsorted data
+
+  /**
+   * @brief This vector contains a list of column indices by which the result
+   *        is sorted. This vector may be empty if the result is not sorted
+   *        on any column. The primary sort column is _sortedBy[0]
+   *        (if it exists).
+   */
   vector<size_t> _sortedBy;
 
   vector<vector<Id>> _varSizeData;


### PR DESCRIPTION
This pr adds special cases for range filters on sorted data to the computation of filer results. Instead of iterating over the entire input data and applying a comparator for each element, the upper and lower bound of the target range are found using `std::lower_bound` and `std::upper_bound` and the range is then copied to the result vector.