### PR TITLE
Fix ORDER BY and FILTER on COUNT() columns #247

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -608,4 +608,21 @@ queries:
       - selected: ["?p", "?count"]
       - contains_row: ["<Hall_of_fame_induction>", 1] 
       - contains_row: ["<Weight>", 1]
+  - query: birth-place-group-count-order
+    type: no-text
+    sparql: |
+      SELECT ?place (COUNT(?person) AS ?count) WHERE {
+        ?person <is-a> <Person> .
+        ?person <Place_of_birth> ?place
+      }
+      GROUP BY ?place
+      HAVING (?count > 5)
+      ORDER BY ASC(?count)
+    checks:
+      - num_cols: 2
+      #- num_rows: 5296 # We currently limit to 4096
+      - selected: ["?place", "?count"]
+      - contains_row: ["<Aachen>", 8]
+      - contains_row: ["<Aarhus>", 6]
+      - order_numeric: {"dir" : "ASC", "var": "?count"}
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -69,12 +69,11 @@ string GroupBy::getDescriptor() const {
 size_t GroupBy::getResultWidth() const { return _varColMap.size(); }
 
 vector<size_t> GroupBy::resultSortedOn() const {
+  auto varCols = getVariableColumns();
   vector<size_t> sortedOn;
-  ad_utility::HashMap<string, size_t> subtreeVarCols =
-      _subtree->getVariableColumns();
-  sortedOn.reserve(subtreeVarCols.size());
+  sortedOn.reserve(_groupByVariables.size());
   for (std::string var : _groupByVariables) {
-    sortedOn.push_back(subtreeVarCols[var]);
+    sortedOn.push_back(varCols[var]);
   }
   return sortedOn;
 }
@@ -92,7 +91,6 @@ vector<pair<size_t, bool>> GroupBy::computeSortColumns(
 
   std::unordered_set<size_t> sortColSet;
 
-  // The returned columns are all groupByVariables followed by aggregrates
   for (std::string var : _groupByVariables) {
     size_t col = inVarColMap[var];
     // avoid sorting by a column twice
@@ -101,6 +99,7 @@ vector<pair<size_t, bool>> GroupBy::computeSortColumns(
       cols.push_back({col, false});
     }
   }
+
   for (const ParsedQuery::Alias& a : _aliases) {
     size_t col = inVarColMap[a._inVarName];
     if (sortColSet.find(col) == sortColSet.end()) {


### PR DESCRIPTION
This PR fixes #247. Where the first commit just adds a reproducer query to the end to end tests.

It turns out the underlying issue is that the `GroupBy` operation would use the subtree column indexes to indicate which columns are already sorted. Upstream operations could then assume a wrong pre-existing order and turn `HAVING` into a binary search on unsorted data or assume an `ORDER BY` to be a no-op.