### PR TITLE
 Allow TurtleParser output into file

### DIFF
--- a/src/TurtleParserMain.cpp
+++ b/src/TurtleParserMain.cpp
@@ -8,7 +8,7 @@
 #include <string>
 #include "./parser/TurtleParser.h"
 
-void write_nt(std::ostream& out, const std::string& filename) {
+void writeNT(std::ostream& out, const std::string& filename) {
   TurtleParser p(filename);
   std::array<std::string, 3> triple;
   while (p.getLine(&triple)) {
@@ -29,9 +29,9 @@ int main(int argc, char** argv) {
       std::cerr << "Error opening '" << argv[2] << "'" << std::endl;
       exit(1);
     }
-    write_nt(of, argv[1]);
+    writeNT(of, argv[1]);
     of.close();
   } else {
-    write_nt(std::cout, argv[1]);
+    writeNT(std::cout, argv[1]);
   }
 }

--- a/src/TurtleParserMain.cpp
+++ b/src/TurtleParserMain.cpp
@@ -3,18 +3,35 @@
 // Author: Johannes Kalmbach(joka921) <johannes.kalmbach@gmail.com>
 
 #include <array>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include "./parser/TurtleParser.h"
 
-int main(int argc, char** argv) {
-  if (argc != 2) {
-    std::cerr << "Usage: ./TurtleParserMain <turtleInput>";
-    exit(1);
-  }
-  TurtleParser p(argv[1]);
+void write_nt(std::ostream& out, const std::string& filename) {
+  TurtleParser p(filename);
   std::array<std::string, 3> triple;
   while (p.getLine(&triple)) {
-    std::cout << triple[0] << " " << triple[1] << " " << triple[2] << '\n';
+    out << triple[0] << " " << triple[1] << " " << triple[2] << " .\n";
+  }
+}
+
+int main(int argc, char** argv) {
+  if (argc < 2 || argc > 3) {
+    std::cerr << "Usage: ./TurtleParserMain <turtleInput> [<nTripleOutput>]"
+              << std::endl;
+    exit(1);
+  }
+
+  if (argc == 3) {
+    std::ofstream of(argv[2]);
+    if (!of) {
+      std::cerr << "Error opening '" << argv[2] << "'" << std::endl;
+      exit(1);
+    }
+    write_nt(of, argv[1]);
+    of.close();
+  } else {
+    write_nt(std::cout, argv[1]);
   }
 }


### PR DESCRIPTION
Allow redirection of the generated .nt formated data without the inclusion of status messages printed to stdout like:
```
INFO:  mapping 2639242643 bytes
INFO:  Parsing of line has Failed, but parseInput is not yet exhausted. Remaining bytes: 1
INFO:  Logging first 1000 unparsed characters
```
These messages remain on stdout.