### PR TITLE
Fix getVariableColumns() for TwoColumnJoin fixes #256

### DIFF
--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -109,8 +109,6 @@ void TwoColumnJoin::computeResult(ResultTable* result) {
         rightFilter ? rightResult->_data : leftResult->_data;
     size_t jc1 = rightFilter ? _jc1Left : _jc1Right;
     size_t jc2 = rightFilter ? _jc2Left : _jc2Right;
-    // TODO(schnelle) Are we sorted on both columns? The old code only had jc1
-    // here but we do add OrderBy on both
     result->_sortedBy = {jc1, jc2};
     result->_data.setCols(toFilter->_data.cols());
     result->_resultTypes.reserve(result->_data.cols());

--- a/src/engine/TwoColumnJoin.h
+++ b/src/engine/TwoColumnJoin.h
@@ -42,7 +42,10 @@ class TwoColumnJoin : public Operation {
       return _left->getSizeEstimate() + _left->getCostEstimate() +
              _right->getSizeEstimate() + _right->getCostEstimate();
     }
-    // PUNISH IF NO DIRECT JOIN IS AVAILABLE FOR FILTER
+    // The case where the above condition does not hold is currently
+    // not implemented so really don't use it!
+    // Important: The / 1000000 prevents overflow
+    // TODO(schnelle) this is pretty fragile
     return std::numeric_limits<size_t>::max() / 1000000;
   }
 


### PR DESCRIPTION
TwoColumnJoin currently only implements a special case. The more general
case is prevented from use by a high cost (this is the current state of
affairs not introduced by this PR).

However for that special case the column mapping was bogus. The old code
assumed that the columns are both sides concatenated with the join
columns removed from the right side. So the same as for normal Join.
However with the special case one side is only join columns and we take
the column mapping always from the other side.

This is still a bit more ugly than I'd like but it's a clear improvement over the
current state, also the way the non-implemented case was avoided with a large cost
is at least better documented now.