### PR TITLE
Make externalization more configurable

### DIFF
--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -12,6 +12,11 @@
 // binary and will be created from this file
 const std::string EXTERNAL_LITS_TEXT_FILE_NAME = ".externalized-text";
 
+// Determines the maximum number of bytes of an internal literal (before
+// compression). Every literal larger as this size is externalized regardless
+// of its language tag
+static const size_t MAX_INTERNAL_LITERAL_BYTES = 100;
+
 // How many lines are parsed at once during index creation.
 // Reduce to save RAM
 static const int NUM_TRIPLES_PER_PARTIAL_VOCAB = 100000000;

--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -15,7 +15,7 @@ const std::string EXTERNAL_LITS_TEXT_FILE_NAME = ".externalized-text";
 // Determines the maximum number of bytes of an internal literal (before
 // compression). Every literal larger as this size is externalized regardless
 // of its language tag
-static const size_t MAX_INTERNAL_LITERAL_BYTES = 100;
+static const size_t MAX_INTERNAL_LITERAL_BYTES = 1024;
 
 // How many lines are parsed at once during index creation.
 // Reduce to save RAM

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -1788,6 +1788,12 @@ void Index::readConfiguration() {
     _vocab.initializeExternalizePrefixes(
         _configurationJson["prefixes-external"]);
   }
+
+  if (_configurationJson.find("languages-internal") !=
+      _configurationJson.end()) {
+    _vocab.initializeInternalizedLangs(
+        _configurationJson["languages-internal"]);
+  }
 }
 
 // ___________________________________________________________________________
@@ -1823,6 +1829,11 @@ void Index::initializeVocabularySettingsBuild() {
   if (j.find("prefixes-external") != j.end()) {
     _vocab.initializeExternalizePrefixes(j["prefixes-external"]);
     _configurationJson["prefixes-external"] = j["prefixes-external"];
+  }
+
+  if (j.find("languages-internal") != j.end()) {
+    _vocab.initializeInternalizedLangs(j["languages-internal"]);
+    _configurationJson["languages-internal"] = j["languages-internal"];
   }
 }
 

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -96,6 +96,7 @@ class Vocabulary {
   template <
       typename = std::enable_if_t<std::is_same_v<StringType, string> ||
                                   std::is_same_v<StringType, CompressedString>>>
+
   Vocabulary(){};
 
   // variable for dispatching
@@ -260,10 +261,11 @@ class Vocabulary {
   static bool isLiteral(const string& word);
   static bool isExternalizedLiteral(const string& word);
 
-  template <bool isEntity = false>
   bool shouldBeExternalized(const string& word) const;
 
   bool shouldEntityBeExternalized(const string& word) const;
+
+  bool shouldLiteralBeExternalized(const string& word) const;
 
   // only still needed for text vocabulary
   template <typename = std::enable_if_t<!_isCompressed>>
@@ -306,6 +308,15 @@ class Vocabulary {
   // works
   template <class StringRange>
   void initializeExternalizePrefixes(const StringRange& prefixes);
+
+  // set the list of languages (in "en" language code format) that should be
+  // kept internalized. By default this is just English
+  //
+  // StringRange prefixes can be of any type where
+  // for (const string& el : prefixes {}
+  // works
+  template <class StringRange>
+  void initializeInternalizedLangs(const StringRange& prefixes);
 
   // Compress the file at path infile, write to file at outfile using the
   // specified prefixes.
@@ -396,6 +407,10 @@ class Vocabulary {
 
   // If a word starts with one of those prefixes it will be externalized
   vector<std::string> _externalizedPrefixes;
+
+  // If a word uses one of these language tags it will be internalized,
+  // defaults to English
+  vector<std::string> _internalizedLangs{"en"};
 
   vector<StringType> _words;
   ExternalVocabulary _externalLiterals;

--- a/src/index/VocabularyImpl.h
+++ b/src/index/VocabularyImpl.h
@@ -146,25 +146,12 @@ bool Vocabulary<S>::isExternalizedLiteral(const string& word) {
 
 // _____________________________________________________________________________
 template <class S>
-template <bool isEntity>
 bool Vocabulary<S>::shouldBeExternalized(const string& word) const {
-  if constexpr (isEntity) {
-    return shouldEntityBeExternalized(word);
-  }
-
   if (!isLiteral(word)) {
     return shouldEntityBeExternalized(word);
   } else {
-    if (word.size() > MAX_INTERNAL_LITERAL_BYTES) {
-      return true;
-    }
-    string lang = getLanguage(word);
-    if (lang != "") {
-      return (lang != "en");  // && lang != "en_gb" && lang != "en_us" &&
-      // lang != "de" && lang != "es" && lang != "fr");
-    }
+    return shouldLiteralBeExternalized(word);
   }
-  return false;
 }
 
 // ___________________________________________________________________
@@ -178,6 +165,25 @@ bool Vocabulary<S>::shouldEntityBeExternalized(const string& word) const {
   return false;
 }
 
+// ___________________________________________________________________
+template <class S>
+bool Vocabulary<S>::shouldLiteralBeExternalized(const string& word) const {
+  if (word.size() > MAX_INTERNAL_LITERAL_BYTES) {
+    return true;
+  }
+
+  const string lang = getLanguage(word);
+  if (lang == "") {
+    return false;
+  }
+
+  for (const auto& p : _internalizedLangs) {
+    if (lang == p) {
+      return false;
+    }
+  }
+  return true;
+}
 // _____________________________________________________________________________
 template <class S>
 string Vocabulary<S>::getLanguage(const string& literal) {
@@ -256,6 +262,16 @@ void Vocabulary<S>::initializeExternalizePrefixes(const StringRange& s) {
   _externalizedPrefixes.clear();
   for (const auto& el : s) {
     _externalizedPrefixes.push_back(el);
+  }
+}
+
+// ______________________________________________________________________________
+template <class S>
+template <class StringRange>
+void Vocabulary<S>::initializeInternalizedLangs(const StringRange& s) {
+  _internalizedLangs.clear();
+  for (const auto& el : s) {
+    _internalizedLangs.push_back(el);
   }
 }
 

--- a/src/index/VocabularyImpl.h
+++ b/src/index/VocabularyImpl.h
@@ -270,9 +270,7 @@ template <class S>
 template <class StringRange>
 void Vocabulary<S>::initializeInternalizedLangs(const StringRange& s) {
   _internalizedLangs.clear();
-  for (const auto& el : s) {
-    _internalizedLangs.push_back(el);
-  }
+  _internalizedLangs.insert(_internalizedLangs.begin(), s.begin(), s.end());
 }
 
 // __________________________________________________________________________

--- a/src/index/VocabularyImpl.h
+++ b/src/index/VocabularyImpl.h
@@ -155,7 +155,7 @@ bool Vocabulary<S>::shouldBeExternalized(const string& word) const {
   if (!isLiteral(word)) {
     return shouldEntityBeExternalized(word);
   } else {
-    if (word.size() > 100) {
+    if (word.size() > MAX_INTERNAL_LITERAL_BYTES) {
       return true;
     }
     string lang = getLanguage(word);

--- a/wikidata_settings.json
+++ b/wikidata_settings.json
@@ -1,0 +1,8 @@
+{
+  "languages-internal": ["en"],
+  "prefixes-external": [
+    "<http://www.wikidata.org/entity/statement",
+    "<http://www.wikidata.org/value",
+    "<http://www.wikidata.org/reference"
+  ]
+}


### PR DESCRIPTION
This enables index build time configuration of which languages to keep in the internal vocabulary. Also the maximum number of bytes for internalized literals is turned into a constant. Finally I want to test increasing this for Wikidata to speed up extracting all entity labels on Wikidata and other large mappings.