### PR TITLE
Unify the Sort Keys of the OrderBy and the Sort Operation

### DIFF
--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -32,7 +32,7 @@ string OrderBy::asString(size_t indent) const {
   std::stringstream columns;
   // TODO<joka921> This produces exactly the same format as SORT operations
   // which is crucial for caching. Please refactor those classes to one class
-  // (this is only an optimization for sorts on a single column);
+  // (this is only an optimization for sorts on a single column)
   for (auto ind : _sortIndices) {
     columns << (ind.second ? "desc(" : "asc(") << ind.first << ") ";
   }

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -20,7 +20,7 @@ class OrderBy : public Operation {
  public:
   OrderBy(QueryExecutionContext* qec,
           std::shared_ptr<QueryExecutionTree> subtree,
-          const vector<pair<size_t, bool>>& sortIndices);
+          vector<pair<size_t, bool>> sortIndices);
 
   virtual string asString(size_t indent = 0) const override;
 

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -647,7 +647,8 @@ TEST(QueryPlannerTest, testActorsBornInEurope) {
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with P = \"<pre/profession>\", "
         "O = \"<pre/Actor>\"\n    qet-width: 1 \n  } join-column:"
-        " [0]\n  |X|\n  {\n    SORT on column:1\n    {\n      "
+        " [0]\n  |X|\n  {\n    SORT / ORDER BY on columns:asc(1) \n    {\n     "
+        " "
         "JOIN\n      {\n        SCAN POS with P = \"<pre/born-i"
         "n>\"\n        qet-width: 2 \n      } join-column: [0]\n "
         "     |X|\n      {\n        SCAN POS with P = \"<pre/in>\""
@@ -1070,7 +1071,8 @@ TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
         "\"manhattan project\" and 1 variables with textLimit = 1 filtered "
         "by\n  {\n    JOIN\n    {\n      SCAN POS with P = \"<is-a>\", O = "
         "\"<Scientist>\"\n      qet-width: 1 \n    } join-column: [0]\n    "
-        "|X|\n    {\n      SORT on column:2\n      {\n        TEXT OPERATION "
+        "|X|\n    {\n      SORT / ORDER BY on columns:asc(2) \n      {\n       "
+        " TEXT OPERATION "
         "WITH FILTER: co-occurrence with words: \"friend*\" and 2 variables "
         "with textLimit = 1 filtered by\n        {\n          SCAN POS with P "
         "= \"<is-a>\", O = \"<Politician>\"\n          qet-width: 1 \n        "
@@ -1098,14 +1100,15 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  TWO_COLUMN_JOIN\n    {\n    ORDER_BY\n    {\n      JOIN\n      "
-        "{\n        SCAN POS with P = \"<Film_performance>\"\n        "
-        "qet-width: 2 \n      } join-column: [0]\n      |X|\n      {\n        "
-        "SCAN POS with P = \"<Film_performance>\"\n        qet-width: 2 \n     "
-        " } join-column: [0]\n      qet-width: 3 \n    } order on asc(1) "
-        "asc(2) \n    qet-width: 3 \n  }\n  join-columns: [1 & 2]\n  |X|\n    "
-        "{\n    SCAN POS with P = \"<Spouse_(or_domestic_partner)>\"\n    "
-        "qet-width: 2 \n  }\n  join-columns: [0 & 1]\n  qet-width: 3 \n}",
+        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN POS with P = "
+        "\"<Film_performance>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & "
+        "1]\n  |X|\n    {\n    SORT / ORDER BY on columns:asc(1) asc(2) \n    "
+        "{\n      JOIN\n      {\n        SCAN PSO with P = "
+        "\"<Film_performance>\"\n        qet-width: 2 \n      } join-column: "
+        "[0]\n      |X|\n      {\n        SCAN PSO with P = "
+        "\"<Spouse_(or_domestic_partner)>\"\n        qet-width: 2 \n      } "
+        "join-column: [0]\n      qet-width: 3 \n    }\n    qet-width: 3 \n  "
+        "}\n  join-columns: [1 & 2]\n  qet-width: 3 \n}",
         qet.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
@@ -1158,11 +1161,11 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq.expandPrefixes();
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  OPTIONAL_JOIN\n  {\n    ORDER_BY\n    {\n      SCAN POS with P = "
-        "\"<rel2>\"\n      qet-width: 2 \n    } order on asc(1) \n    "
-        "qet-width: 2 \n  } join-columns: [1]\n  |X|\n  {\n    SCAN PSO with P "
-        "= \"<rel1>\"\n    qet-width: 2 \n  } join-columns: [0]\n  qet-width: "
-        "3 \n}",
+        "{\n  OPTIONAL_JOIN\n  {\n    SCAN PSO with P = \"<rel1>\"\n    "
+        "qet-width: 2 \n  } join-columns: [0]\n  |X|\n  {\n    SORT / ORDER BY "
+        "on columns:asc(1) \n    {\n      SCAN POS with P = \"<rel2>\"\n      "
+        "qet-width: 2 \n    }\n    qet-width: 2 \n  } join-columns: [1]\n  "
+        "qet-width: 3 \n}",
         qet.asString());
 
     ParsedQuery pq2 = SparqlParser(
@@ -1173,12 +1176,12 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq2.expandPrefixes();
     QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
-        "{\n  SORT on column:2\n  {\n    OPTIONAL_JOIN\n    {\n      "
-        "ORDER_BY\n      {\n        SCAN POS with P = \"<rel2>\"\n        "
-        "qet-width: 2 \n      } order on asc(1) \n      qet-width: 2 \n    } "
-        "join-columns: [1]\n    |X|\n    {\n      SCAN PSO with P = "
-        "\"<rel1>\"\n      qet-width: 2 \n    } join-columns: [0]\n    "
-        "qet-width: 3 \n  }\n  qet-width: 3 \n}"
+        "{\n  SORT / ORDER BY on columns:asc(1) \n  {\n    OPTIONAL_JOIN\n    "
+        "{\n      SCAN PSO with P = \"<rel1>\"\n      qet-width: 2 \n    } "
+        "join-columns: [0]\n    |X|\n    {\n      SORT / ORDER BY on "
+        "columns:asc(1) \n      {\n        SCAN POS with P = \"<rel2>\"\n      "
+        "  qet-width: 2 \n      }\n      qet-width: 2 \n    } join-columns: "
+        "[1]\n    qet-width: 3 \n  }\n  qet-width: 3 \n}"
 
         ,
         qet2.asString());


### PR DESCRIPTION
- The Sort Operation is an optimized version of an ascending OrderBy on a single column.
- Previously their cache key representation was different which prevented a `Sort` to be reused from   the cache when an `OrderBy` on exactly the same column was requested.
- This PR makes the cache key format of those two classes identical which allows more efficient
   cache pinning for the autocompletion feature.
-  In a future PR, those classes should be refactored since they share a lot of common code, e.g.
   `OrderBy<MultiColumns>` and `OrderBy<SingleColumn>`
