### PR TITLE
Fixing Escaped Strings in the Sparql Parser

### DIFF
--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -5,6 +5,7 @@
 #include "SparqlLexer.h"
 #include "../util/StringUtils.h"
 #include "ParseException.h"
+#include "Tokenizer.h"
 
 const std::string SparqlToken::TYPE_NAMES[] = {
     "IRI",       "WS",         "KEYWORD", "VARIABLE", "SYMBOL",
@@ -19,8 +20,8 @@ const std::string SparqlLexer::PN_CHARS_BASE =
     "[\\x{200C}-\\x{200D}]|[\\x{2070}-\\x{218F}]|[\\x{2C00}-\\x{2FEF}]|"
     "[\\x{3001}-\\x{D7FF}]|[\\x{F900}-\\x{FDCF}]|[\\x{FDF0}-\\x{FFFD}]|"
     "[\\x{10000}-\\x{EFFFF}]";
-const std::string SparqlLexer::WS = "(\\x20|\\x09|\\x0D|\\x0A)";
-const std::string SparqlLexer::ECHAR = "\\\\[tbnrf\"']";
+const std::string SparqlLexer::WS = R"((\x20|\x09|\x0D|\x0A))";
+const std::string SparqlLexer::ECHAR = R"(\\[tbnrf\\"'])";
 const std::string SparqlLexer::INTEGER = "(-?[0-9]+)";
 const std::string SparqlLexer::FLOAT = "(-?[0-9]+\\.[0-9]+)";
 
@@ -100,6 +101,7 @@ void SparqlLexer::readNext() {
       _next.type = SparqlToken::Type::IRI;
     } else if (re2::RE2::Consume(&_re_string, RE_RDFLITERAL, &raw)) {
       _next.type = SparqlToken::Type::RDFLITERAL;
+      raw = TurtleToken::normalizeRDFLiteral(raw);
     } else if (re2::RE2::Consume(&_re_string, RE_FLOAT, &raw)) {
       _next.type = SparqlToken::Type::FLOAT;
     } else if (re2::RE2::Consume(&_re_string, RE_INTEGER, &raw)) {

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -748,7 +748,9 @@ bool SparqlParser::parseFilter(
       // of an expensive regex filter.
       bool isSimple = true;
       bool escaped = false;
-      std::vector<size_t> escapePositions;  // position of backslashes that are used for escaping within the regex
+      std::vector<size_t>
+          escapePositions;  // position of backslashes that are used for
+                            // escaping within the regex
       // these have to be removed if the regex is simply a prefix filter.
 
       // Check if the regex is only a prefix regex or also does
@@ -776,7 +778,8 @@ bool SparqlParser::parseFilter(
         f._type = SparqlFilter::PREFIX;
 
         // we have to remove the escaping backslashes
-        for (auto it = escapePositions.rbegin(); it != escapePositions.rend(); ++it) {
+        for (auto it = escapePositions.rbegin(); it != escapePositions.rend();
+             ++it) {
           f._rhs.erase(f._rhs.begin() + *it);
         }
       }

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -100,8 +100,8 @@ struct TurtleToken {
   }
 
   /**
-   * @brief take an unescaped rdfLiteral that has single "" quotes as created by normalizeRDFLiteral
-   *        and escape it again
+   * @brief take an unescaped rdfLiteral that has single "" quotes as created by
+   * normalizeRDFLiteral and escape it again
    */
   static std::string escapeRDFLiteral(std::string_view literal) {
     AD_CHECK(ad_utility::startsWith(literal, "\""));
@@ -143,8 +143,8 @@ struct TurtleToken {
 
         default:
           throw std::runtime_error(
-                  "Illegal switch value in escapeRDFLiteral. This should never "
-                  "happen, please report this");
+              "Illegal switch value in escapeRDFLiteral. This should never "
+              "happen, please report this");
       }
       literal.remove_prefix(pos + 1);
       pos = literal.find_first_of(charactersToEscape);

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -7,8 +7,8 @@
 #include <gtest/gtest.h>
 #include <re2/re2.h>
 #include <regex>
-#include "../util/Log.h"
 #include "../util/Exception.h"
+#include "../util/Log.h"
 
 using re2::RE2;
 using namespace std::string_literals;
@@ -20,15 +20,19 @@ struct TurtleToken {
   /**
    * @brief convert a RDF Literal to a unified form that is used inside QLever
    *
-   * RDFLiterals in Turtle or Sparql can have several forms: Either starting with one (" or ') quotation mark
-   * and containing escape sequences like "\\\t" or with three (""" or ''') quotation marks and allowing most
-   * control sequences to be contained in the string directly.
+   * RDFLiterals in Turtle or Sparql can have several forms: Either starting
+   * with one (" or ') quotation mark and containing escape sequences like
+   * "\\\t" or with three (""" or ''') quotation marks and allowing most control
+   * sequences to be contained in the string directly.
    *
-   * This function converts any of this forms to a literal that starts and ends with a single quotation mark '"'
-   * and contains the originally escaped characters directly, e.g. "al\"pha" becomes "al"pha".
+   * This function converts any of this forms to a literal that starts and ends
+   * with a single quotation mark '"' and contains the originally escaped
+   * characters directly, e.g. "al\"pha" becomes "al"pha".
    *
-   * This is NOT a valid RDF form of literals, but this format is only used inside QLever. By stripping the leading and trailing quotation mark and possible
-   * langtags or datatype URIS one can directly obtain the actual content of the literal.
+   * This is NOT a valid RDF form of literals, but this format is only used
+   * inside QLever. By stripping the leading and trailing quotation mark and
+   * possible langtags or datatype URIS one can directly obtain the actual
+   * content of the literal.
    *
    * @param literal
    * @return
@@ -38,12 +42,14 @@ struct TurtleToken {
     auto lastQuot = literal.find_last_of("\"\'");
     auto langtagOrDatatype = literal.substr(lastQuot + 1);
     literal.remove_suffix(literal.size() - lastQuot - 1);
-    if (ad_utility::startsWith(literal, "\"\"\"") || ad_utility::startsWith(literal, "'''")) {
+    if (ad_utility::startsWith(literal, "\"\"\"") ||
+        ad_utility::startsWith(literal, "'''")) {
       AD_CHECK(ad_utility::endsWith(literal, literal.substr(0, 3)));
       literal.remove_prefix(3);
       literal.remove_suffix(3);
     } else {
-      AD_CHECK(ad_utility::startsWith(literal, "\"") || ad_utility::startsWith(literal, "'"));
+      AD_CHECK(ad_utility::startsWith(literal, "\"") ||
+               ad_utility::startsWith(literal, "'"));
       AD_CHECK(ad_utility::endsWith(literal, literal.substr(0, 1)));
       literal.remove_prefix(1);
       literal.remove_suffix(1);
@@ -79,7 +85,9 @@ struct TurtleToken {
           break;
 
         default:
-          throw std::runtime_error("Illegal escape sequence in RDF Literal. This should never happen, please report this");
+          throw std::runtime_error(
+              "Illegal escape sequence in RDF Literal. This should never "
+              "happen, please report this");
       }
       literal.remove_prefix(pos + 2);
       pos = literal.find('\\');

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -16,6 +16,75 @@ using namespace std::string_literals;
 // turtle grammar cannot be static since google regexes have to be constructed
 // at runtime
 struct TurtleToken {
+  /**
+   * @brief convert a RDF Literal to a unified form that is used inside QLever
+   *
+   * RDFLiterals in Turtle or Sparql can have several forms: Either starting with one (" or ') quotation mark
+   * and containing escape sequences like "\\\t" or with three (""" or ''') quotation marks and allowing most
+   * control sequences to be contained in the string directly.
+   *
+   * This function converts any of this forms to a literal that starts and ends with a single quotation mark '"'
+   * and contains the originally escaped characters directly, e.g. "al\"pha" becomes "al"pha".
+   *
+   * This is NOT a valid RDF form of literals, but this format is only used inside QLever. By stripping the leading and trailing quotation mark and possible
+   * langtags or datatype URIS one can directly obtain the actual content of the literal.
+   *
+   * @param literal
+   * @return
+   */
+  static std::string normalizeRDFLiteral(std::string_view literal) {
+    std::string res = "\"";
+    auto lastQuot = literal.find_last_of("\"\'");
+    auto langtagOrDatatype = literal.substr(lastQuot + 1);
+    literal.remove_suffix(literal.size() - lastQuot - 1);
+    if (ad_utility::startsWith(literal, "\"\"\"") || ad_utility::startsWith(literal, "'''")) {
+      literal.remove_prefix(3);
+      literal.remove_suffix(3);
+    } else {
+      literal.remove_prefix(1);
+      literal.remove_suffix(1);
+    }
+    auto pos = literal.find('\\');
+    while (pos != literal.npos) {
+      res.append(literal.begin(), literal.begin() + pos);
+      switch (literal[pos + 1]) {
+        case 't':
+          res.push_back('\t');
+          break;
+        case 'n':
+          res.push_back('\n');
+          break;
+        case 'r':
+          res.push_back('\r');
+          break;
+        case 'b':
+          res.push_back('\b');
+          break;
+        case 'f':
+          res.push_back('\f');
+          break;
+        case '"':
+          res.push_back('\"');
+          break;
+        case '\'':
+          res.push_back('\'');
+          break;
+        case '\\':
+          res.push_back('\\');
+          break;
+      }
+      literal.remove_prefix(pos + 2);
+      pos = literal.find('\\');
+
+
+
+    }
+    res.append(literal);
+    res.push_back('"');
+    res.append(langtagOrDatatype);
+    return res;
+  }
+
   using string = std::string;
   TurtleToken()
       // those constants are always skipped, so they don't need a group around

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -48,8 +48,7 @@ inline bool startsWith(string_view text, string_view prefix, size_t prefixSize);
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()
 //! will return false. Case sensitive.
-inline bool endsWith(string_view text, const char* suffix,
-                     size_t patternSize);
+inline bool endsWith(string_view text, const char* suffix, size_t patternSize);
 
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -48,18 +48,18 @@ inline bool startsWith(string_view text, string_view prefix, size_t prefixSize);
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()
 //! will return false. Case sensitive.
-inline bool endsWith(const string& text, const char* suffix,
+inline bool endsWith(string_view text, const char* suffix,
                      size_t patternSize);
 
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()
 //! will return false. Case sensitive.
-inline bool endsWith(const string& text, const string& suffix);
+inline bool endsWith(string_view text, const string& suffix);
 
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()
 //! will return false. Case sensitive.
-inline bool endsWith(const string& text, const char* suffix);
+inline bool endsWith(string_view & text, const char* suffix);
 
 //! Returns the longest prefix that the two arguments have in common
 inline string_view commonPrefix(string_view a, const string_view b);
@@ -187,7 +187,7 @@ bool startsWith(const string& text, const char* prefix) {
 */
 
 // ____________________________________________________________________________
-bool endsWith(const string& text, const char* suffix, size_t suffixSize) {
+bool endsWith(string_view text, const char* suffix, size_t suffixSize) {
   if (suffixSize > text.size()) {
     return false;
   }
@@ -200,12 +200,12 @@ bool endsWith(const string& text, const char* suffix, size_t suffixSize) {
 }
 
 // ____________________________________________________________________________
-bool endsWith(const string& text, const string& suffix) {
+inline bool endsWith(string_view text, std::string_view suffix) {
   return endsWith(text, suffix.data(), suffix.size());
 }
 
 // ____________________________________________________________________________
-bool endsWith(const string& text, const char* suffix) {
+inline bool endsWith(string_view text, const char* suffix) {
   return endsWith(text, suffix, std::char_traits<char>::length(suffix));
 }
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -54,12 +54,12 @@ inline bool endsWith(string_view text, const char* suffix,
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()
 //! will return false. Case sensitive.
-inline bool endsWith(string_view text, const string& suffix);
+inline bool endsWith(string_view text, string_view suffix);
 
 //! Safe endsWith function. Returns true iff suffix is a
 //! prefix of text. Using a larger pattern than text.size()
 //! will return false. Case sensitive.
-inline bool endsWith(string_view & text, const char* suffix);
+inline bool endsWith(string_view text, const char* suffix);
 
 //! Returns the longest prefix that the two arguments have in common
 inline string_view commonPrefix(string_view a, const string_view b);
@@ -200,12 +200,12 @@ bool endsWith(string_view text, const char* suffix, size_t suffixSize) {
 }
 
 // ____________________________________________________________________________
-inline bool endsWith(string_view text, std::string_view suffix) {
+bool endsWith(string_view text, std::string_view suffix) {
   return endsWith(text, suffix.data(), suffix.size());
 }
 
 // ____________________________________________________________________________
-inline bool endsWith(string_view text, const char* suffix) {
+bool endsWith(string_view text, const char* suffix) {
   return endsWith(text, suffix, std::char_traits<char>::length(suffix));
 }
 

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -238,6 +238,11 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""simpleLiteral""")";
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
+
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
   {
     std::string l1 = "\"simpleLiteral\"@en-ca";
@@ -248,6 +253,10 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""simpleLiteral"""@en-ca)";
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
   {
     std::string l1 = "\"simpleLiteral\"^^xsd::boolean";
@@ -258,6 +267,11 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""simpleLiteral"""^^xsd::boolean)";
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
+
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
 
   {
@@ -270,6 +284,12 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\""")";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(t));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
   {
     std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"@de-us";
@@ -281,6 +301,12 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\"""@de-us)";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(t));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
 
   {
@@ -293,13 +319,24 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\"""^^xsd::integer)";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(t));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
 
   {
     std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"^^xsd::integer";
+    std::string tEscaped = R"("si\"mple\'Li\n\rt\t\b\fer\\"^^xsd::integer)";
     std::string l3 = "\"\"\"si\"mple\'Li\n\rt\t\b\fer\\\\\"\"\"^^xsd::integer";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = "\'\'\'si\"mple\'Li\n\rt\t\b\fer\\\\\'\'\'^^xsd::integer";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+
+    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(t));
+    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
   }
 }

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -227,3 +227,48 @@ TEST(TokenizerTest, WhitespaceAndComments) {
   tok.skipWhitespaceAndComments();
   ASSERT_EQ(tok.data().begin() - s.data(), 27);
 }
+
+TEST(TokenizerTest, normalizeRDFLiteral) {
+  {
+    std::string l1 = "\"simpleLiteral\"";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l1));
+    std::string l2 = "\'simpleLiteral\'";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l2));
+    std::string l3 = R"('''simpleLiteral''')";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = R"("""simpleLiteral""")";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
+  }
+  {
+    std::string l1 = "\"simpleLiteral\"@en-ca";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l1));
+    std::string l2 = "\'simpleLiteral\'@en-ca";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l2));
+    std::string l3 = R"('''simpleLiteral'''@en-ca)";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = R"("""simpleLiteral"""@en-ca)";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
+  }
+  {
+    std::string l1 = "\"simpleLiteral\"^^xsd::boolean";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l1));
+    std::string l2 = "\'simpleLiteral\'^^xsd::boolean";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l2));
+    std::string l3 = R"('''simpleLiteral'''^^xsd::boolean)";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = R"("""simpleLiteral"""^^xsd::boolean)";
+    ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
+  }
+
+  {
+    std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"";
+    std::string l1 = R"("si\"mple\'Li\n\rt\t\b\fer\\")";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l1));
+    std::string l2 = R"('si\"mple\'Li\n\rt\t\b\fer\\')";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l2));
+    std::string l3 = R"('''si\"mple\'Li\n\rt\t\b\fer\\''')";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\""")";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+  }
+}

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -239,10 +239,14 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     std::string l4 = R"("""simpleLiteral""")";
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
 
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l4)));
   }
   {
     std::string l1 = "\"simpleLiteral\"@en-ca";
@@ -253,10 +257,14 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l3));
     std::string l4 = R"("""simpleLiteral"""@en-ca)";
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l4)));
   }
   {
     std::string l1 = "\"simpleLiteral\"^^xsd::boolean";
@@ -268,10 +276,14 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     std::string l4 = R"("""simpleLiteral"""^^xsd::boolean)";
     ASSERT_EQ(l1, TurtleToken::normalizeRDFLiteral(l4));
 
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l4)));
   }
 
   {
@@ -286,10 +298,14 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
 
     ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(t));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l4)));
   }
   {
     std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"@de-us";
@@ -303,10 +319,14 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
 
     ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(t));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l4)));
   }
 
   {
@@ -321,10 +341,14 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
 
     ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(t));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l1)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l2)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l1)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l2)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(l1, TurtleToken::escapeRDFLiteral(
+                      TurtleToken::normalizeRDFLiteral(l4)));
   }
 
   {
@@ -336,7 +360,9 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
 
     ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(t));
-    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l3)));
-    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(TurtleToken::normalizeRDFLiteral(l4)));
+    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(
+                            TurtleToken::normalizeRDFLiteral(l3)));
+    ASSERT_EQ(tEscaped, TurtleToken::escapeRDFLiteral(
+                            TurtleToken::normalizeRDFLiteral(l4)));
   }
 }

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -302,6 +302,4 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     std::string l4 = "\'\'\'si\"mple\'Li\n\rt\t\b\fer\\\\\'\'\'^^xsd::integer";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
   }
-
-
 }

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -271,4 +271,37 @@ TEST(TokenizerTest, normalizeRDFLiteral) {
     std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\""")";
     ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
   }
+  {
+    std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"@de-us";
+    std::string l1 = R"("si\"mple\'Li\n\rt\t\b\fer\\"@de-us)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l1));
+    std::string l2 = R"('si\"mple\'Li\n\rt\t\b\fer\\'@de-us)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l2));
+    std::string l3 = R"('''si\"mple\'Li\n\rt\t\b\fer\\'''@de-us)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\"""@de-us)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+  }
+
+  {
+    std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"^^xsd::integer";
+    std::string l1 = R"("si\"mple\'Li\n\rt\t\b\fer\\"^^xsd::integer)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l1));
+    std::string l2 = R"('si\"mple\'Li\n\rt\t\b\fer\\'^^xsd::integer)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l2));
+    std::string l3 = R"('''si\"mple\'Li\n\rt\t\b\fer\\'''^^xsd::integer)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = R"("""si\"mple\'Li\n\rt\t\b\fer\\"""^^xsd::integer)";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+  }
+
+  {
+    std::string t = "\"si\"mple\'Li\n\rt\t\b\fer\\\"^^xsd::integer";
+    std::string l3 = "\"\"\"si\"mple\'Li\n\rt\t\b\fer\\\\\"\"\"^^xsd::integer";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l3));
+    std::string l4 = "\'\'\'si\"mple\'Li\n\rt\t\b\fer\\\\\'\'\'^^xsd::integer";
+    ASSERT_EQ(t, TurtleToken::normalizeRDFLiteral(l4));
+  }
+
+
 }


### PR DESCRIPTION
Previously, Regex Filters that contained Escape Sequences were neither handled correct
by the Lexer nor by the Parser (see #296). This PR fixes these bugs.

It implements a function to unify the different ways to specify Strings in Sparql/Turtle (" with escapes versus """ without escapes) to a form, that performs unescaping of `\t \n \\\"`...

Currently, the handling of strings that contain escaped characters is also wrong in the turtle Parser.
However to fix this, we require some more changes since the serialization of the vocabulary has to be changed as soon as the vocabulary elements may contain `\n` characters. So I would recommend first merging this and then using it as a base for the other fix.