### PR TITLE
Treat GraphPatterns in Query Bodies more correctly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,17 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 endif()
 
+## Build targets for address sanitizer
+# AddressSanitize
+set(CMAKE_C_FLAGS_ASAN
+        "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
+        CACHE STRING "Flags used by the C compiler during AddressSanitizer builds."
+        FORCE)
+set(CMAKE_CXX_FLAGS_ASAN
+        "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
+        CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds."
+        FORCE)
+
 ###############################################################################
 ##### Essential settings #####
 ###############################################################################
@@ -124,6 +135,7 @@ message(STATUS "CXX_FLAGS are : " ${CMAKE_CXX_FLAGS})
 message(STATUS "CXX_FLAGS_RELEASE are : " ${CMAKE_CXX_FLAGS_RELEASE})
 message(STATUS "CXX_FLAGS_DEBUG are : " ${CMAKE_CXX_FLAGS_DEBUG})
 message(STATUS "IMPORTANT: Make sure you have selected the desired CMAKE_BUILD_TYPE")
+message(STATUS "CMAKE_BUILD_TYPE is ${CMAKE_BUILD_TYPE}")
 message(STATUS ---)
 
 ###############################################################################

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -273,8 +273,8 @@ queries:
     sparql: |
       SELECT ?x ?y WHERE {
           ?x <is-a> <Scientist> .
+          FILTER (?x < <Ada_Lovelace>) .
           OPTIONAL { ?x <Spouse_(or_domestic_partner)> ?y } .
-          FILTER (?x < <Ada_Lovelace>)
       }
     checks:
       - num_rows: 126
@@ -286,9 +286,9 @@ queries:
     type: no-text
     sparql: |
       SELECT ?x (GROUP_CONCAT(?y; separator=";") AS ?partners) WHERE {
+          FILTER (?x < <Ada_Lovelace>)
           ?x <is-a> <Scientist> .
           OPTIONAL {?x <Spouse_(or_domestic_partner)> ?y .}
-          FILTER (?x < <Ada_Lovelace>)
       }
       GROUP BY ?x
     checks:

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -8,7 +8,6 @@
 #include <type_traits>
 #include <vector>
 
-#include <parallel/algorithm>
 #include "../global/Constants.h"
 #include "../global/Id.h"
 #include "../util/Exception.h"
@@ -102,12 +101,12 @@ class Engine {
     LOG(DEBUG) << "Sorting " << tab->size() << " elements.\n";
     IdTableStatic<WIDTH> stab = tab->moveToStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
-      __gnu_parallel::sort(
+      ad_utility::parallel_sort(
           stab.begin(), stab.end(),
           [keyColumn](const auto& a, const auto& b) {
             return a[keyColumn] < b[keyColumn];
           },
-          __gnu_parallel::parallel_tag(NUM_SORT_THREADS));
+          ad_utility::parallel_tag(NUM_SORT_THREADS));
     } else {
       std::sort(stab.begin(), stab.end(),
                 [keyColumn](const auto& a, const auto& b) {
@@ -123,8 +122,8 @@ class Engine {
     LOG(DEBUG) << "Sorting " << tab->size() << " elements.\n";
     IdTableStatic<WIDTH> stab = tab->moveToStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
-      __gnu_parallel::sort(stab.begin(), stab.end(), comp,
-                           __gnu_parallel::parallel_tag(NUM_SORT_THREADS));
+      ad_utility::parallel_sort(stab.begin(), stab.end(), comp,
+                                ad_utility::parallel_tag(NUM_SORT_THREADS));
     } else {
       std::sort(stab.begin(), stab.end(), comp);
     }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -417,7 +417,11 @@ void Filter::computeFilterFixedValue(
         // remove the leading '^' symbol
         std::string rhs = _rhs.substr(1);
         // TODO<joka921>: handle Levels correctly;
-        auto [lowerBound, upperBound] = getIndex().getVocab().prefix_range(rhs);
+        // according to the standard, structured bindings cannot be captured by
+        // lambdas and clang fails to compile with them
+        Id lowerBound, upperBound;
+        std::tie(lowerBound, upperBound) =
+            getIndex().getVocab().prefix_range(rhs);
 
         LOG(DEBUG) << "upper and lower bound are " << upperBound << ' '
                    << lowerBound << std::endl;

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -79,7 +79,7 @@ vector<size_t> GroupBy::resultSortedOn() const {
 }
 
 vector<pair<size_t, bool>> GroupBy::computeSortColumns(
-    std::shared_ptr<QueryExecutionTree> inputTree) {
+    const QueryExecutionTree* inputTree) {
   vector<pair<size_t, bool>> cols;
   if (_groupByVariables.empty()) {
     // the entire input is a single group, no sorting needs to be done

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -85,7 +85,7 @@ class GroupBy : public Operation {
    *                  creating the sorting operation inputs.
    */
   vector<pair<size_t, bool>> computeSortColumns(
-      std::shared_ptr<QueryExecutionTree> inputTree);
+      const QueryExecutionTree* inputTree);
 
   vector<QueryExecutionTree*> getChildren() override {
     return {_subtree.get()};

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -126,9 +126,7 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
             } else if constexpr (std::is_same_v<T, GraphPatternOperation::Optional>) {
               childrenToAdd.push_back(&arg._child);
             } else if constexpr (std::is_same_v<T, GraphPatternOperation::TransPath>) {
-              if (arg._childGraphPattern) {
-                childrenToAdd.push_back(&arg._childGraphPattern.value());
-              }
+              childrenToAdd.push_back(&arg._childGraphPattern);
             } else {
               static_assert(std::is_same_v<T, GraphPatternOperation::Subquery>);
             }
@@ -197,7 +195,7 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
               childPlans.push_back(&subqueryPlans.back());
             } else if constexpr (std::is_same_v<T, GraphPatternOperation::TransPath>) {
               const SubtreePlan* sub =
-                  &patternPlans[arg._childGraphPattern->_id];
+                  &patternPlans[arg._childGraphPattern._id];
               childPlanStorage.emplace_back(_qec);
               size_t leftCol, rightCol;
               Id leftValue, rightValue;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -147,7 +147,7 @@ class QueryPlanner {
   };
 
   TripleGraph createTripleGraph(
-      std::shared_ptr<const ParsedQuery::GraphPattern> pattern) const;
+          const ParsedQuery::GraphPattern *pattern) const;
 
   static ad_utility::HashMap<string, size_t>
   createVariableColumnsMapForTextOperation(
@@ -252,8 +252,8 @@ class QueryPlanner {
   std::string generateUniqueVarName();
 
   // Creates a tree of unions with the given patterns as the trees leaves
-  std::shared_ptr<ParsedQuery::GraphPattern> uniteGraphPatterns(
-      const std::vector<std::shared_ptr<ParsedQuery::GraphPattern>>& patterns)
+  ParsedQuery::GraphPattern uniteGraphPatterns(
+          std::vector<ParsedQuery::GraphPattern> &&patterns)
       const;
 
   /**

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -127,17 +127,14 @@ class QueryPlanner {
   class SubtreePlan {
    public:
     explicit SubtreePlan(QueryExecutionContext* qec)
-        : _qet(new QueryExecutionTree(qec)),
-          _idsOfIncludedNodes(0),
-          _idsOfIncludedFilters(0),
-          _isOptional(false) {}
+        : _qet(std::make_shared<QueryExecutionTree>(qec)) {}
 
     std::shared_ptr<QueryExecutionTree> _qet;
     std::shared_ptr<ResultTable> _cachedResult;
     bool _isCached = false;
-    uint64_t _idsOfIncludedNodes;
-    uint64_t _idsOfIncludedFilters;
-    bool _isOptional;
+    uint64_t _idsOfIncludedNodes = 0;
+    uint64_t _idsOfIncludedFilters = 0;
+    bool _isOptional = false;
 
     size_t getCostEstimate() const;
 
@@ -146,7 +143,8 @@ class QueryPlanner {
     void addAllNodes(uint64_t otherNodes);
   };
 
-  TripleGraph createTripleGraph(const ParsedQuery::GraphPattern* pattern) const;
+  TripleGraph createTripleGraph(
+      const GraphPatternOperation::BasicGraphPattern* pattern) const;
 
   static ad_utility::HashMap<string, size_t>
   createVariableColumnsMapForTextOperation(
@@ -189,7 +187,8 @@ class QueryPlanner {
 
   bool _enablePatternTrick;
 
-  std::vector<SubtreePlan> optimize(ParsedQuery::GraphPattern* rootPattern);
+  std::vector<QueryPlanner::SubtreePlan> optimize(
+      ParsedQuery::GraphPattern* rootPattern, bool isRoot);
 
   /**
    * @brief Fills varToTrip with a mapping from all variables in the root graph
@@ -262,6 +261,9 @@ class QueryPlanner {
   vector<SubtreePlan> merge(const vector<SubtreePlan>& a,
                             const vector<SubtreePlan>& b,
                             const TripleGraph& tg) const;
+
+  std::optional<QueryPlanner::SubtreePlan> join(const SubtreePlan& a,
+                                                const SubtreePlan& b) const;
 
   vector<SubtreePlan> getOrderByRow(
       const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -191,7 +191,7 @@ class QueryPlanner {
   bool _enablePatternTrick;
 
   std::vector<SubtreePlan> optimize(
-          std::shared_ptr<ParsedQuery::GraphPattern> rootPattern);
+          ParsedQuery::GraphPattern *rootPattern);
 
   /**
    * @brief Fills varToTrip with a mapping from all variables in the root graph

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -191,7 +191,7 @@ class QueryPlanner {
   bool _enablePatternTrick;
 
   std::vector<SubtreePlan> optimize(
-      std::shared_ptr<const ParsedQuery::GraphPattern> pattern);
+          std::shared_ptr<ParsedQuery::GraphPattern> rootPattern);
 
   /**
    * @brief Fills varToTrip with a mapping from all variables in the root graph

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -146,8 +146,7 @@ class QueryPlanner {
     void addAllNodes(uint64_t otherNodes);
   };
 
-  TripleGraph createTripleGraph(
-          const ParsedQuery::GraphPattern *pattern) const;
+  TripleGraph createTripleGraph(const ParsedQuery::GraphPattern* pattern) const;
 
   static ad_utility::HashMap<string, size_t>
   createVariableColumnsMapForTextOperation(
@@ -190,8 +189,7 @@ class QueryPlanner {
 
   bool _enablePatternTrick;
 
-  std::vector<SubtreePlan> optimize(
-          ParsedQuery::GraphPattern *rootPattern);
+  std::vector<SubtreePlan> optimize(ParsedQuery::GraphPattern* rootPattern);
 
   /**
    * @brief Fills varToTrip with a mapping from all variables in the root graph
@@ -253,8 +251,7 @@ class QueryPlanner {
 
   // Creates a tree of unions with the given patterns as the trees leaves
   ParsedQuery::GraphPattern uniteGraphPatterns(
-          std::vector<ParsedQuery::GraphPattern> &&patterns)
-      const;
+      std::vector<ParsedQuery::GraphPattern>&& patterns) const;
 
   /**
    * @brief Merges two rows of the dp optimization table using various types of

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -101,7 +101,26 @@ static const uint8_t NO_PREFIX_CHAR =
 
 #ifdef _PARALLEL_SORT
 static constexpr bool USE_PARALLEL_SORT = true;
+#include <parallel/algorithm>
+namespace ad_utility {
+template <typename... Args>
+auto parallel_sort(Args&&... args) {
+  return __gnu_parallel::sort(std::forward<Args>(args)...);
+}
+using parallel_tag = __gnu_parallel::parallel_tag;
+
+}  // namespace ad_utility
+
 #else
 static constexpr bool USE_PARALLEL_SORT = false;
+namespace ad_utility {
+template <typename... Args>
+auto parallel_sort([[maybe_unused]] Args&&... args) {
+  throw std::runtime_error(
+      "Triggered the parallel sort although it was disabled. Please report to "
+      "the developers!");
+}
+using parallel_tag = int;
+}  // namespace ad_utility
 #endif
 static constexpr size_t NUM_SORT_THREADS = 4;

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -14,7 +14,6 @@
 #include <vector>
 #include "./VocabularyGenerator.h"
 
-#include <parallel/algorithm>
 #include "../util/Conversions.h"
 #include "../util/Exception.h"
 #include "../util/HashMap.h"
@@ -325,8 +324,8 @@ void sortVocabVector(ItemVec* vecPtr, StringSortComparator comp, const bool doPa
   auto& els = *vecPtr;
   if constexpr (USE_PARALLEL_SORT) {
     if (doParallelSort) {
-      __gnu_parallel::sort(begin(els), end(els), comp,
-                           __gnu_parallel::parallel_tag(NUM_SORT_THREADS));
+      ad_utility::parallel_sort(begin(els), end(els), comp,
+                                ad_utility::parallel_tag(NUM_SORT_THREADS));
     } else {
       std::sort(begin(els), end(els), comp);
     }

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -503,44 +503,7 @@ void ParsedQuery::merge(const ParsedQuery& p) {
   _rootGraphPattern->recomputeIds(&_numGraphPatterns);
 }
 
-// _____________________________________________________________________________
-ParsedQuery::GraphPattern::~GraphPattern() {}
 
-// _____________________________________________________________________________
-ParsedQuery::GraphPattern::GraphPattern(GraphPattern&& other)
-    : _whereClauseTriples(std::move(other._whereClauseTriples)),
-      _filters(std::move(other._filters)),
-      _optional(other._optional),
-      _children(std::move(other._children)) {
-  other._children.clear();
-}
-
-/*
-// _____________________________________________________________________________
-ParsedQuery::GraphPattern::GraphPattern(const GraphPattern& other)
-    : _whereClauseTriples(other._whereClauseTriples),
-      _filters(other._filters),
-      _optional(other._optional) {
-  _children.reserve(other._children.size());
-  for (const std::shared_ptr<GraphPatternOperation>& g : other._children) {
-    _children.push_back(std::make_shared<GraphPatternOperation>(*g));
-  }
-}
- */
-
-// _____________________________________________________________________________
-ParsedQuery::GraphPattern& ParsedQuery::GraphPattern::operator=(
-    const ParsedQuery::GraphPattern& other) {
-  _whereClauseTriples = std::vector<SparqlTriple>(other._whereClauseTriples);
-  _filters = std::vector<SparqlFilter>(other._filters);
-  _optional = other._optional;
-  _children.clear();
-  _children.reserve(other._children.size());
-  for (const std::shared_ptr<GraphPatternOperation>& g : other._children) {
-    _children.push_back(std::make_shared<GraphPatternOperation>(*g));
-  }
-  return *this;
-}
 
 // _____________________________________________________________________________
 void ParsedQuery::GraphPattern::toString(std::ostringstream& os,

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -53,7 +53,7 @@ string ParsedQuery::asString() const {
 
   // WHERE
   os << "\nWHERE: \n";
-  _rootGraphPattern->toString(os, 1);
+  _rootGraphPattern.toString(os, 1);
 
   os << "\nLIMIT: " << (_limit.size() > 0 ? _limit : "no limit specified");
   os << "\nTEXTLIMIT: "
@@ -252,7 +252,7 @@ void ParsedQuery::expandPrefixes() {
   }
 
   vector<GraphPattern*> graphPatterns;
-  graphPatterns.push_back(_rootGraphPattern.get());
+  graphPatterns.push_back(&_rootGraphPattern);
   // Traverse the graph pattern tree using dfs expanding the prefixes in every
   // pattern.
   while (!graphPatterns.empty()) {
@@ -485,21 +485,21 @@ std::string ParsedQuery::parseAlias(const std::string& alias) {
 
 void ParsedQuery::merge(const ParsedQuery& p) {
   _prefixes.insert(_prefixes.begin(), p._prefixes.begin(), p._prefixes.end());
-  _rootGraphPattern->_filters.insert(_rootGraphPattern->_filters.begin(),
-                                     p._rootGraphPattern->_filters.begin(),
-                                     p._rootGraphPattern->_filters.end());
-  _rootGraphPattern->_whereClauseTriples.insert(
-      _rootGraphPattern->_whereClauseTriples.begin(),
-      p._rootGraphPattern->_whereClauseTriples.begin(),
-      p._rootGraphPattern->_whereClauseTriples.end());
+  _rootGraphPattern._filters.insert(_rootGraphPattern._filters.begin(),
+                                     p._rootGraphPattern._filters.begin(),
+                                     p._rootGraphPattern._filters.end());
+  _rootGraphPattern._whereClauseTriples.insert(
+      _rootGraphPattern._whereClauseTriples.begin(),
+      p._rootGraphPattern._whereClauseTriples.begin(),
+      p._rootGraphPattern._whereClauseTriples.end());
 
-  auto& children = _rootGraphPattern->_children;
-  auto& otherChildren = p._rootGraphPattern->_children;
+  auto& children = _rootGraphPattern._children;
+  auto& otherChildren = p._rootGraphPattern._children;
   children.insert(children.end(), otherChildren.begin(), otherChildren.end());
 
   // update the ids
   _numGraphPatterns = 0;
-  _rootGraphPattern->recomputeIds(&_numGraphPatterns);
+  _rootGraphPattern.recomputeIds(&_numGraphPatterns);
 }
 
 

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -263,8 +263,8 @@ void ParsedQuery::expandPrefixes() {
           [&graphPatterns, this](auto&& arg) {
             using T = std::decay_t<decltype(arg)>;
             if constexpr (std::is_same_v<T, GraphPatternOperation::Subquery>) {
-              arg._subquery->_prefixes = _prefixes;
-              arg._subquery->expandPrefixes();
+              arg._subquery._prefixes = _prefixes;
+              arg._subquery.expandPrefixes();
             } else if constexpr (std::is_same_v<T, GraphPatternOperation::TransPath>) {
               AD_CHECK(false);
               // we may never be in an transitive path here or a
@@ -586,11 +586,7 @@ void ParsedQuery::GraphPattern::recomputeIds(size_t* id_count) {
     os << " UNION ";
     arg._child2.toString(os, indentation);
     } else if constexpr (std::is_same_v<T, Subquery>) {
-    if (arg._subquery != nullptr) {
-      os << arg._subquery->asString();
-    } else {
-      os << "Missing Subquery\n";
-    }
+      os << arg._subquery.asString();
     } else {
       static_assert(std::is_same_v<T, TransPath>);
       os << "TRANS PATH from " << arg._left << " to " << arg._right

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -557,9 +557,7 @@ void ParsedQuery::GraphPattern::recomputeIds(size_t* id_count) {
           } else if constexpr (std::is_same_v<T, GraphPatternOperation::Optional>) {
             arg._child.recomputeIds(id_count);
           } else if constexpr (std::is_same_v<T, GraphPatternOperation::TransPath>) {
-            if (arg._childGraphPattern) {
-              arg._childGraphPattern->recomputeIds(id_count);
-            }
+              arg._childGraphPattern.recomputeIds(id_count);
           } else {
             static_assert(std::is_same_v<T, GraphPatternOperation::Subquery>);
             // subquery children have their own id space
@@ -598,11 +596,7 @@ void ParsedQuery::GraphPattern::recomputeIds(size_t* id_count) {
       os << "TRANS PATH from " << arg._left << " to " << arg._right
          << " with at least " << arg._min << " and at most "
          << arg._max << " steps of ";
-      if (arg._childGraphPattern) {
-        arg._childGraphPattern->toString(os, indentation);
-      } else {
-        os << "Missing graph pattern.";
-      }
+        arg._childGraphPattern.toString(os, indentation);
     }
   });
 }

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -276,24 +276,20 @@ class ParsedQuery {
     std::string _delimiter = " ";
   };
 
-  ParsedQuery()
-      : _rootGraphPattern(std::make_shared<GraphPattern>()),
-        _numGraphPatterns(1),
-        _reduced(false),
-        _distinct(false) {}
+  ParsedQuery() = default;
 
   vector<SparqlPrefix> _prefixes;
   vector<string> _selectedVariables;
-  std::shared_ptr<GraphPattern> _rootGraphPattern;
+  GraphPattern _rootGraphPattern;
   vector<SparqlFilter> _havingClauses;
-  size_t _numGraphPatterns;
+  size_t _numGraphPatterns = 1;
   vector<OrderKey> _orderBy;
   vector<string> _groupByVariables;
   string _limit;
   string _textLimit;
   string _offset;
-  bool _reduced;
-  bool _distinct;
+  bool _reduced = false;
+  bool _distinct = false;
   string _originalString;
   std::vector<Alias> _aliases;
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -241,11 +241,7 @@ class ParsedQuery {
   using GraphPatternOperation =
       std::variant<Optional, Union, Subquery, TransPath>;
   static void operationtoString(const GraphPatternOperation& op,
-                                std::ostringstream& os, int indentation = 0) {
-    (void)op;
-    os << indentation << "Not yet implemented\n";
-    // TODO<joka921: write
-  }
+                                std::ostringstream& os, int indentation = 0);
 
   // Groups triplets and filters. Represents a node in a tree (as graph patterns
   // are recursive).
@@ -255,7 +251,7 @@ class ParsedQuery {
     GraphPattern() : _optional(false) {}
     // Move and copyconstructors to avoid double deletes on the trees children
     GraphPattern(GraphPattern&& other);
-    GraphPattern(const GraphPattern& other);
+    GraphPattern(const GraphPattern& other) = delete;
     GraphPattern& operator=(const GraphPattern& other);
     virtual ~GraphPattern();
     void toString(std::ostringstream& os, int indentation = 0) const;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -332,7 +332,7 @@ struct GraphPatternOperation {
     ParsedQuery::GraphPattern _child2;
   };
   struct Subquery {
-    std::shared_ptr<ParsedQuery> _subquery;
+    ParsedQuery _subquery;
   };
 
   struct TransPath {

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -5,6 +5,7 @@
 
 #include <initializer_list>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "../util/HashMap.h"
@@ -215,39 +216,36 @@ class ParsedQuery {
  public:
   class GraphPattern;
 
-  class GraphPatternOperation {
-   public:
-    enum class Type { OPTIONAL, UNION, SUBQUERY, TRANS_PATH };
-    GraphPatternOperation(
-        Type type,
-        std::initializer_list<std::shared_ptr<GraphPattern>> children);
-    GraphPatternOperation(Type type);
-
-    // Move and copyconstructors to avoid double deletes on the trees children
-    GraphPatternOperation(GraphPatternOperation&& other);
-    GraphPatternOperation(const GraphPatternOperation& other);
-    GraphPatternOperation& operator=(const GraphPatternOperation& other);
-    virtual ~GraphPatternOperation();
-
-    void toString(std::ostringstream& os, int indentation = 0) const;
-
-    Type _type;
-    union {
-      std::vector<std::shared_ptr<GraphPattern>> _childGraphPatterns;
-      std::shared_ptr<ParsedQuery> _subquery;
-      struct {
-        // The name of the left and right end of the transitive operation
-        std::string _left;
-        std::string _right;
-        // The name of the left and right end of the subpath
-        std::string _innerLeft;
-        std::string _innerRight;
-        size_t _min = 0;
-        size_t _max = 0;
-        std::shared_ptr<GraphPattern> _childGraphPattern;
-      } _pathData;
-    };
+  struct Optional {
+    std::array<std::shared_ptr<GraphPattern>, 1> _children;
   };
+  struct Union {
+    std::array<std::shared_ptr<GraphPattern>, 2> _children;
+  };
+  struct Subquery {
+    std::shared_ptr<ParsedQuery> _subquery;
+  };
+
+  struct TransPath {
+    // The name of the left and right end of the transitive operation
+    std::string _left;
+    std::string _right;
+    // The name of the left and right end of the subpath
+    std::string _innerLeft;
+    std::string _innerRight;
+    size_t _min = 0;
+    size_t _max = 0;
+    std::shared_ptr<GraphPattern> _childGraphPattern;
+  };
+
+  using GraphPatternOperation =
+      std::variant<Optional, Union, Subquery, TransPath>;
+  static void operationtoString(const GraphPatternOperation& op,
+                                std::ostringstream& os, int indentation = 0) {
+    (void)op;
+    os << indentation << "Not yet implemented\n";
+    // TODO<joka921: write
+  }
 
   // Groups triplets and filters. Represents a node in a tree (as graph patterns
   // are recursive).

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -344,8 +344,7 @@ struct GraphPatternOperation {
     std::string _innerRight;
     size_t _min = 0;
     size_t _max = 0;
-    // todo<joka921> can this ever be empty??
-    std::optional<ParsedQuery::GraphPattern> _childGraphPattern;
+    ParsedQuery::GraphPattern _childGraphPattern;
   };
 
   std::variant<Optional, Union, Subquery, TransPath> variant_;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -270,7 +270,7 @@ class ParsedQuery {
      */
     size_t _id;
 
-    vector<std::shared_ptr<GraphPatternOperation>> _children;
+    vector<GraphPatternOperation> _children;
   };
 
   /**

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -250,10 +250,11 @@ class ParsedQuery {
     // deletes the patterns children.
     GraphPattern() : _optional(false) {}
     // Move and copyconstructors to avoid double deletes on the trees children
-    GraphPattern(GraphPattern&& other);
+    GraphPattern(GraphPattern&& other) = default;
     GraphPattern(const GraphPattern& other) = delete;
-    GraphPattern& operator=(const GraphPattern& other);
-    virtual ~GraphPattern();
+    GraphPattern& operator=(const GraphPattern& other) = delete;
+    GraphPattern& operator=( GraphPattern&& other) noexcept = default;
+    ~GraphPattern() = default;
     void toString(std::ostringstream& os, int indentation = 0) const;
     // Traverses the graph pattern tree and assigns a unique id to every graph
     // pattern

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -218,8 +218,6 @@ class ParsedQuery {
  public:
   class GraphPattern;
 
-
-
   // Groups triplets and filters. Represents a node in a tree (as graph patterns
   // are recursive).
   class GraphPattern {
@@ -230,7 +228,7 @@ class ParsedQuery {
     GraphPattern(GraphPattern&& other) = default;
     GraphPattern(const GraphPattern& other) = default;
     GraphPattern& operator=(const GraphPattern& other) = default;
-    GraphPattern& operator=( GraphPattern&& other) noexcept = default;
+    GraphPattern& operator=(GraphPattern&& other) noexcept = default;
     ~GraphPattern() = default;
     void toString(std::ostringstream& os, int indentation = 0) const;
     // Traverses the graph pattern tree and assigns a unique id to every graph
@@ -318,7 +316,6 @@ class ParsedQuery {
   std::string parseAlias(const std::string& alias);
 };
 
-
 struct GraphPatternOperation {
   struct Optional {
     ParsedQuery::GraphPattern _child;
@@ -344,27 +341,33 @@ struct GraphPatternOperation {
   };
 
   std::variant<Optional, Union, Subquery, TransPath> variant_;
-  template<typename A, typename... Args, typename=std::enable_if_t<!std::is_base_of_v<GraphPatternOperation, std::decay_t<A>>>>
-  GraphPatternOperation(A&& a, Args&&... args) : variant_(std::forward<A>(a), std::forward<Args>(args)...) {}
+  template <typename A, typename... Args,
+            typename = std::enable_if_t<
+                !std::is_base_of_v<GraphPatternOperation, std::decay_t<A>>>>
+  GraphPatternOperation(A&& a, Args&&... args)
+      : variant_(std::forward<A>(a), std::forward<Args>(args)...) {}
   GraphPatternOperation() = delete;
   GraphPatternOperation(const GraphPatternOperation&) = default;
   GraphPatternOperation(GraphPatternOperation&&) noexcept = default;
   GraphPatternOperation& operator=(const GraphPatternOperation&) = default;
   GraphPatternOperation& operator=(GraphPatternOperation&&) noexcept = default;
-  template<typename F>
+  template <typename F>
   const auto visit(F f) const {
     return std::visit(f, variant_);
   }
 
-  template<typename F>
+  template <typename F>
   auto visit(F f) {
     return std::visit(f, variant_);
   }
-  template<class T>
-  constexpr T& get() {return std::get<T>(variant_);}
-  template<class T>
-  constexpr const T& get() const {return std::get<T>(variant_);}
+  template <class T>
+  constexpr T& get() {
+    return std::get<T>(variant_);
+  }
+  template <class T>
+  constexpr const T& get() const {
+    return std::get<T>(variant_);
+  }
 
   void toString(std::ostringstream& os, int indentation = 0) const;
 };
-

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -281,8 +281,7 @@ void SparqlParser::parseWhere(
         // subquery
         // create the subquery operation
         GraphPatternOperation::Subquery subq;
-        subq._subquery = std::make_shared<ParsedQuery>();
-        parseQuery(subq._subquery.get());
+        parseQuery(&subq._subquery);
         currentPattern->_children.push_back(std::move(subq));
         // The closing bracked } is consumed by the subquery
         _lexer.accept(".");

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -250,8 +250,8 @@ void SparqlParser::parseWhere(
   if (currentPattern == nullptr) {
     // Make the shared pointer point to the root graphpattern without deleting
     // it.
-    currentPattern = query->_rootGraphPattern.get();
-    query->_rootGraphPattern->_id = 0;
+    currentPattern = &query->_rootGraphPattern;
+    query->_rootGraphPattern._id = 0;
   }
 
   // If these are not empty the last subject and / or predicate is reused
@@ -596,9 +596,9 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
         query->_groupByVariables.emplace_back(_lexer.current().raw);
       }
     } else if (_lexer.accept("having")) {
-      parseFilter(&query->_havingClauses, true, query->_rootGraphPattern.get());
+      parseFilter(&query->_havingClauses, true, &query->_rootGraphPattern);
       while (parseFilter(&query->_havingClauses, false,
-                         query->_rootGraphPattern.get())) {
+                         &query->_rootGraphPattern)) {
       }
     } else if (_lexer.accept("textlimit")) {
       _lexer.expect(SparqlToken::Type::INTEGER);

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -265,8 +265,8 @@ void SparqlParser::parseWhere(
     }
     if (_lexer.accept("optional")) {
 
-      currentPattern->_children.push_back(ParsedQuery::Optional{std::make_shared<ParsedQuery::GraphPattern>()});
-      auto& opt = std::get<ParsedQuery::Optional>(currentPattern->_children.back());
+      currentPattern->_children.push_back(GraphPatternOperation::Optional{std::make_shared<ParsedQuery::GraphPattern>()});
+      auto& opt = currentPattern->_children.back().get<GraphPatternOperation::Optional>();
       auto& child = opt._children[0];
       child->_optional = true;
       child->_id = query->_numGraphPatterns;
@@ -280,7 +280,7 @@ void SparqlParser::parseWhere(
       if (_lexer.accept("select")) {
         // subquery
         // create the subquery operation
-        ParsedQuery::Subquery subq;
+        GraphPatternOperation::Subquery subq;
         subq._subquery = std::make_shared<ParsedQuery>();
         parseQuery(subq._subquery.get());
         currentPattern->_children.push_back(std::move(subq));
@@ -290,7 +290,7 @@ void SparqlParser::parseWhere(
         // union
         // create the union operation
         auto un =
-            ParsedQuery::Union{std::make_shared<ParsedQuery::GraphPattern>(),
+            GraphPatternOperation::Union{std::make_shared<ParsedQuery::GraphPattern>(),
                                std::make_shared<ParsedQuery::GraphPattern>()};
         un._children[0]->_optional = false;
         un._children[1]->_optional = false;

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -244,9 +244,8 @@ ParsedQuery::Alias SparqlParser::parseAlias() {
 }
 
 // _____________________________________________________________________________
-void SparqlParser::parseWhere(
-        ParsedQuery* query,
-        ParsedQuery::GraphPattern *currentPattern) {
+void SparqlParser::parseWhere(ParsedQuery* query,
+                              ParsedQuery::GraphPattern* currentPattern) {
   if (currentPattern == nullptr) {
     // Make the shared pointer point to the root graphpattern without deleting
     // it.
@@ -264,9 +263,10 @@ void SparqlParser::parseWhere(
           "the end of the input.");
     }
     if (_lexer.accept("optional")) {
-
-      currentPattern->_children.push_back(GraphPatternOperation::Optional{ParsedQuery::GraphPattern()});
-      auto& opt = currentPattern->_children.back().get<GraphPatternOperation::Optional>();
+      currentPattern->_children.push_back(
+          GraphPatternOperation::Optional{ParsedQuery::GraphPattern()});
+      auto& opt = currentPattern->_children.back()
+                      .get<GraphPatternOperation::Optional>();
       auto& child = opt._child;
       child._optional = true;
       child._id = query->_numGraphPatterns;
@@ -288,9 +288,8 @@ void SparqlParser::parseWhere(
       } else {
         // union
         // create the union operation
-        auto un =
-            GraphPatternOperation::Union{ParsedQuery::GraphPattern{},
-                               ParsedQuery::GraphPattern{}};
+        auto un = GraphPatternOperation::Union{ParsedQuery::GraphPattern{},
+                                               ParsedQuery::GraphPattern{}};
         un._child1._optional = false;
         un._child2._optional = false;
         un._child1._id = query->_numGraphPatterns;
@@ -612,9 +611,9 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
 }
 
 // _____________________________________________________________________________
-bool SparqlParser::parseFilter(
-        vector<SparqlFilter>* _filters, bool failOnNoFilter,
-        ParsedQuery::GraphPattern *pattern) {
+bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
+                               bool failOnNoFilter,
+                               ParsedQuery::GraphPattern* pattern) {
   if (_lexer.accept("(")) {
     if (_lexer.accept("lang")) {
       _lexer.expect("(");
@@ -811,9 +810,8 @@ bool SparqlParser::parseFilter(
   return false;
 }
 
-void SparqlParser::addLangFilter(
-        const std::string& lhs, const std::string& rhs,
-        ParsedQuery::GraphPattern *pattern) {
+void SparqlParser::addLangFilter(const std::string& lhs, const std::string& rhs,
+                                 ParsedQuery::GraphPattern* pattern) {
   auto langTag = rhs.substr(1, rhs.size() - 2);
   // First find a suitable triple for the given variable. It
   // must use a predicate that is not a variable or complex

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -29,20 +29,18 @@ class SparqlParser {
   void parseQuery(ParsedQuery* query);
   void parsePrologue(ParsedQuery* query);
   void parseSelect(ParsedQuery* query);
-  void parseWhere(
-          ParsedQuery* query,
-          ParsedQuery::GraphPattern *currentPattern = nullptr);
+  void parseWhere(ParsedQuery* query,
+                  ParsedQuery::GraphPattern* currentPattern = nullptr);
   void parseSolutionModifiers(ParsedQuery* query);
   void addPrefix(const string& key, const string& value, ParsedQuery* query);
   void addWhereTriple(const string& str,
                       std::shared_ptr<ParsedQuery::GraphPattern> pattern);
   // Returns true if it found a filter
-  bool parseFilter(
-          vector<SparqlFilter>* _filters, bool failOnNoFilter = true,
-          ParsedQuery::GraphPattern *pattern = nullptr);
+  bool parseFilter(vector<SparqlFilter>* _filters, bool failOnNoFilter = true,
+                   ParsedQuery::GraphPattern* pattern = nullptr);
   // Parses an expressiong of the form (?a) = "en"
   void addLangFilter(const std::string& lhs, const std::string& rhs,
-                     ParsedQuery::GraphPattern *pattern);
+                     ParsedQuery::GraphPattern* pattern);
 
   // takes either DESC or ASC as the parameter
   OrderKey parseOrderKey(const std::string& order, ParsedQuery* query);

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -53,6 +53,13 @@ class SparqlParser {
   std::string_view readTriplePart(const std::string& s, size_t* pos);
 
   static string stripAndLowercaseKeywordLiteral(const string& lit);
+  /**
+   * If *ptr 's last child is a BasicGraphPattern, return a reference to it.
+   * If not, first append a BasicGraphPattern and then return a reference
+   * to the added child
+   */
+  GraphPatternOperation::BasicGraphPattern& lastBasicPattern(
+      ParsedQuery::GraphPattern* ptr) const;
 
   SparqlLexer _lexer;
   string _query;

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -31,18 +31,18 @@ class SparqlParser {
   void parseSelect(ParsedQuery* query);
   void parseWhere(
           ParsedQuery* query,
-          std::shared_ptr<ParsedQuery::GraphPattern> currentPattern = nullptr);
+          ParsedQuery::GraphPattern *currentPattern = nullptr);
   void parseSolutionModifiers(ParsedQuery* query);
   void addPrefix(const string& key, const string& value, ParsedQuery* query);
   void addWhereTriple(const string& str,
                       std::shared_ptr<ParsedQuery::GraphPattern> pattern);
   // Returns true if it found a filter
   bool parseFilter(
-      vector<SparqlFilter>* _filters, bool failOnNoFilter = true,
-      std::shared_ptr<ParsedQuery::GraphPattern> pattern = nullptr);
+          vector<SparqlFilter>* _filters, bool failOnNoFilter = true,
+          ParsedQuery::GraphPattern *pattern = nullptr);
   // Parses an expressiong of the form (?a) = "en"
   void addLangFilter(const std::string& lhs, const std::string& rhs,
-                     std::shared_ptr<ParsedQuery::GraphPattern> pattern);
+                     ParsedQuery::GraphPattern *pattern);
 
   // takes either DESC or ASC as the parameter
   OrderKey parseOrderKey(const std::string& order, ParsedQuery* query);

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -30,8 +30,8 @@ class SparqlParser {
   void parsePrologue(ParsedQuery* query);
   void parseSelect(ParsedQuery* query);
   void parseWhere(
-      ParsedQuery* query,
-      std::shared_ptr<ParsedQuery::GraphPattern> currentPattern = nullptr);
+          ParsedQuery* query,
+          std::shared_ptr<ParsedQuery::GraphPattern> currentPattern = nullptr);
   void parseSolutionModifiers(ParsedQuery* query);
   void addPrefix(const string& key, const string& value, ParsedQuery* query);
   void addWhereTriple(const string& str,

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -644,6 +644,7 @@ TEST(QueryPlannerTest, testActorsBornInEurope) {
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
+    ASSERT_EQ(18340u, qet.getCostEstimate());
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN POS with P = \"<pre/profession>\", "
         "O = \"<pre/Actor>\"\n    qet-width: 1 \n  } join-column:"

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -24,7 +24,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -54,7 +54,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -79,7 +79,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
 
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>({
@@ -112,7 +112,7 @@ TEST(QueryPlannerTest, testCpyCtorWithKeepNodes) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
       ASSERT_EQ(2u, tg._nodeMap.find(0)->second->_variables.size());
       ASSERT_EQ(2u, tg._nodeMap.find(1)->second->_variables.size());
       ASSERT_EQ(1u, tg._nodeMap.find(2)->second->_variables.size());
@@ -175,7 +175,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
       ASSERT_EQ(3u, tg._adjLists.size());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
@@ -197,7 +197,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
       ASSERT_EQ(3u, out.size());
@@ -235,7 +235,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -276,7 +276,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -319,7 +319,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -367,7 +367,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
         TripleGraph expected = TripleGraph(std::vector<std::pair<
                                                Node, std::vector<size_t>>>(
             {std::make_pair<Node, vector<size_t>>(
@@ -451,7 +451,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -940,7 +940,7 @@ TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryPlanner::TripleGraph tg = qp.createTripleGraph(pq._rootGraphPattern);
+    QueryPlanner::TripleGraph tg = qp.createTripleGraph(pq._rootGraphPattern.get());
     ASSERT_EQ(1u, tg._nodeMap.find(0)->second->_variables.size());
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -24,7 +24,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -54,7 +54,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -79,7 +79,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
 
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>({
@@ -112,7 +112,7 @@ TEST(QueryPlannerTest, testCpyCtorWithKeepNodes) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
       ASSERT_EQ(2u, tg._nodeMap.find(0)->second->_variables.size());
       ASSERT_EQ(2u, tg._nodeMap.find(1)->second->_variables.size());
       ASSERT_EQ(1u, tg._nodeMap.find(2)->second->_variables.size());
@@ -175,7 +175,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
       ASSERT_EQ(3u, tg._adjLists.size());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
@@ -197,7 +197,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
       ASSERT_EQ(3u, out.size());
@@ -235,7 +235,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -276,7 +276,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -319,7 +319,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -367,7 +367,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
         TripleGraph expected = TripleGraph(std::vector<std::pair<
                                                Node, std::vector<size_t>>>(
             {std::make_pair<Node, vector<size_t>>(
@@ -451,7 +451,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -940,7 +940,7 @@ TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryPlanner::TripleGraph tg = qp.createTripleGraph(pq._rootGraphPattern.get());
+    QueryPlanner::TripleGraph tg = qp.createTripleGraph(&pq._rootGraphPattern);
     ASSERT_EQ(1u, tg._nodeMap.find(0)->second->_variables.size());
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -24,7 +24,8 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg =
+          qp.createTripleGraph(&pq._rootGraphPattern._children[0].getBasic());
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -54,7 +55,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -79,7 +80,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
 
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>({
@@ -112,7 +113,7 @@ TEST(QueryPlannerTest, testCpyCtorWithKeepNodes) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(2u, tg._nodeMap.find(0)->second->_variables.size());
       ASSERT_EQ(2u, tg._nodeMap.find(1)->second->_variables.size());
       ASSERT_EQ(1u, tg._nodeMap.find(2)->second->_variables.size());
@@ -175,7 +176,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(3u, tg._adjLists.size());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
@@ -197,7 +198,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
       ASSERT_EQ(3u, out.size());
@@ -235,7 +236,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -276,7 +277,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -319,7 +320,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -367,7 +368,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         TripleGraph expected = TripleGraph(std::vector<std::pair<
                                                Node, std::vector<size_t>>>(
             {std::make_pair<Node, vector<size_t>>(
@@ -451,7 +452,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -941,7 +942,8 @@ TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryPlanner::TripleGraph tg = qp.createTripleGraph(&pq._rootGraphPattern);
+    QueryPlanner::TripleGraph tg =
+        qp.createTripleGraph(&pq.children()[0].getBasic());
     ASSERT_EQ(1u, tg._nodeMap.find(0)->second->_variables.size());
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -1159,11 +1161,11 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq.expandPrefixes();
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
-        "{\n  OPTIONAL_JOIN\n  {\n    ORDER_BY\n    {\n      SCAN POS with P = "
-        "\"<rel2>\"\n      qet-width: 2 \n    } order on asc(1) \n    "
-        "qet-width: 2 \n  } join-columns: [1]\n  |X|\n  {\n    SCAN PSO with P "
-        "= \"<rel1>\"\n    qet-width: 2 \n  } join-columns: [0]\n  qet-width: "
+        "{\n  OPTIONAL_JOIN\n  {\n    SCAN PSO with P = \"<rel1>\"\n    "
+        "qet-width: 2 \n  } join-columns: [0]\n  |X|\n  {\n    SCAN PSO with P "
+        "= \"<rel2>\"\n    qet-width: 2 \n  } join-columns: [0]\n  qet-width: "
         "3 \n}",
+
         qet.asString());
 
     ParsedQuery pq2 = SparqlParser(
@@ -1174,14 +1176,11 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq2.expandPrefixes();
     QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
-        "{\n  SORT on column:2\n  {\n    OPTIONAL_JOIN\n    {\n      "
-        "ORDER_BY\n      {\n        SCAN POS with P = \"<rel2>\"\n        "
-        "qet-width: 2 \n      } order on asc(1) \n      qet-width: 2 \n    } "
-        "join-columns: [1]\n    |X|\n    {\n      SCAN PSO with P = "
-        "\"<rel1>\"\n      qet-width: 2 \n    } join-columns: [0]\n    "
-        "qet-width: 3 \n  }\n  qet-width: 3 \n}"
+        "{\n  SORT on column:1\n  {\n    OPTIONAL_JOIN\n    {\n      SCAN PSO "
+        "with P = \"<rel1>\"\n      qet-width: 2 \n    } join-columns: [0]\n   "
+        " |X|\n    {\n      SCAN PSO with P = \"<rel2>\"\n      qet-width: 2 "
+        "\n    } join-columns: [0]\n    qet-width: 3 \n  }\n  qet-width: 3 \n}",
 
-        ,
         qet2.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -14,7 +14,7 @@ TEST(ParserTest, testParse) {
     ASSERT_GT(pq.asString().size(), 0u);
     ASSERT_EQ(0u, pq._prefixes.size());
     ASSERT_EQ(1u, pq._selectedVariables.size());
-    ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+    ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
 
     pq = SparqlParser(
              "PREFIX : <http://rdf.myprefix.com/>\n"
@@ -26,7 +26,7 @@ TEST(ParserTest, testParse) {
              .parse();
     ASSERT_EQ(3u, pq._prefixes.size());
     ASSERT_EQ(2u, pq._selectedVariables.size());
-    ASSERT_EQ(3u, pq._rootGraphPattern->_whereClauseTriples.size());
+    ASSERT_EQ(3u, pq._rootGraphPattern._whereClauseTriples.size());
 
     ASSERT_EQ("", pq._prefixes[0]._prefix);
     ASSERT_EQ("<http://rdf.myprefix.com/>", pq._prefixes[0]._uri);
@@ -34,16 +34,16 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ("<http://rdf.myprefix.com/ns/>", pq._prefixes[1]._uri);
     ASSERT_EQ("?x", pq._selectedVariables[0]);
     ASSERT_EQ("?z", pq._selectedVariables[1]);
-    ASSERT_EQ("?x", pq._rootGraphPattern->_whereClauseTriples[0]._s);
-    ASSERT_EQ(":myrel", pq._rootGraphPattern->_whereClauseTriples[0]._p._iri);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[0]._o);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[1]._s);
-    ASSERT_EQ("ns:myrel", pq._rootGraphPattern->_whereClauseTriples[1]._p._iri);
-    ASSERT_EQ("?z", pq._rootGraphPattern->_whereClauseTriples[1]._o);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[2]._s);
-    ASSERT_EQ("nsx:rel2", pq._rootGraphPattern->_whereClauseTriples[2]._p._iri);
+    ASSERT_EQ("?x", pq._rootGraphPattern._whereClauseTriples[0]._s);
+    ASSERT_EQ(":myrel", pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[0]._o);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[1]._s);
+    ASSERT_EQ("ns:myrel", pq._rootGraphPattern._whereClauseTriples[1]._p._iri);
+    ASSERT_EQ("?z", pq._rootGraphPattern._whereClauseTriples[1]._o);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[2]._s);
+    ASSERT_EQ("nsx:rel2", pq._rootGraphPattern._whereClauseTriples[2]._p._iri);
     ASSERT_EQ("<http://abc.de>",
-              pq._rootGraphPattern->_whereClauseTriples[2]._o);
+              pq._rootGraphPattern._whereClauseTriples[2]._o);
     ASSERT_EQ("", pq._limit);
     ASSERT_EQ("", pq._offset);
 
@@ -57,7 +57,7 @@ TEST(ParserTest, testParse) {
              .parse();
     ASSERT_EQ(3u, pq._prefixes.size());
     ASSERT_EQ(2u, pq._selectedVariables.size());
-    ASSERT_EQ(3u, pq._rootGraphPattern->_whereClauseTriples.size());
+    ASSERT_EQ(3u, pq._rootGraphPattern._whereClauseTriples.size());
 
     ASSERT_EQ("", pq._prefixes[0]._prefix);
     ASSERT_EQ("<http://rdf.myprefix.com/>", pq._prefixes[0]._uri);
@@ -65,16 +65,16 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ("<http://rdf.myprefix.com/ns/>", pq._prefixes[1]._uri);
     ASSERT_EQ("?x", pq._selectedVariables[0]);
     ASSERT_EQ("?z", pq._selectedVariables[1]);
-    ASSERT_EQ("?x", pq._rootGraphPattern->_whereClauseTriples[0]._s);
-    ASSERT_EQ(":myrel", pq._rootGraphPattern->_whereClauseTriples[0]._p._iri);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[0]._o);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[1]._s);
-    ASSERT_EQ("ns:myrel", pq._rootGraphPattern->_whereClauseTriples[1]._p._iri);
-    ASSERT_EQ("?z", pq._rootGraphPattern->_whereClauseTriples[1]._o);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[2]._s);
-    ASSERT_EQ("nsx:rel2", pq._rootGraphPattern->_whereClauseTriples[2]._p._iri);
+    ASSERT_EQ("?x", pq._rootGraphPattern._whereClauseTriples[0]._s);
+    ASSERT_EQ(":myrel", pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[0]._o);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[1]._s);
+    ASSERT_EQ("ns:myrel", pq._rootGraphPattern._whereClauseTriples[1]._p._iri);
+    ASSERT_EQ("?z", pq._rootGraphPattern._whereClauseTriples[1]._o);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[2]._s);
+    ASSERT_EQ("nsx:rel2", pq._rootGraphPattern._whereClauseTriples[2]._p._iri);
     ASSERT_EQ("<http://abc.de>",
-              pq._rootGraphPattern->_whereClauseTriples[2]._o);
+              pq._rootGraphPattern._whereClauseTriples[2]._o);
     ASSERT_EQ("", pq._limit);
     ASSERT_EQ("", pq._offset);
 
@@ -86,24 +86,24 @@ TEST(ParserTest, testParse) {
              .parse();
     ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(2u, pq._selectedVariables.size());
-    ASSERT_EQ(3u, pq._rootGraphPattern->_whereClauseTriples.size());
+    ASSERT_EQ(3u, pq._rootGraphPattern._whereClauseTriples.size());
 
     pq.expandPrefixes();
 
     ASSERT_EQ("?x", pq._selectedVariables[0]);
     ASSERT_EQ("?z", pq._selectedVariables[1]);
-    ASSERT_EQ("?x", pq._rootGraphPattern->_whereClauseTriples[0]._s);
+    ASSERT_EQ("?x", pq._rootGraphPattern._whereClauseTriples[0]._s);
     ASSERT_EQ("<Directed_by>",
-              pq._rootGraphPattern->_whereClauseTriples[0]._p._iri);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[0]._o);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[1]._s);
+              pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[0]._o);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[1]._s);
     ASSERT_EQ("<http://ns/myrel.extend>",
-              pq._rootGraphPattern->_whereClauseTriples[1]._p._iri);
-    ASSERT_EQ("?z", pq._rootGraphPattern->_whereClauseTriples[1]._o);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[2]._s);
-    ASSERT_EQ("nsx:rel2", pq._rootGraphPattern->_whereClauseTriples[2]._p._iri);
+              pq._rootGraphPattern._whereClauseTriples[1]._p._iri);
+    ASSERT_EQ("?z", pq._rootGraphPattern._whereClauseTriples[1]._o);
+    ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[2]._s);
+    ASSERT_EQ("nsx:rel2", pq._rootGraphPattern._whereClauseTriples[2]._p._iri);
     ASSERT_EQ("\"Hello... World\"",
-              pq._rootGraphPattern->_whereClauseTriples[2]._o);
+              pq._rootGraphPattern._whereClauseTriples[2]._o);
     ASSERT_EQ("", pq._limit);
     ASSERT_EQ("", pq._offset);
 
@@ -112,28 +112,28 @@ TEST(ParserTest, testParse) {
              "?y <is-a> <Actor> . FILTER(?y < ?x)} LIMIT 10")
              .parse();
     pq.expandPrefixes();
-    ASSERT_EQ(2u, pq._rootGraphPattern->_filters.size());
-    ASSERT_EQ("?x", pq._rootGraphPattern->_filters[0]._lhs);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_filters[0]._rhs);
+    ASSERT_EQ(2u, pq._rootGraphPattern._filters.size());
+    ASSERT_EQ("?x", pq._rootGraphPattern._filters[0]._lhs);
+    ASSERT_EQ("?y", pq._rootGraphPattern._filters[0]._rhs);
     ASSERT_EQ(SparqlFilter::FilterType::NE,
-              pq._rootGraphPattern->_filters[0]._type);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_filters[1]._lhs);
-    ASSERT_EQ("?x", pq._rootGraphPattern->_filters[1]._rhs);
+              pq._rootGraphPattern._filters[0]._type);
+    ASSERT_EQ("?y", pq._rootGraphPattern._filters[1]._lhs);
+    ASSERT_EQ("?x", pq._rootGraphPattern._filters[1]._rhs);
     ASSERT_EQ(SparqlFilter::FilterType::LT,
-              pq._rootGraphPattern->_filters[1]._type);
-    ASSERT_EQ(2u, pq._rootGraphPattern->_whereClauseTriples.size());
+              pq._rootGraphPattern._filters[1]._type);
+    ASSERT_EQ(2u, pq._rootGraphPattern._whereClauseTriples.size());
 
     pq = SparqlParser(
              "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
              "?y <is-a> <Actor>} LIMIT 10")
              .parse();
     pq.expandPrefixes();
-    ASSERT_EQ(1u, pq._rootGraphPattern->_filters.size());
-    ASSERT_EQ("?x", pq._rootGraphPattern->_filters[0]._lhs);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_filters[0]._rhs);
+    ASSERT_EQ(1u, pq._rootGraphPattern._filters.size());
+    ASSERT_EQ("?x", pq._rootGraphPattern._filters[0]._lhs);
+    ASSERT_EQ("?y", pq._rootGraphPattern._filters[0]._rhs);
     ASSERT_EQ(SparqlFilter::FilterType::NE,
-              pq._rootGraphPattern->_filters[0]._type);
-    ASSERT_EQ(2u, pq._rootGraphPattern->_whereClauseTriples.size());
+              pq._rootGraphPattern._filters[0]._type);
+    ASSERT_EQ(2u, pq._rootGraphPattern._whereClauseTriples.size());
 
     pq = SparqlParser(
              "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
@@ -141,20 +141,20 @@ TEST(ParserTest, testParse) {
              "?c ql:contains-word \"coca* abuse\"} LIMIT 10")
              .parse();
     pq.expandPrefixes();
-    ASSERT_EQ(1u, pq._rootGraphPattern->_filters.size());
-    ASSERT_EQ("?x", pq._rootGraphPattern->_filters[0]._lhs);
-    ASSERT_EQ("?y", pq._rootGraphPattern->_filters[0]._rhs);
+    ASSERT_EQ(1u, pq._rootGraphPattern._filters.size());
+    ASSERT_EQ("?x", pq._rootGraphPattern._filters[0]._lhs);
+    ASSERT_EQ("?y", pq._rootGraphPattern._filters[0]._rhs);
     ASSERT_EQ(SparqlFilter::FilterType::NE,
-              pq._rootGraphPattern->_filters[0]._type);
-    ASSERT_EQ(4u, pq._rootGraphPattern->_whereClauseTriples.size());
-    ASSERT_EQ("?c", pq._rootGraphPattern->_whereClauseTriples[2]._s);
+              pq._rootGraphPattern._filters[0]._type);
+    ASSERT_EQ(4u, pq._rootGraphPattern._whereClauseTriples.size());
+    ASSERT_EQ("?c", pq._rootGraphPattern._whereClauseTriples[2]._s);
     ASSERT_EQ(CONTAINS_ENTITY_PREDICATE,
-              pq._rootGraphPattern->_whereClauseTriples[2]._p._iri);
-    ASSERT_EQ("?x", pq._rootGraphPattern->_whereClauseTriples[2]._o);
-    ASSERT_EQ("?c", pq._rootGraphPattern->_whereClauseTriples[3]._s);
+              pq._rootGraphPattern._whereClauseTriples[2]._p._iri);
+    ASSERT_EQ("?x", pq._rootGraphPattern._whereClauseTriples[2]._o);
+    ASSERT_EQ("?c", pq._rootGraphPattern._whereClauseTriples[3]._s);
     ASSERT_EQ(CONTAINS_WORD_PREDICATE,
-              pq._rootGraphPattern->_whereClauseTriples[3]._p._iri);
-    ASSERT_EQ("coca* abuse", pq._rootGraphPattern->_whereClauseTriples[3]._o);
+              pq._rootGraphPattern._whereClauseTriples[3]._p._iri);
+    ASSERT_EQ("coca* abuse", pq._rootGraphPattern._whereClauseTriples[3]._o);
 
     pq = SparqlParser(
              "PREFIX : <>\n"
@@ -168,7 +168,7 @@ TEST(ParserTest, testParse) {
              "} ORDER BY ?c")
              .parse();
     pq.expandPrefixes();
-    ASSERT_EQ(1u, pq._rootGraphPattern->_filters.size());
+    ASSERT_EQ(1u, pq._rootGraphPattern._filters.size());
 
     pq = SparqlParser(
              "SELECT ?x ?z WHERE {\n"
@@ -179,9 +179,9 @@ TEST(ParserTest, testParse) {
              "}")
              .parse();
 
-    ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
+    ASSERT_EQ(1u, pq._rootGraphPattern._children.size());
     const auto& opt =
-        pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
+        pq._rootGraphPattern._children[0].get<GraphPatternOperation::Optional>();  // throws on error
     auto& child = opt._child;
     ASSERT_EQ(1u, child._whereClauseTriples.size());
     ASSERT_EQ("?y", child._whereClauseTriples[0]._s);
@@ -206,9 +206,9 @@ TEST(ParserTest, testParse) {
               "  }\n"
               "}")
               .parse();
-      ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
+      ASSERT_EQ(1u, pq._rootGraphPattern._children.size());
       const auto &optA =
-              pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
+              pq._rootGraphPattern._children[0].get<GraphPatternOperation::Optional>();  // throws on error
       auto& child = optA._child;
       ASSERT_EQ(2u, child._children.size());
       const auto &opt2 =
@@ -233,18 +233,18 @@ TEST(ParserTest, testParse) {
              "  ?a <rel> ?b ."
              "}")
              .parse();
-    ASSERT_EQ(0u, pq._rootGraphPattern->_children.size());
-    ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
-    ASSERT_EQ(0u, pq._rootGraphPattern->_filters.size());
-    ASSERT_EQ(2u, pq._rootGraphPattern->_inlineValues.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._children.size());
+    ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
+    ASSERT_EQ(2u, pq._rootGraphPattern._inlineValues.size());
 
-    SparqlValues values1 = pq._rootGraphPattern->_inlineValues[0];
+    SparqlValues values1 = pq._rootGraphPattern._inlineValues[0];
     vector<string> vvars = {"?a"};
     ASSERT_EQ(vvars, values1._variables);
     vector<vector<string>> vvals = {{"<1>"}, {"\"2\""}};
     ASSERT_EQ(vvals, values1._values);
 
-    SparqlValues values2 = pq._rootGraphPattern->_inlineValues[1];
+    SparqlValues values2 = pq._rootGraphPattern._inlineValues[1];
     vvars = {"?b", "?c"};
     ASSERT_EQ(vvars, values2._variables);
     vvals = {{"<1>", "<2>"}, {"\"1\"", "\"2\""}};
@@ -258,18 +258,18 @@ SELECT ?a ?b ?c WHERE {
         )")
              .parse();
 
-    ASSERT_EQ(0u, pq._rootGraphPattern->_children.size());
-    ASSERT_EQ(0u, pq._rootGraphPattern->_whereClauseTriples.size());
-    ASSERT_EQ(0u, pq._rootGraphPattern->_filters.size());
-    ASSERT_EQ(2u, pq._rootGraphPattern->_inlineValues.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._children.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._whereClauseTriples.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
+    ASSERT_EQ(2u, pq._rootGraphPattern._inlineValues.size());
 
-    values1 = pq._rootGraphPattern->_inlineValues[0];
+    values1 = pq._rootGraphPattern._inlineValues[0];
     vvars = {"?a"};
     ASSERT_EQ(vvars, values1._variables);
     vvals = {{"<Albert_Einstein>"}};
     ASSERT_EQ(vvals, values1._values);
 
-    values2 = pq._rootGraphPattern->_inlineValues[1];
+    values2 = pq._rootGraphPattern._inlineValues[1];
     vvars = {"?b", "?c"};
     ASSERT_EQ(vvars, values2._variables);
     vvals = {{"<Marie_Curie>", "<Joseph_Jacobson>"},
@@ -286,16 +286,16 @@ SELECT ?a ?b ?c WHERE {
              "}\n")
              .parse();
 
-    ASSERT_EQ(0u, pq._rootGraphPattern->_children.size());
-    ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
-    ASSERT_EQ(0u, pq._rootGraphPattern->_filters.size());
-    ASSERT_EQ(1u, pq._rootGraphPattern->_inlineValues.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._children.size());
+    ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
+    ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
+    ASSERT_EQ(1u, pq._rootGraphPattern._inlineValues.size());
 
-    ASSERT_EQ(pq._rootGraphPattern->_whereClauseTriples[0]._s, "?city");
-    ASSERT_EQ(pq._rootGraphPattern->_whereClauseTriples[0]._p._iri, "wdt:P31");
-    ASSERT_EQ(pq._rootGraphPattern->_whereClauseTriples[0]._s, "?city");
+    ASSERT_EQ(pq._rootGraphPattern._whereClauseTriples[0]._s, "?city");
+    ASSERT_EQ(pq._rootGraphPattern._whereClauseTriples[0]._p._iri, "wdt:P31");
+    ASSERT_EQ(pq._rootGraphPattern._whereClauseTriples[0]._s, "?city");
 
-    values1 = pq._rootGraphPattern->_inlineValues[0];
+    values1 = pq._rootGraphPattern._inlineValues[0];
     vvars = {"?citytype"};
     ASSERT_EQ(vvars, values1._variables);
     vvals = {{"wd:Q515"}, {"wd:Q262166"}};
@@ -325,23 +325,23 @@ TEST(ParserTest, testFilterWithoutDot) {
   pq.expandPrefixes();
   ASSERT_EQ(1u, pq._prefixes.size());
   ASSERT_EQ(1u, pq._selectedVariables.size());
-  ASSERT_EQ(3u, pq._rootGraphPattern->_whereClauseTriples.size());
-  ASSERT_EQ(3u, pq._rootGraphPattern->_filters.size());
-  ASSERT_EQ("?1", pq._rootGraphPattern->_filters[0]._lhs);
+  ASSERT_EQ(3u, pq._rootGraphPattern._whereClauseTriples.size());
+  ASSERT_EQ(3u, pq._rootGraphPattern._filters.size());
+  ASSERT_EQ("?1", pq._rootGraphPattern._filters[0]._lhs);
   ASSERT_EQ("<http://rdf.freebase.com/ns/m.0fkvn>",
-            pq._rootGraphPattern->_filters[0]._rhs);
+            pq._rootGraphPattern._filters[0]._rhs);
   ASSERT_EQ(SparqlFilter::FilterType::NE,
-            pq._rootGraphPattern->_filters[0]._type);
-  ASSERT_EQ("?1", pq._rootGraphPattern->_filters[1]._lhs);
+            pq._rootGraphPattern._filters[0]._type);
+  ASSERT_EQ("?1", pq._rootGraphPattern._filters[1]._lhs);
   ASSERT_EQ("<http://rdf.freebase.com/ns/m.0vmt>",
-            pq._rootGraphPattern->_filters[1]._rhs);
+            pq._rootGraphPattern._filters[1]._rhs);
   ASSERT_EQ(SparqlFilter::FilterType::NE,
-            pq._rootGraphPattern->_filters[1]._type);
-  ASSERT_EQ("?1", pq._rootGraphPattern->_filters[2]._lhs);
+            pq._rootGraphPattern._filters[1]._type);
+  ASSERT_EQ("?1", pq._rootGraphPattern._filters[2]._lhs);
   ASSERT_EQ("<http://rdf.freebase.com/ns/m.018mts>",
-            pq._rootGraphPattern->_filters[2]._rhs);
+            pq._rootGraphPattern._filters[2]._rhs);
   ASSERT_EQ(SparqlFilter::FilterType::NE,
-            pq._rootGraphPattern->_filters[2]._type);
+            pq._rootGraphPattern._filters[2]._type);
 }
 
 TEST(ParserTest, testExpandPrefixes) {
@@ -356,24 +356,24 @@ TEST(ParserTest, testExpandPrefixes) {
   pq.expandPrefixes();
   ASSERT_EQ(3u, pq._prefixes.size());
   ASSERT_EQ(2u, pq._selectedVariables.size());
-  ASSERT_EQ(3u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(3u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("", pq._prefixes[0]._prefix);
   ASSERT_EQ("<http://rdf.myprefix.com/>", pq._prefixes[0]._uri);
   ASSERT_EQ("ns", pq._prefixes[1]._prefix);
   ASSERT_EQ("<http://rdf.myprefix.com/ns/>", pq._prefixes[1]._uri);
   ASSERT_EQ("?x", pq._selectedVariables[0]);
   ASSERT_EQ("?z", pq._selectedVariables[1]);
-  ASSERT_EQ("?x", pq._rootGraphPattern->_whereClauseTriples[0]._s);
+  ASSERT_EQ("?x", pq._rootGraphPattern._whereClauseTriples[0]._s);
   ASSERT_EQ("<http://rdf.myprefix.com/myrel>",
-            pq._rootGraphPattern->_whereClauseTriples[0]._p._iri);
-  ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[0]._o);
-  ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[1]._s);
+            pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
+  ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[0]._o);
+  ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[1]._s);
   ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>",
-            pq._rootGraphPattern->_whereClauseTriples[1]._p._iri);
-  ASSERT_EQ("?z", pq._rootGraphPattern->_whereClauseTriples[1]._o);
-  ASSERT_EQ("?y", pq._rootGraphPattern->_whereClauseTriples[2]._s);
-  ASSERT_EQ("nsx:rel2", pq._rootGraphPattern->_whereClauseTriples[2]._p._iri);
-  ASSERT_EQ("<http://abc.de>", pq._rootGraphPattern->_whereClauseTriples[2]._o);
+            pq._rootGraphPattern._whereClauseTriples[1]._p._iri);
+  ASSERT_EQ("?z", pq._rootGraphPattern._whereClauseTriples[1]._o);
+  ASSERT_EQ("?y", pq._rootGraphPattern._whereClauseTriples[2]._s);
+  ASSERT_EQ("nsx:rel2", pq._rootGraphPattern._whereClauseTriples[2]._p._iri);
+  ASSERT_EQ("<http://abc.de>", pq._rootGraphPattern._whereClauseTriples[2]._o);
   ASSERT_EQ("", pq._limit);
   ASSERT_EQ("", pq._offset);
 }
@@ -383,7 +383,7 @@ TEST(ParserTest, testSolutionModifiers) {
   pq.expandPrefixes();
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(1u, pq._selectedVariables.size());
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("", pq._limit);
   ASSERT_EQ("", pq._offset);
   ASSERT_EQ(size_t(0), pq._orderBy.size());
@@ -394,7 +394,7 @@ TEST(ParserTest, testSolutionModifiers) {
   pq.expandPrefixes();
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(1u, pq._selectedVariables.size());
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("10", pq._limit);
   ASSERT_EQ("", pq._offset);
   ASSERT_EQ(size_t(0), pq._orderBy.size());
@@ -408,7 +408,7 @@ TEST(ParserTest, testSolutionModifiers) {
   pq.expandPrefixes();
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(1u, pq._selectedVariables.size());
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("10", pq._limit);
   ASSERT_EQ("15", pq._offset);
   ASSERT_EQ(size_t(0), pq._orderBy.size());
@@ -422,7 +422,7 @@ TEST(ParserTest, testSolutionModifiers) {
   pq.expandPrefixes();
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(2u, pq._selectedVariables.size());
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("10", pq._limit);
   ASSERT_EQ("15", pq._offset);
   ASSERT_EQ(size_t(1), pq._orderBy.size());
@@ -439,7 +439,7 @@ TEST(ParserTest, testSolutionModifiers) {
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(3u, pq._selectedVariables.size());
   ASSERT_EQ("SCORE(?x)", pq._selectedVariables[1]);
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("10", pq._limit);
   ASSERT_EQ("15", pq._offset);
   ASSERT_EQ(size_t(2), pq._orderBy.size());
@@ -457,7 +457,7 @@ TEST(ParserTest, testSolutionModifiers) {
   pq.expandPrefixes();
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(2u, pq._selectedVariables.size());
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("10", pq._limit);
   ASSERT_EQ("15", pq._offset);
   ASSERT_EQ(size_t(2), pq._orderBy.size());
@@ -483,17 +483,17 @@ TEST(ParserTest, testSolutionModifiers) {
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(1u, pq._selectedVariables.size());
   ASSERT_EQ("?movie", pq._selectedVariables[0]);
-  ASSERT_EQ(2u, pq._rootGraphPattern->_whereClauseTriples.size());
-  ASSERT_EQ("?movie", pq._rootGraphPattern->_whereClauseTriples[0]._s);
+  ASSERT_EQ(2u, pq._rootGraphPattern._whereClauseTriples.size());
+  ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[0]._s);
   ASSERT_EQ("<from-year>",
-            pq._rootGraphPattern->_whereClauseTriples[0]._p._iri);
+            pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
   ASSERT_EQ("\"00-00-2000\"^^xsd:date",
-            pq._rootGraphPattern->_whereClauseTriples[0]._o);
-  ASSERT_EQ("?movie", pq._rootGraphPattern->_whereClauseTriples[1]._s);
+            pq._rootGraphPattern._whereClauseTriples[0]._o);
+  ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[1]._s);
   ASSERT_EQ("<directed-by>",
-            pq._rootGraphPattern->_whereClauseTriples[1]._p._iri);
+            pq._rootGraphPattern._whereClauseTriples[1]._p._iri);
   ASSERT_EQ("<Scott%2C%20Ridley>",
-            pq._rootGraphPattern->_whereClauseTriples[1]._o);
+            pq._rootGraphPattern._whereClauseTriples[1]._o);
 
   pq = SparqlParser(
            "PREFIX xsd: <http://www.w3.org/2010/XMLSchema#>"
@@ -507,17 +507,17 @@ TEST(ParserTest, testSolutionModifiers) {
   ASSERT_EQ(1u, pq._prefixes.size());
   ASSERT_EQ(1u, pq._selectedVariables.size());
   ASSERT_EQ("?movie", pq._selectedVariables[0]);
-  ASSERT_EQ(2u, pq._rootGraphPattern->_whereClauseTriples.size());
-  ASSERT_EQ("?movie", pq._rootGraphPattern->_whereClauseTriples[0]._s);
+  ASSERT_EQ(2u, pq._rootGraphPattern._whereClauseTriples.size());
+  ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[0]._s);
   ASSERT_EQ("<from-year>",
-            pq._rootGraphPattern->_whereClauseTriples[0]._p._iri);
+            pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
   ASSERT_EQ("\"00-00-2000\"^^<http://www.w3.org/2010/XMLSchema#date>",
-            pq._rootGraphPattern->_whereClauseTriples[0]._o);
-  ASSERT_EQ("?movie", pq._rootGraphPattern->_whereClauseTriples[1]._s);
+            pq._rootGraphPattern._whereClauseTriples[0]._o);
+  ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[1]._s);
   ASSERT_EQ("<directed-by>",
-            pq._rootGraphPattern->_whereClauseTriples[1]._p._iri);
+            pq._rootGraphPattern._whereClauseTriples[1]._p._iri);
   ASSERT_EQ("<Scott%2C%20Ridley>",
-            pq._rootGraphPattern->_whereClauseTriples[1]._o);
+            pq._rootGraphPattern._whereClauseTriples[1]._o);
 
   pq = SparqlParser(
            "SELECT ?r (AVG(?r) as ?avg) WHERE {"
@@ -564,7 +564,7 @@ TEST(ParserTest, testSolutionModifiers) {
   pq.expandPrefixes();
   ASSERT_EQ(0u, pq._prefixes.size());
   ASSERT_EQ(2u, pq._selectedVariables.size());
-  ASSERT_EQ(1u, pq._rootGraphPattern->_whereClauseTriples.size());
+  ASSERT_EQ(1u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("10", pq._limit);
   ASSERT_EQ("15", pq._offset);
   ASSERT_EQ(1u, pq._orderBy.size());

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -182,47 +182,49 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
     const auto& opt =
         pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
-    std::shared_ptr<ParsedQuery::GraphPattern> child = opt._children[0];
-    ASSERT_EQ(1u, child->_whereClauseTriples.size());
-    ASSERT_EQ("?y", child->_whereClauseTriples[0]._s);
-    ASSERT_EQ("<test2>", child->_whereClauseTriples[0]._p._iri);
-    ASSERT_EQ("?z", child->_whereClauseTriples[0]._o);
-    ASSERT_EQ(0u, child->_filters.size());
-    ASSERT_TRUE(child->_optional);
+    auto& child = opt._child;
+    ASSERT_EQ(1u, child._whereClauseTriples.size());
+    ASSERT_EQ("?y", child._whereClauseTriples[0]._s);
+    ASSERT_EQ("<test2>", child._whereClauseTriples[0]._p._iri);
+    ASSERT_EQ("?z", child._whereClauseTriples[0]._o);
+    ASSERT_EQ(0u, child._filters.size());
+    ASSERT_TRUE(child._optional);
 
-    pq = SparqlParser(
-             "SELECT ?x ?z WHERE {\n"
-             "  ?x <test> ?y .\n"
-             "  OPTIONAL {\n"
-             "    ?y <test2> ?z .\n"
-             "    optional {\n"
-             "      ?a ?b ?c .\n"
-             "      FILTER(?c > 3)\n"
-             "    }\n"
-             "    optional {\n"
-             "      ?d ?e ?f\n"
-             "    }\n"
-             "  }\n"
-             "}")
-             .parse();
-    ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
-    const auto& optA =
-        pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
-    child = optA._children[0];
-    ASSERT_EQ(2u, child->_children.size());
-    const auto& opt2 =
-        child->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
-    const auto& opt3 =
-        child->_children[1].get<GraphPatternOperation::Optional>();  // throws on error
-    std::shared_ptr<ParsedQuery::GraphPattern> child2 = opt2._children[0];
-    std::shared_ptr<ParsedQuery::GraphPattern> child3 = opt3._children[0];
-    ASSERT_EQ(1u, child2->_whereClauseTriples.size());
-    ASSERT_EQ(1u, child2->_filters.size());
-    ASSERT_EQ(1u, child3->_whereClauseTriples.size());
-    ASSERT_EQ(0u, child3->_filters.size());
-    ASSERT_TRUE(child->_optional);
-    ASSERT_TRUE(child2->_optional);
-    ASSERT_TRUE(child3->_optional);
+    {
+      pq = SparqlParser(
+              "SELECT ?x ?z WHERE {\n"
+              "  ?x <test> ?y .\n"
+              "  OPTIONAL {\n"
+              "    ?y <test2> ?z .\n"
+              "    optional {\n"
+              "      ?a ?b ?c .\n"
+              "      FILTER(?c > 3)\n"
+              "    }\n"
+              "    optional {\n"
+              "      ?d ?e ?f\n"
+              "    }\n"
+              "  }\n"
+              "}")
+              .parse();
+      ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
+      const auto &optA =
+              pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
+      auto& child = optA._child;
+      ASSERT_EQ(2u, child._children.size());
+      const auto &opt2 =
+              child._children[0].get<GraphPatternOperation::Optional>();  // throws on error
+      const auto &opt3 =
+              child._children[1].get<GraphPatternOperation::Optional>();  // throws on error
+      const auto& child2 = opt2._child;
+      const auto& child3 = opt3._child;
+      ASSERT_EQ(1u, child2._whereClauseTriples.size());
+      ASSERT_EQ(1u, child2._filters.size());
+      ASSERT_EQ(1u, child3._whereClauseTriples.size());
+      ASSERT_EQ(0u, child3._filters.size());
+      ASSERT_TRUE(child._optional);
+      ASSERT_TRUE(child2._optional);
+      ASSERT_TRUE(child3._optional);
+    }
 
     pq = SparqlParser(
              "SELECT ?a WHERE {\n"

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -180,10 +180,9 @@ TEST(ParserTest, testParse) {
              .parse();
 
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
-    ASSERT_EQ(1u,
-              pq._rootGraphPattern->_children[0]->_childGraphPatterns.size());
-    std::shared_ptr<ParsedQuery::GraphPattern> child =
-        pq._rootGraphPattern->_children[0]->_childGraphPatterns[0];
+    const auto& opt = std::get<ParsedQuery::Optional>(
+        *pq._rootGraphPattern->_children[0]);  // throws on error
+    std::shared_ptr<ParsedQuery::GraphPattern> child = opt._children[0];
     ASSERT_EQ(1u, child->_whereClauseTriples.size());
     ASSERT_EQ("?y", child->_whereClauseTriples[0]._s);
     ASSERT_EQ("<test2>", child->_whereClauseTriples[0]._p._iri);
@@ -207,16 +206,16 @@ TEST(ParserTest, testParse) {
              "}")
              .parse();
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
-    ASSERT_EQ(1u,
-              pq._rootGraphPattern->_children[0]->_childGraphPatterns.size());
-    child = pq._rootGraphPattern->_children[0]->_childGraphPatterns[0];
+    const auto& optA = std::get<ParsedQuery::Optional>(
+        *pq._rootGraphPattern->_children[0]);  // throws on error
+    child = optA._children[0];
     ASSERT_EQ(2u, child->_children.size());
-    ASSERT_EQ(1u, child->_children[0]->_childGraphPatterns.size());
-    ASSERT_EQ(1u, child->_children[0]->_childGraphPatterns.size());
-    std::shared_ptr<ParsedQuery::GraphPattern> child2 =
-        child->_children[0]->_childGraphPatterns[0];
-    std::shared_ptr<ParsedQuery::GraphPattern> child3 =
-        child->_children[1]->_childGraphPatterns[0];
+    const auto& opt2 = std::get<ParsedQuery::Optional>(
+        *child->_children[0]);  // throws on error
+    const auto& opt3 = std::get<ParsedQuery::Optional>(
+        *child->_children[1]);  // throws on error
+    std::shared_ptr<ParsedQuery::GraphPattern> child2 = opt2._children[0];
+    std::shared_ptr<ParsedQuery::GraphPattern> child3 = opt3._children[0];
     ASSERT_EQ(1u, child2->_whereClauseTriples.size());
     ASSERT_EQ(1u, child2->_filters.size());
     ASSERT_EQ(1u, child3->_whereClauseTriples.size());

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -181,7 +181,7 @@ TEST(ParserTest, testParse) {
 
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
     const auto& opt = std::get<ParsedQuery::Optional>(
-        *pq._rootGraphPattern->_children[0]);  // throws on error
+        pq._rootGraphPattern->_children[0]);  // throws on error
     std::shared_ptr<ParsedQuery::GraphPattern> child = opt._children[0];
     ASSERT_EQ(1u, child->_whereClauseTriples.size());
     ASSERT_EQ("?y", child->_whereClauseTriples[0]._s);
@@ -207,13 +207,13 @@ TEST(ParserTest, testParse) {
              .parse();
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
     const auto& optA = std::get<ParsedQuery::Optional>(
-        *pq._rootGraphPattern->_children[0]);  // throws on error
+        pq._rootGraphPattern->_children[0]);  // throws on error
     child = optA._children[0];
     ASSERT_EQ(2u, child->_children.size());
     const auto& opt2 = std::get<ParsedQuery::Optional>(
-        *child->_children[0]);  // throws on error
+        child->_children[0]);  // throws on error
     const auto& opt3 = std::get<ParsedQuery::Optional>(
-        *child->_children[1]);  // throws on error
+        child->_children[1]);  // throws on error
     std::shared_ptr<ParsedQuery::GraphPattern> child2 = opt2._children[0];
     std::shared_ptr<ParsedQuery::GraphPattern> child3 = opt3._children[0];
     ASSERT_EQ(1u, child2->_whereClauseTriples.size());

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -180,8 +180,8 @@ TEST(ParserTest, testParse) {
              .parse();
 
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
-    const auto& opt = std::get<ParsedQuery::Optional>(
-        pq._rootGraphPattern->_children[0]);  // throws on error
+    const auto& opt =
+        pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
     std::shared_ptr<ParsedQuery::GraphPattern> child = opt._children[0];
     ASSERT_EQ(1u, child->_whereClauseTriples.size());
     ASSERT_EQ("?y", child->_whereClauseTriples[0]._s);
@@ -206,14 +206,14 @@ TEST(ParserTest, testParse) {
              "}")
              .parse();
     ASSERT_EQ(1u, pq._rootGraphPattern->_children.size());
-    const auto& optA = std::get<ParsedQuery::Optional>(
-        pq._rootGraphPattern->_children[0]);  // throws on error
+    const auto& optA =
+        pq._rootGraphPattern->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
     child = optA._children[0];
     ASSERT_EQ(2u, child->_children.size());
-    const auto& opt2 = std::get<ParsedQuery::Optional>(
-        child->_children[0]);  // throws on error
-    const auto& opt3 = std::get<ParsedQuery::Optional>(
-        child->_children[1]);  // throws on error
+    const auto& opt2 =
+        child->_children[0].get<GraphPatternOperation::Optional>();  // throws on error
+    const auto& opt3 =
+        child->_children[1].get<GraphPatternOperation::Optional>();  // throws on error
     std::shared_ptr<ParsedQuery::GraphPattern> child2 = opt2._children[0];
     std::shared_ptr<ParsedQuery::GraphPattern> child3 = opt3._children[0];
     ASSERT_EQ(1u, child2->_whereClauseTriples.size());

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -181,7 +181,8 @@ TEST(ParserTest, testParse) {
 
     ASSERT_EQ(1u, pq._rootGraphPattern._children.size());
     const auto& opt =
-        pq._rootGraphPattern._children[0].get<GraphPatternOperation::Optional>();  // throws on error
+        pq._rootGraphPattern._children[0]
+            .get<GraphPatternOperation::Optional>();  // throws on error
     auto& child = opt._child;
     ASSERT_EQ(1u, child._whereClauseTriples.size());
     ASSERT_EQ("?y", child._whereClauseTriples[0]._s);
@@ -192,29 +193,32 @@ TEST(ParserTest, testParse) {
 
     {
       pq = SparqlParser(
-              "SELECT ?x ?z WHERE {\n"
-              "  ?x <test> ?y .\n"
-              "  OPTIONAL {\n"
-              "    ?y <test2> ?z .\n"
-              "    optional {\n"
-              "      ?a ?b ?c .\n"
-              "      FILTER(?c > 3)\n"
-              "    }\n"
-              "    optional {\n"
-              "      ?d ?e ?f\n"
-              "    }\n"
-              "  }\n"
-              "}")
-              .parse();
+               "SELECT ?x ?z WHERE {\n"
+               "  ?x <test> ?y .\n"
+               "  OPTIONAL {\n"
+               "    ?y <test2> ?z .\n"
+               "    optional {\n"
+               "      ?a ?b ?c .\n"
+               "      FILTER(?c > 3)\n"
+               "    }\n"
+               "    optional {\n"
+               "      ?d ?e ?f\n"
+               "    }\n"
+               "  }\n"
+               "}")
+               .parse();
       ASSERT_EQ(1u, pq._rootGraphPattern._children.size());
-      const auto &optA =
-              pq._rootGraphPattern._children[0].get<GraphPatternOperation::Optional>();  // throws on error
+      const auto& optA =
+          pq._rootGraphPattern._children[0]
+              .get<GraphPatternOperation::Optional>();  // throws on error
       auto& child = optA._child;
       ASSERT_EQ(2u, child._children.size());
-      const auto &opt2 =
-              child._children[0].get<GraphPatternOperation::Optional>();  // throws on error
-      const auto &opt3 =
-              child._children[1].get<GraphPatternOperation::Optional>();  // throws on error
+      const auto& opt2 =
+          child._children[0]
+              .get<GraphPatternOperation::Optional>();  // throws on error
+      const auto& opt3 =
+          child._children[1]
+              .get<GraphPatternOperation::Optional>();  // throws on error
       const auto& child2 = opt2._child;
       const auto& child3 = opt3._child;
       ASSERT_EQ(1u, child2._whereClauseTriples.size());
@@ -485,8 +489,7 @@ TEST(ParserTest, testSolutionModifiers) {
   ASSERT_EQ("?movie", pq._selectedVariables[0]);
   ASSERT_EQ(2u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[0]._s);
-  ASSERT_EQ("<from-year>",
-            pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
+  ASSERT_EQ("<from-year>", pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
   ASSERT_EQ("\"00-00-2000\"^^xsd:date",
             pq._rootGraphPattern._whereClauseTriples[0]._o);
   ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[1]._s);
@@ -509,8 +512,7 @@ TEST(ParserTest, testSolutionModifiers) {
   ASSERT_EQ("?movie", pq._selectedVariables[0]);
   ASSERT_EQ(2u, pq._rootGraphPattern._whereClauseTriples.size());
   ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[0]._s);
-  ASSERT_EQ("<from-year>",
-            pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
+  ASSERT_EQ("<from-year>", pq._rootGraphPattern._whereClauseTriples[0]._p._iri);
   ASSERT_EQ("\"00-00-2000\"^^<http://www.w3.org/2010/XMLSchema#date>",
             pq._rootGraphPattern._whereClauseTriples[0]._o);
   ASSERT_EQ("?movie", pq._rootGraphPattern._whereClauseTriples[1]._s);


### PR DESCRIPTION
TODO: this is a continuation of PR #323 , so that one should be reviewed + merged before.

- The previous version put all triples and filters that appeared directly in a WHERE clause together.
- this is not correct, since always when an OPTIONAL, UNION, SUBQUERY etc. appears a new scope
  is started. For example in
  SELECT ?x ?y WHERE {
    ?x <is-a> <Scientist>
    OPTIONAL { ?x <Spouse> ?y}
    FILTER ?x < <Ada_Lovelace>
  }
  the filter should have no effect, because it is not in the same scope as the x is a scientist triple.
  the probably more useful query would be
  SELECT ?x ?y WHERE {
    ?x <is-a> <Scientist> .
    FILTER ?x < <Ada_Lovelace>
    OPTIONAL { ?x <Spouse> ?y}
  }
  where the filter is actually applied on the entities that are scientists.
  However, QLever previously handled these queries both in the second way.

- To correct this, implemented a BasicGraphPattern (triples, filters and values that are "directly" in the Body of another graph pattern or a WHERE clause) class.
  BasicGraphPatterns are also children of their parent body.

- In addition, Optionals were also treated wrong as the GraphPatterns must be treated in order which makes a difference for Optionals.

- This version of the QueryPlanner does some degree of optimization, however one could optimize multiple adjacent GraphPatterns that are not Optional, if their
  scopes are respected.

- TODO: There still are bugs in the handling of optionals as the SPARQL standard knows "unbound values" which can be rebound, e.g.

  SELECT ?x ?name WHERE {
    ?x <is-a> <human>
    OPTIONAL {?x <TwitterAccount> ?name}
    OPTIONAL {?x rdfs:label ?name }
  }
  which should only add the names only for humans that don't have twitter accounts and the handling of the empty query
  SELECT ?x WHERE {} (1 result where ?x is unbound/NULL)

- TODO: Some candidate plans found by optimizing a TransitivePath are currently unable to be joined with adjacent patterns.
        It seems that we can always find a suitable candidate, so that this works, but we still should inspect, whether this is the correct behavior.