### PR TITLE
Fix FILTER (lang(…) = …) for predicate paths #276

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -8,6 +8,7 @@
 #include <ctime>
 
 #include "../parser/ParseException.h"
+#include "../parser/ParsedQuery.h"
 #include "CountAvailablePredicates.h"
 #include "Distinct.h"
 #include "Filter.h"
@@ -954,15 +955,6 @@ void QueryPlanner::getVarTripleMap(
   }
 }
 
-// _____________________________________________________________________________
-bool QueryPlanner::isVariable(const string& elem) {
-  return ad_utility::startsWith(elem, "?");
-}
-
-bool QueryPlanner::isVariable(const PropertyPath& elem) {
-  return elem._operation == PropertyPath::Operation::IRI &&
-         isVariable(elem._iri);
-}
 // _____________________________________________________________________________
 QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
     std::shared_ptr<const ParsedQuery::GraphPattern> pattern) const {

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -190,9 +190,6 @@ class QueryPlanner {
 
   bool _enablePatternTrick;
 
-  static bool isVariable(const string& elem);
-  static bool isVariable(const PropertyPath& elem);
-
   std::vector<SubtreePlan> optimize(
       std::shared_ptr<const ParsedQuery::GraphPattern> pattern);
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -76,6 +76,15 @@ class PropertyPath {
   bool _can_be_null;
 };
 
+inline bool isVariable(const string& elem) {
+  return ad_utility::startsWith(elem, "?");
+}
+
+inline bool isVariable(const PropertyPath& elem) {
+  return elem._operation == PropertyPath::Operation::IRI &&
+         isVariable(elem._iri);
+}
+
 std::ostream& operator<<(std::ostream& out, const PropertyPath& p);
 
 // Data container for parsed triples from the where clause

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -806,7 +806,7 @@ void SparqlParser::addLangFilter(
     const std::string& lhs, const std::string& rhs,
     std::shared_ptr<ParsedQuery::GraphPattern> pattern) {
   auto langTag = rhs.substr(1, rhs.size() - 2);
-  // First find a suitabke triple for the given variable. It
+  // First find a suitable triple for the given variable. It
   // must use a predicate that is not a variable or complex
   // predicate path
   auto it =


### PR DESCRIPTION
 Improve FILTER (lang(… for predicate paths #276

We were trying to use language tagged predicates on predicate paths.
Instead if the predicate path isn't simple we have to fallback on using
language predicates on the literal variable.

This change also means that if a predicate path mixes predicates with
literal subjects and non-literal subjects we only get the literals when
`FILTER (lang(?var) = "…")` is used.

The spec at https://www.w3.org/TR/sparql11-query/#func-lang

doesn't make it clear what should happen when applied to a non-literal.
Our behaviour matches the Wikidata Query Service though.