### PR TITLE
Move .stxxl file into index directory

### DIFF
--- a/src/index/CreatePatternsMain.cpp
+++ b/src/index/CreatePatternsMain.cpp
@@ -49,7 +49,10 @@ string getStxxlDiskFileName(const string& location, const string& tail) {
 // depends on the structure of words files rather than their size only,
 // because of the "multiplications" performed.
 void writeStxxlConfigFile(const string& location, const string& tail) {
-  ad_utility::File stxxlConfig(getStxxlConfigFileName(location), "w");
+  string stxxlConfigFileName = getStxxlConfigFileName(location);
+  ad_utility::File stxxlConfig(stxxlConfigFileName, "w");
+  // Inform stxxl about .stxxl location
+  setenv("STXXLCFG", stxxlConfigFileName.c_str(), true);
   std::ostringstream config;
   config << "disk=" << getStxxlDiskFileName(location, tail) << ","
          << STXXL_DISK_SIZE_INDEX_BUILDER << ",syscall";

--- a/src/index/CreatePatternsMain.cpp
+++ b/src/index/CreatePatternsMain.cpp
@@ -30,6 +30,12 @@ struct option options[] = {{"help", no_argument, NULL, 'h'},
                            {"index-basename", required_argument, NULL, 'i'},
                            {NULL, 0, NULL, 0}};
 
+string getStxxlConfigFileName(const string& location) {
+  std::ostringstream os;
+  os << location << ".stxxl";
+  return os.str();
+}
+
 string getStxxlDiskFileName(const string& location, const string& tail) {
   std::ostringstream os;
   os << location << tail << "-stxxl.disk";
@@ -39,11 +45,11 @@ string getStxxlDiskFileName(const string& location, const string& tail) {
 // Write a .stxxl config-file.
 // All we want is sufficient space somewhere with enough space.
 // We can use the location of input files and use a constant size for now.
-// The required size can only ben estimation anyway, since index size
+// The required size can only be estimated anyway, since index size
 // depends on the structure of words files rather than their size only,
 // because of the "multiplications" performed.
 void writeStxxlConfigFile(const string& location, const string& tail) {
-  ad_utility::File stxxlConfig(".stxxl", "w");
+  ad_utility::File stxxlConfig(getStxxlConfigFileName(location), "w");
   std::ostringstream config;
   config << "disk=" << getStxxlDiskFileName(location, tail) << ","
          << STXXL_DISK_SIZE_INDEX_BUILDER << ",syscall";

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -64,7 +64,10 @@ string getStxxlDiskFileName(const string& location, const string& tail) {
 // depends on the structure of words files rather than their size only,
 // because of the "multiplications" performed.
 void writeStxxlConfigFile(const string& location, const string& tail) {
-  ad_utility::File stxxlConfig(getStxxlConfigFileName(location), "w");
+  string stxxlConfigFileName = getStxxlConfigFileName(location);
+  ad_utility::File stxxlConfig(stxxlConfigFileName, "w");
+  // Inform stxxl about .stxxl location
+  setenv("STXXLCFG", stxxlConfigFileName.c_str(), true);
   std::ostringstream config;
   config << "disk=" << getStxxlDiskFileName(location, tail) << ","
          << STXXL_DISK_SIZE_INDEX_BUILDER << ",syscall";

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -45,6 +45,12 @@ struct option options[] = {
     {"no-compressed-vocabulary", no_argument, NULL, 'N'},
     {NULL, 0, NULL, 0}};
 
+string getStxxlConfigFileName(const string& location) {
+  std::ostringstream os;
+  os << location << ".stxxl";
+  return os.str();
+}
+
 string getStxxlDiskFileName(const string& location, const string& tail) {
   std::ostringstream os;
   os << location << tail << "-stxxl.disk";
@@ -54,11 +60,11 @@ string getStxxlDiskFileName(const string& location, const string& tail) {
 // Write a .stxxl config-file.
 // All we want is sufficient space somewhere with enough space.
 // We can use the location of input files and use a constant size for now.
-// The required size can only ben estimation anyway, since index size
+// The required size can only be estimated anyway, since index size
 // depends on the structure of words files rather than their size only,
 // because of the "multiplications" performed.
 void writeStxxlConfigFile(const string& location, const string& tail) {
-  ad_utility::File stxxlConfig(".stxxl", "w");
+  ad_utility::File stxxlConfig(getStxxlConfigFileName(location), "w");
   std::ostringstream config;
   config << "disk=" << getStxxlDiskFileName(location, tail) << ","
          << STXXL_DISK_SIZE_INDEX_BUILDER << ",syscall";

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -27,7 +27,10 @@ string getStxxlDiskFileName(const string& location, const string& tail) {
 // depends on the structure of words files rather than their size only,
 // because of the "multiplications" performed.
 void writeStxxlConfigFile(const string& location, const string& tail) {
-  ad_utility::File stxxlConfig(getStxxlConfigFileName(location), "w");
+  string stxxlConfigFileName = getStxxlConfigFileName(location);
+  ad_utility::File stxxlConfig(stxxlConfigFileName, "w");
+  // Inform stxxl about .stxxl location
+  setenv("STXXLCFG", stxxlConfigFileName.c_str(), true);
   std::ostringstream config;
   config << "disk=" << getStxxlDiskFileName(location, tail) << ","
          << STXXL_DISK_SIZE_INDEX_TEST << ",syscall";

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -8,6 +8,12 @@
 #include "../src/global/Pattern.h"
 #include "../src/index/Index.h"
 
+string getStxxlConfigFileName(const string& location) {
+  std::ostringstream os;
+  os << location << ".stxxl";
+  return os.str();
+}
+
 string getStxxlDiskFileName(const string& location, const string& tail) {
   std::ostringstream os;
   os << location << tail << "-stxxl.disk";
@@ -17,11 +23,11 @@ string getStxxlDiskFileName(const string& location, const string& tail) {
 // Write a .stxxl config-file.
 // All we want is sufficient space somewhere with enough space.
 // We can use the location of input files and use a constant size for now.
-// The required size can only ben estimation anyway, since index size
+// The required size can only be estimated anyway, since index size
 // depends on the structure of words files rather than their size only,
 // because of the "multiplications" performed.
 void writeStxxlConfigFile(const string& location, const string& tail) {
-  ad_utility::File stxxlConfig(".stxxl", "w");
+  ad_utility::File stxxlConfig(getStxxlConfigFileName(location), "w");
   std::ostringstream config;
   config << "disk=" << getStxxlDiskFileName(location, tail) << ","
          << STXXL_DISK_SIZE_INDEX_TEST << ",syscall";


### PR DESCRIPTION
When the `.stxxl` file is generated where the binaries are stored some docker setups (related to `--user`/`userns`) can result in the following error:
```
IndexBuilderMain, version Apr 25 2019 10:35:41

Set locale LC_CTYPE to: C.UTF-8
Thu May  9 09:45:38.627	- DEBUG: Configuring STXXL...
terminate called after throwing an instance of 'std::runtime_error'
  what():  ! ERROR opening file ".stxxl" with mode "w" (Permission denied)
```

This pullrequest changes the location of the `.stxxl` file to reside in the index directory next to the disk file so write permissions there hopefully suffices to run the respective binaries.