### PR TITLE
Better handling of several special cases for TransitivePaths.

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1948,7 +1948,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
             (b[j]._qet.get()->getType() ==
                  QueryExecutionTree::OperationType::TRANSITIVE_PATH &&
              jcs[0][1] == 0)) {
-          std::shared_ptr<const TransitivePath> srcpath;
+          std::shared_ptr<TransitivePath> srcpath;
           std::shared_ptr<QueryExecutionTree> other;
           size_t otherCol;
           if (a[i]._qet.get()->getType() ==
@@ -1963,13 +1963,18 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
                 b[j]._qet->getRootOperation());
             otherCol = jcs[0][0];
           }
+
           // Do not bind the side of a path twice
-          if (!srcpath->isBound()) {
+          if (!srcpath->isBound() &&
+              other->getSizeEstimate() < srcpath->getSizeEstimate()) {
             // The left or right side is a TRANSITIVE_PATH and its join column
             // corresponds to the left side of its input.
 
             const vector<size_t>& otherSortedOn = other->resultSortedOn();
             if (otherSortedOn.size() == 0 || otherSortedOn[0] != otherCol) {
+              if (other->getType() == QueryExecutionTree::SCAN) {
+                continue;
+              }
               auto sort = std::make_shared<Sort>(_qec, other, jcs[0][0]);
               std::shared_ptr<QueryExecutionTree> sortedOther =
                   std::make_shared<QueryExecutionTree>(_qec);
@@ -2002,7 +2007,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
             (b[j]._qet.get()->getType() ==
                  QueryExecutionTree::OperationType::TRANSITIVE_PATH &&
              jcs[0][1] == 1)) {
-          std::shared_ptr<const TransitivePath> srcpath;
+          std::shared_ptr<TransitivePath> srcpath;
           std::shared_ptr<QueryExecutionTree> other;
           size_t otherCol;
           if (a[i]._qet.get()->getType() ==
@@ -2018,12 +2023,16 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
             otherCol = jcs[0][0];
           }
           // Do not bind the side of a path twice
-          if (!srcpath->isBound()) {
+          if (!srcpath->isBound() &&
+              other->getSizeEstimate() < srcpath->getSizeEstimate()) {
             // The left or right side is a TRANSITIVE_PATH and its join column
             // corresponds to the left side of its input.
 
             const vector<size_t>& otherSortedOn = other->resultSortedOn();
             if (otherSortedOn.size() == 0 || otherSortedOn[0] != otherCol) {
+              if (other->getType() == QueryExecutionTree::SCAN) {
+                continue;
+              }
               auto sort = std::make_shared<Sort>(_qec, other, jcs[0][0]);
               std::shared_ptr<QueryExecutionTree> sortedOther =
                   std::make_shared<QueryExecutionTree>(_qec);

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -94,9 +94,23 @@ vector<size_t> TransitivePath::resultSortedOn() const {
   const std::vector<size_t>& subSortedOn =
       _subtree->getRootOperation()->getResultSortedOn();
   if (_leftSideTree == nullptr && _rightSideTree == nullptr && _leftIsVar &&
-      subSortedOn.size() > 0 && subSortedOn[0] == _leftSubCol) {
+      _rightIsVar && subSortedOn.size() > 0 && subSortedOn[0] == _leftSubCol) {
     // This operation preserves the order of the _leftCol of the subtree.
     return {0};
+  }
+  if (_leftSideTree != nullptr) {
+    const std::vector<size_t>& leftSortedOn =
+        _leftSideTree->getRootOperation()->getResultSortedOn();
+    if (leftSortedOn.size() > 0 && leftSortedOn[0] == _leftSideCol) {
+      return {0};
+    }
+  }
+  if (_rightSideTree != nullptr) {
+    const std::vector<size_t>& rightSortedOn =
+        _rightSideTree->getRootOperation()->getResultSortedOn();
+    if (rightSortedOn.size() > 0 && rightSortedOn[0] == _rightSideCol) {
+      return {1};
+    }
   }
   return {};
 }

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -684,5 +684,6 @@ std::shared_ptr<TransitivePath> TransitivePath::bindRightSide(
 
 // _____________________________________________________________________________
 bool TransitivePath::isBound() const {
-  return _leftSideTree != nullptr || _rightSideTree != nullptr;
+  return _leftSideTree != nullptr || _rightSideTree != nullptr || !_leftIsVar ||
+         !_rightIsVar;
 }

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -31,10 +31,10 @@ class TransitivePath : public Operation {
       std::shared_ptr<QueryExecutionTree> leftop, size_t inputCol) const;
 
   /**
-   * Returns a new TransitivePath operation that uses the fact that leftop
-   * generates all possible values for the left side of the paths. If the
-   * results of leftop is smaller than all possible values this will result in a
-   * faster transitive path operation (as the transitive paths has to be
+   * Returns a new TransitivePath operation that uses the fact that rightop
+   * generates all possible values for the right side of the paths. If the
+   * results of rightop is smaller than all possible values this will result in
+   * a faster transitive path operation (as the transitive paths has to be
    * computed for fewer elements).
    */
   std::shared_ptr<TransitivePath> bindRightSide(
@@ -104,8 +104,8 @@ class TransitivePath : public Operation {
   std::shared_ptr<QueryExecutionTree> _leftSideTree;
   size_t _leftSideCol;
 
-  // If this is not nullptr then the left side of all paths is within the result
-  // of this tree.
+  // If this is not nullptr then the right side of all paths is within the
+  // result of this tree.
   std::shared_ptr<QueryExecutionTree> _rightSideTree;
   size_t _rightSideCol;
 

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "IdTable.h"
 #include "Operation.h"
 #include "QueryExecutionTree.h"
@@ -17,6 +19,32 @@ class TransitivePath : public Operation {
                  const std::string& leftColName,
                  const std::string& rightColName, size_t minDist,
                  size_t maxDist);
+
+  /**
+   * Returns a new TransitivePath operation that uses the fact that leftop
+   * generates all possible values for the left side of the paths. If the
+   * results of leftop is smaller than all possible values this will result in a
+   * faster transitive path operation (as the transitive paths has to be
+   * computed for fewer elements).
+   */
+  std::shared_ptr<TransitivePath> bindLeftSide(
+      std::shared_ptr<QueryExecutionTree> leftop, size_t inputCol) const;
+
+  /**
+   * Returns a new TransitivePath operation that uses the fact that leftop
+   * generates all possible values for the left side of the paths. If the
+   * results of leftop is smaller than all possible values this will result in a
+   * faster transitive path operation (as the transitive paths has to be
+   * computed for fewer elements).
+   */
+  std::shared_ptr<TransitivePath> bindRightSide(
+      std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
+
+  /**
+   * Returns true if this tree was created using the bindLeftSide method.
+   * Neither side of a tree may be bound twice
+   */
+  bool isBound() const;
 
   virtual std::string asString(size_t indent = 0) const override;
 
@@ -39,10 +67,13 @@ class TransitivePath : public Operation {
   virtual size_t getCostEstimate() override;
 
   // The method is declared here to make it unit testable
-  /**
-   * @brief If leftIsVar is true left is interpreted as a column index in sub,
-   * otherwise it is interpreted as the id of a single entity.
-   */
+
+  template <int SUB_WIDTH, bool leftIsVar, bool rightIsVar>
+  static void computeTransitivePath(IdTable* res, const IdTable& sub,
+                                    size_t leftSubCol, size_t rightSubCol,
+                                    Id leftValue, Id rightValue, size_t minDist,
+                                    size_t maxDist);
+
   template <int SUB_WIDTH>
   static void computeTransitivePath(IdTable* res, const IdTable& sub,
                                     bool leftIsVar, bool rightIsVar,
@@ -50,8 +81,36 @@ class TransitivePath : public Operation {
                                     Id leftValue, Id rightValue, size_t minDist,
                                     size_t maxDist);
 
+  template <int SUB_WIDTH, int LEFT_WIDTH, int RES_WIDTH>
+  static void computeTransitivePathLeftBound(
+      IdTable* res, const IdTable& sub, const IdTable& left, size_t leftSideCol,
+      bool rightIsVar, size_t leftSubCol, size_t rightSubCol, Id rightValue,
+      size_t minDist, size_t maxDist, size_t resWidth);
+
+  template <int SUB_WIDTH, int LEFT_WIDTH, int RES_WIDTH>
+  static void computeTransitivePathRightBound(IdTable* res, const IdTable& sub,
+                                              const IdTable& dynRight,
+                                              size_t rightSideCol,
+                                              bool leftIsVar, size_t leftSubCol,
+                                              size_t rightSubCol, Id leftValue,
+                                              size_t minDist, size_t maxDist,
+                                              size_t resWidth);
+
  private:
   virtual void computeResult(ResultTable* result) override;
+
+  // If this is not nullptr then the left side of all paths is within the result
+  // of this tree.
+  std::shared_ptr<QueryExecutionTree> _leftSideTree;
+  size_t _leftSideCol;
+
+  // If this is not nullptr then the left side of all paths is within the result
+  // of this tree.
+  std::shared_ptr<QueryExecutionTree> _rightSideTree;
+  size_t _rightSideCol;
+
+  size_t _resultWidth;
+  ad_utility::HashMap<std::string, size_t> _variableColumns;
 
   std::shared_ptr<QueryExecutionTree> _subtree;
   bool _leftIsVar;


### PR DESCRIPTION
This pr attempts to improve the speed of `TransitivePath` operations by limiting the number of source vertices. To this end:
 - TransitivePath operations with a fixed right end now invert the input edges and run a dfs from the single right node
 - A transitive path operation can replace a join between a transitive path and another operation to reduce the amount of tree explorations (dfs) that need to be run