### PR TITLE
Fix assertion failure in getFollowBlockForLhs() (#206)

### DIFF
--- a/src/index/MetaDataTypes.cpp
+++ b/src/index/MetaDataTypes.cpp
@@ -139,14 +139,15 @@ pair<off_t, size_t> BlockBasedRelationMetaData::getFollowBlockForLhs(
       _blocks.begin(), _blocks.end(), lhs,
       [](const BlockMetaData& a, Id lhs) { return a._firstLhs < lhs; });
 
-  // Go back one block unless perfect lhs match.
-  if (it == _blocks.end() || it->_firstLhs > lhs) {
-    AD_CHECK(it != _blocks.begin());
-    it--;
+  if (it == _blocks.begin() && it->_firstLhs > lhs) {
+    // We have an empty result as the first element of the first block
+    // is already too big. Indicate like hitting the end
+    AD_CHECK(false);
+    return {it->_startOffset, _startRhs - it->_startOffset};
   }
 
-  // Advance one block again is possible
-  if ((it + 1) != _blocks.end()) {
+  // Advance one block if we can and we don't have a perfect match
+  if (it != _blocks.end() && it->_firstLhs == lhs) {
     ++it;
   }
 


### PR DESCRIPTION
This is currently WiP, the first commit is in preparation for tackling the assertion failure in #206.
Turns out fixing this function looks a bit harder as it's not clear what
to return so the rest doesn't crash. Currently the offending query
triggers the AD_CHECK(false) so we still need to figure out what to do
about it