### PR TITLE
Filter fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ VOLUME ["/input", "/index"]
 ENV INDEX_PREFIX index
 # Need the shell to get the INDEX_PREFIX envirionment variable
 ENTRYPOINT ["/bin/sh", "-c", "exec ServerMain -i \"/index/${INDEX_PREFIX}\" -p 7001 \"$@\"", "--"]
-CMD ["-t", "-a", "-P"]
+CMD ["-t", "-a"]
 
 # docker build -t qlever-<name> .
 # # When running with user namespaces you may need to make the index folder accessible

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -60,8 +60,7 @@ if [ "$1" != "no-index" ]; then
 	./IndexBuilderMain -a -l -i "$INDEX" \
 		-n "$INPUT.nt" \
 		-w "$INPUT.wordsfile.tsv" \
-		-d "$INPUT.docsfile.tsv" \
-		--patterns || bail "Building Index failed"
+		-d "$INPUT.docsfile.tsv" || bail "Building Index failed"
 	popd
 fi
 
@@ -69,7 +68,7 @@ fi
 # then we can't easily get the SERVER_PID out of that subshell
 pushd "$BINARY_DIR"
 echo "Launching server from path $(pwd)"
-./ServerMain -i "$INDEX" -p 9099 -t -a --patterns &> server_log.txt &
+./ServerMain -i "$INDEX" -p 9099 -t -a &> server_log.txt &
 SERVER_PID=$!
 popd
 

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -515,4 +515,19 @@ queries:
       - selected: ["?a", "?o", "?h", "?avg"]
       - contains_row: ['<Steve_Backshall>', '<Actor>', 1.8, 1.76627]
       - contains_row: ['<Carl_Sagan>', '<Astrobiologist>', 1.8, 1.8]
+  - query : filter-on-variable-columns 
+    type: no-text
+    sparql: |
+      SELECT ?p (SAMPLE(?a) as ?a1) (SAMPLE(?a) as ?a2) (SAMPLE(?a) as ?a3) (SAMPLE(?a) as ?a4) (AVG(?h) as ?avg) WHERE {
+        ?a <Height> ?h .
+        ?a <Profession> ?p .
+      }
+      GROUP BY ?p
+      HAVING (?avg > 1.8)
+    checks:
+      - num_rows: 87 
+      - num_cols: 6
+      - selected: ["?p", "?a1", "?a2", "?a3", "?a4", "?avg"]
+      - contains_row: ['<Cameraman>', '<Chris_Packham>', '<Chris_Packham>', '<Chris_Packham>', '<Chris_Packham>', 1.83]
+      - contains_row: ['<Lawyer>', '<Thomas_Jefferson>', '<Thomas_Jefferson>', '<Thomas_Jefferson>', '<Thomas_Jefferson>', 1.8056]
 

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -30,7 +30,7 @@ struct option options[] = {{"all-permutations", no_argument, NULL, 'a'},
                            {"worker-threads", required_argument, NULL, 'j'},
                            {"on-disk-literals", no_argument, NULL, 'l'},
                            {"port", required_argument, NULL, 'p'},
-                           {"patterns", no_argument, NULL, 'P'},
+                           {"no-patterns", no_argument, NULL, 'P'},
                            {"text", no_argument, NULL, 't'},
                            {NULL, 0, NULL, 0}};
 
@@ -51,8 +51,9 @@ void printUsage(char* execName) {
        << "The location of the index files." << endl;
   cout << "  " << std::setw(20) << "p, port" << std::setw(1) << "    "
        << "The port on which to run the web interface." << endl;
-  cout << "  " << std::setw(20) << "P, patterns" << std::setw(1) << "    "
-       << "Use predicate patterns to enable ql:has-predicate queries." << endl;
+  cout << "  " << std::setw(20) << "no-patterns" << std::setw(1) << "    "
+       << "Disable the use of patterns. This disables ql:has-predicate."
+       << endl;
   cout << "  " << std::setw(20) << "t, text" << std::setw(1) << "    "
        << "Enables the usage of text." << endl;
   cout << "  " << std::setw(20) << "j, worker-threads" << std::setw(1) << "    "
@@ -76,12 +77,12 @@ int main(int argc, char** argv) {
   bool allPermutations = false;
   int port = -1;
   int numThreads = 1;
-  bool usePatterns = false;
+  bool usePatterns = true;
 
   optind = 1;
   // Process command line arguments.
   while (true) {
-    int c = getopt_long(argc, argv, "i:p:j:tauhPml", options, NULL);
+    int c = getopt_long(argc, argv, "i:p:j:tauhml", options, NULL);
     if (c == -1) break;
     switch (c) {
       case 'i':
@@ -91,7 +92,7 @@ int main(int argc, char** argv) {
         port = atoi(optarg);
         break;
       case 'P':
-        usePatterns = true;
+        usePatterns = false;
         break;
       case 't':
         text = true;

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -30,7 +30,7 @@ struct option options[] = {{"all-permutations", no_argument, NULL, 'a'},
                            {"index", required_argument, NULL, 'i'},
                            {"interactive", no_argument, NULL, 'I'},
                            {"on-disk-literals", no_argument, NULL, 'l'},
-                           {"patterns", no_argument, NULL, 'P'},
+                           {"no-patterns", no_argument, NULL, 'P'},
                            {"queryfile", required_argument, NULL, 'q'},
                            {"text", no_argument, NULL, 't'},
                            {NULL, 0, NULL, 0}};
@@ -60,8 +60,9 @@ void printUsage(char* execName) {
        << "    "
        << "Indicates that the literals can be found on disk with the index."
        << endl;
-  cout << "  " << std::setw(20) << "P, patterns" << std::setw(1) << "    "
-       << "Use relation patterns for fast ql:has-relation queries." << endl;
+  cout << "  " << std::setw(20) << "no-patterns" << std::setw(1) << "    "
+       << "Disable the use of patterns. This disables ql:has-predicate."
+       << endl;
   cout << "  " << std::setw(20) << "q, queryfile" << std::setw(1) << "    "
        << "Path to a file containing one query per line." << endl;
   cout << "  " << std::setw(20) << "t, text" << std::setw(1) << "    "
@@ -91,7 +92,7 @@ int main(int argc, char** argv) {
   optind = 1;
   // Process command line arguments.
   while (true) {
-    int c = getopt_long(argc, argv, "q:Ii:tc:lahuP", options, NULL);
+    int c = getopt_long(argc, argv, "q:Ii:tc:lahu", options, NULL);
     if (c == -1) break;
     switch (c) {
       case 'q':
@@ -120,7 +121,7 @@ int main(int argc, char** argv) {
         exit(0);
         break;
       case 'P':
-        usePatterns = true;
+        usePatterns = false;
         break;
       default:
         cout << endl

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -68,12 +68,12 @@ string Filter::asString(size_t indent) const {
 
 // _____________________________________________________________________________
 template <class RT, ResultTable::ResultType T>
-vector<RT>* Filter::computeFilterForResultType(
-    vector<RT>* res, size_t lhs, size_t rhs,
-    shared_ptr<const ResultTable> subRes) const {
+vector<RT>* Filter::computeFilterForResultType(vector<RT>* res, size_t lhs,
+                                               size_t rhs,
+                                               const vector<RT>& input) const {
   switch (_type) {
     case SparqlFilter::EQ:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+      getEngine().filter(input,
                          [lhs, rhs](const RT& e) {
                            return ValueReader<T>::get(e[lhs]) ==
                                   ValueReader<T>::get(e[rhs]);
@@ -81,7 +81,7 @@ vector<RT>* Filter::computeFilterForResultType(
                          res);
       break;
     case SparqlFilter::NE:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+      getEngine().filter(input,
                          [lhs, rhs](const RT& e) {
                            return ValueReader<T>::get(e[lhs]) !=
                                   ValueReader<T>::get(e[rhs]);
@@ -89,7 +89,7 @@ vector<RT>* Filter::computeFilterForResultType(
                          res);
       break;
     case SparqlFilter::LT:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+      getEngine().filter(input,
                          [lhs, rhs](const RT& e) {
                            return ValueReader<T>::get(e[lhs]) <
                                   ValueReader<T>::get(e[rhs]);
@@ -97,7 +97,7 @@ vector<RT>* Filter::computeFilterForResultType(
                          res);
       break;
     case SparqlFilter::LE:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+      getEngine().filter(input,
                          [lhs, rhs](const RT& e) {
                            return ValueReader<T>::get(e[lhs]) <=
                                   ValueReader<T>::get(e[rhs]);
@@ -105,7 +105,7 @@ vector<RT>* Filter::computeFilterForResultType(
                          res);
       break;
     case SparqlFilter::GT:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+      getEngine().filter(input,
                          [lhs, rhs](const RT& e) {
                            return ValueReader<T>::get(e[lhs]) >
                                   ValueReader<T>::get(e[rhs]);
@@ -113,7 +113,7 @@ vector<RT>* Filter::computeFilterForResultType(
                          res);
       break;
     case SparqlFilter::GE:
-      getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+      getEngine().filter(input,
                          [lhs, rhs](const RT& e) {
                            return ValueReader<T>::get(e[lhs]) >=
                                   ValueReader<T>::get(e[rhs]);
@@ -139,26 +139,28 @@ vector<RT>* Filter::computeFilterForResultType(
   return res;
 }
 
+// _____________________________________________________________________________
 template <class RT>
 vector<RT>* Filter::computeFilter(vector<RT>* res, size_t lhs, size_t rhs,
+                                  const vector<RT>& input,
                                   shared_ptr<const ResultTable> subRes) const {
   switch (subRes->getResultType(lhs)) {
     case ResultTable::ResultType::KB:
       return computeFilterForResultType<RT, ResultTable::ResultType::KB>(
-          res, lhs, rhs, subRes);
+          res, lhs, rhs, input);
     case ResultTable::ResultType::VERBATIM:
       return computeFilterForResultType<RT, ResultTable::ResultType::VERBATIM>(
-          res, lhs, rhs, subRes);
+          res, lhs, rhs, input);
     case ResultTable::ResultType::FLOAT:
       return computeFilterForResultType<RT, ResultTable::ResultType::FLOAT>(
-          res, lhs, rhs, subRes);
+          res, lhs, rhs, input);
     case ResultTable::ResultType::LOCAL_VOCAB:
       return computeFilterForResultType<RT,
                                         ResultTable::ResultType::LOCAL_VOCAB>(
-          res, lhs, rhs, subRes);
+          res, lhs, rhs, input);
     case ResultTable::ResultType::TEXT:
       return computeFilterForResultType<RT, ResultTable::ResultType::TEXT>(
-          res, lhs, rhs, subRes);
+          res, lhs, rhs, input);
   }
   AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
            "Tried to compute a filter on an unknown result type " +
@@ -183,36 +185,42 @@ void Filter::computeResult(ResultTable* result) const {
     switch (subRes->_nofColumns) {
       case 1: {
         typedef array<Id, 1> RT;
-        result->_fixedSizeData =
-            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        result->_fixedSizeData = computeFilter(
+            new vector<RT>(), lhsInd, rhsInd,
+            *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
         break;
       }
       case 2: {
         typedef array<Id, 2> RT;
-        result->_fixedSizeData =
-            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        result->_fixedSizeData = computeFilter(
+            new vector<RT>(), lhsInd, rhsInd,
+            *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
         break;
       }
       case 3: {
         typedef array<Id, 3> RT;
-        result->_fixedSizeData =
-            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        result->_fixedSizeData = computeFilter(
+            new vector<RT>(), lhsInd, rhsInd,
+            *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
         break;
       }
       case 4: {
         typedef array<Id, 4> RT;
-        result->_fixedSizeData =
-            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        result->_fixedSizeData = computeFilter(
+            new vector<RT>(), lhsInd, rhsInd,
+            *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
         break;
       }
       case 5: {
         typedef array<Id, 5> RT;
-        result->_fixedSizeData =
-            computeFilter(new vector<RT>(), lhsInd, rhsInd, subRes);
+        result->_fixedSizeData = computeFilter(
+            new vector<RT>(), lhsInd, rhsInd,
+            *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
         break;
       }
       default:
-        computeFilter(&result->_varSizeData, lhsInd, rhsInd, subRes);
+        computeFilter(&result->_varSizeData, lhsInd, rhsInd,
+                      subRes->_varSizeData, subRes);
         break;
     }
   } else {
@@ -223,9 +231,10 @@ void Filter::computeResult(ResultTable* result) const {
   LOG(DEBUG) << "Filter result computation done." << endl;
 }
 
+// _____________________________________________________________________________
 template <class RT, ResultTable::ResultType T>
 vector<RT>* Filter::computeFilterFixedValueForResultType(
-    vector<RT>* res, size_t lhs, Id rhs,
+    vector<RT>* res, size_t lhs, Id rhs, const vector<RT>& input,
     shared_ptr<const ResultTable> subRes) const {
   bool lhs_is_sorted =
       subRes->_sortedBy.size() > 0 && subRes->_sortedBy[0] == lhs;
@@ -236,16 +245,15 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         // and last element that match rhs and copy the range.
         RT rhs_array;
         rhs_array[lhs] = rhs;
-        vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-        const typename vector<RT>::iterator& lower = std::lower_bound(
-            data->begin(), data->end(), rhs_array,
+        const typename vector<RT>::const_iterator& lower = std::lower_bound(
+            input.begin(), input.end(), rhs_array,
             [lhs](const RT& l, const RT& r) {
               return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
             });
-        if (lower != data->end() && (*lower)[lhs] == rhs) {
+        if (lower != input.end() && (*lower)[lhs] == rhs) {
           // an element equal to rhs exists in the vector
           const auto& upper = std::upper_bound(
-              lower, data->end(), rhs_array, [lhs](const RT& l, const RT& r) {
+              lower, input.end(), rhs_array, [lhs](const RT& l, const RT& r) {
                 return ValueReader<T>::get(l[lhs]) <
                        ValueReader<T>::get(r[lhs]);
               });
@@ -253,8 +261,8 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         }
       } else {
         getEngine().filter(
-            *static_cast<vector<RT>*>(subRes->_fixedSizeData),
-            [lhs, rhs, &subRes](const RT& e) { return e[lhs] == rhs; }, res);
+            input, [lhs, rhs, &subRes](const RT& e) { return e[lhs] == rhs; },
+            res);
       }
       break;
     case SparqlFilter::NE:
@@ -263,29 +271,27 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         // and last element that match rhs and copy the range.
         RT rhs_array;
         rhs_array[lhs] = rhs;
-        vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-        const typename vector<RT>::iterator& lower = std::lower_bound(
-            data->begin(), data->end(), rhs_array,
+        const typename vector<RT>::const_iterator& lower = std::lower_bound(
+            input.begin(), input.end(), rhs_array,
             [lhs](const RT& l, const RT& r) {
               return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
             });
-        if (lower != data->end() && (*lower)[lhs] == rhs) {
-          // rhs appears within the data, take all elements before and after it
-          const typename vector<RT>::iterator& upper = std::upper_bound(
-              lower, data->end(), rhs_array, [lhs](const RT& l, const RT& r) {
+        if (lower != input.end() && (*lower)[lhs] == rhs) {
+          // rhs appears within the input, take all elements before and after it
+          const typename vector<RT>::const_iterator& upper = std::upper_bound(
+              lower, input.end(), rhs_array, [lhs](const RT& l, const RT& r) {
                 return ValueReader<T>::get(l[lhs]) <
                        ValueReader<T>::get(r[lhs]);
               });
-          res->insert(res->end(), data->begin(), lower);
-          res->insert(res->end(), upper, data->end());
+          res->insert(res->end(), input.begin(), lower);
+          res->insert(res->end(), upper, input.end());
         } else {
-          // rhs does not appear within the data
-          res->insert(res->end(), data->begin(), data->end());
+          // rhs does not appear within the input
+          res->insert(res->end(), input.begin(), input.end());
         }
       } else {
-        getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
-                           [lhs, rhs](const RT& e) { return e[lhs] != rhs; },
-                           res);
+        getEngine().filter(
+            input, [lhs, rhs](const RT& e) { return e[lhs] != rhs; }, res);
       }
       break;
     case SparqlFilter::LT:
@@ -294,15 +300,14 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         // and last element that match rhs and copy the range.
         RT rhs_array;
         rhs_array[lhs] = rhs;
-        vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-        const typename vector<RT>::iterator& lower = std::lower_bound(
-            data->begin(), data->end(), rhs_array,
+        const typename vector<RT>::const_iterator& lower = std::lower_bound(
+            input.begin(), input.end(), rhs_array,
             [lhs](const RT& l, const RT& r) {
               return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
             });
-        res->insert(res->end(), data->begin(), lower);
+        res->insert(res->end(), input.begin(), lower);
       } else {
-        getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+        getEngine().filter(input,
                            [lhs, rhs](const RT& e) {
                              return ValueReader<T>::get(e[lhs]) <
                                     ValueReader<T>::get(rhs);
@@ -316,15 +321,14 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         // and last element that match rhs and copy the range.
         RT rhs_array;
         rhs_array[lhs] = rhs;
-        vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-        const typename vector<RT>::iterator& upper = std::upper_bound(
-            data->begin(), data->end(), rhs_array,
+        const typename vector<RT>::const_iterator& upper = std::upper_bound(
+            input.begin(), input.end(), rhs_array,
             [lhs](const RT& l, const RT& r) {
               return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
             });
-        res->insert(res->end(), data->begin(), upper);
+        res->insert(res->end(), input.begin(), upper);
       } else {
-        getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+        getEngine().filter(input,
                            [lhs, rhs](const RT& e) {
                              return ValueReader<T>::get(e[lhs]) <=
                                     ValueReader<T>::get(rhs);
@@ -338,16 +342,15 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         // and last element that match rhs and copy the range.
         RT rhs_array;
         rhs_array[lhs] = rhs;
-        vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-        const typename vector<RT>::iterator& upper = std::upper_bound(
-            data->begin(), data->end(), rhs_array,
+        const typename vector<RT>::const_iterator& upper = std::upper_bound(
+            input.begin(), input.end(), rhs_array,
             [lhs](const RT& l, const RT& r) {
               return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
             });
         // an element equal to rhs exists in the vector
-        res->insert(res->end(), upper, data->end());
+        res->insert(res->end(), upper, input.end());
       } else {
-        getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+        getEngine().filter(input,
                            [lhs, rhs](const RT& e) {
                              return ValueReader<T>::get(e[lhs]) >
                                     ValueReader<T>::get(rhs);
@@ -361,16 +364,15 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         // and last element that match rhs and copy the range.
         RT rhs_array;
         rhs_array[lhs] = rhs;
-        vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-        const typename vector<RT>::iterator& lower = std::lower_bound(
-            data->begin(), data->end(), rhs_array,
+        const typename vector<RT>::const_iterator& lower = std::lower_bound(
+            input.begin(), input.end(), rhs_array,
             [lhs](const RT& l, const RT& r) {
               return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r[lhs]);
             });
         // an element equal to rhs exists in the vector
-        res->insert(res->end(), lower, data->end());
+        res->insert(res->end(), lower, input.end());
       } else {
-        getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+        getEngine().filter(input,
                            [lhs, rhs](const RT& e) {
                              return ValueReader<T>::get(e[lhs]) >=
                                     ValueReader<T>::get(rhs);
@@ -380,7 +382,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
       break;
     case SparqlFilter::LANG_MATCHES:
       getEngine().filter(
-          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          input,
           [this, lhs, &subRes](const RT& e) {
             std::optional<string> entity;
             if constexpr (T == ResultTable::ResultType::KB) {
@@ -411,22 +413,21 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
           // and last element that match rhs and copy the range.
           RT rhs_array;
           rhs_array[lhs] = lowerBound;
-          vector<RT>* data = static_cast<vector<RT>*>(subRes->_fixedSizeData);
-          const typename vector<RT>::iterator& lower = std::lower_bound(
-              data->begin(), data->end(), rhs_array,
+          const typename vector<RT>::const_iterator& lower = std::lower_bound(
+              input.begin(), input.end(), rhs_array,
               [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
-          if (lower != data->end()) {
-            // There is at least one element in the data that is also within the
-            // range, look for the upper boundary and then copy all elements
+          if (lower != input.end()) {
+            // There is at least one element in the input that is also within
+            // the range, look for the upper boundary and then copy all elements
             // within the range.
             rhs_array[lhs] = upperBound;
-            const typename vector<RT>::iterator& upper = std::upper_bound(
-                lower, data->end(), rhs_array,
+            const typename vector<RT>::const_iterator& upper = std::upper_bound(
+                lower, input.end(), rhs_array,
                 [lhs](const RT& l, const RT& r) { return l[lhs] < r[lhs]; });
             res->insert(res->end(), lower, upper);
           }
         } else {
-          getEngine().filter(*static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          getEngine().filter(input,
                              [this, lhs, lowerBound, upperBound](const RT& e) {
                                return lowerBound <= e[lhs] &&
                                       e[lhs] < upperBound;
@@ -453,7 +454,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
             "'is not an ECMAScript regex: " + std::string(e.what()));
       }
       getEngine().filter(
-          *static_cast<vector<RT>*>(subRes->_fixedSizeData),
+          input,
           [this, self_regex, &lhs, &subRes](const RT& e) {
             std::optional<string> entity;
             if constexpr (T == ResultTable::ResultType::KB) {
@@ -475,7 +476,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
 // _____________________________________________________________________________
 template <class RT>
 vector<RT>* Filter::computeFilterFixedValue(
-    vector<RT>* res, size_t lhs, Id rhs,
+    vector<RT>* res, size_t lhs, Id rhs, const vector<RT>& input,
     shared_ptr<const ResultTable> subRes) const {
   ResultTable::ResultType resultType = subRes->getResultType(lhs);
   // Catch some unsupported combinations
@@ -492,19 +493,20 @@ vector<RT>* Filter::computeFilterFixedValue(
     case ResultTable::ResultType::KB:
       return computeFilterFixedValueForResultType<RT,
                                                   ResultTable::ResultType::KB>(
-          res, lhs, rhs, subRes);
+          res, lhs, rhs, input, subRes);
     case ResultTable::ResultType::VERBATIM:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::VERBATIM>(res, lhs, rhs, subRes);
+          RT, ResultTable::ResultType::VERBATIM>(res, lhs, rhs, input, subRes);
     case ResultTable::ResultType::FLOAT:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::FLOAT>(res, lhs, rhs, subRes);
+          RT, ResultTable::ResultType::FLOAT>(res, lhs, rhs, input, subRes);
     case ResultTable::ResultType::LOCAL_VOCAB:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::LOCAL_VOCAB>(res, lhs, rhs, subRes);
+          RT, ResultTable::ResultType::LOCAL_VOCAB>(res, lhs, rhs, input,
+                                                    subRes);
     case ResultTable::ResultType::TEXT:
       return computeFilterFixedValueForResultType<
-          RT, ResultTable::ResultType::TEXT>(res, lhs, rhs, subRes);
+          RT, ResultTable::ResultType::TEXT>(res, lhs, rhs, input, subRes);
   }
   AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
            "Tried to compute a filter on an unknown result type " +
@@ -602,36 +604,42 @@ void Filter::computeResultFixedValue(
   switch (subRes->_nofColumns) {
     case 1: {
       typedef array<Id, 1> RT;
-      result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
+      result->_fixedSizeData = computeFilterFixedValue(
+          new vector<RT>(), lhs, rhs,
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
       break;
     }
     case 2: {
       typedef array<Id, 2> RT;
-      result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
+      result->_fixedSizeData = computeFilterFixedValue(
+          new vector<RT>(), lhs, rhs,
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
       break;
     }
     case 3: {
       typedef array<Id, 3> RT;
-      result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
+      result->_fixedSizeData = computeFilterFixedValue(
+          new vector<RT>(), lhs, rhs,
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
       break;
     }
     case 4: {
       typedef array<Id, 4> RT;
-      result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
+      result->_fixedSizeData = computeFilterFixedValue(
+          new vector<RT>(), lhs, rhs,
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
       break;
     }
     case 5: {
       typedef array<Id, 5> RT;
-      result->_fixedSizeData =
-          computeFilterFixedValue(new vector<RT>(), lhs, rhs, subRes);
+      result->_fixedSizeData = computeFilterFixedValue(
+          new vector<RT>(), lhs, rhs,
+          *static_cast<vector<RT>*>(subRes->_fixedSizeData), subRes);
       break;
     }
     default: {
-      computeFilterFixedValue(&result->_varSizeData, lhs, rhs, subRes);
+      computeFilterFixedValue(&result->_varSizeData, lhs, rhs,
+                              subRes->_varSizeData, subRes);
       break;
     }
   }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -261,8 +261,7 @@ vector<RT>* Filter::computeFilterFixedValueForResultType(
         }
       } else {
         getEngine().filter(
-            input, [lhs, rhs, &subRes](const RT& e) { return e[lhs] == rhs; },
-            res);
+            input, [lhs, rhs](const RT& e) { return e[lhs] == rhs; }, res);
       }
       break;
     case SparqlFilter::NE:

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -93,9 +93,9 @@ class Filter : public Operation {
    * @return The pointer res.
    */
   template <class RT, ResultTable::ResultType T>
-  vector<RT>* computeFilterForResultType(
-      vector<RT>* res, size_t lhs, size_t rhs,
-      shared_ptr<const ResultTable> subRes) const;
+  vector<RT>* computeFilterForResultType(vector<RT>* res, size_t lhs,
+                                         size_t rhs,
+                                         const vector<RT>& subRes) const;
 
   /**
    * @brief Calls computeFilterForResultType with the correct template
@@ -103,6 +103,7 @@ class Filter : public Operation {
    */
   template <class RT>
   vector<RT>* computeFilter(vector<RT>* res, size_t lhs, size_t rhs,
+                            const vector<RT>& input,
                             shared_ptr<const ResultTable> subRes) const;
   /**
    * @brief Uses the result type and the filter type (_type) to apply the filter
@@ -111,7 +112,7 @@ class Filter : public Operation {
    */
   template <class RT, ResultTable::ResultType T>
   vector<RT>* computeFilterFixedValueForResultType(
-      vector<RT>* res, size_t lhs, Id rhs,
+      vector<RT>* res, size_t lhs, Id rhs, const vector<RT>& input,
       shared_ptr<const ResultTable> subRes) const;
 
   /**
@@ -120,7 +121,7 @@ class Filter : public Operation {
    */
   template <class RT>
   vector<RT>* computeFilterFixedValue(
-      vector<RT>* res, size_t lhs, Id rhs,
+      vector<RT>* res, size_t lhs, Id rhs, const vector<RT>& input,
       shared_ptr<const ResultTable> subRes) const;
 
   void computeResultFixedValue(

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -1365,8 +1365,8 @@ void Index::scanOPS(Id object, Index::WidthTwoList* result) const {
 void Index::throwExceptionIfNoPatterns() const {
   if (!_usePatterns) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-             "The requested feature requires a loaded patterns file (Use the "
-             "-P or --patterns option when running the executable).");
+             "The requested feature requires a loaded patterns file ("
+             "do not specify the --no-patterns option for this to work)");
   }
 }
 

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -34,7 +34,7 @@ struct option options[] = {{"all-permutations", no_argument, NULL, 'a'},
                            {"kb-index-name", required_argument, NULL, 'K'},
                            {"on-disk-literals", no_argument, NULL, 'l'},
                            {"ntriples-file", required_argument, NULL, 'n'},
-                           {"patterns", no_argument, NULL, 'P'},
+                           {"no-patterns", no_argument, NULL, 'P'},
                            {"tsv-file", required_argument, NULL, 't'},
                            {"text-index-name", required_argument, NULL, 'T'},
                            {"words-by-contexts", required_argument, NULL, 'w'},
@@ -89,9 +89,8 @@ void printUsage(char* execName) {
        << "Externalize parts of the KB vocab." << endl;
   cout << "  " << std::setw(20) << "n, ntriples-file" << std::setw(1) << "    "
        << "NT file to build KB index from." << endl;
-  cout << "  " << std::setw(20) << "P, patterns" << std::setw(1) << "    "
-       << "Detect and store prediate patterns to enable ql:has-predicate "
-          "queries."
+  cout << "  " << std::setw(20) << "no-patterns" << std::setw(1) << "    "
+       << "Disable the use of patterns. This disables ql:has-predicate."
        << endl;
   cout << "  " << std::setw(20) << "t, tsv-file" << std::setw(1) << "    "
        << "TSV file to build KB index from." << endl;
@@ -142,13 +141,13 @@ int main(int argc, char** argv) {
   bool useCompression = true;
   bool allPermutations = false;
   bool onDiskLiterals = false;
-  bool usePatterns = false;
+  bool usePatterns = true;
   bool onlyAddTextIndex = false;
   bool keepTemporaryFiles = false;
   optind = 1;
   // Process command line arguments.
   while (true) {
-    int c = getopt_long(argc, argv, "t:n:i:w:d:alT:K:PhAks:N", options, NULL);
+    int c = getopt_long(argc, argv, "t:n:i:w:d:alT:K:hAks:N", options, NULL);
     if (c == -1) {
       break;
     }
@@ -185,7 +184,7 @@ int main(int argc, char** argv) {
         kbIndexName = optarg;
         break;
       case 'P':
-        usePatterns = true;
+        usePatterns = false;
         break;
       case 'A':
         onlyAddTextIndex = true;

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -736,7 +736,7 @@ string SparqlParser::stripAndLowercaseKeywordLiteral(const string& lit) {
 
 // _____________________________________________________________________________
 string SparqlParser::parseLiteral(const string& literal, bool isEntireString,
-                                  size_t off) {
+                                  size_t off /*defaults to 0*/) {
   std::stringstream out;
   size_t pos = off;
   if (isEntireString) {
@@ -775,6 +775,8 @@ string SparqlParser::parseLiteral(const string& literal, bool isEntireString,
   out << '"';
   pos++;
   if (pos < literal.size() && literal[pos] == '@') {
+    out << literal[pos];
+    pos++;
     // add the language tag
     // allow for ascii based language tags (no current language tag should
     // contain non ascii letters).

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -14,6 +14,15 @@ class SparqlParser {
  public:
   static ParsedQuery parse(const string& query);
 
+  /**
+   * @brief This method looks for the first string literal it can find and
+   * parses it. During the parsing any escaped characters are resolved (e.g. \")
+   * If isEntireString is true an exception is thrown if the entire string
+   * is not a literal (apart from any leading and trailing whitespace).
+   **/
+  static string parseLiteral(const string& literal, bool isEntireString,
+                             size_t off = 0);
+
  private:
   static void parsePrologue(string str, ParsedQuery& query);
   static void parseSelect(string const& str, ParsedQuery& query);
@@ -27,13 +36,4 @@ class SparqlParser {
                         ParsedQuery::GraphPattern* pattern = nullptr);
 
   static string stripAndLowercaseKeywordLiteral(const string& lit);
-
-  /**
-   * @brief This method looks for the first string literal it can find and
-   * parses it. During the parsing any escaped characters are resolved (e.g. \")
-   * If isEntireString is true an exception is thrown if the entire string
-   * is not a literal (apart from any leading and trailing whitespace).
-   **/
-  static string parseLiteral(const string& literal, bool isEntireString,
-                             size_t off = 0);
 };

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -27,4 +27,13 @@ class SparqlParser {
                         ParsedQuery::GraphPattern* pattern = nullptr);
 
   static string stripAndLowercaseKeywordLiteral(const string& lit);
+
+  /**
+   * @brief This method looks for the first string literal it can find and
+   * parses it. During the parsing any escaped characters are resolved (e.g. \")
+   * If isEntireString is true an exception is thrown if the entire string
+   * is not a literal (apart from any leading and trailing whitespace).
+   **/
+  static string parseLiteral(const string& literal, bool isEntireString,
+                             size_t off = 0);
 };


### PR DESCRIPTION
This pr removes the --patterns / -P option and replaces them with --no-patterns, making patterns the default option.
Furthermore it adds an aditional literal parsing step, that ensures literals are properly formatted regarding the count, positioning and escaping of qutation marks (as requested in #160).
Finally it adds support for filters on result tables that have more than 5 columns, presumably fixing #162. 