### PR TITLE
Improve Caching

### DIFF
--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -140,6 +140,7 @@ int main(int argc, char** argv) {
   try {
     Engine engine;
     Index index;
+    SubtreeCache cache(NOF_SUBTREES_TO_CACHE);
     index.setUsePatterns(usePatterns);
     index.setOnDiskLiterals(onDiskLiterals);
     index.createFromOnDiskIndex(indexName);
@@ -147,7 +148,7 @@ int main(int argc, char** argv) {
       index.addTextFromOnDiskIndex();
     }
 
-    QueryExecutionContext qec(index, engine);
+    QueryExecutionContext qec(index, engine, &cache);
     if (costFactosFileName.size() > 0) {
       qec.readCostFactorsFromTSVFile(costFactosFileName);
     }

--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -201,7 +201,7 @@ void processQuery(QueryExecutionContext& qec, const string& query) {
   auto qet = qp.createExecutionTree(pq);
   timer.stop();
   LOG(INFO) << "Time to create Execution Tree: " << timer.msecs() << "ms\n";
-  LOG(INFO) << "Execution Tree: " << qet.asString() << "ms\n";
+  LOG(INFO) << "Execution Tree: " << qet->asString() << "ms\n";
   size_t limit = MAX_NOF_ROWS_IN_RESULT;
   size_t offset = 0;
   if (pq._limit.size() > 0) {
@@ -210,10 +210,10 @@ void processQuery(QueryExecutionContext& qec, const string& query) {
   if (pq._offset.size() > 0) {
     offset = static_cast<size_t>(atol(pq._offset.c_str()));
   }
-  qet.writeResultToStream(cout, pq._selectedVariables, limit, offset);
+  qet->writeResultToStream(cout, pq._selectedVariables, limit, offset);
   t.stop();
   std::cout << "\nDone. Time: " << t.usecs() / 1000.0 << " ms\n";
-  size_t numMatches = qet.getResult()->size();
+  size_t numMatches = qet->getResult()->size();
   std::cout << "\nNumber of matches (no limit): " << numMatches << "\n";
   size_t effectiveLimit =
       atoi(pq._limit.c_str()) > 0 ? atoi(pq._limit.c_str()) : numMatches;

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -87,7 +87,8 @@ int main(int argc, char** argv) {
     index.dumpAsciiLists(lists, decodeGapsAndFrequency);
 
     Engine engine;
-    QueryExecutionContext qec(index, engine);
+    SubtreeCache cache(NOF_SUBTREES_TO_CACHE);
+    QueryExecutionContext qec(index, engine, &cache);
     ParsedQuery q;
     if (!freebase) {
       q = SparqlParser("SELECT ?x WHERE {?x <is-a> <Scientist>}").parse();

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
     }
     QueryPlanner queryPlanner(&qec);
     auto qet = queryPlanner.createExecutionTree(q);
-    const auto res = qet.getResult();
+    const auto res = qet->getResult();
     AD_CHECK(res->size() > 0);
     AD_CHECK(res->_data.cols() == 1);
     string personlistFile = indexName + ".list.scientists";

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -127,18 +127,97 @@ vector<size_t> IndexScan::resultSortedOn() const {
 // _____________________________________________________________________________
 ad_utility::HashMap<string, size_t> IndexScan::getVariableColumns() const {
   ad_utility::HashMap<string, size_t> res;
-  size_t colIdx = 0;
-  if (_subject[0] == '?') {
-    res[_subject] = colIdx++;
-  }
-  if (_predicate[0] == '?') {
-    res[_predicate] = colIdx++;
-  }
+  size_t col = 0;
 
-  if (_object[0] == '?') {
-    res[_object] = colIdx++;
+  switch (_type) {
+    case SPO_FREE_P:
+    case FULL_INDEX_SCAN_SPO:
+      if (_subject[0] == '?') {
+        res[_subject] = col++;
+      }
+      if (_predicate[0] == '?') {
+        res[_predicate] = col++;
+      }
+
+      if (_object[0] == '?') {
+        res[_object] = col++;
+      }
+      return res;
+    case SOP_FREE_O:
+    case SOP_BOUND_O:
+    case FULL_INDEX_SCAN_SOP:
+      if (_subject[0] == '?') {
+        res[_subject] = col++;
+      }
+
+      if (_object[0] == '?') {
+        res[_object] = col++;
+      }
+
+      if (_predicate[0] == '?') {
+        res[_predicate] = col++;
+      }
+      return res;
+    case PSO_BOUND_S:
+    case PSO_FREE_S:
+    case FULL_INDEX_SCAN_PSO:
+      if (_predicate[0] == '?') {
+        res[_predicate] = col++;
+      }
+      if (_subject[0] == '?') {
+        res[_subject] = col++;
+      }
+
+      if (_object[0] == '?') {
+        res[_object] = col++;
+      }
+      return res;
+    case POS_BOUND_O:
+    case POS_FREE_O:
+    case FULL_INDEX_SCAN_POS:
+      if (_predicate[0] == '?') {
+        res[_predicate] = col++;
+      }
+
+      if (_object[0] == '?') {
+        res[_object] = col++;
+      }
+
+      if (_subject[0] == '?') {
+        res[_subject] = col++;
+      }
+      return res;
+    case OPS_FREE_P:
+    case FULL_INDEX_SCAN_OPS:
+      if (_object[0] == '?') {
+        res[_object] = col++;
+      }
+
+      if (_predicate[0] == '?') {
+        res[_predicate] = col++;
+      }
+
+      if (_subject[0] == '?') {
+        res[_subject] = col++;
+      }
+      return res;
+    case OSP_FREE_S:
+    case FULL_INDEX_SCAN_OSP:
+      if (_object[0] == '?') {
+        res[_object] = col++;
+      }
+
+      if (_subject[0] == '?') {
+        res[_subject] = col++;
+      }
+
+      if (_predicate[0] == '?') {
+        res[_predicate] = col++;
+      }
+      return res;
+    default:
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED, "Should be unreachable.");
   }
-  return res;
 }
 // _____________________________________________________________________________
 void IndexScan::computeResult(ResultTable* result) {

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -42,9 +42,12 @@ class Operation {
     timer.start();
     auto& cache = _executionContext->getQueryTreeCache();
     const string cacheKey = asString();
+    const bool pinResult = _executionContext->pin;
     LOG(TRACE) << "Check cache for Operation result" << endl;
     LOG(TRACE) << "Using key: \n" << cacheKey << endl;
-    auto [newResult, existingResult] = cache.tryEmplace(cacheKey);
+    auto [newResult, existingResult] = (pinResult)
+                                           ? cache.tryEmplacePinned(cacheKey)
+                                           : cache.tryEmplace(cacheKey);
 
     if (newResult) {
       LOG(TRACE) << "Not in the cache, need to compute result" << endl;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -22,7 +22,7 @@ using std::shared_ptr;
 class Operation {
  public:
   // Default Constructor.
-  Operation() : _executionContext(NULL), _hasComputedSortColumns(false) {}
+  Operation() : _executionContext(nullptr), _hasComputedSortColumns(false) {}
 
   // Typical Constructor.
   explicit Operation(QueryExecutionContext* executionContext)
@@ -40,10 +40,11 @@ class Operation {
   shared_ptr<const ResultTable> getResult() {
     ad_utility::Timer timer;
     timer.start();
+    auto& cache = _executionContext->getQueryTreeCache();
+    const string cacheKey = asString();
     LOG(TRACE) << "Check cache for Operation result" << endl;
-    LOG(TRACE) << "Using key: \n" << asString() << endl;
-    auto [newResult, existingResult] =
-        _executionContext->getQueryTreeCache().tryEmplace(asString());
+    LOG(TRACE) << "Using key: \n" << cacheKey << endl;
+    auto [newResult, existingResult] = cache.tryEmplace(cacheKey);
 
     if (newResult) {
       LOG(TRACE) << "Not in the cache, need to compute result" << endl;
@@ -128,11 +129,6 @@ class Operation {
     cachedResult->_resTable->abort();
   }
 
-  // Set the QueryExecutionContext for this particular element.
-  void setQueryExecutionContext(QueryExecutionContext* executionContext) {
-    _executionContext = executionContext;
-  }
-
   /**
    * @return A list of columns on which the result of this operation is sorted.
    */
@@ -195,6 +191,7 @@ class Operation {
   virtual void computeResult(ResultTable* result) = 0;
 
   vector<size_t> _resultSortedColumns;
-  bool _hasComputedSortColumns;
   RuntimeInformation _runtimeInfo;
+
+  bool _hasComputedSortColumns;
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -162,10 +162,6 @@ class Operation {
   RuntimeInformation& getRuntimeInfo() { return _runtimeInfo; }
 
  protected:
-  QueryExecutionContext* getExecutionContext() const {
-    return _executionContext;
-  }
-
   // The QueryExecutionContext for this particular element.
   // No ownership.
   QueryExecutionContext* _executionContext;

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -32,19 +32,17 @@ typedef ad_utility::LRUCache<string, CacheValue> SubtreeCache;
 // Holds references to index and engine, implements caching.
 class QueryExecutionContext {
  public:
-  QueryExecutionContext(const Index& index, const Engine& engine)
-      : _subtreeCache(NOF_SUBTREES_TO_CACHE),
-        _index(index),
-        _engine(engine),
-        _costFactors() {}
+  QueryExecutionContext(const Index& index, const Engine& engine,
+                        SubtreeCache* const cache)
+      : _index(index), _engine(engine), _subtreeCache(cache), _costFactors() {}
 
-  SubtreeCache& getQueryTreeCache() { return _subtreeCache; }
+  SubtreeCache& getQueryTreeCache() { return *_subtreeCache; }
 
   const Engine& getEngine() const { return _engine; }
 
   const Index& getIndex() const { return _index; }
 
-  void clearCache() { _subtreeCache.clear(); }
+  void clearCache() { getQueryTreeCache().clear(); }
 
   void readCostFactorsFromTSVFile(const string& fileName) {
     _costFactors.readFromFile(fileName);
@@ -55,8 +53,8 @@ class QueryExecutionContext {
   };
 
  private:
-  SubtreeCache _subtreeCache;
   const Index& _index;
   const Engine& _engine;
+  SubtreeCache* const _subtreeCache;
   QueryPlanningCostFactors _costFactors;
 };

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -33,8 +33,13 @@ typedef ad_utility::LRUCache<string, CacheValue> SubtreeCache;
 class QueryExecutionContext {
  public:
   QueryExecutionContext(const Index& index, const Engine& engine,
-                        SubtreeCache* const cache)
-      : _index(index), _engine(engine), _subtreeCache(cache), _costFactors() {}
+                        SubtreeCache* const cache,
+                        const bool pinSubtrees = false)
+      : pin(pinSubtrees),
+        _index(index),
+        _engine(engine),
+        _subtreeCache(cache),
+        _costFactors() {}
 
   SubtreeCache& getQueryTreeCache() { return *_subtreeCache; }
 
@@ -51,6 +56,8 @@ class QueryExecutionContext {
   float getCostFactor(const string& key) const {
     return _costFactors.getCostFactor(key);
   };
+
+  const bool pin;
 
  private:
   const Index& _index;

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -2,7 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
-#include "./QueryExecutionTree.h"
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -11,6 +10,7 @@
 #include "./IndexScan.h"
 #include "./Join.h"
 #include "./OrderBy.h"
+#include "./QueryExecutionTree.h"
 #include "./Sort.h"
 #include "TextOperationWithFilter.h"
 #include "TextOperationWithoutFilter.h"
@@ -19,7 +19,7 @@
 using std::string;
 
 // _____________________________________________________________________________
-QueryExecutionTree::QueryExecutionTree(QueryExecutionContext* qec)
+QueryExecutionTree::QueryExecutionTree(QueryExecutionContext* const qec)
     : _qec(qec),
       _variableColumnMap(),
       _rootOperation(nullptr),

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
+#include "./QueryExecutionTree.h"
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -10,7 +11,6 @@
 #include "./IndexScan.h"
 #include "./Join.h"
 #include "./OrderBy.h"
-#include "./QueryExecutionTree.h"
 #include "./Sort.h"
 #include "TextOperationWithFilter.h"
 #include "TextOperationWithoutFilter.h"

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -53,9 +53,9 @@ string QueryExecutionTree::asString(size_t indent) {
 
 // _____________________________________________________________________________
 void QueryExecutionTree::setOperation(QueryExecutionTree::OperationType type,
-                                      std::shared_ptr<Operation> op) {
+                                      std::unique_ptr<Operation> op) {
   _type = type;
-  _rootOperation = op;
+  _rootOperation = std::move(op);
   _asString = "";
   _sizeEstimate = std::numeric_limits<size_t>::max();
   // with setting the operation the initialization is done and we can try to
@@ -71,11 +71,12 @@ void QueryExecutionTree::setVariableColumn(const string& variable,
 
 // _____________________________________________________________________________
 size_t QueryExecutionTree::getVariableColumn(const string& variable) const {
-  if (_variableColumnMap.count(variable) == 0) {
+  const auto mapIt = _variableColumnMap.find(variable);
+  if (mapIt == _variableColumnMap.end()) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
              "Variable could not be mapped to result column. Var: " + variable);
   }
-  return _variableColumnMap.find(variable)->second;
+  return mapIt->second;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -21,7 +21,7 @@ using std::string;
 // needed to solve a query.
 class QueryExecutionTree {
  public:
-  explicit QueryExecutionTree(QueryExecutionContext* qec);
+  explicit QueryExecutionTree(QueryExecutionContext* const qec);
 
   enum OperationType {
     UNDEFINED = 0,
@@ -134,7 +134,7 @@ class QueryExecutionTree {
   void readFromCache();
 
  private:
-  QueryExecutionContext* _qec;  // No ownership
+  QueryExecutionContext* const _qec;  // No ownership
   ad_utility::HashMap<string, size_t> _variableColumnMap;
   std::unique_ptr<Operation>
       _rootOperation;  // Owned child. Will be deleted at deconstruction.

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -45,17 +45,17 @@ class QueryExecutionTree {
     VALUES = 18
   };
 
-  void setOperation(OperationType type, std::shared_ptr<Operation> op);
+  void setOperation(OperationType type, std::unique_ptr<Operation> op);
 
   string asString(size_t indent = 0);
-
-  QueryExecutionContext* getQec() const { return _qec; }
 
   const ad_utility::HashMap<string, size_t>& getVariableColumns() const {
     return _variableColumnMap;
   }
 
-  std::shared_ptr<Operation> getRootOperation() const { return _rootOperation; }
+  const std::unique_ptr<Operation>& getRootOperation() const {
+    return _rootOperation;
+  }
 
   const OperationType& getType() const { return _type; }
 
@@ -136,7 +136,7 @@ class QueryExecutionTree {
  private:
   QueryExecutionContext* _qec;  // No ownership
   ad_utility::HashMap<string, size_t> _variableColumnMap;
-  std::shared_ptr<Operation>
+  std::unique_ptr<Operation>
       _rootOperation;  // Owned child. Will be deleted at deconstruction.
   OperationType _type;
   std::unordered_set<string> _contextVars;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -14,7 +14,7 @@ class QueryPlanner {
  public:
   explicit QueryPlanner(QueryExecutionContext* qec);
 
-  QueryExecutionTree createExecutionTree(ParsedQuery& pq);
+  shared_ptr<QueryExecutionTree> createExecutionTree(ParsedQuery& pq);
 
   class TripleGraph {
    public:
@@ -298,7 +298,7 @@ class QueryPlanner {
                               const vector<SparqlFilter>& filters,
                               bool replaceInsteadOfAddPlans) const;
 
-  std::shared_ptr<Operation> createFilterOperation(
+  std::unique_ptr<Operation> createFilterOperation(
       const SparqlFilter& filter, const SubtreePlan& parent) const;
 
   vector<vector<SubtreePlan>> fillDpTab(

--- a/src/engine/ScanningJoin.cpp
+++ b/src/engine/ScanningJoin.cpp
@@ -6,34 +6,12 @@
 
 // _____________________________________________________________________________
 ScanningJoin::ScanningJoin(QueryExecutionContext* qec,
-                           const QueryExecutionTree& subtree,
+                           shared_ptr<QueryExecutionTree> subtree,
                            size_t subtreeJoinCol, IndexScan::ScanType scanType)
     : IndexScan(qec, scanType) {
-  _subtree = new QueryExecutionTree(subtree);
+  _subtree = subtree;
   _subtreeJoinCol = subtreeJoinCol;
 }
-
-// _____________________________________________________________________________
-ScanningJoin::ScanningJoin(const ScanningJoin& other)
-    : IndexScan(other._executionContext, other._type) {
-  _subtree = new QueryExecutionTree(*other._subtree);
-  _subtreeJoinCol = other._subtreeJoinCol;
-}
-
-// _____________________________________________________________________________
-ScanningJoin& ScanningJoin::operator=(const ScanningJoin& other) {
-  delete _subtree;
-  _subtree = new QueryExecutionTree(*other._subtree);
-  _subtreeJoinCol = other._subtreeJoinCol;
-  _subject = other._subject;
-  _predicate = other._predicate;
-  _object = other._object;
-  _type = other._type;
-  return *this;
-}
-
-// _____________________________________________________________________________
-ScanningJoin::~ScanningJoin() { delete _subtree; }
 
 // _____________________________________________________________________________
 string ScanningJoin::asString(size_t indent) const {

--- a/src/engine/ScanningJoin.h
+++ b/src/engine/ScanningJoin.h
@@ -15,14 +15,11 @@ using std::list;
 // by performing a scan for each row in the sub-result and thus creating
 // the result of the Join without ever scanning the full, huge relation.
 class ScanningJoin : public IndexScan {
-  ScanningJoin(QueryExecutionContext* qec, const QueryExecutionTree& subtree,
-               size_t subtreeJoinCol, IndexScan::ScanType scanType);
+  ScanningJoin(QueryExecutionContext* qec,
+               shared_ptr<QueryExecutionTree> subtree, size_t subtreeJoinCol,
+               IndexScan::ScanType scanType);
 
-  ScanningJoin(const ScanningJoin& other);
-
-  ScanningJoin& operator=(const ScanningJoin& other);
-
-  virtual ~ScanningJoin();
+  virtual ~ScanningJoin(){};
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -49,7 +46,7 @@ class ScanningJoin : public IndexScan {
   }
 
  private:
-  QueryExecutionTree* _subtree;
+  shared_ptr<QueryExecutionTree> _subtree;
   size_t _subtreeJoinCol;
   virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -161,13 +161,15 @@ void Server::process(Socket* client) {
         exit(0);
       }
 #endif
+      const bool pinSubtrees =
+          ad_utility::getLowercase(params["pinsubtrees"]) == "true";
       query = createQueryFromHttpParams(params);
-      bool pinSubtrees = params.find("pinall") != params.end();
-      LOG(INFO) << "Query:\n" << query << '\n';
+      LOG(INFO) << "Query" << ((pinSubtrees) ? " (Cache pinned): " : ": ")
+                << query << '\n';
       ParsedQuery pq = SparqlParser(query).parse();
       pq.expandPrefixes();
 
-      QueryExecutionContext qec(_index, _engine, &_cache);
+      QueryExecutionContext qec(_index, _engine, &_cache, pinSubtrees);
       QueryPlanner qp(&qec);
       qp.setEnablePatternTrick(_enablePatternTrick);
       auto qet = qp.createExecutionTree(pq);

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -57,17 +57,16 @@ void Server::run() {
     LOG(ERROR) << "Cannot start an uninitialized server!" << std::endl;
     exit(1);
   }
-  QueryExecutionContext qec(_index, _engine);
   std::vector<std::thread> threads;
   for (int i = 0; i < _numThreads; ++i) {
-    threads.emplace_back(&Server::runAcceptLoop, this, &qec);
+    threads.emplace_back(&Server::runAcceptLoop, this);
   }
   for (std::thread& worker : threads) {
     worker.join();
   }
 }
 // _____________________________________________________________________________
-void Server::runAcceptLoop(QueryExecutionContext* qec) {
+void Server::runAcceptLoop() {
   // Loop and wait for queries. Run forever, for now.
   while (true) {
     // Wait for new query
@@ -85,19 +84,19 @@ void Server::runAcceptLoop(QueryExecutionContext* qec) {
     }
     client.setKeepAlive(true);
     LOG(INFO) << "Incoming connection, processing..." << std::endl;
-    process(&client, qec);
+    process(&client);
     client.close();
   }
 }
 
 // _____________________________________________________________________________
-void Server::process(Socket* client, QueryExecutionContext* qec) const {
-  string response;
-  string query;
+void Server::process(Socket* client) {
   string contentType;
   LOG(DEBUG) << "Waiting for receive call to complete." << endl;
   string request;
+  string response;
   string headers;
+  string query;
   client->getHTTPRequest(request, headers);
   LOG(DEBUG) << "Got request from client with size: " << request.size()
              << " and headers with total size: " << headers.size() << endl;
@@ -147,7 +146,7 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
       }
 
       if (ad_utility::getLowercase(params["cmd"]) == "clearcache") {
-        qec->clearCache();
+        _cache.clear();
       }
       auto it = params.find("send");
       size_t maxSend = MAX_NOF_ROWS_IN_RESULT;
@@ -163,11 +162,13 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
       }
 #endif
       query = createQueryFromHttpParams(params);
+      bool pinSubtrees = params.find("pinall") != params.end();
       LOG(INFO) << "Query:\n" << query << '\n';
       ParsedQuery pq = SparqlParser(query).parse();
       pq.expandPrefixes();
 
-      QueryPlanner qp(qec);
+      QueryExecutionContext qec(_index, _engine, &_cache);
+      QueryPlanner qp(&qec);
       qp.setEnablePatternTrick(_enablePatternTrick);
       auto qet = qp.createExecutionTree(pq);
       LOG(TRACE) << qet->asString() << std::endl;
@@ -180,7 +181,7 @@ void Server::process(Socket* client, QueryExecutionContext* qec) const {
             "Content-Disposition: attachment;filename=export.csv";
       } else if (ad_utility::getLowercase(params["action"]) == "tsv_export") {
         // TSV export
-        response = composeResponseSepValues(pq, *qet, '\t');
+        string response = composeResponseSepValues(pq, *qet, '\t');
         contentType =
             "text/tsv\r\n"
             "Content-Disposition: attachment;filename=export.tsv";

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -28,6 +28,7 @@ class Server {
       : _numThreads(numThreads),
         _serverSocket(),
         _port(port),
+        _cache(NOF_SUBTREES_TO_CACHE),
         _index(),
         _engine(),
         _initialized(false) {}
@@ -48,15 +49,16 @@ class Server {
   const int _numThreads;
   Socket _serverSocket;
   int _port;
+  SubtreeCache _cache;
   Index _index;
   Engine _engine;
 
   bool _initialized;
   bool _enablePatternTrick;
 
-  void runAcceptLoop(QueryExecutionContext* qec);
+  void runAcceptLoop();
 
-  void process(Socket* client, QueryExecutionContext* qec) const;
+  void process(Socket* client);
 
   void serveFile(Socket* client, const string& requestedFile) const;
 

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -92,10 +92,10 @@ void TextOperationWithFilter::computeResult(ResultTable* result) {
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
   }
   if (filterResult->_data.cols() == 1) {
-    getExecutionContext()->getIndex().getFilteredECListForWordsWidthOne(
+    _executionContext->getIndex().getFilteredECListForWordsWidthOne(
         _words, filterResult->_data, getNofVars(), _textLimit, &result->_data);
   } else {
-    getExecutionContext()->getIndex().getFilteredECListForWords(
+    _executionContext->getIndex().getFilteredECListForWords(
         _words, filterResult->_data, _filterColumn, getNofVars(), _textLimit,
         &result->_data);
   }

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -77,8 +77,7 @@ void TextOperationWithoutFilter::computeResultNoVar(ResultTable* result) const {
   result->_data.setCols(2);
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);
   result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);
-  getExecutionContext()->getIndex().getContextListForWords(_words,
-                                                           &result->_data);
+  _executionContext->getIndex().getContextListForWords(_words, &result->_data);
 }
 
 // _____________________________________________________________________________
@@ -88,8 +87,8 @@ void TextOperationWithoutFilter::computeResultOneVar(
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);
   result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
-  getExecutionContext()->getIndex().getECListForWordsOneVar(_words, _textLimit,
-                                                            &result->_data);
+  _executionContext->getIndex().getECListForWordsOneVar(_words, _textLimit,
+                                                        &result->_data);
 }
 
 // _____________________________________________________________________________
@@ -102,8 +101,8 @@ void TextOperationWithoutFilter::computeResultMultVars(
   for (size_t i = 2; i < result->_data.cols(); i++) {
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
   }
-  getExecutionContext()->getIndex().getECListForWords(
-      _words, getNofVars(), _textLimit, &result->_data);
+  _executionContext->getIndex().getECListForWords(_words, getNofVars(),
+                                                  _textLimit, &result->_data);
 }
 
 // _____________________________________________________________________________

--- a/src/util/LRUCache.h
+++ b/src/util/LRUCache.h
@@ -149,6 +149,19 @@ class LRUCache {
     return _accessMap.count(key) > 0;
   }
 
+  //! Erase an item from the cache if it exists, do nothing otherwise
+  void erase(const Key& key) {
+    std::lock_guard<std::mutex> lock(_lock);
+    const auto mapIt = _accessMap.find(key);
+    if (mapIt == _accessMap.end()) {
+      // Item already erased do nothing
+      return;
+    }
+    const auto listIt = mapIt->second;
+    _data.erase(listIt);
+    _accessMap.erase(mapIt);
+  }
+
   //! Clear the cache
   void clear() {
     std::lock_guard<std::mutex> lock(_lock);

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -218,7 +218,8 @@ TEST(HasPredicateScan, subtreeS) {
 
   Index index;
   Engine engine;
-  QueryExecutionContext ctx(index, engine);
+  SubtreeCache cache(NOF_SUBTREES_TO_CACHE);
+  QueryExecutionContext ctx(index, engine, &cache);
 
   // create the subtree operation
   std::shared_ptr<QueryExecutionTree> subtree =

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -223,10 +223,10 @@ TEST(HasPredicateScan, subtreeS) {
   // create the subtree operation
   std::shared_ptr<QueryExecutionTree> subtree =
       std::make_shared<QueryExecutionTree>(&ctx);
-  std::shared_ptr<Operation> operation = std::make_shared<DummyOperation>(&ctx);
+  auto operation = std::make_unique<DummyOperation>(&ctx);
 
   subtree->setOperation(QueryExecutionTree::OperationType::HAS_RELATION_SCAN,
-                        operation);
+                        std::move(operation));
 
   std::shared_ptr<const ResultTable> subresult = subtree->getResult();
   int in_width = 2;

--- a/test/LRUCacheTest.cpp
+++ b/test/LRUCacheTest.cpp
@@ -10,7 +10,7 @@ using std::string;
 
 namespace ad_utility {
 // _____________________________________________________________________________
-TEST(LRUCacheTest, testTypicalUsage) {
+TEST(LRUCacheTest, testSimpleMapUsage) {
   LRUCache<string, string> cache(5);
   cache.insert("1", "x");
   cache.insert("2", "xx");
@@ -28,6 +28,26 @@ TEST(LRUCacheTest, testTypicalUsage) {
   ASSERT_FALSE(cache["non-existant"]);
 }
 // _____________________________________________________________________________
+TEST(LRUCacheTest, testSimpleMapUsageWithDrop) {
+  LRUCache<string, string> cache(3);
+  cache.insert("1", "x");
+  cache.insert("2", "xx");
+  cache.insert("3", "xxx");
+  cache.insert("4", "xxxx");
+  cache.insert("5", "xxxxx");
+
+  ASSERT_FALSE(cache["2"]);         // second oldest dropped
+  ASSERT_FALSE(cache["1"]);         // oldest dropped
+  ASSERT_EQ(*cache["5"], "xxxxx");  // not dropped
+  ASSERT_EQ(*cache["4"], "xxxx");   // not dropped
+  ASSERT_EQ(*cache["3"], "xxx");    // not dropped
+  cache.insert("6", "xxxxxx");
+  ASSERT_FALSE(cache["5"]);          // oldest access driooed
+  ASSERT_EQ(*cache["3"], "xxx");     // not dropped
+  ASSERT_EQ(*cache["4"], "xxxx");    // not dropped
+  ASSERT_EQ(*cache["6"], "xxxxxx");  // not dropped
+}
+// _____________________________________________________________________________
 TEST(LRUCacheTest, testTryEmplace) {
   LRUCache<string, string> cache(5);
   cache.insert("1", "x");
@@ -41,6 +61,64 @@ TEST(LRUCacheTest, testTryEmplace) {
   ASSERT_TRUE(emplaced);
   *emplaced += "bar";
   ASSERT_EQ(*cache["5"], "foobar");
+}
+// _____________________________________________________________________________
+TEST(LRUCacheTest, testTryEmplaceWithDrop) {
+  LRUCache<string, string> cache(3);
+  cache.insert("1", "x");
+  cache.insert("2", "xx");
+  ASSERT_FALSE(cache.tryEmplace("2", "foo").first);
+  ASSERT_EQ(*cache.tryEmplace("3", "bar").first, "bar");
+  auto emplaced = cache.tryEmplace("4", "foo").first;
+  ASSERT_TRUE(emplaced);
+  *emplaced += "bar";
+  ASSERT_EQ(*cache["4"], "foobar");
+  ASSERT_FALSE(cache["1"]);      // Dropped oldest
+  ASSERT_EQ(*cache["2"], "xx");  // Kept second oldest
+}
+// _____________________________________________________________________________
+TEST(LRUCacheTest, testTryEmplacePinnedSimple) {
+  LRUCache<string, string> cache(3);
+  ASSERT_EQ(*cache.tryEmplacePinned("pinned", "bar").first, "bar");
+  cache.insert("1", "x");
+  cache.insert("2", "xx");
+  cache.insert("3", "xxx");
+  cache.insert("4", "xxxx");
+  ASSERT_EQ(*cache["pinned"], "bar");  // pinned still there
+  ASSERT_FALSE(cache["1"]);            // oldest already gone
+  ASSERT_EQ(*cache["2"], "xx");  // not dropped because pinned not in capacity
+  ASSERT_EQ(*cache["pinned"], "bar");  // pinned still there
+}
+// _____________________________________________________________________________
+TEST(LRUCacheTest, testTryEmplacePinnedExisting) {
+  LRUCache<string, string> cache(2);
+  cache.insert("1", "x");
+  cache.insert("2", "xx");
+  // tryEmplacePinned on an existing element doesn't emplace but it does pin
+  ASSERT_FALSE(cache.tryEmplacePinned("2", "yy").first);
+  cache.insert("3", "xxx");
+  cache.insert("4", "xxxx");
+  cache.insert("5", "xxxxx");
+  ASSERT_FALSE(cache["1"]);         // oldest already gone
+  ASSERT_EQ(*cache["2"], "xx");     // pinned still there
+  ASSERT_FALSE(cache["3"]);         // third oldest not pinned and gone
+  ASSERT_EQ(*cache["4"], "xxxx");   // second newest still there
+  ASSERT_EQ(*cache["5"], "xxxxx");  // newest still there
+}
+
+// _____________________________________________________________________________
+TEST(LRUCacheTest, testTryEmplacePinnedClear) {
+  LRUCache<string, string> cache(3);
+  ASSERT_EQ(*cache.tryEmplacePinned("pinned", "bar").first, "bar");
+  cache.insert("1", "x");
+  cache.insert("2", "xx");
+  ASSERT_EQ(*cache["1"], "x");         // there
+  ASSERT_EQ(*cache["2"], "xx");        // there
+  ASSERT_EQ(*cache["pinned"], "bar");  // there
+  cache.clear();
+  ASSERT_FALSE(cache["1"]);            // gone
+  ASSERT_FALSE(cache["2"]);            // gone
+  ASSERT_EQ(*cache["pinned"], "bar");  // still there
 }
 
 // _____________________________________________________________________________
@@ -72,20 +150,23 @@ TEST(LRUCacheTest, testIncreasingCapacity) {
 TEST(LRUCacheTest, testDecreasingCapacity) {
   LRUCache<string, string> cache(10);
   cache.insert("1", "x");
-  cache.insert("2", "x");
-  cache.insert("3", "x");
-  cache.insert("4", "x");
-  cache.insert("5", "x");
+  cache.insert("2", "xx");
+  cache.insert("3", "xxx");
+  cache.insert("4", "xxxx");
+  cache.insert("5", "xxxxx");
   ASSERT_EQ(*cache["1"], "x");
-  ASSERT_EQ(*cache["2"], "x");
-  ASSERT_EQ(*cache["3"], "x");
-  ASSERT_EQ(*cache["4"], "x");
-  ASSERT_EQ(*cache["5"], "x");
-  cache.insert("9", "x");
-  cache.insert("10", "x");
-  cache.setCapacity(5);
-  ASSERT_EQ(*cache["9"], "x");
-  ASSERT_EQ(*cache["10"], "x");
+  ASSERT_EQ(*cache["2"], "xx");
+  ASSERT_EQ(*cache["3"], "xxx");
+  ASSERT_EQ(*cache["4"], "xxxx");
+  ASSERT_EQ(*cache["5"], "xxxxx");
+  cache.insert("9", "xxxxxxxxx");
+  cache.setCapacity(2);
+  ASSERT_EQ(*cache["9"], "xxxxxxxxx");  // freshly inserted
+  ASSERT_EQ(*cache["5"], "xxxxx");      // second leat recently used
+  ASSERT_FALSE(cache["1"]);
+  ASSERT_FALSE(cache["2"]);
+  ASSERT_FALSE(cache["3"]);
+  ASSERT_FALSE(cache["4"]);
 }
 }  // namespace ad_utility
 

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -520,11 +520,11 @@ TEST(QueryPlannerTest, testSPX) {
                        .parse();
   pq.expandPrefixes();
   QueryPlanner qp(nullptr);
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
+  auto qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
       "{\n  SCAN POS with P = \"<http://rdf.myprefix.com/myrel>\","
       " O = \"<http://rdf.myprefix.com/obj>\"\n  qet-width: 1 \n}",
-      qet.asString());
+      qet->asString());
 }
 
 TEST(QueryPlannerTest, testXPO) {
@@ -535,11 +535,11 @@ TEST(QueryPlannerTest, testXPO) {
                        .parse();
   pq.expandPrefixes();
   QueryPlanner qp(nullptr);
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
+  auto qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
       "{\n  SCAN PSO with P = \"<http://rdf.myprefix.com/myrel>\", "
       "S = \"<http://rdf.myprefix.com/subj>\"\n  qet-width: 1 \n}",
-      qet.asString());
+      qet->asString());
 }
 
 TEST(QueryPlannerTest, testSP_free_) {
@@ -550,11 +550,11 @@ TEST(QueryPlannerTest, testSP_free_) {
                        .parse();
   pq.expandPrefixes();
   QueryPlanner qp(nullptr);
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
+  auto qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
       "{\n  SCAN PSO with P = \"<http://rdf.myprefix.com/myrel>\"\n  "
       "qet-width: 2 \n}",
-      qet.asString());
+      qet->asString());
 }
 
 TEST(QueryPlannerTest, testSPX_SPX) {
@@ -566,13 +566,13 @@ TEST(QueryPlannerTest, testSPX_SPX) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN PSO with P = \"<pre/r>\", S = \"<pre/s1>\"\n "
         "   qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    S"
         "CAN PSO with P = \"<pre/r>\", S = \"<pre/s2>\"\n    qet-w"
         "idth: 1 \n  } join-column: [0]\n  qet-width: 1 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -591,13 +591,13 @@ TEST(QueryPlannerTest, test_free_PX_SPX) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with P = \"<pre/r>\"\n    "
         "qet-width: 2 \n  } join-column: [0]\n  |X|\n  {\n   "
         " SCAN PSO with P = \"<pre/r>\", S = \"<pre/s2>\"\n  "
         "  qet-width: 1 \n  } join-column: [0]\n  qet-width: 2 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -616,13 +616,13 @@ TEST(QueryPlannerTest, test_free_PX__free_PX) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with P = \"<pre/r>\"\n    "
         "qet-width: 2 \n  } join-column: [0]\n  |X|\n  {\n    "
         "SCAN POS with P = \"<pre/r>\"\n    qet-width: 2 \n"
         "  } join-column: [0]\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -643,7 +643,7 @@ TEST(QueryPlannerTest, testActorsBornInEurope) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with P = \"<pre/profession>\", "
         "O = \"<pre/Actor>\"\n    qet-width: 1 \n  } join-column:"
@@ -654,7 +654,7 @@ TEST(QueryPlannerTest, testActorsBornInEurope) {
         ", O = \"<pre/Europe>\"\n        qet-width: 1 \n      }"
         " join-column: [0]\n      qet-width: 2 \n    }\n    "
         "qet-width: 2 \n  } join-column: [1]\n  qet-width: 2 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -678,7 +678,7 @@ TEST(QueryPlannerTest, testStarTwoFree) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      QueryExecutionTree qet = qp.createExecutionTree(pq);
+      auto qet = qp.createExecutionTree(pq);
       ASSERT_EQ(
           "{\n  JOIN\n  {\n    JOIN\n    {\n      SCAN POS with P = \""
           "<http://rdf.myprefix.com/myrel>\"\n      qet-width: 2 \n "
@@ -689,7 +689,7 @@ TEST(QueryPlannerTest, testStarTwoFree) {
           "\"<http://rdf.myprefix.com/xxx/rel2>\", O = \"<http://a"
           "bc.de>\"\n    qet-width: 1 \n  } join-column: [0]\n  qet"
           "-width: 3 \n}",
-          qet.asString());
+          qet->asString());
     }
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -708,7 +708,7 @@ TEST(QueryPlannerTest, testFilterAfterSeed) {
                          "FILTER(?x != ?y) }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    FILTER     {\n      "
         "SCAN POS with P = \"<r>\"\n      qet-width: 2 \n   "
@@ -716,7 +716,7 @@ TEST(QueryPlannerTest, testFilterAfterSeed) {
         " join-column: [0]\n  |X|\n  {\n    SCAN PSO with P = \""
         "<r>\"\n    qet-width: 2 \n  } join-column: [0]\n "
         " qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -734,7 +734,7 @@ TEST(QueryPlannerTest, testFilterAfterJoin) {
                          "FILTER(?x != ?z) }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  FILTER   {\n    JOIN\n    {\n      "
         "SCAN POS with P = \"<r>\"\n      qet-width: 2 \n"
@@ -742,7 +742,7 @@ TEST(QueryPlannerTest, testFilterAfterJoin) {
         "SCAN PSO with P = \"<r>\"\n      qet-width: 2 \n"
         "    } join-column: [0]\n    qet-width: 3 \n  }"
         " with ?x != ?z\n\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -759,13 +759,13 @@ TEST(QueryPlannerTest, threeVarTriples) {
                          "<s> <p> ?x . ?x ?p ?o }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SPO (DUMMY OPERATION)\n   "
         " qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n    SCAN"
         " PSO with P = \"<p>\", S = \"<s>\"\n    qet-width: 1 \n  }"
         " join-column: [0]\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -780,13 +780,13 @@ TEST(QueryPlannerTest, threeVarTriples) {
                          "<s> ?x <o> . ?x ?p ?o }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SPO (DUMMY OP"
         "ERATION)\n    qet-width: 3 \n  } join-column: [0]"
         "\n  |X|\n  {\n    SCAN SOP with S = \"<s>\", O = \"<o>\"\n "
         "   qet-width: 1 \n  } join-column: [0]\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -801,13 +801,13 @@ TEST(QueryPlannerTest, threeVarTriples) {
                          "<s> <p> ?p . ?s ?p ?o }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX PSO (DUMMY OPERATION)\n"
         "    qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n "
         "   SCAN PSO with P = \"<p>\", S = \"<s>\"\n  "
         "  qet-width: 1 \n  } join-column: [0]\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -824,14 +824,14 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
                          "<s> ?p ?x . ?x ?p ?o }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TWO_COLUMN_JOIN\n    {\n    "
         "SCAN FOR FULL INDEX SPO (DUMMY OPERATION)\n    qet-width: 3 \n  }"
         "\n  join-columns: [0 & 1]\n  |X|\n    {\n    SCAN SOP with S ="
         " \"<s>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & 1]\n "
         " qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -846,14 +846,14 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
                          "?s ?p ?o . ?s ?p <x> }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN FOR FULL INDEX SPO"
         " (DUMMY OPERATION)\n    qet-width: 3 \n  }\n  join-"
         "columns: [0 & 1]\n  |X|\n    {\n    SCAN OSP with "
         "O = \"<x>\"\n    qet-width: 2 \n  }\n  join-columns"
         ": [0 & 1]\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -870,7 +870,7 @@ TEST(QueryPlannerTest, threeVarXthreeVarException) {
                          "?s ?p ?o . ?s2 ?p ?o }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     FAIL() << "Was expecting exception" << std::endl;
   } catch (const ad_semsearch::Exception& e) {
     ASSERT_EQ(
@@ -892,14 +892,14 @@ TEST(QueryExecutionTreeTest, testBooksbyNewman) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with "
         "P = \"<Author>\", O = \"<Anthony_Newman_(Author)>\"\n   "
         " qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n  "
         "  SCAN POS with P = \"<is-a>\", O = \"<Book>\"\n  "
         "  qet-width: 1 \n  } join-column: [0]\n  qet-width: 1 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -920,8 +920,8 @@ TEST(QueryExecutionTreeTest, testBooksGermanAwardNomAuth) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_GT(qet.asString().size(), 0u);
+    auto qet = qp.createExecutionTree(pq);
+    ASSERT_GT(qet->asString().size(), 0u);
     // Just check that ther is no exception, here.
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -944,14 +944,14 @@ TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
     QueryPlanner qp(nullptr);
     QueryPlanner::TripleGraph tg = qp.createTripleGraph(pq._rootGraphPattern);
     ASSERT_EQ(1u, tg._nodeMap.find(0)->second->_variables.size());
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TEXT OPERATION WITH FILTER: co-occurrence with words: "
         "\"edible leaves\" and 1 variables with textLimit = 5 "
         "filtered by\n  {\n    SCAN POS with P = \"<is-a>\", "
         "O = \"<Plant>\"\n    qet-width: 1 \n  }\n   filtered on "
         "column 0\n  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -969,12 +969,12 @@ TEST(QueryExecutionTreeTest, testTextQuerySE) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TEXT OPERATION WITHOUT FILTER: co-occurrence with words:"
         " \"search engine\" and 0 variables with textLimit = 1\n"
         "  qet-width: 2 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -998,7 +998,7 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TEXT OPERATION WITH FILTER: co-occurrence with words: "
         "\"cocaine\" and 1 variables with textLimit = 1 filtered by\n  "
@@ -1007,10 +1007,10 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
         "    |X|\n    {\n      SCAN POS with P = \"<Place_of_birth>\"\n"
         "      qet-width: 2 \n    } join-column: [0]\n    qet-width: 2 \n"
         "  }\n   filtered on column 1\n  qet-width: 4 \n}",
-        qet.asString());
-    ASSERT_EQ(0u, qet.getVariableColumn("?c"));
-    ASSERT_EQ(1u, qet.getVariableColumn("SCORE(?c)"));
-    ASSERT_EQ(2u, qet.getVariableColumn("?y"));
+        qet->asString());
+    ASSERT_EQ(0u, qet->getVariableColumn("?c"));
+    ASSERT_EQ(1u, qet->getVariableColumn("SCORE(?c)"));
+    ASSERT_EQ(2u, qet->getVariableColumn("?y"));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1033,14 +1033,14 @@ TEST(QueryExecutionTreeTest, testCoOccFreeVar) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TEXT OPERATION WITH FILTER: co-occurrence with words: "
         "\"friend*\" and 2 variables with textLimit = 1 filtered by\n"
         "  {\n    SCAN POS with P = \"<is-a>\", O = \"<Politician>"
         "\"\n    qet-width: 1 \n  }\n   filtered on column 0\n "
         " qet-width: 4 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1065,7 +1065,7 @@ TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
                          .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with P = \"<is-a>\", O = "
         "\"<Scientist>\"\n    qet-width: 1 \n  } join-column: [0]\n  |X|\n  "
@@ -1078,7 +1078,7 @@ TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
         "}\n         filtered on column 0\n        qet-width: 4 \n      }\n    "
         "   filtered on column 2\n      qet-width: 6 \n    }\n    qet-width: 6 "
         "\n  } join-column: [4]\n  qet-width: 6 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1097,7 +1097,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  TWO_COLUMN_JOIN\n    {\n    ORDER_BY\n    {\n      JOIN\n"
         "      {\n        SCAN PSO with P = \"<Film_performance>\"\n"
@@ -1110,7 +1110,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
         "    {\n    SCAN PSO with P = \"<Film_performance>\"\n"
         "    qet-width: 2 \n  }\n  join-columns: [0 & 1]\n"
         "  qet-width: 3 \n}",
-        qet.asString());
+        qet->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1139,9 +1139,9 @@ TEST(QueryExecutionTreeTest, testFormerSegfaultTriFilter) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_TRUE(qet.varCovered("?1"));
-    ASSERT_TRUE(qet.varCovered("?0"));
+    auto qet = qp.createExecutionTree(pq);
+    ASSERT_TRUE(qet->varCovered("?1"));
+    ASSERT_TRUE(qet->varCovered("?0"));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1160,7 +1160,7 @@ TEST(QueryPlannerTest, testSimpleOptional) {
                          "WHERE  {?a <rel1> ?b . OPTIONAL { ?a <rel2> ?c }}")
                          .parse();
     pq.expandPrefixes();
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
+    auto qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n"
         "  OPTIONAL_JOIN\n"
@@ -1175,7 +1175,7 @@ TEST(QueryPlannerTest, testSimpleOptional) {
         "  } join-columns: [0]\n"
         "  qet-width: 3 \n"
         "}",
-        qet.asString());
+        qet->asString());
 
     ParsedQuery pq2 = SparqlParser(
                           "SELECT ?a ?b \n "
@@ -1183,7 +1183,7 @@ TEST(QueryPlannerTest, testSimpleOptional) {
                           "OPTIONAL { ?a <rel2> ?c }} ORDER BY ?b")
                           .parse();
     pq2.expandPrefixes();
-    QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
+    auto qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
         "{\n"
         "  SORT on column:1\n"
@@ -1202,7 +1202,7 @@ TEST(QueryPlannerTest, testSimpleOptional) {
         "  }\n"
         "  qet-width: 3 \n"
         "}",
-        qet2.asString());
+        qet2->asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();


### PR DESCRIPTION
This adds cache pinning, meaning an element can be marked so that it is never cleared from the cache unless erased explicitly. Together with this major feature we don't keep aborted `Operation`s in the cache, fix wrongly calculated variable column maps for `IndexScan` and use `unique_ptr` for the `_rootOperation` in `QueryExecutionTree` to make it explicit and tested that this is owned.