### PR TITLE
Remove all temporary files that are created by the IndexBuilder

### DIFF
--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -713,4 +713,14 @@ class Index {
     }
     LOG(INFO) << "Done" << std::endl;
   }
+
+  /**
+   * Delete a temporary file unless the _keepTempFiles flag is set
+   * @param path
+   */
+  void deleteTemporaryFile(const string& path) {
+    if (!_keepTempFiles) {
+      ad_utility::deleteFile(path);
+    }
+  }
 };

--- a/src/index/VocabularyGenerator.cpp
+++ b/src/index/VocabularyGenerator.cpp
@@ -41,7 +41,7 @@ class QueueCompare {
 // ___________________________________________________________________
 size_t mergeVocabulary(const std::string& basename, size_t numFiles,
                        Id* langPredLowerBound, Id* langPredUpperBound) {
-  std::vector<std::fstream> infiles;
+  std::vector<std::ifstream> infiles;
 
   // we will store pairs of <partialId, globalId>
   std::vector<IdPairMMapVec> idVecs;
@@ -56,8 +56,8 @@ size_t mergeVocabulary(const std::string& basename, size_t numFiles,
 
   // open and prepare all infiles and mmap output vectors
   for (size_t i = 0; i < numFiles; i++) {
-    infiles.emplace_back(basename + PARTIAL_VOCAB_FILE_NAME + std::to_string(i),
-                         std::ios_base::in | std::ios_base::out);
+    infiles.emplace_back(basename + PARTIAL_VOCAB_FILE_NAME +
+                         std::to_string(i));
     idVecs.emplace_back(0, basename + PARTIAL_MMAP_IDS + std::to_string(i));
     AD_CHECK(infiles.back().is_open());
 

--- a/src/util/BufferedVector.h
+++ b/src/util/BufferedVector.h
@@ -14,6 +14,7 @@ namespace ad_utility {
 // is big The switching threshold can be set when creating the vector Currently
 // only push_back and clear are supported (+ all kinds of access to existing
 // elements) Can be trivially extended to complete the interface
+// The backup file is temporary and will be deleted in the destructor
 template <class T>
 class BufferedVector {
  public:
@@ -109,6 +110,6 @@ class BufferedVector {
 
   // the two possible data storages
   std::vector<T> _vec;
-  ad_utility::MmapVector<T> _extVec;
+  ad_utility::MmapVectorTmp<T> _extVec;
 };
 }  // namespace ad_utility

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "./Exception.h"
+#include "Log.h"
 
 using std::cerr;
 using std::cout;
@@ -244,4 +245,19 @@ class File {
     return (stat(path.c_str(), &buffer) == 0);
   }
 };
+
+/**
+ * @brief Delete the file at a given path
+ * Currently uses the linux rm command until we support std::filesystem
+ * @param path
+ */
+inline void deleteFile(const string& path) {
+  // TODO<all>: As soon as we have GCC 8, we can use std::filesystem
+  string command = "rm -- " + path;
+  if (system(command.c_str())) {
+    LOG(WARN) << "Deletion of file " << path << " was probably not successful"
+              << std::endl;
+  }
+}
+
 }  // namespace ad_utility

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <sstream>
 #include "../util/Exception.h"
+#include "File.h"
 
 using std::string;
 
@@ -332,5 +333,25 @@ class MmapVectorView : private MmapVector<T> {
   // _____________________________________________________________
   std::string getFilename() const { return this->_filename; }
 };
+
+// MmapVector that deletes the underlying file on destruction.
+// This is the only difference to the ordinary MmapVector(which is persistent)
+template <class T>
+class MmapVectorTmp : public MmapVector<T> {
+ public:
+  using MmapVector<T>::MmapVector;
+
+  // If we still own a file, delete it after cleaning up
+  // everything else
+  ~MmapVectorTmp() {
+    // if the filename is not empty, we still own a file
+    std::string oldFilename = this->_filename;
+    this->close();
+    if (!oldFilename.empty()) {
+      ad_utility::deleteFile(oldFilename);
+    }
+  }
+};
+
 }  // namespace ad_utility
 #include "./MmapVectorImpl.h"


### PR DESCRIPTION
- use a function for this, that can easily be changed when we have std::filesystem support.

- Includes a version of MmapVector called MmapVectorTmp that automatically deletes its backup file on destruction

Adresses #215 