### PR TITLE
Various bugfixes. Ensured node ids in the triple graph use 64 bits.

### DIFF
--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -215,8 +215,6 @@ ad_utility::HashMap<string, size_t> MultiColumnJoin::getVariableColumns()
   size_t columnIndex = retVal.size();
   for (const auto& it : _right->getVariableColumnMap()) {
     bool isJoinColumn = false;
-    // Reduce the index for every column of _right that is beeing joined on,
-    // and the index of which is smaller than the index of it.
     for (const std::array<Id, 2>& a : _joinColumns) {
       if (a[1] == it.second) {
         isJoinColumn = true;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -212,23 +212,20 @@ void MultiColumnJoin::computeResult(ResultTable* result) const {
 ad_utility::HashMap<string, size_t> MultiColumnJoin::getVariableColumns()
     const {
   ad_utility::HashMap<string, size_t> retVal(_left->getVariableColumnMap());
-  size_t leftSize = _left->getResultWidth();
-  for (auto it = _right->getVariableColumnMap().begin();
-       it != _right->getVariableColumnMap().end(); ++it) {
-    size_t columnIndex = leftSize + it->second;
+  size_t columnIndex = retVal.size();
+  for (const auto& it : _right->getVariableColumnMap()) {
     bool isJoinColumn = false;
     // Reduce the index for every column of _right that is beeing joined on,
     // and the index of which is smaller than the index of it.
     for (const std::array<Id, 2>& a : _joinColumns) {
-      if (a[1] < it->second) {
-        columnIndex--;
-      } else if (a[1] == it->second) {
+      if (a[1] == it.second) {
         isJoinColumn = true;
         break;
       }
     }
     if (!isJoinColumn) {
-      retVal[it->first] = columnIndex;
+      retVal[it.first] = columnIndex;
+      columnIndex++;
     }
   }
   return retVal;

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -561,7 +561,6 @@ void SparqlParser::addFilter(const string& str, vector<SparqlFilter>* _filters,
                    "lang function.");
         }
         std::string lvar = lhs.substr(5, lhs.size() - 6);
-        std::cout << "lvar:" << lvar << std::endl;
 
         auto langTag = rhs.substr(1, rhs.size() - 2);
         // first find a predicate for the given variable


### PR DESCRIPTION
The main problem fixed was the vectors storing the SubtreePlans of a
graphs children in the QueryPlanner being resized and thus reallocating
while pointers to the previous location of these plans were still in
use. This fixes the following query:
```
PREFIX wikibase: <http://wikiba.se/ontology#>
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX wd: <http://www.wikidata.org/entity/>
PREFIX p: <http://www.wikidata.org/prop/>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX wdt: <http://www.wikidata.org/prop/direct/>
PREFIX psv: <http://www.wikidata.org/prop/statement/value/>

SELECT ?QLC_COMPLETE ?QLC_COUNT ?QLC_ALIAS_COMPLETE WHERE {
 {
  SELECT ?QLC_COMPLETE (COUNT(?QLC_COMPLETE) AS ?QLC_COUNT) WHERE {
   ?occupation_id ql:has-predicate ?QLC_COMPLETE .
   ?x wdt:P106 ?occupation_id .
   ?x wdt:P31 wd:Q5 .
   ?x p:P2048 ?statement .
   ?x wdt:P21 ?gender_id .
   ?gender_id @en@<http://www.w3.org/2000/01/rdf-schema#label> ?gender .
   ?statement psv:P2048 ?value .
   ?value wikibase:quantityNormalized ?quantity .
   ?quantity wikibase:quantityUnit wd:Q11573 .
   ?quantity wikibase:quantityAmount ?height .
  }
  GROUP BY ?QLC_COMPLETE
 }
 {
  {
   ?QLC_CLAIM wikibase:directClaim ?QLC_COMPLETE .
  } UNION {
   ?QLC_CLAIM wikibase:claim ?QLC_COMPLETE .
  }
 } UNION {
  ?QLC_CLAIM wikibase:statementValue ?QLC_COMPLETE .
 }

 { ?QLC_CLAIM @en@rdfs:label ?QLC_ALIAS_COMPLETE . } UNION { ?QLC_CLAIM @en@skos:altLabel ?QLC_ALIAS_COMPLETE .}
}
ORDER BY DESC(?QLC_COUNT) 
```