### PR TITLE
Fix broken TSV export

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -183,9 +183,9 @@ void Server::process(Socket* client) {
             "Content-Disposition: attachment;filename=export.csv";
       } else if (ad_utility::getLowercase(params["action"]) == "tsv_export") {
         // TSV export
-        string response = composeResponseSepValues(pq, qet, '\t');
+        response = composeResponseSepValues(pq, qet, '\t');
         contentType =
-            "text/tsv\r\n"
+            "text/tab-separated-values\r\n"
             "Content-Disposition: attachment;filename=export.tsv";
       } else {
         // Normal case: JSON response


### PR DESCRIPTION
Fix broken TSV export
    
1. Fixes a classical bug (string response -> response, so that response from the surrounding context is set instead of a local variable that is never used)
    
2. Corrects media type of the HTTP response: was text/tsv, should be text/tab-separated-values
