### PR TITLE
Faster Turtle Parsing using Compile Time Regexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,12 @@ include_directories(third_party/googletest/googletest/include)
 include_directories(third_party/json/)
 
 ################################
+# CTRE, Compile-Time-Regular-Expressions
+################################
+# Header only, nothing to include
+include_directories(third_party/ctre/include)
+
+################################
 # ABSEIL
 ################################
 set(BUILD_TESTING OFF CACHE BOOL "Don't build tests for abseil" FORCE)

--- a/e2e/e2e-build-settings.json
+++ b/e2e/e2e-build-settings.json
@@ -1,4 +1,5 @@
 {
   "num-triples-per-partial-vocab" : 40000,
-  "parser-batch-size" : 1000
+  "parser-batch-size" : 1000,
+  "ascii-prefixes-only":true
 }

--- a/misc/convertUnicodeRegexes.py
+++ b/misc/convertUnicodeRegexes.py
@@ -1,0 +1,80 @@
+
+def utf8_bytes_required(num):
+    if num < 2**7:
+        return 1
+    if num < 2**11:
+        return 2
+    if num < 2**16:
+        return 3
+    return 4
+
+def utf8_min_codepoint_for_num_bytes(num_bytes):
+    if num_bytes == 1:
+        return 0
+    if num_bytes == 2:
+        return 2**7
+    if num_bytes == 3:
+        return 2**11
+    if num_bytes == 4:
+        return 2**16
+
+def utf8_max_codepoint_for_num_bytes(num_bytes):
+    if num_bytes < 4:
+        return utf8_min_codepoint_for_num_bytes(num_bytes - 1) - 1
+    raise RuntimeError("Should never be reached")
+
+
+def utf8_bytes_actual_value(num):
+    if num < 2**7:
+        return [num]
+    if num < 2**11:
+        return [num & (int("00111111",2) << 6), num & int("00111111",2)]
+    if num < 2**16:
+        return [(num >>12) & int("00001111", 2) , (num >> 6)  & int("00111111",2), num & int("00111111",2)]
+    return [num & (int("00000111", 2) << 15 ), num & (int("00001111", 2) << 11), num & (int("00011111",2) << 6), num & int("00111111",2)]
+
+
+def utf8_encode(num):
+    m = [[]] * 5
+    m[2] = [int("11000000", 2), int("10000000", 2)]
+    m[3] = [int("11100000", 2), int("10000000", 2), int("10000000", 2)]
+    m[4] = [int("11110000", 2) ,int("10000000", 2), int("10000000", 2) , int("10000000", 2)]
+
+    b = utf8_bytes_actual_value(num)
+    print("b is ", b)
+    if len(b) == 1:
+        return b
+    return [x | y for x, y in zip(b, m[len(b)])]
+
+def to_hex(nums):
+    return " ".join(hex(i) for i in nums)
+
+def utf8_range(lower, upper):
+    if utf8_bytes_required(lower) != 2 or utf8_bytes_required(upper) != 2:
+        raise RuntimeError("currently only two byte characters supported")
+    res = []
+    first, second = utf8_encode(lower)
+    print("first, second are {} {}".format(hex(first), hex(second)))
+    last_second = second
+    for i in range(lower + 1, upper + 1):
+        cur_first, cur_second = utf8_encode(i)
+        if cur_first != first:
+            res.append((first, (second, last_second)))
+            first = cur_first
+            second = cur_second
+        last_second = cur_second
+
+    res.append((first, (second, last_second)))
+    return res
+
+
+def to_hex_nested(nested):
+    res = []
+    for a, (b, c) in nested:
+        res.append((hex(a), (hex(b), hex(c))))
+    return res
+
+
+print(to_hex(utf8_encode(int("ff3a", 16))))
+print(to_hex_nested(utf8_range(int("c0", 16), int("d6", 16))))
+

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -69,6 +69,12 @@ static const std::string ERROR_IGNORE_CASE_UNSUPPORTED =
     "Key \"ignore-case\" is no longer supported. Please remove this key from "
     "your settings.json and rebuild your index. You can optionally specify the "
     "\"locale\" key, otherwise \"en.US\" will be used as default";
+static const std::string WARNING_ASCII_ONLY_PREFIXES =
+    "You explicitly requested the ascii-prefixes-only settings or the ctre "
+    "regex engine for Tokenization. This means "
+    "that prefixes in the input Turtle may only use characters from "
+    "the ascii range. This is stricter than the Sparql standard but "
+    "makes parsing faster and works e.g. for wikidata dumps\n";
 
 static const std::string LOCALE_DEFAULT_LANG = "en";
 static const std::string LOCALE_DEFAULT_COUNTRY = "US";

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -35,8 +35,6 @@ Index::Index()
 // _____________________________________________________________________________________________
 template <class Parser>
 VocabularyData Index::createIdTriplesAndVocab(const string& ntFile) {
-  initializeVocabularySettingsBuild();
-
   auto vocabData =
       passFileForVocabulary<Parser>(ntFile, _numTriplesPerPartialVocab);
   // first save the total number of words, this is needed to initialize the
@@ -67,7 +65,23 @@ void Index::createFromFile(const string& filename) {
   string indexFilename = _onDiskBase + ".index";
   _configurationJson["external-literals"] = _onDiskLiterals;
 
-  auto vocabData = createIdTriplesAndVocab<Parser>(filename);
+  initializeVocabularySettingsBuild<Parser>();
+
+  VocabularyData vocabData;
+  if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserDummy>) {
+    if (_onlyAsciiTurtlePrefixes) {
+      LOG(INFO) << "Using the CTRE library for Tokenization\n";
+      vocabData =
+          createIdTriplesAndVocab<TurtleStreamParser<TokenizerCtre>>(filename);
+    } else {
+      LOG(INFO) << "Using the Google Re2 library for Tokenization\n";
+      vocabData =
+          createIdTriplesAndVocab<TurtleStreamParser<Tokenizer>>(filename);
+    }
+
+  } else {
+    vocabData = createIdTriplesAndVocab<Parser>(filename);
+  }
 
   // also perform unique for first permutation
   createPermutationPair<IndexMetaDataHmapDispatcher>(&vocabData, _PSO, _POS,
@@ -113,8 +127,11 @@ void Index::createFromFile(const string& filename) {
 // explicit instantiations
 template void Index::createFromFile<TsvParser>(const string& filename);
 template void Index::createFromFile<NTriplesParser>(const string& filename);
-template void Index::createFromFile<TurtleStreamParser>(const string& filename);
-template void Index::createFromFile<TurtleMmapParser>(const string& filename);
+template void Index::createFromFile<TurtleStreamParser<Tokenizer>>(
+    const string& filename);
+template void Index::createFromFile<TurtleMmapParser<Tokenizer>>(
+    const string& filename);
+template void Index::createFromFile<TurtleParserDummy>(const string& filename);
 
 // _____________________________________________________________________________
 template <class Parser>
@@ -225,6 +242,13 @@ VocabularyData Index::passFileForVocabulary(const string& filename,
   LOG(INFO) << "Merging vocabulary\n";
   VocabularyMerger::VocMergeRes mergeRes = [&]() {
     VocabularyMerger v;
+    auto identicalPred = [c = _vocab.getCaseComparator()](const auto& a,
+                                                          const auto& b) {
+      return c(a, b, decltype(c)::Level::IDENTICAL);
+    };
+    mergeRes = v.mergeVocabulary(_onDiskBase, numFiles, identicalPred);
+    LOG(INFO) << "Finished Merging Vocabulary.\n";
+  }
     const auto identicalPred = [& c = _vocab.getCaseComparator()](
                                    const auto& a, const auto& b) {
       return c(a, b, decltype(_vocab)::SortLevel::IDENTICAL);
@@ -1409,6 +1433,7 @@ LangtagAndTriple Index::tripleToInternalRepresentation(Triple&& tripleIn) {
 }
 
 // ___________________________________________________________________________
+template <class Parser>
 void Index::initializeVocabularySettingsBuild() {
   json j;  // if we have no settings, we still have to initialize some default
            // values
@@ -1474,6 +1499,22 @@ void Index::initializeVocabularySettingsBuild() {
     _onDiskLiterals = true;
     _configurationJson["external-literals"] = true;
   }
+  if (j.count("ascii-prefixes-only")) {
+    if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserDummy>) {
+      bool v = j["ascii-prefixes-only"];
+      if (v) {
+        LOG(WARN) << WARNING_ASCII_ONLY_PREFIXES;
+        _onlyAsciiTurtlePrefixes = true;
+      } else {
+        _onlyAsciiTurtlePrefixes = false;
+      }
+    } else {
+      LOG(WARN) << "You specified the ascii-prefixes-only but a parser that is "
+                   "not the Turtle stream parser. This means that this setting "
+                   "is ignored\n";
+    }
+  }
+}
 
   if (j.count("num-triples-per-partial-vocab")) {
     _numTriplesPerPartialVocab = j["num-triples-per-partial-vocab"];

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -242,13 +242,6 @@ VocabularyData Index::passFileForVocabulary(const string& filename,
   LOG(INFO) << "Merging vocabulary\n";
   VocabularyMerger::VocMergeRes mergeRes = [&]() {
     VocabularyMerger v;
-    auto identicalPred = [c = _vocab.getCaseComparator()](const auto& a,
-                                                          const auto& b) {
-      return c(a, b, decltype(c)::Level::IDENTICAL);
-    };
-    mergeRes = v.mergeVocabulary(_onDiskBase, numFiles, identicalPred);
-    LOG(INFO) << "Finished Merging Vocabulary.\n";
-  }
     const auto identicalPred = [& c = _vocab.getCaseComparator()](
                                    const auto& a, const auto& b) {
       return c(a, b, decltype(_vocab)::SortLevel::IDENTICAL);
@@ -1514,7 +1507,6 @@ void Index::initializeVocabularySettingsBuild() {
                    "is ignored\n";
     }
   }
-}
 
   if (j.count("num-triples-per-partial-vocab")) {
     _numTriplesPerPartialVocab = j["num-triples-per-partial-vocab"];

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -56,6 +56,12 @@ struct VocabularyData {
   std::unique_ptr<TripleVec> idTriples;
 };
 
+/**
+ * Used as a Template Argument to the createFromFile method, when we do not yet
+ * know, which Tokenizer Specialization of the TurtleParser we are going to use
+ */
+class TurtleParserDummy {};
+
 class Index {
  public:
   using TripleVec = stxxl::vector<array<Id, 3>>;
@@ -119,6 +125,14 @@ class Index {
   // by createFromOnDiskIndex after this call.
   template <class Parser>
   void createFromFile(const string& filename);
+
+  /**
+   * @brief create an Index from a turtle file
+   * Determine from the settings, which Tokenizer regex engine (google re2 or
+   * ctre) should be used
+   * @param filename
+   */
+  void createFromTurtleFile(const string& filename);
 
   void addPatternsToExistingIndex();
 
@@ -448,6 +462,7 @@ class Index {
  private:
   string _onDiskBase;
   string _settingsFileName;
+  bool _onlyAsciiTurtlePrefixes = false;
   bool _onDiskLiterals = false;
   bool _keepTempFiles = false;
   json _configurationJson;
@@ -729,6 +744,7 @@ class Index {
   void readConfiguration();
 
   // initialize the index-build-time settings for the vocabulary
+  template <class Parser>
   void initializeVocabularySettingsBuild();
 
   // Helper function for Debugging during the index build.

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -306,7 +306,7 @@ int main(int argc, char** argv) {
       if (filetype == "ttl") {
         LOG(INFO) << "Reading from uncompressed turtle file or stream "
                   << inputFile << std::endl;
-        index.createFromFile<TurtleStreamParser>(inputFile);
+        index.createFromFile<TurtleParserDummy>(inputFile);
       } else if (filetype == "tsv") {
         LOG(INFO) << "Reading from uncompressed tsv file" << inputFile
                   << std::endl;
@@ -321,7 +321,7 @@ int main(int argc, char** argv) {
         LOG(WARN) << "We will load this file using mmap. This will only work "
                      "for files on hard disk and fail for streams.\n";
         LOG(WARN) << "For Turtle streams please use --file-format ttl\n";
-        index.createFromFile<TurtleMmapParser>(inputFile);
+        index.createFromFile<TurtleMmapParser<Tokenizer>>(inputFile);
       } else {
         LOG(ERROR)
             << "Argument to --file-format (-F) must be one of [tsv|nt|ttl|mmap]"

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -575,12 +575,8 @@ class TripleComponentComparator {
   }
 
   /**
-   * @brief Normalize a Utf8 string to a canonical representation.
-   * Maps e.g. single codepoint é and e + accent aigu to single codepoint é by
-   * applying the UNICODE NFC (Normalization form C) This is independent from
-   * the locale
-   * @param input The String to be normalized. Must be UTF-8 encoded
-   * @return The NFC canonical form of NFC in UTF-8 encoding.
+   * @brief trivialy wraps LocaleManager::normalizeUtf8, see there for
+   * documentation
    */
   std::string normalizeUtf8(std::string_view sv) const {
     return _locManager.normalizeUtf8(sv);

--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -50,3 +50,66 @@ std::tuple<bool, size_t, std::string> Tokenizer::getNextToken(
   reset(beg + maxMatchSize, dataSize - maxMatchSize);
   return {success, maxMatchIndex, maxMatch};
 }
+
+// ______________________________________________________________________________________________________
+const RE2& Tokenizer::idToRegex(const TokId reg) {
+  switch (reg) {
+    case TokId::TurtlePrefix:
+      return _tokens.TurtlePrefix;
+    case TokId::SparqlPrefix:
+      return _tokens.SparqlPrefix;
+    case TokId::TurtleBase:
+      return _tokens.TurtleBase;
+    case TokId::SparqlBase:
+      return _tokens.SparqlBase;
+    case TokId::Dot:
+      return _tokens.Dot;
+    case TokId::Comma:
+      return _tokens.Comma;
+    case TokId::Semicolon:
+      return _tokens.Semicolon;
+    case TokId::OpenSquared:
+      return _tokens.OpenSquared;
+    case TokId::CloseSquared:
+      return _tokens.CloseSquared;
+    case TokId::OpenRound:
+      return _tokens.OpenRound;
+    case TokId::CloseRound:
+      return _tokens.CloseRound;
+    case TokId::A:
+      return _tokens.A;
+    case TokId::DoubleCircumflex:
+      return _tokens.DoubleCircumflex;
+    case TokId::True:
+      return _tokens.True;
+    case TokId::False:
+      return _tokens.False;
+    case TokId::Langtag:
+      return _tokens.Langtag;
+    case TokId::Decimal:
+      return _tokens.Decimal;
+    case TokId::Exponent:
+      return _tokens.Exponent;
+    case TokId::Double:
+      return _tokens.Double;
+    case TokId::Iriref:
+      return _tokens.Iriref;
+    case TokId::PnameNS:
+      return _tokens.PnameNS;
+    case TokId::PnameLN:
+      return _tokens.PnameLN;
+    case TokId::BlankNodeLabel:
+      return _tokens.BlankNodeLabel;
+    case TokId::WsMultiple:
+      return _tokens.WsMultiple;
+    case TokId::Anon:
+      return _tokens.Anon;
+    case TokId::Comment:
+      return _tokens.Comment;
+    case TokId::Integer:
+      return _tokens.Integer;
+  }
+  throw std::runtime_error(
+      "Illegal switch value in Tokenizer::getNextToken. This should never "
+      "happen");
+}

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -4,6 +4,7 @@
 //
 #pragma once
 
+#include <ctre/ctre.h>
 #include <gtest/gtest.h>
 #include <re2/re2.h>
 #include <regex>
@@ -13,9 +14,237 @@
 using re2::RE2;
 using namespace std::string_literals;
 
-// holds all the google re2 regexes that correspond to all terminals in the
-// turtle grammar cannot be static since google regexes have to be constructed
-// at runtime
+/// Helper function for ctre: concatenation of fixed_strings
+template <size_t A, size_t B>
+constexpr ctll::fixed_string<A + B - 1> operator+(
+    const ctll::fixed_string<A>& a, const ctll::fixed_string<B>& b) {
+  char32_t comb[A + B - 1] = {};
+  for (size_t i = 0; i < A - 1;
+       ++i) {  // omit the trailing 0 of the first string
+    comb[i] = a.content[i];
+  }
+  for (size_t i = 0; i < B; ++i) {
+    comb[i + A - 1] = b.content[i];
+  }
+  return ctll::fixed_string(comb);
+}
+
+/// Helper function for ctre: concatenation of fixed_strings
+template <size_t A, size_t B>
+constexpr ctll::fixed_string<A + B - 1> operator+(
+    const ctll::fixed_string<A>& a, const char (&b)[B]) {
+  auto bStr = ctll::fixed_string(b);
+  return a + bStr;
+}
+
+/// Helper function for ctre: concatenation of fixed_strings
+template <size_t A, size_t B>
+constexpr ctll::fixed_string<A + B - 1> operator+(
+    const char (&a)[A], const ctll::fixed_string<B>& b) {
+  auto aStr = ctll::fixed_string(a);
+  return aStr + b;
+}
+
+using ctll::fixed_string;
+using namespace ctre::literals;
+
+/// Create a regex group by putting the argument in parentheses
+template <size_t N>
+static constexpr auto grp(const ctll::fixed_string<N>& s) {
+  return fixed_string("(") + s + fixed_string(")");
+}
+
+/// Create a regex character class by putting the argument in square brackets
+template <size_t N>
+static constexpr auto cls(const ctll::fixed_string<N>& s) {
+  return fixed_string("[") + s + fixed_string("]");
+}
+
+/// Create a ctll::fixed string from a compile time character constant. Is
+/// needed for some magical reasons
+template <typename T, size_t N>
+constexpr fixed_string<N> fs(const T (&input)[N]) noexcept {
+  return fixed_string(input);
+}
+
+/// One entry for each Token in the Turtle Grammar. Used to create a unified
+/// Interface to the two different Tokenizers
+enum class TokId : int {
+  TurtlePrefix,
+  SparqlPrefix,
+  TurtleBase,
+  SparqlBase,
+  Dot,
+  Comma,
+  Semicolon,
+  OpenSquared,
+  CloseSquared,
+  OpenRound,
+  CloseRound,
+  A,
+  DoubleCircumflex,
+  True,
+  False,
+  Langtag,
+  Integer,
+  Decimal,
+  Exponent,
+  Double,
+  Iriref,
+  PnameNS,
+  PnameLN,
+  BlankNodeLabel,
+  WsMultiple,
+  Anon,
+  Comment
+};
+
+/**
+ * @brief Holds the Compile-Time-Regexes for the Turtle Grammar used by the
+ * TokenizerCTRE
+ *
+ * Caveat: The Prefix names are currently restricted to ascii values.
+ */
+struct TurtleTokenCtre {
+  template <size_t N>
+  using STR = ctll::fixed_string<N>;
+
+  static constexpr auto TurtlePrefix = grp(fixed_string("@prefix"));
+  // TODO: this is actually case-insensitive
+  static constexpr auto SparqlPrefix = grp(fixed_string("PREFIX"));
+  static constexpr auto TurtleBase = grp(fixed_string("@base"));
+  static constexpr auto SparqlBase = grp(fixed_string("BASE"));
+  static constexpr auto Dot = grp(fixed_string("\\."));
+  static constexpr auto Comma = grp(fixed_string(","));
+  static constexpr auto Semicolon = grp(fixed_string(";"));
+  static constexpr auto OpenSquared = grp(fixed_string("\\["));
+  static constexpr auto CloseSquared = grp(fixed_string("\\]"));
+  static constexpr auto OpenRound = grp(fixed_string("\\("));
+  static constexpr auto CloseRound = grp(fixed_string("\\)"));
+  static constexpr auto A = grp(fixed_string("a"));
+  static constexpr auto DoubleCircumflex = grp(fixed_string("\\^\\^"));
+  static constexpr auto True = grp(fixed_string("true"));
+  static constexpr auto False = grp(fixed_string("false"));
+
+  static constexpr auto Langtag =
+      grp(fixed_string("@[a-zA-Z]+(\\-[a-zA-Z0-9]+)*"));
+  static constexpr auto Integer = grp(fixed_string("[\\+\\-]?[0-9]+"));
+  static constexpr auto Decimal = grp(fixed_string("[\\+\\-]?[0-9]*\\.[0-9]+"));
+  static constexpr auto ExponentString = fixed_string("[eE][\\+\\-]?[0-9]+");
+  static constexpr auto Exponent = grp(ExponentString);
+
+  static constexpr auto DoubleString = fs("[\\+\\-]?([0-9]+\\.[0-9]*") +
+                                       ExponentString + fs("|") +
+                                       ExponentString + fs(")");
+
+  static constexpr auto Double = grp(DoubleString);
+
+  static constexpr auto HexString = fs("0-9A-Fa-f");
+  static constexpr auto UcharString =
+      fs("\\\\u[0-9a-fA-f]{4}|\\\\U[0-9a-fA-f]{8}");
+
+  static constexpr auto EcharString = fs("\\\\[tbnrf\"\'\\\\]");
+
+  static constexpr auto StringLiteralQuoteString =
+      fs("\"([^\\x22\\x5C\\x0A\\x0D]|") + EcharString + fs("|") + UcharString +
+      fs(")*\"");
+
+  static constexpr auto StringLiteralSingleQuoteString =
+      fs("'([^\\x27\\x5C\\x0A\\x0D]|") + EcharString + fs("|") + UcharString +
+      fs(")*'");
+  static constexpr auto StringLiteralLongSingleQuoteString =
+      fs("'''((''|')?([^'\\\\]|") + EcharString + fs(u8"|") + UcharString +
+      fs("))*'''");
+
+  static constexpr auto StringLiteralLongQuoteString =
+      u8"\"\"\"((\"\"|\")?([^\"\\\\]|" + EcharString + u8"|" + UcharString +
+      u8"))*\"\"\"";
+
+  // TODO: fix this!
+  static constexpr auto IrirefString =
+      R"(<([^\x00-\x20<>"{}\x7c^`\\]|)" + UcharString + u8")*>";
+
+  static constexpr auto PercentString = "%" + cls(HexString) + "{2}";
+
+  /*
+  // TODO<joka921: Currently CTRE does not really support UTF-8. I tried to hack
+  the UTF-8 byte patterns
+  for this regex, see the file Utf8RegexTest.cpp, but this did increase
+  compile time by an infeasible amount ( more than 20 minutes for this file
+  alone which made debugging impossible) Thus we will currently only allow
+  simple prefixes and emit proper warnings.
+            u8"A-Za-z\\x{00C0}-\\x{00D6}\\x{00D8}-\\x{00F6}\\x{00F8}-"
+            u8"\\x{02FF}"
+            u8"\\x{0370}-"
+            u8"\\x{037D}\\x{037F}-\\x{1FFF}\\x{200C}-\\x{200D}\\x{2070}-\\x{"
+            u8"218F}"
+            u8"\\x{2C00}-"
+            u8"\\x{2FEF}"
+            u8"\\x{3001}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFFD}"
+            u8"\\x{00010000}-"
+            u8"\\x{000EFFFF}");
+            */
+  static constexpr auto PnCharsBaseString = fixed_string("A-Za-z");
+
+  static constexpr auto PnCharsUString = PnCharsBaseString + u8"_";
+
+  // TODO<joka921>:  here we have the same issue with UTF-8 in CTRE as above
+  /*
+  static constexpr auto PnCharsString =
+            PnCharsUString +
+            u8"\\-0-9\\x{00B7}\\x{0300}-\\x{036F}\\x{203F}-\\x{2040}";
+            */
+
+  static constexpr auto PnCharsString = PnCharsUString + u8"\\-0-9";
+
+  static constexpr auto PnPrefixString = cls(PnCharsBaseString) + u8"(\\." +
+                                         cls(PnCharsString) + u8"|" +
+                                         cls(PnCharsString) + ")*";
+
+  static constexpr auto PnameNSString = PnPrefixString + u8":";
+
+  static constexpr fixed_string PnLocalEscString =
+      u8"\\\\[_~.\\-!$&'()*+,;=/?#@%]";
+
+  static constexpr fixed_string PlxString =
+      PercentString + u8"|" + PnLocalEscString;
+
+  static constexpr fixed_string TmpNoDot =
+      cls(PnCharsString + ":") + "|" + PlxString;
+  static constexpr fixed_string PnLocalString =
+      grp(cls(PnCharsUString + u8":0-9") + "|" + PlxString) +
+      grp(u8"\\.*" + grp(TmpNoDot)) + "*";
+
+  static constexpr fixed_string PnameLNString =
+      grp(PnameNSString) + grp(PnLocalString);
+
+  static constexpr fixed_string BlankNodeLabelString =
+      u8"_:" + cls(PnCharsUString + u8"0-9") +
+      grp("\\.*" + cls(PnCharsString)) + "*";
+
+  static constexpr fixed_string WsSingleString = u8"\\x20\\x09\\x0D\\x0A";
+
+  static constexpr fixed_string WsMultipleString = cls(WsSingleString) + u8"*";
+
+  static constexpr fixed_string AnonString =
+      u8"\\[" + WsMultipleString + u8"\\]";
+
+  static constexpr fixed_string CommentString = u8"#[^\\n]*\\n";
+
+  static constexpr fixed_string Iriref = grp(IrirefString);
+  static constexpr fixed_string PnameNS = grp(PnameNSString);
+  static constexpr fixed_string PnameLN = grp(PnameLNString);
+  static constexpr fixed_string BlankNodeLabel = grp(BlankNodeLabelString);
+
+  static constexpr fixed_string WsMultiple = grp(WsMultipleString);
+  static constexpr fixed_string Anon = grp(AnonString);
+  static constexpr fixed_string Comment = grp(CommentString);
+};
+
+/** holds all the google re2 regexes that correspond to all terminals in the
+ * turtle grammar cannot be static since google regexes have to be constructed
+ * at runtime
+ */
 struct TurtleToken {
   /**
    * @brief convert a RDF Literal to a unified form that is used inside QLever
@@ -334,22 +563,267 @@ struct TurtleToken {
   static string cls(const string& s) { return '[' + s + ']'; }
 };
 
+/**
+ * @brief Tokenizer that uses the Ctre library
+ *
+ * It has exactly the same public interface as the Tokenizer class from above,
+ * so it can be used as a drop-in replacement. CAVEAT: Currently this does only
+ * support prefixes that only contain ascii characters
+ */
+class TokenizerCtre {
+  FRIEND_TEST(TokenizerTest, Compilation);
+
+ public:
+  /**
+   * @brief Construct from a char ptr (the bytes to parse) and the number of
+   * bytes that can be read/parsed from this ptr
+   *
+   * @param data the data from which we will parse. Only taken by reference
+   * without ownership
+   */
+  explicit TokenizerCtre(std::string_view data) : _data(data) {}
+
+  /// iterator to the next character that we have not yet consumed
+  [[nodiscard]] auto begin() const { return _data.begin(); }
+
+  /**
+   * if a prefix of the input stream matches the regex argument,
+   * return true and that prefix and move the input stream forward
+   * by the length of the match. If no match is found,
+   * false is returned and the input stream remains the same
+   */
+  template <TokId id>
+  std::pair<bool, std::string_view> getNextToken() noexcept {
+    auto res = apply<Matcher, id>();
+    _data.remove_prefix(res.second.size());
+    return res;
+  }
+
+  /**
+   * @brief determines and matches the longest prefix match of the held _data
+   * with one of the regexes.
+   *
+   * If such a match is found, the input stream is advanced by the longest match
+   * prefix
+   * @tparam fst the first of the candidate regexes
+   * @tparam ids the following candidate regexes
+   * @return
+   *  - bool: True iff any match was found
+   * - size_t: The index of the regex that was responsible for the longest match
+   * - string_view: The prefix that forms the longest match
+   */
+  template <TokId fst, TokId... ids>
+  std::tuple<bool, size_t, std::string_view> getNextTokenMultiple() {
+    const char* beg = _data.begin();
+    size_t dataSize = _data.size();
+
+    auto innerResult = getNextTokenRecurse<0, fst, ids...>();
+
+    // advance for the length of the longest match
+    auto maxMatchSize = std::get<1>(innerResult);
+    reset(beg + maxMatchSize, dataSize - maxMatchSize);
+    return innerResult;
+  }
+
+  /// skip any whitespace or comments at the beginning of the held characters
+  void skipWhitespaceAndComments() {
+    skipWhitespace();
+    skipComments();
+    skipWhitespace();
+  }
+
+  /** If there is a prefix match with the argument, move forward the beginning
+   * of _data and return true. Else return false.Can be used if we are not
+   * interested in the actual value of the match
+   */
+  template <TokId id>
+  bool skip() {
+    return getNextToken<id>().first;
+  }
+
+  /// reinitialize with a new byte pointer and size pair
+  void reset(const char* ptr, size_t sz) { _data = std::string_view(ptr, sz); }
+  /// reinitialize with a string_view
+  void reset(std::string_view s) { _data = s; }
+
+  /// Access to input stream as std::string_view
+  [[nodiscard]] std::string_view view() const { return _data; }
+  /// Access to input stream as std::string_view
+  [[nodiscard]] const std::string_view data() const { return _data; }
+  /// remove the first n characters from our input stream (e.g. if they have
+  /// been dealt with externally)
+  void remove_prefix(size_t n) { _data.remove_prefix(n); }
+
+ private:
+  /// string_view of the characters we are parsing from.
+  std::string_view _data;
+
+  // ________________________________________________________________
+  void skipWhitespace() {
+    auto v = view();
+    auto pos = v.find_first_not_of("\x20\x09\x0D\x0A");
+    if (pos != string::npos) {
+      _data.remove_prefix(pos);
+    }
+  }
+
+  // ___________________________________________________________________________________
+  void skipComments() {
+    // if not successful, then there was no comment, but this does not matter to
+    // us
+    auto v = view();
+    if (ad_utility::startsWith(v, "#")) {
+      auto pos = v.find("\n");
+      if (pos == string::npos) {
+        // TODO: this actually should yield a n error
+        LOG(INFO) << "Warning, unfinished comment found while parsing";
+      } else {
+        _data.remove_prefix(pos + 1);
+      }
+    }
+  }
+  FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
+
+  /*
+   * Determine, which of the compile-timer regexes in the TurtleTokenCtre class
+   * belongs to the specified TokId Then call the static templated process
+   * Function of the class template f, so F::template process<TheRegex>(_data)
+   */
+  template <class F, TokId id>
+  constexpr auto apply() {
+    if constexpr (id == TokId::Langtag) {
+      return F::template process<TurtleTokenCtre::Langtag>(_data);
+    } else if constexpr (id == TokId::Double) {
+      return F::template process<TurtleTokenCtre::Double>(_data);
+    } else if constexpr (id == TokId::Iriref) {
+      return F::template process<TurtleTokenCtre::Iriref>(_data);
+    } else if constexpr (id == TokId::PnameNS) {
+      return F::template process<TurtleTokenCtre::PnameNS>(_data);
+    } else if constexpr (id == TokId::PnameLN) {
+      return F::template process<TurtleTokenCtre::PnameLN>(_data);
+    } else if constexpr (id == TokId::BlankNodeLabel) {
+      return F::template process<TurtleTokenCtre::BlankNodeLabel>(_data);
+    } else {
+      switch (id) {
+        case TokId::TurtlePrefix:
+          return F::template process<TurtleTokenCtre::TurtlePrefix>(_data);
+        case TokId::SparqlPrefix:
+          return F::template process<TurtleTokenCtre::SparqlPrefix>(_data);
+        case TokId::TurtleBase:
+          return F::template process<TurtleTokenCtre::TurtleBase>(_data);
+        case TokId::SparqlBase:
+          return F::template process<TurtleTokenCtre::SparqlBase>(_data);
+        case TokId::Dot:
+          return F::template process<TurtleTokenCtre::Dot>(_data);
+        case TokId::Comma:
+          return F::template process<TurtleTokenCtre::Comma>(_data);
+        case TokId::Semicolon:
+          return F::template process<TurtleTokenCtre::Semicolon>(_data);
+        case TokId::OpenSquared:
+          return F::template process<TurtleTokenCtre::OpenSquared>(_data);
+        case TokId::CloseSquared:
+          return F::template process<TurtleTokenCtre::CloseSquared>(_data);
+
+        case TokId::OpenRound:
+          return F::template process<TurtleTokenCtre::OpenRound>(_data);
+        case TokId::CloseRound:
+          return F::template process<TurtleTokenCtre::CloseRound>(_data);
+        case TokId::A:
+          return F::template process<TurtleTokenCtre::A>(_data);
+        case TokId::DoubleCircumflex:
+          return F::template process<TurtleTokenCtre::DoubleCircumflex>(_data);
+        case TokId::True:
+          return F::template process<TurtleTokenCtre::True>(_data);
+        case TokId::False:
+          return F::template process<TurtleTokenCtre::False>(_data);
+
+        case TokId::Integer:
+          return F::template process<TurtleTokenCtre::Integer>(_data);
+        case TokId::Decimal:
+          return F::template process<TurtleTokenCtre::Decimal>(_data);
+        case TokId::Exponent:
+          return F::template process<TurtleTokenCtre::Exponent>(_data);
+        case TokId::WsMultiple:
+          return F::template process<TurtleTokenCtre::WsMultiple>(_data);
+        case TokId::Anon:
+          return F::template process<TurtleTokenCtre::Anon>(_data);
+        case TokId::Comment:
+          return F::template process<TurtleTokenCtre::Comment>(_data);
+      }
+    }
+  }
+
+  // base case for the recursion on longest match for multiple regexes. No regex
+  // left, so there's no match
+  template <size_t idx>
+  std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
+    return std::tuple(false, idx, "");
+  }
+
+  /*
+   * Recursion for the longest match of multiple regexes.
+   * Returns the idx of the longest match and the longestMatch.
+   * Does not change the internal data stream, this has to be done by the
+   * external call
+   *
+   * @tparam idx the idx to start with (has to be 0 when called externally)
+   * @tparam fst The first regex to check
+   * @tparam ids The other regexes to check
+   * @return <anyMatchFound?, idxOfLongestMatch, contentOfLongestMatch>
+   */
+  template <size_t idx, TokId fst, TokId... ids>
+  std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
+    const auto [success, unusedIdx, content] =
+        getNextTokenRecurse<idx + 1, ids...>();
+    const char* beg = _data.begin();
+    size_t dataSize = _data.size();
+    const auto [currentSuccess, res] = getNextToken<fst>();
+    reset(beg, dataSize);
+    bool curBetter = currentSuccess && res.size() > content.size();
+
+    return std::tuple(success || currentSuccess, curBetter ? idx : unusedIdx,
+                      curBetter ? res : content);
+  }
+
+  /*
+   * The helper struct used for the intenal apply function
+   * Its static function process<regex>(string_view)
+   * tries to match a prefix of the string_view with the regex and returns
+   * <true, matchContent> on sucess and <false, emptyStringView> on failure
+   */
+  struct Matcher {
+    template <auto& regex>
+    static std::pair<bool, std::string_view> process(
+        std::string_view data) noexcept {
+      static constexpr auto ext = grp(regex) + ".*";
+      if (auto m = ctre::match<ext>(data)) {
+        return {true, m.template get<1>().to_view()};
+      } else {
+        return {false, std::string_view()};
+      }
+    }
+  };
+};
+
 // The currently used hand-written tokenizer
-// TODO<joka921>: Use a automatically generated lexer (e.g. from flex)
 // for this for correctness and efficiency
 class Tokenizer {
   FRIEND_TEST(TokenizerTest, Compilation);
 
  public:
-  // Construct from a char ptr (the bytes to parse) and the number of bytes that
-  // can be read/parsed from this ptr
-  Tokenizer(const char* ptr, size_t size) : _tokens(), _data(ptr, size) {}
+  // Construct from a std::string_view;
+  Tokenizer(std::string_view input)
+      : _tokens(), _data(input.data(), input.size()) {}
 
   // if a prefix of the input stream matches the regex argument,
   // return true and that prefix and move the input stream forward
   // by the length of the match. If no match is found,
   // false is returned and the input stream remains the same
   std::pair<bool, std::string> getNextToken(const RE2& reg);
+  template <TokId id>
+  std::pair<bool, std::string> getNextToken() {
+    return getNextToken(idToRegex(id));
+  }
 
   // overload that takes multiple regexes
   // determines the longest match of the input stream prefix
@@ -362,6 +836,39 @@ class Tokenizer {
   std::tuple<bool, size_t, std::string> getNextToken(
       const std::vector<const RE2*>& regs);
 
+  template <TokId fst, TokId... ids>
+  std::tuple<bool, size_t, std::string_view> getNextTokenMultiple() {
+    const char* beg = _data.begin();
+    size_t dataSize = _data.size();
+
+    auto innerResult = getNextTokenRecurse<0, fst, ids...>();
+
+    // advance for the length of the longest match
+    auto maxMatchSize = std::get<1>(innerResult);
+    reset(beg + maxMatchSize, dataSize - maxMatchSize);
+    return innerResult;
+  }
+
+  template <size_t idx>
+  std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
+    return std::tuple(false, idx, "");
+  }
+
+  template <size_t idx, TokId fst, TokId... ids>
+  std::tuple<bool, size_t, std::string_view> getNextTokenRecurse() {
+    // TODO<joka921> : write unit tests for this Overload!!
+    const auto [success, unusedIdx, content] =
+        getNextTokenRecurse<idx + 1, ids...>();
+    const char* beg = _data.begin();
+    size_t dataSize = _data.size();
+    const auto [currentSuccess, res] = getNextToken<fst>();
+    reset(beg, dataSize);
+    bool curBetter = currentSuccess && res.size() > content.size();
+
+    return std::tuple(success || currentSuccess, curBetter ? idx : unusedIdx,
+                      curBetter ? res : content);
+  }
+
   // _______________________________________________________________________________
   void skipWhitespaceAndComments();
 
@@ -369,6 +876,10 @@ class Tokenizer {
   // and return true. Can be used if we are not interested in the actual value
   // of the match
   bool skip(const RE2& reg) { return RE2::Consume(&_data, reg); }
+  template <TokId id>
+  bool skip() {
+    return skip(idToRegex(id));
+  }
 
   // reinitialize with a new byte pointer and size pair
   void reset(const char* ptr, size_t size) {
@@ -382,10 +893,16 @@ class Tokenizer {
   // Access to input stream as std::string_view
   std::string_view view() const { return {_data.data(), _data.size()}; }
 
+  auto begin() const { return _data.begin(); }
+  void remove_prefix(size_t n) { _data.remove_prefix(n); }
+
   // holds all the regexes needed for Tokenization
   TurtleToken _tokens;
 
  private:
+  // convert the (external) TokId to the internally used google-regex
+  const RE2& idToRegex(const TokId reg);
+
   // ________________________________________________________________
   void skipWhitespace() {
     auto v = view();

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -7,26 +7,29 @@
 #include <string.h>
 
 // _______________________________________________________________
-bool TurtleParser::statement() {
+template <class T>
+bool TurtleParser<T>::statement() {
   _tok.skipWhitespaceAndComments();
-  return directive() || (triples() && skip(tokens().Dot));
+  return directive() || (triples() && skip<TokId::Dot>());
 }
 
 // ______________________________________________________________
-bool TurtleParser::directive() {
+template <class T>
+bool TurtleParser<T>::directive() {
   return prefixID() || base() || sparqlPrefix() || sparqlBase();
 }
 
 // ________________________________________________________________
-bool TurtleParser::prefixID() {
-  if (skip(tokens().TurtlePrefix)) {
-    if (check(pnameNS()) && check(iriref()) && check(skip(tokens().Dot))) {
+template <class T>
+bool TurtleParser<T>::prefixID() {
+  if (skip<TokId::TurtlePrefix>()) {
+    if (check(pnameNS()) && check(iriref()) && check(skip<TokId::Dot>())) {
       // strip  the angled brackes <bla> -> bla
       _prefixMap[_activePrefix] =
           _lastParseResult.substr(1, _lastParseResult.size() - 2);
       return true;
     } else {
-      throw ParseException("prefixID");
+      throw TurtleParser<T>::ParseException("prefixID");
     }
   } else {
     return false;
@@ -34,8 +37,9 @@ bool TurtleParser::prefixID() {
 }
 
 // ________________________________________________________________
-bool TurtleParser::base() {
-  if (skip(tokens().TurtleBase)) {
+template <class T>
+bool TurtleParser<T>::base() {
+  if (skip<TokId::TurtleBase>()) {
     if (iriref()) {
       _baseIRI = _lastParseResult;
       return true;
@@ -48,8 +52,9 @@ bool TurtleParser::base() {
 }
 
 // ________________________________________________________________
-bool TurtleParser::sparqlPrefix() {
-  if (skip(tokens().SparqlPrefix)) {
+template <class T>
+bool TurtleParser<T>::sparqlPrefix() {
+  if (skip<TokId::SparqlPrefix>()) {
     if (pnameNS() && iriref()) {
       _prefixMap[_activePrefix] = _lastParseResult;
       return true;
@@ -62,8 +67,9 @@ bool TurtleParser::sparqlPrefix() {
 }
 
 // ________________________________________________________________
-bool TurtleParser::sparqlBase() {
-  if (skip(tokens().SparqlBase)) {
+template <class T>
+bool TurtleParser<T>::sparqlBase() {
+  if (skip<TokId::SparqlBase>()) {
     if (iriref()) {
       _baseIRI = _lastParseResult;
       return true;
@@ -76,7 +82,8 @@ bool TurtleParser::sparqlBase() {
 }
 
 // ________________________________________________
-bool TurtleParser::triples() {
+template <class T>
+bool TurtleParser<T>::triples() {
   if (subject()) {
     if (predicateObjectList()) {
       return true;
@@ -95,9 +102,10 @@ bool TurtleParser::triples() {
 }
 
 // __________________________________________________
-bool TurtleParser::predicateObjectList() {
+template <class T>
+bool TurtleParser<T>::predicateObjectList() {
   if (verb() && check(objectList())) {
-    while (skip(tokens().Semicolon)) {
+    while (skip<TokId::Semicolon>()) {
       if (verb() && check(objectList())) {
         continue;
       }
@@ -109,9 +117,10 @@ bool TurtleParser::predicateObjectList() {
 }
 
 // _____________________________________________________
-bool TurtleParser::objectList() {
+template <class T>
+bool TurtleParser<T>::objectList() {
   if (object()) {
-    while (skip(tokens().Comma) && check(object())) {
+    while (skip<TokId::Comma>() && check(object())) {
       continue;
     }
     return true;
@@ -121,12 +130,16 @@ bool TurtleParser::objectList() {
 }
 
 // ______________________________________________________
-bool TurtleParser::verb() { return predicateSpecialA() || predicate(); }
+template <class T>
+bool TurtleParser<T>::verb() {
+  return predicateSpecialA() || predicate();
+}
 
 // ___________________________________________________________________
-bool TurtleParser::predicateSpecialA() {
+template <class T>
+bool TurtleParser<T>::predicateSpecialA() {
   _tok.skipWhitespaceAndComments();
-  if (auto [success, word] = _tok.getNextToken(tokens().A); success) {
+  if (auto [success, word] = _tok.template getNextToken<TokId::A>(); success) {
     (void)word;
     _activePredicate = u8"<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
     return true;
@@ -136,7 +149,8 @@ bool TurtleParser::predicateSpecialA() {
 }
 
 // ____________________________________________________________________
-bool TurtleParser::subject() {
+template <class T>
+bool TurtleParser<T>::subject() {
   if (blankNode() || iri() || collection()) {
     _activeSubject = _lastParseResult;
     return true;
@@ -146,7 +160,8 @@ bool TurtleParser::subject() {
 }
 
 // ____________________________________________________________________
-bool TurtleParser::predicate() {
+template <class T>
+bool TurtleParser<T>::predicate() {
   if (iri()) {
     _activePredicate = _lastParseResult;
     return true;
@@ -156,7 +171,8 @@ bool TurtleParser::predicate() {
 }
 
 // ____________________________________________________________________
-bool TurtleParser::object() {
+template <class T>
+bool TurtleParser<T>::object() {
   // these produce a single object that becomes part of a triple
   // check blank Node first because _: also could look like a prefix
   if (blankNode() || literal() || iri()) {
@@ -171,13 +187,15 @@ bool TurtleParser::object() {
 }
 
 // ____________________________________________________________________
-bool TurtleParser::literal() {
+template <class T>
+bool TurtleParser<T>::literal() {
   return (rdfLiteral() || numericLiteral() || booleanLiteral());
 }
 
 // _____________________________________________________________________
-bool TurtleParser::blankNodePropertyList() {
-  if (!skip(tokens().OpenSquared)) {
+template <class T>
+bool TurtleParser<T>::blankNodePropertyList() {
+  if (!skip<TokId::OpenSquared>()) {
     return false;
   }
   // save subject and predicate
@@ -190,7 +208,7 @@ bool TurtleParser::blankNodePropertyList() {
   // the following triples have the blank node as subject
   _activeSubject = blank;
   check(predicateObjectList());
-  check(skip(tokens().CloseSquared));
+  check(skip<TokId::CloseSquared>());
   // restore subject and predicate
   _activeSubject = savedSubject;
   _activePredicate = savedPredicate;
@@ -198,8 +216,9 @@ bool TurtleParser::blankNodePropertyList() {
 }
 
 // _____________________________________________________________________
-bool TurtleParser::collection() {
-  if (!skip(tokens().OpenRound)) {
+template <class T>
+bool TurtleParser<T>::collection() {
+  if (!skip<TokId::OpenRound>()) {
     return false;
   }
   throw ParseException(
@@ -208,12 +227,14 @@ bool TurtleParser::collection() {
 }
 
 // ______________________________________________________________________
-bool TurtleParser::numericLiteral() {
+template <class T>
+bool TurtleParser<T>::numericLiteral() {
   return integer() || decimal() || doubleParse();
 }
 
 // ______________________________________________________________________
-bool TurtleParser::rdfLiteral() {
+template <class T>
+bool TurtleParser<T>::rdfLiteral() {
   if (!stringParse()) {
     return false;
   }
@@ -223,7 +244,7 @@ bool TurtleParser::rdfLiteral() {
     return true;
     // TODO<joka921> this allows spaces here since the ^^ is unique in the
     // sparql syntax. is this correct?
-  } else if (skip(tokens().DoubleCircumflex) && check(iri())) {
+  } else if (skip<TokId::DoubleCircumflex>() && check(iri())) {
     _lastParseResult = s + "^^" + _lastParseResult;
     return true;
   } else {
@@ -233,26 +254,19 @@ bool TurtleParser::rdfLiteral() {
 }
 
 // ______________________________________________________________________
-bool TurtleParser::booleanLiteral() {
-  std::vector<const RE2*> candidates;
-  candidates.push_back(&(tokens().True));
-  candidates.push_back(&(tokens().False));
-  if (auto [success, index, word] = _tok.getNextToken(candidates); success) {
-    (void)index;
-    _lastParseResult = word;
-    return true;
-  } else {
-    return false;
-  }
+template <class T>
+bool TurtleParser<T>::booleanLiteral() {
+  return parseTerminal<TokId::True>() || parseTerminal<TokId::False>();
 }
 
 // ______________________________________________________________________
-bool TurtleParser::stringParse() {
+template <class T>
+bool TurtleParser<T>::stringParse() {
   // manually parse strings for efficiency
   auto view = _tok.view();
   size_t startPos = 0;
   size_t endPos = 1;
-  std::array<string, 4> quotes{"\"\"\"", "\'\'\'", "\"", "\'"};
+  std::array<string, 4> quotes{R"(""")", R"(''')", "\"", "\'"};
   bool foundString = false;
   for (const auto& q : quotes) {
     if (ad_utility::startsWith(view, q)) {
@@ -290,19 +304,21 @@ bool TurtleParser::stringParse() {
   // also include the quotation marks in the word
   // TODO <joka921> how do we have to translate multiline strings for QLever?
   _lastParseResult = view.substr(0, endPos + startPos);
-  _tok.data().remove_prefix(endPos + startPos);
+  _tok.remove_prefix(endPos + startPos);
   return true;
 }
 
 // ______________________________________________________________________
-bool TurtleParser::iri() {
+template <class T>
+bool TurtleParser<T>::iri() {
   // irirefs always start with "<", prefixedNames never, so the lookahead always
   // works
   return iriref() || prefixedName();
 }
 
 // _____________________________________________________________________
-bool TurtleParser::prefixedName() {
+template <class T>
+bool TurtleParser<T>::prefixedName() {
   if (pnameLN() || pnameNS()) {
     _lastParseResult =
         '<' + expandPrefix(_activePrefix) + _lastParseResult + '>';
@@ -313,12 +329,17 @@ bool TurtleParser::prefixedName() {
 }
 
 // _____________________________________________________________________
-bool TurtleParser::blankNode() { return blankNodeLabel() || anon(); }
+template <class T>
+bool TurtleParser<T>::blankNode() {
+  return blankNodeLabel() || anon();
+}
 
 // _______________________________________________________________________
-bool TurtleParser::parseTerminal(const RE2& terminal) {
+template <class T>
+template <TokId terminal>
+bool TurtleParser<T>::parseTerminal() {
   _tok.skipWhitespaceAndComments();
-  auto [success, word] = _tok.getNextToken(terminal);
+  auto [success, word] = _tok.template getNextToken<terminal>();
   if (success) {
     _lastParseResult = word;
     return true;
@@ -329,13 +350,15 @@ bool TurtleParser::parseTerminal(const RE2& terminal) {
 }
 
 // ________________________________________________________________________
-bool TurtleParser::blankNodeLabel() {
-  return parseTerminal(tokens().BlankNodeLabel);
+template <class T>
+bool TurtleParser<T>::blankNodeLabel() {
+  return parseTerminal<TokId::BlankNodeLabel>();
 }
 
 // __________________________________________________________________________
-bool TurtleParser::pnameNS() {
-  if (parseTerminal(tokens().PnameNS)) {
+template <class T>
+bool TurtleParser<T>::pnameNS() {
+  if (parseTerminal<TokId::PnameNS>()) {
     // this also includes a ":" which we do not need, hence the "-1"
     _activePrefix = _lastParseResult.substr(0, _lastParseResult.size() - 1);
     _lastParseResult = "";
@@ -346,7 +369,8 @@ bool TurtleParser::pnameNS() {
 }
 
 // ________________________________________________________________________
-bool TurtleParser::pnameLN() {
+template <class T>
+bool TurtleParser<T>::pnameLN() {
   // relaxed parsing, only works if the greedy parsing of the ":"
   // is ok
   _tok.skipWhitespaceAndComments();
@@ -367,12 +391,13 @@ bool TurtleParser::pnameLN() {
   _activePrefix = view.substr(0, pos);
   _lastParseResult = view.substr(pos + 1, posEnd - (pos + 1));
   // we do not remove the whitespace or the ,; since they are needed
-  _tok.data().remove_prefix(posEnd);
+  _tok.remove_prefix(posEnd);
   return true;
 }
 
 // _____________________________________________________________________
-bool TurtleParser::iriref() {
+template <class T>
+bool TurtleParser<T>::iriref() {
   // manually check if the input starts with "<" and then find the next ">"
   // this might accept invalid irirefs but is faster than checking the
   // complete regexes
@@ -383,7 +408,7 @@ bool TurtleParser::iriref() {
     if (endPos == string::npos || view[endPos] != '>') {
       throw ParseException("Iriref");
     } else {
-      _tok.data().remove_prefix(endPos + 1);
+      _tok.remove_prefix(endPos + 1);
       _lastParseResult = view.substr(0, endPos + 1);
       return true;
     }
@@ -393,18 +418,20 @@ bool TurtleParser::iriref() {
 }
 
 // ______________________________________________________________________
-TurtleStreamParser::TurtleParserBackupState TurtleStreamParser::backupState()
-    const {
+template <class T>
+typename TurtleStreamParser<T>::TurtleParserBackupState
+TurtleStreamParser<T>::backupState() const {
   TurtleParserBackupState b;
-  b._numBlankNodes = _numBlankNodes;
-  b._numTriples = _triples.size();
-  b._tokenizerPosition = _tok.data().begin();
-  b._tokenizerSize = _tok.data().size();
+  b._numBlankNodes = this->_numBlankNodes;
+  b._numTriples = this->_triples.size();
+  b._tokenizerPosition = this->_tok.data().begin();
+  b._tokenizerSize = this->_tok.data().size();
   return b;
 }
 
 // _______________________________________________________________
-bool TurtleStreamParser::resetStateAndRead(
+template <class T>
+bool TurtleStreamParser<T>::resetStateAndRead(
     const TurtleStreamParser::TurtleParserBackupState b) {
   auto nextBytesOpt = _fileBuffer->getNextBlock();
   if (!nextBytesOpt || nextBytesOpt.value().empty()) {
@@ -416,10 +443,10 @@ bool TurtleStreamParser::resetStateAndRead(
   auto nextBytes = std::move(nextBytesOpt.value());
 
   // return to the state of the last backup
-  _numBlankNodes = b._numBlankNodes;
-  AD_CHECK(_triples.size() >= b._numTriples);
-  _triples.resize(b._numTriples);
-  _tok.reset(b._tokenizerPosition, b._tokenizerSize);
+  this->_numBlankNodes = b._numBlankNodes;
+  AD_CHECK(this->_triples.size() >= b._numTriples);
+  this->_triples.resize(b._numTriples);
+  this->_tok.reset(b._tokenizerPosition, b._tokenizerSize);
 
   std::vector<char> buf;
   buf.resize(_tok.data().size() + nextBytes.size());
@@ -434,9 +461,10 @@ bool TurtleStreamParser::resetStateAndRead(
 }
 
 // __________________________________________________________________________
-void TurtleMmapParser::initialize(const string& filename) {
+template <class T>
+void TurtleMmapParser<T>::initialize(const string& filename) {
   unmapFile();
-  clear();
+  this->clear();
   ad_utility::File f(filename.c_str(), "r");
   size_t size = f.sizeOfFile();
   LOG(INFO) << "mapping " << size << " bytes" << std::endl;
@@ -450,18 +478,19 @@ void TurtleMmapParser::initialize(const string& filename) {
   _tok.reset(_data, _dataSize);
 }
 
-bool TurtleMmapParser::getLine(std::array<string, 3>* triple) {
+template <class T>
+bool TurtleMmapParser<T>::getLine(std::array<string, 3>* triple) {
   if (_triples.empty()) {
     // always try to parse a batch of triples at once to make up for the
     // relatively expensive backup calls.
     while (_triples.size() < PARSER_MIN_TRIPLES_AT_ONCE &&
            !_isParserExhausted) {
-      if (statement()) {
+      if (this->statement()) {
         // we cannot parse anymore from an mmaped file but there was no
         // error. check if we are just at the end of the input, otherwise
         // inform.
         _tok.skipWhitespaceAndComments();
-        auto& d = _tok.data();
+        auto d = _tok.view();
         if (!d.empty()) {
           LOG(INFO) << "Parsing of line has Failed, but parseInput is not "
                        "yet exhausted. Remaining bytes: "
@@ -486,8 +515,9 @@ bool TurtleMmapParser::getLine(std::array<string, 3>* triple) {
   return true;
 }
 
-void TurtleStreamParser::initialize(const string& filename) {
-  clear();
+template <class T>
+void TurtleStreamParser<T>::initialize(const string& filename) {
+  this->clear();
   _fileBuffer = std::make_unique<ParallelFileBuffer>(_bufferSize);
   _fileBuffer->open(filename);
   _byteVec.resize(_bufferSize);
@@ -501,7 +531,8 @@ void TurtleStreamParser::initialize(const string& filename) {
   }
 }
 
-bool TurtleStreamParser::getLine(std::array<string, 3>* triple) {
+template <class T>
+bool TurtleStreamParser<T>::getLine(std::array<string, 3>* triple) {
   if (_triples.empty()) {
     // if parsing the line fails because our buffer ends before the end of
     // the next statement we need to be able to recover
@@ -512,15 +543,15 @@ bool TurtleStreamParser::getLine(std::array<string, 3>* triple) {
            !_isParserExhausted) {
       bool parsedStatement;
       bool exceptionThrown = false;
-      ParseException ex;
+      typename TurtleParser<T>::ParseException ex;
       // If this buffer reads from an mmaped file, then exceptions are
       // immediately rethrown. If we are reading from a stream in chunks of
       // bytes, we can try again with a larger buffer.
       try {
         // variable parsedStatement will be true iff a statement can
         // successfully be parsed
-        parsedStatement = statement();
-      } catch (const ParseException& p) {
+        parsedStatement = this->statement();
+      } catch (const typename TurtleParser<T>::ParseException& p) {
         parsedStatement = false;
         exceptionThrown = true;
         ex = p;
@@ -533,7 +564,7 @@ bool TurtleStreamParser::getLine(std::array<string, 3>* triple) {
         if (resetStateAndRead(b)) {
           // we have succesfully extended our buffer
           if (_byteVec.size() > BZIP2_MAX_TOTAL_BUFFER_SIZE) {
-            auto& d = _tok.data();
+            auto d = _tok.view();
             LOG(ERROR) << "Could not parse " << PARSER_MIN_TRIPLES_AT_ONCE
                        << " Within " << (BZIP2_MAX_TOTAL_BUFFER_SIZE >> 10)
                        << "MB of Turtle input\n";
@@ -549,7 +580,7 @@ bool TurtleStreamParser::getLine(std::array<string, 3>* triple) {
               throw ex;
 
             } else {
-              throw ParseException(
+              throw typename TurtleParser<T>::ParseException(
                   "Too many bytes parsed without finishing a turtle "
                   "statement");
             }
@@ -567,7 +598,7 @@ bool TurtleStreamParser::getLine(std::array<string, 3>* triple) {
             // triples parsed so far, check if we have indeed parsed through
             // the complete input
             _tok.skipWhitespaceAndComments();
-            auto& d = _tok.data();
+            auto d = _tok.view();
             if (!d.empty()) {
               LOG(INFO) << "Parsing of line has Failed, but parseInput is not "
                            "yet exhausted. Remaining bytes: "
@@ -594,3 +625,10 @@ bool TurtleStreamParser::getLine(std::array<string, 3>* triple) {
   _triples.pop_back();
   return true;
 }
+
+template class TurtleParser<Tokenizer>;
+template class TurtleParser<TokenizerCtre>;
+template class TurtleStreamParser<Tokenizer>;
+template class TurtleStreamParser<TokenizerCtre>;
+template class TurtleMmapParser<Tokenizer>;
+template class TurtleMmapParser<TokenizerCtre>;

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -24,13 +24,16 @@
 using std::string;
 
 // The actual parser class
+template <class Tokenizer_T>
 class TurtleParser {
  public:
   class ParseException : public std::exception {
    public:
     ParseException() = default;
-    ParseException(const string& msg) : _msg(msg) {}
-    const char* what() const throw() { return _msg.c_str(); }
+    explicit ParseException(string msg) : _msg(std::move(msg)) {}
+    [[nodiscard]] const char* what() const noexcept override {
+      return _msg.c_str();
+    }
 
    private:
     string _msg = "Error while parsing Turtle";
@@ -94,7 +97,7 @@ class TurtleParser {
   bool _isParserExhausted = false;
 
   // The tokenizer
-  Tokenizer _tok{nullptr, 0};
+  Tokenizer_T _tok{std::string_view("")};
 
   // the result of the last succesful call to a parsing function
   // (a function named after a (non-)terminal of the Turtle grammar
@@ -111,7 +114,6 @@ class TurtleParser {
   std::string _activePrefix;
   std::string _activeSubject;
   std::string _activePredicate;
-  [[nodiscard]] const TurtleToken& tokens() const { return _tok._tokens; }
   size_t _numBlankNodes = 0;
 
  private:
@@ -145,37 +147,39 @@ class TurtleParser {
   // Terminal symbols from the grammar
   // Behavior of the functions is similar to the nonterminals (see above)
   bool iriref();
-  bool integer() { return parseTerminal(tokens().Integer); }
-  bool decimal() { return parseTerminal(tokens().Decimal); }
-  bool doubleParse() { return parseTerminal(tokens().Double); }
+  bool integer() { return parseTerminal<TokId::Integer>(); }
+  bool decimal() { return parseTerminal<TokId::Decimal>(); }
+  bool doubleParse() { return parseTerminal<TokId::Double>(); }
   bool pnameLN();
 
   // __________________________________________________________________________
   bool pnameNS();
 
   // __________________________________________________________________________
-  bool langtag() { return parseTerminal(tokens().Langtag); }
+  bool langtag() { return parseTerminal<TokId::Langtag>(); }
   bool blankNodeLabel();
 
   bool anon() {
-    if (!parseTerminal(tokens().Anon)) {
+    if (!parseTerminal<TokId::Anon>()) {
       return false;
     }
     _lastParseResult = createAnonNode();
     return true;
   }
 
-  // Skip a givene regex without parsing it
-  bool skip(const RE2& reg) {
+  // Skip a given regex without parsing it
+  template <TokId reg>
+  bool skip() {
     _tok.skipWhitespaceAndComments();
-    return _tok.skip(reg);
+    return _tok.template skip<reg>();
   }
 
   // if the prefix of the current input position matches the regex argument,
   // put the matching prefix into _lastParseResult, move the input position
   // forward by the length of the match and return true else return false and do
   // not change the parser's state
-  bool parseTerminal(const RE2& terminal);
+  template <TokId terminal>
+  bool parseTerminal();
 
   // ______________________________________________________________________________________
   void emitTriple() {
@@ -226,17 +230,18 @@ class TurtleParser {
  * Parses turtle from std::string. Used to perform unit tests for
  * the different parser rules
  */
-class TurtleStringParser : public TurtleParser {
+template <class Tokenizer_T>
+class TurtleStringParser : public TurtleParser<Tokenizer_T> {
  public:
-  using TurtleParser::getLine;
-  virtual bool getLine(std::array<string, 3>* triple) override {
+  using TurtleParser<Tokenizer_T>::getLine;
+  bool getLine(std::array<string, 3>* triple) override {
     (void)triple;
     throw std::runtime_error(
         "TurtleStringParser doesn't support calls to getLine. Only use "
         "parseUtf8String() for unit tests\n");
   }
 
-  virtual void initialize(const string& filename) override {
+  void initialize(const string& filename) override {
     (void)filename;
     throw std::runtime_error(
         "TurtleStringParser doesn't support calls to initialize. Only use "
@@ -247,9 +252,9 @@ class TurtleStringParser : public TurtleParser {
   // allows easier testing without a file object
   void parseUtf8String(const std::string& toParse) {
     _tmpToParse = toParse;
-    _tok.reset(_tmpToParse.data(), _tmpToParse.size());
+    this->_tok.reset(_tmpToParse.data(), _tmpToParse.size());
     // directly parse the whole triple
-    turtleDoc();
+    this->turtleDoc();
   }
 
  private:
@@ -263,16 +268,14 @@ class TurtleStringParser : public TurtleParser {
   // Does not alter the tokenizers state
   void setInputStream(const string& utf8String) {
     _tmpToParse = utf8String;
-    _tok.reset(_tmpToParse.data(), _tmpToParse.size());
+    this->_tok.reset(_tmpToParse.data(), _tmpToParse.size());
   }
 
   // testing interface, only works when parsing from an utf8-string
   // return the current position of the tokenizer in the input string
   // can be used to test if the advancing of the tokenizer works
   // as expected
-  size_t getPosition() const {
-    return _tok.data().begin() - _tmpToParse.data();
-  }
+  size_t getPosition() const { return this->_tok.begin() - _tmpToParse.data(); }
 
   FRIEND_TEST(TurtleParserTest, prefixedName);
   FRIEND_TEST(TurtleParserTest, prefixID);
@@ -290,7 +293,8 @@ class TurtleStringParser : public TurtleParser {
  * its input file is an uncompressed .ttl file that will be read in
  * chunks. Input file can also be a stream like stdin.
  */
-class TurtleStreamParser : public TurtleParser {
+template <class Tokenizer_T>
+class TurtleStreamParser : public TurtleParser<Tokenizer_T> {
   // struct that can store the state of a parser
   // the previously extracted triples are not stored
   // but only the number of triples that were already present
@@ -305,20 +309,24 @@ class TurtleStreamParser : public TurtleParser {
  public:
   // Default construction needed for tests
   TurtleStreamParser() = default;
-  TurtleStreamParser(const string& filename) {
+  explicit TurtleStreamParser(const string& filename) {
     LOG(INFO) << "Initialize turtle Parsing from uncompressed file or stream "
               << filename << '\n';
     initialize(filename);
   }
 
   // inherit the wrapper overload
-  using TurtleParser::getLine;
 
-  virtual bool getLine(std::array<string, 3>* triple) override;
+  using TurtleParser<Tokenizer_T>::getLine;
 
-  virtual void initialize(const string& filename) override;
+  bool getLine(std::array<string, 3>* triple) override;
+
+  void initialize(const string& filename) override;
 
  private:
+  using TurtleParser<Tokenizer_T>::_tok;
+  using TurtleParser<Tokenizer_T>::_triples;
+  using TurtleParser<Tokenizer_T>::_isParserExhausted;
   // Backup the current state of the turtle parser to a
   // TurtleparserBackupState object
   // This can be used e.g. when parsing from a compressed input
@@ -329,7 +337,7 @@ class TurtleStreamParser : public TurtleParser {
   // Reset the parser to the state indicated by the argument
   // Must be called on the same parser object that was used to create the backup
   // state (the actual triples are not backed up)
-  bool resetStateAndRead(const TurtleParserBackupState state);
+  bool resetStateAndRead(TurtleParserBackupState state);
 
   // stores the current batch of bytes we have to parse.
   // Might end in the middle of a statement or even a multibyte utf8 character,
@@ -348,9 +356,10 @@ class TurtleStreamParser : public TurtleParser {
  * It will be loaded at once using Mmap. Thus this class does not support
  * Parsing from streams like stdin
  */
-class TurtleMmapParser : public TurtleParser {
+template <class Tokenizer_T>
+class TurtleMmapParser : public TurtleParser<Tokenizer_T> {
  public:
-  TurtleMmapParser(const string& filename) {
+  explicit TurtleMmapParser(const string& filename) {
     LOG(INFO) << "Initialize turtle Parsing from uncompressed file " << filename
               << '\n';
     LOG(INFO) << "This file must reside in memory since it will be loaded "
@@ -363,12 +372,12 @@ class TurtleMmapParser : public TurtleParser {
   TurtleMmapParser& operator=(TurtleMmapParser&& rhs) = default;
 
   // inherit the other overload
-  using TurtleParser::getLine;
+  using TurtleParser<Tokenizer_T>::getLine;
   // overload of the actual mmap-based parsing logic
-  virtual bool getLine(std::array<string, 3>* triple) override;
+  bool getLine(std::array<string, 3>* triple) override;
 
   // initialize parse input from a turtle file using mmap
-  virtual void initialize(const string& filename) override;
+  void initialize(const string& filename) override;
 
   // has to be called after finishing parsing of an mmaped .ttl file
   // if no file is currently mapped this function has no effect
@@ -385,4 +394,7 @@ class TurtleMmapParser : public TurtleParser {
   // store the size of the mapped input when using the _data ptr
   // via mmap
   size_t _dataSize = 0;
+  using TurtleParser<Tokenizer_T>::_tok;
+  using TurtleParser<Tokenizer_T>::_isParserExhausted;
+  using TurtleParser<Tokenizer_T>::_triples;
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,10 @@ add_executable(SparqlLexerTest SparqlLexerTest.cpp)
 add_test(SparqlLexerTest SparqlLexerTest)
 target_link_libraries(SparqlLexerTest parser gtest_main ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(Utf8RegexTest Utf8RegexTest.cpp)
+add_test(Utf8RegexTest Utf8RegexTest)
+target_link_libraries(Utf8RegexTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+
 add_executable(BatchedPipelineTest BatchedPipelineTest.cpp)
 add_test(BatchedPipelineTest BatchedPipelineTest)
 target_link_libraries(BatchedPipelineTest gtest_main parser ${CMAKE_THREAD_LIBS_INIT})

--- a/test/StringSortComparatorTest.cpp
+++ b/test/StringSortComparatorTest.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include "../src/index/StringSortComparator.h"
 
+using namespace std::literals;
+
 TEST(LocaleManagerTest, Levels) {
   using L = LocaleManager::Level;
   LocaleManager loc;
@@ -43,11 +45,9 @@ TEST(LocaleManagerTest, Punctuation) {
 
 TEST(LocaleManagerTest, Normalization) {
   // é as single codepoints
-  const char a[] = {static_cast<char>(0xC3), static_cast<char>(0xA9), 0};
+  std::string as = "\xc3\xa9"s;
   // é as e + accent aigu
-  const char b[] = {'e', static_cast<char>(0xCC), static_cast<char>(0x81), 0};
-  std::string as(a);
-  std::string bs(b);
+  std::string bs = "e\xcc\x81"s;
   ASSERT_EQ(2u, as.size());
   ASSERT_EQ(3u, bs.size());
   LocaleManager loc;

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -47,8 +47,32 @@ TEST(TokenTest, Numbers) {
   ASSERT_TRUE(RE2::FullMatch(double5, t.Double));
   ASSERT_FALSE(RE2::FullMatch(decimal1, t.Double));
   ASSERT_FALSE(RE2::FullMatch(integer2, t.Double));
+
+  // same for ctre
+  using c = TurtleTokenCtre;
+  ASSERT_TRUE(ctre::match<c::Integer>(integer1));
+  ASSERT_TRUE(ctre::match<c::Integer>(integer2));
+  ASSERT_TRUE(ctre::match<c::Integer>(integer3));
+  ASSERT_FALSE(ctre::match<c::Integer>(noInteger));
+  ASSERT_FALSE(ctre::match<c::Integer>(decimal1));
+
+  ASSERT_TRUE(ctre::match<c::Decimal>(decimal1));
+  ASSERT_TRUE(ctre::match<c::Decimal>(decimal2));
+  ASSERT_TRUE(ctre::match<c::Decimal>(decimal3));
+  ASSERT_FALSE(ctre::match<c::Decimal>(noDecimal));
+  ASSERT_FALSE(ctre::match<c::Decimal>(integer3));
+  ASSERT_FALSE(ctre::match<c::Decimal>(double2));
+
+  ASSERT_TRUE(ctre::match<c::Double>(double1));
+  ASSERT_TRUE(ctre::match<c::Double>(double2));
+  ASSERT_TRUE(ctre::match<c::Double>(double3));
+  ASSERT_TRUE(ctre::match<c::Double>(double4));
+  ASSERT_TRUE(ctre::match<c::Double>(double5));
+  ASSERT_FALSE(ctre::match<c::Double>(decimal1));
+  ASSERT_FALSE(ctre::match<c::Double>(integer2));
 }
 
+static constexpr auto x = cls(TurtleTokenCtre::PnCharsBaseString);
 TEST(TokenizerTest, SingleChars) {
   TurtleToken t;
 
@@ -57,6 +81,17 @@ TEST(TokenizerTest, SingleChars) {
   ASSERT_TRUE(RE2::FullMatch(u8"\u00DD", t.cls(t.PnCharsBaseString)));
   ASSERT_TRUE(RE2::FullMatch(u8"\u00De", t.cls(t.PnCharsBaseString)));
   ASSERT_FALSE(RE2::FullMatch(u8"\u00D7", t.cls(t.PnCharsBaseString)));
+
+  // same for ctre
+  // TODO<joka921>: fix those regexes to the unicode stuff and test more
+  // extensively
+  ASSERT_TRUE(ctre::match<x>(u8"A"));
+  /*
+  ASSERT_TRUE(ctre::match<x>(u8"\u00dd"));
+  ASSERT_TRUE(ctre::match<x>(u8"\u00DD"));
+  ASSERT_TRUE(ctre::match<x>(u8"\u00De"));
+  ASSERT_FALSE(ctre::match<x>(u8"\u00D7"));
+   */
 }
 
 TEST(TokenizerTest, StringLiterals) {
@@ -67,11 +102,19 @@ TEST(TokenizerTest, StringLiterals) {
   string sQuote3 = u8"\"\\uAB23SomeotherChars\"";
   string NoSQuote1 = "\"illegalQuoteBecauseOfNewline\n\"";
   string NoSQuote2 = "\"illegalQuoteBecauseOfBackslash\\  \"";
+
   ASSERT_TRUE(RE2::FullMatch(sQuote1, t.StringLiteralQuote, nullptr));
   ASSERT_TRUE(RE2::FullMatch(sQuote2, t.StringLiteralQuote, nullptr));
   ASSERT_TRUE(RE2::FullMatch(sQuote3, t.StringLiteralQuote, nullptr));
   ASSERT_FALSE(RE2::FullMatch(NoSQuote1, t.StringLiteralQuote, nullptr));
   ASSERT_FALSE(RE2::FullMatch(NoSQuote2, t.StringLiteralQuote, nullptr));
+  // same for CTRE
+  using c = TurtleTokenCtre;
+  ASSERT_TRUE(ctre::match<c::StringLiteralQuoteString>(sQuote1));
+  ASSERT_TRUE(ctre::match<c::StringLiteralQuoteString>(sQuote2));
+  ASSERT_TRUE(ctre::match<c::StringLiteralQuoteString>(sQuote3));
+  ASSERT_FALSE(ctre::match<c::StringLiteralQuoteString>(NoSQuote1));
+  ASSERT_FALSE(ctre::match<c::StringLiteralQuoteString>(NoSQuote2));
 
   string sSingleQuote1 = "\'this is a quote \'";
   string sSingleQuote2 =
@@ -89,6 +132,12 @@ TEST(TokenizerTest, StringLiterals) {
   ASSERT_FALSE(RE2::FullMatch(NoSQuote1, t.StringLiteralSingleQuote, nullptr));
   ASSERT_FALSE(RE2::FullMatch(NoSQuote2, t.StringLiteralSingleQuote, nullptr));
 
+  ASSERT_TRUE(ctre::match<c::StringLiteralSingleQuoteString>(sSingleQuote1));
+  ASSERT_TRUE(ctre::match<c::StringLiteralSingleQuoteString>(sSingleQuote2));
+  ASSERT_TRUE(ctre::match<c::StringLiteralSingleQuoteString>(sSingleQuote3));
+  ASSERT_FALSE(ctre::match<c::StringLiteralSingleQuoteString>(NoSQuote1));
+  ASSERT_FALSE(ctre::match<c::StringLiteralSingleQuoteString>(NoSQuote2));
+
   string sMultiline1 = u8"\"\"\"test\n\"\"\"";
   string sMultiline2 =
       "\"\"\"MultilineString\' \'\'\'\n\\n\\u00FF\\U0001AB34\"  \"\" "
@@ -101,6 +150,11 @@ TEST(TokenizerTest, StringLiterals) {
       RE2::FullMatch(sNoMultiline1, t.StringLiteralLongQuote, nullptr));
   ASSERT_FALSE(
       RE2::FullMatch(sNoMultiline2, t.StringLiteralLongQuote, nullptr));
+
+  ASSERT_TRUE(ctre::match<c::StringLiteralLongQuoteString>(sMultiline1));
+  ASSERT_TRUE(ctre::match<c::StringLiteralLongQuoteString>(sMultiline2));
+  ASSERT_FALSE(ctre::match<c::StringLiteralLongQuoteString>(sNoMultiline1));
+  ASSERT_FALSE(ctre::match<c::StringLiteralLongQuoteString>(sNoMultiline2));
 
   string sSingleMultiline1 = u8"\'\'\'test\n\'\'\'";
   string sSingleMultiline2 =
@@ -116,8 +170,18 @@ TEST(TokenizerTest, StringLiterals) {
                               t.StringLiteralLongSingleQuote, nullptr));
   ASSERT_FALSE(RE2::FullMatch(sSingleNoMultiline2,
                               t.StringLiteralLongSingleQuote, nullptr));
+
+  ASSERT_TRUE(
+      ctre::match<c::StringLiteralLongSingleQuoteString>(sSingleMultiline1));
+  ASSERT_TRUE(
+      ctre::match<c::StringLiteralLongSingleQuoteString>(sSingleMultiline2));
+  ASSERT_FALSE(
+      ctre::match<c::StringLiteralLongSingleQuoteString>(sSingleNoMultiline1));
+  ASSERT_FALSE(
+      ctre::match<c::StringLiteralLongSingleQuoteString>(sSingleNoMultiline2));
 }
 
+static constexpr auto pnCharsUGrp = cls(TurtleTokenCtre::PnCharsUString);
 TEST(TokenizerTest, Entities) {
   TurtleToken t;
   string iriref1 = "<>";
@@ -132,6 +196,14 @@ TEST(TokenizerTest, Entities) {
   ASSERT_TRUE(RE2::FullMatch(iriref4, t.Iriref, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noIriref1, t.Iriref, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noIriref2, t.Iriref, nullptr));
+
+  using c = TurtleTokenCtre;
+  ASSERT_TRUE(ctre::match<c::Iriref>(iriref1));
+  ASSERT_TRUE(ctre::match<c::Iriref>(iriref2));
+  ASSERT_TRUE(ctre::match<c::Iriref>(iriref3));
+  ASSERT_TRUE(ctre::match<c::Iriref>(iriref4));
+  ASSERT_FALSE(ctre::match<c::Iriref>(noIriref1));
+  ASSERT_FALSE(ctre::match<c::Iriref>(noIriref2));
 
   string prefix1 = "wd:";
   string prefix2 = "wdDDäéa_afa:";
@@ -148,6 +220,17 @@ TEST(TokenizerTest, Entities) {
   ASSERT_FALSE(RE2::FullMatch(noPrefix1, t.PnameNS, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noPrefix2, t.PnameNS, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noPrefix3, t.PnameNS, nullptr));
+
+  // TODO<joka921>: fix those unicode regexes and test them extensively
+  /*
+  ASSERT_TRUE(ctre::match<c::PnameNS>(prefix1));
+  ASSERT_TRUE(ctre::match<c::PnameNS>(prefix2));
+  ASSERT_TRUE(ctre::match<c::PnameNS>(prefix3));
+  ASSERT_TRUE(ctre::match<c::PnameNS>(prefix4));
+  ASSERT_FALSE(ctre::match<c::PnameNS>(noPrefix1));
+  ASSERT_FALSE(ctre::match<c::PnameNS>(noPrefix2));
+  ASSERT_FALSE(ctre::match<c::PnameNS>(noPrefix3));
+   */
 
   string prefName1 = "wd:Q34";
   string prefName2 = "wdDDäé_afa::93.x";
@@ -176,6 +259,25 @@ TEST(TokenizerTest, Entities) {
   ASSERT_FALSE(RE2::FullMatch(noPrefName2, t.PnameLN, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noPrefName3, t.PnameLN, nullptr));
 
+  // CTRE
+  ASSERT_FALSE(ctre::match<pnCharsUGrp>("\xBF"));
+  ASSERT_FALSE(ctre::match<c::PnLocalString>("\xBF"));
+
+  // TODO<joka921>: those are also broken
+  /*
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName1));
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName2));
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName3));
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName4));
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName5));
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName6));
+  ASSERT_TRUE(ctre::match<c::PnameLN>(prefName7));
+
+  ASSERT_FALSE(ctre::match<c::PnameLN>(noPrefName1));
+  ASSERT_FALSE(ctre::match<c::PnameLN>(noPrefName2));
+  ASSERT_FALSE(ctre::match<c::PnameLN>(noPrefName3));
+   */
+
   string blank1 = "_:easy";
   string blank2 = "_:_easy";
   string blank3 = "_:d-35\u00B7";
@@ -199,6 +301,22 @@ TEST(TokenizerTest, Entities) {
   ASSERT_FALSE(RE2::FullMatch(noBlank2, t.BlankNodeLabel, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noBlank3, t.BlankNodeLabel, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noBlank4, t.BlankNodeLabel, nullptr));
+
+  // CTRE
+  // TODO<joka921> also broken because of the unicode business
+  /*
+  ASSERT_TRUE(ctre::match<c::BlankNodeLabel>(blank1));
+  ASSERT_TRUE(ctre::match<c::BlankNodeLabel>(blank2));
+  ASSERT_TRUE(ctre::match<c::BlankNodeLabel>(blank3));
+  ASSERT_TRUE(ctre::match<c::BlankNodeLabel>(blank4));
+  ASSERT_TRUE(ctre::match<c::BlankNodeLabel>(blank5));
+  ASSERT_TRUE(ctre::match<c::BlankNodeLabel>(blank6));
+
+  ASSERT_FALSE(ctre::match<c::BlankNodeLabel>(noBlank1));
+  ASSERT_FALSE(ctre::match<c::BlankNodeLabel>(noBlank2));
+  ASSERT_FALSE(ctre::match<c::BlankNodeLabel>(noBlank3));
+  ASSERT_FALSE(ctre::match<c::BlankNodeLabel>(noBlank4));
+   */
 }
 
 TEST(TokenizerTest, Consume) {
@@ -211,21 +329,40 @@ TEST(TokenizerTest, Consume) {
 
 TEST(TokenizerTest, WhitespaceAndComments) {
   TurtleToken t;
+  using c = TurtleTokenCtre;
   ASSERT_TRUE(RE2::FullMatch(u8"  \t  \n", t.WsMultiple));
   ASSERT_TRUE(RE2::FullMatch(u8"# theseareComme$#n  \tts\n", t.Comment));
   ASSERT_TRUE(RE2::FullMatch(u8"#", u8"\\#"));
   ASSERT_TRUE(RE2::FullMatch(u8"\n", u8"\\n"));
-  std::string s2(u8"#only Comment\n");
-  Tokenizer tok(s2.data(), s2.size());
-  tok.skipComments();
-  ASSERT_EQ(tok.data().begin() - s2.data(), 14);
-  std::string s(u8"    #comment of some way\n  start");
-  tok.reset(s.data(), s.size());
-  auto [success2, ws] = tok.getNextToken(tok._tokens.Comment);
-  (void)ws;
-  ASSERT_FALSE(success2);
-  tok.skipWhitespaceAndComments();
-  ASSERT_EQ(tok.data().begin() - s.data(), 27);
+  ASSERT_TRUE(ctre::match<c::WsMultiple>(u8"  \t  \n"));
+  ASSERT_TRUE(ctre::match<c::Comment>(u8"# theseareComme$#n  \tts\n"));
+  {
+    std::string s2(u8"#only Comment\n");
+    Tokenizer tok(s2);
+    tok.skipComments();
+    ASSERT_EQ(tok.data().begin() - s2.data(), 14);
+    std::string s(u8"    #comment of some way\n  start");
+    tok.reset(s.data(), s.size());
+    auto [success2, ws] = tok.getNextToken(tok._tokens.Comment);
+    (void)ws;
+    ASSERT_FALSE(success2);
+    tok.skipWhitespaceAndComments();
+    ASSERT_EQ(tok.data().begin() - s.data(), 27);
+  }
+
+  {
+    std::string s2(u8"#only Comment\n");
+    TokenizerCtre tok(s2);
+    tok.skipComments();
+    ASSERT_EQ(tok.data().begin() - s2.data(), 14);
+    std::string s(u8"    #comment of some way\n  start");
+    tok.reset(s.data(), s.size());
+    auto [success2, ws] = tok.getNextToken<TokId::Comment>();
+    (void)ws;
+    ASSERT_FALSE(success2);
+    tok.skipWhitespaceAndComments();
+    ASSERT_EQ(tok.data().begin() - s.data(), 27);
+  }
 }
 
 TEST(TokenizerTest, normalizeRDFLiteral) {

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -9,7 +9,7 @@
 
 using std::string;
 TEST(TurtleParserTest, prefixedName) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   p._prefixMap["wd"] = "www.wikidata.org/";
   p.setInputStream("wd:Q430 someotherContent");
   ASSERT_TRUE(p.prefixedName());
@@ -34,11 +34,11 @@ TEST(TurtleParserTest, prefixedName) {
   ASSERT_EQ(p.getPosition(), 0u);
 
   p.setInputStream("unregistered:bla");
-  ASSERT_THROW(p.prefixedName(), TurtleParser::ParseException);
+  ASSERT_THROW(p.prefixedName(), TurtleParser<Tokenizer>::ParseException);
 }
 
 TEST(TurtleParserTest, prefixID) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   string s = "@prefix bla:<www.bla.org/> .";
   p.setInputStream(s);
   ASSERT_TRUE(p.prefixID());
@@ -55,7 +55,7 @@ TEST(TurtleParserTest, prefixID) {
   // invalid LL1
   s = "@prefix bla<www.bla.org/>.";
   p.setInputStream(s);
-  ASSERT_THROW(p.prefixID(), TurtleParser::ParseException);
+  ASSERT_THROW(p.prefixID(), TurtleParser<Tokenizer>::ParseException);
 
   s = "@prefxxix bla<www.bla.org/>.";
   p.setInputStream(s);
@@ -66,7 +66,7 @@ TEST(TurtleParserTest, prefixID) {
 }
 
 TEST(TurtleParserTest, stringParse) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   string s1("\"double quote\"");
   string s2("\'single quote\'");
   string s3("\"\"\"multiline \n double quote\"\"\"");
@@ -103,7 +103,7 @@ TEST(TurtleParserTest, rdfLiteral) {
   literals.push_back("\"langtag\"@en-gb");
   literals.push_back("\"valueLong\"^^<www.xsd.org/integer>");
 
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   for (const auto& s : literals) {
     p.setInputStream(s);
     ASSERT_TRUE(p.rdfLiteral());
@@ -120,7 +120,7 @@ TEST(TurtleParserTest, rdfLiteral) {
 }
 
 TEST(TurtleParserTest, blankNode) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   p.setInputStream(" _:blank1");
   ASSERT_TRUE(p.blankNode());
   ASSERT_EQ(p._lastParseResult, "_:blank1");
@@ -146,7 +146,7 @@ TEST(TurtleParserTest, blankNode) {
 }
 
 TEST(TurtleParserTest, blankNodePropertyList) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   p._activeSubject = "<s>";
   p._activePredicate = "<p1>";
 
@@ -162,11 +162,12 @@ TEST(TurtleParserTest, blankNodePropertyList) {
 
   blankNodeL = "[<2> <ob2>; \"invalidPred\" <ob3>]";
   p.setInputStream(blankNodeL);
-  ASSERT_THROW(p.blankNodePropertyList(), TurtleParser::ParseException);
+  ASSERT_THROW(p.blankNodePropertyList(),
+               TurtleParser<Tokenizer>::ParseException);
 }
 
 TEST(TurtleParserTest, object) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   string sub = "<sub>";
   string pred = "<pred>";
   using triple = std::array<string, 3>;
@@ -197,7 +198,7 @@ TEST(TurtleParserTest, object) {
 }
 
 TEST(TurtleParserTest, objectList) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   p._activeSubject = "<s>";
   p._activePredicate = "<p>";
   string objectL = " <ob1>, <ob2>, <ob3>";
@@ -214,11 +215,11 @@ TEST(TurtleParserTest, objectList) {
   ASSERT_FALSE(p.objectList());
 
   p.setInputStream("<obj1>, @illFormed");
-  ASSERT_THROW(p.objectList(), TurtleParser::ParseException);
+  ASSERT_THROW(p.objectList(), TurtleParser<Tokenizer>::ParseException);
 }
 
 TEST(TurtleParserTest, predicateObjectList) {
-  TurtleStringParser p;
+  TurtleStringParser<Tokenizer> p;
   p._activeSubject = "<s>";
   string predL = "\n <p1> <ob1>;<p2> \"ob2\",\n <ob3>";
   std::vector<std::array<string, 3>> exp;

--- a/test/Utf8RegexTest.cpp
+++ b/test/Utf8RegexTest.cpp
@@ -1,0 +1,158 @@
+// Copyright 2020, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach(johannes.kalmbach@gmail.com)
+
+// Regexes in CTRE that match Turtle Prefix declarations
+// CTRE currently doesn't support UTF-8 properly so these have to be converted
+// to Explicit ascii bytes pattern.
+// These are currently not used in production because of compile times being to
+// long but might be useful in the future
+
+#include <ctre/ctre.h>
+#include <gtest/gtest.h>
+#include <codecvt>
+#include <locale>
+#include <string>
+#include "../src/parser/Tokenizer.h"
+
+using namespace std::literals::string_literals;
+
+std::string codePointToUtf8(char32_t codepoint) {
+  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> convert;
+  auto res = convert.to_bytes(&codepoint, (&codepoint) + 1);
+  return res;
+}
+
+TEST(UTF8Test, Foo) { ASSERT_EQ(u8"Ä", codePointToUtf8(0xc4)); }
+
+constexpr ctre::fixed_string r1(R"(\xc3([\x80-\x96]|[\x98-\xb6]|[\xB8-\xBF]))");
+constexpr ctre::fixed_string r2(R"([\xc4-\xcb][\x80-\xBF])");
+constexpr ctre::fixed_string r3(
+    R"((\xcd[\xb0-\xbd\xbf])|([\xce-\xdf][\x80-\xbf]))");
+constexpr ctre::fixed_string r4(R"(([\xe0\xe1][\x80-\xbf][\x80-\xbf]))");
+constexpr ctre::fixed_string r5(
+    R"((\xe2((\x80[\x8c-\x8d])|(\x81[\xb0-\xbf])|([\x82-\x85][\x80-\xbf])|(\x86[\x80-\x8f])|([\xb0-\xbe][\x80-\xbf])|(\xbf[\x80-\xaf]))))");
+constexpr ctre::fixed_string r6(
+    R"(\xe3((\x80[\x81-\xbf])|([\x81-\xbf][\x80-\xbf])))");
+constexpr ctre::fixed_string r7(R"([\xe4-\xec][\x80-\xbf][\x80-\xbf])");
+constexpr ctre::fixed_string r8(R"(\xed[\x80-\x9f][\x80-\xbf])");
+constexpr ctre::fixed_string r9(
+    R"(\xef([\xa4-\xb6\xb8-\xbe][\x80-\xbf]|\xb7[\x80-\x8f\xb0-\xbf]|\xbf[\x80-\xbd]))");
+constexpr ctre::fixed_string r10(
+    R"([\xf0-\xf2]...)");  // a little relaxed, invalid utf-8 also recognized
+constexpr ctre::fixed_string r11(
+    R"(\xf3[\x80-\xaf][\x80-\xbf][\x80-\xbf])");  // a little relaxed, invalid
+                                                  // utf-8 also recognized
+constexpr auto r = grp(r1) + "|" + grp(r2) + "|" + grp(r3) + "|" + grp(r4) +
+                   "|" + grp(r5) + "|" + grp(r6) + "|" + grp(r7) + "|" +
+                   grp(r8) + "|" + grp(r9) + "|" + grp(r10) + "|" + grp(r11);
+TEST(UTF8Test, FirstReges) {
+  for (char32_t i = 0x0; i < 0xc0; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+  for (char32_t i = 0xc0; i <= 0xD6; ++i) {
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+  ASSERT_FALSE(ctre::match<r>(codePointToUtf8(0xd7)));
+  for (char32_t i = 0xd8; i <= 0xf6; ++i) {
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+  ASSERT_FALSE(ctre::match<r>(codePointToUtf8(0xf7)));
+  for (char32_t i = 0xf8; i <= 0x2ff; ++i) {
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+  for (char32_t i = 0x300; i < 0x370; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+  for (char32_t i = 0x370; i <= 0x37d; ++i) {
+    ASSERT_TRUE(ctre::match<r3>(codePointToUtf8(i)));
+  }
+
+  ASSERT_FALSE(ctre::match<r>(codePointToUtf8(0x37e)));
+
+  for (char32_t i = 0x37f; i <= 0x1fff; ++i) {
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x2000; i <= 0x200b; ++i) {
+    // std::cout << std::hex << i << std::endl;
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x37f; i <= 0x1fff; ++i) {
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x2000; i <= 0x200b; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x200C; i <= 0x200d; ++i) {
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x200e; i < 0x2070; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x2070; i <= 0x218f; ++i) {
+    // std::cout << std::hex << i << std::endl;
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x2190; i < 0x2c00; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x2c00; i <= 0x2fef; ++i) {
+    // std::cout << std::hex << i << std::endl;
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x2ff0; i < 0x3001; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x3001; i <= 0xd7ff; ++i) {
+    // std::cout << std::hex << i << std::endl;
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0xd7ff + 1; i < 0xF900; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0xF900; i <= 0xFDCF; ++i) {
+    // std::cout << std::hex << i << std::endl;
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0xFDCF + 1; i < 0xFDF0; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0xFDF0; i <= 0xfffd; ++i) {
+    // std::cout << std::hex << i << std::endl;
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0xFFFD + 1; i < 0x10000; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0x10000; i <= 0xEFFFF; ++i) {
+    if (!(ctre::match<r>(codePointToUtf8(i)))) {
+      std::cout << std::hex << i << std::endl;
+      auto x = codePointToUtf8(i);
+      for (auto& c : x) {
+        std::cout << std::hex << static_cast<u_char>(c);
+      }
+      std::cout << std::endl;
+    }
+    ASSERT_TRUE(ctre::match<r>(codePointToUtf8(i)));
+  }
+
+  for (char32_t i = 0xEFFFF + 1; i <= 0x10FFFF; ++i) {
+    ASSERT_FALSE(ctre::match<r>(codePointToUtf8(i)));
+  }
+}

--- a/third_party/ctre/include/ctre/ctre.h
+++ b/third_party/ctre/include/ctre/ctre.h
@@ -1,0 +1,4014 @@
+/*
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+*/
+
+#ifndef CTRE_V2__CTRE__HPP
+#define CTRE_V2__CTRE__HPP
+
+#ifndef CTRE_V2__CTRE__LITERALS__HPP
+#define CTRE_V2__CTRE__LITERALS__HPP
+
+#ifndef CTRE_V2__CTLL__HPP
+#define CTRE_V2__CTLL__HPP
+
+#ifndef CTLL__PARSER__HPP
+#define CTLL__PARSER__HPP
+
+#ifndef CTLL__FIXED_STRING__GPP
+#define CTLL__FIXED_STRING__GPP
+
+#include <utility>
+#include <cstddef>
+#include <string_view>
+#include <cstdint>
+
+namespace ctll {
+
+struct length_value_t {
+  uint32_t value;
+  uint8_t length;
+};
+
+constexpr length_value_t length_and_value_of_utf8_code_point(uint8_t first_unit) noexcept {
+  if ((first_unit & 0b1000'0000) == 0b0000'0000) return {static_cast<uint32_t>(first_unit), 1};
+  else if ((first_unit & 0b1110'0000) == 0b1100'0000) return {static_cast<uint32_t>(first_unit & 0b0001'1111), 2};
+  else if ((first_unit & 0b1111'0000) == 0b1110'0000) return {static_cast<uint32_t>(first_unit & 0b0000'1111), 3};
+  else if ((first_unit & 0b1111'1000) == 0b1111'0000) return {static_cast<uint32_t>(first_unit & 0b0000'0111), 4};
+  else if ((first_unit & 0b1111'1100) == 0b1111'1000) return {static_cast<uint32_t>(first_unit & 0b0000'0011), 5};
+  else if ((first_unit & 0b1111'1100) == 0b1111'1100) return {static_cast<uint32_t>(first_unit & 0b0000'0001), 6};
+  else return {0, 0};
+}
+
+constexpr char32_t value_of_trailing_utf8_code_point(uint8_t unit, bool & correct) noexcept {
+  if ((unit & 0b1100'0000) == 0b1000'0000) return unit & 0b0011'1111;
+  else {
+    correct = false;
+    return 0;
+  }
+}
+
+constexpr length_value_t length_and_value_of_utf16_code_point(uint16_t first_unit) noexcept {
+  if ((first_unit & 0b1111110000000000) == 0b1101'1000'0000'0000) return {static_cast<uint32_t>(first_unit & 0b0000001111111111), 2};
+  else return {first_unit, 1};
+}
+
+template <size_t N> struct fixed_string {
+  char32_t content[N] = {};
+  size_t real_size{0};
+  bool correct_flag{true};
+
+  template <typename T> constexpr fixed_string(const T (&input)[N]) noexcept {
+    if constexpr (std::is_same_v<T, char>) {
+#if CTRE_STRING_IS_UTF8
+      size_t out{0};
+				for (size_t i{0}; i < N; ++i) {
+					if ((i == (N-1)) && (input[i] == 0)) break;
+					length_value_t info = length_and_value_of_utf8_code_point(input[i]);
+					switch (info.length) {
+						case 6:
+							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+							[[fallthrough]];
+						case 5:
+							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+							[[fallthrough]];
+						case 4:
+							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+							[[fallthrough]];
+						case 3:
+							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+							[[fallthrough]];
+						case 2:
+							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+							[[fallthrough]];
+						case 1:
+							content[out++] = static_cast<char32_t>(info.value);
+							real_size++;
+							break;
+						default:
+							correct_flag = false;
+							return;
+					}
+				}
+#else
+      for (size_t i{0}; i < N; ++i) {
+        content[i] = static_cast<uint8_t>(input[i]);
+        if ((i == (N-1)) && (input[i] == 0)) break;
+        real_size++;
+      }
+#endif
+#if __cpp_char8_t
+      } else if constexpr (std::is_same_v<T, char8_t>) {
+			size_t out{0};
+			for (size_t i{0}; i < N; ++i) {
+				if ((i == (N-1)) && (input[i] == 0)) break;
+				length_value_t info = length_and_value_of_utf8_code_point(input[i]);
+				switch (info.length) {
+					case 6:
+						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+						[[fallthrough]];
+					case 5:
+						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+						[[fallthrough]];
+					case 4:
+						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+						[[fallthrough]];
+					case 3:
+						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+						[[fallthrough]];
+					case 2:
+						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+						[[fallthrough]];
+					case 1:
+						content[out++] = static_cast<char32_t>(info.value);
+						real_size++;
+						break;
+					default:
+						correct_flag = false;
+						return;
+				}
+			}
+#endif
+    } else if constexpr (std::is_same_v<T, char16_t>) {
+      size_t out{0};
+      for (size_t i{0}; i < N; ++i) {
+        length_value_t info = length_and_value_of_utf16_code_point(input[i]);
+        if (info.length == 2) {
+          if (++i < N) {
+            if ((input[i] & 0b1111'1100'0000'0000) == 0b1101'1100'0000'0000) {
+              content[out++] = (info.value << 10) | (input[i] & 0b0000'0011'1111'1111);
+            } else {
+              correct_flag = false;
+              break;
+            }
+          }
+        } else {
+          if ((i == (N-1)) && (input[i] == 0)) break;
+          content[out++] = info.value;
+        }
+      }
+      real_size = out;
+    } else if constexpr (std::is_same_v<T, wchar_t> || std::is_same_v<T, char32_t>) {
+      for (size_t i{0}; i < N; ++i) {
+        content[i] = input[i];
+        if ((i == (N-1)) && (input[i] == 0)) break;
+        real_size++;
+      }
+    }
+  }
+  constexpr fixed_string(const fixed_string & other) noexcept {
+    for (size_t i{0}; i < N; ++i) {
+      content[i] = other.content[i];
+    }
+    real_size = other.real_size;
+    correct_flag = other.correct_flag;
+  }
+  constexpr bool correct() const noexcept {
+    return correct_flag;
+  }
+  constexpr size_t size() const noexcept {
+    return real_size;
+  }
+  constexpr const char32_t * begin() const noexcept {
+    return content;
+  }
+  constexpr const char32_t * end() const noexcept {
+    return content + size();
+  }
+  constexpr char32_t operator[](size_t i) const noexcept {
+    return content[i];
+  }
+  template <size_t M> constexpr bool is_same_as(const fixed_string<M> & rhs) const noexcept {
+    if (real_size != rhs.size()) return false;
+    for (size_t i{0}; i != real_size; ++i) {
+      if (content[i] != rhs[i]) return false;
+    }
+    return true;
+  }
+};
+
+template <> class fixed_string<0> {
+  static constexpr char32_t __empty[1] = {0};
+public:
+  template <typename T> constexpr fixed_string(const T *) noexcept {
+
+  }
+  constexpr fixed_string(std::initializer_list<char32_t>) noexcept {
+
+  }
+  constexpr fixed_string(const fixed_string &) noexcept {
+
+  }
+  constexpr bool correct() const noexcept {
+    return true;
+  }
+  constexpr size_t size() const noexcept {
+    return 0;
+  }
+  constexpr const char32_t * begin() const noexcept {
+    return __empty;
+  }
+  constexpr const char32_t * end() const noexcept {
+    return __empty + size();
+  }
+  constexpr char32_t operator[](size_t) const noexcept {
+    return 0;
+  }
+};
+
+template <typename CharT, size_t N> fixed_string(const CharT (&)[N]) -> fixed_string<N>;
+template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
+
+template <typename T, size_t N> class basic_fixed_string: public fixed_string<N> {
+  using parent = fixed_string<N>;
+public:
+  template <typename... Args> constexpr basic_fixed_string(Args && ... args) noexcept: parent(std::forward<Args>(args)...) { }
+};
+
+template <typename CharT, size_t N> basic_fixed_string(const CharT (&)[N]) -> basic_fixed_string<CharT, N>;
+template <typename CharT, size_t N> basic_fixed_string(basic_fixed_string<CharT, N>) -> basic_fixed_string<CharT, N>;
+
+}
+
+#endif
+
+#ifndef CTLL__TYPE_STACK__HPP
+#define CTLL__TYPE_STACK__HPP
+
+#ifndef CTLL__UTILITIES__HPP
+#define CTLL__UTILITIES__HPP
+
+#include <type_traits>
+
+#ifdef _MSC_VER
+#define CTLL_FORCE_INLINE __forceinline
+#else
+#define CTLL_FORCE_INLINE __attribute__((always_inline))
+#endif
+
+namespace ctll {
+
+template <bool> struct conditional_helper;
+
+template <> struct conditional_helper<true> {
+  template <typename A, typename> using type = A;
+};
+
+template <> struct conditional_helper<false> {
+  template <typename, typename B> using type = B;
+};
+
+template <bool V, typename A, typename B> using conditional = typename conditional_helper<V>::template type<A,B>;
+
+}
+
+#endif
+
+namespace ctll {
+
+template <typename... Ts> struct list { };
+
+struct _nothing { };
+
+using empty_list = list<>;
+
+// calculate size of list content
+template <typename... Ts> constexpr auto size(list<Ts...>) noexcept { return sizeof...(Ts); }
+
+
+// check if the list is empty
+template <typename... Ts> constexpr bool empty(list<Ts...>) noexcept { return false; }
+constexpr bool empty(empty_list) { return true; }
+
+// concat two lists together left to right
+template <typename... As, typename... Bs> constexpr auto concat(list<As...>, list<Bs...>) noexcept -> list<As..., Bs...> { return {}; }
+
+// push something to the front of a list
+template <typename T, typename... As> constexpr auto push_front(T, list<As...>) noexcept -> list<T, As...> { return {}; }
+
+// pop element from the front of a list
+template <typename T, typename... As> constexpr auto pop_front(list<T, As...>) noexcept -> list<As...> { return {}; }
+constexpr auto pop_front(empty_list) -> empty_list;
+
+// pop element from the front of a list and return new typelist too
+template <typename Front, typename List> struct list_pop_pair {
+  Front front{};
+  List list{};
+  constexpr list_pop_pair() = default;
+};
+
+template <typename Head, typename... As, typename T = _nothing> constexpr auto pop_and_get_front(list<Head, As...>, T = T()) noexcept -> list_pop_pair<Head, list<As...>> { return {}; }
+template <typename T = _nothing> constexpr auto pop_and_get_front(empty_list, T = T()) noexcept -> list_pop_pair<T, empty_list> { return {}; }
+
+// return front of the list
+template <typename Head, typename... As, typename T = _nothing> constexpr auto front(list<Head, As...>, T = T()) noexcept -> Head { return {}; }
+template <typename T = _nothing> constexpr auto front(empty_list, T = T()) noexcept -> T { return {}; }
+
+}
+
+#endif
+
+#ifndef CTLL__GRAMMARS__HPP
+#define CTLL__GRAMMARS__HPP
+
+namespace ctll {
+
+// terminal type representing symbol / character of any type
+template <auto v> struct term {
+  static constexpr auto value = v;
+};
+
+// epsilon = nothing on input tape
+// also used as an command for parsing means "do nothing"
+struct epsilon {
+  static constexpr auto value = '-';
+};
+
+// empty_stack_symbol = nothing on stack
+struct empty_stack_symbol {};
+
+// push<T...> is alias to list<T...>
+template <typename... Ts> using push = list<Ts...>;
+
+// accept/reject type for controlling output of LL1 machine
+struct accept { constexpr explicit operator bool() noexcept { return true; } };
+struct reject { constexpr explicit operator bool() noexcept { return false; } };
+
+// action type, every action item in grammar must inherit from
+struct action {
+  struct action_tag { };
+};
+
+// move one character forward and pop it from stack command
+struct pop_input {
+  struct pop_input_tag { };
+};
+
+// additional overloads for type list
+template <typename... Ts> constexpr auto push_front(pop_input, list<Ts...>) -> list<Ts...> { return {}; }
+
+template <typename... Ts> constexpr auto push_front(epsilon, list<Ts...>) -> list<Ts...> { return {}; }
+
+template <typename... As, typename... Bs> constexpr auto push_front(list<As...>, list<Bs...>) -> list<As..., Bs...> { return {}; }
+
+template <typename T, typename... As> constexpr auto pop_front_and_push_front(T item, list<As...> l) {
+  return push_front(item, pop_front(l));
+}
+
+// SPECIAL matching types for nicer grammars
+
+// match any term
+struct anything {
+  constexpr inline anything() noexcept { }
+  template <auto V> constexpr anything(term<V>) noexcept;
+};
+
+// match range of term A-B
+template <auto A, decltype(A) B> struct range {
+  constexpr inline range() noexcept { }
+  //template <auto V> constexpr range(term<V>) noexcept requires (A <= V) && (V <= B);
+  template <auto V, typename = std::enable_if_t<(A <= V) && (V <= B)>> constexpr inline range(term<V>) noexcept;
+};
+
+#ifdef __EDG__
+template <auto V, auto... Set> struct contains {
+	static constexpr bool value = ((Set == V) || ... || false);
+};
+#endif
+
+// match terms defined in set
+template <auto... Def> struct set {
+  constexpr inline set() noexcept { }
+#ifdef __EDG__
+  template <auto V, typename = std::enable_if_t<contains<V, Def...>::value>> constexpr inline set(term<V>) noexcept;
+#else
+  template <auto V, typename = std::enable_if_t<((Def == V) || ... || false)>> constexpr inline set(term<V>) noexcept;
+#endif
+};
+
+// match terms not defined in set
+template <auto... Def> struct neg_set {
+  constexpr inline neg_set() noexcept { }
+
+#ifdef __EDG__
+  template <auto V, typename = std::enable_if_t<!contains<V, Def...>::value>> constexpr inline neg_set(term<V>) noexcept;
+#else
+  template <auto V, typename = std::enable_if_t<!((Def == V) || ... || false)>> constexpr inline neg_set(term<V>) noexcept;
+#endif
+};
+
+// AUGMENTED grammar which completes user-defined grammar for all other cases
+template <typename Grammar> struct augment_grammar: public Grammar {
+  // start nonterminal is defined in parent type
+  using typename Grammar::_start;
+
+  // grammar rules are inherited from Grammar parent type
+  using Grammar::rule;
+
+  // term on stack and on input means pop_input;
+  template <auto A> static constexpr auto rule(term<A>, term<A>) -> ctll::pop_input;
+
+  // if the type on stack (range, set, neg_set, anything) is constructible from the terminal => pop_input
+  template <typename Expected, auto V> static constexpr auto rule(Expected, term<V>) -> std::enable_if_t<std::is_constructible_v<Expected, term<V>>, ctll::pop_input>;
+
+  // empty stack and empty input means we are accepting
+  static constexpr auto rule(empty_stack_symbol, epsilon) -> ctll::accept;
+
+  // not matching anything else => reject
+  static constexpr auto rule(...) -> ctll::reject;
+
+  // start stack is just a list<Grammar::_start>;
+  using start_stack = list<typename Grammar::_start>;
+};
+
+}
+
+#endif
+
+#ifndef CTLL__ACTIONS__HPP
+#define CTLL__ACTIONS__HPP
+
+namespace ctll {
+struct empty_subject { };
+
+struct empty_actions {
+  // dummy operator so using Actions::operator() later will not give error
+  template <typename Action, typename InputSymbol, typename Subject> static constexpr auto apply(Action, InputSymbol, Subject subject) {
+    return subject;
+  }
+};
+
+template <typename Actions> struct identity: public Actions {
+  using Actions::apply;
+  // allow empty_subject to exists
+  template <typename Action, auto V> constexpr static auto apply(Action, term<V>, empty_subject) -> empty_subject { return {}; }
+  template <typename Action> constexpr static auto apply(Action, epsilon, empty_subject) -> empty_subject { return {}; }
+};
+
+template <typename Actions> struct ignore_unknown: public Actions {
+  using Actions::apply;
+  // allow flow thru unknown actions
+  template <typename Action, auto V, typename Subject> constexpr static auto apply(Action, term<V>, Subject) -> Subject { return {}; }
+  template <typename Action, typename Subject> constexpr static auto apply(Action, epsilon, Subject) -> Subject { return {}; }
+};
+}
+
+#endif
+
+#include <limits>
+
+namespace ctll {
+
+enum class decision {
+  reject,
+  accept,
+  undecided
+};
+
+struct placeholder { };
+
+template <size_t> using index_placeholder = placeholder;
+
+#if !__cpp_nontype_template_parameter_class
+template <typename Grammar, const auto & input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser {
+#else
+  template <typename Grammar, ctll::fixed_string input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser { // in c++20
+#endif
+
+#ifdef __GNUC__ // workaround to GCC bug
+#if __cpp_nontype_template_parameter_class
+  static constexpr auto _input = input;  // c++20 mode
+#else
+  static constexpr auto & _input = input; // c++17 mode
+#endif
+#else
+  static constexpr auto _input = input; // everyone else
+#endif
+
+  using Actions = ctll::conditional<IgnoreUnknownActions, ignore_unknown<ActionSelector>, identity<ActionSelector>>;
+  using grammar = augment_grammar<Grammar>;
+
+  template <size_t Pos, typename Stack, typename Subject, decision Decision> struct results {
+    constexpr inline CTLL_FORCE_INLINE operator bool() const noexcept {
+      return Decision == decision::accept;
+    }
+
+#ifdef __GNUC__ // workaround to GCC bug
+#if __cpp_nontype_template_parameter_class
+    static constexpr auto _input = input;  // c++20 mode
+#else
+    static constexpr auto & _input = input; // c++17 mode
+#endif
+#else
+    static constexpr auto _input = input; // everyone else
+#endif
+
+    using output_type = Subject;
+
+    constexpr auto operator+(placeholder) const noexcept {
+      if constexpr (Decision == decision::undecided) {
+        // parse for current char (RPos) with previous stack and subject :)
+        return parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template decide<Pos, Stack, Subject>({}, {});
+      } else {
+        // if there is decision already => just push it to the end of fold expression
+        return *this;
+      }
+    }
+  };
+
+  template <size_t Pos> static constexpr auto get_current_term() noexcept {
+    if constexpr (Pos < input.size()) {
+      constexpr auto value = input[Pos];
+      if constexpr (value <= std::numeric_limits<char>::max()) {
+        return term<static_cast<char>(value)>{};
+      } else {
+        return term<input[Pos]>{};
+      }
+
+    } else {
+      // return epsilon if we are past the input
+      return epsilon{};
+    }
+  }
+  template <size_t Pos> static constexpr auto get_previous_term() noexcept {
+    if constexpr (Pos == 0) {
+      // there is no previous character on input if we are on start
+      return epsilon{};
+    } else if constexpr ((Pos-1) < input.size()) {
+      constexpr auto value = input[Pos-1];
+      if constexpr (value <= std::numeric_limits<char>::max()) {
+        return term<static_cast<char>(value)>{};
+      } else {
+        return term<value>{};
+      }
+    } else {
+      return epsilon{};
+    }
+  }
+  // if rule is accept => return true and subject
+  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+  static constexpr auto move(ctll::accept, Terminal, Stack, Subject) noexcept {
+    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::accept>();
+  }
+  // if rule is reject => return false and subject
+  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+  static constexpr auto move(ctll::reject, Terminal, Stack, Subject) noexcept {
+    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
+  }
+  // if rule is pop_input => move to next character
+  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+  static constexpr auto move(ctll::pop_input, Terminal, Stack, Subject) noexcept {
+    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, Stack, Subject, decision::undecided>();
+  }
+  // if rule is string => push it to the front of stack
+  template <size_t Pos, typename... Content, typename Terminal, typename Stack, typename Subject>
+  static constexpr auto move(push<Content...> string, Terminal, Stack stack, Subject subject) noexcept {
+    return decide<Pos>(push_front(string, stack), subject);
+  }
+  // if rule is epsilon (empty string) => continue
+  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+  static constexpr auto move(epsilon, Terminal, Stack stack, Subject subject) noexcept {
+    return decide<Pos>(stack, subject);
+  }
+  // if rule is string with current character at the beginning (term<V>) => move to next character
+  // and push string without the character (quick LL(1))
+  template <size_t Pos, auto V, typename... Content, typename Stack, typename Subject>
+  static constexpr auto move(push<term<V>, Content...>, term<V>, Stack stack, Subject) noexcept {
+    constexpr auto _input = input;
+    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
+  }
+  // if rule is string with any character at the beginning (compatible with current term<T>) => move to next character
+  // and push string without the character (quick LL(1))
+  template <size_t Pos, auto V, typename... Content, auto T, typename Stack, typename Subject>
+  static constexpr auto move(push<anything, Content...>, term<T>, Stack stack, Subject) noexcept {
+    constexpr auto _input = input;
+    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
+  }
+  // decide if we need to take action or move
+  template <size_t Pos, typename Stack, typename Subject> static constexpr auto decide(Stack previous_stack, Subject previous_subject) noexcept {
+    // each call means we pop something from stack
+    auto top_symbol = decltype(ctll::front(previous_stack, empty_stack_symbol()))();
+    // gcc pedantic warning
+    [[maybe_unused]] auto stack = decltype(ctll::pop_front(previous_stack))();
+
+    // in case top_symbol is action type (apply it on previous subject and get new one)
+    if constexpr (std::is_base_of_v<ctll::action, decltype(top_symbol)>) {
+      auto subject = Actions::apply(top_symbol, get_previous_term<Pos>(), previous_subject);
+
+      // in case that semantic action is error => reject input
+      if constexpr (std::is_same_v<ctll::reject, decltype(subject)>) {
+        return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
+      } else {
+        return decide<Pos>(stack, subject);
+      }
+    } else {
+      // all other cases are ordinary for LL(1) parser
+      auto current_term = get_current_term<Pos>();
+      auto rule = decltype(grammar::rule(top_symbol,current_term))();
+      return move<Pos>(rule, current_term, stack, previous_subject);
+    }
+  }
+
+  // trampolines with folded expression
+  template <typename Subject, size_t... Pos> static constexpr auto trampoline_decide(Subject, std::index_sequence<Pos...>) noexcept {
+    // parse everything for first char and than for next and next ...
+    // Pos+1 is needed as we want to finish calculation with epsilons on stack
+    auto v = (decide<0, typename grammar::start_stack, Subject>({}, {}) + ... + index_placeholder<Pos+1>());
+    return v;
+  }
+
+  template <typename Subject = empty_subject> static constexpr auto trampoline_decide(Subject subject = {}) noexcept {
+    // there will be no recursion, just sequence long as the input
+    return trampoline_decide(subject, std::make_index_sequence<input.size()>());
+  }
+
+  template <typename Subject = empty_subject> using output = decltype(trampoline_decide<Subject>());
+  template <typename Subject = empty_subject> static inline constexpr bool correct_with = trampoline_decide<Subject>();
+
+};
+
+} // end of ctll namespace
+
+#endif
+
+#endif
+
+#ifndef CTRE__PCRE_ACTIONS__HPP
+#define CTRE__PCRE_ACTIONS__HPP
+
+#ifndef CTRE__PCRE__HPP
+#define CTRE__PCRE__HPP
+
+// THIS FILE WAS GENERATED BY DESATOMAT TOOL, DO NOT MODIFY THIS FILE
+
+namespace ctre {
+
+struct pcre {
+
+// NONTERMINALS:
+  struct a {};
+  struct atom_repeat {};
+  struct b {};
+  struct backslash {};
+  struct backslash_range {};
+  struct block {};
+  struct block_name2 {};
+  struct block_name {};
+  struct c {};
+  struct character_class {};
+  struct class_named {};
+  struct class_named_name {};
+  struct collate_char {};
+  struct content2 {};
+  struct content {};
+  struct content_in_capture {};
+  struct d {};
+  struct e {};
+  struct f {};
+  struct g {};
+  struct h {};
+  struct hexdec_repeat {};
+  struct i {};
+  struct j {};
+  struct k {};
+  struct l {};
+  struct m {};
+  struct mod {};
+  struct mod_opt {};
+  struct n {};
+  struct number2 {};
+  struct number {};
+  struct o {};
+  struct p {};
+  struct property_name2 {};
+  struct property_name {};
+  struct property_value2 {};
+  struct property_value {};
+  struct q {};
+  struct r {};
+  struct range {};
+  struct repeat {};
+  struct s {}; using _start = s;
+  struct set2a {};
+  struct set2b {};
+  struct set {};
+  struct setitem2 {};
+  struct setitem {};
+  struct string2 {};
+
+// 'action' types:
+  struct class_digit: ctll::action {};
+  struct class_named_alnum: ctll::action {};
+  struct class_named_alpha: ctll::action {};
+  struct class_named_ascii: ctll::action {};
+  struct class_named_blank: ctll::action {};
+  struct class_named_cntrl: ctll::action {};
+  struct class_named_digit: ctll::action {};
+  struct class_named_graph: ctll::action {};
+  struct class_named_lower: ctll::action {};
+  struct class_named_print: ctll::action {};
+  struct class_named_punct: ctll::action {};
+  struct class_named_space: ctll::action {};
+  struct class_named_upper: ctll::action {};
+  struct class_named_word: ctll::action {};
+  struct class_named_xdigit: ctll::action {};
+  struct class_nondigit: ctll::action {};
+  struct class_nonnewline: ctll::action {};
+  struct class_nonspace: ctll::action {};
+  struct class_nonword: ctll::action {};
+  struct class_space: ctll::action {};
+  struct class_word: ctll::action {};
+  struct create_hexdec: ctll::action {};
+  struct create_number: ctll::action {};
+  struct equivalent_character: ctll::action {};
+  struct finish_hexdec: ctll::action {};
+  struct look_finish: ctll::action {};
+  struct make_alternate: ctll::action {};
+  struct make_back_reference: ctll::action {};
+  struct make_capture: ctll::action {};
+  struct make_capture_with_name: ctll::action {};
+  struct make_lazy: ctll::action {};
+  struct make_optional: ctll::action {};
+  struct make_possessive: ctll::action {};
+  struct make_property: ctll::action {};
+  struct make_property_negative: ctll::action {};
+  struct make_range: ctll::action {};
+  struct make_relative_back_reference: ctll::action {};
+  struct make_sequence: ctll::action {};
+  struct negate_class_named: ctll::action {};
+  struct prepare_capture: ctll::action {};
+  struct push_assert_begin: ctll::action {};
+  struct push_assert_end: ctll::action {};
+  struct push_character: ctll::action {};
+  struct push_character_alarm: ctll::action {};
+  struct push_character_anything: ctll::action {};
+  struct push_character_escape: ctll::action {};
+  struct push_character_formfeed: ctll::action {};
+  struct push_character_newline: ctll::action {};
+  struct push_character_null: ctll::action {};
+  struct push_character_return_carriage: ctll::action {};
+  struct push_character_tab: ctll::action {};
+  struct push_empty: ctll::action {};
+  struct push_hexdec: ctll::action {};
+  struct push_name: ctll::action {};
+  struct push_number: ctll::action {};
+  struct push_property_name: ctll::action {};
+  struct push_property_value: ctll::action {};
+  struct repeat_ab: ctll::action {};
+  struct repeat_at_least: ctll::action {};
+  struct repeat_exactly: ctll::action {};
+  struct repeat_plus: ctll::action {};
+  struct repeat_star: ctll::action {};
+  struct reset_capture: ctll::action {};
+  struct set_combine: ctll::action {};
+  struct set_make: ctll::action {};
+  struct set_make_negative: ctll::action {};
+  struct set_start: ctll::action {};
+  struct start_lookahead_negative: ctll::action {};
+  struct start_lookahead_positive: ctll::action {};
+
+// (q)LL1 function:
+  using _others = ctll::neg_set<'!','$','\x28','\x29','*','+',',','-','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','0','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>;
+  static constexpr auto rule(s, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+  static constexpr auto rule(s, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
+  static constexpr auto rule(s, ctll::epsilon) -> ctll::push<push_empty>;
+  static constexpr auto rule(s, ctll::set<'\x29','*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(a, ctll::set<'!','$','\x28',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<content, make_alternate>;
+  static constexpr auto rule(a, _others) -> ctll::push<content, make_alternate>;
+  static constexpr auto rule(a, ctll::term<'\x29'>) -> ctll::push<push_empty, make_alternate>;
+  static constexpr auto rule(a, ctll::epsilon) -> ctll::push<push_empty, make_alternate>;
+  static constexpr auto rule(a, ctll::set<'*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(atom_repeat, ctll::term<'['>) -> ctll::push<character_class, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat>;
+  static constexpr auto rule(atom_repeat, _others) -> ctll::push<ctll::anything, push_character, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat>;
+  static constexpr auto rule(atom_repeat, ctll::set<'\x29','*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(b, ctll::term<','>) -> ctll::push<ctll::anything, n>;
+  static constexpr auto rule(b, ctll::term<'\x7D'>) -> ctll::push<repeat_exactly, ctll::anything>;
+
+  static constexpr auto rule(backslash, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
+  static constexpr auto rule(backslash, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
+  static constexpr auto rule(backslash, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
+  static constexpr auto rule(backslash, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
+  static constexpr auto rule(backslash, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
+  static constexpr auto rule(backslash, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
+  static constexpr auto rule(backslash, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
+  static constexpr auto rule(backslash, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
+  static constexpr auto rule(backslash, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, m>;
+  static constexpr auto rule(backslash, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
+  static constexpr auto rule(backslash, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
+  static constexpr auto rule(backslash, ctll::term<'u'>) -> ctll::push<ctll::anything, k>;
+  static constexpr auto rule(backslash, ctll::term<'x'>) -> ctll::push<ctll::anything, l>;
+  static constexpr auto rule(backslash, ctll::set<'$','\x28','\x29','*','+','-','.','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
+  static constexpr auto rule(backslash, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm>;
+  static constexpr auto rule(backslash, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape>;
+  static constexpr auto rule(backslash, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed>;
+  static constexpr auto rule(backslash, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline>;
+  static constexpr auto rule(backslash, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null>;
+  static constexpr auto rule(backslash, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage>;
+  static constexpr auto rule(backslash, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab>;
+
+  static constexpr auto rule(backslash_range, ctll::term<'u'>) -> ctll::push<ctll::anything, k>;
+  static constexpr auto rule(backslash_range, ctll::term<'x'>) -> ctll::push<ctll::anything, l>;
+  static constexpr auto rule(backslash_range, ctll::term<'-'>) -> ctll::push<ctll::anything, push_character>;
+  static constexpr auto rule(backslash_range, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm>;
+  static constexpr auto rule(backslash_range, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape>;
+  static constexpr auto rule(backslash_range, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed>;
+  static constexpr auto rule(backslash_range, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline>;
+  static constexpr auto rule(backslash_range, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null>;
+  static constexpr auto rule(backslash_range, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage>;
+  static constexpr auto rule(backslash_range, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab>;
+
+  static constexpr auto rule(block, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<content_in_capture, make_capture, ctll::term<'\x29'>>;
+  static constexpr auto rule(block, _others) -> ctll::push<content_in_capture, make_capture, ctll::term<'\x29'>>;
+  static constexpr auto rule(block, ctll::term<'?'>) -> ctll::push<ctll::anything, d>;
+  static constexpr auto rule(block, ctll::set<'*','+','\x7B','|','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(block_name2, ctll::set<'>','\x7D'>) -> ctll::epsilon;
+  static constexpr auto rule(block_name2, ctll::set<'0','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_name, block_name2>;
+
+  static constexpr auto rule(block_name, ctll::set<'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'>) -> ctll::push<ctll::anything, push_name, block_name2>;
+
+  static constexpr auto rule(c, ctll::term<'^'>) -> ctll::push<ctll::anything, set2a, set_make_negative, ctll::term<']'>>;
+  static constexpr auto rule(c, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<set, set_make, ctll::term<']'>>;
+  static constexpr auto rule(c, _others) -> ctll::push<set, set_make, ctll::term<']'>>;
+  static constexpr auto rule(c, ctll::set<'-',']','|'>) -> ctll::reject;
+
+  static constexpr auto rule(character_class, ctll::term<'['>) -> ctll::push<ctll::anything, c>;
+
+  static constexpr auto rule(class_named, ctll::term<'['>) -> ctll::push<ctll::anything, i>;
+
+  static constexpr auto rule(class_named_name, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit>;
+  static constexpr auto rule(class_named_name, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit>;
+  static constexpr auto rule(class_named_name, ctll::term<'b'>) -> ctll::push<ctll::anything, ctll::term<'l'>, ctll::term<'a'>, ctll::term<'n'>, ctll::term<'k'>, class_named_blank>;
+  static constexpr auto rule(class_named_name, ctll::term<'c'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'t'>, ctll::term<'r'>, ctll::term<'l'>, class_named_cntrl>;
+  static constexpr auto rule(class_named_name, ctll::term<'w'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'r'>, ctll::term<'d'>, class_named_word>;
+  static constexpr auto rule(class_named_name, ctll::term<'l'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'w'>, ctll::term<'e'>, ctll::term<'r'>, class_named_lower>;
+  static constexpr auto rule(class_named_name, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'a'>, ctll::term<'c'>, ctll::term<'e'>, class_named_space>;
+  static constexpr auto rule(class_named_name, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'p'>, ctll::term<'e'>, ctll::term<'r'>, class_named_upper>;
+  static constexpr auto rule(class_named_name, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'r'>, ctll::term<'a'>, ctll::term<'p'>, ctll::term<'h'>, class_named_graph>;
+  static constexpr auto rule(class_named_name, ctll::term<'a'>) -> ctll::push<ctll::anything, g>;
+  static constexpr auto rule(class_named_name, ctll::term<'p'>) -> ctll::push<ctll::anything, h>;
+
+  static constexpr auto rule(collate_char, ctll::set<'!','$','\x28','\x29','*','+',',','-','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','0','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character>;
+  static constexpr auto rule(collate_char, _others) -> ctll::push<ctll::anything, push_character>;
+
+  static constexpr auto rule(content2, ctll::term<'\x29'>) -> ctll::epsilon;
+  static constexpr auto rule(content2, ctll::epsilon) -> ctll::epsilon;
+  static constexpr auto rule(content2, ctll::term<'|'>) -> ctll::push<ctll::anything, a>;
+
+  static constexpr auto rule(content, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+  static constexpr auto rule(content, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
+  static constexpr auto rule(content, ctll::set<'\x29','*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(content_in_capture, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
+  static constexpr auto rule(content_in_capture, ctll::term<'\x29'>) -> ctll::push<push_empty>;
+  static constexpr auto rule(content_in_capture, ctll::set<'*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(d, ctll::term<'<'>) -> ctll::push<ctll::anything, block_name, ctll::term<'>'>, content_in_capture, make_capture_with_name, ctll::term<'\x29'>>;
+  static constexpr auto rule(d, ctll::term<':'>) -> ctll::push<reset_capture, ctll::anything, content_in_capture, ctll::term<'\x29'>>;
+  static constexpr auto rule(d, ctll::term<'!'>) -> ctll::push<reset_capture, ctll::anything, start_lookahead_negative, content_in_capture, look_finish, ctll::term<'\x29'>>;
+  static constexpr auto rule(d, ctll::term<'='>) -> ctll::push<reset_capture, ctll::anything, start_lookahead_positive, content_in_capture, look_finish, ctll::term<'\x29'>>;
+
+  static constexpr auto rule(e, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
+  static constexpr auto rule(e, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
+  static constexpr auto rule(e, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
+  static constexpr auto rule(e, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
+  static constexpr auto rule(e, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
+  static constexpr auto rule(e, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
+  static constexpr auto rule(e, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
+  static constexpr auto rule(e, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
+  static constexpr auto rule(e, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
+  static constexpr auto rule(e, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
+  static constexpr auto rule(e, ctll::term<'u'>) -> ctll::push<ctll::anything, k, range>;
+  static constexpr auto rule(e, ctll::term<'x'>) -> ctll::push<ctll::anything, l, range>;
+  static constexpr auto rule(e, ctll::set<'$','\x28','\x29','*','+','.','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
+  static constexpr auto rule(e, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm, range>;
+  static constexpr auto rule(e, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape, range>;
+  static constexpr auto rule(e, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed, range>;
+  static constexpr auto rule(e, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline, range>;
+  static constexpr auto rule(e, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null, range>;
+  static constexpr auto rule(e, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage, range>;
+  static constexpr auto rule(e, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab, range>;
+  static constexpr auto rule(e, ctll::term<'-'>) -> ctll::push<ctll::anything, q>;
+
+  static constexpr auto rule(f, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
+  static constexpr auto rule(f, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
+  static constexpr auto rule(f, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
+  static constexpr auto rule(f, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
+  static constexpr auto rule(f, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
+  static constexpr auto rule(f, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
+  static constexpr auto rule(f, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
+  static constexpr auto rule(f, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
+  static constexpr auto rule(f, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
+  static constexpr auto rule(f, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
+  static constexpr auto rule(f, ctll::term<'u'>) -> ctll::push<ctll::anything, k, range>;
+  static constexpr auto rule(f, ctll::term<'x'>) -> ctll::push<ctll::anything, l, range>;
+  static constexpr auto rule(f, ctll::set<'$','\x28','\x29','*','+','.','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
+  static constexpr auto rule(f, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm, range>;
+  static constexpr auto rule(f, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape, range>;
+  static constexpr auto rule(f, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed, range>;
+  static constexpr auto rule(f, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline, range>;
+  static constexpr auto rule(f, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null, range>;
+  static constexpr auto rule(f, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage, range>;
+  static constexpr auto rule(f, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab, range>;
+  static constexpr auto rule(f, ctll::term<'-'>) -> ctll::push<ctll::anything, r>;
+
+  static constexpr auto rule(g, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'c'>, ctll::term<'i'>, ctll::term<'i'>, class_named_ascii>;
+  static constexpr auto rule(g, ctll::term<'l'>) -> ctll::push<ctll::anything, o>;
+
+  static constexpr auto rule(h, ctll::term<'r'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'n'>, ctll::term<'t'>, class_named_print>;
+  static constexpr auto rule(h, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'c'>, ctll::term<'t'>, class_named_punct>;
+
+  static constexpr auto rule(hexdec_repeat, ctll::term<'\x7D'>) -> ctll::epsilon;
+  static constexpr auto rule(hexdec_repeat, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_hexdec, hexdec_repeat>;
+
+  static constexpr auto rule(i, ctll::term<'='>) -> ctll::push<ctll::anything, collate_char, equivalent_character, ctll::term<'='>, ctll::term<']'>>;
+  static constexpr auto rule(i, ctll::term<':'>) -> ctll::push<ctll::anything, p>;
+
+  static constexpr auto rule(j, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash_range, make_range>;
+  static constexpr auto rule(j, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, make_range>;
+  static constexpr auto rule(j, _others) -> ctll::push<ctll::anything, push_character, make_range>;
+  static constexpr auto rule(j, ctll::set<'-','[',']','^','|'>) -> ctll::reject;
+
+  static constexpr auto rule(k, ctll::term<'\x7B'>) -> ctll::push<create_hexdec, ctll::anything, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, hexdec_repeat, ctll::term<'\x7D'>, finish_hexdec>;
+  static constexpr auto rule(k, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<create_hexdec, ctll::anything, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, finish_hexdec>;
+
+  static constexpr auto rule(l, ctll::term<'\x7B'>) -> ctll::push<create_hexdec, ctll::anything, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, hexdec_repeat, ctll::term<'\x7D'>, finish_hexdec>;
+  static constexpr auto rule(l, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<create_hexdec, ctll::anything, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, finish_hexdec>;
+
+  static constexpr auto rule(m, ctll::set<'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'>) -> ctll::push<block_name, ctll::term<'\x7D'>, make_back_reference>;
+  static constexpr auto rule(m, ctll::term<'-'>) -> ctll::push<ctll::anything, number, ctll::term<'\x7D'>, make_relative_back_reference>;
+  static constexpr auto rule(m, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<number, ctll::term<'\x7D'>, make_back_reference>;
+
+  static constexpr auto rule(mod, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+  static constexpr auto rule(mod, ctll::epsilon) -> ctll::epsilon;
+  static constexpr auto rule(mod, _others) -> ctll::epsilon;
+  static constexpr auto rule(mod, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
+  static constexpr auto rule(mod, ctll::term<'+'>) -> ctll::push<ctll::anything, make_possessive>;
+  static constexpr auto rule(mod, ctll::set<'*','\x7B','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(mod_opt, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+  static constexpr auto rule(mod_opt, ctll::epsilon) -> ctll::epsilon;
+  static constexpr auto rule(mod_opt, _others) -> ctll::epsilon;
+  static constexpr auto rule(mod_opt, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
+  static constexpr auto rule(mod_opt, ctll::set<'*','+','\x7B','\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(n, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<number, repeat_ab, ctll::term<'\x7D'>, mod>;
+  static constexpr auto rule(n, ctll::term<'\x7D'>) -> ctll::push<repeat_at_least, ctll::anything, mod>;
+
+  static constexpr auto rule(number2, ctll::set<',','\x7D'>) -> ctll::epsilon;
+  static constexpr auto rule(number2, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_number, number2>;
+
+  static constexpr auto rule(number, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2>;
+
+  static constexpr auto rule(o, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'h'>, ctll::term<'a'>, class_named_alpha>;
+  static constexpr auto rule(o, ctll::term<'n'>) -> ctll::push<ctll::anything, ctll::term<'u'>, ctll::term<'m'>, class_named_alnum>;
+
+  static constexpr auto rule(p, ctll::set<'a','b','c','d','g','l','p','s','u','w','x'>) -> ctll::push<class_named_name, ctll::term<':'>, ctll::term<']'>>;
+  static constexpr auto rule(p, ctll::term<'^'>) -> ctll::push<ctll::anything, class_named_name, negate_class_named, ctll::term<':'>, ctll::term<']'>>;
+
+  static constexpr auto rule(property_name2, ctll::term<'\x7D'>) -> ctll::epsilon;
+  static constexpr auto rule(property_name2, ctll::term<'='>) -> ctll::push<ctll::anything, property_value>;
+  static constexpr auto rule(property_name2, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_name, property_name2>;
+
+  static constexpr auto rule(property_name, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_name, property_name2>;
+
+  static constexpr auto rule(property_value2, ctll::term<'\x7D'>) -> ctll::epsilon;
+  static constexpr auto rule(property_value2, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_value, property_value2>;
+
+  static constexpr auto rule(property_value, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_value, property_value2>;
+
+  static constexpr auto rule(q, ctll::term<'-'>) -> ctll::push<push_character, ctll::anything, j>;
+  static constexpr auto rule(q, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<push_character>;
+  static constexpr auto rule(q, ctll::epsilon) -> ctll::push<push_character>;
+  static constexpr auto rule(q, _others) -> ctll::push<push_character>;
+  static constexpr auto rule(q, ctll::term<'|'>) -> ctll::reject;
+
+  static constexpr auto rule(r, ctll::term<'-'>) -> ctll::push<push_character, ctll::anything, j>;
+  static constexpr auto rule(r, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<push_character>;
+  static constexpr auto rule(r, ctll::epsilon) -> ctll::push<push_character>;
+  static constexpr auto rule(r, _others) -> ctll::push<push_character>;
+  static constexpr auto rule(r, ctll::term<'|'>) -> ctll::reject;
+
+  static constexpr auto rule(range, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+  static constexpr auto rule(range, ctll::epsilon) -> ctll::epsilon;
+  static constexpr auto rule(range, _others) -> ctll::epsilon;
+  static constexpr auto rule(range, ctll::term<'-'>) -> ctll::push<ctll::anything, j>;
+  static constexpr auto rule(range, ctll::term<'|'>) -> ctll::reject;
+
+  static constexpr auto rule(repeat, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+  static constexpr auto rule(repeat, ctll::epsilon) -> ctll::epsilon;
+  static constexpr auto rule(repeat, _others) -> ctll::epsilon;
+  static constexpr auto rule(repeat, ctll::term<'?'>) -> ctll::push<ctll::anything, make_optional, mod_opt>;
+  static constexpr auto rule(repeat, ctll::term<'\x7B'>) -> ctll::push<ctll::anything, number, b>;
+  static constexpr auto rule(repeat, ctll::term<'+'>) -> ctll::push<ctll::anything, repeat_plus, mod>;
+  static constexpr auto rule(repeat, ctll::term<'*'>) -> ctll::push<ctll::anything, repeat_star, mod>;
+  static constexpr auto rule(repeat, ctll::term<'\x7D'>) -> ctll::reject;
+
+  static constexpr auto rule(set2a, ctll::term<']'>) -> ctll::epsilon;
+  static constexpr auto rule(set2a, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<setitem2, set_start, set2b>;
+  static constexpr auto rule(set2a, _others) -> ctll::push<setitem2, set_start, set2b>;
+  static constexpr auto rule(set2a, ctll::set<'-','|'>) -> ctll::reject;
+
+  static constexpr auto rule(set2b, ctll::term<']'>) -> ctll::epsilon;
+  static constexpr auto rule(set2b, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<setitem2, set_combine, set2b>;
+  static constexpr auto rule(set2b, _others) -> ctll::push<setitem2, set_combine, set2b>;
+  static constexpr auto rule(set2b, ctll::set<'-','|'>) -> ctll::reject;
+
+  static constexpr auto rule(set, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<setitem, set_start, set2b>;
+  static constexpr auto rule(set, _others) -> ctll::push<setitem, set_start, set2b>;
+  static constexpr auto rule(set, ctll::set<'-',']','^','|'>) -> ctll::reject;
+
+  static constexpr auto rule(setitem2, ctll::term<'['>) -> ctll::push<class_named, range>;
+  static constexpr auto rule(setitem2, ctll::term<'\\'>) -> ctll::push<ctll::anything, f>;
+  static constexpr auto rule(setitem2, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range>;
+  static constexpr auto rule(setitem2, _others) -> ctll::push<ctll::anything, push_character, range>;
+  static constexpr auto rule(setitem2, ctll::set<'-',']','|'>) -> ctll::reject;
+
+  static constexpr auto rule(setitem, ctll::term<'['>) -> ctll::push<class_named, range>;
+  static constexpr auto rule(setitem, ctll::term<'\\'>) -> ctll::push<ctll::anything, e>;
+  static constexpr auto rule(setitem, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range>;
+  static constexpr auto rule(setitem, _others) -> ctll::push<ctll::anything, push_character, range>;
+  static constexpr auto rule(setitem, ctll::set<'-',']','^','|'>) -> ctll::reject;
+
+  static constexpr auto rule(string2, ctll::set<'\x29','|'>) -> ctll::epsilon;
+  static constexpr auto rule(string2, ctll::epsilon) -> ctll::epsilon;
+  static constexpr auto rule(string2, ctll::set<'!','$','\x28',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<atom_repeat, string2, make_sequence>;
+  static constexpr auto rule(string2, _others) -> ctll::push<atom_repeat, string2, make_sequence>;
+  static constexpr auto rule(string2, ctll::set<'*','+','?','\x7B','\x7D'>) -> ctll::reject;
+
+};
+
+}
+
+#endif //CTRE__PCRE__HPP
+
+#ifndef CTRE__ATOMS__HPP
+#define CTRE__ATOMS__HPP
+
+#include <cstdint>
+
+namespace ctre {
+
+// special helpers for matching
+struct accept { };
+struct reject { };
+struct start_mark { };
+struct end_mark { };
+struct end_cycle_mark { };
+struct end_lookahead_mark { };
+template <size_t Id> struct numeric_mark { };
+
+// actual AST of regexp
+template <auto... Str> struct string { };
+template <typename... Opts> struct select { };
+template <typename... Content> struct optional { };
+template <typename... Content> struct lazy_optional { };
+template <typename... Content> struct sequence { };
+struct empty { };
+
+template <typename... Content> struct plus { };
+template <typename... Content> struct star { };
+template <size_t a, size_t b, typename... Content> struct repeat { };
+
+template <typename... Content> struct lazy_plus { };
+template <typename... Content> struct lazy_star { };
+template <size_t a, size_t b, typename... Content> struct lazy_repeat { };
+
+template <typename... Content> struct possessive_plus { };
+template <typename... Content> struct possessive_star { };
+template <size_t a, size_t b, typename... Content> struct possessive_repeat { };
+
+template <size_t Index, typename... Content> struct capture { };
+
+template <size_t Index, typename Name, typename... Content> struct capture_with_name { };
+
+template <size_t Index> struct back_reference { };
+template <typename Name> struct back_reference_with_name { };
+
+template <typename Type> struct look_start { };
+
+template <typename... Content> struct lookahead_positive { };
+template <typename... Content> struct lookahead_negative { };
+
+struct assert_begin { };
+struct assert_end { };
+
+}
+
+#endif
+
+#ifndef CTRE__ATOMS_CHARACTERS__HPP
+#define CTRE__ATOMS_CHARACTERS__HPP
+
+#ifndef CTRE__UTILITY__HPP
+#define CTRE__UTILITY__HPP
+
+#ifdef _MSC_VER
+#define CTRE_FORCE_INLINE __forceinline
+#define CTRE_FLATTEN
+#else
+#define CTRE_FORCE_INLINE inline __attribute__((always_inline))
+#define CTRE_FLATTEN __attribute__((flatten))
+#endif
+
+#endif
+
+#include <cstdint>
+
+namespace ctre {
+
+// sfinae check for types here
+
+template <typename T> class MatchesCharacter {
+  template <typename Y, typename CharT> static auto test(CharT c) -> decltype(Y::match_char(c), std::true_type());
+  template <typename> static auto test(...) -> std::false_type;
+public:
+  template <typename CharT> static inline constexpr bool value = decltype(test<T>(std::declval<CharT>()))();
+};
+
+template <auto V> struct character {
+  template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+    return value == V;
+  }
+};
+
+struct any {
+  template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT) noexcept { return true; }
+};
+
+template <typename... Content> struct negative_set {
+  template <typename CharT> inline static constexpr bool match_char(CharT value) noexcept {
+    return !(Content::match_char(value) || ... || false);
+  }
+};
+
+template <typename... Content> struct set {
+  template <typename CharT> inline static constexpr bool match_char(CharT value) noexcept {
+    return (Content::match_char(value) || ... || false);
+  }
+};
+
+template <auto... Cs> struct enumeration : set<character<Cs>...> { };
+
+template <typename... Content> struct negate {
+  template <typename CharT> inline static constexpr bool match_char(CharT value) noexcept {
+    return !(Content::match_char(value) || ... || false);
+  }
+};
+
+template <auto A, auto B> struct char_range {
+  template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+    return (value >= A) && (value <= B);
+  }
+};
+
+using word_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'>, character<'_'> >;
+
+using space_chars = enumeration<' ', '\t', '\n', '\v', '\f', '\r'>;
+
+using alphanum_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'> >;
+
+using alpha_chars = set<char_range<'A','Z'>, char_range<'a','z'> >;
+
+using xdigit_chars = set<char_range<'A','F'>, char_range<'a','f'>, char_range<'0','9'> >;
+
+using punct_chars
+= enumeration<'!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', ',', '-',
+        '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']',
+        '^', '_', '`', '{', '|', '}', '~'>;
+
+using digit_chars = char_range<'0','9'>;
+
+using ascii_chars = char_range<'\x00','\x7F'>;
+
+}
+
+#endif
+
+#ifndef CTRE__ATOMS_UNICODE__HPP
+#define CTRE__ATOMS_UNICODE__HPP
+
+// master branch is not including unicode db (for now)
+// #include "../unicode-db/unicode.hpp"
+#include <array>
+
+namespace ctre {
+
+// properties name & value
+
+template <auto... Str> struct property_name { };
+template <auto... Str> struct property_value { };
+
+template <size_t Sz> constexpr std::string_view get_string_view(const std::array<char, Sz> & arr) noexcept {
+  return std::string_view(arr.data(), arr.size());
+}
+
+// basic support for binary and type-value properties
+
+template <auto Name> struct binary_property;
+template <auto Name, auto Value> struct property;
+
+// unicode TS#18 level 1.2 general_category
+//template <uni::__binary_prop Property> struct binary_property<Property> {
+//	template <typename CharT> inline static constexpr bool match_char(CharT) noexcept {
+//		return uni::__get_binary_prop<Property>(c);
+//	}
+//};
+
+// unicode TS#18 level 1.2.2
+
+enum class property_type {
+  script, script_extension, age, block, unknown
+};
+
+// unicode TS#18 level 1.2.2
+
+//template <uni::script Script> struct binary_property<Script> {
+//	template <typename CharT> inline static constexpr bool match_char(CharT) noexcept {
+//		return uni::cp_script(c) == Script;
+//	}
+//};
+//
+//template <uni::script Script> struct property<property_type::script_extension, Script> {
+//	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+//		for (uni::script sc: uni::cp_script_extensions(c)) {
+//			if (sc == Script) return true;
+//		}
+//		return false;
+//	}
+//};
+
+//template <uni::version Age> struct binary_property<Age> {
+//	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+//		return uni::cp_age(c) <= Age;
+//	}
+//};
+//
+//template <uni::block Block> struct binary_property<Block> {
+//	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+//		return uni::cp_block(c) == Block;
+//	}
+//};
+
+// nonbinary properties
+
+constexpr property_type property_type_from_name(std::string_view) noexcept {
+  return property_type::unknown;
+  //using namespace std::string_view_literals;
+  //if (uni::__pronamecomp(str, "script"sv) == 0 || uni::__pronamecomp(str, "sc"sv) == 0) {
+  //	return property_type::script;
+  //} else if (uni::__pronamecomp(str, "script_extension"sv) == 0 || uni::__pronamecomp(str, "scx"sv) == 0) {
+  //	return property_type::script_extension;
+  //} else if (uni::__pronamecomp(str, "age"sv) == 0) {
+  //	return property_type::age;
+  //} else if (uni::__pronamecomp(str, "block"sv) == 0) {
+  //	return property_type::block;
+  //} else {
+  //	return property_type::unknown;
+  //}
+}
+
+template <property_type Property> struct property_type_builder {
+  template <auto... Value> static constexpr auto get() {
+    return ctll::reject{};
+  }
+};
+
+template <auto... Name> struct property_builder {
+  static constexpr std::array<char, sizeof...(Name)> name{static_cast<char>(Name)...};
+  static constexpr property_type type = property_type_from_name(get_string_view(name));
+
+  using helper = property_type_builder<type>;
+
+  template <auto... Value> static constexpr auto get() {
+    return helper::template get<Value...>();
+  }
+};
+
+// unicode TS#18 level 1.2.2 script support
+
+//template <> struct property_type_builder<property_type::script> {
+//	template <auto... Value> static constexpr auto get() {
+//		constexpr std::array<char, sizeof...(Value)> value{Value...};
+//		constexpr auto sc = uni::__script_from_string(get_string_view(value));
+//		if constexpr (sc == uni::script::unknown) {
+//			return ctll::reject{};
+//		} else {
+//			return binary_property<sc>();
+//		}
+//	}
+//};
+//
+//template <> struct property_type_builder<property_type::script_extension> {
+//	template <auto... Value> static constexpr auto get() {
+//		constexpr std::array<char, sizeof...(Value)> value{Value...};
+//		constexpr auto sc = uni::__script_from_string(get_string_view(value));
+//		if constexpr (sc == uni::script::unknown) {
+//			return ctll::reject{};
+//		} else {
+//			return property<property_type::script_extension, sc>();
+//		}
+//	}
+//};
+//
+//template <> struct property_type_builder<property_type::age> {
+//	template <auto... Value> static constexpr auto get() {
+//		constexpr std::array<char, sizeof...(Value)> value{Value...};
+//		constexpr auto age = uni::__age_from_string(get_string_view(value));
+//		if constexpr (age == uni::version::unassigned) {
+//			return ctll::reject{};
+//		} else {
+//			return binary_property<age>();
+//		}
+//	}
+//};
+//
+//template <> struct property_type_builder<property_type::block> {
+//	template <auto... Value> static constexpr auto get() {
+//		constexpr std::array<char, sizeof...(Value)> value{Value...};
+//		constexpr auto block = uni::__block_from_string(get_string_view(value));
+//		if constexpr (block == uni::block::no_block) {
+//			return ctll::reject{};
+//		} else {
+//			return binary_property<block>();
+//		}
+//	}
+//};
+
+}
+
+#endif
+
+#ifndef CTRE__ID__HPP
+#define CTRE__ID__HPP
+
+#include <type_traits>
+
+namespace ctre {
+
+template <auto... Name> struct id {
+  static constexpr auto name = ctll::fixed_string<sizeof...(Name)>{{Name...}};
+};
+
+template <auto... Name> constexpr auto operator==(id<Name...>, id<Name...>) noexcept -> std::true_type { return {}; }
+
+template <auto... Name1, auto... Name2> constexpr auto operator==(id<Name1...>, id<Name2...>) noexcept -> std::false_type { return {}; }
+
+template <auto... Name, typename T> constexpr auto operator==(id<Name...>, T) noexcept -> std::false_type { return {}; }
+
+}
+
+#endif
+
+#include <cstdint>
+#include <limits>
+
+namespace ctre {
+
+template <size_t Counter> struct pcre_parameters {
+  static constexpr size_t current_counter = Counter;
+};
+
+template <typename Stack = ctll::list<>, typename Parameters = pcre_parameters<0>> struct pcre_context {
+  using stack_type = Stack;
+  using parameters_type = Parameters;
+  static constexpr inline auto stack = stack_type();
+  static constexpr inline auto parameters = parameters_type();
+  constexpr pcre_context() noexcept { }
+  constexpr pcre_context(Stack, Parameters) noexcept { }
+};
+
+template <typename... Content, typename Parameters> pcre_context(ctll::list<Content...>, Parameters) -> pcre_context<ctll::list<Content...>, Parameters>;
+
+template <size_t Value> struct number { };
+
+template <size_t Id> struct capture_id { };
+
+struct pcre_actions {
+// i know it's ugly, but it's more readable
+#ifndef CTRE__ACTIONS__ASSERTS__HPP
+#define CTRE__ACTIONS__ASSERTS__HPP
+
+// push_assert_begin
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_begin, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(assert_begin(), subject.stack), subject.parameters};
+  }
+
+// push_assert_end
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_end, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(assert_end(), subject.stack), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__BACKREFERENCE__HPP
+#define CTRE__ACTIONS__BACKREFERENCE__HPP
+
+// backreference with name
+  template <auto... Str, auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_back_reference, ctll::term<V>, pcre_context<ctll::list<id<Str...>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::push_front(back_reference_with_name<id<Str...>>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+  }
+
+// with just a number
+  template <auto V, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_back_reference, ctll::term<V>, pcre_context<ctll::list<number<Id>, Ts...>, pcre_parameters<Counter>>) {
+    // if we are looking outside of existing list of Ids ... reject input during parsing
+    if constexpr (Counter < Id) {
+      return ctll::reject{};
+    } else {
+      return pcre_context{ctll::push_front(back_reference<Id>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+    }
+  }
+
+// relative backreference
+  template <auto V, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_relative_back_reference, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<number<Id>, Ts...>, pcre_parameters<Counter>>) {
+    // if we are looking outside of existing list of Ids ... reject input during parsing
+    if constexpr (Counter < Id) {
+      return ctll::reject{};
+    } else {
+      constexpr size_t absolute_id = (Counter + 1) - Id;
+      return pcre_context{ctll::push_front(back_reference<absolute_id>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+    }
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__CAPTURE__HPP
+#define CTRE__ACTIONS__CAPTURE__HPP
+
+// prepare_capture
+  template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::prepare_capture, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::push_front(capture_id<Counter+1>(), ctll::list<Ts...>()), pcre_parameters<Counter+1>()};
+  }
+
+// reset_capture
+  template <auto V, typename... Ts, size_t Id, size_t Counter> static constexpr auto apply(pcre::reset_capture, ctll::term<V>, pcre_context<ctll::list<capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<Ts...>(), pcre_parameters<Counter-1>()};
+  }
+
+// capture
+  template <auto V, typename A, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture, ctll::term<V>, pcre_context<ctll::list<A, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::push_front(capture<Id, A>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+  }
+// capture (sequence)
+  template <auto V, typename... Content, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::push_front(capture<Id, Content...>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+  }
+// push_name
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_name, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(id<V>(), subject.stack), subject.parameters};
+  }
+// push_name (concat)
+  template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_name, ctll::term<V>, pcre_context<ctll::list<id<Str...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(id<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// capture with name
+  template <auto... Str, auto V, typename A, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture_with_name, ctll::term<V>, pcre_context<ctll::list<A, id<Str...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::push_front(capture_with_name<Id, id<Str...>, A>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+  }
+// capture with name (sequence)
+  template <auto... Str, auto V, typename... Content, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture_with_name, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, id<Str...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::push_front(capture_with_name<Id, id<Str...>, Content...>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__CHARACTERS__HPP
+#define CTRE__ACTIONS__CHARACTERS__HPP
+
+// push character
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<V>(), subject.stack), subject.parameters};
+  }
+// push_any_character
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_anything, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(any(), subject.stack), subject.parameters};
+  }
+// character_alarm
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_alarm, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\x07'>(), subject.stack), subject.parameters};
+  }
+// character_escape
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_escape, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\x14'>(), subject.stack), subject.parameters};
+  }
+// character_formfeed
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_formfeed, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\x0C'>(), subject.stack), subject.parameters};
+  }
+// push_character_newline
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_newline, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\x0A'>(), subject.stack), subject.parameters};
+  }
+// push_character_null
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_null, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\0'>(), subject.stack), subject.parameters};
+  }
+// push_character_return_carriage
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_return_carriage, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\x0D'>(), subject.stack), subject.parameters};
+  }
+// push_character_tab
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_tab, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(character<'\x09'>(), subject.stack), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__CLASS__HPP
+#define CTRE__ACTIONS__CLASS__HPP
+
+// class_digit
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_digit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::set<ctre::digit_chars>(), subject.stack), subject.parameters};
+  }
+// class_non_digit
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nondigit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::negative_set<ctre::digit_chars>(), subject.stack), subject.parameters};
+  }
+// class_space
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::set<ctre::space_chars>(), subject.stack), subject.parameters};
+  }
+// class_nonspace
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonspace, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::negative_set<ctre::space_chars>(), subject.stack), subject.parameters};
+  }
+// class_word
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_word, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::set<ctre::word_chars>(), subject.stack), subject.parameters};
+  }
+// class_nonword
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonword, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::negative_set<ctre::word_chars>(), subject.stack), subject.parameters};
+  }
+// class_nonnewline
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonnewline, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::negative_set<character<'\n'>>(), subject.stack), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__HEXDEC__HPP
+#define CTRE__ACTIONS__HEXDEC__HPP
+
+// hexdec character support (seed)
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::create_hexdec, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(number<0ull>(), subject.stack), subject.parameters};
+  }
+// hexdec character support (push value)
+  template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
+    constexpr auto previous = N << 4ull;
+    if constexpr (V >= 'a' && V <= 'f') {
+      return pcre_context{ctll::push_front(number<(previous + (V - 'a' + 10))>(), ctll::list<Ts...>()), subject.parameters};
+    } else if constexpr (V >= 'A' && V <= 'F') {
+      return pcre_context{ctll::push_front(number<(previous + (V - 'A' + 10))>(), ctll::list<Ts...>()), subject.parameters};
+    } else {
+      return pcre_context{ctll::push_front(number<(previous + (V - '0'))>(), ctll::list<Ts...>()), subject.parameters};
+    }
+  }
+// hexdec character support (convert to character)
+  template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::finish_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
+    if constexpr (N <= std::numeric_limits<unsigned char>::max()) {
+      return pcre_context{ctll::push_front(character<(char)N>(), ctll::list<Ts...>()), subject.parameters};
+    } else {
+      return pcre_context{ctll::push_front(character<N>(), ctll::list<Ts...>()), subject.parameters};
+    }
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__LOOKAHEAD__HPP
+#define CTRE__ACTIONS__LOOKAHEAD__HPP
+
+// lookahead positive start
+  template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_lookahead_positive, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<look_start<lookahead_positive<>>, Ts...>(), pcre_parameters<Counter>()};
+  }
+
+// lookahead positive end
+  template <auto V, typename Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<Look, look_start<lookahead_positive<>>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<lookahead_positive<Look>, Ts...>(), pcre_parameters<Counter>()};
+  }
+
+// lookahead positive end (sequence)
+  template <auto V, typename... Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<ctre::sequence<Look...>, look_start<lookahead_positive<>>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<lookahead_positive<Look...>, Ts...>(), pcre_parameters<Counter>()};
+  }
+
+// lookahead negative start
+  template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_lookahead_negative, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<look_start<lookahead_negative<>>, Ts...>(), pcre_parameters<Counter>()};
+  }
+
+// lookahead negative end
+  template <auto V, typename Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<Look, look_start<lookahead_negative<>>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<lookahead_negative<Look>, Ts...>(), pcre_parameters<Counter>()};
+  }
+
+// lookahead negative end (sequence)
+  template <auto V, typename... Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<ctre::sequence<Look...>, look_start<lookahead_negative<>>, Ts...>, pcre_parameters<Counter>>) {
+    return pcre_context{ctll::list<lookahead_negative<Look...>, Ts...>(), pcre_parameters<Counter>()};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__NAMED_CLASS__HPP
+#define CTRE__ACTIONS__NAMED_CLASS__HPP
+
+// class_named_alnum
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_alnum, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::alphanum_chars(), subject.stack), subject.parameters};
+  }
+// class_named_alpha
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_alpha, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::alpha_chars(), subject.stack), subject.parameters};
+  }
+// class_named_digit
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_digit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::digit_chars(), subject.stack), subject.parameters};
+  }
+// class_named_ascii
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_ascii, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::ascii_chars(), subject.stack), subject.parameters};
+  }
+// class_named_blank
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_blank, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::enumeration<' ','\t'>(), subject.stack), subject.parameters};
+  }
+// class_named_cntrl
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_cntrl, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::set<ctre::char_range<'\x00','\x1F'>, ctre::character<'\x7F'>>(), subject.stack), subject.parameters};
+  }
+// class_named_graph
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_graph, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::char_range<'\x21','\x7E'>(), subject.stack), subject.parameters};
+  }
+// class_named_lower
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_lower, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::char_range<'a','z'>(), subject.stack), subject.parameters};
+  }
+// class_named_upper
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_upper, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::char_range<'A','Z'>(), subject.stack), subject.parameters};
+  }
+// class_named_print
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_print, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(ctre::char_range<'\x20','\x7E'>(), subject.stack), subject.parameters};
+  }
+// class_named_space
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(space_chars(), subject.stack), subject.parameters};
+  }
+// class_named_word
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_word, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(word_chars(), subject.stack), subject.parameters};
+  }
+// class_named_punct
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_punct, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(punct_chars(), subject.stack), subject.parameters};
+  }
+// class_named_xdigit
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_xdigit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(xdigit_chars(), subject.stack), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__OPTIONS__HPP
+#define CTRE__ACTIONS__OPTIONS__HPP
+
+// empty option for alternate
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_empty, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(empty(), subject.stack), subject.parameters};
+  }
+
+// empty option for empty regex
+  template <typename Parameters> static constexpr auto apply(pcre::push_empty, ctll::epsilon, pcre_context<ctll::list<>, Parameters> subject) {
+    return pcre_context{ctll::push_front(empty(), subject.stack), subject.parameters};
+  }
+
+// make_alternate (A|B)
+  template <auto V, typename A, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_alternate, ctll::term<V>, pcre_context<ctll::list<B, A, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(select<A,B>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// make_alternate (As..)|B => (As..|B)
+  template <auto V, typename A, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_alternate, ctll::term<V>, pcre_context<ctll::list<ctre::select<Bs...>, A, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(select<A,Bs...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_optional
+  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(optional<A>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(optional<Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_lazy (optional)
+  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<optional<Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(lazy_optional<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__REPEAT__HPP
+#define CTRE__ACTIONS__REPEAT__HPP
+
+// repeat 1..N
+  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_plus, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(plus<A>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// repeat 1..N (sequence)
+  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_plus, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(plus<Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// repeat 0..N
+  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_star, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(star<A>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// repeat 0..N (sequence)
+  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_star, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(star<Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// create_number (seed)
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::create_number, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(number<static_cast<size_t>(V - '0')>(), subject.stack), subject.parameters};
+  }
+// push_number
+  template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_number, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
+    constexpr size_t previous = N * 10ull;
+    return pcre_context{ctll::push_front(number<(previous + (V - '0'))>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// repeat A..B
+  template <auto V, typename Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_ab, ctll::term<V>, pcre_context<ctll::list<number<B>, number<A>, Subject, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(repeat<A,B,Subject>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// repeat A..B (sequence)
+  template <auto V, typename... Content, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_ab, ctll::term<V>, pcre_context<ctll::list<number<B>, number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(repeat<A,B,Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// repeat_exactly
+  template <auto V, typename Subject, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_exactly, ctll::term<V>, pcre_context<ctll::list<number<A>, Subject, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(repeat<A,A,Subject>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// repeat_exactly A..B (sequence)
+  template <auto V, typename... Content, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_exactly, ctll::term<V>, pcre_context<ctll::list<number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(repeat<A,A,Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// repeat_at_least (A+)
+  template <auto V, typename Subject, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_at_least, ctll::term<V>, pcre_context<ctll::list<number<A>, Subject, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(repeat<A,0,Subject>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// repeat_at_least (A+) (sequence)
+  template <auto V, typename... Content, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_at_least, ctll::term<V>, pcre_context<ctll::list<number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(repeat<A,0,Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_lazy (plus)
+  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<plus<Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(lazy_plus<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_lazy (star)
+  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<star<Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(lazy_star<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_lazy (repeat<A,B>)
+  template <auto V, typename... Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<repeat<A,B,Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(lazy_repeat<A,B,Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_possessive (plus)
+  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<plus<Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(possessive_plus<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_possessive (star)
+  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<star<Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(possessive_star<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_possessive (repeat<A,B>)
+  template <auto V, typename... Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<repeat<A,B,Subject...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(possessive_repeat<A,B,Subject...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__SEQUENCE__HPP
+#define CTRE__ACTIONS__SEQUENCE__HPP
+
+// make_sequence
+  template <auto V, typename A, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<B,A,Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(sequence<A,B>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// make_sequence (concat)
+  template <auto V, typename... As, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<As...>,B,Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(sequence<B,As...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// make_sequence (make string)
+  template <auto V, auto A, auto B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>,Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(string<A,B>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// make_sequence (concat string)
+  template <auto V, auto... As, auto B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<string<As...>,character<B>,Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(string<B,As...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__SET__HPP
+#define CTRE__ACTIONS__SET__HPP
+
+// UTILITY
+// add into set if not exists
+  template <template <typename...> typename SetType, typename T, typename... As, bool Exists = (std::is_same_v<T, As> || ... || false)> static constexpr auto push_back_into_set(T, SetType<As...>) -> ctll::conditional<Exists, SetType<As...>, SetType<As...,T>> { return {}; }
+
+//template <template <typename...> typename SetType, typename A, typename BHead, typename... Bs> struct set_merge_helper {
+//	using step = decltype(push_back_into_set<SetType>(BHead(), A()));
+//	using type = ctll::conditional<(sizeof...(Bs) > 0), set_merge_helper<SetType, step, Bs...>, step>;
+//};
+//
+//// add set into set if not exists
+//template <template <typename...> typename SetType, typename... As, typename... Bs> static constexpr auto push_back_into_set(SetType<As...>, SetType<Bs...>) -> typename set_merge_helper<SetType, SetType<As...>, Bs...>::type { return pcre_context{{};), subject.parameters}}
+//
+//template <template <typename...> typename SetType, typename... As> static constexpr auto push_back_into_set(SetType<As...>, SetType<>) -> SetType<As...> { return pcre_context{{};), subject.parameters}}
+
+// END OF UTILITY
+
+// set_start
+  template <auto V, typename A,typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_start, ctll::term<V>, pcre_context<ctll::list<A,Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(set<A>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// set_make
+  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_make, ctll::term<V>, pcre_context<ctll::list<set<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(set<Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// set_make_negative
+  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_make_negative, ctll::term<V>, pcre_context<ctll::list<set<Content...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(negative_set<Content...>(), ctll::list<Ts...>()), subject.parameters};
+  }
+// set{A...} + B = set{A,B}
+  template <auto V, typename A, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<A,set<Content...>,Ts...>, Parameters> subject) {
+    auto new_set = push_back_into_set<set>(A(), set<Content...>());
+    return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
+  }
+// TODO checkme
+//// set{A...} + set{B...} = set{A...,B...}
+//template <auto V, typename... As, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<set<As...>,set<Bs...>,Ts...>, Parameters> subject) {
+//	auto new_set = push_back_into_set<set>(set<As...>(), set<Bs...>());
+//	return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
+//}
+
+// negative_set{A...} + B = negative_set{A,B}
+  template <auto V, typename A, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<A,negative_set<Content...>,Ts...>, Parameters> subject) {
+    auto new_set = push_back_into_set<set>(A(), set<Content...>());
+    return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
+  }
+// TODO checkme
+//// negative_set{A...} + negative_set{B...} = negative_set{A...,B...}
+//template <auto V, typename... As, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<negative_set<As...>,negative_set<Bs...>,Ts...>, Parameters> subject) {
+//	auto new_set = push_back_into_set<negative_set>(negative_set<As...>(), negative_set<Bs...>());
+//	return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
+//}
+// negate_class_named: [[^:digit:]] = [^[:digit:]]
+  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::negate_class_named, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(negate<A>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// add range to set
+  template <auto V, auto B, auto A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_range, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(char_range<A,B>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+#endif
+
+#ifndef CTRE__ACTIONS__PROPERTIES__HPP
+#define CTRE__ACTIONS__PROPERTIES__HPP
+
+// push_property_name
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_name, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(property_name<V>(), subject.stack), subject.parameters};
+  }
+// push_property_name (concat)
+  template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_name, ctll::term<V>, pcre_context<ctll::list<property_name<Str...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(property_name<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// push_property_value
+  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_value, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(property_value<V>(), subject.stack), subject.parameters};
+  }
+// push_property_value (concat)
+  template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_value, ctll::term<V>, pcre_context<ctll::list<property_value<Str...>, Ts...>, Parameters> subject) {
+    return pcre_context{ctll::push_front(property_value<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
+  }
+
+// make_property
+  template <auto V, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_name<Name...>, Ts...>, Parameters> subject) {
+    return ctll::reject{};
+    //constexpr std::array<char, sizeof...(Name)> name{static_cast<char>(Name)...};
+    //constexpr auto p = uni::__binary_prop_from_string(get_string_view(name));
+    //
+    //if constexpr (p == uni::__binary_prop::unknown) {
+    //	return ctll::reject{};
+    //} else {
+    //	return pcre_context{ctll::push_front(binary_property<p>(), ctll::list<Ts...>()), subject.parameters};
+    //}
+  }
+
+// make_property
+  template <auto V, auto... Value, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_value<Value...>, property_name<Name...>, Ts...>, Parameters> subject) {
+    return ctll::reject{};
+    //constexpr auto prop = property_builder<Name...>::template get<Value...>();
+    //
+    //if constexpr (std::is_same_v<decltype(prop), ctll::reject>) {
+    //	return ctll::reject{};
+    //} else {
+    //	return pcre_context{ctll::push_front(prop, ctll::list<Ts...>()), subject.parameters};
+    //}
+  }
+
+// make_property_negative
+  template <auto V, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property_negative, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_name<Name...>, Ts...>, Parameters> subject) {
+    return ctll::reject{};
+    //constexpr std::array<char, sizeof...(Name)> name{static_cast<char>(Name)...};
+    //constexpr auto p = uni::__binary_prop_from_string(get_string_view(name));
+    //
+    //if constexpr (p == uni::__binary_prop::unknown) {
+    //	return ctll::reject{};
+    //} else {
+    //	return pcre_context{ctll::push_front(negate<binary_property<p>>(), ctll::list<Ts...>()), subject.parameters};
+    //}
+  }
+
+// make_property_negative
+  template <auto V, auto... Value, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property_negative, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_value<Value...>, property_name<Name...>, Ts...>, Parameters> subject) {
+    return ctll::reject{};
+    //constexpr auto prop = property_builder<Name...>::template get<Value...>();
+    //
+    //if constexpr (std::is_same_v<decltype(prop), ctll::reject>) {
+    //	return ctll::reject{};
+    //} else {
+    //	return pcre_context{ctll::push_front(negate<decltype(prop)>(), ctll::list<Ts...>()), subject.parameters};
+    //}
+  }
+
+#endif
+
+};
+
+}
+
+#endif
+
+#ifndef CTRE__EVALUATION__HPP
+#define CTRE__EVALUATION__HPP
+
+#ifndef CTRE__RETURN_TYPE__HPP
+#define CTRE__RETURN_TYPE__HPP
+
+#include <type_traits>
+#include <tuple>
+#include <string_view>
+#include <string>
+
+namespace ctre {
+
+struct not_matched_tag_t { };
+
+static constexpr inline auto not_matched = not_matched_tag_t{};
+
+template <size_t Id, typename Name = void> struct captured_content {
+  template <typename Iterator> class storage {
+    Iterator _begin{};
+    Iterator _end{};
+
+    bool _matched{false};
+  public:
+    using char_type = typename std::iterator_traits<Iterator>::value_type;
+
+    using name = Name;
+
+    constexpr CTRE_FORCE_INLINE storage() noexcept {}
+
+    constexpr CTRE_FORCE_INLINE void matched() noexcept {
+      _matched = true;
+    }
+    constexpr CTRE_FORCE_INLINE void unmatch() noexcept {
+      _matched = false;
+    }
+    constexpr CTRE_FORCE_INLINE void set_start(Iterator pos) noexcept {
+      _begin = pos;
+    }
+    constexpr CTRE_FORCE_INLINE storage & set_end(Iterator pos) noexcept {
+      _end = pos;
+      return *this;
+    }
+    constexpr CTRE_FORCE_INLINE Iterator get_end() const noexcept {
+      return _end;
+    }
+
+
+    constexpr auto begin() const noexcept {
+      return _begin;
+    }
+    constexpr auto end() const noexcept {
+      return _end;
+    }
+
+    constexpr CTRE_FORCE_INLINE operator bool() const noexcept {
+      return _matched;
+    }
+
+    constexpr CTRE_FORCE_INLINE auto size() const noexcept {
+      return static_cast<size_t>(std::distance(_begin, _end));
+    }
+
+    constexpr CTRE_FORCE_INLINE auto to_view() const noexcept {
+      return std::basic_string_view<char_type>(&*_begin, static_cast<size_t>(std::distance(_begin, _end)));
+    }
+
+    constexpr CTRE_FORCE_INLINE auto to_string() const noexcept {
+      return std::basic_string<char_type>(begin(), end());
+    }
+
+    constexpr CTRE_FORCE_INLINE auto view() const noexcept {
+      return std::basic_string_view<char_type>(&*_begin, static_cast<size_t>(std::distance(_begin, _end)));
+    }
+
+    constexpr CTRE_FORCE_INLINE auto str() const noexcept {
+      return std::basic_string<char_type>(begin(), end());
+    }
+
+    constexpr CTRE_FORCE_INLINE operator std::basic_string_view<char_type>() const noexcept {
+      return to_view();
+    }
+
+    constexpr CTRE_FORCE_INLINE explicit operator std::basic_string<char_type>() const noexcept {
+      return to_string();
+    }
+
+    constexpr CTRE_FORCE_INLINE static size_t get_id() noexcept {
+      return Id;
+    }
+  };
+};
+
+struct capture_not_exists_tag { };
+
+static constexpr inline auto capture_not_exists = capture_not_exists_tag{};
+
+template <typename... Captures> struct captures;
+
+template <typename Head, typename... Tail> struct captures<Head, Tail...>: captures<Tail...> {
+  Head head{};
+  constexpr CTRE_FORCE_INLINE captures() noexcept { }
+  template <size_t id> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+    if constexpr (id == Head::get_id()) {
+      return true;
+    } else {
+      return captures<Tail...>::template exists<id>();
+    }
+  }
+  template <typename Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+    if constexpr (std::is_same_v<Name, typename Head::name>) {
+      return true;
+    } else {
+      return captures<Tail...>::template exists<Name>();
+    }
+  }
+#if __cpp_nontype_template_parameter_class
+  template <ctll::fixed_string Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+		if constexpr (std::is_same_v<typename Head::name, void>) {
+			return captures<Tail...>::template exists<Name>();
+		} else {
+			if constexpr (Head::name::name.is_same_as(Name)) {
+				return true;
+			} else {
+				return captures<Tail...>::template exists<Name>();
+			}
+		}
+	}
+#endif
+  template <size_t id> CTRE_FORCE_INLINE constexpr auto & select() noexcept {
+    if constexpr (id == Head::get_id()) {
+      return head;
+    } else {
+      return captures<Tail...>::template select<id>();
+    }
+  }
+  template <typename Name> CTRE_FORCE_INLINE constexpr auto & select() noexcept {
+    if constexpr (std::is_same_v<Name, typename Head::name>) {
+      return head;
+    } else {
+      return captures<Tail...>::template select<Name>();
+    }
+  }
+  template <size_t id> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+    if constexpr (id == Head::get_id()) {
+      return head;
+    } else {
+      return captures<Tail...>::template select<id>();
+    }
+  }
+  template <typename Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+    if constexpr (std::is_same_v<Name, typename Head::name>) {
+      return head;
+    } else {
+      return captures<Tail...>::template select<Name>();
+    }
+  }
+#if __cpp_nontype_template_parameter_class
+  template <ctll::fixed_string Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+		if constexpr (std::is_same_v<typename Head::name, void>) {
+			return captures<Tail...>::template select<Name>();
+		} else {
+			if constexpr (Head::name::name.is_same_as(Name)) {
+				return head;
+			} else {
+				return captures<Tail...>::template select<Name>();
+			}
+		}
+	}
+#endif
+};
+
+template <> struct captures<> {
+  constexpr CTRE_FORCE_INLINE captures() noexcept { }
+  template <size_t> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+    return false;
+  }
+  template <typename> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+    return false;
+  }
+#if __cpp_nontype_template_parameter_class
+  template <ctll::fixed_string> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+		return false;
+	}
+#endif
+  template <size_t> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+    return capture_not_exists;
+  }
+  template <typename> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+    return capture_not_exists;
+  }
+#if __cpp_nontype_template_parameter_class
+  template <ctll::fixed_string> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+		return capture_not_exists;
+	}
+#endif
+};
+
+template <typename Iterator, typename... Captures> class regex_results {
+  captures<captured_content<0>::template storage<Iterator>, typename Captures::template storage<Iterator>...> _captures{};
+public:
+  using char_type = typename std::iterator_traits<Iterator>::value_type;
+
+  constexpr CTRE_FORCE_INLINE regex_results() noexcept { }
+  constexpr CTRE_FORCE_INLINE regex_results(not_matched_tag_t) noexcept { }
+
+  // special constructor for deducting
+  constexpr CTRE_FORCE_INLINE regex_results(Iterator, ctll::list<Captures...>) noexcept { }
+
+  template <size_t Id, typename = std::enable_if_t<decltype(_captures)::template exists<Id>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+    return _captures.template select<Id>();
+  }
+  template <typename Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+    return _captures.template select<Name>();
+  }
+#if __cpp_nontype_template_parameter_class
+  template <ctll::fixed_string Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+		return _captures.template select<Name>();
+	}
+#endif
+  static constexpr size_t size() noexcept {
+    return sizeof...(Captures) + 1;
+  }
+  constexpr CTRE_FORCE_INLINE regex_results & matched() noexcept {
+    _captures.template select<0>().matched();
+    return *this;
+  }
+  constexpr CTRE_FORCE_INLINE regex_results & unmatch() noexcept {
+    _captures.template select<0>().unmatch();
+    return *this;
+  }
+  constexpr CTRE_FORCE_INLINE operator bool() const noexcept {
+    return bool(_captures.template select<0>());
+  }
+
+  constexpr CTRE_FORCE_INLINE operator std::basic_string_view<char_type>() const noexcept {
+    return to_view();
+  }
+
+  constexpr CTRE_FORCE_INLINE explicit operator std::basic_string<char_type>() const noexcept {
+    return to_string();
+  }
+
+  constexpr CTRE_FORCE_INLINE auto to_view() const noexcept {
+    return _captures.template select<0>().to_view();
+  }
+
+  constexpr CTRE_FORCE_INLINE auto to_string() const noexcept {
+    return _captures.template select<0>().to_string();
+  }
+
+  constexpr CTRE_FORCE_INLINE auto view() const noexcept {
+    return _captures.template select<0>().view();
+  }
+
+  constexpr CTRE_FORCE_INLINE auto str() const noexcept {
+    return _captures.template select<0>().to_string();
+  }
+
+  constexpr CTRE_FORCE_INLINE regex_results & set_start_mark(Iterator pos) noexcept {
+    _captures.template select<0>().set_start(pos);
+    return *this;
+  }
+  constexpr CTRE_FORCE_INLINE regex_results & set_end_mark(Iterator pos) noexcept {
+    _captures.template select<0>().set_end(pos);
+    return *this;
+  }
+  constexpr CTRE_FORCE_INLINE Iterator get_end_position() const noexcept {
+    return _captures.template select<0>().get_end();
+  }
+  template <size_t Id> CTRE_FORCE_INLINE constexpr regex_results & start_capture(Iterator pos) noexcept {
+    _captures.template select<Id>().set_start(pos);
+    return *this;
+  }
+  template <size_t Id> CTRE_FORCE_INLINE constexpr regex_results & end_capture(Iterator pos) noexcept {
+    _captures.template select<Id>().set_end(pos).matched();
+    return *this;
+  }
+};
+
+template <typename Iterator, typename... Captures> regex_results(Iterator, ctll::list<Captures...>) -> regex_results<Iterator, Captures...>;
+
+}
+
+// support for structured bindings
+
+#ifndef __EDG__
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
+
+namespace std {
+template <typename... Captures> struct tuple_size<ctre::regex_results<Captures...>> : public std::integral_constant<size_t, ctre::regex_results<Captures...>::size()> { };
+
+template <size_t N, typename... Captures> struct tuple_element<N, ctre::regex_results<Captures...>> {
+public:
+  using type = decltype(
+  std::declval<const ctre::regex_results<Captures...> &>().template get<N>()
+  );
+};
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+#endif
+
+#endif
+
+#ifndef CTRE__FIND_CAPTURES__HPP
+#define CTRE__FIND_CAPTURES__HPP
+
+namespace ctre {
+
+template <typename Pattern> constexpr auto find_captures(Pattern) noexcept {
+  return find_captures(ctll::list<Pattern>(), ctll::list<>());
+}
+
+template <typename... Output> constexpr auto find_captures(ctll::list<>, ctll::list<Output...> output) noexcept {
+  return output;
+}
+
+template <auto... String, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<string<String...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Tail...>(), output);
+}
+
+template <typename... Options, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<select<Options...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Options..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<optional<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_optional<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<sequence<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<empty, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Tail...>(), output);
+}
+
+template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<assert_begin, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Tail...>(), output);
+}
+
+template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<assert_end, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Tail...>(), output);
+}
+
+// , typename = std::enable_if_t<(MatchesCharacter<CharacterLike>::template value<char>)
+template <typename CharacterLike, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<CharacterLike, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<plus<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<star<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <size_t A, size_t B, typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<repeat<A,B,Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_plus<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_star<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <size_t A, size_t B, typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_repeat<A,B,Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<possessive_plus<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<possessive_star<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <size_t A, size_t B, typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<possessive_repeat<A,B,Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lookahead_positive<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lookahead_negative<Content...>, Tail...>, Output output) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), output);
+}
+
+template <size_t Id, typename... Content, typename... Tail, typename... Output> constexpr auto find_captures(ctll::list<capture<Id,Content...>, Tail...>, ctll::list<Output...>) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), ctll::list<Output..., captured_content<Id>>());
+}
+
+template <size_t Id, typename Name, typename... Content, typename... Tail, typename... Output> constexpr auto find_captures(ctll::list<capture_with_name<Id,Name,Content...>, Tail...>, ctll::list<Output...>) noexcept {
+  return find_captures(ctll::list<Content..., Tail...>(), ctll::list<Output..., captured_content<Id, Name>>());
+}
+
+}
+
+#endif
+
+#ifndef CTRE__FIRST__HPP
+#define CTRE__FIRST__HPP
+
+namespace ctre {
+
+struct can_be_anything {};
+
+
+template <typename... Content>
+constexpr auto first(ctll::list<Content...> l, ctll::list<>) noexcept {
+  return l;
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<accept, Tail...>) noexcept {
+  return l;
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<end_mark, Tail...>) noexcept {
+  return l;
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<end_cycle_mark, Tail...>) noexcept {
+  return l;
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<end_lookahead_mark, Tail...>) noexcept {
+  return l;
+}
+
+template <typename... Content, size_t Id, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<numeric_mark<Id>, Tail...>) noexcept {
+  return first(l, ctll::list<Tail...>{});
+}
+
+// empty
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<empty, Tail...>) noexcept {
+  return first(l, ctll::list<Tail...>{});
+}
+
+// asserts
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_begin, Tail...>) noexcept {
+  return first(l, ctll::list<Tail...>{});
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_end, Tail...>) noexcept {
+  return l;
+}
+
+// sequence
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<sequence<Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+// plus
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<plus<Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+// lazy_plus
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_plus<Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+// possessive_plus
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_plus<Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+// star
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<star<Seq...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+}
+
+// lazy_star
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_star<Seq...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+}
+
+// possessive_star
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_star<Seq...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+}
+
+// lazy_repeat
+template <typename... Content, size_t A, size_t B, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_repeat<A, B, Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+template <typename... Content, size_t B, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_repeat<0, B, Seq...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+}
+
+// possessive_repeat
+template <typename... Content, size_t A, size_t B, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_repeat<A, B, Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+template <typename... Content, size_t B, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_repeat<0, B, Seq...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+}
+
+// repeat
+template <typename... Content, size_t A, size_t B, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<repeat<A, B, Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+template <typename... Content, size_t B, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<repeat<0, B, Seq...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+}
+
+// lookahead_positive
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<lookahead_positive<Seq...>, Tail...>) noexcept {
+  return ctll::list<can_be_anything>{};
+}
+
+// lookahead_negative TODO fixme
+template <typename... Content, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<lookahead_negative<Seq...>, Tail...>) noexcept {
+  return ctll::list<can_be_anything>{};
+}
+
+// capture
+template <typename... Content, size_t Id, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<capture<Id, Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+template <typename... Content, size_t Id, typename Name, typename... Seq, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<capture_with_name<Id, Name, Seq...>, Tail...>) noexcept {
+  return first(l, ctll::list<Seq..., Tail...>{});
+}
+
+// backreference
+template <typename... Content, size_t Id, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<back_reference<Id>, Tail...>) noexcept {
+  return ctll::list<can_be_anything>{};
+}
+
+template <typename... Content, typename Name, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<back_reference_with_name<Name>, Tail...>) noexcept {
+  return ctll::list<can_be_anything>{};
+}
+
+// string First extraction
+template <typename... Content, auto First, auto... String, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<string<First, String...>, Tail...>) noexcept {
+  return ctll::list<Content..., character<First>>{};
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<string<>, Tail...>) noexcept {
+  return first(l, ctll::list<Tail...>{});
+}
+
+// optional
+template <typename... Content, typename... Opt, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<optional<Opt...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Opt..., Tail...>{}), ctll::list<Tail...>{});
+}
+
+template <typename... Content, typename... Opt, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_optional<Opt...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<Opt..., Tail...>{}), ctll::list<Tail...>{});
+}
+
+// select (alternation)
+template <typename... Content, typename SHead, typename... STail, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<select<SHead, STail...>, Tail...>) noexcept {
+  return first(first(l, ctll::list<SHead, Tail...>{}), ctll::list<select<STail...>, Tail...>{});
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<select<>, Tail...>) noexcept {
+  return l;
+}
+
+// characters / sets
+
+template <typename... Content, auto V, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<character<V>, Tail...>) noexcept {
+  return ctll::list<Content..., character<V>>{};
+}
+
+template <typename... Content, auto... Values, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<enumeration<Values...>, Tail...>) noexcept {
+  return ctll::list<Content..., character<Values>...>{};
+}
+
+template <typename... Content, typename... SetContent, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<set<SetContent...>, Tail...>) noexcept {
+  return ctll::list<Content..., SetContent...>{};
+}
+
+template <typename... Content, auto A, auto B, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<char_range<A,B>, Tail...>) noexcept {
+  return ctll::list<Content..., char_range<A,B>>{};
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<any, Tail...>) noexcept {
+  return ctll::list<can_be_anything>{};
+}
+
+// negative
+template <typename... Content, typename... SetContent, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<negate<SetContent...>, Tail...>) noexcept {
+  return ctll::list<Content..., negative_set<SetContent...>>{};
+}
+
+template <typename... Content, typename... SetContent, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<negative_set<SetContent...>, Tail...>) noexcept {
+  return ctll::list<Content..., negative_set<SetContent...>>{};
+}
+
+// user facing interface
+template <typename... Content> constexpr auto calculate_first(Content...) noexcept {
+  return first(ctll::list<>{}, ctll::list<Content...>{});
+}
+
+// calculate mutual exclusivity
+template <typename... Content> constexpr size_t calculate_size_of_first(ctre::negative_set<Content...>) {
+  return 1 + 1 * sizeof...(Content);
+}
+
+template <auto... V> constexpr size_t calculate_size_of_first(ctre::enumeration<V...>) {
+  return sizeof...(V);
+}
+
+constexpr size_t calculate_size_of_first(...) {
+  return 1;
+}
+
+template <typename... Content> constexpr size_t calculate_size_of_first(ctll::list<Content...>) {
+  return (calculate_size_of_first(Content{}) + ... + 0);
+}
+
+template <typename... Content> constexpr size_t calculate_size_of_first(ctre::set<Content...>) {
+  return (calculate_size_of_first(Content{}) + ... + 0);
+}
+
+template <auto A, typename CB> constexpr int64_t negative_helper(ctre::character<A>, CB & cb, int64_t start) {
+  if (A != std::numeric_limits<int64_t>::min()) {
+    if (start < A) {
+      cb(start, A-1);
+    }
+  }
+  if (A != std::numeric_limits<int64_t>::max()) {
+    return A+1;
+  } else {
+    return A;
+  }
+}
+
+template <auto A, auto B, typename CB> constexpr int64_t negative_helper(ctre::char_range<A,B>, CB & cb, int64_t start) {
+  if (A != std::numeric_limits<int64_t>::min()) {
+    if (start < A) {
+      cb(start, A-1);
+    }
+  }
+  if (B != std::numeric_limits<int64_t>::max()) {
+    return B+1;
+  } else {
+    return B;
+  }
+}
+
+template <auto Head, auto... Tail, typename CB> constexpr int64_t negative_helper(ctre::enumeration<Head, Tail...>, CB & cb, int64_t start) {
+  int64_t nstart = negative_helper(ctre::character<Head>{}, cb, start);
+  return negative_helper(ctre::enumeration<Tail...>{}, cb, nstart);
+}
+
+template <typename CB> constexpr int64_t negative_helper(ctre::enumeration<>, CB &, int64_t start) {
+  return start;
+}
+
+template <typename CB> constexpr int64_t negative_helper(ctre::set<>, CB &, int64_t start) {
+  return start;
+}
+
+template <typename Head, typename... Rest, typename CB> constexpr int64_t negative_helper(ctre::set<Head, Rest...>, CB & cb, int64_t start) {
+  start = negative_helper(Head{}, cb, start);
+  return negative_helper(ctre::set<Rest...>{}, cb, start);
+}
+
+template <typename Head, typename... Rest, typename CB> constexpr void negative_helper(ctre::negative_set<Head, Rest...>, CB && cb, int64_t start = std::numeric_limits<int64_t>::min()) {
+  start = negative_helper(Head{}, cb, start);
+  negative_helper(ctre::negative_set<Rest...>{}, std::forward<CB>(cb), start);
+}
+
+template <typename CB> constexpr void negative_helper(ctre::negative_set<>, CB && cb, int64_t start = std::numeric_limits<int64_t>::min()) {
+  if (start < std::numeric_limits<int64_t>::max()) {
+    cb(start, std::numeric_limits<int64_t>::max());
+  }
+}
+
+// simple fixed set
+// TODO: this needs some optimizations
+template <size_t Capacity> class point_set {
+  struct point {
+    int64_t low{};
+    int64_t high{};
+    constexpr bool operator<(const point & rhs) const {
+      return low < rhs.low;
+    }
+    constexpr point() { }
+    constexpr point(int64_t l, int64_t h): low{l}, high{h} { }
+  };
+  point points[Capacity+1]{};
+  size_t used{0};
+  constexpr point * begin() {
+    return points;
+  }
+  constexpr point * begin() const {
+    return points;
+  }
+  constexpr point * end() {
+    return points + used;
+  }
+  constexpr point * end() const {
+    return points + used;
+  }
+  constexpr point * lower_bound(point obj) {
+    auto first = begin();
+    auto last = end();
+    auto it = first;
+    size_t count = std::distance(first, last);
+    while (count > 0) {
+      it = first;
+      size_t step = count / 2;
+      std::advance(it, step);
+      if (*it < obj) {
+        first = ++it;
+        count -= step + 1;
+      } else {
+        count = step;
+      }
+    }
+    return it;
+  }
+  constexpr point * insert_point(int64_t position, int64_t other) {
+    point obj{position, other};
+    auto it = lower_bound(obj);
+    if (it == end()) {
+      *it = obj;
+      used++;
+      return it;
+    } else {
+      auto out = it;
+      auto e = end();
+      while (it != e) {
+        auto tmp = *it;
+        *it = obj;
+        obj = tmp;
+        //std::swap(*it, obj);
+        it++;
+      }
+      auto tmp = *it;
+      *it = obj;
+      obj = tmp;
+      //std::swap(*it, obj);
+
+      used++;
+      return out;
+    }
+  }
+public:
+  constexpr point_set() { }
+  constexpr void insert(int64_t low, int64_t high) {
+    insert_point(low, high);
+    //insert_point(high, low);
+  }
+  constexpr bool check(int64_t low, int64_t high) {
+    for (auto r: *this) {
+      if (r.low <= low && low <= r.high) {
+        return true;
+      } else if (r.low <= high && high <= r.high) {
+        return true;
+      } else if (low <= r.low && r.low <= high) {
+        return true;
+      } else if (low <= r.high && r.high <= high) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  template <auto V> constexpr bool check(ctre::character<V>) {
+    return check(V,V);
+  }
+  template <auto A, auto B> constexpr bool check(ctre::char_range<A,B>) {
+    return check(A,B);
+  }
+  constexpr bool check(can_be_anything) {
+    return used > 0;
+  }
+  template <typename... Content> constexpr bool check(ctre::negative_set<Content...> nset) {
+    bool collision = false;
+    negative_helper(nset, [&](int64_t low, int64_t high){
+      collision |= this->check(low, high);
+    });
+    return collision;
+  }
+  template <auto... V> constexpr bool check(ctre::enumeration<V...>) {
+
+    return (check(V,V) || ... || false);
+  }
+  template <typename... Content> constexpr bool check(ctll::list<Content...>) {
+    return (check(Content{}) || ... || false);
+  }
+  template <typename... Content> constexpr bool check(ctre::set<Content...>) {
+    return (check(Content{}) || ... || false);
+  }
+
+
+  template <auto V> constexpr void populate(ctre::character<V>) {
+    insert(V,V);
+  }
+  template <auto A, auto B> constexpr void populate(ctre::char_range<A,B>) {
+    insert(A,B);
+  }
+  constexpr void populate(can_be_anything) {
+    insert(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+  }
+  template <typename... Content> constexpr void populate(ctre::negative_set<Content...> nset) {
+    negative_helper(nset, [&](int64_t low, int64_t high){
+      this->insert(low, high);
+    });
+  }
+  template <typename... Content> constexpr void populate(ctre::set<Content...>) {
+    (populate(Content{}), ...);
+  }
+  template <typename... Content> constexpr void populate(ctll::list<Content...>) {
+    (populate(Content{}), ...);
+  }
+};
+
+template <typename... A, typename... B> constexpr bool collides(ctll::list<A...> rhs, ctll::list<B...> lhs) {
+  constexpr size_t capacity = calculate_size_of_first(rhs);
+
+  point_set<capacity> set;
+  set.populate(rhs);
+
+  return set.check(lhs);
+}
+
+}
+
+#endif
+
+// remove me when MSVC fix the constexpr bug
+#ifdef _MSC_VER
+#ifndef CTRE_MSVC_GREEDY_WORKAROUND
+#define CTRE_MSVC_GREEDY_WORKAROUND
+#endif
+#endif
+
+namespace ctre {
+
+// calling with pattern prepare stack and triplet of iterators
+template <typename Iterator, typename EndIterator, typename Pattern>
+constexpr inline auto match_re(const Iterator begin, const EndIterator end, Pattern pattern) noexcept {
+  using return_type = decltype(regex_results(std::declval<Iterator>(), find_captures(pattern)));
+  return evaluate(begin, begin, end, return_type{}, ctll::list<start_mark, Pattern, assert_end, end_mark, accept>());
+}
+
+template <typename Iterator, typename EndIterator, typename Pattern>
+constexpr inline auto search_re(const Iterator begin, const EndIterator end, Pattern pattern) noexcept {
+  using return_type = decltype(regex_results(std::declval<Iterator>(), find_captures(pattern)));
+
+  auto it = begin;
+  for (; end != it; ++it) {
+    if (auto out = evaluate(begin, it, end, return_type{}, ctll::list<start_mark, Pattern, end_mark, accept>())) {
+      return out;
+    }
+  }
+
+  // in case the RE is empty
+  return evaluate(begin, it, end, return_type{}, ctll::list<start_mark, Pattern, end_mark, accept>());
+}
+
+// sink for making the errors shorter
+template <typename R, typename Iterator, typename EndIterator>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R, ...) noexcept {
+  return R{};
+}
+
+// if we found "accept" object on stack => ACCEPT
+template <typename R, typename Iterator, typename EndIterator>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R captures, ctll::list<accept>) noexcept {
+  return captures.matched();
+}
+
+// if we found "reject" object on stack => REJECT
+template <typename R, typename... Rest, typename Iterator, typename EndIterator>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R, ctll::list<reject, Rest...>) noexcept {
+  return R{}; // just return not matched return type
+}
+
+// mark start of outer capture
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<start_mark, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures.set_start_mark(current), ctll::list<Tail...>());
+}
+
+// mark end of outer capture
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<end_mark, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures.set_end_mark(current), ctll::list<Tail...>());
+}
+
+// mark end of cycle
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator current, const EndIterator, R captures, ctll::list<end_cycle_mark>) noexcept {
+  return captures.set_end_mark(current).matched();
+}
+
+// matching everything which behave as a one character matcher
+
+template <typename R, typename Iterator, typename EndIterator, typename CharacterLike, typename... Tail, typename = std::enable_if_t<(MatchesCharacter<CharacterLike>::template value<decltype(*std::declval<Iterator>())>)>>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<CharacterLike, Tail...>) noexcept {
+  if (end == current) return not_matched;
+  if (!CharacterLike::match_char(*current)) return not_matched;
+  return evaluate(begin, current+1, end, captures, ctll::list<Tail...>());
+}
+
+// matching strings in patterns
+
+template <typename Iterator> struct string_match_result {
+  Iterator current;
+  bool match;
+};
+
+template <auto Head, auto... String, typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> evaluate_match_string(Iterator current, const EndIterator end) noexcept {
+  if ((end != current) && (Head == *current)) {
+    if constexpr (sizeof...(String) > 0) {
+      return evaluate_match_string<String...>(++current, end);
+    } else {
+      return {++current, true};
+    }
+  } else {
+    return {++current, false}; // not needed but will optimize
+  }
+}
+
+template <typename R, typename Iterator, typename EndIterator, auto... String, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<string<String...>, Tail...>) noexcept {
+  if constexpr (sizeof...(String) == 0) {
+    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+  } else if (auto tmp = evaluate_match_string<String...>(current, end); tmp.match) {
+    return evaluate(begin, tmp.current, end, captures, ctll::list<Tail...>());
+  } else {
+    return not_matched;
+  }
+}
+
+// matching select in patterns
+template <typename R, typename Iterator, typename EndIterator, typename HeadOptions, typename... TailOptions, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<select<HeadOptions, TailOptions...>, Tail...>) noexcept {
+  if (auto r = evaluate(begin, current, end, captures, ctll::list<HeadOptions, Tail...>())) {
+    return r;
+  } else {
+    return evaluate(begin, current, end, captures, ctll::list<select<TailOptions...>, Tail...>());
+  }
+}
+
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R, ctll::list<select<>, Tail...>) noexcept {
+  // no previous option was matched => REJECT
+  return not_matched;
+}
+
+// matching optional in patterns
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<optional<Content...>, Tail...>) noexcept {
+  if (auto r1 = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, Tail...>())) {
+    return r1;
+  } else if (auto r2 = evaluate(begin, current, end, captures, ctll::list<Tail...>())) {
+    return r2;
+  } else {
+    return not_matched;
+  }
+}
+
+// lazy optional
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_optional<Content...>, Tail...>) noexcept {
+  if (auto r1 = evaluate(begin, current, end, captures, ctll::list<Tail...>())) {
+    return r1;
+  } else if (auto r2 = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, Tail...>())) {
+    return r2;
+  } else {
+    return not_matched;
+  }
+}
+
+// matching sequence in patterns
+template <typename R, typename Iterator, typename EndIterator, typename HeadContent, typename... TailContent, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<sequence<HeadContent, TailContent...>, Tail...>) noexcept {
+  if constexpr (sizeof...(TailContent) > 0) {
+    return evaluate(begin, current, end, captures, ctll::list<HeadContent, sequence<TailContent...>, Tail...>());
+  } else {
+    return evaluate(begin, current, end, captures, ctll::list<HeadContent, Tail...>());
+  }
+}
+
+// matching empty in patterns
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<empty, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+}
+
+// matching asserts
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<assert_begin, Tail...>) noexcept {
+  if (begin != current) {
+    return not_matched;
+  }
+  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+}
+
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<assert_end, Tail...>) noexcept {
+  if (end != current) {
+    return not_matched;
+  }
+  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+}
+
+// lazy repeat
+template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_repeat<A,B,Content...>, Tail...>) noexcept {
+  // A..B
+  size_t i{0};
+  for (; i < A && (A != 0); ++i) {
+    if (auto outer_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
+      captures = outer_result.unmatch();
+      current = outer_result.get_end_position();
+    } else {
+      return not_matched;
+    }
+  }
+
+  if (auto outer_result = evaluate(begin, current, end, captures, ctll::list<Tail...>())) {
+    return outer_result;
+  } else {
+    for (; (i < B) || (B == 0); ++i) {
+      if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
+        if (auto outer_result = evaluate(begin, inner_result.get_end_position(), end, inner_result.unmatch(), ctll::list<Tail...>())) {
+          return outer_result;
+        } else {
+          captures = inner_result.unmatch();
+          current = inner_result.get_end_position();
+          continue;
+        }
+      } else {
+        return not_matched;
+      }
+    }
+    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+  }
+}
+
+// possessive repeat
+template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<possessive_repeat<A,B,Content...>, Tail...>) noexcept {
+
+  for (size_t i{0}; (i < B) || (B == 0); ++i) {
+    // try as many of inner as possible and then try outer once
+    if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
+      captures = inner_result.unmatch();
+      current = inner_result.get_end_position();
+    } else {
+      if (i < A && (A != 0)) return not_matched;
+      else return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+    }
+  }
+
+  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+}
+
+// (gready) repeat
+template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
+#ifdef CTRE_MSVC_GREEDY_WORKAROUND
+constexpr inline void evaluate_recursive(R & result, size_t i, const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<repeat<A,B,Content...>, Tail...> stack) {
+#else
+constexpr inline R evaluate_recursive(size_t i, const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<repeat<A,B,Content...>, Tail...> stack) {
+#endif
+  if ((B == 0) || (i < B)) {
+
+    // a*ab
+    // aab
+
+    if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
+      // TODO MSVC issue:
+      // if I uncomment this return it will not fail in constexpr (but the matching result will not be correct)
+      //  return inner_result
+      // I tried to add all constructors to R but without any success
+#ifdef CTRE_MSVC_GREEDY_WORKAROUND
+      evaluate_recursive(result, i+1, begin, inner_result.get_end_position(), end, inner_result.unmatch(), stack);
+			if (result) {
+				return;
+			}
+#else
+      if (auto rec_result = evaluate_recursive(i+1, begin, inner_result.get_end_position(), end, inner_result.unmatch(), stack)) {
+        return rec_result;
+      }
+#endif
+    }
+  }
+#ifdef CTRE_MSVC_GREEDY_WORKAROUND
+  result = evaluate(begin, current, end, captures, ctll::list<Tail...>());
+#else
+  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+#endif
+}
+
+// (gready) repeat optimization
+// basic one, if you are at the end of RE, just change it into possessive
+// TODO do the same if there is no collision with rest of the RE
+template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<repeat<A,B,Content...>,assert_end, Tail...>) {
+  return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<A,B,Content...>, assert_end, Tail...>());
+}
+
+template <typename... T> struct identify_type;
+
+// (greedy) repeat
+template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, [[maybe_unused]] ctll::list<repeat<A,B,Content...>, Tail...> stack) {
+  // check if it can be optimized
+#ifndef CTRE_DISABLE_GREEDY_OPT
+  if constexpr (collides(calculate_first(Content{}...), calculate_first(Tail{}...))) {
+#endif
+    // A..B
+    size_t i{0};
+    for (; i < A && (A != 0); ++i) {
+      if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
+        captures = inner_result.unmatch();
+        current = inner_result.get_end_position();
+      } else {
+        return not_matched;
+      }
+    }
+#ifdef CTRE_MSVC_GREEDY_WORKAROUND
+    R result;
+		evaluate_recursive(result, i, begin, current, end, captures, stack);
+		return result;
+#else
+    return evaluate_recursive(i, begin, current, end, captures, stack);
+#endif
+#ifndef CTRE_DISABLE_GREEDY_OPT
+  } else {
+    // if there is no collision we can go possessive
+    return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<A,B,Content...>, Tail...>());
+  }
+#endif
+
+}
+
+// repeat lazy_star
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_star<Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<lazy_repeat<0,0,Content...>, Tail...>());
+}
+
+// repeat (lazy_plus)
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_plus<Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<lazy_repeat<1,0,Content...>, Tail...>());
+}
+
+// repeat (possessive_star)
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<possessive_star<Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<0,0,Content...>, Tail...>());
+}
+
+// repeat (possessive_plus)
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<possessive_plus<Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<1,0,Content...>, Tail...>());
+}
+
+// repeat (greedy) star
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<star<Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<repeat<0,0,Content...>, Tail...>());
+}
+
+// repeat (greedy) plus
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<plus<Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures, ctll::list<repeat<1,0,Content...>, Tail...>());
+}
+
+// capture (numeric ID)
+template <typename R, typename Iterator, typename EndIterator, size_t Id, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<capture<Id, Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures.template start_capture<Id>(current), ctll::list<sequence<Content...>, numeric_mark<Id>, Tail...>());
+}
+
+// capture end mark (numeric and string ID)
+template <typename R, typename Iterator, typename EndIterator, size_t Id, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<numeric_mark<Id>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures.template end_capture<Id>(current), ctll::list<Tail...>());
+}
+
+// capture (string ID)
+template <typename R, typename Iterator, typename EndIterator, size_t Id, typename Name, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<capture_with_name<Id, Name, Content...>, Tail...>) noexcept {
+  return evaluate(begin, current, end, captures.template start_capture<Id>(current), ctll::list<sequence<Content...>, numeric_mark<Id>, Tail...>());
+}
+
+// backreference support (match agains content of iterators)
+template <typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> match_against_range(Iterator current, const EndIterator end, Iterator range_current, const Iterator range_end) noexcept {
+  while (end != current && range_end != range_current) {
+    if (*current == *range_current) {
+      current++;
+      range_current++;
+    } else {
+      return {current, false};
+    }
+  }
+  return {current, range_current == range_end};
+}
+
+// backreference with name
+template <typename R, typename Id, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<back_reference_with_name<Id>, Tail...>) noexcept {
+
+  if (const auto ref = captures.template get<Id>()) {
+    if (auto tmp = match_against_range(current, end, ref.begin(), ref.end()); tmp.match) {
+      return evaluate(begin, tmp.current, end, captures, ctll::list<Tail...>());
+    }
+  }
+  return not_matched;
+}
+
+// backreference
+template <typename R, size_t Id, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<back_reference<Id>, Tail...>) noexcept {
+
+  if (const auto ref = captures.template get<Id>()) {
+    if (auto tmp = match_against_range(current, end, ref.begin(), ref.end()); tmp.match) {
+      return evaluate(begin, tmp.current, end, captures, ctll::list<Tail...>());
+    }
+  }
+  return not_matched;
+}
+
+// end of lookahead
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R captures, ctll::list<end_lookahead_mark>) noexcept {
+  return captures.matched();
+}
+
+// lookahead positive
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lookahead_positive<Content...>, Tail...>) noexcept {
+
+  if (auto lookahead_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_lookahead_mark>())) {
+    captures = lookahead_result.unmatch();
+    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+  } else {
+    return not_matched;
+  }
+}
+
+// lookahead negative
+template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lookahead_negative<Content...>, Tail...>) noexcept {
+
+  if (auto lookahead_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_lookahead_mark>())) {
+    return not_matched;
+  } else {
+    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+  }
+}
+
+// property matching
+
+}
+
+#endif
+
+#ifndef CTRE__WRAPPER__HPP
+#define CTRE__WRAPPER__HPP
+
+#include <string_view>
+#include <string>
+
+namespace ctre {
+
+struct zero_terminated_string_end_iterator {
+  constexpr inline zero_terminated_string_end_iterator() = default;
+  constexpr CTRE_FORCE_INLINE bool operator==(const char * ptr) const noexcept {
+    return *ptr == '\0';
+  }
+  constexpr CTRE_FORCE_INLINE bool operator==(const wchar_t * ptr) const noexcept {
+    return *ptr == 0;
+  }
+  constexpr CTRE_FORCE_INLINE bool operator!=(const char * ptr) const noexcept {
+    return *ptr != '\0';
+  }
+  constexpr CTRE_FORCE_INLINE bool operator!=(const wchar_t * ptr) const noexcept {
+    return *ptr != 0;
+  }
+};
+
+template <typename T> class RangeLikeType {
+  template <typename Y> static auto test(Y *) -> decltype(std::declval<const Y &>().begin(), std::declval<const Y &>().end(), std::true_type());
+  template <typename> static auto test(...) -> std::false_type;
+public:
+  static inline constexpr bool value = decltype(test<std::remove_reference_t<std::remove_const_t<T>>>( nullptr ))::value;
+};
+
+template <typename RE> struct regular_expression {
+  template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto match_2(IteratorBegin begin, IteratorEnd end) noexcept {
+    return match_re(begin, end, RE());
+  }
+  template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto search_2(IteratorBegin begin, IteratorEnd end) noexcept {
+    return search_re(begin, end, RE());
+  }
+  constexpr CTRE_FORCE_INLINE regular_expression() noexcept { }
+  constexpr CTRE_FORCE_INLINE regular_expression(RE) noexcept { }
+  template <typename Iterator> constexpr CTRE_FORCE_INLINE static auto match(Iterator begin, Iterator end) noexcept {
+    return match_re(begin, end, RE());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(const char * s) noexcept {
+    return match_2(s, zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(const wchar_t * s) noexcept {
+    return match_2(s, zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(const std::string & s) noexcept {
+    return match_2(s.c_str(), zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(const std::wstring & s) noexcept {
+    return match_2(s.c_str(), zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(std::string_view sv) noexcept {
+    return match(sv.begin(), sv.end());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(std::wstring_view sv) noexcept {
+    return match(sv.begin(), sv.end());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(std::u16string_view sv) noexcept {
+    return match(sv.begin(), sv.end());
+  }
+  static constexpr CTRE_FORCE_INLINE auto match(std::u32string_view sv) noexcept {
+    return match(sv.begin(), sv.end());
+  }
+  template <typename Range, typename = typename std::enable_if<RangeLikeType<Range>::value>::type> static constexpr CTRE_FORCE_INLINE auto match(Range && range) noexcept {
+    return match(std::begin(range), std::end(range));
+  }
+  template <typename Iterator> constexpr CTRE_FORCE_INLINE static auto search(Iterator begin, Iterator end) noexcept {
+    return search_re(begin, end, RE());
+  }
+  constexpr CTRE_FORCE_INLINE static auto search(const char * s) noexcept {
+    return search_2(s, zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(const wchar_t * s) noexcept {
+    return search_2(s, zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(const std::string & s) noexcept {
+    return search_2(s.c_str(), zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(const std::wstring & s) noexcept {
+    return search_2(s.c_str(), zero_terminated_string_end_iterator());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(std::string_view sv) noexcept {
+    return search(sv.begin(), sv.end());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(std::wstring_view sv) noexcept {
+    return search(sv.begin(), sv.end());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(std::u16string_view sv) noexcept {
+    return search(sv.begin(), sv.end());
+  }
+  static constexpr CTRE_FORCE_INLINE auto search(std::u32string_view sv) noexcept {
+    return search(sv.begin(), sv.end());
+  }
+  template <typename Range> static constexpr CTRE_FORCE_INLINE auto search(Range && range) noexcept {
+    return search(std::begin(range), std::end(range));
+  }
+};
+
+template <typename RE> regular_expression(RE) -> regular_expression<RE>;
+
+}
+
+#endif
+
+#ifndef __EDG__
+
+namespace ctre {
+
+// in C++17 (clang & gcc with gnu extension) we need translate character pack into ctll::fixed_string
+// in C++20 we have `class nontype template parameters`
+
+#if !__cpp_nontype_template_parameter_class
+template <typename CharT, CharT... input> static inline constexpr auto _fixed_string_reference = ctll::fixed_string< sizeof...(input)>({input...});
+#endif
+
+namespace literals {
+
+// clang and GCC <9 supports LITERALS with packs
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-string-literal-operator-template"
+#define CTRE_ENABLE_LITERALS
+#endif
+
+#ifdef __INTEL_COMPILER
+// not enable literals
+#elif defined __GNUC__
+#if not(__GNUC__ == 9)
+#define CTRE_ENABLE_LITERALS
+#endif
+#endif
+
+#ifdef CTRE_ENABLE_LITERALS
+
+// add this when we will have concepts
+// requires ctll::parser<ctre::pcre, _fixed_string_reference<CharT, charpack...>, ctre::pcre_actions>::template correct_with<pcre_context<>>
+
+#if !__cpp_nontype_template_parameter_class
+template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre() noexcept {
+  constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+#else
+  template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre() noexcept {
+	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+#endif
+  using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+  static_assert(tmp(), "Regular Expression contains syntax error.");
+  if constexpr (tmp()) {
+    using re = decltype(front(typename tmp::output_type::stack_type()));
+    return ctre::regular_expression(re());
+  } else {
+    return ctre::regular_expression(reject());
+  }
+}
+
+// this will need to be fixed with C++20
+#if !__cpp_nontype_template_parameter_class
+template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre_id() noexcept {
+  return id<charpack...>();
+}
+#endif
+
+#endif // CTRE_ENABLE_LITERALS
+
+}
+
+namespace test_literals {
+
+#ifdef CTRE_ENABLE_LITERALS
+
+#if !__cpp_nontype_template_parameter_class
+template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr inline auto operator""_ctre_test() noexcept {
+  constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+#else
+  template <ctll::fixed_string input> CTRE_FLATTEN constexpr inline auto operator""_ctre_test() noexcept {
+	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+#endif
+  return ctll::parser<ctre::pcre, _input>::template correct_with<>;
+}
+
+#if !__cpp_nontype_template_parameter_class
+template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr inline auto operator""_ctre_gen() noexcept {
+  constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+#else
+  template <ctll::fixed_string input> CTRE_FLATTEN constexpr inline auto operator""_ctre_gen() noexcept {
+	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+#endif
+  using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+  static_assert(tmp(), "Regular Expression contains syntax error.");
+  return typename tmp::output_type::stack_type();
+}
+
+#if !__cpp_nontype_template_parameter_class
+template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre_syntax() noexcept {
+  constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+#else
+  template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre_syntax() noexcept {
+	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+#endif
+  return ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template correct_with<pcre_context<>>;
+}
+
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+} // literals
+
+} // ctre
+
+#endif
+
+#endif
+
+#ifndef CTRE_V2__CTRE__FUNCTIONS__HPP
+#define CTRE_V2__CTRE__FUNCTIONS__HPP
+
+namespace ctre {
+
+#if !__cpp_nontype_template_parameter_class
+// avoiding CTAD limitation in C++17
+template <typename CharT, size_t N> class pattern: public ctll::fixed_string<N> {
+  using parent = ctll::fixed_string<N>;
+public:
+  constexpr pattern(const CharT (&input)[N]) noexcept: parent(input) { }
+};
+
+template <typename CharT, size_t N> pattern(const CharT (&)[N]) -> pattern<CharT, N>;
+
+// for better examples
+template <typename CharT, size_t N> class fixed_string: public ctll::fixed_string<N> {
+  using parent = ctll::fixed_string<N>;
+public:
+  constexpr fixed_string(const CharT (&input)[N]) noexcept: parent(input) { }
+};
+
+template <typename CharT, size_t N> fixed_string(const CharT (&)[N]) -> fixed_string<CharT, N>;
+#endif
+
+#if __cpp_nontype_template_parameter_class
+template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto re() noexcept {
+constexpr auto _input = input; // workaround for GCC 9 bug 88092
+#else
+template <auto & input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto re() noexcept {
+  constexpr auto & _input = input;
+#endif
+
+  using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+  static_assert(tmp(), "Regular Expression contains syntax error.");
+  using re = decltype(front(typename tmp::output_type::stack_type()));
+  return ctre::regular_expression(re());
+}
+
+// in moment when we get C++20 support this will start to work :)
+
+template <typename RE> struct regex_match_t {
+  template <typename... Args> CTRE_FORCE_INLINE constexpr auto operator()(Args && ... args) const noexcept {
+    auto re_obj = ctre::regular_expression<RE>();
+    return re_obj.match(std::forward<Args>(args)...);
+  }
+  template <typename... Args> CTRE_FORCE_INLINE constexpr auto try_extract(Args && ... args) const noexcept {
+    return operator()(std::forward<Args>(args)...);
+  }
+};
+
+template <typename RE> struct regex_search_t {
+  template <typename... Args> CTRE_FORCE_INLINE constexpr auto operator()(Args && ... args) const noexcept {
+    auto re_obj = ctre::regular_expression<RE>();
+    return re_obj.search(std::forward<Args>(args)...);
+  }
+  template <typename... Args> CTRE_FORCE_INLINE constexpr auto try_extract(Args && ... args) const noexcept {
+    return operator()(std::forward<Args>(args)...);
+  }
+};
+
+#if __cpp_nontype_template_parameter_class
+
+template <auto input> struct regex_builder {
+	static constexpr auto _input = input;
+	using _tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+	static_assert(_tmp(), "Regular Expression contains syntax error.");
+	using type = ctll::conditional<(bool)(_tmp()), decltype(ctll::front(typename _tmp::output_type::stack_type())), ctll::list<reject>>;
+};
+
+template <ctll::fixed_string input> static constexpr inline auto match = regex_match_t<typename regex_builder<input>::type>();
+
+template <ctll::fixed_string input> static constexpr inline auto search = regex_search_t<typename regex_builder<input>::type>();
+
+#else
+
+template <auto & input> struct regex_builder {
+  using _tmp = typename ctll::parser<ctre::pcre, input, ctre::pcre_actions>::template output<pcre_context<>>;
+  static_assert(_tmp(), "Regular Expression contains syntax error.");
+  using type = ctll::conditional<(bool)(_tmp()), decltype(ctll::front(typename _tmp::output_type::stack_type())), ctll::list<reject>>;
+};
+
+template <auto & input> static constexpr inline auto match = regex_match_t<typename regex_builder<input>::type>();
+
+template <auto & input> static constexpr inline auto search = regex_search_t<typename regex_builder<input>::type>();
+
+#endif
+
+}
+
+#endif
+
+#ifndef CTRE_V2__CTRE__ITERATOR__HPP
+#define CTRE_V2__CTRE__ITERATOR__HPP
+
+namespace ctre {
+
+struct regex_end_iterator {
+  constexpr regex_end_iterator() noexcept { }
+};
+
+template <typename BeginIterator, typename EndIterator, typename RE> struct regex_iterator {
+  BeginIterator current;
+  const EndIterator end;
+  decltype(RE::search_2(std::declval<BeginIterator>(), std::declval<EndIterator>())) current_match;
+
+  constexpr regex_iterator(BeginIterator begin, EndIterator end) noexcept: current{begin}, end{end}, current_match{RE::search_2(current, end)} {
+    if (current_match) {
+      current = current_match.template get<0>().end();
+    }
+  }
+  constexpr const auto & operator*() const noexcept {
+    return current_match;
+  }
+  constexpr regex_iterator & operator++() noexcept {
+    current_match = RE::search_2(current, end);
+    if (current_match) {
+      current = current_match.template get<0>().end();
+    }
+    return *this;
+  }
+  constexpr regex_iterator operator++(int) noexcept {
+    auto previous = *this;
+    current_match = RE::search_2(current, end);
+    if (current_match) {
+      current = current_match.template get<0>().end();
+    }
+    return previous;
+  }
+};
+
+template <typename BeginIterator, typename EndIterator, typename RE> constexpr bool operator!=(const regex_iterator<BeginIterator, EndIterator, RE> & left, regex_end_iterator) {
+  return bool(left.current_match);
+}
+
+template <typename BeginIterator, typename EndIterator, typename RE> constexpr bool operator!=(regex_end_iterator, const regex_iterator<BeginIterator, EndIterator, RE> & right) {
+  return bool(right.current_match);
+}
+
+template <typename BeginIterator, typename EndIterator, typename RE> constexpr auto iterator(BeginIterator begin, EndIterator end, RE) noexcept {
+  return regex_iterator<BeginIterator, EndIterator, RE>(begin, end);
+}
+
+constexpr auto iterator() noexcept {
+  return regex_end_iterator{};
+}
+
+template <typename Subject, typename RE> constexpr auto iterator(const Subject & subject, RE re) noexcept {
+  return iterator(subject.begin(), subject.end(), re);
+}
+
+#if __cpp_nontype_template_parameter_class
+template <ctll::fixed_string input, typename BeginIterator, typename EndIterator> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto iterator(BeginIterator begin, EndIterator end) noexcept {
+	constexpr auto _input = input;
+	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+	static_assert(tmp(), "Regular Expression contains syntax error.");
+	using re = decltype(front(typename tmp::output_type::stack_type()));
+	return iterator(begin, end, re());
+}
+#endif
+
+#if __cpp_nontype_template_parameter_class
+template <ctll::fixed_string input, typename Subject> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto iterator(const Subject & subject) noexcept {
+	constexpr auto _input = input;
+	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+	static_assert(tmp(), "Regular Expression contains syntax error.");
+	using re = decltype(front(typename tmp::output_type::stack_type()));
+	return iterator(subject.begin(), subject.end(), re());
+}
+#endif
+
+} // ctre
+
+#endif
+
+#ifndef CTRE_V2__CTRE__RANGE__HPP
+#define CTRE_V2__CTRE__RANGE__HPP
+
+namespace ctre {
+
+template <typename BeginIterator, typename EndIterator, typename RE> struct regex_range {
+  BeginIterator _begin;
+  const EndIterator _end;
+  constexpr regex_range(BeginIterator begin, EndIterator end) noexcept: _begin{begin}, _end{end} { }
+
+  constexpr auto begin() const noexcept {
+    return regex_iterator<BeginIterator, EndIterator, RE>(_begin, _end);
+  }
+  constexpr auto end() const noexcept {
+    return regex_end_iterator{};
+  }
+};
+
+template <typename BeginIterator, typename EndIterator, typename RE> constexpr auto range(BeginIterator begin, EndIterator end, RE) noexcept {
+  return regex_range<BeginIterator, EndIterator, RE>(begin, end);
+}
+
+#if __cpp_nontype_template_parameter_class
+template <ctll::fixed_string input, typename BeginIterator, typename EndIterator> constexpr auto range(BeginIterator begin, EndIterator end) noexcept {
+	constexpr auto _input = input;
+	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+	static_assert(tmp(), "Regular Expression contains syntax error.");
+	using re = decltype(front(typename tmp::output_type::stack_type()));
+	auto re_obj = ctre::regular_expression(re());
+	return range(begin, end, re_obj);
+}
+#endif
+
+template <typename Subject, typename RE> constexpr auto range(const Subject & subject, RE re) noexcept {
+  return range(subject.begin(), subject.end(), re);
+}
+
+template <typename RE> constexpr auto range(const char * subject, RE re) noexcept {
+  return range(subject, zero_terminated_string_end_iterator(), re);
+}
+
+#if __cpp_nontype_template_parameter_class
+template <ctll::fixed_string input, typename Subject> constexpr auto range(const Subject & subject) noexcept {
+	constexpr auto _input = input;
+	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+	static_assert(tmp(), "Regular Expression contains syntax error.");
+	using re = decltype(front(typename tmp::output_type::stack_type()));
+	auto re_obj = ctre::regular_expression(re());
+	return range(subject.begin(), subject.end(), re_obj);
+}
+#else
+template <auto & input, typename Subject> constexpr auto range(const Subject & subject) noexcept {
+  constexpr auto & _input = input;
+  using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+  static_assert(tmp(), "Regular Expression contains syntax error.");
+  using re = decltype(front(typename tmp::output_type::stack_type()));
+  auto re_obj = ctre::regular_expression(re());
+  return range(subject.begin(), subject.end(), re_obj);
+}
+#endif
+
+}
+
+#endif
+
+#ifndef CTRE_V2__CTRE__OPERATORS__HPP
+#define CTRE_V2__CTRE__OPERATORS__HPP
+
+template <typename A, typename B> constexpr auto operator|(ctre::regular_expression<A>, ctre::regular_expression<B>) -> ctre::regular_expression<ctre::select<A,B>> {
+  return {};
+}
+
+template <typename A, typename B> constexpr auto operator>>(ctre::regular_expression<A>, ctre::regular_expression<B>) -> ctre::regular_expression<ctre::sequence<A,B>> {
+  return {};
+}
+
+#endif
+
+#endif

--- a/wikidata_settings.json
+++ b/wikidata_settings.json
@@ -10,8 +10,6 @@
 	  "country": "US",
 	  "ignore-punctuation": true
   },
-  "ascii-prefixes-only":true
-
-  },
+  "ascii-prefixes-only":true,
   "num-triples-per-partial-vocab" : 50000000
 }

--- a/wikidata_settings.json
+++ b/wikidata_settings.json
@@ -10,5 +10,8 @@
 	  "country": "US",
 	  "ignore-punctuation": true
   },
+  "ascii-prefixes-only":true
+
+  },
   "num-triples-per-partial-vocab" : 50000000
 }


### PR DESCRIPTION
- Implement An alternative Lexer for the Turtle Parser using Hana Dusikova's Compile-time-regex engine [(https://github.com/hanickadot/compile-time-regular-expressions)]

- This alternative Tokenizer currently increases the Parsing speed by 25% and seems to be required to    actually speed up the Index Building pipeline.

- Currently it only alllows Ascii characters in prefixes or blankNodeLabels. This suffices to handle the Wikidata dumps, but is stricter than the actual sparql standard. This is due to the fact, that the ctre library does not properly support UTF-8 as of now.

- It is possible to optionally activate this alternative parsing mode in the `settings.json`, which will cause a warning to the user about the restrictions imposed above.