### PR TITLE
Speeding up the first phase of Index Building

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "third_party/re2"]
 	path = third_party/re2
 	url = https://github.com/google/re2.git
-[submodule "third_party/abseil-cpp"]
-	path = third_party/abseil-cpp
-	url = https://github.com/abseil/abseil-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "third_party/re2"]
 	path = third_party/re2
 	url = https://github.com/google/re2.git
+[submodule "third_party/abseil-cpp"]
+	path = third_party/abseil-cpp
+	url = https://github.com/abseil/abseil-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,13 @@ add_subdirectory(third_party/googletest/googletest)
 include_directories(third_party/googletest/googletest/include)
 
 ################################
+# ABSEIL
+################################
+set(BUILD_TESTING OFF CACHE BOOL "Don't build tests for abseil" FORCE)
+add_subdirectory(third_party/abseil-cpp)
+include_directories(third_party/abseil-cpp/)
+
+################################
 # NLOHNMANN-JSON
 ################################
 # Header only, nothing to include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ include_directories(third_party/googletest/googletest/include)
 # Header only, nothing to include
 include_directories(third_party/json/)
 
+################################
+# ABSEIL
+################################
+set(BUILD_TESTING OFF CACHE BOOL "Don't build tests for abseil" FORCE)
+add_subdirectory(third_party/abseil-cpp)
+include_directories(third_party/abseil-cpp/)
+
 if (USE_PARALLEL)
     include(FindOpenMP)
     if(OPENMP_FOUND)
@@ -163,7 +170,7 @@ add_executable(PrefixHeuristicEvaluatorMain src/PrefixHeuristicEvaluatorMain.cpp
 target_link_libraries (PrefixHeuristicEvaluatorMain index ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(TurtleParserMain src/TurtleParserMain.cpp)
-target_link_libraries(TurtleParserMain parser ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(TurtleParserMain parser ${CMAKE_THREAD_LIBS_INIT} absl::flat_hash_map)
 
 add_executable(VocabularyMergerMain src/VocabularyMergerMain.cpp)
 target_link_libraries(VocabularyMergerMain index ${CMAKE_THREAD_LIBS_INIT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,13 +60,6 @@ add_subdirectory(third_party/googletest/googletest)
 include_directories(third_party/googletest/googletest/include)
 
 ################################
-# ABSEIL
-################################
-set(BUILD_TESTING OFF CACHE BOOL "Don't build tests for abseil" FORCE)
-add_subdirectory(third_party/abseil-cpp)
-include_directories(third_party/abseil-cpp/)
-
-################################
 # NLOHNMANN-JSON
 ################################
 # Header only, nothing to include

--- a/e2e/e2e-build-settings.json
+++ b/e2e/e2e-build-settings.json
@@ -1,0 +1,4 @@
+{
+  "num-triples-per-partial-vocab" : 40000,
+  "parser-batch-size" : 1000
+}

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -61,6 +61,7 @@ if [ "$1" != "no-index" ]; then
 	./IndexBuilderMain -l -i "$INDEX" \
 	    -F ttl \
 		-f "$INPUT.nt" \
+		-s "$PROJECT_DIR/e2e/e2e-build-settings.json" \
 		-w "$INPUT.wordsfile.tsv" \
 		-d "$INPUT.docsfile.tsv" || bail "Building Index failed"
 	popd

--- a/misc/check_binary_index_equality.sh
+++ b/misc/check_binary_index_equality.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#compare two indices for binary equality. Can be used for regression testing of the Index Building procedure
+
+if [ "$#" -ne 2 ]
+then
+  echo "Usage: $0 <indexPrefix1> <indexPrefix2>"
+  echo "Passed $# command line arguments"
+  exit 1
+fi
+
+
+
+for i in .index.pso .index.pos \
+         .index.spo .index.spo.meta-mmap .index.sop .index.spo.meta-mmap \
+         .index.osp .index.osp.meta-mmap .index.ops .index.ops.meta-mmap \
+         .index.patterns .prefixes .vocabulary .meta-data.json .literals-index
+do
+  f1=$1$i
+  f2=$2$i
+  echo "Comparing $f1 and $f2"
+  if  cmp $f1 $f2
+  then
+    echo "$f1 and $f2 match, continuing"
+  else
+    echo "Error, $f1 and $f2 are not equal"
+    #exit 1
+  fi
+
+done
+
+echo "Indices with prefixes $1 and $2 are binary equal"

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -164,13 +164,10 @@ size_t QueryExecutionTree::getSizeEstimate() {
   if (_sizeEstimate == std::numeric_limits<size_t>::max()) {
     if (_cachedResult && _cachedResult->status() == ResultTable::FINISHED) {
       _sizeEstimate = _cachedResult->size();
-    } else if (_qec) {
-      _sizeEstimate = _rootOperation->getSizeEstimate();
     } else {
-      // For test cases without index only:
-      // Make it deterministic by using the asString.
-      _sizeEstimate =
-          1000 + std::hash<string>{}(_rootOperation->asString()) % 1000;
+      // if we are in a unit test setting and there is no QueryExecutionContest specified
+      // it is the _rootOperation's obligation to handle this case correctly
+      _sizeEstimate = _rootOperation->getSizeEstimate();
     }
   }
   return _sizeEstimate;

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -165,8 +165,9 @@ size_t QueryExecutionTree::getSizeEstimate() {
     if (_cachedResult && _cachedResult->status() == ResultTable::FINISHED) {
       _sizeEstimate = _cachedResult->size();
     } else {
-      // if we are in a unit test setting and there is no QueryExecutionContest specified
-      // it is the _rootOperation's obligation to handle this case correctly
+      // if we are in a unit test setting and there is no QueryExecutionContest
+      // specified it is the _rootOperation's obligation to handle this case
+      // correctly
       _sizeEstimate = _rootOperation->getSizeEstimate();
     }
   }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2096,7 +2096,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::merge(
   // as key.
   LOG(TRACE) << "Pruning...\n";
   vector<SubtreePlan> prunedPlans;
-  for (const auto& [[[maybe_unused]] key, value] : candidates) {
+  for (const auto& [key, value] : candidates) {
+    (void)key;  // silence unused warning
     size_t minIndex = findCheapestExecutionTree(value);
     prunedPlans.push_back(value[minIndex]);
   }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2884,7 +2884,7 @@ size_t QueryPlanner::findCheapestExecutionTree(
   AD_CHECK_GT(lastRow.size(), 0);
   size_t minCost = std::numeric_limits<size_t>::max();
   size_t minInd = 0;
-  LOG(INFO) << "\nFinding the cheapest row in the optimizer\n";
+  LOG(TRACE) << "\nFinding the cheapest row in the optimizer\n";
   for (size_t i = 0; i < lastRow.size(); ++i) {
     [[maybe_unused]] auto repr = lastRow[i]._qet->asString();
     std::transform(repr.begin(), repr.end(), repr.begin(),
@@ -2892,8 +2892,8 @@ size_t QueryPlanner::findCheapestExecutionTree(
 
     size_t thisSize = lastRow[i].getSizeEstimate();
     size_t thisCost = lastRow[i].getCostEstimate();
-    LOG(INFO) << "Estimated cost and size  of " << thisCost << " " << thisSize
-              << " for Tree " << repr << '\n';
+    LOG(TRACE) << "Estimated cost and size  of " << thisCost << " " << thisSize
+               << " for Tree " << repr << '\n';
     if (thisCost < minCost) {
       minCost = lastRow[i].getCostEstimate();
       minInd = i;
@@ -2906,6 +2906,6 @@ size_t QueryPlanner::findCheapestExecutionTree(
       minInd = i;
     }
   }
-  LOG(INFO) << "Finished\n";
+  LOG(TRACE) << "Finished\n";
   return minInd;
 };

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2884,8 +2884,15 @@ size_t QueryPlanner::findCheapestExecutionTree(
   AD_CHECK_GT(lastRow.size(), 0);
   size_t minCost = std::numeric_limits<size_t>::max();
   size_t minInd = 0;
+  LOG(INFO) << "\nFinding the cheapest row in the optimizer\n";
   for (size_t i = 0; i < lastRow.size(); ++i) {
+    [[maybe_unused]] auto repr = lastRow[i]._qet->asString();
+    std::transform(repr.begin(), repr.end(), repr.begin(),
+                   [](char c) { return c == '\n' ? ' ' : c; });
+
     size_t thisCost = lastRow[i].getCostEstimate();
+    LOG(INFO) << "Estimated cost of " << thisCost << " for Tree " << repr
+              << '\n';
     if (thisCost < minCost) {
       minCost = lastRow[i].getCostEstimate();
       minInd = i;
@@ -2898,5 +2905,6 @@ size_t QueryPlanner::findCheapestExecutionTree(
       minInd = i;
     }
   }
+  LOG(INFO) << "Finished\n";
   return minInd;
 };

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2890,9 +2890,10 @@ size_t QueryPlanner::findCheapestExecutionTree(
     std::transform(repr.begin(), repr.end(), repr.begin(),
                    [](char c) { return c == '\n' ? ' ' : c; });
 
+    size_t thisSize = lastRow[i].getSizeEstimate();
     size_t thisCost = lastRow[i].getCostEstimate();
-    LOG(INFO) << "Estimated cost of " << thisCost << " for Tree " << repr
-              << '\n';
+    LOG(INFO) << "Estimated cost and size  of " << thisCost << " " << thisSize
+              << " for Tree " << repr << '\n';
     if (thisCost < minCost) {
       minCost = lastRow[i].getCostEstimate();
       minInd = i;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -323,4 +323,18 @@ class QueryPlanner {
    */
   bool checkUsePatternTrick(ParsedQuery* pq,
                             SparqlTriple* patternTrickTriple) const;
+
+  /**
+   * @brief return the index of the cheapest execution tree in the argument.
+   *
+   * If we are in the unit test mode, this is deterministic by additionally
+   * sorting by the cache key when comparing equally cheap indices, else the
+   * first element that has the minimum index is returned.
+   */
+  size_t findCheapestExecutionTree(
+      const std::vector<SubtreePlan>& lastRow) const;
+
+  /// if this Planner is not associated with a queryExecutionContext we are only
+  /// in the unit test mode
+  [[nodiscard]] bool isInTestMode() const { return _qec == nullptr; }
 };

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(index
         FTSAlgorithms.cpp FTSAlgorithms.h
         PrefixHeuristic.cpp PrefixHeuristic.h)
 
-target_link_libraries(index parser ${STXXL_LIBRARIES} ${ICU_LIBRARIES})
+target_link_libraries(index parser ${STXXL_LIBRARIES} absl::flat_hash_map ${ICU_LIBRARIES})
 
 add_library(metaConverter
             MetaDataConverter.cpp MetaDataConverter.h)

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(index
         FTSAlgorithms.cpp FTSAlgorithms.h
         PrefixHeuristic.cpp PrefixHeuristic.h)
 
-target_link_libraries(index parser ${STXXL_LIBRARIES} ${ICU_LIBRARIES})
+target_link_libraries(index parser ${STXXL_LIBRARIES} ${ICU_LIBRARIES} absl::flat_hash_map)
 
 add_library(metaConverter
             MetaDataConverter.cpp MetaDataConverter.h)

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(index
         FTSAlgorithms.cpp FTSAlgorithms.h
         PrefixHeuristic.cpp PrefixHeuristic.h)
 
-target_link_libraries(index parser ${STXXL_LIBRARIES} absl::flat_hash_map ${ICU_LIBRARIES})
+target_link_libraries(index parser ${STXXL_LIBRARIES} ${ICU_LIBRARIES})
 
 add_library(metaConverter
             MetaDataConverter.cpp MetaDataConverter.h)

--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -55,5 +55,8 @@ static const std::string PARTIAL_MMAP_IDS = ".partial-ids-mmap";
 static const std::string TMP_BASENAME_COMPRESSION = ".tmp.compression_index";
 
 // _________________________________________________________________
-// TODO: Comment
+// The degree of parallelism that is used for IndexBuilding step where the
+// unique elements of the vocabulary are identified via hash maps. Typically, 4
+// is a good value. On systems with very few CPUs, a lower value might be
+// beneficial.
 constexpr size_t NUM_PARALLEL_ITEM_MAPS = 4;

--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -53,3 +53,7 @@ static const std::string PARTIAL_MMAP_IDS = ".partial-ids-mmap";
 
 // ________________________________________________________________
 static const std::string TMP_BASENAME_COMPRESSION = ".tmp.compression_index";
+
+// _________________________________________________________________
+// TODO: Comment
+constexpr size_t NUM_PARALLEL_ITEM_MAPS = 4;

--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -517,9 +517,7 @@ void FTSAlgorithms::multVarsAggScoresAndTakeTopKContexts(
     using ScoreToContext = std::set<pair<Score, Id>>;
     using ScoreAndStC = pair<Score, ScoreToContext>;
     using AggMap = ad_utility::HashMap<vector<Id>, ScoreAndStC, IdVectorHash>;
-    vector<Id> emptyKey = {{std::numeric_limits<Id>::max()}};
-    vector<Id> deletedKey = {{std::numeric_limits<Id>::max() - 1}};
-    AggMap map(emptyKey, deletedKey);
+    AggMap map;
     vector<Id> entitiesInContext;
     Id currentCid = cids[0];
     Score cscore = scores[0];
@@ -645,7 +643,7 @@ void FTSAlgorithms::multVarsAggScoresAndTakeTopContext(
                           IdVectorHash>;
   vector<Id> emptyKey = {{std::numeric_limits<Id>::max()}};
   vector<Id> deletedKey = {{std::numeric_limits<Id>::max() - 1}};
-  AggMap map(emptyKey, deletedKey);
+  AggMap map;
   vector<Id> entitiesInContext;
   Id currentCid = cids[0];
   Score cscore = scores[0];
@@ -1027,9 +1025,7 @@ void FTSAlgorithms::multVarsFilterAggScoresAndTakeTopKContexts(
   using ScoreToContext = std::set<pair<Score, Id>>;
   using ScoreAndStC = pair<Score, ScoreToContext>;
   using AggMap = ad_utility::HashMap<vector<Id>, ScoreAndStC, IdVectorHash>;
-  vector<Id> emptyKey = {{std::numeric_limits<Id>::max()}};
-  vector<Id> deletedKey = {{std::numeric_limits<Id>::max() - 1}};
-  AggMap map(emptyKey, deletedKey);
+  AggMap map;
   vector<Id> entitiesInContext;
   vector<Id> filteredEntitiesInContext;
   Id currentCid = cids[0];
@@ -1201,9 +1197,7 @@ void FTSAlgorithms::multVarsFilterAggScoresAndTakeTopKContexts(
   using ScoreToContext = std::set<pair<Score, Id>>;
   using ScoreAndStC = pair<Score, ScoreToContext>;
   using AggMap = ad_utility::HashMap<vector<Id>, ScoreAndStC, IdVectorHash>;
-  vector<Id> emptyKey = {{std::numeric_limits<Id>::max()}};
-  vector<Id> deletedKey = {{std::numeric_limits<Id>::max() - 1}};
-  AggMap map(emptyKey, deletedKey);
+  AggMap map;
   vector<Id> entitiesInContext;
   vector<Id> filteredEntitiesInContext;
   Id currentCid = cids[0];

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -1389,6 +1389,9 @@ void Index::readConfiguration() {
 LangtagAndTriple Index::tripleToInternalRepresentation(Triple&& tripleIn) {
   LangtagAndTriple res{"", std::move(tripleIn)};
   auto& spo = res._triple;
+  for (auto& el : spo) {
+    el = _vocab.getLocaleManager().normalizeUtf8(el);
+  }
   size_t upperBound = 3;
   if (ad_utility::isXsdValue(spo[2])) {
     spo[2] = ad_utility::convertValueLiteralToIndexWord(spo[2]);

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -161,7 +161,7 @@ VocabularyData Index::passFileForVocabulary(const string& filename,
           // get the Ids for the original triple and the possibly added language
           // Tag triples using the provided HashMaps via itemArray. See
           // documentation of the function for more details
-          getIdMapLambdas<NUM_PARALLEL_ITEM_MAPS>(&itemArray, linesPerPartial));
+          getIdMapLambdas<NUM_PARALLEL_ITEM_MAPS>(&itemArray, linesPerPartial, &(_vocab.getCaseComparator())));
 
       while (auto opt = p.getNextValue()) {
         i++;
@@ -1509,18 +1509,25 @@ std::future<void> Index::writeNextPartialVocabulary(
     auto vec = vocabMapsToVector(items);
     const auto identicalPred = [& c = vocab->getCaseComparator()](
                                    const auto& a, const auto& b) {
-      return c(a, b, decltype(_vocab)::SortLevel::IDENTICAL);
+      return c(a.second.m_splitVal, b.second.m_splitVal, decltype(_vocab)::SortLevel::IDENTICAL);
     };
+    LOG(INFO) << "Start sorting of vocabulary with #elements: " << vec.size() << std::endl;
     sortVocabVector(&vec, identicalPred, false);
+    LOG(INFO) << "Finished sorting of vocabulary" << std::endl;
     auto mapping = createInternalMapping(&vec);
+    LOG(INFO) << "Finished creating of Mapping vocabulary" << std::endl;
     auto sz = vec.size();
-    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
+    // since now adjacent duplicates also have the same Ids, it suffices to compare those
+    vec.erase(std::unique(vec.begin(), vec.end(), [](const auto& a, const auto& b){return a.second.m_id == b.second.m_id;}), vec.end());
     LOG(INFO) << "Removed " << sz - vec.size()
               << " Duplicates from the local partial vocabularies\n";
     writeMappedIdsToExtVec(*localIds, mapping, globalWritePtr);
     writePartialVocabularyToFile(vec, partialFilename);
     if (vocabPrefixCompressed) {
-      sortVocabVector(&vec, std::less<>(), false);
+      // sort according to the actual byte values
+      LOG(INFO) << "Start sorting of vocabulary for prefix compression" << std::endl;
+      sortVocabVector(&vec, [](const auto& a, const auto& b){return a.first < b.first;}, false);
+      LOG(INFO) << "Finished sorting of vocabulary for prefix compression" << std::endl;
       writePartialVocabularyToFile(vec, partialCompressionFilename);
     }
     LOG(INFO) << "Finished writing the partial vocabulary" << std::endl;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -256,9 +256,11 @@ VocabularyData Index::passFileForVocabulary(const string& filename,
   VocabularyMerger::VocMergeRes mergeRes;
   {
     VocabularyMerger v;
-    auto identicalPred = [c = _vocab.getCaseComparator()](const auto& a, const auto&b) {return c(a, b, decltype(c)::Level::IDENTICAL);};
-    mergeRes =
-        v.mergeVocabulary(_onDiskBase, numFiles, identicalPred);
+    auto identicalPred = [c = _vocab.getCaseComparator()](const auto& a,
+                                                          const auto& b) {
+      return c(a, b, decltype(c)::Level::IDENTICAL);
+    };
+    mergeRes = v.mergeVocabulary(_onDiskBase, numFiles, identicalPred);
     LOG(INFO) << "Finished Merging Vocabulary.\n";
   }
   VocabularyData res;
@@ -1559,7 +1561,10 @@ std::future<void> Index::writeNextPartialVocabulary(
                  vocab = &_vocab, partialFilename, partialCompressionFilename,
                  vocabPrefixCompressed = _vocabPrefixCompressed]() {
     auto vec = vocabMapsToVector(items);
-    auto identicalPred = [c = vocab->getCaseComparator()](const auto& a, const auto&b) {return c(a, b, decltype(c)::Level::IDENTICAL);};
+    auto identicalPred = [c = vocab->getCaseComparator()](const auto& a,
+                                                          const auto& b) {
+      return c(a, b, decltype(c)::Level::IDENTICAL);
+    };
     sortVocabVector(&vec, identicalPred, false);
     auto mapping = createInternalMapping(&vec);
     auto sz = vec.size();

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -256,8 +256,9 @@ VocabularyData Index::passFileForVocabulary(const string& filename,
   VocabularyMerger::VocMergeRes mergeRes;
   {
     VocabularyMerger v;
+    auto identicalPred = [c = _vocab.getCaseComparator()](const auto& a, const auto&b) {return c(a, b, decltype(c)::Level::IDENTICAL);};
     mergeRes =
-        v.mergeVocabulary(_onDiskBase, numFiles, _vocab.getCaseComparator());
+        v.mergeVocabulary(_onDiskBase, numFiles, identicalPred);
     LOG(INFO) << "Finished Merging Vocabulary.\n";
   }
   VocabularyData res;
@@ -1558,7 +1559,8 @@ std::future<void> Index::writeNextPartialVocabulary(
                  vocab = &_vocab, partialFilename, partialCompressionFilename,
                  vocabPrefixCompressed = _vocabPrefixCompressed]() {
     auto vec = vocabMapsToVector(items);
-    sortVocabVector(&vec, vocab->getCaseComparator(), false);
+    auto identicalPred = [c = vocab->getCaseComparator()](const auto& a, const auto&b) {return c(a, b, decltype(c)::Level::IDENTICAL);};
+    sortVocabVector(&vec, identicalPred, false);
     auto mapping = createInternalMapping(&vec);
     auto sz = vec.size();
     vec.erase(std::unique(vec.begin(), vec.end()), vec.end());

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 #pragma once
 
+#include <absl/container/flat_hash_map.h>
 #include <array>
 #include <fstream>
 #include <google/sparse_hash_set>
@@ -444,7 +445,11 @@ class Index {
     LOG(DEBUG) << "Scan done, got " << result->size() << " elements.\n";
   }
 
-  using ItemMap = ad_utility::HashMap<string, Id>;
+  template <typename K, typename V>
+  using HashMap = absl::flat_hash_map<K, V>;
+
+  using ItemMap = absl::flat_hash_map<std::string, Id>;
+  using ItemMapArray = std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS>;
 
  private:
   string _onDiskBase;
@@ -470,6 +475,9 @@ class Index {
   double _fullHasPredicateMultiplicityEntities;
   double _fullHasPredicateMultiplicityPredicates;
   size_t _fullHasPredicateSize;
+
+  size_t _parserBatchSize = PARSER_BATCH_SIZE;
+  size_t _numTriplesPerPartialVocab = NUM_TRIPLES_PER_PARTIAL_VOCAB;
   /**
    * @brief Maps pattern ids to sets of predicate ids.
    */
@@ -483,6 +491,12 @@ class Index {
    */
   CompactStringVector<Id, Id> _hasPredicate;
 
+  using Triple = std::array<std::string, 3>;
+  struct LangtagAndTriple {
+    std::string _langtag;
+    Triple _triple;
+  };
+
   // Create Vocabulary and directly write it to disk. Create TripleVec with all
   // the triples converted to id space. This Vec can be used for creating
   // permutations. Member _vocab will be empty after this because it is not
@@ -494,7 +508,36 @@ class Index {
   // ___________________________________________________________________
   template <class Parser>
   VocabularyData passFileForVocabulary(const string& ntFile,
-                                       size_t linesPerPartial = 100000000);
+                                       size_t linesPerPartial);
+
+  struct ItemMapManager {
+    explicit ItemMapManager(Id minId) : _map(), _minId(minId) {
+      _map[LANGUAGE_PREDICATE] = _minId;
+    }
+    // ______________________________________________________________
+    ItemMapManager() = default;
+
+    [[nodiscard]] Id getLanguagePredicateId() const { return _minId; }
+
+    ItemMap&& moveMap() { return std::move(_map); }
+
+    // __________________________________________________
+    Id assignNextId(const string& key) {
+      if (!_map.count(key)) {
+        Id res = _map.size() + _minId;
+        _map[key] = res;
+        return res;
+      } else {
+        return _map[key];
+      }
+    }
+
+    std::array<Id, 3> assignNextId(const Index::Triple& t) {
+      return {assignNextId(t[0]), assignNextId(t[1]), assignNextId(t[2])};
+    }
+    ItemMap _map;
+    Id _minId = 0;
+  };
 
   /**
    * @brief Everything that has to be done when we have seen all the triples
@@ -510,16 +553,24 @@ class Index {
    * @param items Contains our unsorted vocabulary. Maps words to their local
    * ids within this vocabulary.
    */
-  pair<std::future<void>, std::future<void>> writeNextPartialVocabulary(
+  std::future<void> writeNextPartialVocabulary(
       size_t numLines, size_t numFiles, size_t actualCurrentPartialSize,
-      std::shared_ptr<const ItemMap> items);
+      std::shared_ptr<const ItemMapArray> items,
+      std::unique_ptr<TripleVec> localIds,
+      TripleVec::bufwriter_type* globalWritePtr);
 
   void convertPartialToGlobalIds(TripleVec& data,
                                  const vector<size_t>& actualLinesPerPartial,
                                  size_t linesPerPartial);
 
   // ___________________________________________________________________________
-  Id assignNextId(ItemMap* mapPtr, const string& key);
+  // TODO<joka921> this is again the unused function.
+  template <class Map>
+  static Id assignNextId(Map* mapPtr, const string& key);
+
+  // TODO<joka921> This should also be unused
+  template <class Map>
+  static std::array<Id, 3> assignNextId(Map* m, const Index::Triple& t);
 
   size_t passContextFileForVocabulary(const string& contextFile);
 
@@ -715,7 +766,7 @@ class Index {
   // and add externalization characters if necessary.
   // Returns the language tag of spo[2] (the object) or ""
   // if there is none.
-  string tripleToInternalRepresentation(array<string, 3>* spo);
+  LangtagAndTriple tripleToInternalRepresentation(Triple&& spo);
 
   /**
    * @brief Throws an exception if no patterns are loaded. Should be called from

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -33,7 +33,8 @@ using ItemVec = std::vector<std::pair<std::string, IdAndSplitVal>>;
  */
 struct ItemMapManager {
   /// Construct by assigning the minimum Id that shall be returned by the map
-  explicit ItemMapManager(Id minId, const TripleComponentComparator* cmp) : _map(), _minId(minId), m_comp(cmp) {}
+  explicit ItemMapManager(Id minId, const TripleComponentComparator* cmp)
+      : _map(), _minId(minId), m_comp(cmp) {}
   /// Minimum Id is 0
   ItemMapManager() = default;
 
@@ -46,7 +47,8 @@ struct ItemMapManager {
   Id assignNextId(const string& key) {
     if (!_map.count(key)) {
       Id res = _map.size() + _minId;
-      _map[key] = {res, m_comp->extractAndTransformComparable(key, TripleComponentComparator::Level::IDENTICAL)};
+      _map[key] = {res, m_comp->extractAndTransformComparable(
+                            key, TripleComponentComparator::Level::IDENTICAL)};
       return res;
     } else {
       return _map[key].m_id;
@@ -99,7 +101,8 @@ struct LangtagAndTriple {
  */
 template <size_t Parallelism>
 auto getIdMapLambdas(std::array<ItemMapManager, Parallelism>* itemArrayPtr,
-                     size_t maxNumberOfTriples, const TripleComponentComparator* comp) {
+                     size_t maxNumberOfTriples,
+                     const TripleComponentComparator* comp) {
   // that way the different ids won't interfere
   auto& itemArray = *itemArrayPtr;
   for (size_t j = 0; j < Parallelism; ++j) {

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -1,0 +1,145 @@
+//
+// Created by johannes on 26.01.20.
+//
+// Common classes / Typedefs that are used during Index Creation
+
+#include "../global/Constants.h"
+#include "../global/Id.h"
+#include "../util/Conversions.h"
+#include "../util/HashMap.h"
+#include "../util/TupleHelpers.h"
+#include "./ConstantsIndexCreation.h"
+
+#ifndef QLEVER_INDEXBUILDERTYPES_H
+#define QLEVER_INDEXBUILDERTYPES_H
+
+using Triple = std::array<std::string, 3>;
+
+using ItemMap = ad_utility::HashMap<std::string, Id>;
+using ItemMapArray = std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS>;
+
+/**
+ * Manage a HashMap of string->Id to create unique Ids for strings.
+ * Ids are assigned in an adjacent range starting with a configurable
+ * minimum Id. That way multiple maps can be used with non overlapping ranges.
+ */
+struct ItemMapManager {
+  /// Construct by assigning the minimum Id that shall be returned by the map
+  explicit ItemMapManager(Id minId) : _map(), _minId(minId) {}
+  /// Minimum Id is 0
+  ItemMapManager() = default;
+
+  /// Move the held HashMap out as soon as we are done inserting and only need
+  /// the actual vocabulary
+  ItemMap&& moveMap() && { return std::move(_map); }
+
+  /// If the key was seen before, return its preassigned Id. Else assign the
+  /// Next free Id to the string, store and return it.
+  Id assignNextId(const string& key) {
+    if (!_map.count(key)) {
+      Id res = _map.size() + _minId;
+      _map[key] = res;
+      return res;
+    } else {
+      return _map[key];
+    }
+  }
+
+  /// call assignNextId for each of the Triple elements.
+  std::array<Id, 3> assignNextId(const Triple& t) {
+    return {assignNextId(t[0]), assignNextId(t[1]), assignNextId(t[2])};
+  }
+  ItemMap _map;
+  Id _minId = 0;
+};
+
+/// Combines a triple (three strings) together with the (possibly empty)
+/// language tag of its object.
+struct LangtagAndTriple {
+  std::string _langtag;
+  Triple _triple;
+};
+
+/**
+ * @brief Get the tuple of lambda functions that is needed for the String-> Id
+ * step of the Index building Pipeline
+ *
+ * return a tuple of <Parallelism> lambda functions, each lambda does the
+ * following
+ *
+ * given an index idx, returns a lambda that
+ * - Takes a triple and a language tag
+ * - Returns OptionalIds where the first entry are the Ids for the triple,
+ *   the second and third entry are the Ids of the extra triples for the
+ *   language filter implementation (or std::nullopt if there was no language
+ * tag)
+ * - in the <i-th> lambda all Ids are assigned according to itemArray[i]
+ * - if the argument maxNumberOfTriples is set correctly, the Id ranges assigned
+ * by the different lambdas  never intersect
+ *
+ * The ItemMapMangers at *itemArrayPtr are also cleared and reset by this
+ * function.
+ *
+ * @param itemArray These Maps are used for assigning the ids. Their lifetime
+ * must exceed that of this function's return value, since they are captured by
+ * reference
+ * @param maxNumberOfTriples The maximum total number of triples that will be
+ * processed by all the lambdas together. Needed to correctly setup the Id
+ * ranges for the individual HashMaps
+ * @return A Tuple of lambda functions (see above)
+ */
+template <size_t Parallelism>
+auto getIdMapLambdas(std::array<ItemMapManager, Parallelism>* itemArrayPtr,
+                     size_t maxNumberOfTriples) {
+  // that way the different ids won't interfere
+  auto& itemArray = *itemArrayPtr;
+  for (size_t j = 0; j < Parallelism; ++j) {
+    itemArray[j] = ItemMapManager(j * 100 * maxNumberOfTriples);
+    itemArray[j].assignNextId(
+        LANGUAGE_PREDICATE);  // not really needed here, but also not harmful
+                              // and needed to make some completely unrelated
+                              // unit tests pass.
+  }
+  using OptionalIds = std::array<std::optional<std::array<Id, 3>>, 3>;
+
+  /* given an index idx, returns a lambda that
+   * - Takes a triple and a language tag
+   * - Returns OptionalIds where the first entry are the Ids for the triple,
+   *   the second and third entry are the Ids of the extra triples for the
+   *   language filter implementation (or std::nullopt if there was no language
+   * tag)
+   * - All Ids are assigned according to itemArray[idx]
+   */
+  const auto itemMapLamdaCreator = [&itemArray](const size_t idx) {
+    return [&map = itemArray[idx]](LangtagAndTriple&& lt) {
+      OptionalIds res;
+      // get Ids for the actual triple and store them in the result.
+      res[0] = map.assignNextId(lt._triple);
+      if (!lt._langtag.empty()) {  // the object of the triple was a literal
+                                   // with a language tag
+        // get the Id for the corresponding langtag Entity
+        auto langTagId = map.assignNextId(
+            ad_utility::convertLangtagToEntityUri(lt._langtag));
+        // get the Id for the tagged predicate, e.g. @en@rdfs:label
+        auto langTaggedPredId =
+            map.assignNextId(ad_utility::convertToLanguageTaggedPredicate(
+                lt._triple[1], lt._langtag));
+        auto& spoIds = *(res[0]);  // ids of original triple
+        // extra triple <subject> @language@<predicate> <object>
+        res[1].emplace(array<Id, 3>{spoIds[0], langTaggedPredId, spoIds[2]});
+        // extra triple <object> ql:language-tag <@language>
+        res[2].emplace(array<Id, 3>{
+            spoIds[2], map.assignNextId(LANGUAGE_PREDICATE), langTagId});
+      }
+      return res;
+    };
+  };
+
+  // setup a tuple with one lambda function per map in the itemArray
+  // (the first lambda will assign ids according to itemArray[1]...
+  auto itemMapLambdaTuple =
+      ad_tuple_helpers::setupTupleFromCallable<Parallelism>(
+          itemMapLamdaCreator);
+  return itemMapLambdaTuple;
+}
+#endif  // QLEVER_INDEXBUILDERTYPES_H

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -3,7 +3,6 @@
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
 #pragma once
 
-#include <absl/container/flat_hash_map.h>
 #include <string>
 #include <stxxl/vector>
 #include <utility>
@@ -13,14 +12,13 @@
 #include "../util/HashMap.h"
 #include "../util/MmapVector.h"
 #include "./ConstantsIndexCreation.h"
+#include "./IndexBuilderTypes.h"
 #include "Vocabulary.h"
 
 using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
 using std::string;
 
-using ItemMapArray =
-    std::array<absl::flat_hash_map<std::string, Id>, NUM_PARALLEL_ITEM_MAPS>;
 using TripleVec = stxxl::vector<array<Id, 3>>;
 
 /**
@@ -136,7 +134,7 @@ ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
  * @param els  Must be sorted(at least duplicates must be adjacent) according to
  * the strings and the Ids must be unique to work correctly.
  */
-absl::flat_hash_map<Id, Id> createInternalMapping(
+ad_utility::HashMap<Id, Id> createInternalMapping(
     std::vector<std::pair<string, Id>>* els);
 
 /**
@@ -144,7 +142,7 @@ absl::flat_hash_map<Id, Id> createInternalMapping(
  * <map> and write the resulting Id triple to <*writePtr>
  */
 void writeMappedIdsToExtVec(const TripleVec& input,
-                            const absl::flat_hash_map<Id, Id>& map,
+                            const ad_utility::HashMap<Id, Id>& map,
                             TripleVec::bufwriter_type* writePtr);
 
 /**

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -134,8 +134,7 @@ ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
  * @param els  Must be sorted(at least duplicates must be adjacent) according to
  * the strings and the Ids must be unique to work correctly.
  */
-ad_utility::HashMap<Id, Id> createInternalMapping(
-    ItemVec * els);
+ad_utility::HashMap<Id, Id> createInternalMapping(ItemVec* els);
 
 /**
  * @brief for each of the IdTriples in <input>: map the three Ids using the
@@ -154,16 +153,14 @@ void writeMappedIdsToExtVec(const TripleVec& input,
  * @param els The input
  * @param fileName will write to this file. If it exists it will be overwritten
  */
-void writePartialVocabularyToFile(const ItemVec & els,
-                                  const string& fileName);
+void writePartialVocabularyToFile(const ItemVec& els, const string& fileName);
 
 /**
  * @brief Take an Array of HashMaps of Strings to Ids and insert all the
  * elements from all the hashMaps into a single vector No reordering or
  * deduplication is done, so result.size() == summed size of all the hash maps
  */
-ItemVec vocabMapsToVector(
-    std::shared_ptr<const ItemMapArray> map);
+ItemVec vocabMapsToVector(std::shared_ptr<const ItemMapArray> map);
 
 // _____________________________________________________________________________________________________________
 /**
@@ -175,7 +172,7 @@ ItemVec vocabMapsToVector(
  * parallel extension for sorting.
  */
 template <class StringSortComparator>
-void sortVocabVector(ItemVec * vecPtr,
-                     StringSortComparator comp, bool doParallelSort);
+void sortVocabVector(ItemVec* vecPtr, StringSortComparator comp,
+                     bool doParallelSort);
 
 #include "VocabularyGeneratorImpl.h"

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -3,19 +3,25 @@
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
 #pragma once
 
+#include <absl/container/flat_hash_map.h>
 #include <string>
+#include <stxxl/vector>
 #include <utility>
 
 #include "../global/Constants.h"
 #include "../global/Id.h"
 #include "../util/HashMap.h"
 #include "../util/MmapVector.h"
-#include "Index.h"
+#include "./ConstantsIndexCreation.h"
 #include "Vocabulary.h"
 
 using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
 using std::string;
+
+using ItemMapArray =
+    std::array<absl::flat_hash_map<std::string, Id>, NUM_PARALLEL_ITEM_MAPS>;
+using TripleVec = stxxl::vector<array<Id, 3>>;
 
 /**
  * class for merging the partial vocabularies. The main function is still in the
@@ -107,14 +113,71 @@ class VocabularyMerger {
       const std::vector<std::pair<size_t, std::pair<size_t, size_t>>>& buffer);
 };
 
-// _________________________________________________________________________________________
+// ______________
+// TODO<joka921> is this even used
+// anymore?___________________________________________________________________________
 template <class Comp>
 void writePartialIdMapToBinaryFileForMerging(
-    std::shared_ptr<const Index::ItemMap> map, const string& fileName,
-    Comp comp);
+    std::shared_ptr<const ItemMapArray> map, const string& fileName, Comp comp,
+    bool doParallelSort);
 
 // _________________________________________________________________________________________
 ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
     const string& mmapFilename);
+
+/**
+ * @brief Create a hashMap that maps the Id of the pair<string, Id> to the
+ * position of the string in the vector. The resulting ids will be ascending and
+ * duplicates strings that appear adjacent to each other will be given the same
+ * ID. If Input is sorted this will mean if result[x] == result[y] then the
+ * strings that were connected to x and y in the input were identical. Also
+ * modifies the input Ids to their mapped values.
+ *
+ * @param els  Must be sorted(at least duplicates must be adjacent) according to
+ * the strings and the Ids must be unique to work correctly.
+ */
+absl::flat_hash_map<Id, Id> createInternalMapping(
+    std::vector<std::pair<string, Id>>* els);
+
+/**
+ * @brief for each of the IdTriples in <input>: map the three Ids using the
+ * <map> and write the resulting Id triple to <*writePtr>
+ */
+void writeMappedIdsToExtVec(const TripleVec& input,
+                            const absl::flat_hash_map<Id, Id>& map,
+                            TripleVec::bufwriter_type* writePtr);
+
+/**
+ * @brief Serialize a std::vector<std::pair<string, Id>> to a binary file
+ *
+ * For each string first writes the size of the string (64 bits). Then the
+ * actual string content (no trailing zero) and then the Id (sizeof(Id)
+ *
+ * @param els The input
+ * @param fileName will write to this file. If it exists it will be overwritten
+ */
+void writePartialVocabularyToFile(const std::vector<std::pair<string, Id>>& els,
+                                  const string& fileName);
+
+/**
+ * @brief Take an Array of HashMaps of Strings to Ids and insert all the
+ * elements from all the hashMaps into a single vector No reordering or
+ * deduplication is done, so result.size() == summed size of all the hash maps
+ */
+std::vector<std::pair<string, Id>> vocabMapsToVector(
+    std::shared_ptr<const ItemMapArray> map);
+
+// _____________________________________________________________________________________________________________
+/**
+ * @brief Sort the input in-place according to the strings as compared by the
+ * StringComparator
+ * @tparam A binary Function object to compare strings (e.g.
+ * std::less<std::string>())
+ * @param doParallelSort if true and USE_PARALLEL_SORT is true, use the gnu
+ * parallel extension for sorting.
+ */
+template <class StringSortComparator>
+void sortVocabVector(std::vector<std::pair<string, Id>>* vecPtr,
+                     StringSortComparator comp, bool doParallelSort);
 
 #include "VocabularyGeneratorImpl.h"

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -135,7 +135,7 @@ ad_utility::HashMap<Id, Id> IdMapFromPartialIdMapFile(
  * the strings and the Ids must be unique to work correctly.
  */
 ad_utility::HashMap<Id, Id> createInternalMapping(
-    std::vector<std::pair<string, Id>>* els);
+    ItemVec * els);
 
 /**
  * @brief for each of the IdTriples in <input>: map the three Ids using the
@@ -154,7 +154,7 @@ void writeMappedIdsToExtVec(const TripleVec& input,
  * @param els The input
  * @param fileName will write to this file. If it exists it will be overwritten
  */
-void writePartialVocabularyToFile(const std::vector<std::pair<string, Id>>& els,
+void writePartialVocabularyToFile(const ItemVec & els,
                                   const string& fileName);
 
 /**
@@ -162,7 +162,7 @@ void writePartialVocabularyToFile(const std::vector<std::pair<string, Id>>& els,
  * elements from all the hashMaps into a single vector No reordering or
  * deduplication is done, so result.size() == summed size of all the hash maps
  */
-std::vector<std::pair<string, Id>> vocabMapsToVector(
+ItemVec vocabMapsToVector(
     std::shared_ptr<const ItemMapArray> map);
 
 // _____________________________________________________________________________________________________________
@@ -175,7 +175,7 @@ std::vector<std::pair<string, Id>> vocabMapsToVector(
  * parallel extension for sorting.
  */
 template <class StringSortComparator>
-void sortVocabVector(std::vector<std::pair<string, Id>>* vecPtr,
+void sortVocabVector(ItemVec * vecPtr,
                      StringSortComparator comp, bool doParallelSort);
 
 #include "VocabularyGeneratorImpl.h"

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -57,7 +57,7 @@ VocabularyMerger::VocMergeRes VocabularyMerger::mergeVocabulary(const std::strin
     // read the first entry of the vocabulary and add it to the queue
     endOfFile[i] = true;
 
-    uint64_t len;
+    size_t len;
     if (infiles[i].read((char*)&len, sizeof(len))) {
       std::string word(len, '\0');
       infiles[i].read(&(word[0]), len);
@@ -104,7 +104,7 @@ VocabularyMerger::VocMergeRes VocabularyMerger::mergeVocabulary(const std::strin
     }  // file is exhausted, nothing to add
 
     endOfFile[i] = true;
-    uint64_t len;
+    size_t len;
     if (infiles[i].read((char*)&len, sizeof(len))) {
       std::string word(len, '\0');
       infiles[i].read(&(word[0]), len);
@@ -216,9 +216,9 @@ void VocabularyMerger::doActualWrite(
 }
 
 // ____________________________________________________________________________________________________________
-absl::flat_hash_map<Id, Id> createInternalMapping(std::vector<std::pair<string, Id>>* elsPtr) {
+ad_utility::HashMap<Id, Id> createInternalMapping(std::vector<std::pair<string, Id>>* elsPtr) {
   auto& els = *elsPtr;
-  absl::flat_hash_map<Id, Id> res;
+  ad_utility::HashMap<Id, Id> res;
   bool first = true;
   std::string lastWord;
   size_t nextWordId = 0;
@@ -236,12 +236,12 @@ absl::flat_hash_map<Id, Id> createInternalMapping(std::vector<std::pair<string, 
 }
 
 // ________________________________________________________________________________________________________
-void writeMappedIdsToExtVec(const TripleVec& input, const absl::flat_hash_map<Id, Id>& map,
+void writeMappedIdsToExtVec(const TripleVec& input, const ad_utility::HashMap<Id, Id>& map,
                             TripleVec::bufwriter_type* writePtr) {
   auto& writer = *writePtr;
   for (const auto& curTriple : input) {
     // for all triple elements find their mapping from partial to global ids
-    absl::flat_hash_map<Id, Id>::const_iterator iterators[3];
+    ad_utility::HashMap<Id, Id>::const_iterator iterators[3];
     for (size_t k = 0; k < 3; ++k) {
       iterators[k] = map.find(curTriple[k]);
       if (iterators[k] == map.end()) {
@@ -263,7 +263,7 @@ void writePartialVocabularyToFile(const std::vector<std::pair<string, Id>>& els,
   AD_CHECK(out.is_open());
   for (const auto& el : els) {
     std::string_view word = el.first;
-    uint64_t len = word.size();
+    size_t len = word.size();
     out.write((char*)&len, sizeof(len));
     out.write(word.data(), len);
     Id id = el.second;

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -10,4 +10,4 @@ add_library(parser
               ParallelParseBuffer.h
               PropertyPathParser.h PropertyPathParser.cpp
               SparqlLexer.h SparqlLexer.cpp)
-target_link_libraries(parser re2)
+target_link_libraries(parser re2 absl::flat_hash_map)

--- a/src/parser/NTriplesParser.h
+++ b/src/parser/NTriplesParser.h
@@ -17,6 +17,8 @@ class NTriplesParser {
   // Don't allow copy & assignment
   explicit NTriplesParser(const NTriplesParser& other) = delete;
   NTriplesParser& operator=(const NTriplesParser& other) = delete;
+  explicit NTriplesParser(NTriplesParser&& other) = default;
+  NTriplesParser& operator=(NTriplesParser&& other) = default;
 
   // Get the next line from the file.
   // Returns true if something was stored.

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -198,6 +198,11 @@ struct TurtleToken {
         Anon(grp(AnonString)),
         Comment(grp(CommentString)) {}
 
+  TurtleToken(const TurtleToken& other) : TurtleToken() { (void)other; }
+  TurtleToken& operator=([[maybe_unused]] const TurtleToken& other) {
+    return *this;
+  }
+
   const RE2 TurtlePrefix;
   const RE2 SparqlPrefix;
   const RE2 TurtleBase;
@@ -378,7 +383,7 @@ class Tokenizer {
   std::string_view view() const { return {_data.data(), _data.size()}; }
 
   // holds all the regexes needed for Tokenization
-  const TurtleToken _tokens;
+  TurtleToken _tokens;
 
  private:
   // ________________________________________________________________

--- a/src/parser/TsvParser.h
+++ b/src/parser/TsvParser.h
@@ -17,6 +17,8 @@ class TsvParser {
   // Don't allow copy & assignment
   explicit TsvParser(const TsvParser& other) = delete;
   TsvParser& operator=(const TsvParser& other) = delete;
+  TsvParser(TsvParser&& other) = default;
+  TsvParser& operator=(TsvParser&& other) = default;
 
   // Get the next line from the file.
   // Returns true if something was stored.

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -9,7 +9,7 @@
 // _______________________________________________________________
 bool TurtleParser::statement() {
   _tok.skipWhitespaceAndComments();
-  return directive() || (triples() && skip(_tokens.Dot));
+  return directive() || (triples() && skip(tokens().Dot));
 }
 
 // ______________________________________________________________
@@ -19,8 +19,8 @@ bool TurtleParser::directive() {
 
 // ________________________________________________________________
 bool TurtleParser::prefixID() {
-  if (skip(_tokens.TurtlePrefix)) {
-    if (check(pnameNS()) && check(iriref()) && check(skip(_tokens.Dot))) {
+  if (skip(tokens().TurtlePrefix)) {
+    if (check(pnameNS()) && check(iriref()) && check(skip(tokens().Dot))) {
       // strip  the angled brackes <bla> -> bla
       _prefixMap[_activePrefix] =
           _lastParseResult.substr(1, _lastParseResult.size() - 2);
@@ -35,7 +35,7 @@ bool TurtleParser::prefixID() {
 
 // ________________________________________________________________
 bool TurtleParser::base() {
-  if (skip(_tokens.TurtleBase)) {
+  if (skip(tokens().TurtleBase)) {
     if (iriref()) {
       _baseIRI = _lastParseResult;
       return true;
@@ -49,7 +49,7 @@ bool TurtleParser::base() {
 
 // ________________________________________________________________
 bool TurtleParser::sparqlPrefix() {
-  if (skip(_tokens.SparqlPrefix)) {
+  if (skip(tokens().SparqlPrefix)) {
     if (pnameNS() && iriref()) {
       _prefixMap[_activePrefix] = _lastParseResult;
       return true;
@@ -63,7 +63,7 @@ bool TurtleParser::sparqlPrefix() {
 
 // ________________________________________________________________
 bool TurtleParser::sparqlBase() {
-  if (skip(_tokens.SparqlBase)) {
+  if (skip(tokens().SparqlBase)) {
     if (iriref()) {
       _baseIRI = _lastParseResult;
       return true;
@@ -97,7 +97,7 @@ bool TurtleParser::triples() {
 // __________________________________________________
 bool TurtleParser::predicateObjectList() {
   if (verb() && check(objectList())) {
-    while (skip(_tokens.Semicolon)) {
+    while (skip(tokens().Semicolon)) {
       if (verb() && check(objectList())) {
         continue;
       }
@@ -111,7 +111,7 @@ bool TurtleParser::predicateObjectList() {
 // _____________________________________________________
 bool TurtleParser::objectList() {
   if (object()) {
-    while (skip(_tokens.Comma) && check(object())) {
+    while (skip(tokens().Comma) && check(object())) {
       continue;
     }
     return true;
@@ -126,7 +126,7 @@ bool TurtleParser::verb() { return predicateSpecialA() || predicate(); }
 // ___________________________________________________________________
 bool TurtleParser::predicateSpecialA() {
   _tok.skipWhitespaceAndComments();
-  if (auto [success, word] = _tok.getNextToken(_tokens.A); success) {
+  if (auto [success, word] = _tok.getNextToken(tokens().A); success) {
     (void)word;
     _activePredicate = u8"<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
     return true;
@@ -177,7 +177,7 @@ bool TurtleParser::literal() {
 
 // _____________________________________________________________________
 bool TurtleParser::blankNodePropertyList() {
-  if (!skip(_tokens.OpenSquared)) {
+  if (!skip(tokens().OpenSquared)) {
     return false;
   }
   // save subject and predicate
@@ -190,7 +190,7 @@ bool TurtleParser::blankNodePropertyList() {
   // the following triples have the blank node as subject
   _activeSubject = blank;
   check(predicateObjectList());
-  check(skip(_tokens.CloseSquared));
+  check(skip(tokens().CloseSquared));
   // restore subject and predicate
   _activeSubject = savedSubject;
   _activePredicate = savedPredicate;
@@ -199,7 +199,7 @@ bool TurtleParser::blankNodePropertyList() {
 
 // _____________________________________________________________________
 bool TurtleParser::collection() {
-  if (!skip(_tokens.OpenRound)) {
+  if (!skip(tokens().OpenRound)) {
     return false;
   }
   throw ParseException(
@@ -223,7 +223,7 @@ bool TurtleParser::rdfLiteral() {
     return true;
     // TODO<joka921> this allows spaces here since the ^^ is unique in the
     // sparql syntax. is this correct?
-  } else if (skip(_tokens.DoubleCircumflex) && check(iri())) {
+  } else if (skip(tokens().DoubleCircumflex) && check(iri())) {
     _lastParseResult = s + "^^" + _lastParseResult;
     return true;
   } else {
@@ -235,8 +235,8 @@ bool TurtleParser::rdfLiteral() {
 // ______________________________________________________________________
 bool TurtleParser::booleanLiteral() {
   std::vector<const RE2*> candidates;
-  candidates.push_back(&(_tokens.True));
-  candidates.push_back(&(_tokens.False));
+  candidates.push_back(&(tokens().True));
+  candidates.push_back(&(tokens().False));
   if (auto [success, index, word] = _tok.getNextToken(candidates); success) {
     (void)index;
     _lastParseResult = word;
@@ -330,12 +330,12 @@ bool TurtleParser::parseTerminal(const RE2& terminal) {
 
 // ________________________________________________________________________
 bool TurtleParser::blankNodeLabel() {
-  return parseTerminal(_tokens.BlankNodeLabel);
+  return parseTerminal(tokens().BlankNodeLabel);
 }
 
 // __________________________________________________________________________
 bool TurtleParser::pnameNS() {
-  if (parseTerminal(_tokens.PnameNS)) {
+  if (parseTerminal(tokens().PnameNS)) {
     // this also includes a ":" which we do not need, hence the "-1"
     _activePrefix = _lastParseResult.substr(0, _lastParseResult.size() - 1);
     _lastParseResult = "";

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -39,6 +39,9 @@ class TurtleParser {
   // open an input file or stream
   virtual void initialize(const string& filename) = 0;
   virtual ~TurtleParser() = default;
+  TurtleParser() = default;
+  TurtleParser(TurtleParser&& rhs) = default;
+  TurtleParser& operator=(TurtleParser&& rhs) = default;
 
   // Wrapper to getLine that is expected by the rest of QLever
   bool getLine(std::array<string, 3>& triple) { return getLine(&triple); }
@@ -108,7 +111,7 @@ class TurtleParser {
   std::string _activePrefix;
   std::string _activeSubject;
   std::string _activePredicate;
-  const TurtleToken& _tokens = _tok._tokens;
+  [[nodiscard]] const TurtleToken& tokens() const { return _tok._tokens; }
   size_t _numBlankNodes = 0;
 
  private:
@@ -142,20 +145,20 @@ class TurtleParser {
   // Terminal symbols from the grammar
   // Behavior of the functions is similar to the nonterminals (see above)
   bool iriref();
-  bool integer() { return parseTerminal(_tokens.Integer); }
-  bool decimal() { return parseTerminal(_tokens.Decimal); }
-  bool doubleParse() { return parseTerminal(_tokens.Double); }
+  bool integer() { return parseTerminal(tokens().Integer); }
+  bool decimal() { return parseTerminal(tokens().Decimal); }
+  bool doubleParse() { return parseTerminal(tokens().Double); }
   bool pnameLN();
 
   // __________________________________________________________________________
   bool pnameNS();
 
   // __________________________________________________________________________
-  bool langtag() { return parseTerminal(_tokens.Langtag); }
+  bool langtag() { return parseTerminal(tokens().Langtag); }
   bool blankNodeLabel();
 
   bool anon() {
-    if (!parseTerminal(_tokens.Anon)) {
+    if (!parseTerminal(tokens().Anon)) {
       return false;
     }
     _lastParseResult = createAnonNode();
@@ -356,6 +359,8 @@ class TurtleMmapParser : public TurtleParser {
   }
 
   ~TurtleMmapParser() { unmapFile(); }
+  TurtleMmapParser(TurtleMmapParser&& rhs) = default;
+  TurtleMmapParser& operator=(TurtleMmapParser&& rhs) = default;
 
   // inherit the other overload
   using TurtleParser::getLine;

--- a/src/util/BatchedPipeline.cpp
+++ b/src/util/BatchedPipeline.cpp
@@ -1,0 +1,5 @@
+//
+// Created by johannes on 04.01.20.
+//
+
+#include "BatchedPipeline.h"

--- a/src/util/BatchedPipeline.h
+++ b/src/util/BatchedPipeline.h
@@ -1,0 +1,652 @@
+// Copyright 2020, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
+
+#ifndef QLEVER_BATCHEDPIPELINE_H
+#define QLEVER_BATCHEDPIPELINE_H
+
+#include <future>
+#include <utility>
+#include "./Timer.h"
+#include "./TupleHelpers.h"
+
+namespace ad_pipeline {
+
+using namespace ad_tuple_helpers;
+
+namespace detail {
+
+/* This is used as a return value for the produceBatch calls of our pipeline
+ * elements If the first element (the bool) is false this means that our
+ * pipeline is exhausted and there is no point in asking it for further batches.
+ */
+template <class T>
+using VecT = std::pair<bool, std::vector<T>>;
+
+/*
+ * The Batcher class takes a Creator (A Functor that returns a std::optional<T>
+ * and will call the creator and store the results. A call to produceBatch will
+ * return a batch of these results and trigger the concurrent calculation of the
+ * next batch. Once the creator returns std::nullopt, the Batcher will stop
+ * calling it. The next call to produce batch will then set its first element
+ * (the a flag) to false as a signal that this batcher is exhausted and return a
+ * possibly incomplete batch.
+ */
+template <class Creator>
+class Batcher {
+ public:
+  using ValueT = std::decay_t<decltype(std::declval<Creator>()().value())>;
+
+  // construct from the batchSize and Creator Rvalue Reference
+  /// @brief Don't use these, call setupPipeline or setupParallelPipeline
+  /// instead
+  Batcher(size_t batchSize, Creator&& creator)
+      : _batchSize(batchSize),
+        _creator(std::make_unique<Creator>(std::move(creator))) {
+    orderNextBatch();
+  }
+
+  // construct from the batchSize and Creator const Reference
+  /// @brief Don't use these, call setupPipeline or setupParallelPipeline
+  /// instead
+  Batcher(size_t batchSize, const Creator& creator)
+      : _batchSize(batchSize), _creator(std::make_unique<Creator>(creator)) {
+    orderNextBatch();
+  }
+
+  /* Get the next batch of values. A batch exactly batchSize values
+   * unless this was the last batch. Then result.first will be false
+   * and the batch might have < batchSize elements
+   */
+  detail::VecT<ValueT> produceBatch() {
+    try {
+      _timer.cont();
+      auto res = _fut.get();
+      _timer.stop();
+      orderNextBatch();
+      return res;
+    } catch (const std::future_error& e) {
+      throw std::runtime_error(
+          "encountered std::future_error in the Batcher class. Should never "
+          "happen, please report this");
+    }
+  }
+
+  // get the accumulated time that calls to produceBatch had to block until they
+  // could return the next batch
+  std::vector<off_t> getWaitingTime() const { return {_timer.msecs()}; }
+
+  // returns the batchSize. The last batch might be smaller
+  [[nodiscard]] size_t getBatchSize() const { return _batchSize; }
+
+ private:
+  size_t _batchSize;
+  std::unique_ptr<Creator> _creator;
+  std::future<detail::VecT<ValueT>> _fut;
+  ad_utility::Timer _timer;
+
+  // start assembling the next batch in parallel
+  void orderNextBatch() {
+    // since the unique_ptr _creator owns the creator,
+    // the captured pointer will stay valid even while this
+    // class is moved.
+    _fut = std::async(std::launch::async,
+                      [bs = _batchSize, ptr = _creator.get()]() {
+                        return produceBatchInternal(bs, ptr);
+                      });
+  }
+
+  /* retrieve values from the creator and store them in the VecT result.
+   * Once we have reached batchSize Elements or the creator returns std::nullopt
+   * we return. In the latter case, result.first is false
+   */
+  static detail::VecT<ValueT> produceBatchInternal(size_t batchSize,
+                                                   Creator* creator) {
+    detail::VecT<ValueT> res;
+    res.first = true;
+    res.second.reserve(batchSize);
+    for (size_t i = 0; i < batchSize; ++i) {
+      auto opt = (*creator)();
+      if (!opt) {
+        res.first = false;
+        return res;
+      }
+      res.second.push_back(std::move(opt.value()));
+    }
+    return res;
+  }
+};
+
+/*
+ * This class represents an intermediate step of the Pipeline.
+ * It gets batches from the Producer and Applies the Transformer(s) (see below)
+ * to each element of the batch and returns the produced batch via the
+ * produceBatch() method. Each time a transformed batch is returned, we issue
+ * transformation of the next batch in a concurrent thread
+ *
+ * Concerning the Parallelism, there are two cases
+ * case 1: There is only one Transformer. we start <Parallelism> threads
+ * that execute the FirstTransformer concurrently on consecutive part of the
+ * batch. If Parallelism > 1 this means that the FirstTransformer must be
+ * threadsafe
+ *
+ * case 2: <Parallelism> == Total Number of Transformers
+ * Then the FirstTransformer is applied to the first batchSize /
+ * #AllTransformers elements and so on. In this case the return type of the
+ * FirstTransformer determines the produced Value type and the return types of
+ * the remaining transformers must be implicitly convertible to this type.
+ */
+template <size_t Parallelism, class Producer, class FirstTransformer,
+          class... Transformers>
+class BatchedPipeline {
+ public:
+  // either the same transformer is applied in all parallel Branches, or there
+  // is exactly one transformer for all
+  static_assert(sizeof...(Transformers) == 0 ||
+                sizeof...(Transformers) + 1 == Parallelism);
+
+  // the value type our producer delivers to us
+  using InT = std::decay_t<decltype(
+      std::declval<Producer&>().produceBatch().second[0])>;
+
+  // the value type this BatchedPipeline produces
+  using ResT = std::invoke_result_t<FirstTransformer, InT>;
+
+  /* TODO<joka921>: Currently the Transformers have to be copy-constructible.
+   * could be changed to some kind of perfect forwarding should this ever become
+   * an issue, but copying is pretty much the default for Function objects in
+   * C++
+   */
+  BatchedPipeline(Producer&& p, FirstTransformer t, Transformers... ts)
+      : _transformers(toUniquePtrTuple(t, ts...)),
+        _rawTransformers(toRawPtrTuple(_transformers)),
+        _producer(std::make_unique<Producer>(std::move(p))) {
+    orderNextBatch();
+  }
+
+  // _____________________________________________________________________
+  VecT<ResT> produceBatch() {
+    try {
+      _timer.cont();
+      auto res = _fut.get();
+      _timer.stop();
+      orderNextBatch();
+      return res;
+    } catch (std::future_error& e) {
+      throw std::runtime_error(
+          "encountered std::future_error in the BatchedPipeline class. Should "
+          "never happen, please report this");
+    }
+  }
+
+  // asynchronously prepare the next Batch in a different thread
+  void orderNextBatch() {
+    auto lambda = [p = _producer.get(), batchSize = _producer->getBatchSize()](
+                      auto... transformerPtrs) {
+      return std::async(
+          std::launch::async, [p, batchSize, transformerPtrs...]() {
+            return produceBatchInternal(p, batchSize, transformerPtrs...);
+          });
+    };
+    _fut = std::apply(lambda, _rawTransformers);
+  }
+
+  // for this and all previous steps of the pipeline, get the total blocking
+  // time in calls to produce batch
+  std::vector<off_t> getWaitingTime() const {
+    auto res = _producer->getWaitingTime();
+    res.push_back(_timer.msecs());
+    return res;
+  }
+
+  // Return the batch size
+  [[nodiscard]] size_t getBatchSize() const {
+    return _producer->getBatchSize();
+  }
+
+ private:
+  /*  The actual transformation logic
+   *  is a static function to easily pass it to a std::future
+   *  takes raw pointers to the transformers and the producer, so the
+   *  ownership remains with the unique_ptrs within the class.
+   *  This implies that this class can be safely moved, even this method runs in
+   * parallel also takes the actual batchSize of the pipeline. That way it can
+   * apply the correct transformer to the correct element even for the last
+   * (possibly incomplete batch)
+   */
+  template <typename FirstPtr, typename... OtherPtrs>
+  static VecT<ResT> produceBatchInternal(Producer* producer, size_t inBatchSize,
+                                         FirstPtr fst, OtherPtrs... other) {
+    auto inBatch = producer->produceBatch();
+    auto& in = inBatch.second;
+    VecT<ResT> result;
+    auto& out = result.second;
+    result.first = inBatch.first;
+    out.reserve(in.size());
+    if constexpr (Parallelism == 1) {
+      // simplest case, only one thread and one transformer
+      std::transform(std::make_move_iterator(in.begin()),
+                     std::make_move_iterator(in.end()), std::back_inserter(out),
+                     [transformer = fst](
+                         typename std::decay_t<decltype(in)>::value_type&& x) {
+                       return (*transformer)(std::move(x));
+                     });
+    } else {
+      // currently each of the <parallelism> threads first creates its own VecT
+      // and later we merge doing this in place would require something like a
+      // std::vector without default construction on insert.
+      std::array<std::future<std::vector<ResT>>, Parallelism> futures;
+      const size_t batchSize = inBatchSize / Parallelism;
+      if constexpr (sizeof...(OtherPtrs) == 0) {
+        // only one transformer, but multiple threads that all use the same
+        // transformer
+        for (size_t i = 0; i < Parallelism; ++i) {
+          // correctly calculate the boundaries for the subbatch
+          auto startIt = std::min(in.begin() + i * batchSize, in.end());
+          auto endIt =
+              i < Parallelism - 1
+                  ? std::min(in.begin() + (i + 1) * batchSize, in.end())
+                  : in.end();
+          // start a thread returns a transformed version of all the elements in
+          // [startIt, endIt)
+          futures[i] = std::async(
+              std::launch::async,
+              [i, transformer = fst, batchSize, startIt, endIt] {
+                std::vector<ResT> res;
+                res.reserve(endIt - startIt);
+                std::transform(
+                    std::make_move_iterator(startIt),
+                    std::make_move_iterator(endIt), std::back_inserter(res),
+                    [transformer](
+                        typename std::decay_t<decltype(in)>::value_type&& x) {
+                      return (*transformer)(std::move(x));
+                    });
+                return res;
+              });
+        }
+      } else {  // we have one transformer per parallel Branch
+        // this was outsourced since we need template magic for the different
+        // transformers
+        createInternalParallelism(&futures, batchSize, 0, in, fst, other...);
+      }
+      // if we had multiple threads, we have to merge the partial results in the
+      // correct order.
+      for (size_t i = 0; i < Parallelism; ++i) {
+        auto vec = futures[i].get();
+        out.insert(out.end(), std::make_move_iterator(vec.begin()),
+                   std::make_move_iterator(vec.end()));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * @brief This function makes sure that each of the different transformers,
+   * which possibly have different types (lambdas!) are applied to the correct
+   * subbatch.
+   * @tparam InVec std::vector of the Producer's value type
+   * @param futuresPtr pointer to one future per Transformer that will be
+   * associated with the respective subbatch calculation
+   * @param batchSize the correct batchSize that will also be respected for
+   * incomplete batches
+   * @param index 0 <= index < Parallelism. The index of the next transformer
+   * that is to be assigned. Only used for recursion purposes, must be 0 when
+   * called externally
+   * @param in The InVec of elements to transform
+   * @param transformer Pointer to the first transformer
+   * @param transformers Pointers to the remaining transformers
+   */
+  template <typename InVec, typename TransformerPtr,
+            typename... TransformerPtrs>
+  static void createInternalParallelism(
+      std::array<std::future<std::vector<ResT>>, Parallelism>* futuresPtr,
+      size_t batchSize, size_t index, InVec& in, TransformerPtr transformer,
+      TransformerPtrs... transformers) {
+    auto& futures = *futuresPtr;
+    // calculate the correct bounds for the next subbatch
+    auto startIt = std::min(in.begin() + index * batchSize, in.end());
+    auto endIt = index < Parallelism - 1
+                     ? std::min(in.begin() + (index + 1) * batchSize, in.end())
+                     : in.end();
+    // start a thread for the first transformer. This function will
+    // be called recursively s.t. the index-th transformer will always be
+    // the first in the respective recursion step
+    futures[index] = std::async(std::launch::async, [index, transformer,
+                                                     batchSize, startIt,
+                                                     endIt] {
+      std::vector<ResT> res;
+      res.reserve(endIt - startIt);
+      std::transform(
+          std::make_move_iterator(startIt), std::make_move_iterator(endIt),
+          std::back_inserter(res),
+          [transformer](typename std::decay_t<decltype(in)>::value_type&& x) {
+            return (*transformer)(std::move(x));
+          });
+      return res;
+    });
+
+    if (index < Parallelism - 1) {
+      // this was not the last transformer, recursive
+      if constexpr (sizeof...(transformers) > 0) {
+        createInternalParallelism(futuresPtr, batchSize, index + 1, in,
+                                  transformers...);
+      } else {
+        // this can never happen by the static_asserted invariants of the class
+        // but we need the constexpr if to make the instantiation for the last
+        // transformer work
+        throw std::runtime_error(
+            "This path should never be called in createInternalParallelism. "
+            "Please report to the developers.");
+      }
+    }
+  }
+
+ private:
+  ad_utility::Timer _timer;
+  // the unique_ptrs to our Transformers
+  using uniquePtrTuple = toUniquePtrTuple_t<FirstTransformer, Transformers...>;
+  // raw non-owning pointers to the transformers
+  using rawPtrTuple = toRawPtrTuple_t<uniquePtrTuple>;
+  uniquePtrTuple _transformers;
+  rawPtrTuple _rawTransformers;
+  std::unique_ptr<Producer> _producer;
+  std::future<VecT<ResT>> _fut;
+};
+
+/*
+ * Factory function for the BatchedPipeline class
+ * That allows us to explicitly specify the Parallelism parameter
+ * and implicitly specify the other template types by the constructor
+ * arguments.
+ */
+template <size_t Parallelism, class Producer, class Transformer,
+          class... OtherTransformers>
+auto makeBatchedPipeline(Producer&& p, Transformer&& t,
+                         OtherTransformers&&... other) {
+  return BatchedPipeline<Parallelism, std::decay_t<Producer>,
+                         std::decay_t<Transformer>,
+                         std::decay_t<OtherTransformers>...>(
+      std::forward<Producer>(p), std::forward<Transformer>(t),
+      std::forward<OtherTransformers>(other)...);
+}
+
+/* recursion base case, we are trying to setup a Pipeline but are out of
+ * transformers, just return the pipeline used by the global setupPipeline
+ * function
+ */
+template <typename SoFar>
+auto setupPipelineRecursive(SoFar&& sofar) {
+  return std::forward<SoFar>(sofar);
+}
+
+/* add one BatchedPipeline Layer to the pipeline sofar using the
+ * first transformer and then recurse for the remaining transformers
+ * Used by the global setupPipeline function
+ */
+template <typename SoFar, typename NextTransformer,
+          typename... MoreTransformers>
+auto setupPipelineRecursive(SoFar&& sofar, NextTransformer&& next,
+                            MoreTransformers&&... transformers) {
+  return setupPipelineRecursive(
+      makeBatchedPipeline<1>(std::forward<SoFar>(sofar),
+                             std::forward<NextTransformer>(next)),
+      std::forward<MoreTransformers>(transformers)...);
+}
+
+/*
+ * Base case for the recursive creation of a parallel Pipeline,
+ * We are out of Transformers so only return the pipeline
+ */
+template <typename SoFar>
+auto setupParallelPipelineRecursive(SoFar&& sofar) {
+  return std::forward<SoFar>(sofar);
+}
+
+/*
+ * Recursion For the setupParallelPipeline function.
+ * This is the case where the nextTransformer is not a tuple.
+ * This means that our next BatchedPipeline layer will use the
+ * same transformer for all its <NextParallelis> threads.
+ */
+template <size_t NextParallelism, size_t... Parallelisms, typename SoFar,
+          typename NextTransformer,
+          typename = std::enable_if_t<!is_tuple<NextTransformer>::value>,
+          typename... MoreTransformers>
+auto setupParallelPipelineRecursive(SoFar&& sofar, NextTransformer&& next,
+                                    MoreTransformers&&... transformers) {
+  return setupParallelPipelineRecursive<Parallelisms...>(
+      makeBatchedPipeline<NextParallelism>(std::forward<SoFar>(sofar),
+                                           std::forward<NextTransformer>(next)),
+      std::forward<MoreTransformers>(transformers)...);
+}
+
+/*
+ * Recursion For the setupParallelPipeline function.
+ * This is the case where the nextTransformer is a tuple of <NextParallelism>
+ * different transformers. (the size of the tuple is statically asserted inside
+ * the BatchedPipeline class) This means that our next BatchedPipeline layer
+ * will each of the transformers for exactly one of its <NextParallelism>
+ * threads.
+ */
+template <size_t NextParallelism, size_t... Parallelisms, typename SoFar,
+          typename... NextTransformer, typename... MoreTransformers>
+auto setupParallelPipelineRecursive(SoFar&& sofar,
+                                    std::tuple<NextTransformer...>&& next,
+                                    MoreTransformers&&... transformers) {
+  auto lambda = [&sofar](NextTransformer&&... transformers) {
+    return makeBatchedPipeline<NextParallelism>(
+        std::forward<SoFar>(sofar),
+        std::forward<NextTransformer>(transformers)...);
+  };
+
+  return setupParallelPipelineRecursive<Parallelisms...>(
+      std::apply(lambda, std::move(next)),
+      std::forward<MoreTransformers>(transformers)...);
+}
+
+class Interface;  // forward declaration needed below for friend declaration
+
+}  // namespace detail
+
+/* Holds a Pipeline (Object on which we can call "produceBatch" and get a
+ * VecT<ValueType> and extracts its elements one by one. Internally buffers one
+ * batch and concurrently produces the nextBatch while it issues the element
+ * from the buffer one at a time via the getNextValue() method.
+ */
+/**
+ * @brief An instantiation of this templated class is created by the calls to
+ * setupPipeline() and setupParallelPipeline() It supports the getNextValue()
+ * interface that will return std::optional<ValueT> for each of the completely
+ * transformed elements in a pipeline and std::nullopt once it is exhausted. See
+ * the documentation of the setup* functions
+ */
+template <class Pipeline>
+class BatchExtractor {
+ public:
+  /// The type of our elements after all transformations were applied
+  using ValueT =
+      std::decay_t<decltype(std::declval<Pipeline>().produceBatch().second[0])>;
+
+  // Retrieve and return the next triple from the internal buffer.
+  // If the buffer is exhausted blocks
+  // until the (asynchronous) call to _pipeline.produceBatch() has finished. A
+  // nullopt signals the parser has completely parsed the file.
+  /// get the next completely transformed value from the pipeline. std::nullopt
+  /// means that all elements have been extracted
+  std::optional<ValueT> getNextValue() {
+    // we return the elements in order
+    if (_buffer.size() == _bufferPosition && _isPipelineValid) {
+      // we have to wait for the next parallel batch to be completed.
+      _timer.cont();
+      std::tie(_isPipelineValid, _buffer) = _fut.get();
+      _timer.stop();
+      _bufferPosition = 0;
+      if (_isPipelineValid) {
+        // if possible, directly submit the next parsing job
+        _fut = std::async(std::launch::async, [ptr = _pipeline.get()]() {
+          return ptr->produceBatch();
+        });
+      }
+    }
+    // we now should have some values in our buffer
+    if (_bufferPosition < _buffer.size()) {
+      return std::move(_buffer[_bufferPosition++]);
+    } else {
+      // we can only reach this if the buffer is exhausted and there is nothing
+      // more to parse
+      return std::nullopt;
+    }
+  }
+
+  /**
+   * @brief for all steps in the pipeline, report how long their calls to
+   * produceBatch were blocking. TODO<joka921>: how useful is this measure?
+   */
+  [[nodiscard]] std::vector<off_t> getWaitingTime() const {
+    auto res = _pipeline->getWaitingTime();
+    res.push_back(_timer.msecs());
+    return res;
+  }
+
+  /// return the batchSize
+  [[nodiscard]] size_t getBatchSize() const { return _pipeline.getBatchSize(); }
+
+ private:
+  ad_utility::Timer _timer;
+  std::unique_ptr<Pipeline> _pipeline;
+  std::future<detail::VecT<ValueT>> _fut;
+  std::vector<ValueT> _buffer;
+  size_t _bufferPosition = 0;
+  bool _isPipelineValid = true;
+
+  // Pipelines are move-only types
+  explicit BatchExtractor(Pipeline&& pipeline)
+      : _pipeline(std::make_unique<Pipeline>(std::move(pipeline))) {
+    _fut = std::async(std::launch::async, [ptr = _pipeline.get()]() {
+      return ptr->produceBatch();
+    });
+  }
+  friend class detail::Interface;
+};
+
+namespace detail {
+class Interface {
+ public:
+  // the actual implementation of setupPipeline, hidden in this class s.t.
+  // we can make the BatchExtractor's constructor private and expose a minimal
+  // interface
+  template <typename Creator, typename... Ts>
+  static auto setupPipeline(size_t batchSize, Creator&& creator,
+                            Ts&&... transformers) {
+    auto batcher = detail::Batcher(batchSize, std::forward<Creator>(creator));
+    auto pipeline = detail::setupPipelineRecursive(
+        std::move(batcher), std::forward<Ts>(transformers)...);
+    return BatchExtractor(std::move(pipeline));
+  }
+
+  // the actual implementation of setupParallelPipeline, hidden in this class
+  // s.t. we can make the BatchExtractor's constructor private and expose a
+  // minimal interface
+  template <size_t... Parallelisms, typename Creator, typename... Ts>
+  static auto setupParallelPipeline(size_t batchSize, Creator&& creator,
+                                    Ts&&... transformers) {
+    static_assert(sizeof...(Parallelisms) == sizeof...(Ts),
+                  "setupParallelPipeline needs same number of parallelism "
+                  "specifiers and transformers");
+    auto batcher = detail::Batcher(batchSize, std::forward<Creator>(creator));
+    auto pipeline = detail::setupParallelPipelineRecursive<Parallelisms...>(
+        std::move(batcher), std::forward<Ts>(transformers)...);
+    return BatchExtractor(std::move(pipeline));
+  }
+};
+}  // namespace detail
+
+/**
+ * @brief setup a pipeline that efficiently creates and transforms values. The
+ * Concurrency is used between the different levels
+ *
+ * Each element is created by the creator and then transformed by all of the
+ * transformers one after another s.t. it becomes
+ * ... TransformerN(....(Transformer1(creator()))
+ * This is implemented by first creating a batch of values. Then this batch is
+ * passed to the first transformer which transforms it while the creator creates
+ * the nextBatch in Parallel. This principle applies to all the transformers.
+ * This means that all the transformers/ different stages of the pipeline must
+ * be able to run in Parallel without conflicts (but of course, no two
+ * transformers access the same element at a time. This allows us to use
+ * Transformers which might have sideeffects. For examples see the corresponding
+ * unitTests.
+ * @param batchSize the size of the batches. Might influence Performance (time
+ * vs. memory consumption)
+ * @param creator repeated calls to creator() must create the initial values of
+ * type T_0 one at a time as std::optional<T_0> a return value of std::nullopt
+ * means that no more elements are created
+ * @param transformers Function objects that perform the different
+ * transformations in the order they are listed. The i-th transformer takes a
+ * T_i&& and returns a T_{i+1}; Currently the transformers must be
+ * copy-constructible
+ * @return a BatchExtractor on which we can call getNextValue() to get
+ * std::optional<ReturnTypeOfLastTransformers> here also a std::nullopt
+ * signalizes the last value.
+ */
+template <typename Creator, typename... Ts>
+auto setupPipeline(size_t batchSize, Creator&& creator, Ts&&... transformers) {
+  return detail::Interface::setupPipeline(batchSize,
+                                          std::forward<Creator>(creator),
+                                          std::forward<Ts>(transformers)...);
+}
+
+/**
+ * @brief setup a pipeline that efficiently creates and transforms values.
+ * Concurrency is used between and within the different levels
+ *
+ * In general this works similar to the setupPipeline() function template. Make
+ * sure to read and understand the corresponding documentation first. It has the
+ * following difference::
+ *
+ * With each Transformer there is a degree of Parallelism (a size_t) associated.
+ * If this is degree is 1, this level behaves exactly the same as in the
+ * setupPipeline function above.
+ *
+ * Otherwise let p be the degree of Parallelism of the i-th Transformer. then
+ * there are two possibilities:
+ * - The transformer is a single function object. Then for each batch p threads
+ * are started that each are assigned a part of the batch. Those are then
+ * transformed concurrently by calls to the transformer. This means that the
+ * transformer must be threadsafe.
+ *
+ * - The transformer is a std::tuple of p function objects. Then again the batch
+ * is split into p parts where the first part is transformed by the first
+ * element of the tuple, the second part by the second element... In this case
+ * it is of course necessary, that the return types of the function objects in
+ * the tuple are compatible, the return type of this level is derived from the
+ * first tuple element. The following guarantee holds: If two (not necessary
+ * consecutive) levels i and j have the same degree of parallelism p > 1  and
+ * both specify a tuple of p function objects then the elements that are
+ * transformed by the k-th tuple element on level i are also transformed by the
+ * k-th tuple element on level j.
+ *
+ * @tparam Parallelisms One size_t for each transformer, assigning it a degree
+ * of parallelism
+ * @param batchSize the size of the batches. Might influence Performance (time
+ * vs. memory consumption)
+ * @param creator repeated calls to creator() must create the initial values of
+ * type T_0 one at a time as std::optional<T_0> a return value of std::nullopt
+ * means that no more elements are created
+ * @param transformers for each element either one FunctionObject or a tuple of
+ * k function objects, where k is the corresponding entry in the Parallelisms.
+ * @return a BatchExtractor on which we can call getNextValue() to get
+ * std::optional<ReturnTypeOfLastTransformers> here also a std::nullopt
+ * signalizes the last value.
+ */
+template <size_t... Parallelisms, typename Creator, typename... Ts>
+static auto setupParallelPipeline(size_t batchSize, Creator&& creator,
+                                  Ts&&... transformers) {
+  return detail::Interface::setupParallelPipeline<Parallelisms...>(
+      batchSize, std::forward<Creator>(creator),
+      std::forward<Ts>(transformers)...);
+}
+
+}  // namespace ad_pipeline
+
+#endif  // QLEVER_BATCHEDPIPELINE_H

--- a/src/util/HashMap.h
+++ b/src/util/HashMap.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <google/dense_hash_map>
+#include <absl/container/flat_hash_map.h>
 
 #include "./DefaultKeyProvider.h"
 
@@ -18,21 +18,13 @@ namespace ad_utility {
 // functions. It only adds a constructor which automatically sets the empty and
 // deleted keys.  This may be changed in the future.
 template <class K, class V,
-          class HashFcn = SPARSEHASH_HASH<K>,  // defined in sparseconfig.h
-          class EqualKey = std::equal_to<K>,
-          class Alloc =
-              google::libc_allocator_with_realloc<std::pair<const K, V> > >
-class HashMap : private google::dense_hash_map<K, V, HashFcn, EqualKey, Alloc> {
-  using Base = typename google::dense_hash_map<K, V, HashFcn, EqualKey, Alloc>;
+          class HashFcn = absl::container_internal::hash_default_hash<K>,
+          class EqualKey = absl::container_internal::hash_default_eq<K>,
+          class Alloc = std::allocator<std::pair<const K, V>>>
+class HashMap : private absl::flat_hash_map<K, V, HashFcn, EqualKey, Alloc> {
+  using Base = typename absl::flat_hash_map<K, V, HashFcn, EqualKey, Alloc>;
 
  public:
-  HashMap<K, V, HashFcn, EqualKey, Alloc>(
-      K emptyKey = DefaultKeyProvider<K>::DEFAULT_EMPTY_KEY,
-      K deletedKey = DefaultKeyProvider<K>::DEFAULT_DELETED_KEY) {
-    Base::set_empty_key(emptyKey);
-    Base::set_deleted_key(deletedKey);
-  }
-
   // Iterator type of this map, it.first is the key, it.second the value
   using typename Base::iterator;
 

--- a/src/util/LRUCache.h
+++ b/src/util/LRUCache.h
@@ -33,11 +33,12 @@ using std::shared_ptr;
 //! enforces read-only access for all operations which can't guarantee only
 //! one thread getting write access. It uses shared_ptrs so as to ensure
 //! that deletes do not free in-use memory.
-template <class Key, class Value,
-          template <typename K, typename V> typename MapType =
-              ad_utility::HashMap>
+template <class Key, class Value>
 class LRUCache {
  private:
+  template <typename K, typename V>
+  using MapType = ad_utility::HashMap<K, V>;
+
   using EntryValue = shared_ptr<const Value>;
   using EmplacedValue = shared_ptr<Value>;
   using Entry = pair<Key, EntryValue>;

--- a/src/util/TupleHelpers.h
+++ b/src/util/TupleHelpers.h
@@ -1,0 +1,128 @@
+// Copyright 2020, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach (johannes.kalmbach@gmail.com)
+
+#ifndef QLEVER_TUPLEHELPERS_H
+#define QLEVER_TUPLEHELPERS_H
+#include <utility>
+
+namespace ad_tuple_helpers {
+
+namespace detail {
+// Recursive implementation of setupTupleFromCallable (see below)
+template <size_t NumEntries, size_t Current, class F>
+auto setupTupleFromCallableImpl(F&& f) {
+  if constexpr (Current == NumEntries - 1) {
+    return std::tuple(f(Current));
+  } else {
+    auto fst = std::tuple(f(Current));
+    return std::tuple_cat(std::move(fst),
+                          setupTupleFromCallableImpl<NumEntries, Current + 1>(
+                              std::forward<F>(f)));
+  }
+}
+}  // namespace detail
+
+/**
+ * @brief create a Tuple with numEntries entries where the i-th entry is created
+ * by a call to f(i)
+ * @tparam numEntries the size of the tuple to be created
+ * @tparam F A function object that takes a single size_t as an argument
+ * @param f
+ * @return std::tuple(f(0), f(1), f(2), ... f(numEntries - 1));
+ * @todo<joka921> Can we simplify this implementation via fold expressions etc?
+ */
+template <size_t numEntries, class F>
+auto setupTupleFromCallable(F&& f) {
+  static_assert(numEntries > 0);
+  return detail::setupTupleFromCallableImpl<numEntries, 0>(std::forward<F>(f));
+}
+
+/**
+ * @brief convert a parameter pack to a tuple of unique_ptrs that are
+ * constructed from the elements of the parameter pack. E.g.
+ * toUniquePtrTuple(int(3), std::string("foo")) ==
+ * std::tuple(std::make_unique<int>(3), std::make_unique<std::string>("foo")) It
+ * can take an arbitrary positive number of arguments. Currently this template
+ * is linearly expanded, if this becomes a bottleneck at compiletime (e.g. for
+ * very long parameter packs) we could do something more intelligent.
+ * @return std::tuple(std::make_unique<First>(std::forward<First>(l),
+ * std::make_unique<FirstOfRem.....
+ */
+template <typename First, typename... Rest>
+auto toUniquePtrTuple(First&& l, Rest&&... rem) {
+  if constexpr (sizeof...(Rest) == 0) {
+    return std::tuple(
+        std::make_unique<std::decay_t<First>>(std::forward<First>(l)));
+  } else {
+    return std::tuple_cat(std::tuple(std::make_unique<std::decay_t<First>>(
+                              std::forward<First>(l))),
+                          toUniquePtrTuple(std::forward<Rest>(rem)...));
+  }
+}
+
+/// For a pack of types returns the return type of a call to toUniquePtrTuple
+/// with arguments of that type
+template <typename... ts>
+using toUniquePtrTuple_t = decltype(toUniquePtrTuple(std::declval<ts>()...));
+
+namespace detail {
+// the implementation of toRawPtrTuple, idx denotes the next index to deal with
+// (initially 0)
+template <size_t idx, typename Tuple>
+auto toRawPtrTupleImpl(Tuple&& tuple) {
+  if constexpr (idx == std::tuple_size_v<std::decay_t<Tuple>> - 1) {
+    return std::tuple(std::get<idx>(tuple).get());
+  } else {
+    return std::tuple_cat(
+        std::tuple(std::get<idx>(tuple).get()),
+        toRawPtrTupleImpl<idx + 1>(std::forward<Tuple>(tuple)));
+  }
+}
+}  // namespace detail
+
+/**
+ * @brief converts a tuple of smart pointers (or other types that have a .get()
+ * method) to a tuple of the corresponding raw pointers (return types of the
+ * get() methods). Does NOT change ownership.
+ * @tparam Tuple Must have form T<Ts...> where T must support
+ * std::get<size_t>(T), and the types Ts contained in T must support a call to a
+ * .get() method e.g. std::tuple<std::unique_ptr<int>,
+ * std::shared_ptr<std::string>> or std::array<std::shared_ptr<int>, 42>;
+ * @param tuple A tuple/array of type Tuple
+ * @return std::tuple(std::get<0>(tuple).get(), std::get<1>(tuple).get(), ...
+ * std::get<std::tuple_size_v<Tuple>>(tuple).get());
+ */
+template <typename Tuple>
+auto toRawPtrTuple(Tuple&& tuple) {
+  static_assert(!std::is_rvalue_reference_v<decltype(tuple)>,
+                "You can't pass an rvalue reference to toRawPtrTuple, because "
+                "the argument preserves the ownership to the pointers");
+  return detail::toRawPtrTupleImpl<0>(std::forward<Tuple>(tuple));
+}
+
+/// The return type of toRawPtrTuple<T>(T&& t);
+template <typename T>
+using toRawPtrTuple_t = decltype(detail::toRawPtrTupleImpl<0>(
+    std::declval<T>()));  // we have to bypass the toRawPtrTuple function since
+                          // declval returns an rvalue reference
+
+namespace detail {
+// _____________________________________________________
+template <typename T>
+struct is_tuple_impl : std::false_type {};
+
+template <typename... Ts>
+struct is_tuple_impl<std::tuple<Ts...>> : std::true_type {};
+}  // namespace detail
+
+/// is_tuple<T>::value is true iff T is a specialization of std::tuple
+template <typename T>
+struct is_tuple : detail::is_tuple_impl<std::decay_t<T>> {};
+
+/// is_tuple_v is true iff T is a specialization of std::tuple
+template <typename T>
+constexpr bool is_tuple_v = is_tuple<T>::value;
+}  // namespace ad_tuple_helpers
+
+#endif  // QLEVER_TUPLEHELPERS_H

--- a/test/BatchedPipelineTest.cpp
+++ b/test/BatchedPipelineTest.cpp
@@ -11,9 +11,9 @@ TEST(BatcherTest, MoveOnlyCreator) {
   auto pipeline = ad_pipeline::detail::Batcher(
       20, [ptr = std::unique_ptr<int>()]() { return std::optional(25); });
   auto batch = pipeline.produceBatch();
-  ASSERT_TRUE(batch.first);
-  ASSERT_EQ(20u, batch.second.size());
-  ASSERT_EQ(batch.second[0], 25);
+  ASSERT_TRUE(batch._isLast);
+  ASSERT_EQ(20u, batch._content.size());
+  ASSERT_EQ(batch._content[0], 25);
 }
 
 TEST(BatcherTest, MoveOnlyCreator2) {
@@ -28,23 +28,23 @@ TEST(BatchedPipelineTest, BasicPipeline) {
   auto pipeline =
       ad_pipeline::detail::Batcher(20, []() { return std::optional(25); });
   auto batch = pipeline.produceBatch();
-  ASSERT_TRUE(batch.first);
-  ASSERT_EQ(20u, batch.second.size());
-  ASSERT_EQ(batch.second[0], 25);
+  ASSERT_TRUE(batch._isLast);
+  ASSERT_EQ(20u, batch._content.size());
+  ASSERT_EQ(batch._content[0], 25);
 
   auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<1>(
       std::move(pipeline), [](const auto x) { return x + 3; });
   auto batch2 = pipeline2.produceBatch();
-  ASSERT_TRUE(batch2.first);
-  ASSERT_EQ(20u, batch2.second.size());
-  ASSERT_EQ(batch2.second[0], 28);
+  ASSERT_TRUE(batch2._isLast);
+  ASSERT_EQ(20u, batch2._content.size());
+  ASSERT_EQ(batch2._content[0], 28);
 
   auto pipeline3 = ad_pipeline::detail::makeBatchedPipeline<1>(
       std::move(pipeline2), [](const auto x) { return std::to_string(x); });
   auto batch3 = pipeline3.produceBatch();
-  ASSERT_TRUE(batch3.first);
-  ASSERT_EQ(20u, batch3.second.size());
-  ASSERT_EQ(batch3.second[0], std::string("28"));
+  ASSERT_TRUE(batch3._isLast);
+  ASSERT_EQ(20u, batch3._content.size());
+  ASSERT_EQ(batch3._content[0], std::string("28"));
 
   {
     auto finalPipeline = ad_pipeline::setupPipeline(
@@ -88,10 +88,10 @@ TEST(BatchedPipelineTest, SimpleParallelism) {
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<3>(
         std::move(pipeline), [](const auto x) { return x * 3; });
     auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2.first);
-    ASSERT_EQ(20u, batch2.second.size());
+    ASSERT_TRUE(batch2._isLast);
+    ASSERT_EQ(20u, batch2._content.size());
     for (size_t i = 0; i < 20u; ++i) {
-      ASSERT_EQ(batch2.second[i], i * 3);
+      ASSERT_EQ(batch2._content[i], i * 3);
     }
   }
   {
@@ -101,10 +101,10 @@ TEST(BatchedPipelineTest, SimpleParallelism) {
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<40>(
         std::move(pipeline), [](const auto x) { return x * 3; });
     auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2.first);
-    ASSERT_EQ(20u, batch2.second.size());
+    ASSERT_TRUE(batch2._isLast);
+    ASSERT_EQ(20u, batch2._content.size());
     for (size_t i = 0; i < 20u; ++i) {
-      ASSERT_EQ(batch2.second[i], i * 3);
+      ASSERT_EQ(batch2._content[i], i * 3);
     }
   }
 
@@ -137,13 +137,13 @@ TEST(BatchedPipelineTest, BranchedParallelism) {
         std::move(pipeline), [](const auto x) { return x * 3; },
         [](const auto x) { return x * 2; });
     auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2.first);
-    ASSERT_EQ(20u, batch2.second.size());
+    ASSERT_TRUE(batch2._isLast);
+    ASSERT_EQ(20u, batch2._content.size());
     for (size_t i = 0; i < 10u; ++i) {
-      ASSERT_EQ(batch2.second[i], i * 3);
+      ASSERT_EQ(batch2._content[i], i * 3);
     }
     for (size_t i = 10; i < 20u; ++i) {
-      ASSERT_EQ(batch2.second[i], i * 2);
+      ASSERT_EQ(batch2._content[i], i * 2);
     }
   }
   {
@@ -153,10 +153,10 @@ TEST(BatchedPipelineTest, BranchedParallelism) {
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<40>(
         std::move(pipeline), [](const auto x) { return x * 3; });
     auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2.first);
-    ASSERT_EQ(20u, batch2.second.size());
+    ASSERT_TRUE(batch2._isLast);
+    ASSERT_EQ(20u, batch2._content.size());
     for (size_t i = 0; i < 20u; ++i) {
-      ASSERT_EQ(batch2.second[i], i * 3);
+      ASSERT_EQ(batch2._content[i], i * 3);
     }
   }
 

--- a/test/BatchedPipelineTest.cpp
+++ b/test/BatchedPipelineTest.cpp
@@ -1,0 +1,186 @@
+// Copyright 2020, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
+
+#include <gtest/gtest.h>
+#include <optional>
+#include "../src/parser/TurtleParser.h"
+#include "../src/util/BatchedPipeline.h"
+
+TEST(BatcherTest, MoveOnlyCreator) {
+  auto pipeline = ad_pipeline::detail::Batcher(
+      20, [ptr = std::unique_ptr<int>()]() { return std::optional(25); });
+  auto batch = pipeline.produceBatch();
+  ASSERT_TRUE(batch.first);
+  ASSERT_EQ(20u, batch.second.size());
+  ASSERT_EQ(batch.second[0], 25);
+}
+
+TEST(BatcherTest, MoveOnlyCreator2) {
+  auto pipeline = ad_pipeline::setupPipeline(
+      20, [ptr = std::make_unique<int>(23)]() { return std::optional(*ptr); });
+  auto batch = pipeline.getNextValue();
+  ASSERT_TRUE(batch);
+  ASSERT_EQ(23, batch.value());
+}
+
+TEST(BatchedPipelineTest, BasicPipeline) {
+  auto pipeline =
+      ad_pipeline::detail::Batcher(20, []() { return std::optional(25); });
+  auto batch = pipeline.produceBatch();
+  ASSERT_TRUE(batch.first);
+  ASSERT_EQ(20u, batch.second.size());
+  ASSERT_EQ(batch.second[0], 25);
+
+  auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<1>(
+      std::move(pipeline), [](const auto x) { return x + 3; });
+  auto batch2 = pipeline2.produceBatch();
+  ASSERT_TRUE(batch2.first);
+  ASSERT_EQ(20u, batch2.second.size());
+  ASSERT_EQ(batch2.second[0], 28);
+
+  auto pipeline3 = ad_pipeline::detail::makeBatchedPipeline<1>(
+      std::move(pipeline2), [](const auto x) { return std::to_string(x); });
+  auto batch3 = pipeline3.produceBatch();
+  ASSERT_TRUE(batch3.first);
+  ASSERT_EQ(20u, batch3.second.size());
+  ASSERT_EQ(batch3.second[0], std::string("28"));
+
+  {
+    auto finalPipeline = ad_pipeline::setupPipeline(
+        20,
+        [i = 0]() mutable -> std::optional<int> {
+          if (i < 100) {
+            ++i;
+            return std::optional(i);
+          }
+          return std::nullopt;
+        },
+        [a = int(0)](const auto& x) mutable {
+          a += 3;
+          return (x + a) * (x + a);
+        },
+        [a = int(0)](const auto& x) mutable {
+          a += 2;
+          return x + a;
+        });
+    int n = 1;
+    while (auto opt = finalPipeline.getNextValue()) {
+      ASSERT_EQ((n + 3 * n) * (n + 3 * n) + 2 * n, opt.value());
+      ++n;
+      if (n == 50) break;
+    }
+
+    auto pipelineMoved = std::move(finalPipeline);
+    while (auto opt = pipelineMoved.getNextValue()) {
+      ASSERT_EQ((n + 3 * n) * (n + 3 * n) + 2 * n, opt.value());
+      ++n;
+    }
+    ASSERT_EQ(n, 101);
+  }
+}
+
+TEST(BatchedPipelineTest, SimpleParallelism) {
+  {
+    auto pipeline = ad_pipeline::detail::Batcher(
+        20, [i = 0ull]() mutable { return std::optional(i++); });
+
+    auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<3>(
+        std::move(pipeline), [](const auto x) { return x * 3; });
+    auto batch2 = pipeline2.produceBatch();
+    ASSERT_TRUE(batch2.first);
+    ASSERT_EQ(20u, batch2.second.size());
+    for (size_t i = 0; i < 20u; ++i) {
+      ASSERT_EQ(batch2.second[i], i * 3);
+    }
+  }
+  {
+    auto pipeline = ad_pipeline::detail::Batcher(
+        20, [i = 0ull]() mutable { return std::optional(i++); });
+
+    auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<40>(
+        std::move(pipeline), [](const auto x) { return x * 3; });
+    auto batch2 = pipeline2.produceBatch();
+    ASSERT_TRUE(batch2.first);
+    ASSERT_EQ(20u, batch2.second.size());
+    for (size_t i = 0; i < 20u; ++i) {
+      ASSERT_EQ(batch2.second[i], i * 3);
+    }
+  }
+
+  {
+    auto pipeline = ad_pipeline::setupParallelPipeline<4>(
+        20,
+        [i = 0ull]() mutable -> std::optional<size_t> {
+          if (i >= 67) {
+            return std::nullopt;
+          }
+          return std::optional(i++);
+        },
+        [](const auto x) { return x * 3; });
+
+    size_t j = 0;
+    while (auto opt = pipeline.getNextValue()) {
+      ASSERT_EQ(opt.value(), j * 3);
+      j++;
+    }
+    ASSERT_EQ(j, 67u);
+  }
+}
+
+TEST(BatchedPipelineTest, BranchedParallelism) {
+  {
+    auto pipeline = ad_pipeline::detail::Batcher(
+        20, [i = 0ull]() mutable { return std::optional(i++); });
+
+    auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<2>(
+        std::move(pipeline), [](const auto x) { return x * 3; },
+        [](const auto x) { return x * 2; });
+    auto batch2 = pipeline2.produceBatch();
+    ASSERT_TRUE(batch2.first);
+    ASSERT_EQ(20u, batch2.second.size());
+    for (size_t i = 0; i < 10u; ++i) {
+      ASSERT_EQ(batch2.second[i], i * 3);
+    }
+    for (size_t i = 10; i < 20u; ++i) {
+      ASSERT_EQ(batch2.second[i], i * 2);
+    }
+  }
+  {
+    auto pipeline = ad_pipeline::detail::Batcher(
+        20, [i = 0ull]() mutable { return std::optional(i++); });
+
+    auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<40>(
+        std::move(pipeline), [](const auto x) { return x * 3; });
+    auto batch2 = pipeline2.produceBatch();
+    ASSERT_TRUE(batch2.first);
+    ASSERT_EQ(20u, batch2.second.size());
+    for (size_t i = 0; i < 20u; ++i) {
+      ASSERT_EQ(batch2.second[i], i * 3);
+    }
+  }
+
+  {
+    auto pipeline = ad_pipeline::setupParallelPipeline<2>(
+        20,
+        [i = 0ull]() mutable -> std::optional<size_t> {
+          if (i >= 67) {
+            return std::nullopt;
+          }
+          return std::optional(i++);
+        },
+        std::tuple([](const auto x) { return x * 3; },
+                   [](const auto x) { return x * 2; }));
+
+    size_t j = 0;
+    while (auto opt = pipeline.getNextValue()) {
+      if (j % 20 < 10) {
+        ASSERT_EQ(opt.value(), j * 3);
+      } else {
+        ASSERT_EQ(opt.value(), j * 2);
+      }
+      j++;
+    }
+    ASSERT_EQ(j, 67u);
+  }
+}

--- a/test/BatchedPipelineTest.cpp
+++ b/test/BatchedPipelineTest.cpp
@@ -10,10 +10,10 @@
 TEST(BatcherTest, MoveOnlyCreator) {
   auto pipeline = ad_pipeline::detail::Batcher(
       20, [ptr = std::unique_ptr<int>()]() { return std::optional(25); });
-  auto batch = pipeline.produceBatch();
-  ASSERT_TRUE(batch._isLast);
-  ASSERT_EQ(20u, batch._content.size());
-  ASSERT_EQ(batch._content[0], 25);
+  auto batch = pipeline.pickupBatch();
+  ASSERT_TRUE(batch.m_isPipelineGood);
+  ASSERT_EQ(20u, batch.m_content.size());
+  ASSERT_EQ(batch.m_content[0], 25);
 }
 
 TEST(BatcherTest, MoveOnlyCreator2) {
@@ -27,24 +27,24 @@ TEST(BatcherTest, MoveOnlyCreator2) {
 TEST(BatchedPipelineTest, BasicPipeline) {
   auto pipeline =
       ad_pipeline::detail::Batcher(20, []() { return std::optional(25); });
-  auto batch = pipeline.produceBatch();
-  ASSERT_TRUE(batch._isLast);
-  ASSERT_EQ(20u, batch._content.size());
-  ASSERT_EQ(batch._content[0], 25);
+  auto batch = pipeline.pickupBatch();
+  ASSERT_TRUE(batch.m_isPipelineGood);
+  ASSERT_EQ(20u, batch.m_content.size());
+  ASSERT_EQ(batch.m_content[0], 25);
 
   auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<1>(
       std::move(pipeline), [](const auto x) { return x + 3; });
-  auto batch2 = pipeline2.produceBatch();
-  ASSERT_TRUE(batch2._isLast);
-  ASSERT_EQ(20u, batch2._content.size());
-  ASSERT_EQ(batch2._content[0], 28);
+  auto batch2 = pipeline2.pickupBatch();
+  ASSERT_TRUE(batch2.m_isPipelineGood);
+  ASSERT_EQ(20u, batch2.m_content.size());
+  ASSERT_EQ(batch2.m_content[0], 28);
 
   auto pipeline3 = ad_pipeline::detail::makeBatchedPipeline<1>(
       std::move(pipeline2), [](const auto x) { return std::to_string(x); });
-  auto batch3 = pipeline3.produceBatch();
-  ASSERT_TRUE(batch3._isLast);
-  ASSERT_EQ(20u, batch3._content.size());
-  ASSERT_EQ(batch3._content[0], std::string("28"));
+  auto batch3 = pipeline3.pickupBatch();
+  ASSERT_TRUE(batch3.m_isPipelineGood);
+  ASSERT_EQ(20u, batch3.m_content.size());
+  ASSERT_EQ(batch3.m_content[0], std::string("28"));
 
   {
     auto finalPipeline = ad_pipeline::setupPipeline(
@@ -56,7 +56,7 @@ TEST(BatchedPipelineTest, BasicPipeline) {
           }
           return std::nullopt;
         },
-        [a = int(0)](const auto& x) mutable {
+        [a = 0](const auto& x) mutable {
           a += 3;
           return (x + a) * (x + a);
         },
@@ -87,11 +87,11 @@ TEST(BatchedPipelineTest, SimpleParallelism) {
 
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<3>(
         std::move(pipeline), [](const auto x) { return x * 3; });
-    auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2._isLast);
-    ASSERT_EQ(20u, batch2._content.size());
+    auto batch2 = pipeline2.pickupBatch();
+    ASSERT_TRUE(batch2.m_isPipelineGood);
+    ASSERT_EQ(20u, batch2.m_content.size());
     for (size_t i = 0; i < 20u; ++i) {
-      ASSERT_EQ(batch2._content[i], i * 3);
+      ASSERT_EQ(batch2.m_content[i], i * 3);
     }
   }
   {
@@ -100,11 +100,11 @@ TEST(BatchedPipelineTest, SimpleParallelism) {
 
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<40>(
         std::move(pipeline), [](const auto x) { return x * 3; });
-    auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2._isLast);
-    ASSERT_EQ(20u, batch2._content.size());
+    auto batch2 = pipeline2.pickupBatch();
+    ASSERT_TRUE(batch2.m_isPipelineGood);
+    ASSERT_EQ(20u, batch2.m_content.size());
     for (size_t i = 0; i < 20u; ++i) {
-      ASSERT_EQ(batch2._content[i], i * 3);
+      ASSERT_EQ(batch2.m_content[i], i * 3);
     }
   }
 
@@ -136,14 +136,14 @@ TEST(BatchedPipelineTest, BranchedParallelism) {
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<2>(
         std::move(pipeline), [](const auto x) { return x * 3; },
         [](const auto x) { return x * 2; });
-    auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2._isLast);
-    ASSERT_EQ(20u, batch2._content.size());
+    auto batch2 = pipeline2.pickupBatch();
+    ASSERT_TRUE(batch2.m_isPipelineGood);
+    ASSERT_EQ(20u, batch2.m_content.size());
     for (size_t i = 0; i < 10u; ++i) {
-      ASSERT_EQ(batch2._content[i], i * 3);
+      ASSERT_EQ(batch2.m_content[i], i * 3);
     }
     for (size_t i = 10; i < 20u; ++i) {
-      ASSERT_EQ(batch2._content[i], i * 2);
+      ASSERT_EQ(batch2.m_content[i], i * 2);
     }
   }
   {
@@ -152,11 +152,11 @@ TEST(BatchedPipelineTest, BranchedParallelism) {
 
     auto pipeline2 = ad_pipeline::detail::makeBatchedPipeline<40>(
         std::move(pipeline), [](const auto x) { return x * 3; });
-    auto batch2 = pipeline2.produceBatch();
-    ASSERT_TRUE(batch2._isLast);
-    ASSERT_EQ(20u, batch2._content.size());
+    auto batch2 = pipeline2.pickupBatch();
+    ASSERT_TRUE(batch2.m_isPipelineGood);
+    ASSERT_EQ(20u, batch2.m_content.size());
     for (size_t i = 0; i < 20u; ++i) {
-      ASSERT_EQ(batch2._content[i], i * 3);
+      ASSERT_EQ(batch2.m_content[i], i * 3);
     }
   }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(StringUtilsTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(LRUCacheTest LRUCacheTest.cpp)
 add_test(LRUCacheTest LRUCacheTest)
-target_link_libraries(LRUCacheTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(LRUCacheTest gtest_main ${CMAKE_THREAD_LIBS_INIT} absl::flat_hash_map)
 
 add_executable(FileTest FileTest.cpp)
 add_test(FileTest FileTest)
@@ -64,7 +64,7 @@ target_link_libraries(ConversionsTest gtest_main engine ${CMAKE_THREAD_LIBS_INIT
 
 add_executable(HashMapTest HashMapTest.cpp)
 add_test(HashMapTest HashMapTest)
-target_link_libraries(HashMapTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(HashMapTest gtest_main ${CMAKE_THREAD_LIBS_INIT} absl::flat_hash_map)
 
 add_executable(HashSetTest HashSetTest.cpp)
 add_test(HashSetTest HashSetTest)
@@ -100,7 +100,7 @@ target_link_libraries(TokenTest parser re2 gtest_main -pthread)
 
 add_executable(TurtleParserTest TurtleParserTest.cpp)
 add_test(TurtleParserTest TurtleParserTest)
-target_link_libraries(TurtleParserTest parser re2 gtest_main -pthread)
+target_link_libraries(TurtleParserTest parser absl::flat_hash_map re2 gtest_main -pthread)
 
 add_executable(MultiColumnJoinTest MultiColumnJoinTest.cpp)
 add_test(MultiColumnJoinTest MultiColumnJoinTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,14 @@ add_executable(SparqlLexerTest SparqlLexerTest.cpp)
 add_test(SparqlLexerTest SparqlLexerTest)
 target_link_libraries(SparqlLexerTest parser gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(BatchedPipelineTest BatchedPipelineTest.cpp)
+add_test(BatchedPipelineTest BatchedPipelineTest)
+target_link_libraries(BatchedPipelineTest gtest_main parser ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(TupleHelpersTest TupleHelpersTest.cpp)
+add_test(TupleHelpersTest TupleHelpersTest)
+target_link_libraries(TupleHelpersTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(StringSortComparatorTest StringSortComparatorTest.cpp)
 add_test(StringSortComparatorTest StringSortComparatorTest)
 target_link_libraries(StringSortComparatorTest gtest_main ${CMAKE_THREAD_LIBS_INIT} ${ICU_LIBRARIES})

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -49,7 +49,10 @@ class DummyOperation : public Operation {
 
   virtual ad_utility::HashMap<string, size_t> getVariableColumns()
       const override {
-    return {{"?a", 0}, {"?b", 1}};
+    ad_utility::HashMap<string, size_t> m;
+    m["?a"] = 0;
+    m["?b"] = 1;
+    return m;
   }
 };
 
@@ -359,6 +362,10 @@ TEST(CountAvailablePredicates, patternTrickTest) {
     std::cout << e.what() << std::endl;
     ASSERT_TRUE(false);
   }
+  std::sort(
+      result.begin(), result.end(),
+      [](const auto& i1, const auto& i2) -> bool { return i1[0] < i2[0]; });
+
   ASSERT_EQ(5u, result.size());
 
   ASSERT_EQ(0u, result[0][0]);

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -680,17 +680,17 @@ TEST(QueryPlannerTest, testStarTwoFree) {
       QueryPlanner qp(nullptr);
       QueryExecutionTree qet = qp.createExecutionTree(pq);
       ASSERT_EQ(
-          "{\n  JOIN\n  {\n    JOIN\n    {\n      SCAN POS with P = \""
-          "<http://rdf.myprefix.com/myrel>\"\n      qet-width: 2 \n "
-          "   } join-column: [0]\n    |X|\n    {\n      SCAN PSO wit"
-          "h P = \"<http://rdf.myprefix.com/ns/myrel>\"\n      qet-"
-          "width: 2 \n    } join-column: [0]\n    qet-width: 3 \n  "
-          "} join-column: [0]\n  |X|\n  {\n    SCAN POS with P = "
-          "\"<http://rdf.myprefix.com/xxx/rel2>\", O = \"<http://a"
-          "bc.de>\"\n    qet-width: 1 \n  } join-column: [0]\n  qet"
-          "-width: 3 \n}",
+          "{\n  JOIN\n  {\n    JOIN\n    {\n      SCAN POS with P = "
+          "\"<http://rdf.myprefix.com/myrel>\"\n      qet-width: 2 \n    } "
+          "join-column: [0]\n    |X|\n    {\n      SCAN POS with P = "
+          "\"<http://rdf.myprefix.com/xxx/rel2>\", O = \"<http://abc.de>\"\n   "
+          "   qet-width: 1 \n    } join-column: [0]\n    qet-width: 2 \n  } "
+          "join-column: [0]\n  |X|\n  {\n    SCAN PSO with P = "
+          "\"<http://rdf.myprefix.com/ns/myrel>\"\n    qet-width: 2 \n  } "
+          "join-column: [0]\n  qet-width: 3 \n}",
           qet.asString());
     }
+
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -761,10 +761,10 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SPO (DUMMY OPERATION)\n   "
-        " qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n    SCAN"
-        " PSO with P = \"<p>\", S = \"<s>\"\n    qet-width: 1 \n  }"
-        " join-column: [0]\n  qet-width: 3 \n}",
+        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SOP (DUMMY OPERATION)\n    "
+        "qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n    SCAN PSO with P "
+        "= \"<p>\", S = \"<s>\"\n    qet-width: 1 \n  } join-column: [0]\n  "
+        "qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -782,10 +782,10 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SOP (DUMMY OP"
-        "ERATION)\n    qet-width: 3 \n  } join-column: [0]"
-        "\n  |X|\n  {\n    SCAN SOP with S = \"<s>\", O = \"<o>\"\n "
-        "   qet-width: 1 \n  } join-column: [0]\n  qet-width: 3 \n}",
+        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SOP (DUMMY OPERATION)\n    "
+        "qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n    SCAN SOP with S "
+        "= \"<s>\", O = \"<o>\"\n    qet-width: 1 \n  } join-column: [0]\n  "
+        "qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -803,10 +803,10 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX PSO (DUMMY OPERATION)\n"
-        "    qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n "
-        "   SCAN PSO with P = \"<p>\", S = \"<s>\"\n  "
-        "  qet-width: 1 \n  } join-column: [0]\n  qet-width: 3 \n}",
+        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX POS (DUMMY OPERATION)\n    "
+        "qet-width: 3 \n  } join-column: [0]\n  |X|\n  {\n    SCAN PSO with P "
+        "= \"<p>\", S = \"<s>\"\n    qet-width: 1 \n  } join-column: [0]\n  "
+        "qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -826,11 +826,10 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  TWO_COLUMN_JOIN\n    {\n    "
-        "SCAN FOR FULL INDEX SPO (DUMMY OPERATION)\n    qet-width: 3 \n  }"
-        "\n  join-columns: [0 & 1]\n  |X|\n    {\n    SCAN SOP with S ="
-        " \"<s>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & 1]\n "
-        " qet-width: 3 \n}",
+        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN FOR FULL INDEX POS (DUMMY "
+        "OPERATION)\n    qet-width: 3 \n  }\n  join-columns: [0 & 2]\n  |X|\n  "
+        "  {\n    SCAN SPO with S = \"<s>\"\n    qet-width: 2 \n  }\n  "
+        "join-columns: [0 & 1]\n  qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -848,11 +847,10 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN FOR FULL INDEX SPO"
-        " (DUMMY OPERATION)\n    qet-width: 3 \n  }\n  join-"
-        "columns: [0 & 1]\n  |X|\n    {\n    SCAN OSP with "
-        "O = \"<x>\"\n    qet-width: 2 \n  }\n  join-columns"
-        ": [0 & 1]\n  qet-width: 3 \n}",
+        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN FOR FULL INDEX POS (DUMMY "
+        "OPERATION)\n    qet-width: 3 \n  }\n  join-columns: [0 & 2]\n  |X|\n  "
+        "  {\n    SCAN OPS with O = \"<x>\"\n    qet-width: 2 \n  }\n  "
+        "join-columns: [0 & 1]\n  qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -1067,17 +1065,18 @@ TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  JOIN\n  {\n    SCAN POS with P = \"<is-a>\", O = "
-        "\"<Scientist>\"\n    qet-width: 1 \n  } join-column: [0]\n  |X|\n  "
-        "{\n    SORT on column:4\n    {\n      TEXT OPERATION WITH FILTER: "
-        "co-occurrence with words: \"manhattan project\" and 1 variables with "
-        "textLimit = 1 filtered by\n      {\n        TEXT OPERATION WITH "
-        "FILTER: co-occurrence with words: \"friend*\" and 2 variables with "
-        "textLimit = 1 filtered by\n        {\n          SCAN POS with P = "
-        "\"<is-a>\", O = \"<Politician>\"\n          qet-width: 1 \n        "
+
+        "{\n  TEXT OPERATION WITH FILTER: co-occurrence with words: "
+        "\"manhattan project\" and 1 variables with textLimit = 1 filtered "
+        "by\n  {\n    JOIN\n    {\n      SCAN POS with P = \"<is-a>\", O = "
+        "\"<Scientist>\"\n      qet-width: 1 \n    } join-column: [0]\n    "
+        "|X|\n    {\n      SORT on column:2\n      {\n        TEXT OPERATION "
+        "WITH FILTER: co-occurrence with words: \"friend*\" and 2 variables "
+        "with textLimit = 1 filtered by\n        {\n          SCAN POS with P "
+        "= \"<is-a>\", O = \"<Politician>\"\n          qet-width: 1 \n        "
         "}\n         filtered on column 0\n        qet-width: 4 \n      }\n    "
-        "   filtered on column 2\n      qet-width: 6 \n    }\n    qet-width: 6 "
-        "\n  } join-column: [4]\n  qet-width: 6 \n}",
+        "  qet-width: 4 \n    } join-column: [2]\n    qet-width: 4 \n  }\n   "
+        "filtered on column 0\n  qet-width: 6 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -1099,17 +1098,14 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  TWO_COLUMN_JOIN\n    {\n    ORDER_BY\n    {\n      JOIN\n"
-        "      {\n        SCAN PSO with P = \"<Film_performance>\"\n"
-        "        qet-width: 2 \n      } join-column: [0]\n      |X|\n"
-        "      {\n        "
-        "SCAN PSO with P = \"<Spouse_(or_domestic_partner)>\"\n    "
-        "    qet-width: 2 \n      } join-column: [0]\n "
-        "     qet-width: 3 \n    } order on asc(2) asc(1) \n"
-        "    qet-width: 3 \n  }\n  join-columns: [2 & 1]\n  |X|\n"
-        "    {\n    SCAN PSO with P = \"<Film_performance>\"\n"
-        "    qet-width: 2 \n  }\n  join-columns: [0 & 1]\n"
-        "  qet-width: 3 \n}",
+        "{\n  TWO_COLUMN_JOIN\n    {\n    ORDER_BY\n    {\n      JOIN\n      "
+        "{\n        SCAN POS with P = \"<Film_performance>\"\n        "
+        "qet-width: 2 \n      } join-column: [0]\n      |X|\n      {\n        "
+        "SCAN POS with P = \"<Film_performance>\"\n        qet-width: 2 \n     "
+        " } join-column: [0]\n      qet-width: 3 \n    } order on asc(1) "
+        "asc(2) \n    qet-width: 3 \n  }\n  join-columns: [1 & 2]\n  |X|\n    "
+        "{\n    SCAN POS with P = \"<Spouse_(or_domestic_partner)>\"\n    "
+        "qet-width: 2 \n  }\n  join-columns: [0 & 1]\n  qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -552,7 +552,7 @@ TEST(QueryPlannerTest, testSP_free_) {
   QueryPlanner qp(nullptr);
   QueryExecutionTree qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
-      "{\n  SCAN PSO with P = \"<http://rdf.myprefix.com/myrel>\"\n  "
+      "{\n  SCAN POS with P = \"<http://rdf.myprefix.com/myrel>\"\n  "
       "qet-width: 2 \n}",
       qet.asString());
 }
@@ -782,7 +782,7 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SPO (DUMMY OP"
+        "{\n  JOIN\n  {\n    SCAN FOR FULL INDEX SOP (DUMMY OP"
         "ERATION)\n    qet-width: 3 \n  } join-column: [0]"
         "\n  |X|\n  {\n    SCAN SOP with S = \"<s>\", O = \"<o>\"\n "
         "   qet-width: 1 \n  } join-column: [0]\n  qet-width: 3 \n}",
@@ -1162,19 +1162,11 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq.expandPrefixes();
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n"
-        "  OPTIONAL_JOIN\n"
-        "  {\n"
-        "    SCAN PSO with P = \"<rel1>\"\n"
-        "    qet-width: 2 \n"
-        "  } join-columns: [0]\n"
-        "  |X|\n"
-        "  {\n"
-        "    SCAN PSO with P = \"<rel2>\"\n"
-        "    qet-width: 2 \n"
-        "  } join-columns: [0]\n"
-        "  qet-width: 3 \n"
-        "}",
+        "{\n  OPTIONAL_JOIN\n  {\n    ORDER_BY\n    {\n      SCAN POS with P = "
+        "\"<rel2>\"\n      qet-width: 2 \n    } order on asc(1) \n    "
+        "qet-width: 2 \n  } join-columns: [1]\n  |X|\n  {\n    SCAN PSO with P "
+        "= \"<rel1>\"\n    qet-width: 2 \n  } join-columns: [0]\n  qet-width: "
+        "3 \n}",
         qet.asString());
 
     ParsedQuery pq2 = SparqlParser(
@@ -1185,23 +1177,14 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq2.expandPrefixes();
     QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
-        "{\n"
-        "  SORT on column:1\n"
-        "  {\n"
-        "    OPTIONAL_JOIN\n"
-        "    {\n"
-        "      SCAN PSO with P = \"<rel1>\"\n"
-        "      qet-width: 2 \n"
-        "    } join-columns: [0]\n"
-        "    |X|\n"
-        "    {\n"
-        "      SCAN PSO with P = \"<rel2>\"\n"
-        "      qet-width: 2 \n"
-        "    } join-columns: [0]\n"
-        "    qet-width: 3 \n"
-        "  }\n"
-        "  qet-width: 3 \n"
-        "}",
+        "{\n  SORT on column:2\n  {\n    OPTIONAL_JOIN\n    {\n      "
+        "ORDER_BY\n      {\n        SCAN POS with P = \"<rel2>\"\n        "
+        "qet-width: 2 \n      } order on asc(1) \n      qet-width: 2 \n    } "
+        "join-columns: [1]\n    |X|\n    {\n      SCAN PSO with P = "
+        "\"<rel1>\"\n      qet-width: 2 \n    } join-columns: [0]\n    "
+        "qet-width: 3 \n  }\n  qet-width: 3 \n}"
+
+        ,
         qet2.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;

--- a/test/StringSortComparatorTest.cpp
+++ b/test/StringSortComparatorTest.cpp
@@ -41,6 +41,22 @@ TEST(LocaleManagerTest, Punctuation) {
   }
 }
 
+TEST(LocaleManagerTest, Normalization) {
+  // é as single codepoints
+  const char a[] = {static_cast<char>(0xC3), static_cast<char>(0xA9), 0};
+  // é as e + accent aigu
+  const char b[] = {'e', static_cast<char>(0xCC), static_cast<char>(0x81), 0};
+  std::string as(a);
+  std::string bs(b);
+  ASSERT_EQ(2u, as.size());
+  ASSERT_EQ(3u, bs.size());
+  LocaleManager loc;
+  auto resA = loc.normalizeUtf8(as);
+  auto resB = loc.normalizeUtf8(bs);
+  ASSERT_EQ(resA, resB);
+  ASSERT_EQ(resA, as);
+}
+
 // ______________________________________________________________________________________________
 TEST(StringSortComparatorTest, TripleComponentComparator) {
   TripleComponentComparator comp("en", "US", false);

--- a/test/TupleHelpersTest.cpp
+++ b/test/TupleHelpersTest.cpp
@@ -19,18 +19,6 @@ TEST(TupleHelpersTest, SetupFromCallable) {
   }
 
   {
-    // lambda with sideeffect
-    size_t i = 2;
-    auto f = [&i](const size_t x) {
-      i *= 2;
-      return x + i;
-    };
-    ASSERT_EQ(setupTupleFromCallable<3>(f), std::tuple(4, 9, 18));
-    static_assert(std::is_same_v<decltype(setupTupleFromCallable<3>(f)),
-                                 std::tuple<size_t, size_t, size_t>>);
-  }
-
-  {
     // lambda that returns a lambda
     auto f = [](const size_t x) {
       return [x](const size_t y) { return static_cast<int>(x + y); };

--- a/test/TupleHelpersTest.cpp
+++ b/test/TupleHelpersTest.cpp
@@ -1,0 +1,170 @@
+// Copyright 2020, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach (johannes.kalmbach@gmail.com)
+
+#include <gtest/gtest.h>
+#include <string>
+#include "../src/util/TupleHelpers.h"
+
+using namespace ad_tuple_helpers;
+using namespace std::literals;
+
+TEST(TupleHelpersTest, SetupFromCallable) {
+  {
+    auto f = [](const size_t x) { return std::to_string(x); };
+    ASSERT_EQ(setupTupleFromCallable<3>(f), std::tuple("0"s, "1"s, "2"s));
+    static_assert(
+        std::is_same_v<decltype(setupTupleFromCallable<3>(f)),
+                       std::tuple<std::string, std::string, std::string>>);
+  }
+
+  {
+    // lambda with sideeffect
+    size_t i = 2;
+    auto f = [&i](const size_t x) {
+      i *= 2;
+      return x + i;
+    };
+    ASSERT_EQ(setupTupleFromCallable<3>(f), std::tuple(4, 9, 18));
+    static_assert(std::is_same_v<decltype(setupTupleFromCallable<3>(f)),
+                                 std::tuple<size_t, size_t, size_t>>);
+  }
+
+  {
+    // lambda that returns a lambda
+    auto f = [](const size_t x) {
+      return [x](const size_t y) { return static_cast<int>(x + y); };
+    };
+    auto tuple = setupTupleFromCallable<3>(f);
+    ASSERT_EQ(std::get<0>(tuple)(3), 3);
+    static_assert(std::is_same_v<decltype(std::get<0>(tuple)(4)), int>);
+    ASSERT_EQ(std::get<1>(tuple)(3), 4);
+    static_assert(std::is_same_v<decltype(std::get<1>(tuple)(4)), int>);
+    ASSERT_EQ(std::get<2>(tuple)(3), 5);
+    static_assert(std::is_same_v<decltype(std::get<2>(tuple)(4)), int>);
+  }
+  {
+    // don't ask me why but this also works with generic lambdas in the tuple;
+    auto f = [](const size_t x) {
+      return [x](const auto& y) { return std::vector(x, y); };
+    };
+    auto tup = setupTupleFromCallable<3>(f);
+    ASSERT_EQ(std::get<0>(tup)("kart"s), std::vector<std::string>());
+
+    ASSERT_EQ(std::get<1>(tup)("kart"s), std::vector{"kart"s});
+    ASSERT_EQ(std::get<2>(tup)("offel"s), std::vector({"offel"s, "offel"s}));
+    static_assert(std::is_same_v<decltype(std::get<0>(tup)("kart"s)),
+                                 std::vector<std::string>>);
+    static_assert(std::is_same_v<decltype(std::get<1>(tup)("kart"s)),
+                                 std::vector<std::string>>);
+    static_assert(std::is_same_v<decltype(std::get<2>(tup)("kart"s)),
+                                 std::vector<std::string>>);
+
+    ASSERT_EQ(std::get<0>(tup)(3), std::vector<int>());
+    ASSERT_EQ(std::get<1>(tup)(3), std::vector({3}));
+    ASSERT_EQ(std::get<2>(tup)(3), std::vector({3, 3}));
+
+    static_assert(
+        std::is_same_v<decltype(std::get<0>(tup)(3)), std::vector<int>>);
+    static_assert(
+        std::is_same_v<decltype(std::get<1>(tup)(3)), std::vector<int>>);
+    static_assert(
+        std::is_same_v<decltype(std::get<2>(tup)(3)), std::vector<int>>);
+  }
+}
+
+TEST(TupleHelpersTest, ToUniquePtrTuple) {
+  {
+    auto x = toUniquePtrTuple(3, "kartoffel"s, true);
+    ASSERT_EQ(3, *std::get<0>(x));
+    ASSERT_EQ("kartoffel"s, *std::get<1>(x));
+    ASSERT_TRUE(*std::get<2>(x));
+    static_assert(
+        std::is_same_v<decltype(std::get<0>(x)), std::unique_ptr<int>&>);
+    static_assert(std::is_same_v<decltype(std::get<1>(x)),
+                                 std::unique_ptr<std::string>&>);
+    static_assert(
+        std::is_same_v<decltype(std::get<2>(x)), std::unique_ptr<bool>&>);
+    static_assert(std::tuple_size_v<decltype(x)> == 3);
+    static_assert(std::is_same_v<toUniquePtrTuple_t<int, std::string, bool>,
+                                 decltype(x)>);
+  }
+
+  {
+    // check if forwarding works correctly
+    std::string a{"kartoffel"};
+    std::string b{"salat"};
+    auto x = toUniquePtrTuple(a, std::move(b));
+    ASSERT_EQ(a, "kartoffel"s);
+    ASSERT_TRUE(b.empty());  // I am not sure if this is implementation-defined,
+                             // but this should hold on all sane platforms
+    ASSERT_EQ("kartoffel"s, *std::get<0>(x));
+    ASSERT_EQ("salat"s, *std::get<1>(x));
+    static_assert(std::is_same_v<decltype(std::get<0>(x)),
+                                 std::unique_ptr<std::string>&>);
+    static_assert(std::is_same_v<decltype(std::get<1>(x)),
+                                 std::unique_ptr<std::string>&>);
+    static_assert(std::tuple_size_v<decltype(x)> == 2);
+    static_assert(std::is_same_v<toUniquePtrTuple_t<std::string, std::string>,
+                                 decltype(x)>);
+  }
+}
+
+TEST(TupleHelpersTest, ToRawPtrTuple) {
+  {
+    auto x = std::tuple(std::make_unique<int>(3),
+                        std::make_unique<std::string>("kartoffel"),
+                        std::make_unique<bool>(false));
+    auto y = toRawPtrTuple(x);
+
+    // the following lines make a static assertion fail, since temporary tuples
+    // are not allowed auto z = toRawPtrTuple(std::move(x)); auto a =
+    // toRawPtrTuple(std::tuple(std::make_unique<int>(4)));
+
+    static_assert(std::tuple_size_v<decltype(y)> == 3);
+    ASSERT_EQ(std::get<0>(x).get(), std::get<0>(y));
+    ASSERT_EQ(std::get<1>(x).get(), std::get<1>(y));
+    ASSERT_EQ(std::get<2>(x).get(), std::get<2>(y));
+
+    ASSERT_EQ(3, *std::get<0>(y));
+    ASSERT_EQ("kartoffel"s, *std::get<1>(y));
+    ASSERT_EQ(false, *std::get<2>(y));
+    static_assert(
+        std::is_same_v<decltype(y), std::tuple<int*, std::string*, bool*>>);
+  }
+
+  {
+    auto x = std::tuple(std::make_unique<int>(3),
+                        std::make_unique<std::string>("kartoffel"),
+                        std::make_unique<bool>(false));
+    auto y = toRawPtrTuple(x);
+
+    static_assert(std::tuple_size_v<decltype(y)> == 3);
+    ASSERT_EQ(std::get<0>(x).get(), std::get<0>(y));
+    ASSERT_EQ(std::get<1>(x).get(), std::get<1>(y));
+    ASSERT_EQ(std::get<2>(x).get(), std::get<2>(y));
+
+    ASSERT_EQ(3, *std::get<0>(y));
+    ASSERT_EQ("kartoffel"s, *std::get<1>(y));
+    ASSERT_EQ(false, *std::get<2>(y));
+    static_assert(
+        std::is_same_v<decltype(y), std::tuple<int*, std::string*, bool*>>);
+  }
+}
+
+TEST(TupleHelpersTest, IsTuple) {
+  std::tuple<int, bool> a;
+  std::tuple<int, std::string> b;
+  class X {};
+  std::tuple<X, X, std::vector<X>> c;
+  ASSERT_TRUE(is_tuple_v<decltype(a)>);
+  ASSERT_TRUE(is_tuple_v<decltype(b)>);
+  ASSERT_TRUE(is_tuple_v<decltype(c)>);
+
+  int d;
+  std::string e;
+  std::array<bool, 5> f;
+  ASSERT_FALSE(is_tuple_v<decltype(d)>);
+  ASSERT_FALSE(is_tuple_v<decltype(e)>);
+  ASSERT_FALSE(is_tuple_v<decltype(f)>);
+}

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -216,7 +216,7 @@ TEST_F(MergeVocabularyTest, bla) {
 
 TEST(VocabularyGenerator, ReadAndWritePartial) {
   {
-    Index::ItemMapArray arr;
+    ItemMapArray arr;
     auto& s = arr[0];
     s["A"] = 5;
     s["a"] = 6;
@@ -224,7 +224,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
     s["car"] = 8;
     TextVocabulary v;
     std::string basename = "_tmp_testidx";
-    auto ptr = std::make_shared<const Index::ItemMapArray>(std::move(arr));
+    auto ptr = std::make_shared<const ItemMapArray>(std::move(arr));
     writePartialIdMapToBinaryFileForMerging(
         ptr, basename + PARTIAL_VOCAB_FILE_NAME + "0", std::less<std::string>(),
         false);
@@ -246,7 +246,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
   try {
     RdfsVocabulary v;
     v.setLocale("en", "US", false);
-    Index::ItemMapArray arr;
+    ItemMapArray arr;
     auto& s = arr[0];
     s["\"A\""] = 5;
     s["\"a\""] = 6;
@@ -254,7 +254,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
     s["\"car\""] = 8;
     s["\"Ä\""] = 9;
     std::string basename = "_tmp_testidx";
-    auto ptr = std::make_shared<const Index::ItemMapArray>(std::move(arr));
+    auto ptr = std::make_shared<const ItemMapArray>(std::move(arr));
     writePartialIdMapToBinaryFileForMerging(
         ptr, basename + PARTIAL_VOCAB_FILE_NAME + "0", v.getCaseComparator(),
         false);

--- a/wikidata_settings.json
+++ b/wikidata_settings.json
@@ -9,5 +9,6 @@
 	  "language": "en",
 	  "country": "US",
 	  "ignore-punctuation": true
-  }
+  },
+  "num-triples-per-partial-vocab" : 50000000
 }


### PR DESCRIPTION
- Identified the writing of Triple elements to hash maps for deduplication as a bottleneck.
- Speed this up by writing to multiple hash maps at once and merging them afterwards
- Also concurrently pipelined all the other steps in the first index building phase.
- That way the TurtleParsing now becomes the bottleneck (Teaser: This can be sped up by 30% using
  compile time regexes, so this might become even faster in a later PR).

- This was done by Implementing an abstract, templated BatchedPipeline that abstracts
  over the creation and transformation of values in a pipeline that allows to control
  the degree of concurrency used on each level and between the different levels.

- This pipeline infrastructure was heavily unit-tested to ensure its correctness since it internally
  uses quite some template magic.

- This Commit also introduces the absl::flat_hash_map that is faster than the dense_hash_map used before.
  But in doubt I can also revert this change since in the meantime the parallelism is what helps us more
  than the faster hash maps. But I have thought, that we wanted to try out those anyway.

- This can already be reviewed, especially the BatchedPipeline.h file. Before merging I would suggest merging
  the Unicode PR, because there is some merging work to be done (but not too much) between those PRs.