### PR TITLE
Patterns exclude lang predicates

### DIFF
--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -478,15 +478,15 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
   Pattern pattern;
 
   size_t patternIndex = 0;
-  Id currentRel;
-  currentRel = vec[0][0];
+  Id currentSubj;
+  currentSubj = vec[0][0];
   bool isValidPattern = true;
   size_t numInvalidPatterns = 0;
   size_t numValidPatterns = 0;
 
   for (StxxlVec::bufreader_type reader(vec); !reader.empty(); ++reader) {
-    if ((*reader)[0] != currentRel) {
-      currentRel = (*reader)[0];
+    if ((*reader)[0] != currentSubj) {
+      currentSubj = (*reader)[0];
       if (isValidPattern) {
         numValidPatterns++;
         auto it = patternCounts.find(pattern);
@@ -503,8 +503,9 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
       patternIndex = 0;
     }
     // don't list predicates twice
-    if (patternIndex == 0 || pattern[patternIndex - 1] != ((*reader)[1])) {
-      pattern.push_back((*reader)[1]);
+    Id currentPred = (*reader)[1];
+    if (patternIndex == 0 || pattern[patternIndex - 1] != currentPred) {
+      pattern.push_back(currentPred);
       patternIndex++;
     }
   }
@@ -519,7 +520,7 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
   }
   LOG(INFO) << "Counted patterns and found " << patternCounts.size()
             << " distinct patterns." << std::endl;
-  LOG(INFO) << "Patterns where found for " << numValidPatterns << " entities."
+  LOG(INFO) << "Patterns were found for " << numValidPatterns << " entities."
             << std::endl;
   LOG(INFO) << "Discarded the patterns of " << numInvalidPatterns
             << " entities"
@@ -614,11 +615,11 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
   ad_utility::HashSet<Id> predicateHashSet;
 
   pattern.clear();
-  currentRel = vec[0][0];
+  currentSubj = vec[0][0];
   patternIndex = 0;
-  // Create the has-relation and has-pattern predicates
+  // Create the has-predicate and has-pattern predicates
   for (StxxlVec::bufreader_type reader2(vec); !reader2.empty(); ++reader2) {
-    if ((*reader2)[0] != currentRel) {
+    if ((*reader2)[0] != currentSubj) {
       // we have arrived at a new entity;
       fullHasPredicateEntitiesDistinctSize++;
       std::unordered_map<Pattern, Id>::iterator it;
@@ -641,12 +642,12 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
             fullHasPredicatePredicatesDistinctSize++;
           }
           entityHasPredicate.push_back(
-              std::array<Id, 2>{currentRel, pattern[i]});
+              std::array<Id, 2>{currentSubj, pattern[i]});
         }
       } else {
         numEntitiesWithPatterns++;
         // The pattern does exist, add an entry to the has-pattern predicate
-        entityHasPattern.push_back(std::array<Id, 2>{currentRel, it->second});
+        entityHasPattern.push_back(std::array<Id, 2>{currentSubj, it->second});
         if (!haveCountedPattern[it->second]) {
           haveCountedPattern[it->second] = true;
           // iterate over the pattern once to
@@ -659,13 +660,14 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
         }
       }
       pattern.clear();
-      currentRel = (*reader2)[0];
+      currentSubj = (*reader2)[0];
       patternIndex = 0;
       isValidPattern = true;
     }
     // don't list predicates twice
-    if (patternIndex == 0 || pattern[patternIndex - 1] != ((*reader2)[1])) {
-      pattern.push_back((*reader2)[1]);
+    Id currentPred = (*reader2)[1];
+    if (patternIndex == 0 || pattern[patternIndex - 1] != currentPred) {
+      pattern.push_back(currentPred);
       patternIndex++;
     }
   }
@@ -682,7 +684,7 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
     numEntitiesWithoutPatterns++;
     // The pattern does not exist, use the has-relation predicate instead
     for (size_t i = 0; i < patternIndex; i++) {
-      entityHasPredicate.push_back(std::array<Id, 2>{currentRel, pattern[i]});
+      entityHasPredicate.push_back(std::array<Id, 2>{currentSubj, pattern[i]});
       if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
         predicateHashSet.insert(pattern[i]);
         fullHasPredicatePredicatesDistinctSize++;
@@ -691,7 +693,7 @@ void Index::createPatternsImpl(const string& fileName, const StxxlVec& vec,
   } else {
     numEntitiesWithPatterns++;
     // The pattern does exist, add an entry to the has-pattern predicate
-    entityHasPattern.push_back(std::array<Id, 2>{currentRel, it->second});
+    entityHasPattern.push_back(std::array<Id, 2>{currentSubj, it->second});
     for (size_t i = 0; i < patternIndex; i++) {
       if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
         predicateHashSet.insert(pattern[i]);

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -44,6 +44,9 @@ struct VocabularyData {
   using StxxlVec = stxxl::vector<array<Id, 3>>;
   // The total number of distinct words in the complete Vocabulary
   size_t nofWords;
+  // Id lower and upper bound of @lang@<predicate> predicates
+  Id langPredLowerBound;
+  Id langPredUpperBound;
   // The number of triples in the idTriples vec that each partial vocabulary is
   // responsible for (depends on the number of additional language filter
   // triples)
@@ -319,6 +322,8 @@ class Index {
   bool hasAllPermutations() const { return _spoFile.isOpen(); }
 
  private:
+  Id _langPredLowerBound;
+  Id _langPredUpperBound;
   string _onDiskBase;
   string _settingsFileName;
   bool _onDiskLiterals = false;
@@ -380,7 +385,6 @@ class Index {
   VocabularyData passFileForVocabulary(const string& ntFile,
                                        size_t linesPerPartial = 100000000);
 
-  template <class Parser>
   void convertPartialToGlobalIds(StxxlVec& data,
                                  const vector<size_t>& actualLinesPerPartial,
                                  size_t linesPerPartial);
@@ -444,14 +448,13 @@ class Index {
    * @param fileName The name of the file in which the data should be stored
    * @param vec The vectors of triples in spo order.
    */
-  static void createPatternsImpl(const string& fileName, const StxxlVec& vec,
-                                 CompactStringVector<Id, Id>& hasPredicate,
-                                 std::vector<PatternID>& hasPattern,
-                                 CompactStringVector<size_t, Id>& patterns,
-                                 double& fullHasPredicateMultiplicityEntities,
-                                 double& fullHasPredicateMultiplicityPredicates,
-                                 size_t& fullHasPredicateSize,
-                                 size_t maxNumPatterns);
+  void createPatternsImpl(const string& fileName, const StxxlVec& vec,
+                          CompactStringVector<Id, Id>& hasPredicate,
+                          std::vector<PatternID>& hasPattern,
+                          CompactStringVector<size_t, Id>& patterns,
+                          double& fullHasPredicateMultiplicityEntities,
+                          double& fullHasPredicateMultiplicityPredicates,
+                          size_t& fullHasPredicateSize, size_t maxNumPatterns);
 
   // wrap the static function using the internal member variables
   // the bool indicates wether the StxxlVec has to be sorted before the pattern

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -15,15 +15,17 @@ using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
 using std::string;
 // _______________________________________________________________
-// merge the partial vocabularies at  binary files
+// merge the partial vocabularies in the  binary files
 // basename + PARTIAL_VOCAB_FILE_NAME + to_string(i)
 // where 0 <= i < numFiles
 // Directly Writes .vocabulary file at basename (no more need to pass
 // through Vocabulary class
 // Writes file "externalTextFile" which can be used to directly write external
 // Literals
-// Returns the number of total Words merged
-size_t mergeVocabulary(const std::string& basename, size_t numFiles);
+// Returns the number of total Words merged and via the parameters
+// the lower and upper bound of language tagged predicates
+size_t mergeVocabulary(const std::string& basename, size_t numFiles,
+                       Id* langPredLowerBound, Id* langPredUpperBound);
 
 // _________________________________________________________________________________________
 void writePartialIdMapToBinaryFileForMerging(

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -190,7 +190,11 @@ class MergeVocabularyTest : public ::testing::Test {
 // Test for merge Vocabulary
 TEST_F(MergeVocabularyTest, bla) {
   // mergeVocabulary only gets name of directory and number of files.
-  mergeVocabulary(_basePath, 2);
+  Id langPredLowerBound, langPredUpperBound;
+  mergeVocabulary(_basePath, 2, &langPredLowerBound, &langPredUpperBound);
+  // No language tags in text file
+  ASSERT_EQ(langPredLowerBound, 0);
+  ASSERT_EQ(langPredUpperBound, 0);
   // Assert that partial vocabularies have the expected ids
   ASSERT_TRUE(areBinaryFilesEqual(_path0, _pathExp0));
   ASSERT_TRUE(areBinaryFilesEqual(_path1, _pathExp1));


### PR DESCRIPTION
@floriankramer this is my (untested since scientists has no literals) version of ignoring the `@lang@<predicate>` predicates. It also includes some small clean ups, so maybe we can figure out what to take from which version.