### PR TITLE
Finish result in Operation::getResult() and add size to performance digest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,6 @@ add_definitions(-DLOGLEVEL=${LOG_LEVEL_${LOGLEVEL}})
 add_subdirectory(src/parser)
 add_subdirectory(src/engine)
 add_subdirectory(src/index)
-#add_subdirectory(src/experiments)
 add_subdirectory(test)
 
 

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -355,18 +355,13 @@ void CountAvailablePredicates::computePatternTrick(
              << std::endl;
 
   // Add these values to the runtime info
-  runtimeInfo->addDetail("numEntities", std::to_string(input->size()));
+  runtimeInfo->addDetail("numEntities", input->size());
   runtimeInfo->addDetail("numPredicatesWithRepetitions",
-                         std::to_string(numPredicatesWithRepetitions));
-  runtimeInfo->addDetail(
-      "percentEntitesWithPatterns",
-      ad_utility::to_string(ratioHasPatterns * 100, 2) + "%");
-  runtimeInfo->addDetail(
-      "percentPredicatesFromPatterns",
-      ad_utility::to_string(ratioCountedWithPatterns * 100, 2) + "%");
-  runtimeInfo->addDetail("costWithoutPatterns",
-                         std::to_string(costWithoutPatterns));
-  runtimeInfo->addDetail("costWithPatterns", std::to_string(costWithPatterns));
-  runtimeInfo->addDetail("costRatio",
-                         ad_utility::to_string(costRatio * 100, 2) + "%");
+                         numPredicatesWithRepetitions);
+  runtimeInfo->addDetail("percentEntitesWithPatterns", ratioHasPatterns * 100);
+  runtimeInfo->addDetail("percentPredicatesFromPatterns",
+                         ratioCountedWithPatterns * 100);
+  runtimeInfo->addDetail("costWithoutPatterns", costWithoutPatterns);
+  runtimeInfo->addDetail("costWithPatterns", costWithPatterns);
+  runtimeInfo->addDetail("costRatio", costRatio * 100);
 }

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -204,7 +204,6 @@ void CountAvailablePredicates::computeResult(ResultTable* result) {
   }
   LOG(DEBUG) << "CountAvailablePredicates result computation done."
              << std::endl;
-  result->finish();
 }
 
 void CountAvailablePredicates::computePatternTrickAllEntities(

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -358,12 +358,15 @@ void CountAvailablePredicates::computePatternTrick(
   runtimeInfo->addDetail("numEntities", std::to_string(input->size()));
   runtimeInfo->addDetail("numPredicatesWithRepetitions",
                          std::to_string(numPredicatesWithRepetitions));
-  runtimeInfo->addDetail("percentEntitesWithPatterns",
-                         std::to_string(ratioHasPatterns * 100) + "%");
-  runtimeInfo->addDetail("percentPredicatesFromPatterns",
-                         std::to_string(ratioCountedWithPatterns * 100) + "%");
+  runtimeInfo->addDetail(
+      "percentEntitesWithPatterns",
+      ad_utility::to_string(ratioHasPatterns * 100, 2) + "%");
+  runtimeInfo->addDetail(
+      "percentPredicatesFromPatterns",
+      ad_utility::to_string(ratioCountedWithPatterns * 100, 2) + "%");
   runtimeInfo->addDetail("costWithoutPatterns",
                          std::to_string(costWithoutPatterns));
   runtimeInfo->addDetail("costWithPatterns", std::to_string(costWithPatterns));
-  runtimeInfo->addDetail("costRatio", std::to_string(costRatio * 100) + "%");
+  runtimeInfo->addDetail("costRatio",
+                         ad_utility::to_string(costRatio * 100, 2) + "%");
 }

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -101,6 +101,6 @@ void Distinct::computeResult(ResultTable* result) {
       break;
     }
   }
-  result->finish();
+
   LOG(DEBUG) << "Distinct result computation done." << endl;
 }

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -664,8 +664,8 @@ class Engine {
   static void doJoin(const vector<array<E, N>>& a, const vector<array<E, M>>& b,
                      vector<array<E, (N + M - 1)>>* result) {
     LOG(DEBUG) << "Performing join between two fixed width tables.\n";
-    LOG(DEBUG) << "A: witdth = " << N << ", size = " << a.size() << "\n";
-    LOG(DEBUG) << "B: witdth = " << M << ", size = " << b.size() << "\n";
+    LOG(DEBUG) << "A: width = " << N << ", size = " << a.size() << "\n";
+    LOG(DEBUG) << "B: width = " << M << ", size = " << b.size() << "\n";
 
     // Typedefs can hopefully prevent insanity. Read as:
     // "Tuple 1", "Tuple 2", "Tuple for Result", etc.
@@ -838,7 +838,7 @@ class Engine {
   static void doSelfJoin(const vector<array<E, N>>& v,
                          vector<array<E, N + N - 1>>* result) {
     LOG(DEBUG) << "Performing self join on fixed width tables.\n";
-    LOG(DEBUG) << "TAB: witdth = " << N << ", size = " << v.size() << "\n";
+    LOG(DEBUG) << "TAB: width = " << N << ", size = " << v.size() << "\n";
 
     // Always detect ranges of equal join col values and then
     // build a cross product for each range.

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -270,7 +270,7 @@ void Filter::computeResult(ResultTable* result) {
     // compare the left column to a fixed value
     return computeResultFixedValue(result, subRes);
   }
-  result->finish();
+
   LOG(DEBUG) << "Filter result computation done." << endl;
 }
 
@@ -685,6 +685,6 @@ void Filter::computeResultFixedValue(
       break;
     }
   }
-  result->finish();
+
   LOG(DEBUG) << "Filter result computation done." << endl;
 }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -783,7 +783,7 @@ void GroupBy::computeResult(ResultTable* result) {
       } else if (result->_nofColumns == 5) {
         result->_fixedSizeData = new vector<array<Id, 5>>();
       }
-      result->finish();
+
       return;
     }
     groupByColumns.push_back(it->second);
@@ -904,7 +904,7 @@ void GroupBy::computeResult(ResultTable* result) {
         } else if (result->_nofColumns == 5) {
           result->_fixedSizeData = new vector<array<Id, 5>>();
         }
-        result->finish();
+
         return;
       }
       aggregates.back()._inCol = inIt->second;
@@ -974,6 +974,6 @@ void GroupBy::computeResult(ResultTable* result) {
       delete static_cast<std::string*>(a._userData);
     }
   }
-  result->finish();
+
   LOG(DEBUG) << "GroupBy result computation done." << std::endl;
 }

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -231,7 +231,7 @@ void HasPredicateScan::computeResult(ResultTable* result) {
       runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
       break;
   }
-  result->finish();
+
   LOG(DEBUG) << "HasPredicateScan result compuation done." << std::endl;
 }
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -176,7 +176,6 @@ void IndexScan::computePSOboundS(ResultTable* result) const {
   _executionContext->getIndex().scanPSO(
       _predicate, _subject,
       static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -188,7 +187,6 @@ void IndexScan::computePSOfreeS(ResultTable* result) const {
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanPSO(
       _predicate, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -200,7 +198,6 @@ void IndexScan::computePOSboundO(ResultTable* result) const {
   _executionContext->getIndex().scanPOS(
       _predicate, _object,
       static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -212,7 +209,6 @@ void IndexScan::computePOSfreeO(ResultTable* result) const {
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanPOS(
       _predicate, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -257,7 +253,6 @@ void IndexScan::computeSPOfreeP(ResultTable* result) const {
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanSPO(
       _subject, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -269,7 +264,6 @@ void IndexScan::computeSOPboundO(ResultTable* result) const {
   _executionContext->getIndex().scanSOP(
       _subject, _object,
       static_cast<vector<array<Id, 1>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -281,7 +275,6 @@ void IndexScan::computeSOPfreeO(ResultTable* result) const {
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanSOP(
       _subject, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -293,7 +286,6 @@ void IndexScan::computeOPSfreeP(ResultTable* result) const {
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanOPS(
       _object, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________
@@ -305,7 +297,6 @@ void IndexScan::computeOSPfreeS(ResultTable* result) const {
   result->_fixedSizeData = new vector<array<Id, 2>>();
   _executionContext->getIndex().scanOSP(
       _object, static_cast<vector<array<Id, 2>>*>(result->_fixedSizeData));
-  result->finish();
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -84,7 +84,7 @@ void Join::computeResult(ResultTable* result) {
     } else if (resWidth == 5) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
     }
-    result->finish();
+
     return;
   }
 
@@ -118,7 +118,7 @@ void Join::computeResult(ResultTable* result) {
     } else if (resWidth == 5) {
       result->_fixedSizeData = new vector<array<Id, 5>>();
     }
-    result->finish();
+
     return;
   }
 
@@ -391,7 +391,7 @@ void Join::computeResult(ResultTable* result) {
                                           &result->_varSizeData);
     }
   }
-  result->finish();
+
   LOG(DEBUG) << "Join result computation done." << endl;
 }
 
@@ -588,7 +588,7 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) const {
       doComputeJoinWithFullScanDummyRight(r, &result->_varSizeData);
     }
   }
-  result->finish();
+
   LOG(DEBUG) << "Join (with dummy) done. Size: " << result->size() << endl;
 }
 

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -222,7 +222,7 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
   MultiColumnJoinCaller<1, 1, 1>::call(
       leftResult->_nofColumns, rightResult->_nofColumns, result->_nofColumns,
       leftResult, rightResult, _joinColumns, result, result->_nofColumns);
-  result->finish();
+
   LOG(DEBUG) << "MultiColumnJoin result computation done." << endl;
 }
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -80,7 +80,7 @@ class Operation {
       timer.stop();
       _runtimeInformation.setRows(newResult->_resTable->size());
       _runtimeInformation.setCols(getResultWidth());
-      _runtimeInformation.setTime(timer.secs());
+      _runtimeInformation.setTime(timer.msecs());
       _runtimeInformation.setWasCached(false);
       // cache the runtime information for the execution as well
       newResult->_runtimeInfo = _runtimeInformation;
@@ -102,8 +102,9 @@ class Operation {
       // information.
       _runtimeInformation = existingResult->_runtimeInfo;
       _runtimeInformation.addDetail(
-          "InitialTime", std::to_string(_runtimeInformation.getTime()));
-      _runtimeInformation.setTime(timer.secs());
+          "OriginalTime",
+          ad_utility::to_string(_runtimeInformation.getTime(), 2) + " ms");
+      _runtimeInformation.setTime(timer.msecs());
       _runtimeInformation.setWasCached(true);
     }
     return existingResult->_resTable;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -78,10 +78,15 @@ class Operation {
         throw ad_semsearch::AbortException("WEIRD_EXCEPTION");
       }
       timer.stop();
+      _runtimeInformation.setRows(newResult->_resTable->size());
+      _runtimeInformation.setCols(getResultWidth());
       _runtimeInformation.setTime(timer.secs());
       _runtimeInformation.setWasCached(false);
       // cache the runtime information for the execution as well
       newResult->_runtimeInfo = _runtimeInformation;
+      // Only now we can let other threads access the result
+      // and runtime information
+      newResult->_resTable->finish();
       return newResult->_resTable;
     }
     existingResult->_resTable->awaitFinished();
@@ -91,9 +96,10 @@ class Operation {
                "Operation was found aborted in the cache");
     }
     timer.stop();
-    if (_runtimeInformation.getTime() == 0) {
-      // If this operation object was computed already we don't want to update
-      // the runtime information.
+    if (!newResult) {
+      // If the result for this Operation came from the cache we take the
+      // original runtime information and only update the time and caching
+      // information.
       _runtimeInformation = existingResult->_runtimeInfo;
       _runtimeInformation.addDetail(
           "InitialTime", std::to_string(_runtimeInformation.getTime()));

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -101,9 +101,8 @@ class Operation {
       // original runtime information and only update the time and caching
       // information.
       _runtimeInformation = existingResult->_runtimeInfo;
-      _runtimeInformation.addDetail(
-          "OriginalTime",
-          ad_utility::to_string(_runtimeInformation.getTime(), 2) + " ms");
+      _runtimeInformation.addDetail("OriginalTime",
+                                    _runtimeInformation.getTime());
       _runtimeInformation.setTime(timer.msecs());
       _runtimeInformation.setWasCached(true);
     }

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -234,7 +234,7 @@ void OptionalJoin::computeResult(ResultTable* result) {
                       result->_nofColumns, leftResult, rightResult,
                       _leftOptional, _rightOptional, _joinColumns, result,
                       result->_nofColumns);
-  result->finish();
+
   LOG(DEBUG) << "OptionalJoin result computation done." << endl;
 }
 

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -115,6 +115,6 @@ void OrderBy::computeResult(ResultTable* result) {
     }
   }
   result->_sortedBy = resultSortedOn();
-  result->finish();
+
   LOG(DEBUG) << "OrderBy result computation done." << endl;
 }

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -15,10 +15,18 @@
 class RuntimeInformation {
  public:
   RuntimeInformation()
-      : _descriptor(), _details(), _time(0), _wasCached(false), _children() {}
+      : _time(0),
+        _rows(0),
+        _cols(0),
+        _wasCached(false),
+        _descriptor(),
+        _details(),
+        _children() {}
   void toJson(std::ostream& out) const {
     out << "{";
     out << "\"description\" : " << ad_utility::toJson(_descriptor) << ",";
+    out << "\"result_rows\" : " << _rows << ", ";
+    out << "\"result_cols\" : " << _cols << ", ";
     out << "\"total_time\" : " << _time << ", ";
     out << "\"operation_time\" : " << getOperationTime() << ", ";
     out << "\"was_chached\" : " << ((_wasCached) ? "true" : "false") << ", ";
@@ -56,6 +64,8 @@ class RuntimeInformation {
   void toString(std::ostream& out, size_t indent) const {
     out << '\n';
     out << std::string(indent * 2, ' ') << _descriptor << std::endl;
+    out << std::string(indent * 2, ' ') << "result_size: " << _rows << " x "
+        << _cols << std::endl;
     out << std::string(indent * 2, ' ') << "total_time: " << _time << "s"
         << std::endl;
     out << std::string(indent * 2, ' ')
@@ -77,8 +87,21 @@ class RuntimeInformation {
 
   // Set the overall time
   void setTime(double time) { _time = time; }
+
   // Get the overall time
   double getTime() const { return _time; }
+
+  // Set the number of rows
+  void setRows(size_t rows) { _rows = rows; }
+
+  // Get the number of rows
+  size_t getRows() { return _rows; }
+
+  // Set the number of columns
+  void setCols(size_t cols) { _cols = cols; }
+
+  // Get the number of columns
+  size_t getCols() { return _cols; }
 
   double getOperationTime() const {
     if (_wasCached) {
@@ -106,9 +129,11 @@ class RuntimeInformation {
   }
 
  private:
+  double _time;
+  size_t _rows;
+  size_t _cols;
+  bool _wasCached;
   std::string _descriptor;
   ad_utility::HashMap<std::string, std::string> _details;
-  double _time;
-  bool _wasCached;
   std::vector<RuntimeInformation> _children;
 };

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -57,19 +57,24 @@ class RuntimeInformation {
 
   std::string toString() const {
     std::ostringstream buffer;
-    toString(buffer, 0);
+    // imbue with the same locale as std::cout which uses for exanoke
+    // thousands separators
+    buffer.imbue(ad_utility::commaLocale);
+    // So floats use fixed precision
+    buffer << std::fixed << std::setprecision(2);
+    writeToStream(buffer, 0);
     return buffer.str();
   }
 
-  void toString(std::ostream& out, size_t indent) const {
+  void writeToStream(std::ostream& out, size_t indent) const {
     out << '\n';
     out << std::string(indent * 2, ' ') << _descriptor << std::endl;
     out << std::string(indent * 2, ' ') << "result_size: " << _rows << " x "
         << _cols << std::endl;
-    out << std::string(indent * 2, ' ') << "total_time: " << _time << "s"
+    out << std::string(indent * 2, ' ') << "total_time: " << _time << " ms"
         << std::endl;
     out << std::string(indent * 2, ' ')
-        << "operation_time: " << getOperationTime() << "s" << std::endl;
+        << "operation_time: " << getOperationTime() << " ms" << std::endl;
     out << std::string(indent * 2, ' ')
         << "cached: " << ((_wasCached) ? "true" : "false") << std::endl;
     for (auto detail : _details) {
@@ -77,7 +82,7 @@ class RuntimeInformation {
           << detail.second << std::endl;
     }
     for (const RuntimeInformation& child : _children) {
-      child.toString(out, indent + 1);
+      child.writeToStream(out, indent + 1);
     }
   }
 
@@ -85,10 +90,10 @@ class RuntimeInformation {
     _descriptor = descriptor;
   }
 
-  // Set the overall time
+  // Set the overall time in milliseconds
   void setTime(double time) { _time = time; }
 
-  // Get the overall time
+  // Get the overall time in milliseconds
   double getTime() const { return _time; }
 
   // Set the number of rows

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <iostream>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
@@ -14,6 +15,8 @@
 
 class RuntimeInformation {
  public:
+  friend void to_json(nlohmann::json& j, const RuntimeInformation& rti);
+
   RuntimeInformation()
       : _time(0),
         _rows(0),
@@ -22,38 +25,6 @@ class RuntimeInformation {
         _descriptor(),
         _details(),
         _children() {}
-  void toJson(std::ostream& out) const {
-    out << "{";
-    out << "\"description\" : " << ad_utility::toJson(_descriptor) << ",";
-    out << "\"result_rows\" : " << _rows << ", ";
-    out << "\"result_cols\" : " << _cols << ", ";
-    out << "\"total_time\" : " << _time << ", ";
-    out << "\"operation_time\" : " << getOperationTime() << ", ";
-    out << "\"was_chached\" : " << ((_wasCached) ? "true" : "false") << ", ";
-    out << "\"details\" : {";
-    auto it = _details.begin();
-    while (it != _details.end()) {
-      out << "" << ad_utility::toJson(it->first) << " : "
-          << ad_utility::toJson(it->second);
-      ++it;
-      if (it != _details.end()) {
-        out << ", ";
-      }
-    }
-    out << "}, ";
-    out << "\"children\" : [";
-    auto it2 = _children.begin();
-    while (it2 != _children.end()) {
-      // recursively call the childs to json method
-      it2->toJson(out);
-      ++it2;
-      if (it2 != _children.end()) {
-        out << ", ";
-      }
-    }
-    out << "]";
-    out << "}";
-  }
 
   std::string toString() const {
     std::ostringstream buffer;
@@ -67,6 +38,7 @@ class RuntimeInformation {
   }
 
   void writeToStream(std::ostream& out, size_t indent) const {
+    using json = nlohmann::json;
     out << '\n';
     out << std::string(indent * 2, ' ') << _descriptor << std::endl;
     out << std::string(indent * 2, ' ') << "result_size: " << _rows << " x "
@@ -77,9 +49,24 @@ class RuntimeInformation {
         << "operation_time: " << getOperationTime() << " ms" << std::endl;
     out << std::string(indent * 2, ' ')
         << "cached: " << ((_wasCached) ? "true" : "false") << std::endl;
-    for (auto detail : _details) {
-      out << std::string((indent + 2) * 2, ' ') << detail.first << ": "
-          << detail.second << std::endl;
+    for (const auto& el : _details.items()) {
+      out << std::string((indent + 2) * 2, ' ') << el.key() << ": ";
+      // We want to print doubles with fixed precision and stream ints as their
+      // native type so they get thousands separators. For everything else we
+      // let nlohmann::json handle it
+      if (el.value().type() == json::value_t::number_float) {
+        out << ad_utility::to_string(el.value().get<double>(), 2);
+      } else if (el.value().type() == json::value_t::number_unsigned) {
+        out << el.value().get<uint64_t>();
+      } else if (el.value().type() == json::value_t::number_integer) {
+        out << el.value().get<int64_t>();
+      } else {
+        out << el.value();
+      }
+      if (ad_utility::endsWith(el.key(), "Time")) {
+        out << " ms";
+      }
+      out << std::endl;
     }
     for (const RuntimeInformation& child : _children) {
       child.writeToStream(out, indent + 1);
@@ -129,7 +116,8 @@ class RuntimeInformation {
 
   void addChild(const RuntimeInformation& r) { _children.push_back(r); }
 
-  void addDetail(const std::string& key, const std::string& value) {
+  template <typename T>
+  void addDetail(const std::string& key, const T& value) {
     _details[key] = value;
   }
 
@@ -139,6 +127,18 @@ class RuntimeInformation {
   size_t _cols;
   bool _wasCached;
   std::string _descriptor;
-  ad_utility::HashMap<std::string, std::string> _details;
+  nlohmann::json _details;
   std::vector<RuntimeInformation> _children;
 };
+
+inline void to_json(nlohmann::json& j, const RuntimeInformation& rti) {
+  using nlohmann::json;
+  j = json{{"description", rti._descriptor},
+           {"result_rows", rti._rows},
+           {"result_cols", rti._cols},
+           {"total_time", rti._time},
+           {"operation_time", rti.getOperationTime()},
+           {"was_cached", rti._wasCached},
+           {"details", rti._details},
+           {"children", rti._children}};
+}

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -155,7 +155,7 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
       }
 #endif
       query = createQueryFromHttpParams(params);
-      LOG(INFO) << "Query: " << query << '\n';
+      LOG(INFO) << "Query:\n" << query << '\n';
       ParsedQuery pq = SparqlParser::parse(query);
       pq.expandPrefixes();
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -340,7 +341,7 @@ string Server::composeResponseJson(const ParsedQuery& query,
   }
 
   os << "\"runtimeInformation\" : ";
-  qet.getRootOperation()->getRuntimeInfo().toJson(os);
+  os << nlohmann::json(qet.getRootOperation()->getRuntimeInfo());
   os << ", \n";
 
   os << "\"res\": ";

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -184,8 +184,7 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
       }
       // Print the runtime info. This needs to be done after the query
       // was computed.
-      LOG(DEBUG) << qet.getRootOperation()->getRuntimeInfo().toString()
-                 << std::endl;
+      LOG(INFO) << qet.getRootOperation()->getRuntimeInfo().toString();
     } catch (const ad_semsearch::Exception& e) {
       response = composeResponseJson(query, e);
     } catch (const std::exception& e) {

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -90,6 +90,6 @@ void Sort::computeResult(ResultTable* result) {
     }
   }
   result->_sortedBy = resultSortedOn();
-  result->finish();
+
   LOG(DEBUG) << "Sort result computation done." << endl;
 }

--- a/src/engine/TextOperationForContexts.cpp
+++ b/src/engine/TextOperationForContexts.cpp
@@ -68,6 +68,6 @@ void TextOperationForContexts::computeResult(ResultTable* result) {
     AD_THROW(ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
              "Complex text query is a todo for the future.");
   }
-  result->finish();
+
   LOG(DEBUG) << "TextOperationForContexts result computation done." << endl;
 }

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -142,7 +142,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) {
         _words, filterResult->_varSizeData, _filterColumn, _nofVars, _textLimit,
         result->_varSizeData);
   }
-  result->finish();
+
   LOG(DEBUG) << "TextOperationWithFilter result computation done." << endl;
 }
 

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -50,7 +50,7 @@ void TextOperationWithoutFilter::computeResult(ResultTable* result) {
   } else {
     computeResultMultVars(result);
   }
-  result->finish();
+
   LOG(DEBUG) << "TextOperationWithoutFilter result computation done." << endl;
 }
 

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -151,7 +151,6 @@ void TwoColumnJoin::computeResult(ResultTable* result) {
                          &result->_varSizeData);
     }
 
-    result->finish();
     LOG(DEBUG) << "TwoColumnJoin result computation done." << endl;
     return;
   }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -142,7 +142,6 @@ void Union::computeResult(ResultTable* result) {
   result->_nofColumns = getResultWidth();
   computeUnion(result, subRes1, subRes2, _columnOrigins);
 
-  result->finish();
   LOG(DEBUG) << "Union result computation done." << std::endl;
 }
 

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -241,7 +241,7 @@ void SparqlParser::parseWhere(const string& str, ParsedQuery& query,
         }
         std::string subquery_string =
             inner.substr(selectPos, endBracket - selectPos);
-        LOG(DEBUG) << "Found subquery: " << subquery_string << std::endl;
+        LOG(DEBUG) << "Found subquery:\n" << subquery_string << std::endl;
 
         // create the subquery operation
         ParsedQuery::GraphPatternOperation* u =

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -6,6 +6,7 @@
 
 #include <sys/timeb.h>
 #include <time.h>
+#include <iomanip>
 #include <iostream>
 #include <locale>
 #include <sstream>
@@ -33,9 +34,35 @@
 #define ERROR 1
 #define FATAL 0
 
-using std::string;
-
 namespace ad_utility {
+
+using std::string;
+//! Helper class to get thousandth separators in a locale
+class CommaNumPunct : public std::numpunct<char> {
+ protected:
+  virtual char do_thousands_sep() const { return ','; }
+
+  virtual std::string do_grouping() const { return "\03"; }
+};
+
+const static std::locale commaLocale(std::locale(), new CommaNumPunct());
+
+//! String representation of a double with precision and thousandth separators
+inline string to_string(double in, size_t precision) {
+  std::ostringstream buffer;
+  buffer.imbue(commaLocale);
+  buffer << std::setprecision(precision) << std::fixed << in;
+  return buffer.str();
+}
+
+//! String representation of a long with thousandth separators
+inline string to_string(long in) {
+  std::ostringstream buffer;
+  buffer.imbue(commaLocale);
+  buffer << in;
+  return buffer.str();
+}
+
 //! Log
 class Log {
  public:


### PR DESCRIPTION
Doing `result->finish()` in `Operation::getResult()` makes sure that no other
thread accesses an unfinished `RuntimeInformation`. Also it is easier to
maintain and resembles the use of `result->abort()`

We also add the result size (rows and columns) to the performance
digest.