### PR TITLE
Fix missing assignment/uninitialized value

### DIFF
--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -193,7 +193,7 @@ TEST_F(MergeVocabularyTest, bla) {
   VocabularyMerger::VocMergeRes res;
   {
     VocabularyMerger m;
-    m.mergeVocabulary(_basePath, 2, StringSortComparator());
+    res = m.mergeVocabulary(_basePath, 2, StringSortComparator());
   }
 
   // No language tags in text file


### PR DESCRIPTION
The test checked for _langPredLower/UpperBound being zero but did never
correctly set them. Thus the stack value for res was indeed
uninitalized. Only found this because valgrind seems to be better on
s390x.