### PR TITLE
Add libicu-dev to package requirements in native_setup.md

### DIFF
--- a/docs/native_setup.md
+++ b/docs/native_setup.md
@@ -5,7 +5,7 @@ Arch Linux.
 
 For Ubuntu 18.04 the following packages are required
 
-* build-essential cmake libsparsehash-dev
+* build-essential cmake libsparsehash-dev libicu-dev
 * wget python3-yaml unzip curl (for End-to-End Tests)
 
 This roughly translates to


### PR DESCRIPTION
Following the instructions in [native_setup.md](https://github.com/ad-freiburg/QLever/blob/master/docs/native_setup.md) in a freshly installed `ubuntu 18.04.4 server` vm it is not possible to compile qlever, this PR addresses this issue by adding `libicu-dev` to the list of required packages, the culprit was found by looking in the [Dockerfile](https://github.com/ad-freiburg/QLever/blob/master/Dockerfile#L8).

Issued commands:
```
vm@vm:~/qlever/build$ history
    1  sudo apt install git
    2  sudo apt install build-essential cmake libsparsehash-dev
    3  sudo apt install wget python3-yaml unzip curl
    4  git clone --recursive https://github.com/ad-freiburg/QLever.git qlever
    5  cd qlever
    6  mkdir build && cd build
    7  cmake -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc)
    8  history
```
cmake error:
```
...
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- The following ICU libraries were not found:
--   uc (required)
--   i18n (required)
CMake Error at /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:137 (message):
  Failed to find all ICU components (missing: ICU_INCLUDE_DIR ICU_LIBRARY
  _ICU_REQUIRED_LIBS_FOUND) (Required is at least version "60")
Call Stack (most recent call first):
  /usr/share/cmake-3.10/Modules/FindPackageHandleStandardArgs.cmake:378 (_FPHSA_FAILURE_MESSAGE)
  /usr/share/cmake-3.10/Modules/FindICU.cmake:298 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:32 (find_package)


-- Configuring incomplete, errors occurred!
See also "/home/vm/qlever/build/CMakeFiles/CMakeOutput.log".
See also "/home/vm/qlever/build/CMakeFiles/CMakeError.log".
```
After running `sudo apt install libicu-dev` the build succeeds.
