### PR TITLE
Improve Pattern Trick Stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,6 @@ message(STATUS ---)
 ###############################################################################
 ##### Actual project configuration #####
 ###############################################################################
-
-option(DISABLE_PATTERN_TRICK_STATISTICS "This disables the computation of statistics when using the pattern trick." OFF)
-if (DISABLE_PATTERN_TRICK_STATISTICS)
-  add_definitions(-DDISABLE_PATTERN_TRICK_STATISTICS)
-endif (DISABLE_PATTERN_TRICK_STATISTICS)
-
 set(LOG_LEVEL_FATAL 0)
 set(LOG_LEVEL_ERROR 1)
 set(LOG_LEVEL_WARN 2)


### PR DESCRIPTION
This builds on the #187 PR so that should be merged first.

This changes the computation of the stats to (I think) match @hannahbast's idea. The total number of predicates has to be with repetitions i.e. what a non pattern trick version would use as subresult.