### PR TITLE
Caching Improvements (Old version with memory size limit, discard)

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -197,6 +197,6 @@ void QueryExecutionTree::readFromCache() {
   auto& cache = _qec->getQueryTreeCache();
   std::shared_ptr<const CacheValue> res = cache[asString()];
   if (res) {
-    _cachedResult = cache[asString()]->_resTable;
+    _cachedResult = cache[asString()]->resTable;
   }
 }

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -34,6 +34,3 @@ string ResultTable::asDebugString() const {
   }
   return os.str();
 }
-
-// _____________________________________________________________________________
-size_t ResultTable::size() const { return _data.size(); }

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -109,7 +109,11 @@ class ResultTable {
     return std::nullopt;
   }
 
-  size_t size() const;
+  size_t size() const { return _data.size(); };
+
+  size_t rows() const { return _data.rows(); };
+
+  size_t cols() const { return _data.cols(); };
 
   void clear();
 

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -9,7 +9,7 @@ static const size_t STXXL_MEMORY_TO_USE = 1024L * 1024L * 1024L * 2L;
 static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000 * 1000;
 static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 
-static const size_t NOF_SUBTREES_TO_CACHE = 1000;
+static const size_t CACHE_SIZE_BYTES = 1024L * 1024L * 1024L * 20L;  // 20 GB
 static const size_t MAX_NOF_ROWS_IN_RESULT = 100000;
 static const size_t MIN_WORD_PREFIX_SIZE = 4;
 static const char PREFIX_CHAR = '*';

--- a/src/util/LRUCache.h
+++ b/src/util/LRUCache.h
@@ -149,6 +149,19 @@ class LRUCache {
     return _accessMap.count(key) > 0;
   }
 
+  //! Erase an item from the cache if it exists, do nothing otherwise
+  void erase(const Key& key) {
+    std::lock_guard<std::mutex> lock(_lock);
+    const auto mapIt = _accessMap.find(key);
+    if (mapIt == _accessMap.end()) {
+      // Item already erased do nothing
+      return;
+    }
+    const auto listIt = mapIt->second;
+    _data.erase(listIt);
+    _accessMap.erase(mapIt);
+  }
+
   //! Clear the cache
   void clear() {
     std::lock_guard<std::mutex> lock(_lock);


### PR DESCRIPTION
The theory behind caching aborted Operations was that they would fail
again anyway. However, under memory pressure Operations may fail due to
failing allocations and will succeed in the future once memory pressure
drops, if we kept them in the cache we wouldn't try again.

While we are at it, improve wording and use an extra abort() method on
Operation.

As a next step we should make the cache limited by the amount of memory not the number of cached results.