### PR TITLE
Added a FullRelationScan operation.

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -495,6 +495,52 @@ queries:
       - selected: ["?a", "?h"]
       - contains_row: ['<Daryl_Hannah>', 1.78]
       - contains_row: ['<Marissa_Mayer>', 1.73]
+  - query : full-relation-scan-subject 
+    type: no-text
+    sparql: |
+      SELECT ?a (COUNT(?a) as ?count2) WHERE {
+        ?a ?b ?c .
+      }
+      GROUP BY ?a
+      ORDER BY DESC(?count2)
+      LIMIT 100
+    checks:
+      - num_rows: 100
+      - num_cols: 2
+      - selected: ["?a", "?count2"]
+      - contains_row: ['<Ed_Begley,_Jr.>', 270]
+      - contains_row: ['<Isaac_Newton>', 74]
+  - query : full-relation-scan-predicate
+    type: no-text
+    sparql: |
+      SELECT ?b (COUNT(?b) as ?count2) WHERE {
+        ?a ?b ?c .
+      }
+      GROUP BY ?b
+      ORDER BY ASC(?count2)
+      LIMIT 100
+    checks:
+      - num_rows: 100
+      - num_cols: 2
+      - selected: ["?b", "?count2"]
+      - contains_row: ['<Source>', 1]
+      - contains_row: ['<Venture_Investment>', 12]
+  - query : full-relation-scan-object
+    type: no-text
+    sparql: |
+      SELECT ?c (COUNT(?c) as ?count2) WHERE {
+        ?a ?b ?c .
+      }
+      GROUP BY ?c
+      HAVING regex(?c, "^<Ma")
+      ORDER BY DESC(?count2)
+      LIMIT 200
+    checks:
+      - num_rows: 200
+      - num_cols: 2
+      - selected: ["?c", "?count2"]
+      - contains_row: ['<Manhattan>', 32]
+      - contains_row: ['<Max_Planck>', 13]
   - query : subquery-profession-avg-height 
     type: no-text
     sparql: |

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(engine
         CountAvailablePredicates.cpp CountAvailablePredicates.h
         GroupBy.cpp GroupBy.h
         HasPredicateScan.cpp HasPredicateScan.h
+        FullRelationScan.cpp FullRelationScan.h
         Union.cpp Union.h
         MultiColumnJoin.cpp MultiColumnJoin.h
 )

--- a/src/engine/FullRelationScan.cpp
+++ b/src/engine/FullRelationScan.cpp
@@ -1,0 +1,108 @@
+// Copyright 2018, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+
+#include "FullRelationScan.h"
+
+FullRelationScan::FullRelationScan(QueryExecutionContext* qec, ScanType type,
+                                   const std::string& entity_var_name,
+                                   const std::string& count_var_name)
+    : Operation(qec),
+      _type(type),
+      _entity_var_name(entity_var_name),
+      _count_var_name(count_var_name) {}
+
+string FullRelationScan::asString(size_t indent) const {
+  std::ostringstream os;
+  for (size_t i = 0; i < indent; ++i) {
+    os << " ";
+  }
+  switch (_type) {
+    case ScanType::SUBJECT:
+      os << "FULL_RELATION_SCAN for subjects.";
+      break;
+    case ScanType::PREDICATE:
+      os << "FULL_RELATION_SCAN for predicates.";
+      break;
+    case ScanType::OBJECT:
+      os << "FULL_RELATION_SCAN for objects.";
+      break;
+  }
+  return os.str();
+}
+
+size_t FullRelationScan::getResultWidth() const { return 2; }
+
+vector<size_t> FullRelationScan::resultSortedOn() const { return {0}; }
+
+ad_utility::HashMap<string, size_t> FullRelationScan::getVariableColumns()
+    const {
+  ad_utility::HashMap<string, size_t> varCols;
+  varCols[_entity_var_name] = 0;
+  varCols[_count_var_name] = 1;
+  return varCols;
+}
+
+void FullRelationScan::setTextLimit(size_t limit) {}
+
+bool FullRelationScan::knownEmptyResult() { return false; }
+
+float FullRelationScan::getMultiplicity(size_t col) { return 1; }
+
+size_t FullRelationScan::getSizeEstimate() {
+  switch (_type) {
+    case ScanType::SUBJECT:
+      return getIndex().getNofSubjects();
+    case ScanType::PREDICATE:
+      return getIndex().getNofPredicates();
+    case ScanType::OBJECT:
+      return getIndex().getNofObjects();
+  }
+  return 0;
+}
+
+size_t FullRelationScan::getCostEstimate() { return getSizeEstimate(); }
+
+void FullRelationScan::computeResult(ResultTable* result) const {
+  result->_nofColumns = getResultWidth();
+  result->_sortedBy = resultSortedOn();
+  computeFullScan(result, getIndex(), _type);
+  result->finish();
+}
+
+void FullRelationScan::computeFullScan(ResultTable* result, const Index& index,
+                                       FullRelationScan::ScanType type) {
+  result->_resultTypes.push_back(ResultTable::ResultType::KB);
+  result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);
+  std::vector<std::array<Id, 2>>* fixedSizeData =
+      new std::vector<std::array<Id, 2>>();
+  result->_fixedSizeData = fixedSizeData;
+  if (type == FullRelationScan::ScanType::PREDICATE) {
+    fixedSizeData->reserve(index.getNofPredicates());
+    const IndexMetaDataHmap& meta = index.getPsoMeta();
+    for (const std::pair<size_t, const FullRelationMetaData&> elem :
+         meta.data()) {
+      fixedSizeData->push_back({elem.first, elem.second.getNofElements()});
+    }
+  } else {
+    const IndexMetaDataMmapView* meta;
+    if (type == FullRelationScan::ScanType::SUBJECT) {
+      fixedSizeData->reserve(index.getNofSubjects());
+      meta = &index.getSpoMeta();
+    } else if (type == FullRelationScan::ScanType::OBJECT) {
+      fixedSizeData->reserve(index.getNofObjects());
+      meta = &index.getOpsMeta();
+    } else {
+      AD_THROW(ad_semsearch::Exception::INVALID_PARAMETER_VALUE,
+               "FullRelationScan called with an unsupported scan type : " +
+                   std::to_string(static_cast<int>(type)));
+    }
+
+    for (const std::pair<size_t, const FullRelationMetaData&> elem :
+         meta->data()) {
+      fixedSizeData->push_back({elem.first, elem.second.getNofElements()});
+    }
+  }
+}
+
+FullRelationScan::ScanType FullRelationScan::getType() const { return _type; }

--- a/src/engine/FullRelationScan.h
+++ b/src/engine/FullRelationScan.h
@@ -48,6 +48,11 @@ class FullRelationScan : public Operation {
   static void computeFullScan(ResultTable* result, const Index& index,
                               ScanType type);
 
+  template <typename T>
+  static void computeFullScanForMeta(std::vector<std::array<Id, 2>>* result,
+                                     const T& metaDataStorage,
+                                     size_t numResults);
+
   static void computeSubqueryS(
       ResultTable* result, const std::shared_ptr<QueryExecutionTree> _subtree,
       const size_t subtreeColIndex, const std::vector<PatternID>& hasPattern,

--- a/src/engine/FullRelationScan.h
+++ b/src/engine/FullRelationScan.h
@@ -1,0 +1,63 @@
+// Copyright 2018, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../parser/ParsedQuery.h"
+#include "./Operation.h"
+#include "./QueryExecutionTree.h"
+
+class FullRelationScan : public Operation {
+ public:
+  enum class ScanType {
+    // Only subject scans are curently supported
+    SUBJECT,
+    PREDICATE,
+    OBJECT
+  };
+
+  FullRelationScan(QueryExecutionContext* qec, ScanType type,
+                   const std::string& entity_var_name,
+                   const std::string& count_var_name);
+
+  virtual string asString(size_t indent = 0) const override;
+
+  virtual size_t getResultWidth() const override;
+
+  virtual vector<size_t> resultSortedOn() const override;
+
+  ad_utility::HashMap<string, size_t> getVariableColumns() const;
+
+  virtual void setTextLimit(size_t limit) override;
+
+  virtual bool knownEmptyResult() override;
+
+  virtual float getMultiplicity(size_t col) override;
+
+  virtual size_t getSizeEstimate() override;
+
+  virtual size_t getCostEstimate() override;
+
+  ScanType getType() const;
+
+  static void computeFullScan(ResultTable* result, const Index& index,
+                              ScanType type);
+
+  static void computeSubqueryS(
+      ResultTable* result, const std::shared_ptr<QueryExecutionTree> _subtree,
+      const size_t subtreeColIndex, const std::vector<PatternID>& hasPattern,
+      const CompactStringVector<Id, Id>& hasPredicate,
+      const CompactStringVector<size_t, Id>& patterns);
+
+ private:
+  ScanType _type;
+  std::string _entity_var_name;
+  std::string _count_var_name;
+
+  virtual void computeResult(ResultTable* result) const override;
+};

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -40,7 +40,8 @@ class QueryExecutionTree {
     GROUP_BY = 13,
     HAS_RELATION_SCAN = 14,
     UNION = 15,
-    MULTICOLUMN_JOIN = 16
+    MULTICOLUMN_JOIN = 16,
+    FULL_RELATION_SCAN = 17
   };
 
   void setOperation(OperationType type, std::shared_ptr<Operation> op);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -225,4 +225,18 @@ class QueryPlanner {
    */
   bool checkUsePatternTrick(ParsedQuery* pq,
                             SparqlTriple* patternTrickTriple) const;
+
+  /**
+   * @brief Check if the query fulfills the requirements of a FullRelationScan
+   *        and build a QueryExecutionTree if the requirements are fulfilled.
+   *        The requirements for a FullRelationScan are:
+   *         - There must only be one triple that only contains variables
+   *         - Only one of these variables (and optionaly its count) must be
+   *           selected.
+   *         - The query must group on the selected variable.
+   * @returns An optional that containts a QueryExecutionTree if the query
+   *          matches the requirements for a FullRelationScan.
+   */
+  std::optional<QueryExecutionTree> checkUseFullRelationScan(
+      const ParsedQuery& pq) const;
 };

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -307,6 +307,39 @@ class Index {
 
   bool hasAllPermutations() const { return _spoFile.isOpen(); }
 
+  const IndexMetaDataHmap& getPsoMeta() const {
+    if (hasAllPermutations()) {
+      return _psoMeta;
+    } else {
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+               "Can only use the spo metadta if all 6 permutations "
+               "have been registered on sever start (and index build time) "
+               "with the -a option.")
+    }
+  }
+
+  const IndexMetaDataMmapView& getSpoMeta() const {
+    if (hasAllPermutations()) {
+      return _spoMeta;
+    } else {
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+               "Can only use the spo metadta if all 6 permutations "
+               "have been registered on sever start (and index build time) "
+               "with the -a option.")
+    }
+  }
+
+  const IndexMetaDataMmapView& getOpsMeta() const {
+    if (hasAllPermutations()) {
+      return _opsMeta;
+    } else {
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+               "Can only use the spo metadta if all 6 permutations "
+               "have been registered on sever start (and index build time) "
+               "with the -a option.")
+    }
+  }
+
  private:
   string _onDiskBase;
   string _settingsFileName;

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -307,16 +307,7 @@ class Index {
 
   bool hasAllPermutations() const { return _spoFile.isOpen(); }
 
-  const IndexMetaDataHmap& getPsoMeta() const {
-    if (hasAllPermutations()) {
-      return _psoMeta;
-    } else {
-      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-               "Can only use the spo metadta if all 6 permutations "
-               "have been registered on sever start (and index build time) "
-               "with the -a option.")
-    }
-  }
+  const IndexMetaDataHmap& getPsoMeta() const { return _psoMeta; }
 
   const IndexMetaDataMmapView& getSpoMeta() const {
     if (hasAllPermutations()) {

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -158,6 +158,8 @@ class IndexMetaData {
 
   MapType& data() { return _data; }
 
+  const MapType& data() const { return _data; }
+
  private:
   off_t _offsetAfter = 0;
 

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -215,11 +215,17 @@ class MetaDataWrapperHashMap {
   // __________________________________________________________________
   Iterator begin() { return _map.begin(); }
 
+  // __________________________________________________________________
+  ConstIterator begin() const { return _map.begin(); }
+
   // ____________________________________________________________
   ConstIterator cend() const { return _map.end(); }
 
   // ____________________________________________________________
   Iterator end() { return _map.end(); }
+
+  // ____________________________________________________________
+  ConstIterator end() const { return _map.end(); }
 
   // ____________________________________________________________
   void set(Id id, const FullRelationMetaData& value) { _map[id] = value; }


### PR DESCRIPTION
This implements a FullRelationScan opertion, which allows for queries of the form:
```
SELECT ?a WHERE {
 ?a ?b ?c
}
GROUP BY ?a
```
as we had discussed. The current implementation is based upon the `FullRelationMetadata` stored in the index. It does not do any optimizations (e.g. applying prefix filters when scanning the metadata or caching a prefix of the result and applying `LIMIT` early).
The FullRelationScan is used if all of these three conditions are met by the query: 
  - There must only be one triple which must only contain variables
  - Only one of these variables (and optionally its count) must be selected.
  - The query must group on the selected variable.
