### PR TITLE
Explicitly set LOGLEVEL to DEBUG in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app/
 RUN misc/format-check.sh
 
 WORKDIR /app/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc) && make test
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=DEBUG .. && make -j $(nproc) && make test
 
 FROM base as runtime
 WORKDIR /app


### PR DESCRIPTION
The previous PR #181 changed the LOGLEVEL used for docker containers which was okay because it wasn't set explicitly and it is weird to have it at DEBUG by default. Instead make it explicit.