### PR TITLE
Radix sort

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ configure_file(src/web/style.css style.css)
 configure_file(src/web/script.js script.js)
 
 
+# add_executable(SpeedTest src/SpeedTest.cpp)
+# target_link_libraries(SpeedTest engine ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(IndexBuilderMain src/index/IndexBuilderMain.cpp)
 target_link_libraries(IndexBuilderMain index ${CMAKE_THREAD_LIBS_INIT})
 

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -48,6 +48,10 @@ class Sort : public Operation {
 
   virtual size_t getResultWidth() const;
 
+  template <int WIDTH>
+  static void sort(IdTable* dynTable, size_t sortCol,
+                   ResultTable::ResultType sortType);
+
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   size_t _sortCol;

--- a/src/util/kxsort.h
+++ b/src/util/kxsort.h
@@ -1,0 +1,129 @@
+/* The MIT License
+   Copyright (c) 2016 Dinghua Li <voutcn@gmail.com>
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+// This version of the sorting algorithm was adapted to operate on IdTables
+
+#ifndef KXSORT_H__
+#define KXSORT_H__
+
+#include <algorithm>
+#include <iterator>
+
+#include "../engine/IdTable.h"
+
+namespace kx {
+
+static constexpr int kRadixBits = 8;
+static constexpr size_t kInsertSortThreshold = 64;
+static constexpr int kRadixMask = (1 << kRadixBits) - 1;
+static constexpr int kRadixBin = 1 << kRadixBits;
+
+//================= HELPING FUNCTIONS ====================
+
+template <int WIDTH>
+inline void insert_sort_core_(IdTableStatic<WIDTH>& table, size_t beginRow,
+                              size_t endRow, unsigned int compRow) {
+  for (size_t i = beginRow + 1; i < endRow; i++) {
+    if (table(i, compRow) < table(i - 1, compRow)) {
+      size_t j = i - 1;
+      for (; j > 0 && table(i, compRow) < table(j - 1, compRow); j--) {
+      }
+      // Move i to be the element right before j
+      table.moveRow(i, j);
+    }
+  }
+}
+
+template <int WIDTH, int kWhichByte>
+// inline void radix_sort_core_(RandomIt s, RandomIt e, RadixTraits
+// radix_traits) {
+inline void radix_sort_core_(IdTableStatic<WIDTH>& table, size_t beginRow,
+                             size_t endRow, unsigned int compRow) {
+  size_t last_[kRadixBin + 1];
+  size_t* last = last_ + 1;
+  size_t count[kRadixBin] = {0};
+
+  for (size_t i = beginRow; i < endRow; ++i) {
+    ++count[(table(i, compRow) >> (kWhichByte * kRadixBits)) & kRadixMask];
+  }
+
+  last_[0] = last_[1] = beginRow;
+
+  for (int i = 1; i < kRadixBin; ++i) {
+    last[i] = last[i - 1] + count[i - 1];
+  }
+
+  // Move every entry into its bin
+  for (int i = 0; i < kRadixBin; ++i) {
+    // check if the current bucket is already full
+    size_t end = last[i - 1] + count[i];
+    if (end == endRow) {
+      last[i] = endRow;
+      break;
+    }
+    // while the bucket is not full
+    while (last[i] != end) {
+      size_t swapper = last[i];
+      // compute the bucket into which the row at i belongs into
+      int tag =
+          (table(swapper, compRow) >> (kWhichByte * kRadixBits)) & kRadixMask;
+      if (tag != i) {
+        // While our current value does not belong into the ith bucket switch
+        // it with another value from the bucket it belongs into
+        do {
+          table.swapRows(swapper, last[tag]++);
+        } while ((tag = (table(swapper, compRow) >> (kWhichByte * kRadixBits)) &
+                        kRadixMask) != i);
+        // this should already have been done by the swap
+        // *last[i] = swapper;
+      }
+      ++last[i];
+    }
+  }
+
+  if constexpr (kWhichByte > 0) {
+    for (int i = 0; i < kRadixBin; ++i) {
+      if (count[i] > kInsertSortThreshold) {
+        radix_sort_core_<WIDTH, kWhichByte - 1>(table, last[i - 1], last[i],
+                                                compRow);
+      } else if (count[i] > 1) {
+        insert_sort_core_<WIDTH>(table, last[i - 1], last[i], compRow);
+      }
+    }
+  }
+}
+
+//================= INTERFACES ====================
+
+template <int WIDTH>
+inline void radix_sort(IdTableStatic<WIDTH>& table, unsigned int compRow) {
+  if (table.size() <= (int)kInsertSortThreshold)
+    insert_sort_core_(table, 0, table.size(), compRow);
+  else
+    radix_sort_core_<WIDTH, sizeof(Id) - 1>(table, 0, table.size(), compRow);
+}
+
+}  // namespace kx
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -109,3 +109,7 @@ target_link_libraries(MultiColumnJoinTest gtest_main engine ${CMAKE_THREAD_LIBS_
 add_executable(IdTableTest IdTableTest.cpp)
 add_test(IdTableTest IdTableTest)
 target_link_libraries(IdTableTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(SortTest SortTest.cpp)
+add_test(SortTest SortTest)
+target_link_libraries(SortTest engine gtest_main ${CMAKE_THREAD_LIBS_INIT})

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -279,6 +279,23 @@ TEST(IdTableTest, sortTest) {
   ASSERT_EQ(orig[1], test[5]);
 }
 
+TEST(IdTableTest, moveRow) {
+  IdTable init(3);
+  init.push_back({1, 2, 3});
+  init.push_back({4, 5, 6});
+  init.push_back({7, 8, 9});
+  init.push_back({10, 11, 12});
+
+  IdTable t = init;
+
+  t.moveRow(2, 0);
+  t.moveRow(1, 3);
+  ASSERT_EQ(init[0], t[3]);
+  ASSERT_EQ(init[1], t[1]);
+  ASSERT_EQ(init[2], t[0]);
+  ASSERT_EQ(init[3], t[2]);
+}
+
 // =============================================================================
 // IdTableStatic tests
 // =============================================================================
@@ -502,6 +519,23 @@ TEST(IdTableStaticTest, iterating) {
     }
     row_index++;
   }
+}
+
+TEST(IdTableStaticTest, moveRow) {
+  IdTableStatic<3> init;
+  init.push_back({1, 2, 3});
+  init.push_back({4, 5, 6});
+  init.push_back({7, 8, 9});
+  init.push_back({10, 11, 12});
+
+  IdTableStatic<3> t = init;
+
+  t.moveRow(2, 0);
+  t.moveRow(1, 3);
+  ASSERT_EQ(init[0], t[3]);
+  ASSERT_EQ(init[1], t[1]);
+  ASSERT_EQ(init[2], t[0]);
+  ASSERT_EQ(init[3], t[2]);
 }
 
 // =============================================================================

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -1,0 +1,97 @@
+// Copyright 2019, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+
+#include <gtest/gtest.h>
+#include <cstdio>
+#include <unordered_set>
+#include "../src/engine/Sort.h"
+
+namespace std {
+template <>
+struct hash<std::array<Id, 3>> {
+  size_t operator()(const std::array<Id, 3>& row) const {
+    return row[0] + row[1] + row[2];
+  }
+};
+}  // namespace std
+
+TEST(SortTest, radix_sort) {
+  IdTableStatic<3> init;
+  unsigned int seed = time(NULL);
+  for (size_t i = 0; i < 1000; i++) {
+    init.push_back({static_cast<Id>(rand_r(&seed)),
+                    static_cast<Id>(rand_r(&seed)),
+                    static_cast<Id>(rand_r(&seed))});
+  }
+
+  IdTableStatic<3> stdSorted = init;
+  IdTableStatic<3> radixSorted = init;
+  std::sort(stdSorted.begin(), stdSorted.end(),
+            [](const auto& a, const auto& b) { return a[1] < b[1]; });
+  IdTable tmp = radixSorted.moveToDynamic();
+  Sort::sort<3>(&tmp, 1, ResultTable::ResultType::KB);
+  radixSorted = tmp.moveToStatic<3>();
+
+  ASSERT_EQ(stdSorted.size(), radixSorted.size());
+  size_t pos_radix = 0;
+  // Use an unordered set to allow for comparisons of the two sorted arrays
+  // without the sorting being stable.
+  std::unordered_set<std::array<Id, 3>> current_block;
+  for (size_t i = 0; i < stdSorted.size();) {
+    size_t v = stdSorted[i][1];
+    size_t num = 0;
+    current_block.clear();
+    while (i < stdSorted.size() && stdSorted[i][1] == v) {
+      current_block.insert(stdSorted[i]);
+      i++;
+      num++;
+    }
+    for (size_t j = 0; j < num; j++) {
+      ASSERT_EQ(v, radixSorted[pos_radix][1]);
+      ASSERT_TRUE(current_block.find(radixSorted[pos_radix]) !=
+                  current_block.end());
+      pos_radix++;
+    }
+  }
+}
+
+TEST(SortTest, radix_sort_short) {
+  IdTableStatic<3> init;
+  unsigned int seed = time(NULL);
+  for (size_t i = 0; i < 32; i++) {
+    init.push_back({static_cast<Id>(rand_r(&seed)),
+                    static_cast<Id>(rand_r(&seed)),
+                    static_cast<Id>(rand_r(&seed))});
+  }
+
+  IdTableStatic<3> stdSorted = init;
+  IdTableStatic<3> radixSorted = init;
+  std::sort(stdSorted.begin(), stdSorted.end(),
+            [](const auto& a, const auto& b) { return a[1] < b[1]; });
+  IdTable tmp = radixSorted.moveToDynamic();
+  Sort::sort<3>(&tmp, 1, ResultTable::ResultType::KB);
+  radixSorted = tmp.moveToStatic<3>();
+
+  ASSERT_EQ(stdSorted.size(), radixSorted.size());
+  size_t pos_radix = 0;
+  // Use an unordered set to allow for comparisons of the two sorted arrays
+  // without the sorting being stable.
+  std::unordered_set<std::array<Id, 3>> current_block;
+  for (size_t i = 0; i < stdSorted.size();) {
+    size_t v = stdSorted[i][1];
+    size_t num = 0;
+    current_block.clear();
+    while (i < stdSorted.size() && stdSorted[i][1] == v) {
+      current_block.insert(stdSorted[i]);
+      i++;
+      num++;
+    }
+    for (size_t j = 0; j < num; j++) {
+      ASSERT_EQ(v, radixSorted[pos_radix][1]);
+      ASSERT_TRUE(current_block.find(radixSorted[pos_radix]) !=
+                  current_block.end());
+      pos_radix++;
+    }
+  }
+}


### PR DESCRIPTION
This pr adds radixsort using a modified version of (kxsort)[https://github.com/voutcn/kxsort]. In the current implementation radix sort is only used for single column sorts on `KB`, `LOCAL_VOCAB` and `VERBATIM` columns.