### PR TITLE
F.case insensitive label sorting

### DIFF
--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "Filter.h"
+#include <algorithm>
 #include <optional>
 #include <regex>
 #include <sstream>
@@ -504,6 +505,39 @@ void Filter::computeResultFixedValue(
         rhs_string = ad_utility::convertValueLiteralToIndexWord(rhs_string);
       } else if (ad_utility::isNumeric(_rhs)) {
         rhs_string = ad_utility::convertNumericToIndexWord(rhs_string);
+      } else {
+        if (getIndex().getVocab().getCaseInsensitiveOrdering()) {
+          // We have to move to the correct end of the
+          // "same letters but different case" - range
+          // to make the filters work
+          // TODO<kalmbach, schnelle>: thoroughly test this
+          // (End-To-End or unit tests? probably both but the unit tests
+          // would also be in an end-to-end fashion for those nested
+          // mechanisms).
+          switch (_type) {
+            case SparqlFilter::GE:
+            case SparqlFilter::LT: {
+              rhs_string = ad_utility::getUppercaseUtf8(rhs_string);
+              auto split = StringSortComparator::extractComparable(rhs_string);
+              if (split.isLiteral && !split.langtag.empty()) {
+                // get rid of possible langtags to move to the beginning of the
+                // range
+                rhs_string = '\"' + std::string(split.val) + '\"';
+              }
+            }
+
+            break;
+            case SparqlFilter::GT:
+            case SparqlFilter::LE: {
+              rhs_string = ad_utility::getLowercaseUtf8(rhs_string);
+              auto split2 = StringSortComparator::extractComparable(rhs_string);
+              if (split2.isLiteral) {
+                rhs_string =
+                    '\"' + std::string(split2.val) + '\"' + "@" + char(127);
+              }
+            } break;
+          }
+        }
       }
       if (_type == SparqlFilter::EQ || _type == SparqlFilter::NE) {
         if (!getIndex().getVocab().getId(_rhs, &rhs)) {

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -536,6 +536,8 @@ void Filter::computeResultFixedValue(
                     '\"' + std::string(split2.val) + '\"' + "@" + char(127);
               }
             } break;
+            default:
+              break;
           }
         }
       }

--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -50,3 +50,6 @@ static const size_t THRESHOLD_RELATION_CREATION = 2 << 20;
 // ________________________________________________________________
 static const std::string PARTIAL_VOCAB_FILE_NAME = ".partial-vocabulary";
 static const std::string PARTIAL_MMAP_IDS = ".partial-ids-mmap";
+
+// ________________________________________________________________
+static const std::string TMP_BASENAME_COMPRESSION = ".tmp.compression_index";

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -494,6 +494,24 @@ class Index {
   VocabularyData passFileForVocabulary(const string& ntFile,
                                        size_t linesPerPartial = 100000000);
 
+  /**
+   * @brief Everything that has to be done when we have seen all the triples
+   * that belong to one partial vocabulary, including Log output used inside
+   * passFileForVocabulary
+   *
+   * @param numLines How many Lines from the KB have we already parsed (only for
+   * Logging)
+   * @param numFiles How many partial vocabularies have we seen before/which is
+   * the index of the voc we are going to write
+   * @param actualCurrentPartialSize How many triples belong to this partition
+   * (including extra langfilter triples)
+   * @param items Contains our unsorted vocabulary. Maps words to their local
+   * ids within this vocabulary.
+   */
+  void writeNextPartialVocabulary(size_t numLines, size_t numFiles,
+                                  size_t actualCurrentPartialSize,
+                                  const ad_utility::HashMap<string, Id>& items);
+
   void convertPartialToGlobalIds(TripleVec& data,
                                  const vector<size_t>& actualLinesPerPartial,
                                  size_t linesPerPartial);

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -207,6 +207,8 @@ int main(int argc, char** argv) {
         cout << endl
              << "! ERROR in processing options (getopt returned '" << c
              << "' = 0x" << std::setbase(16) << c << ")" << endl
+             << "Corresponding ascii option : -" << std::string(1, c) << endl
+             << "This is either an unsupported option or there was an error"
              << endl;
         exit(1);
     }

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -10,6 +10,7 @@
 #include "../global/Id.h"
 #include "../util/HashMap.h"
 #include "../util/MmapVector.h"
+#include "Vocabulary.h"
 
 using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
@@ -24,12 +25,15 @@ using std::string;
 // Literals
 // Returns the number of total Words merged and via the parameters
 // the lower and upper bound of language tagged predicates
+// Argument comp gives the way to order strings (case-sensitive or not)
 size_t mergeVocabulary(const std::string& basename, size_t numFiles,
-                       Id* langPredLowerBound, Id* langPredUpperBound);
+                       Id* langPredLowerBound, Id* langPredUpperBound,
+                       StringSortComparator comp);
 
 // _________________________________________________________________________________________
 void writePartialIdMapToBinaryFileForMerging(
-    const ad_utility::HashMap<string, Id>& map, const string& fileName);
+    const ad_utility::HashMap<string, Id>& map, const string& fileName,
+    StringSortComparator comp);
 
 // _________________________________________________________________________________________
 ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(

--- a/src/index/VocabularyImpl.h
+++ b/src/index/VocabularyImpl.h
@@ -97,7 +97,7 @@ void Vocabulary<S>::createFromSet(const ad_utility::HashSet<S>& set) {
   _words.reserve(set.size());
   _words.insert(begin(_words), begin(set), end(set));
   LOG(INFO) << "... sorting ...\n";
-  std::sort(begin(_words), end(_words));
+  std::sort(begin(_words), end(_words), _caseComparator);
   LOG(INFO) << "Done creating vocabulary.\n";
 }
 
@@ -119,8 +119,9 @@ template <class S>
 template <typename>
 void Vocabulary<S>::externalizeLiterals(const string& fileName) {
   LOG(INFO) << "Externalizing literals..." << std::endl;
-  auto ext = std::lower_bound(_words.begin(), _words.end(),
-                              string({EXTERNALIZED_LITERALS_PREFIX}));
+  auto ext =
+      std::lower_bound(_words.begin(), _words.end(),
+                       string({EXTERNALIZED_LITERALS_PREFIX}), _caseComparator);
   size_t nofInternal = ext - _words.begin();
   vector<string> extVocab;
   while (ext != _words.end()) {
@@ -293,9 +294,16 @@ bool PrefixComparator<S>::operator()(const string& lhs,
 template <class S>
 bool PrefixComparator<S>::operator()(const string& lhs,
                                      const string& rhs) const {
-  // TODO<joka921> use string_view for the substrings
-  return (lhs.size() > _prefixLength ? lhs.substr(0, _prefixLength) : lhs) <
-         (rhs.size() > _prefixLength ? rhs.substr(0, _prefixLength) : rhs);
+  // we cannot use string_views as parameters as they will unfortunately lead
+  // to ambiguous overloads (even though the CompressedString overload wouldn't
+  // work.
+  return _vocab->getCaseComparator()(
+      lhs.size() > _prefixLength
+          ? std::string_view(lhs).substr(0, _prefixLength)
+          : lhs,
+      rhs.size() > _prefixLength
+          ? std::string_view(rhs).substr(0, _prefixLength)
+          : rhs);
 }
 
 // _____________________________________________________

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -68,9 +68,9 @@ inline string getLowercase(const string& orig);
 
 inline string getUppercase(const string& orig);
 
-inline string getLowercaseUtf8(const string& orig);
+inline string getLowercaseUtf8(std::string_view orig);
 
-inline string getUppercaseUtf8(const string& orig);
+inline string getUppercaseUtf8(std::string_view orig);
 
 inline string firstCharToUpperUtf8(const string& orig);
 
@@ -234,7 +234,7 @@ string getUppercase(const string& orig) {
 }
 
 // ____________________________________________________________________________
-string getLowercaseUtf8(const string& orig) {
+string getLowercaseUtf8(std::string_view orig) {
   string retVal;
   retVal.reserve(orig.size());
   std::mbstate_t state = std::mbstate_t();
@@ -263,7 +263,7 @@ string getLowercaseUtf8(const string& orig) {
 }
 
 // ____________________________________________________________________________
-string getUppercaseUtf8(const string& orig) {
+string getUppercaseUtf8(std::string_view orig) {
   string retVal;
   retVal.reserve(orig.size());
   std::mbstate_t state = std::mbstate_t();

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -191,7 +191,8 @@ class MergeVocabularyTest : public ::testing::Test {
 TEST_F(MergeVocabularyTest, bla) {
   // mergeVocabulary only gets name of directory and number of files.
   Id langPredLowerBound, langPredUpperBound;
-  mergeVocabulary(_basePath, 2, &langPredLowerBound, &langPredUpperBound);
+  mergeVocabulary(_basePath, 2, &langPredLowerBound, &langPredUpperBound,
+                  StringSortComparator());
   // No language tags in text file
   ASSERT_EQ(langPredLowerBound, 0ul);
   ASSERT_EQ(langPredUpperBound, 0ul);
@@ -207,4 +208,54 @@ TEST_F(MergeVocabularyTest, bla) {
   ASSERT_TRUE(vocabTestCompare(mapping0, _expMapping0));
   IdPairMMapVecView mapping1(_basePath + PARTIAL_MMAP_IDS + std::to_string(1));
   ASSERT_TRUE(vocabTestCompare(mapping1, _expMapping1));
+}
+
+TEST(VocabularyGenerator, ReadAndWritePartial) {
+  {
+    ad_utility::HashMap<string, Id> s;
+    s["A"] = 5;
+    s["a"] = 6;
+    s["Ba"] = 7;
+    s["car"] = 8;
+    Vocabulary<string> v;
+    std::string basename = "_tmp_testidx";
+    writePartialIdMapToBinaryFileForMerging(
+        s, basename + PARTIAL_VOCAB_FILE_NAME + "0", v.getCaseComparator());
+    Id tmp1;
+    Id tmp2;
+
+    mergeVocabulary(basename, 1, &tmp1, &tmp2, v.getCaseComparator());
+    auto idMap = IdMapFromPartialIdMapFile(basename + PARTIAL_MMAP_IDS + "0");
+    ASSERT_EQ(0u, idMap[5]);
+    ASSERT_EQ(1u, idMap[7]);
+    ASSERT_EQ(2u, idMap[6]);
+    ASSERT_EQ(3u, idMap[8]);
+    auto res = system("rm _tmp_testidx*");
+    (void)res;
+  }
+
+  // again with the case insensitive variant.
+  {
+    ad_utility::HashMap<string, Id> s;
+    s["A"] = 5;
+    s["a"] = 6;
+    s["Ba"] = 7;
+    s["car"] = 8;
+    Vocabulary<string> v;
+    v.setCaseInsensitiveOrdering(true);
+    std::string basename = "_tmp_testidx";
+    writePartialIdMapToBinaryFileForMerging(
+        s, basename + PARTIAL_VOCAB_FILE_NAME + "0", v.getCaseComparator());
+    Id tmp1;
+    Id tmp2;
+
+    mergeVocabulary(basename, 1, &tmp1, &tmp2, v.getCaseComparator());
+    auto idMap = IdMapFromPartialIdMapFile(basename + PARTIAL_MMAP_IDS + "0");
+    ASSERT_EQ(0u, idMap[5]);
+    ASSERT_EQ(1u, idMap[6]);
+    ASSERT_EQ(2u, idMap[7]);
+    ASSERT_EQ(3u, idMap[8]);
+    auto res = system("rm _tmp_testidx*");
+    (void)res;
+  }
 }

--- a/wikidata_settings.json
+++ b/wikidata_settings.json
@@ -4,5 +4,6 @@
     "<http://www.wikidata.org/entity/statement",
     "<http://www.wikidata.org/value",
     "<http://www.wikidata.org/reference"
-  ]
+  ],
+  "ignore-case": true
 }


### PR DESCRIPTION
Allow case-insensitive ordering/filtering as a index-build-time option.

- setting "ignore-case: true" in the settings.json will enable this setting for the index build.
- Entity Names in triples have to match exactly.
- All filters for string values are done in a case-insensitive manner (this includes the prefix filters for autocompletion)