### PR TITLE
Make the optimizer (more) correct

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -273,8 +273,8 @@ queries:
     sparql: |
       SELECT ?x ?y WHERE {
           ?x <is-a> <Scientist> .
+          FILTER (?x < <Ada_Lovelace>) .
           OPTIONAL { ?x <Spouse_(or_domestic_partner)> ?y } .
-          FILTER (?x < <Ada_Lovelace>)
       }
     checks:
       - num_rows: 126
@@ -286,9 +286,9 @@ queries:
     type: no-text
     sparql: |
       SELECT ?x (GROUP_CONCAT(?y; separator=";") AS ?partners) WHERE {
+          FILTER (?x < <Ada_Lovelace>)
           ?x <is-a> <Scientist> .
           OPTIONAL {?x <Spouse_(or_domestic_partner)> ?y .}
-          FILTER (?x < <Ada_Lovelace>)
       }
       GROUP BY ?x
     checks:

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -734,4 +734,34 @@ queries:
       - num_rows: 1
       - selected: ["?a", "?b"]
       - contains_row: ["<Charles,_Prince_of_Wales>", "<Lord_of_the_Isles>"]
+  - query : filter-depending-on-last-optional
+    type: no-text
+    sparql: |
+      SELECT ?s ?a WHERE {
+          ?s <is-a> <Scientist> .
+          OPTIONAL { ?s <Award_Won> ?a }
+          FILTER regex(?a, "^<Nob")
+      }
+    checks:
+      - num_rows: 543
+      - num_cols: 2
+      - selected: ["?s", "?a"]
+      - contains_row: ["<Albert_Einstein>", "<Nobel_Prize_in_Physics>"]
+      - contains_row: ["<Al_Gore>", "<Nobel_Peace_Prize>"]
+      - contains_row: ["<Dennis_Gabor>", "<Nobel_Prize_in_Physics>"]
+  - query : filter-depending-on-last-optional-reordered
+    type: no-text
+    sparql: |
+      SELECT ?s ?a WHERE {
+          ?s <is-a> <Scientist> .
+          FILTER regex(?a, "^<Nob")
+          OPTIONAL { ?s <Award_Won> ?a }
+      }
+    checks:
+      - num_rows: 543
+      - num_cols: 2
+      - selected: ["?s", "?a"]
+      - contains_row: ["<Albert_Einstein>", "<Nobel_Prize_in_Physics>"]
+      - contains_row: ["<Al_Gore>", "<Nobel_Peace_Prize>"]
+      - contains_row: ["<Dennis_Gabor>", "<Nobel_Prize_in_Physics>"]
 

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -8,7 +8,6 @@
 #include <type_traits>
 #include <vector>
 
-#include <parallel/algorithm>
 #include "../global/Constants.h"
 #include "../global/Id.h"
 #include "../util/Exception.h"
@@ -102,12 +101,12 @@ class Engine {
     LOG(DEBUG) << "Sorting " << tab->size() << " elements.\n";
     IdTableStatic<WIDTH> stab = tab->moveToStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
-      __gnu_parallel::sort(
+      ad_utility::parallel_sort(
           stab.begin(), stab.end(),
           [keyColumn](const auto& a, const auto& b) {
             return a[keyColumn] < b[keyColumn];
           },
-          __gnu_parallel::parallel_tag(NUM_SORT_THREADS));
+          ad_utility::parallel_tag(NUM_SORT_THREADS));
     } else {
       std::sort(stab.begin(), stab.end(),
                 [keyColumn](const auto& a, const auto& b) {
@@ -123,8 +122,8 @@ class Engine {
     LOG(DEBUG) << "Sorting " << tab->size() << " elements.\n";
     IdTableStatic<WIDTH> stab = tab->moveToStatic<WIDTH>();
     if constexpr (USE_PARALLEL_SORT) {
-      __gnu_parallel::sort(stab.begin(), stab.end(), comp,
-                           __gnu_parallel::parallel_tag(NUM_SORT_THREADS));
+      ad_utility::parallel_sort(stab.begin(), stab.end(), comp,
+                                ad_utility::parallel_tag(NUM_SORT_THREADS));
     } else {
       std::sort(stab.begin(), stab.end(), comp);
     }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -417,7 +417,11 @@ void Filter::computeFilterFixedValue(
         // remove the leading '^' symbol
         std::string rhs = _rhs.substr(1);
         // TODO<joka921>: handle Levels correctly;
-        auto [lowerBound, upperBound] = getIndex().getVocab().prefix_range(rhs);
+        // according to the standard, structured bindings cannot be captured by
+        // lambdas and clang fails to compile with them
+        Id lowerBound, upperBound;
+        std::tie(lowerBound, upperBound) =
+            getIndex().getVocab().prefix_range(rhs);
 
         LOG(DEBUG) << "upper and lower bound are " << upperBound << ' '
                    << lowerBound << std::endl;

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -79,7 +79,7 @@ vector<size_t> GroupBy::resultSortedOn() const {
 }
 
 vector<pair<size_t, bool>> GroupBy::computeSortColumns(
-    std::shared_ptr<QueryExecutionTree> inputTree) {
+    const QueryExecutionTree* inputTree) {
   vector<pair<size_t, bool>> cols;
   if (_groupByVariables.empty()) {
     // the entire input is a single group, no sorting needs to be done

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -85,7 +85,7 @@ class GroupBy : public Operation {
    *                  creating the sorting operation inputs.
    */
   vector<pair<size_t, bool>> computeSortColumns(
-      std::shared_ptr<QueryExecutionTree> inputTree);
+      const QueryExecutionTree* inputTree);
 
   vector<QueryExecutionTree*> getChildren() override {
     return {_subtree.get()};

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -207,8 +207,7 @@ class QueryPlanner {
    */
   vector<SubtreePlan> seedWithScansAndText(
       const TripleGraph& tg,
-      const vector<const QueryPlanner::SubtreePlan*>& children,
-      const vector<SparqlValues>& values);
+      const vector<vector<QueryPlanner::SubtreePlan>>& children);
 
   /**
    * @brief Returns a subtree plan that will compute the values for the
@@ -299,8 +298,7 @@ class QueryPlanner {
 
   vector<vector<SubtreePlan>> fillDpTab(
       const TripleGraph& graph, const vector<SparqlFilter>& fs,
-      const vector<const SubtreePlan*>& children,
-      const vector<SparqlValues>& values);
+      const vector<vector<SubtreePlan>>& children);
 
   size_t getTextLimit(const string& textLimitString) const;
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -127,17 +127,14 @@ class QueryPlanner {
   class SubtreePlan {
    public:
     explicit SubtreePlan(QueryExecutionContext* qec)
-        : _qet(new QueryExecutionTree(qec)),
-          _idsOfIncludedNodes(0),
-          _idsOfIncludedFilters(0),
-          _isOptional(false) {}
+        : _qet(std::make_shared<QueryExecutionTree>(qec)) {}
 
     std::shared_ptr<QueryExecutionTree> _qet;
     std::shared_ptr<ResultTable> _cachedResult;
     bool _isCached = false;
-    uint64_t _idsOfIncludedNodes;
-    uint64_t _idsOfIncludedFilters;
-    bool _isOptional;
+    uint64_t _idsOfIncludedNodes = 0;
+    uint64_t _idsOfIncludedFilters = 0;
+    bool _isOptional = false;
 
     size_t getCostEstimate() const;
 
@@ -146,7 +143,8 @@ class QueryPlanner {
     void addAllNodes(uint64_t otherNodes);
   };
 
-  TripleGraph createTripleGraph(const ParsedQuery::GraphPattern* pattern) const;
+  TripleGraph createTripleGraph(
+      const GraphPatternOperation::BasicGraphPattern* pattern) const;
 
   static ad_utility::HashMap<string, size_t>
   createVariableColumnsMapForTextOperation(
@@ -189,7 +187,8 @@ class QueryPlanner {
 
   bool _enablePatternTrick;
 
-  std::vector<SubtreePlan> optimize(ParsedQuery::GraphPattern* rootPattern);
+  std::vector<QueryPlanner::SubtreePlan> optimize(
+      ParsedQuery::GraphPattern* rootPattern, bool isRoot);
 
   /**
    * @brief Fills varToTrip with a mapping from all variables in the root graph
@@ -262,6 +261,9 @@ class QueryPlanner {
   vector<SubtreePlan> merge(const vector<SubtreePlan>& a,
                             const vector<SubtreePlan>& b,
                             const TripleGraph& tg) const;
+
+  std::optional<QueryPlanner::SubtreePlan> join(const SubtreePlan& a,
+                                                const SubtreePlan& b) const;
 
   vector<SubtreePlan> getOrderByRow(
       const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -188,7 +188,7 @@ class QueryPlanner {
   bool _enablePatternTrick;
 
   std::vector<QueryPlanner::SubtreePlan> optimize(
-      ParsedQuery::GraphPattern* rootPattern, bool isRoot);
+      ParsedQuery::GraphPattern* rootPattern);
 
   /**
    * @brief Fills varToTrip with a mapping from all variables in the root graph
@@ -261,8 +261,9 @@ class QueryPlanner {
                             const vector<SubtreePlan>& b,
                             const TripleGraph& tg) const;
 
-  std::optional<QueryPlanner::SubtreePlan> join(const SubtreePlan& a,
-                                                const SubtreePlan& b) const;
+  std::vector<QueryPlanner::SubtreePlan> createJoinCandidates(
+      const SubtreePlan& a, const SubtreePlan& b,
+      std::optional<TripleGraph> tg) const;
 
   vector<SubtreePlan> getOrderByRow(
       const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
@@ -296,6 +297,63 @@ class QueryPlanner {
   std::shared_ptr<Operation> createFilterOperation(
       const SparqlFilter& filter, const SubtreePlan& parent) const;
 
+  /**
+   * @brief Optimize a set of triples, filters and precomputed candidates
+   * for child graph patterns
+   *
+   *
+   * Optimize every GraphPattern starting with the leaves of the
+   * GraphPattern tree.
+
+   * Strategy:
+   * Create a graph.
+   * Each triple corresponds to a node, there is an edge between two nodes
+   * iff they share a variable.
+
+   * TripleGraph tg = createTripleGraph(&arg);
+
+   * Each node/triple corresponds to a scan (more than one way possible),
+   * each edge corresponds to a possible join.
+
+   * Enumerate and judge possible query plans using a DP table.
+   * Each ExecutionTree for a sub-problem gives an estimate:
+   * There are estimates for cost and size ( and multiplicity per column).
+   * Start bottom up, i.e. with the scans for triples.
+   * Always merge two solutions from the table by picking one possible
+   * join. A join is possible, if there is an edge between the results.
+   * Therefore we keep track of all edges that touch a sub-result.
+   * When joining two sub-results, the results edges are those that belong
+   * to exactly one of the two input sub-trees.
+   * If two of them have the same target, only one out edge is created.
+   * All edges that are shared by both subtrees, are checked if they are
+   * covered by the join or if an extra filter/select is needed.
+
+   * The algorithm then creates all possible plans for 1 to n triples.
+   * To generate a plan for k triples, all subsets between i and k-i are
+   * joined.
+
+   * Filters are now added to the mix when building execution plans.
+   * Without them, a plan has an execution tree and a set of
+   * covered triple nodes.
+   * With them, it also has a set of covered filters.
+   * A filter can be applied as soon as all variables that occur in the
+   * filter Are covered by the query. This is also always the place where
+   * this is done.
+
+   * Text operations form cliques (all triples connected via the context
+   * cvar). Detect them and turn them into nodes with stored word part and
+   * edges to connected variables.
+
+   * Each text operation has two ways how it can be used.
+   * 1) As leave in the bottom row of the tab.
+   * According to the number of connected variables, the operation creates
+   * a cross product with n entities that can be used in subsequent joins.
+   * 2) as intermediate unary (downwards) nodes in the execution tree.
+   * This is a bit similar to sorts: they can be applied after each step
+   * and will filter on one variable.
+   * Cycles have to be avoided (by previously removing a triple and using
+   * it as a filter later on).
+   */
   vector<vector<SubtreePlan>> fillDpTab(
       const TripleGraph& graph, const vector<SparqlFilter>& fs,
       const vector<vector<SubtreePlan>>& children);

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -9,7 +9,9 @@
 
 class Values : public Operation {
  public:
-  Values(QueryExecutionContext* qec, const SparqlValues& values);
+  /// constructor sanitizes the input by removing completely undefined variables
+  /// and values.
+  Values(QueryExecutionContext* qec, SparqlValues values);
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -46,4 +48,8 @@ class Values : public Operation {
   template <size_t I>
   void writeValues(IdTable* res, const Index& index,
                    const SparqlValues& values);
+
+  /// remove all completely undefined values and variables
+  /// throw if nothing remains
+  SparqlValues sanitizeValues(SparqlValues&& values);
 };

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -101,7 +101,26 @@ static const uint8_t NO_PREFIX_CHAR =
 
 #ifdef _PARALLEL_SORT
 static constexpr bool USE_PARALLEL_SORT = true;
+#include <parallel/algorithm>
+namespace ad_utility {
+template <typename... Args>
+auto parallel_sort(Args&&... args) {
+  return __gnu_parallel::sort(std::forward<Args>(args)...);
+}
+using parallel_tag = __gnu_parallel::parallel_tag;
+
+}  // namespace ad_utility
+
 #else
 static constexpr bool USE_PARALLEL_SORT = false;
+namespace ad_utility {
+template <typename... Args>
+auto parallel_sort([[maybe_unused]] Args&&... args) {
+  throw std::runtime_error(
+      "Triggered the parallel sort although it was disabled. Please report to "
+      "the developers!");
+}
+using parallel_tag = int;
+}  // namespace ad_utility
 #endif
 static constexpr size_t NUM_SORT_THREADS = 4;

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -211,7 +211,7 @@ class LocaleManager {
     int32_t i = 0;
     for (i = 0; i < length && numCodepoints < prefixLength;) {
       UChar32 c;
-      U8_NEXT(s, i, length, c)
+      U8_NEXT(s, i, length, c);
       if (c >= 0) {
         ++numCodepoints;
       } else {

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -14,7 +14,6 @@
 #include <vector>
 #include "./VocabularyGenerator.h"
 
-#include <parallel/algorithm>
 #include "../util/Conversions.h"
 #include "../util/Exception.h"
 #include "../util/HashMap.h"
@@ -325,8 +324,8 @@ void sortVocabVector(ItemVec* vecPtr, StringSortComparator comp, const bool doPa
   auto& els = *vecPtr;
   if constexpr (USE_PARALLEL_SORT) {
     if (doParallelSort) {
-      __gnu_parallel::sort(begin(els), end(els), comp,
-                           __gnu_parallel::parallel_tag(NUM_SORT_THREADS));
+      ad_utility::parallel_sort(begin(els), end(els), comp,
+                                ad_utility::parallel_tag(NUM_SORT_THREADS));
     } else {
       std::sort(begin(els), end(els), comp);
     }

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -240,8 +240,12 @@ class ParsedQuery {
      * @brief A id that is unique for the ParsedQuery. Ids are guaranteed to
      * start with zero and to be dense.
      */
-    size_t _id;
+    size_t _id = size_t(-1);
 
+    // Filters always apply to the complete GraphPattern, no matter where
+    // they appear. For VALUES and Triples, the order matters, so they
+    // become children.
+    std::vector<SparqlFilter> _filters;
     vector<GraphPatternOperation> _children;
   };
 
@@ -319,8 +323,10 @@ class ParsedQuery {
 struct GraphPatternOperation {
   struct BasicGraphPattern {
     vector<SparqlTriple> _whereClauseTriples;
-    vector<SparqlFilter> _filters;
-    vector<SparqlValues> _inlineValues;
+  };
+  struct Values {
+    SparqlValues _inlineValues;
+    size_t _id;
   };
   struct GroupGraphPattern {
     ParsedQuery::GraphPattern _child;
@@ -348,7 +354,8 @@ struct GraphPatternOperation {
     ParsedQuery::GraphPattern _childGraphPattern;
   };
 
-  std::variant<BasicGraphPattern, GroupGraphPattern, Optional, Union, Subquery, TransPath>
+  std::variant<BasicGraphPattern, GroupGraphPattern, Optional, Union, Subquery,
+               TransPath, Values>
       variant_;
   template <typename A, typename... Args,
             typename = std::enable_if_t<

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -305,9 +305,8 @@ void SparqlParser::parseWhere(ParsedQuery* query,
         currentPattern->_children.push_back(std::move(un));
       }
     } else if (_lexer.accept("filter")) {
-      // append to the ongoing graph pattern or start a new one
-      auto& curBasicPattern = lastBasicPattern(currentPattern);
-      parseFilter(&curBasicPattern._filters, true, currentPattern);
+      // append to the global filters of the pattern.
+      parseFilter(&currentPattern->_filters, true, currentPattern);
       // A filter may have an optional dot after it
       _lexer.accept(".");
     } else if (_lexer.accept("values")) {
@@ -345,7 +344,8 @@ void SparqlParser::parseWhere(ParsedQuery* query,
             "Expected either a single or a set of variables "
             "after VALUES");
       }
-      lastBasicPattern(currentPattern)._inlineValues.emplace_back(values);
+      currentPattern->_children.emplace_back(
+          GraphPatternOperation::Values{std::move(values)});
       _lexer.accept(".");
     } else {
       std::string subject;

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -53,6 +53,13 @@ class SparqlParser {
   std::string_view readTriplePart(const std::string& s, size_t* pos);
 
   static string stripAndLowercaseKeywordLiteral(const string& lit);
+  /**
+   * If *ptr 's last child is a BasicGraphPattern, return a reference to it.
+   * If not, first append a BasicGraphPattern and then return a reference
+   * to the added child
+   */
+  GraphPatternOperation::BasicGraphPattern& lastBasicPattern(
+      ParsedQuery::GraphPattern* ptr) const;
 
   SparqlLexer _lexer;
   string _query;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -24,7 +24,8 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg =
+          qp.createTripleGraph(&pq._rootGraphPattern._children[0].getBasic());
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -54,7 +55,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
               {std::make_pair<Node, vector<size_t>>(
@@ -79,7 +80,7 @@ TEST(QueryPlannerTest, createTripleGraph) {
                            .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
 
       TripleGraph expected =
           TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>({
@@ -112,7 +113,7 @@ TEST(QueryPlannerTest, testCpyCtorWithKeepNodes) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(2u, tg._nodeMap.find(0)->second->_variables.size());
       ASSERT_EQ(2u, tg._nodeMap.find(1)->second->_variables.size());
       ASSERT_EQ(1u, tg._nodeMap.find(2)->second->_variables.size());
@@ -175,7 +176,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(3u, tg._adjLists.size());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
@@ -197,7 +198,7 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
               .parse();
       pq.expandPrefixes();
       QueryPlanner qp(nullptr);
-      auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+      auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ad_utility::HashSet<size_t> lo;
       auto out = tg.bfsLeaveOut(0, lo);
       ASSERT_EQ(3u, out.size());
@@ -235,7 +236,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -276,7 +277,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -319,7 +320,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -367,7 +368,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         TripleGraph expected = TripleGraph(std::vector<std::pair<
                                                Node, std::vector<size_t>>>(
             {std::make_pair<Node, vector<size_t>>(
@@ -451,7 +452,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                 .parse();
         pq.expandPrefixes();
         QueryPlanner qp(nullptr);
-        auto tg = qp.createTripleGraph(&pq._rootGraphPattern);
+        auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
             "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
             "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
@@ -942,7 +943,8 @@ TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
             .parse();
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
-    QueryPlanner::TripleGraph tg = qp.createTripleGraph(&pq._rootGraphPattern);
+    QueryPlanner::TripleGraph tg =
+        qp.createTripleGraph(&pq.children()[0].getBasic());
     ASSERT_EQ(1u, tg._nodeMap.find(0)->second->_variables.size());
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -1163,10 +1165,10 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  OPTIONAL_JOIN\n  {\n    SCAN PSO with P = \"<rel1>\"\n    "
-        "qet-width: 2 \n  } join-columns: [0]\n  |X|\n  {\n    SORT / ORDER BY "
-        "on columns:asc(1) \n    {\n      SCAN POS with P = \"<rel2>\"\n      "
-        "qet-width: 2 \n    }\n    qet-width: 2 \n  } join-columns: [1]\n  "
-        "qet-width: 3 \n}",
+        "qet-width: 2 \n  } join-columns: [0]\n  |X|\n  {\n    SCAN PSO with P "
+        "= \"<rel2>\"\n    qet-width: 2 \n  } join-columns: [0]\n  qet-width: "
+        "3 \n}",
+
         qet.asString());
 
     ParsedQuery pq2 = SparqlParser(
@@ -1177,12 +1179,10 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq2.expandPrefixes();
     QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
-        "{\n  SORT / ORDER BY on columns:asc(1) \n  {\n    OPTIONAL_JOIN\n    "
-        "{\n      SCAN PSO with P = \"<rel1>\"\n      qet-width: 2 \n    } "
-        "join-columns: [0]\n    |X|\n    {\n      SORT / ORDER BY on "
-        "columns:asc(1) \n      {\n        SCAN POS with P = \"<rel2>\"\n      "
-        "  qet-width: 2 \n      }\n      qet-width: 2 \n    } join-columns: "
-        "[1]\n    qet-width: 3 \n  }\n  qet-width: 3 \n}"
+        "{\n  SORT on column:1\n  {\n    OPTIONAL_JOIN\n    {\n      SCAN PSO "
+        "with P = \"<rel1>\"\n      qet-width: 2 \n    } join-columns: [0]\n   "
+        " |X|\n    {\n      SCAN PSO with P = \"<rel2>\"\n      qet-width: 2 "
+        "\n    } join-columns: [0]\n    qet-width: 3 \n  }\n  qet-width: 3 \n}",
 
         ,
         qet2.asString());

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1179,12 +1179,11 @@ TEST(QueryPlannerTest, testSimpleOptional) {
     pq2.expandPrefixes();
     QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
-        "{\n  SORT on column:1\n  {\n    OPTIONAL_JOIN\n    {\n      SCAN PSO "
-        "with P = \"<rel1>\"\n      qet-width: 2 \n    } join-columns: [0]\n   "
-        " |X|\n    {\n      SCAN PSO with P = \"<rel2>\"\n      qet-width: 2 "
-        "\n    } join-columns: [0]\n    qet-width: 3 \n  }\n  qet-width: 3 \n}",
-
-        ,
+        "{\n  SORT / ORDER BY on columns:asc(1) \n  {\n    OPTIONAL_JOIN\n    "
+        "{\n      SCAN PSO with P = \"<rel1>\"\n      qet-width: 2 \n    } "
+        "join-columns: [0]\n    |X|\n    {\n      SCAN PSO with P = "
+        "\"<rel2>\"\n      qet-width: 2 \n    } join-columns: [0]\n    "
+        "qet-width: 3 \n  }\n  qet-width: 3 \n}",
         qet2.asString());
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;


### PR DESCRIPTION
- Previously, QLever was allowed to optimize all Graph patterns in an arbitrary order on the same nesting level
- This is generally speaking not correct, since they have to be evaluated top to bottom.
- Reordering Joins is no problem, since it does not change the result, but reordering across `OPTIONAL` joins is dangerous and can lead to errors. 

- This PR forces the optimizer to first optimize all the graph patterns before the first optional join, then perform the optional join (leading to a non-optional pattern) and then treat this result as an input to optimize together with the rest of the query in the same manner.

- In some cases it could be legal to optimize across optionals, but currently we simply ignore those.
  The prize for this is currently some "Joins of the full index with itself are not allowed" errors which could be prevented, but those have been there before due to the internals and limitations of the current QueryPlanner.

- TODO: there is actually a lot more stuff to fix with optional joins and treating columns where some values are defined and some are not, but that is a different story, that will be fixed later.