### PR TITLE
Added the basics for detailed query processing time tracking.

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -107,13 +107,15 @@ size_t CountAvailablePredicates::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-void CountAvailablePredicates::computeResult(ResultTable* result) const {
+void CountAvailablePredicates::computeResult(ResultTable* result) {
   LOG(DEBUG) << "CountAvailablePredicates result computation..." << std::endl;
   result->_nofColumns = 2;
   result->_sortedBy = resultSortedOn();
   result->_fixedSizeData = new vector<array<Id, 2>>();
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
 
   const std::vector<PatternID>& hasPattern =
       _executionContext->getIndex().getHasPattern();
@@ -123,6 +125,7 @@ void CountAvailablePredicates::computeResult(ResultTable* result) const {
       _executionContext->getIndex().getPatterns();
 
   if (_subtree == nullptr) {
+    runtimeInfo.setDescriptor("CountAvailablePredicates for all entities");
     // Compute the predicates for all entities
     CountAvailablePredicates::computePatternTrickAllEntities(
         static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData), hasPattern,
@@ -131,39 +134,47 @@ void CountAvailablePredicates::computeResult(ResultTable* result) const {
     // Compute the predicates for entities in subresult's _subjectColumnIndex
     // column.
     std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
+    runtimeInfo.setDescriptor("CountAvailablePredicates");
+    runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
     if (subresult->_nofColumns > 5) {
       CountAvailablePredicates::computePatternTrick<vector<Id>>(
           &subresult->_varSizeData,
           static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-          hasPattern, hasPredicate, patterns, _subjectColumnIndex);
+          hasPattern, hasPredicate, patterns, _subjectColumnIndex,
+          &runtimeInfo);
     } else {
       if (subresult->_nofColumns == 1) {
         CountAvailablePredicates::computePatternTrick<array<Id, 1>>(
             static_cast<vector<array<Id, 1>>*>(subresult->_fixedSizeData),
             static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-            hasPattern, hasPredicate, patterns, _subjectColumnIndex);
+            hasPattern, hasPredicate, patterns, _subjectColumnIndex,
+            &runtimeInfo);
       } else if (subresult->_nofColumns == 2) {
         CountAvailablePredicates::computePatternTrick<array<Id, 2>>(
             static_cast<vector<array<Id, 2>>*>(subresult->_fixedSizeData),
             static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-            hasPattern, hasPredicate, patterns, _subjectColumnIndex);
+            hasPattern, hasPredicate, patterns, _subjectColumnIndex,
+            &runtimeInfo);
       } else if (subresult->_nofColumns == 3) {
         CountAvailablePredicates::computePatternTrick<array<Id, 3>>(
             static_cast<vector<array<Id, 3>>*>(subresult->_fixedSizeData),
             static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-            hasPattern, hasPredicate, patterns, _subjectColumnIndex);
+            hasPattern, hasPredicate, patterns, _subjectColumnIndex,
+            &runtimeInfo);
       } else if (subresult->_nofColumns == 4) {
         CountAvailablePredicates::computePatternTrick<array<Id, 4>>(
             static_cast<vector<array<Id, 4>>*>(subresult->_fixedSizeData),
             static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-            hasPattern, hasPredicate, patterns, _subjectColumnIndex);
+            hasPattern, hasPredicate, patterns, _subjectColumnIndex,
+            &runtimeInfo);
       } else if (subresult->_nofColumns == 5) {
         CountAvailablePredicates::computePatternTrick<array<Id, 5>>(
             static_cast<vector<array<Id, 5>>*>(subresult->_fixedSizeData),
             static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData),
-            hasPattern, hasPredicate, patterns, _subjectColumnIndex);
+            hasPattern, hasPredicate, patterns, _subjectColumnIndex,
+            &runtimeInfo);
       }
     }
   }
@@ -220,8 +231,8 @@ void CountAvailablePredicates::computePatternTrick(
     const vector<A>* input, vector<array<Id, 2>>* result,
     const vector<PatternID>& hasPattern,
     const CompactStringVector<Id, Id>& hasPredicate,
-    const CompactStringVector<size_t, Id>& patterns,
-    const size_t subjectColumn) {
+    const CompactStringVector<size_t, Id>& patterns, const size_t subjectColumn,
+    RuntimeInformation* runtimeInfo) {
   LOG(DEBUG) << "For " << input->size() << " entities in column "
              << subjectColumn << std::endl;
   ad_utility::HashMap<Id, size_t> predicateCounts;
@@ -327,5 +338,18 @@ void CountAvailablePredicates::computePatternTrick(
   // Print the cost improvement using the the pattern trick gave us
   LOG(DEBUG) << "This equals a ratio of cost with to cost without patterns of "
              << cost_ratio << std::endl;
+
+  // Add these values to the runtime info
+  runtimeInfo->addDetail("percentEntitesWithPatterns",
+                         std::to_string(ratio_has_pattern * 100) + "%");
+  runtimeInfo->addDetail(
+      "percentPredicatesThroughPatterns",
+      std::to_string(ratio_counted_with_pattern * 100) + "%");
+  runtimeInfo->addDetail("costWithoutPatterns",
+                         std::to_string(cost_without_patterns));
+  runtimeInfo->addDetail("costWithPatterns",
+                         std::to_string(cost_with_patterns));
+  runtimeInfo->addDetail("costImprovement",
+                         std::to_string(cost_ratio * 100) + "%");
 #endif
 }

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -90,7 +90,7 @@ class CountAvailablePredicates : public Operation {
       const vector<PatternID>& hasPattern,
       const CompactStringVector<Id, Id>& hasPredicate,
       const CompactStringVector<size_t, Id>& patterns,
-      const size_t subjectColumn);
+      const size_t subjectColumn, RuntimeInformation* runtimeInfo);
 
   static void computePatternTrickAllEntities(
       vector<array<Id, 2>>* result, const vector<PatternID>& hasPattern,
@@ -103,5 +103,5 @@ class CountAvailablePredicates : public Operation {
   std::string _predicateVarName;
   std::string _countVarName;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -41,9 +41,13 @@ ad_utility::HashMap<string, size_t> Distinct::getVariableColumns() const {
 }
 
 // _____________________________________________________________________________
-void Distinct::computeResult(ResultTable* result) const {
+void Distinct::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("DISTINCT");
+  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "Distinct result computation..." << endl;
   result->_nofColumns = subRes->_nofColumns;
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -57,5 +57,5 @@ class Distinct : public Operation {
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<size_t> _keepIndices;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -66,6 +66,46 @@ string Filter::asString(size_t indent) const {
   return os.str();
 }
 
+std::string Filter::getDescriptor() const {
+  std::ostringstream os;
+  os << "FILTER ";
+  os << _lhs;
+  switch (_type) {
+    case SparqlFilter::EQ:
+      os << " == ";
+      break;
+    case SparqlFilter::NE:
+      os << " != ";
+      break;
+    case SparqlFilter::LT:
+      os << " < ";
+      break;
+    case SparqlFilter::LE:
+      os << " <= ";
+      break;
+    case SparqlFilter::GT:
+      os << " > ";
+      break;
+    case SparqlFilter::GE:
+      os << " >= ";
+      break;
+    case SparqlFilter::LANG_MATCHES:
+      os << " LANG_MATCHES ";
+      break;
+    case SparqlFilter::REGEX:
+      os << " REGEX ";
+      if (_regexIgnoreCase) {
+        os << "ignoring case ";
+      };
+      break;
+    case SparqlFilter::PREFIX:
+      os << " PREFIX ";
+      break;
+  }
+  os << _rhs;
+  return os.str();
+}
+
 // _____________________________________________________________________________
 template <class RT, ResultTable::ResultType T>
 vector<RT>* Filter::computeFilterForResultType(vector<RT>* res, size_t lhs,
@@ -168,9 +208,12 @@ vector<RT>* Filter::computeFilter(vector<RT>* res, size_t lhs, size_t rhs,
 }
 
 // _____________________________________________________________________________
-void Filter::computeResult(ResultTable* result) const {
+void Filter::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor(getDescriptor());
+  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "Filter result computation..." << endl;
   result->_nofColumns = subRes->_nofColumns;
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -81,6 +81,8 @@ class Filter : public Operation {
   }
 
  private:
+  std::string getDescriptor() const;
+
   std::shared_ptr<QueryExecutionTree> _subtree;
   SparqlFilter::FilterType _type;
   string _lhs;
@@ -127,7 +129,7 @@ class Filter : public Operation {
   void computeResultFixedValue(
       ResultTable* result,
       const std::shared_ptr<const ResultTable> subRes) const;
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 
   /**
    * @brief This struct handles the extraction of the data from an id based upon

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -754,7 +754,7 @@ struct callDoGroupBy<6, 6> {
   }
 };
 
-void GroupBy::computeResult(ResultTable* result) const {
+void GroupBy::computeResult(ResultTable* result) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
   std::vector<size_t> groupByColumns;
 
@@ -914,6 +914,10 @@ void GroupBy::computeResult(ResultTable* result) const {
 
   std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
   LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("GROUP BY");
+  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
 
   // populate the result type vector
   result->_resultTypes.resize(result->_nofColumns);

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -106,7 +106,7 @@ class GroupBy : public Operation {
   std::vector<ParsedQuery::Alias> _aliases;
   ad_utility::HashMap<string, size_t> _varColMap;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };
 
 // This method is declared here solely for unit testing purposes

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -85,5 +85,5 @@ class HasPredicateScan : public Operation {
   std::string _subject;
   std::string _object;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -223,7 +223,6 @@ size_t IndexScan::computeSizeEstimate() {
     // We have to do a simple scan anyway so might as well do it now
     if (getResultWidth() == 1) {
       RuntimeInformation& runtimeInfo = getRuntimeInfo();
-      bool firstRun = runtimeInfo.getTime() == 0;
       size_t size = getResult()->size();
       // When a cached result is loaded but the runtimeInfo for that
       // Operation object was already computed the old values are
@@ -232,15 +231,7 @@ size_t IndexScan::computeSizeEstimate() {
       // a single column scan as its child, as that operation itself
       // would measure the time of the cache access for the result
       // of that scan, while the scan itself would report the time
-      // required for the actual scan that is done in here. As both
-      // times are interestin we add the time for the initial scan
-      // as a detail to the RuntimeInformation and then reset the
-      // runtime information time to ensure the resulting runtime
-      // information trees operation runtimes are actually correct.
-      if (firstRun) {
-        runtimeInfo.addDetail("IntialScanTime",
-                              std::to_string(runtimeInfo.getTime()));
-      }
+      // required for the actual scan that is done in here.
       runtimeInfo.setTime(0);
       return size;
     }

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -120,8 +120,12 @@ vector<size_t> IndexScan::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-void IndexScan::computeResult(ResultTable* result) const {
+void IndexScan::computeResult(ResultTable* result) {
   LOG(DEBUG) << "IndexScan result computation...\n";
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("IndexScan " + _subject + " " + _predicate + " " +
+                            _object);
   switch (_type) {
     case PSO_BOUND_S:
       computePSOboundS(result);
@@ -212,7 +216,7 @@ void IndexScan::computePOSfreeO(ResultTable* result) const {
 }
 
 // _____________________________________________________________________________
-size_t IndexScan::computeSizeEstimate() const {
+size_t IndexScan::computeSizeEstimate() {
   if (_executionContext) {
     // Should always be in this branch. Else is only for test cases.
 
@@ -220,7 +224,14 @@ size_t IndexScan::computeSizeEstimate() const {
     if (getResultWidth() == 1) {
       return getResult()->size();
     }
-    return getIndex().sizeEstimate(_subject, _predicate, _object);
+    if (_type == SPO_FREE_P || _type == SOP_FREE_O) {
+      return getIndex().sizeEstimate(_subject, "", "");
+    } else if (_type == POS_FREE_O || _type == PSO_FREE_S) {
+      return getIndex().sizeEstimate("", _predicate, "");
+    } else if (_type == OPS_FREE_P || _type == OSP_FREE_S) {
+      return getIndex().sizeEstimate("", "", _object);
+    }
+    return getIndex().sizeEstimate("", "", "");
   } else {
     return 1000 + _subject.size() + _predicate.size() + _object.size();
   }

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -91,7 +91,7 @@ class IndexScan : public Operation {
   size_t _sizeEstimate;
   vector<float> _multiplicity;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 
   void computePSOboundS(ResultTable* result) const;
 
@@ -111,5 +111,5 @@ class IndexScan : public Operation {
 
   void computeOSPfreeS(ResultTable* result) const;
 
-  size_t computeSizeEstimate() const;
+  size_t computeSizeEstimate();
 };

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -49,7 +49,17 @@ string Join::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
-void Join::computeResult(ResultTable* result) const {
+void Join::computeResult(ResultTable* result) {
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  std::string joinVar = "";
+  for (auto p : _left->getVariableColumnMap()) {
+    if (p.second == _leftJoinCol) {
+      joinVar = p.first;
+      break;
+    }
+  }
+  runtimeInfo.setDescriptor("Join on " + joinVar);
+
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   size_t leftWidth = _left->getResultWidth();
   size_t rightWidth = _right->getResultWidth();
@@ -58,6 +68,7 @@ void Join::computeResult(ResultTable* result) const {
   // avoid the computation of an non-empty subtree.
   if (_left->knownEmptyResult() || _right->knownEmptyResult()) {
     LOG(TRACE) << "Either side is empty thus join result is empty" << endl;
+    runtimeInfo.addDetail("Either side was empty", "");
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_resultTypes.resize(result->_nofColumns);
@@ -86,10 +97,12 @@ void Join::computeResult(ResultTable* result) const {
 
   LOG(TRACE) << "Computing left side..." << endl;
   shared_ptr<const ResultTable> leftRes = _left->getResult();
+  runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
 
   // Check if we can stop early.
   if (leftRes->size() == 0) {
     LOG(TRACE) << "Left side empty thus join result is empty" << endl;
+    runtimeInfo.addDetail("The left side was empty", "");
     size_t resWidth = leftWidth + rightWidth - 1;
     result->_nofColumns = resWidth;
     result->_resultTypes.resize(result->_nofColumns);
@@ -111,6 +124,7 @@ void Join::computeResult(ResultTable* result) const {
 
   LOG(TRACE) << "Computing right side..." << endl;
   shared_ptr<const ResultTable> rightRes = _right->getResult();
+  runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
 
   LOG(DEBUG) << "Computing Join result..." << endl;
 

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -66,7 +66,7 @@ class Join : public Operation {
 
   vector<float> _multiplicities;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 
   static bool isFullScanDummy(std::shared_ptr<QueryExecutionTree> tree) {
     return tree->getType() == QueryExecutionTree::SCAN &&

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -62,5 +62,5 @@ class MultiColumnJoin : public Operation {
   size_t _sizeEstimate;
   bool _multiplicitiesComputed;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -40,12 +40,12 @@ class Operation {
   shared_ptr<const ResultTable> getResult() {
     ad_utility::Timer timer;
     timer.start();
-    LOG(DEBUG) << "Check cache for Operation result" << endl;
+    LOG(TRACE) << "Check cache for Operation result" << endl;
     LOG(TRACE) << "Using key: \n" << asString() << endl;
     auto [newResult, existingResult] =
         _executionContext->getQueryTreeCache().tryEmplace(asString());
     if (newResult) {
-      LOG(DEBUG) << "Not in the cache, need to compute result" << endl;
+      LOG(TRACE) << "Not in the cache, need to compute result" << endl;
       // Passing the raw pointer here is ok as the result shared_ptr remains
       // in scope
       try {

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -95,6 +95,8 @@ class Operation {
       // If this operation object was computed already we don't want to update
       // the runtime information.
       _runtimeInformation = existingResult->_runtimeInfo;
+      _runtimeInformation.addDetail(
+          "InitialTime", std::to_string(_runtimeInformation.getTime()));
       _runtimeInformation.setTime(timer.secs());
       _runtimeInformation.setWasCached(true);
     }

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -11,8 +11,8 @@
 #include "../util/Exception.h"
 #include "../util/Log.h"
 #include "../util/Timer.h"
-#include "./QueryExecutionContext.h"
-#include "./ResultTable.h"
+#include "QueryExecutionContext.h"
+#include "ResultTable.h"
 #include "RuntimeInformation.h"
 
 using std::endl;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -41,7 +41,7 @@ class Operation {
     ad_utility::Timer timer;
     timer.start();
     LOG(DEBUG) << "Check cache for Operation result" << endl;
-    LOG(DEBUG) << "Using key: \n" << asString() << endl;
+    LOG(TRACE) << "Using key: \n" << asString() << endl;
     auto [newResult, existingResult] =
         _executionContext->getQueryTreeCache().tryEmplace(asString());
     if (newResult) {

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -176,10 +176,23 @@ struct meta_for<6, 6, 6> {
 };
 
 // _____________________________________________________________________________
-void OptionalJoin::computeResult(ResultTable* result) const {
+void OptionalJoin::computeResult(ResultTable* result) {
   AD_CHECK(result);
   AD_CHECK(!result->_fixedSizeData);
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  std::string joinVars = "";
+  for (auto p : _left->getVariableColumnMap()) {
+    for (auto jc : _joinColumns) {
+      // If the left join column matches the index of a variable in the left
+      // subresult.
+      if (jc[0] == p.second) {
+        joinVars += p.first + " ";
+      }
+    }
+  }
+  runtimeInfo.setDescriptor("OptionalJoin on " + joinVars);
 
   result->_sortedBy = resultSortedOn();
   result->_nofColumns = getResultWidth();
@@ -188,6 +201,9 @@ void OptionalJoin::computeResult(ResultTable* result) const {
 
   const auto leftResult = _left->getResult();
   const auto rightResult = _right->getResult();
+
+  runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
+  runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "OptionalJoin subresult computation done." << std::endl;
 
   // compute the result types

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -57,5 +57,5 @@ class OptionalJoin : public Operation {
   size_t _sizeEstimate;
   bool _multiplicitiesComputed;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -47,10 +47,26 @@ vector<size_t> OrderBy::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-void OrderBy::computeResult(ResultTable* result) const {
+void OrderBy::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Gettign sub-result for OrderBy result computation..." << endl;
   AD_CHECK(_sortIndices.size() > 0);
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
+
+  std::string orderByVars = "";
+  for (auto p : _subtree->getVariableColumnMap()) {
+    for (auto oc : _sortIndices) {
+      if (oc.first == p.second) {
+        if (oc.second) {
+          orderByVars += "DESC(" + p.first + ") ";
+        } else {
+          orderByVars += "ASC(" + p.first + ") ";
+        }
+      }
+    }
+  }
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("OrderBy on " + orderByVars);
+  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "OrderBy result computation..." << endl;
   result->_nofColumns = subRes->_nofColumns;
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -58,5 +58,5 @@ class OrderBy : public Operation {
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<pair<size_t, bool>> _sortIndices;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -14,12 +14,19 @@
 #include "./Engine.h"
 #include "./ResultTable.h"
 #include "QueryPlanningCostFactors.h"
+#include "RuntimeInformation.h"
 
 using std::shared_ptr;
 using std::string;
 using std::vector;
 
-typedef ad_utility::LRUCache<string, ResultTable> SubtreeCache;
+struct CacheValue {
+  CacheValue() : _resTable(std::make_shared<ResultTable>()), _runtimeInfo() {}
+  std::shared_ptr<ResultTable> _resTable;
+  RuntimeInformation _runtimeInfo;
+};
+
+typedef ad_utility::LRUCache<string, CacheValue> SubtreeCache;
 
 // Execution context for queries.
 // Holds references to index and engine, implements caching.

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -237,5 +237,8 @@ void QueryExecutionTree::readFromCache() {
     return;
   }
   auto& cache = _qec->getQueryTreeCache();
-  _cachedResult = cache[asString()];
+  std::shared_ptr<const CacheValue> res = cache[asString()];
+  if (res) {
+    _cachedResult = cache[asString()]->_resTable;
+  }
 }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -777,6 +777,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
         } else if (isVariable(node._triple._s)) {
           std::shared_ptr<Operation> scan(
               new IndexScan(_qec, IndexScan::ScanType::POS_BOUND_O));
+          static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
           static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
           static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
           tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
@@ -784,14 +785,16 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
         } else if (isVariable(node._triple._o)) {
           std::shared_ptr<Operation> scan(
               new IndexScan(_qec, IndexScan::ScanType::PSO_BOUND_S));
-          static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
           static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
+          static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
+          static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
           tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
           tree.setVariableColumn(node._triple._o, 0);
         } else {
           std::shared_ptr<Operation> scan(
               new IndexScan(_qec, IndexScan::ScanType::SOP_BOUND_O));
           static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
+          static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
           static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
           tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
           tree.setVariableColumn(node._triple._p, 0);
@@ -822,7 +825,9 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             auto& tree = *plan._qet.get();
             std::shared_ptr<Operation> scan(
                 new IndexScan(_qec, IndexScan::ScanType::PSO_FREE_S));
+            static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
             static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
+            static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
             static_cast<IndexScan*>(scan.get())->precomputeSizeEstimate();
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
             tree.setVariableColumn(node._triple._s, 0);
@@ -835,7 +840,9 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             auto& tree = *plan._qet.get();
             std::shared_ptr<Operation> scan(
                 new IndexScan(_qec, IndexScan::ScanType::POS_FREE_O));
+            static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
             static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
+            static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
             static_cast<IndexScan*>(scan.get())->precomputeSizeEstimate();
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
             tree.setVariableColumn(node._triple._o, 0);
@@ -850,6 +857,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             std::shared_ptr<Operation> scan(
                 new IndexScan(_qec, IndexScan::ScanType::SPO_FREE_P));
             static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
+            static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
+            static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
             static_cast<IndexScan*>(scan.get())->precomputeSizeEstimate();
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
             tree.setVariableColumn(node._triple._p, 0);
@@ -863,6 +872,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             std::shared_ptr<Operation> scan(
                 new IndexScan(_qec, IndexScan::ScanType::SOP_FREE_O));
             static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
+            static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
+            static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
             static_cast<IndexScan*>(scan.get())->precomputeSizeEstimate();
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
             tree.setVariableColumn(node._triple._o, 0);
@@ -876,6 +887,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             auto& tree = *plan._qet.get();
             std::shared_ptr<Operation> scan(
                 new IndexScan(_qec, IndexScan::ScanType::OSP_FREE_S));
+            static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
+            static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
             static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
             static_cast<IndexScan*>(scan.get())->precomputeSizeEstimate();
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
@@ -889,6 +902,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             auto& tree = *plan._qet.get();
             std::shared_ptr<Operation> scan(
                 new IndexScan(_qec, IndexScan::ScanType::OPS_FREE_P));
+            static_cast<IndexScan*>(scan.get())->setSubject(node._triple._s);
+            static_cast<IndexScan*>(scan.get())->setPredicate(node._triple._p);
             static_cast<IndexScan*>(scan.get())->setObject(node._triple._o);
             static_cast<IndexScan*>(scan.get())->precomputeSizeEstimate();
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -19,7 +19,7 @@ class RuntimeInformation {
     out << "{";
     out << "\"description\" : \"" << _descriptor << "\",";
     out << "\"total_time\" : " << _time << ", ";
-    out << "\"operation_time\" : " << _time - getChildrenTime() << ", ";
+    out << "\"operation_time\" : " << getOperationTime() << ", ";
     out << "\"was_chached\" : " << ((_wasCached) ? "true" : "false") << ", ";
     out << "\"details\" : {";
     auto it = _details.begin();
@@ -56,7 +56,7 @@ class RuntimeInformation {
     out << std::string(indent * 2, ' ') << "total_time: " << _time << "s"
         << std::endl;
     out << std::string(indent * 2, ' ')
-        << "operation_time: " << _time - getChildrenTime() << "s" << std::endl;
+        << "operation_time: " << getOperationTime() << "s" << std::endl;
     out << std::string(indent * 2, ' ')
         << "cached: " << ((_wasCached) ? "true" : "false") << std::endl;
     for (auto detail : _details) {
@@ -76,6 +76,14 @@ class RuntimeInformation {
   void setTime(double time) { _time = time; }
   // Get the overall time
   double getTime() const { return _time; }
+
+  double getOperationTime() const {
+    if (_wasCached) {
+      return getTime();
+    } else {
+      return getTime() - getChildrenTime();
+    }
+  }
 
   // The time spend in children
   double getChildrenTime() const {

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -61,7 +61,7 @@ class RuntimeInformation {
     out << std::string(indent * 2, ' ')
         << "cached: " << ((_wasCached) ? "true" : "false") << std::endl;
     for (auto detail : _details) {
-      out << std::string((indent + 2) * 2, ' ') << detail.first << ", "
+      out << std::string((indent + 2) * 2, ' ') << detail.first << ": "
           << detail.second << std::endl;
     }
     for (const RuntimeInformation& child : _children) {

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -1,0 +1,89 @@
+// Copyright 2019, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
+//
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "../util/HashMap.h"
+#include "../util/Timer.h"
+
+class RuntimeInformation {
+ public:
+  RuntimeInformation()
+      : _descriptor(), _details(), _time(0), _wasCached(false), _children() {}
+  void toJson(std::ostream& out) const {
+    out << "{";
+    out << "\"description\" : \"" << _descriptor << "\",";
+    out << "\"time\" : " << _time << ", ";
+    out << "\"was_chached\" : " << _wasCached << ", ";
+    out << "\"details\" : {";
+    auto it = _details.begin();
+    while (it != _details.end()) {
+      out << "\"" << it->first << "\" : \"" << it->second << "\"";
+      ++it;
+      if (it != _details.end()) {
+        out << ", ";
+      }
+    }
+    out << "}, ";
+    out << "\"children\" : [";
+    auto it2 = _children.begin();
+    while (it2 != _children.end()) {
+      // recursively call the childs to json method
+      it2->toJson(out);
+      ++it2;
+      if (it2 != _children.end()) {
+        out << ", ";
+      }
+    }
+    out << "]";
+    out << "}";
+  }
+
+  std::string toString() const {
+    std::ostringstream buffer;
+    toString(buffer, 0);
+    return buffer.str();
+  }
+
+  void toString(std::ostream& out, size_t indent) const {
+    out << std::string(indent * 2, ' ') << _descriptor << std::endl;
+    out << std::string(indent * 2, ' ') << "time: " << _time << "s"
+        << std::endl;
+    out << std::string(indent * 2, ' ') << "cached: " << _wasCached
+        << std::endl;
+    for (auto detail : _details) {
+      out << std::string((indent + 2) * 2, ' ') << detail.first << ", "
+          << detail.second << std::endl;
+    }
+    for (const RuntimeInformation& child : _children) {
+      child.toString(out, indent + 1);
+    }
+  }
+
+  void setDescriptor(const std::string& descriptor) {
+    _descriptor = descriptor;
+  }
+
+  void setTime(double time) { _time = time; }
+  double getTime() const { return _time; }
+
+  void setWasCached(bool wasCached) { _wasCached = wasCached; }
+
+  void addChild(const RuntimeInformation& r) { _children.push_back(r); }
+
+  void addDetail(const std::string& key, const std::string& value) {
+    _details[key] = value;
+  }
+
+ private:
+  std::string _descriptor;
+  ad_utility::HashMap<std::string, std::string> _details;
+  double _time;
+  bool _wasCached;
+  std::vector<RuntimeInformation> _children;
+};

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -52,6 +52,7 @@ class RuntimeInformation {
   }
 
   void toString(std::ostream& out, size_t indent) const {
+    out << '\n';
     out << std::string(indent * 2, ' ') << _descriptor << std::endl;
     out << std::string(indent * 2, ' ') << "total_time: " << _time << "s"
         << std::endl;

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -18,8 +18,9 @@ class RuntimeInformation {
   void toJson(std::ostream& out) const {
     out << "{";
     out << "\"description\" : \"" << _descriptor << "\",";
-    out << "\"time\" : " << _time << ", ";
-    out << "\"was_chached\" : " << _wasCached << ", ";
+    out << "\"total_time\" : " << _time << ", ";
+    out << "\"operation_time\" : " << _time - getChildrenTime() << ", ";
+    out << "\"was_chached\" : " << ((_wasCached) ? "true" : "false") << ", ";
     out << "\"details\" : {";
     auto it = _details.begin();
     while (it != _details.end()) {
@@ -52,10 +53,12 @@ class RuntimeInformation {
 
   void toString(std::ostream& out, size_t indent) const {
     out << std::string(indent * 2, ' ') << _descriptor << std::endl;
-    out << std::string(indent * 2, ' ') << "time: " << _time << "s"
+    out << std::string(indent * 2, ' ') << "total_time: " << _time << "s"
         << std::endl;
-    out << std::string(indent * 2, ' ') << "cached: " << _wasCached
-        << std::endl;
+    out << std::string(indent * 2, ' ')
+        << "operation_time: " << _time - getChildrenTime() << "s" << std::endl;
+    out << std::string(indent * 2, ' ')
+        << "cached: " << ((_wasCached) ? "true" : "false") << std::endl;
     for (auto detail : _details) {
       out << std::string((indent + 2) * 2, ' ') << detail.first << ", "
           << detail.second << std::endl;
@@ -69,8 +72,19 @@ class RuntimeInformation {
     _descriptor = descriptor;
   }
 
+  // Set the overall time
   void setTime(double time) { _time = time; }
+  // Get the overall time
   double getTime() const { return _time; }
+
+  // The time spend in children
+  double getChildrenTime() const {
+    double sum = 0;
+    for (const RuntimeInformation& child : _children) {
+      sum += child.getTime();
+    }
+    return sum;
+  }
 
   void setWasCached(bool wasCached) { _wasCached = wasCached; }
 

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "../util/HashMap.h"
+#include "../util/StringUtils.h"
 #include "../util/Timer.h"
 
 class RuntimeInformation {
@@ -17,14 +18,15 @@ class RuntimeInformation {
       : _descriptor(), _details(), _time(0), _wasCached(false), _children() {}
   void toJson(std::ostream& out) const {
     out << "{";
-    out << "\"description\" : \"" << _descriptor << "\",";
+    out << "\"description\" : " << ad_utility::toJson(_descriptor) << ",";
     out << "\"total_time\" : " << _time << ", ";
     out << "\"operation_time\" : " << getOperationTime() << ", ";
     out << "\"was_chached\" : " << ((_wasCached) ? "true" : "false") << ", ";
     out << "\"details\" : {";
     auto it = _details.begin();
     while (it != _details.end()) {
-      out << "\"" << it->first << "\" : \"" << it->second << "\"";
+      out << "" << ad_utility::toJson(it->first) << " : "
+          << ad_utility::toJson(it->second);
       ++it;
       if (it != _details.end()) {
         out << ", ";

--- a/src/engine/ScanningJoin.cpp
+++ b/src/engine/ScanningJoin.cpp
@@ -50,7 +50,7 @@ size_t ScanningJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-void ScanningJoin::computeResult(ResultTable* result) const {
+void ScanningJoin::computeResult(ResultTable* result) {
   AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED, "TODO");
   IndexScan::computeResult(result);
 }

--- a/src/engine/ScanningJoin.h
+++ b/src/engine/ScanningJoin.h
@@ -51,5 +51,5 @@ class ScanningJoin : public IndexScan {
  private:
   QueryExecutionTree* _subtree;
   size_t _subtreeJoinCol;
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -163,7 +163,7 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
       // const QueryExecutionTree& qet = qg.getExecutionTree();
       QueryPlanner qp(qec);
       QueryExecutionTree qet = qp.createExecutionTree(pq);
-      LOG(INFO) << qet.asString() << std::endl;
+      LOG(TRACE) << qet.asString() << std::endl;
 
       if (ad_utility::getLowercase(params["action"]) == "csv_export") {
         // CSV export

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -182,6 +182,10 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
         response = composeResponseJson(pq, qet, maxSend);
         contentType = "application/json";
       }
+      // Print the runtime info. This needs to be done after the query
+      // was computed.
+      LOG(DEBUG) << qet.getRootOperation()->getRuntimeInfo().toString()
+                 << std::endl;
     } catch (const ad_semsearch::Exception& e) {
       response = composeResponseJson(query, e);
     } catch (const std::exception& e) {
@@ -335,6 +339,10 @@ string Server::composeResponseJson(const ParsedQuery& query,
   } else {
     os << "[],\n";
   }
+
+  os << "\"runtimeInformation\" : ";
+  qet.getRootOperation()->getRuntimeInfo().toJson(os);
+  os << ", \n";
 
   os << "\"res\": ";
   size_t limit = MAX_NOF_ROWS_IN_RESULT;

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -27,9 +27,21 @@ string Sort::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
-void Sort::computeResult(ResultTable* result) const {
+void Sort::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
+
+  std::string orderByVars = "";
+  for (auto p : _subtree->getVariableColumnMap()) {
+    if (p.second == _sortCol) {
+      orderByVars = "ASC(" + p.first + ")";
+      break;
+    }
+  }
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("Sort on " + orderByVars);
+  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
+
   LOG(DEBUG) << "Sort result computation..." << endl;
   result->_nofColumns = subRes->_nofColumns;
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -52,5 +52,5 @@ class Sort : public Operation {
   std::shared_ptr<QueryExecutionTree> _subtree;
   size_t _sortCol;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/TextOperationForContexts.cpp
+++ b/src/engine/TextOperationForContexts.cpp
@@ -51,8 +51,11 @@ string TextOperationForContexts::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
-void TextOperationForContexts::computeResult(ResultTable* result) const {
+void TextOperationForContexts::computeResult(ResultTable* result) {
   LOG(DEBUG) << "TextOperationForContexts result computation..." << endl;
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("TextOperationForContexts " + _words);
   if (_subtrees.size() == 0) {
     result->_nofColumns = 2;
     result->_resultTypes.push_back(ResultTable::ResultType::TEXT);

--- a/src/engine/TextOperationForContexts.h
+++ b/src/engine/TextOperationForContexts.h
@@ -72,5 +72,5 @@ class TextOperationForContexts : public Operation {
   vector<pair<std::shared_ptr<QueryExecutionTree>, size_t>> _subtrees;
   size_t _textLimit;
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -45,11 +45,16 @@ string TextOperationWithFilter::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
-void TextOperationWithFilter::computeResult(ResultTable* result) const {
+void TextOperationWithFilter::computeResult(ResultTable* result) {
   LOG(DEBUG) << "TextOperationWithFilter result computation..." << endl;
   AD_CHECK_GE(_nofVars, 1);
   result->_nofColumns = 1 + _filterResult->getResultWidth() + _nofVars;
   shared_ptr<const ResultTable> filterResult = _filterResult->getResult();
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("Text operation with filter: " + _words);
+  runtimeInfo.addChild(_filterResult->getRootOperation()->getRuntimeInfo());
+
   result->_resultTypes.reserve(result->_nofColumns);
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);
   result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);

--- a/src/engine/TextOperationWithFilter.h
+++ b/src/engine/TextOperationWithFilter.h
@@ -66,5 +66,5 @@ class TextOperationWithFilter : public Operation {
 
   void computeMultiplicities();
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -39,7 +39,9 @@ string TextOperationWithoutFilter::asString(size_t indent) const {
 }
 
 // _____________________________________________________________________________
-void TextOperationWithoutFilter::computeResult(ResultTable* result) const {
+void TextOperationWithoutFilter::computeResult(ResultTable* result) {
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("Text operation without filter: " + _words);
   LOG(DEBUG) << "TextOperationWithoutFilter result computation..." << endl;
   if (_nofVars == 0) {
     computeResultNoVar(result);

--- a/src/engine/TextOperationWithoutFilter.h
+++ b/src/engine/TextOperationWithoutFilter.h
@@ -60,7 +60,7 @@ class TextOperationWithoutFilter : public Operation {
 
   void computeMultiplicities();
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 
   void computeResultNoVar(ResultTable* result) const;
 

--- a/src/engine/TwoColumnJoin.h
+++ b/src/engine/TwoColumnJoin.h
@@ -63,5 +63,5 @@ class TwoColumnJoin : public Operation {
 
   void computeMultiplicities();
 
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -118,11 +118,16 @@ size_t Union::getCostEstimate() {
          getSizeEstimate();
 }
 
-void Union::computeResult(ResultTable* result) const {
+void Union::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Union result computation..." << std::endl;
   shared_ptr<const ResultTable> subRes1 = _subtrees[0]->getResult();
   shared_ptr<const ResultTable> subRes2 = _subtrees[1]->getResult();
   LOG(DEBUG) << "Union subresult computation done." << std::endl;
+
+  RuntimeInformation& runtimeInfo = getRuntimeInfo();
+  runtimeInfo.setDescriptor("Union");
+  runtimeInfo.addChild(_subtrees[0]->getRootOperation()->getRuntimeInfo());
+  runtimeInfo.addChild(_subtrees[1]->getRootOperation()->getRuntimeInfo());
 
   result->_sortedBy = resultSortedOn();
   for (const std::array<size_t, 2>& o : _columnOrigins) {

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -45,7 +45,7 @@ class Union : public Operation {
       const std::vector<std::array<size_t, 2>>& columnOrigins);
 
  private:
-  virtual void computeResult(ResultTable* result) const override;
+  virtual void computeResult(ResultTable* result) override;
 
   /**
    * @brief This method is used to convert runtime information about the

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -12,7 +12,7 @@
 class DummyOperation : public Operation {
  public:
   DummyOperation(QueryExecutionContext* ctx) : Operation(ctx) {}
-  virtual void computeResult(ResultTable* result) const {
+  virtual void computeResult(ResultTable* result) {
     result->_nofColumns = 2;
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
@@ -289,9 +289,10 @@ TEST(CountAvailablePredicates, patternTrickTest) {
   CompactStringVector<Id, Id> hasRelation(hasRelationSrc);
   CompactStringVector<size_t, Id> patterns(patternsSrc);
 
+  RuntimeInformation runtimeInfo;
   try {
     CountAvailablePredicates::computePatternTrick<std::array<Id, 1>>(
-        &input, &result, hasPattern, hasRelation, patterns, 0);
+        &input, &result, hasPattern, hasRelation, patterns, 0, &runtimeInfo);
   } catch (ad_semsearch::Exception e) {
     // More verbose output in the case of an exception occuring.
     std::cout << e.getErrorMessage() << std::endl


### PR DESCRIPTION
I'm just creating a pr now to avoid duplicate work, and to get some early feedback on whether or not this is how we want our detailed query timing information to be structured (especially regarding caching).
The next step from my point of view would be to modify all computeResult methods of all operations to access their `RuntimeInformation` and fill in the missing data.
This implementation currently would not report information for the subtree of a cached result, but instead only show the root node of that cached result and have a flag set that indicates that that subtree was cached.