### PR TITLE
Fixed getFilteredECListForWords ignoring the first occurence of an entity.

### DIFF
--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -726,10 +726,9 @@ void Index::getFilteredECListForWords(const string& words,
       Id eid = filter(i, filterColumn);
       auto it = fMap.find(eid);
       if (it == fMap.end()) {
-        fMap[eid] = IdTable(filter.cols());
-      } else {
-        it->second.push_back(filter, i);
+        it = fMap.insert(std::make_pair(eid, IdTable(filter.cols()))).first;
       }
+      it->second.push_back(filter, i);
     }
     vector<Id> cids;
     vector<Id> eids;


### PR DESCRIPTION
When updating getFilteredECListForWords to IdTables I apparently messed up the building of the filter HashMap used to map entity ids to their row in the filter table. When the filter table is size 1 another optimized method that uses a HashSet is used instead, which is why this didn't affect #240 .
This should fix #239, but I haven't been able to test this on wikidata yet. @niklas88 is there an easy way of testing this?