### PR TITLE
Don't crash on empty index. Fixes #262

### DIFF
--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -561,17 +561,21 @@ void Index::createPatternsImpl(const string& fileName,
   typedef std::unordered_map<Pattern, size_t> PatternsCountMap;
 
   LOG(INFO) << "Creating patterns file..." << std::endl;
-  PatternsCountMap patternCounts;
+  VecReaderType reader(vecReaderArgs...);
+  if (reader.empty()) {
+    LOG(WARN) << "Triple vector was empty, no patterns created" << std::endl;
+    return;
+  }
 
+  PatternsCountMap patternCounts;
   // determine the most common patterns
   Pattern pattern;
 
   size_t patternIndex = 0;
-  Id currentSubj;
-  currentSubj = (*VecReaderType(vecReaderArgs...))[0];
   size_t numValidPatterns = 0;
+  Id currentSubj = (*reader)[0];
 
-  for (VecReaderType reader(vecReaderArgs...); !reader.empty(); ++reader) {
+  for (; !reader.empty(); ++reader) {
     auto triple = *reader;
     if (triple[0] != currentSubj) {
       currentSubj = triple[0];


### PR DESCRIPTION
There is already several warnings but since we continue trying all steps
even on an empty index we really shouldn't crash.

We can still think about just refusing to process empty input but then
again it's always nice when things "work" even in special cases.

No matter what we do crashing isn't right