### PR TITLE
Added a duplicate alias check to the parser. Fixes #153.

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -463,3 +463,17 @@ queries:
       - selected: ["?a", "?t"]
       - contains_row: ['<Carl_Sagan>', '1.8']
       - contains_row: ['<Noreena_Hertz>', '<Judaism>']
+  - query : duplicate-alias 
+    type: no-text
+    sparql: |
+      SELECT ?object (COUNT(?object) AS ?count) WHERE {
+              ?subject <Profession> ?object
+      }
+      GROUP BY ?object
+      ORDER BY DESC((COUNT(?object) AS ?count))
+    checks:
+      - num_rows: 836 
+      - num_cols: 2
+      - selected: ["?object", "?count"]
+      - contains_row: ['<Inventor>', '1616']
+      - contains_row: ['<Astrologer>', '43']


### PR DESCRIPTION
This is a quick fix for #153.
Due to split parsing of aliases in both the parser and the GroupBy operation queries with theoretically equal aliases, that differ in their spelling (e.g. `(COUNT(?object) as ?count)` and `(COUNT(?object) AS ?count)`) will be rejected. Due to that the query from the issue is only fixed in so far as it results in an error message instead of a crash.
Better detection of alias equality would require parsing aliases more fully during the parsing stage. I can create a pr for that, but it might be worth waiting until the planned sparql parser replacement, especially as this only concerns a small subset of queries.