### PR TITLE
Bugfix on the refactor PR

### DIFF
--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -913,7 +913,7 @@ void Index::createFromOnDiskIndex(const string& onDiskBase) {
   _OPS.loadFromDisk(_onDiskBase);
   _OSP.loadFromDisk(_onDiskBase);
   _SPO.loadFromDisk(_onDiskBase);
-  _SPO.loadFromDisk(_onDiskBase);
+  _SOP.loadFromDisk(_onDiskBase);
 
   if (_usePatterns) {
     // Read the pattern info from the patterns file

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -43,8 +43,8 @@ class PermutationImpl {
                    "this file. If it does not exist, your index is broken.");
     }
     _meta.readFromFile(&_file);
-    LOG(INFO) << "Registered SPO permutation: " << _meta.statistics()
-              << std::endl;
+    LOG(INFO) << "Registered " << _readableName
+              << " permutation: " << _meta.statistics() << std::endl;
   }
 
   // _______________________________________________________

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -324,7 +324,7 @@ class MmapVectorView : private MmapVector<T> {
 
   // explicitly close the vector to an unitialized state and free the associated
   // ressources
-  void close() { MmapVector<T>::close(); }
+  void close();
 
   // destructor
   ~MmapVectorView() { close(); }

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -353,4 +353,17 @@ MmapVectorView<T>& MmapVectorView<T>::operator=(
   return *this;
 }
 
+template <class T>
+void MmapVectorView<T>::close() {
+  // we need the correct size to make the file persistent
+  if (this->_ptr != nullptr) {
+    MmapVector<T>::unmap();
+  }
+  this->_filename = "";
+  this->_size = 0;
+  this->_ptr = nullptr;
+  this->_bytesize = 0;
+  this->_capacity = 0;
+}
+
 }  // namespace ad_utility


### PR DESCRIPTION
- We opened the same permutation twice and another not at all

- This triggered another bug in the MmapVectorView that inherited a non-const method from MmapVector where it shouldn't have.

This addresses #218 