### PR TITLE
removed -a key from dockerfile CMD and quickstart docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ VOLUME ["/input", "/index"]
 ENV INDEX_PREFIX index
 # Need the shell to get the INDEX_PREFIX envirionment variable
 ENTRYPOINT ["/bin/sh", "-c", "exec ServerMain -i \"/index/${INDEX_PREFIX}\" -p 7001 \"$@\"", "--"]
-CMD ["-t", "-a"]
+CMD ["-t"]
 
 # docker build -t qlever-<name> .
 # # When running with user namespaces you may need to make the index folder accessible

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,7 @@ Base.
     docker run -it --rm \
         -v "$(pwd)/scientists:/input" \
         -v "$(pwd)/index:/index" --entrypoint "bash" qlever
-    qlever@xyz:/app$ IndexBuilderMain -a -l -i /index/scientists \
+    qlever@xyz:/app$ IndexBuilderMain -l -i /index/scientists \
         -n /input/scientists.nt \
         -w /input/scientists.wordsfile.tsv \
         -d /input/scientists.docsfile.tsv


### PR DESCRIPTION
After the commit 863e7aa59c9e4ebd1840732eed4dc3a1defc37c2 the -a key was removed, this broke default docker file and quick start commands