### PR TITLE
Fix TEXT(?t) broken by sentinel removal (#238)

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -14,10 +14,35 @@ queries:
       - num_cols: 3
       - num_rows: 1653
       - selected: ["?x", "SCORE(?t)", "TEXT(?t)"]
-#null cells are ignored
-      - contains_row: ["<Albert_Einstein>", null, null]
+      - contains_row:
+        - "<Albert_Einstein>"
+        - 169
+        - "He realized, however, that the principle of relativity could also be extended
+          to gravitational fields, and with his subsequent theory of gravitation in 1916,
+          he published a paper on general relativity."
+      - contains_row: ["<Albert_Einstein>", null, null] # null cells are ignored
       - contains_row: ["<Luís_Lindley_Cintra>", null, null] # Test Unicode
       - order_numeric: {"dir" : "DESC", "var": "SCORE(?t)"}
+  - query: relativ-star-scientists-from-ulm  # should use TextOperationWithFilter
+    type: text
+    sparql: |
+      SELECT ?x SCORE(?t) TEXT(?t) WHERE {
+          ?x <is-a> <Scientist> .
+          ?x <Place_of_birth> <Ulm> .
+          ?t ql:contains-entity ?x .
+          ?t ql:contains-word "relati*"
+      }
+      ORDER BY DESC(SCORE(?t))
+    checks:
+      - num_cols: 3
+      - num_rows: 1
+      - selected: ["?x", "SCORE(?t)", "TEXT(?t)"]
+      - contains_row:
+        - "<Albert_Einstein>"
+        - 169
+        - "He realized, however, that the principle of relativity could also be extended
+          to gravitational fields, and with his subsequent theory of gravitation in 1916,
+          he published a paper on general relativity."
   - query: algo-star-female-scientists
     type: text
     sparql: |
@@ -34,6 +59,27 @@ queries:
       - selected: ["?x", "SCORE(?t)"]
       - contains_row: ["<Grete_Hermann>"]
       - order_numeric: {"dir": "DESC", "var" : "SCORE(?t)"}
+  - query: algor-start-female-born-before-1940
+    type: text
+    sparql: |
+      SELECT ?x ?date SCORE(?t) TEXT(?t) WHERE {
+        ?x <is-a> <Scientist> .
+        ?x <Date_of_birth> ?date .
+        ?x <Gender> <Female> .
+        ?t ql:contains-entity ?x .
+        ?t ql:contains-word "algor*" .
+
+        FILTER (?date < "1940-01-01"^^xsd:date)
+      }
+      ORDER BY DESC(SCORE(?t))
+    checks:
+      - num_cols: 4
+      - num_rows: 3
+      - contains_row:
+        - "<Grete_Hermann>"
+        - "1901-03-02T00:00:00"
+        - 1
+        - "Hermann's algorithm for primary decomposition is still in use now."
   - query: scientists-from-new-york
     type: no-text
     sparql: |

--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -87,7 +87,7 @@ void FTSAlgorithms::intersect(const vector<Id>& matchingContexts,
       // If there are multiple elements for that context in l1,
       // we can safely skip them unless we want to incorporate the scores
       // later on.
-      resultCids.push_back(matchingContexts[j]);
+      resultCids.push_back(eBlockCids[j]);
       resultEids.push_back(eBlockWids[j]);
       resultScores.push_back(eBlockScores[j]);
       j++;


### PR DESCRIPTION
The first commit adds an e2e test showing the problem. This version is therefore expected to fail CI!

The second commit fixes what turns out to be a mix up of variables which got better names in a6b47759bef18c23175a81093561722b34df588c
