### PR TITLE
Enable aborting an Operation result, fix dead lock

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -145,7 +145,12 @@ int main(int argc, char** argv) {
     server.initialize(index, text, allPermutations, usePatterns);
     server.run();
   } catch (const std::exception& e) {
+    // This code should never be reached as all exceptions should be handled
+    // within server.run()
     LOG(ERROR) << e.what() << std::endl;
+    return 1;
   }
-  return 0;
+  // This should also never be reached as the server threads are not supposed
+  // to terminate.
+  return 2;
 }

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -144,9 +144,8 @@ int main(int argc, char** argv) {
     Server server(port, numThreads);
     server.initialize(index, text, allPermutations, usePatterns);
     server.run();
-  } catch (const ad_semsearch::Exception& e) {
-    LOG(ERROR) << e.getFullErrorMessage() << '\n';
-    return 1;
+  } catch (const std::exception& e) {
+    LOG(ERROR) << e.what() << std::endl;
   }
   return 0;
 }

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -191,10 +191,7 @@ int main(int argc, char** argv) {
       }
     }
   } catch (const std::exception& e) {
-    cout << string("Caught exceptions: ") + e.what() << std::endl;
-    return 1;
-  } catch (ad_semsearch::Exception& e) {
-    cout << e.getFullErrorMessage() << std::endl;
+    cout << e.what() << std::endl;
   }
 
   return 0;

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -112,10 +112,7 @@ int main(int argc, char** argv) {
     f.close();
 
   } catch (const std::exception& e) {
-    cout << string("Caught exceptions: ") + e.what();
-    return 1;
-  } catch (ad_semsearch::Exception& e) {
-    cout << e.getFullErrorMessage() << std::endl;
+    cout << e.what() << std::endl;
   }
 
   return 0;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -45,6 +45,7 @@ class Operation {
       try {
         computeResult(newResult.get());
       } catch (const ad_semsearch::AbortException& e) {
+        newResult->abort();
         // AbortExceptions have already been printed simply rethrow to
         // unwind the callstack until the whole query is aborted
         throw;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -58,6 +58,17 @@ class Operation {
         // Rethrow as QUERY_ABORTED allowing us to print the Operation
         // only at innermost failure of a recursive call
         throw ad_semsearch::AbortException(e);
+      } catch (...) {
+        // Only print the Operation at the innermost (original) failure
+        // then create not so weird AbortException
+        LOG(ERROR) << "Failed to compute Operation result for:" << endl;
+        LOG(ERROR) << asString() << endl;
+        LOG(ERROR) << "WEIRD_EXCEPTION not inheriting from std::exception"
+                   << endl;
+        newResult->abort();
+        // Rethrow as QUERY_ABORTED allowing us to print the Operation
+        // only at innermost failure of a recursive call
+        throw ad_semsearch::AbortException("WEIRD_EXCEPTION");
       }
       return newResult;
     }

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -13,7 +13,7 @@ ResultTable::ResultTable()
       _fixedSizeData(nullptr),
       _resultTypes(),
       _localVocab(std::make_shared<std::vector<std::string>>()),
-      _status(ResultTable::OTHER) {}
+      _status(ResultTable::IN_PROGESS) {}
 
 // _____________________________________________________________________________
 void ResultTable::clear() {
@@ -45,8 +45,9 @@ void ResultTable::clear() {
     }
   }
   _fixedSizeData = nullptr;
+  _localVocab = nullptr;
   _varSizeData.clear();
-  _status = OTHER;
+  _status = IN_PROGESS;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -13,7 +13,7 @@ ResultTable::ResultTable()
       _fixedSizeData(nullptr),
       _resultTypes(),
       _localVocab(std::make_shared<std::vector<std::string>>()),
-      _status(ResultTable::IN_PROGESS) {}
+      _status(ResultTable::IN_PROGRESS) {}
 
 // _____________________________________________________________________________
 void ResultTable::clear() {
@@ -47,7 +47,7 @@ void ResultTable::clear() {
   _fixedSizeData = nullptr;
   _localVocab = nullptr;
   _varSizeData.clear();
-  _status = IN_PROGESS;
+  _status = IN_PROGRESS;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -20,7 +20,7 @@ using std::vector;
 
 class ResultTable {
  public:
-  enum Status { FINISHED = 0, OTHER = 1 };
+  enum Status { IN_PROGESS = 0, FINISHED = 1, ABORTED = 2 };
 
   /**
    * @brief Describes the type of a columns data
@@ -79,16 +79,22 @@ class ResultTable {
 
   virtual ~ResultTable();
 
+  void abort() {
+    lock_guard<mutex> lk(_cond_var_m);
+    clear();
+    _status = ResultTable::ABORTED;
+    _cond_var.notify_all();
+  }
+
   void finish() {
     lock_guard<mutex> lk(_cond_var_m);
     _status = ResultTable::FINISHED;
     _cond_var.notify_all();
   }
 
-  bool isFinished() const {
+  Status status() const {
     lock_guard<mutex> lk(_cond_var_m);
-    bool tmp = _status == ResultTable::FINISHED;
-    return tmp;
+    return _status;
   }
 
   void awaitFinished() const {

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -20,7 +20,7 @@ using std::vector;
 
 class ResultTable {
  public:
-  enum Status { IN_PROGESS = 0, FINISHED = 1, ABORTED = 2 };
+  enum Status { IN_PROGRESS = 0, FINISHED = 1, ABORTED = 2 };
 
   /**
    * @brief Describes the type of a columns data
@@ -99,7 +99,7 @@ class ResultTable {
 
   void awaitFinished() const {
     unique_lock<mutex> lk(_cond_var_m);
-    _cond_var.wait(lk, [&] { return _status == ResultTable::FINISHED; });
+    _cond_var.wait(lk, [&] { return _status != ResultTable::IN_PROGRESS; });
   }
 
   std::optional<std::string> idToOptionalString(Id id) const {

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -38,7 +38,8 @@ class Server {
   void initialize(const string& ontologyBaseName, bool useText,
                   bool allPermutations = false, bool usePatterns = false);
 
-  //! Loop, wait for requests and trigger processing.
+  //! Loop, wait for requests and trigger processing. This method never returns
+  //! except when throwing an exceptiob
   void run();
 
  private:

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -91,12 +91,14 @@ namespace ad_semsearch {
 //! message just in case
 class AbortException : public std::exception {
  public:
-  AbortException(const std::exception& original) : _origWhat(original.what()) {}
+  AbortException(const std::exception& original) : _what(original.what()) {}
 
-  const char* what() const noexcept { return _origWhat.c_str(); }
+  AbortException(const std::string& whatthe) : _what(whatthe) {}
+
+  const char* what() const noexcept { return _what.c_str(); }
 
  private:
-  string _origWhat;
+  string _what;
 };
 
 //! Exception class for all kinds of exceptions.

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -6,6 +6,7 @@
 #ifndef GLOBALS_EXCEPTION_H_
 #define GLOBALS_EXCEPTION_H_
 
+#include <exception>
 #include <sstream>
 #include <string>
 
@@ -22,10 +23,6 @@ using std::string;
     throw ad_semsearch::Exception(e, __os.str(), __FILE__, __LINE__, \
                                   __PRETTY_FUNCTION__);              \
   }  // NOLINT
-// Rethrow an exception
-#define AD_RETHROW(e)                             \
-  throw ad_semsearch::Exception(e.getErrorCode(), \
-                                e.getErrorDetails())  // NOLINT
 
 // --------------------------------------------------------------------------
 // Macros for assertions that will throw Exceptions.
@@ -88,13 +85,27 @@ using std::string;
 // Exception class code
 // -------------------------------------------
 namespace ad_semsearch {
+
+//! Exception class for rethrowing exceptions during a query abort
+//! such exceptions are never printed but still keep the original what()
+//! message just in case
+class AbortException : public std::exception {
+ public:
+  AbortException(const std::exception& original) : _origWhat(original.what()) {}
+
+  const char* what() const noexcept { return _origWhat.c_str(); }
+
+ private:
+  string _origWhat;
+};
+
 //! Exception class for all kinds of exceptions.
 //! Compatibility with the THROW macro is ensured by using error
 //! codes inside this exception class instead of implementing an
 //! exception hierarchy through inheritance.
 //! This approach is taken from CompleteSearch's exception code.
 //! Add error codes whenever necessary.
-class Exception {
+class Exception : public std::exception {
  private:
   //! Error code
   int _errorCode;
@@ -103,7 +114,9 @@ class Exception {
   //! optionally provided by thrower)
   string _errorDetails;
 
-  string _errorDetailsNoFileAndLines;
+  string _errorDetailsFileAndLines;
+
+  string _errorMessageFull;
 
  public:
   //! Error codes
@@ -127,7 +140,6 @@ class Exception {
 
     // query errors
     BAD_QUERY = 16 * 4 + 1,
-    QUERY_ABORTED = 16 * 4 + 2,
 
     // history errors
 
@@ -149,7 +161,7 @@ class Exception {
   };
 
   //! Error messages (one per code)
-  const char* errorCodeAsString(int errorCode) const {
+  static const string errorCodeAsString(int errorCode) {
     switch (errorCode) {
       case VOCABULARY_MISS:
         return "VOCABULARY MISS";
@@ -162,16 +174,12 @@ class Exception {
         return "BAD REQUEST STRING";
       case BAD_QUERY:
         return "BAD QUERY";
-      case QUERY_ABORTED:
-        return "QUERY ABORTED";
       case REALLOC_FAILED:
         return "MEMORY ALLOCATION ERROR: Realloc failed";
       case NEW_FAILED:
         return "MEMORY ALLOCATION ERROR: new failed";
       case ERROR_PASSED_ON:
         return "PASSING ON ERROR";
-        return "QUERY EXCEPTION: "
-               "Check of query result failed";
       case UNCOMPRESS_ERROR:
         return "UNCOMPRESSION PROBLEM";
       case COULD_NOT_GET_MUTEX:
@@ -202,27 +210,28 @@ class Exception {
   explicit Exception(int errorCode) {
     _errorCode = errorCode;
     _errorDetails = "";
-    _errorDetailsNoFileAndLines = "";
+    _errorDetailsFileAndLines = "";
+    _errorMessageFull = errorCodeAsString(_errorCode);
   }
 
   //! Constructor (code + details)
-  Exception(int errorCode, string errorDetails) {
+  Exception(int errorCode, const string& errorDetails) {
     _errorCode = errorCode;
     _errorDetails = errorDetails;
-    _errorDetailsNoFileAndLines = errorDetails;
+    _errorDetailsFileAndLines = "";
+    _errorMessageFull = getErrorMessage() + " (" + _errorDetails + ")";
   }
 
   //! Constructor
   //! (code + details + file name + line number + enclosing method)
-  Exception(int errorCode, const string& errorDetails, const char* file_name,
-            int line_no, const char* fct_name) {
+  Exception(int errorCode, const string& errorDetails, const string& file_name,
+            int line_no, const string& fct_name) {
     _errorCode = errorCode;
-    _errorDetailsNoFileAndLines = errorDetails;
-    std::ostringstream os;
-    if (errorDetails.size() > 0) os << errorDetails << "; ";
-    os << "in " << file_name << ", line " << line_no << ", function "
-       << fct_name;
-    _errorDetails = os.str();
+    _errorDetails = errorDetails;
+    _errorDetailsFileAndLines = "in " + file_name + ", line " +
+                                std::to_string(line_no) + ", function " +
+                                fct_name;
+    _errorMessageFull = getErrorMessage() + " (" + getErrorDetails() + ")";
   }
 
   //! Set error code
@@ -231,28 +240,30 @@ class Exception {
   //! Set error details
   void setErrorDetails(const string& errorDetails) {
     _errorDetails = errorDetails;
-    _errorDetailsNoFileAndLines = _errorDetailsNoFileAndLines;
   }
 
   //! Get error Code
-  int getErrorCode() const { return _errorCode; }
+  int getErrorCode() const noexcept { return _errorCode; }
 
   //! Get error message pertaining to code
-  string getErrorMessage() const { return errorCodeAsString(_errorCode); }
+  string getErrorMessage() const noexcept {
+    return errorCodeAsString(_errorCode);
+  }
 
   //! Get error details
-  const string& getErrorDetails() const { return _errorDetails; }
-
-  //! Get full error message (generic message + specific details if available)
-  string getFullErrorMessage() const {
-    return _errorDetails.length() > 0
-               ? getErrorMessage() + " (" + _errorDetails + ")"
-               : getErrorMessage();
+  const string getErrorDetails() const noexcept {
+    return _errorDetails + "; " + _errorDetailsFileAndLines;
   }
 
-  const string& getErrorMsgNoFileAndLines() const {
-    return _errorDetailsNoFileAndLines;
+  const string getErrorDetailsNoFileAndLines() const noexcept {
+    return _errorDetails;
   }
+
+  const string& getFullErrorMessage() const noexcept {
+    return _errorMessageFull;
+  }
+
+  const char* what() const noexcept { return _errorMessageFull.c_str(); }
 };
 }  // namespace ad_semsearch
 

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -23,8 +23,9 @@ using std::string;
                                   __PRETTY_FUNCTION__);              \
   }  // NOLINT
 // Rethrow an exception
-#define AD_RETHROW(e) \
-  throw semsearch::Exception(e.getErrorCode(), e.getErrorDetails())  // NOLINT
+#define AD_RETHROW(e)                             \
+  throw ad_semsearch::Exception(e.getErrorCode(), \
+                                e.getErrorDetails())  // NOLINT
 
 // --------------------------------------------------------------------------
 // Macros for assertions that will throw Exceptions.
@@ -119,13 +120,14 @@ class Exception {
     // formatting errors
     BAD_INPUT = 16 * 2 + 5,
     BAD_REQUEST = 16 * 2 + 6,
-    BAD_QUERY = 16 * 2 + 7,
 
     // memory allocation errors
     REALLOC_FAILED = 16 * 3 + 1,
     NEW_FAILED = 16 * 3 + 2,
 
-    // intersect errors
+    // query errors
+    BAD_QUERY = 16 * 4 + 1,
+    QUERY_ABORTED = 16 * 4 + 2,
 
     // history errors
 
@@ -160,6 +162,8 @@ class Exception {
         return "BAD REQUEST STRING";
       case BAD_QUERY:
         return "BAD QUERY";
+      case QUERY_ABORTED:
+        return "QUERY ABORTED";
       case REALLOC_FAILED:
         return "MEMORY ALLOCATION ERROR: Realloc failed";
       case NEW_FAILED:

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -673,7 +673,7 @@ TEST(QueryPlannerTest, threeVarXthreeVarException) {
         "Could not find a suitable execution tree. "
         "Likely cause: Queries that require joins of the full index with "
         "itself are not supported at the moment.",
-        e.getErrorMsgNoFileAndLines());
+        e.getErrorDetailsNoFileAndLines());
   } catch (const std::exception& e) {
     std::cout << "Caught: " << e.what() << std::endl;
     FAIL() << e.what();


### PR DESCRIPTION
When an exception is thrown during Operation::computeResult() the
computing thread would leave the ResultTable in its unfinished state in
the subtree cache. Another thread waiting on it to be finished would
wait indefinitely.

We fix this by introducing the concept of aborting an Operation result.
When an exception is thrown in Operation::computeResult() we call the
newly added ResultTable::abort() to mark the result as aborted unlocking
waiting threads. Then we propagate the exception up the stack of
recursive Operation::getResult() calls.

To improve error output we propagate the exception with the original
details but a new QUERY_ABORTED error code which allows us to only print
the inner most Operation which caused the original error while all
Operations up the stack are silently aborted.

The aborted Operation result is left in the cache intentionally. It is
cleared during ResultTable::abort() and thus takes little memory and
will be pruned from the cache like any other result until which time it
may serve as a zero cost warning that a particular subtree fails.