### PR TITLE
Fixed a bug making CountAvailablePredicates not work for _varSizedData.

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -530,4 +530,23 @@ queries:
       - selected: ["?p", "?a1", "?a2", "?a3", "?a4", "?avg"]
       - contains_row: ['<Cameraman>', '<Chris_Packham>', '<Chris_Packham>', '<Chris_Packham>', '<Chris_Packham>', 1.83]
       - contains_row: ['<Lawyer>', '<Thomas_Jefferson>', '<Thomas_Jefferson>', '<Thomas_Jefferson>', '<Thomas_Jefferson>', 1.8056]
+  - query : count-available-predicates-on-variable-columns 
+    type: no-text
+    sparql: |
+      SELECT ?p (COUNT(?p) as ?count) WHERE {
+        ?a ql:has-predicate ?p .
+        ?a <Height> ?h1 .
+        ?a <Height> ?h2 .
+        ?a <Height> ?h3 .
+        ?a <Height> ?h4 .
+        ?a <Height> ?h5 .
+        ?a <Profession> ?profession .
+      }
+      GROUP BY ?p
+    checks:
+      - num_rows: 108 
+      - num_cols: 2
+      - selected: ["?p", "?count"]
+      - contains_row: ["<Film_appeared_in>", 56] 
+      - contains_row: ["<Patent>", 2]
 

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -130,7 +130,7 @@ void CountAvailablePredicates::computeResult(ResultTable* result) const {
     // Compute the predicates for entities in subresult's _subjectColumnIndex
     // column.
     std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-    if (result->_nofColumns > 5) {
+    if (subresult->_nofColumns > 5) {
       CountAvailablePredicates::computePatternTrick<vector<Id>>(
           &subresult->_varSizeData,
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),


### PR DESCRIPTION
There was a typo in the CountAvailablePredicates operation due to which the size of the result instead of the subresult was used to determine when to use the variable sized data. As the result of the operation always has size 2 that branch of the Operation was never used, and the result for subresults with more than five columns was always empty.