### PR TITLE
Implemented disjunction (or) via '|| ' for prefix filters.

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -381,20 +381,6 @@ queries:
       - contains_row: ["<Albert_Einstein>", "<Nobel_Prize_in_Physics>"]
       - contains_row: ["<Albert_Fert>", "<Wolf_Prize_in_Physics>"]
       - contains_row: ["<Albert_Overhauser>", "<National_Medal_of_Science_for_Physical_Science>"]
-  - query : having-height
-    type: no-text
-    sparql: |
-      SELECT (COUNT(?profession) as ?count) ?height WHERE {
-        ?x <Profession> ?profession .
-        ?x <Height> ?height
-      }
-      GROUP BY ?height
-      HAVING (?height > 1.7)
-    checks:
-      - num_rows: 32
-      - num_cols: 2
-      - selected: ["?count", "?height"]
-      - contains_row: ["5", "1.803"]
   - query : having-predicate-religion
     type: no-text
     sparql: |
@@ -734,6 +720,20 @@ queries:
       - num_rows: 1
       - selected: ["?a", "?b"]
       - contains_row: ["<Charles,_Prince_of_Wales>", "<Lord_of_the_Isles>"]
+  - query : having-height
+    type: no-text
+    sparql: |
+      SELECT (COUNT(?profession) as ?count) ?height WHERE {
+        ?x <Profession> ?profession .
+        ?x <Height> ?height
+      }
+      GROUP BY ?height
+      HAVING (?height > 1.7)
+    checks:
+      - num_rows: 32
+      - num_cols: 2
+      - selected: ["?count", "?height"]
+      - contains_row: ["5", "1.803"]
   - query : filter-depending-on-last-optional
     type: no-text
     sparql: |
@@ -764,4 +764,34 @@ queries:
       - contains_row: ["<Albert_Einstein>", "<Nobel_Prize_in_Physics>"]
       - contains_row: ["<Al_Gore>", "<Nobel_Peace_Prize>"]
       - contains_row: ["<Dennis_Gabor>", "<Nobel_Prize_in_Physics>"]
-
+  - query : prefix-filter-disjunction
+    type: no-text
+    sparql: |
+      SELECT ?s  WHERE {
+                ?s <is-a> <Scientist> .
+                FILTER ((regex(?s, "^<Albert") || regex(?s, "^<Marie"))) .
+            }
+    checks:
+      - num_rows: 106
+      - num_cols: 1
+      - selected: ["?s"]
+      - contains_row: ["<Albert_Einstein>"]
+      - contains_row: ["<Albert_Fert>"]
+      - contains_row: ["<Albert_Overhauser>"]
+      - contains_row: ["<Marie_Curie>"]
+  - query : prefix-filter-disjunction-different-lhs
+    type: no-text
+    sparql: |
+      SELECT ?s ?a WHERE {
+          ?s <is-a> <Scientist> .
+          ?s <Award_Won> ?a .
+          FILTER (regex(?s, "^<Albert") || regex(?a, "^<Nobel"))
+      }
+    checks:
+      - num_rows: 579
+      - num_cols: 2
+      - selected: ["?s", "?a"]
+      - contains_row: ["<Albert_Einstein>", "<Nobel_Prize_in_Physics>"]
+      - contains_row: ["<Albert_Fert>", "<Wolf_Prize_in_Physics>"]
+      - contains_row: ["<Albert_Overhauser>", "<National_Medal_of_Science_for_Physical_Science>"]
+      - contains_row: ["<Andre_Geim>", "<Nobel_Prize_in_Physics>"]

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -21,7 +21,8 @@ class Filter : public Operation {
  public:
   Filter(QueryExecutionContext* qec,
          std::shared_ptr<QueryExecutionTree> subtree,
-         SparqlFilter::FilterType type, string lhs, string rhs);
+         SparqlFilter::FilterType type, string lhs, string rhs,
+         vector<string> additionalLhs, vector<string> additionalPrefixes);
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -101,6 +102,9 @@ class Filter : public Operation {
   SparqlFilter::FilterType _type;
   string _lhs;
   string _rhs;
+
+  std::vector<string> _additionalLhs;
+  std::vector<string> _additionalPrefixRegexes;
   bool _regexIgnoreCase;
   bool _lhsAsString;
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -197,6 +197,8 @@ class SparqlFilter {
   FilterType _type;
   string _lhs;
   string _rhs;
+  vector<string> _additionalLhs;
+  vector<string> _additionalPrefixes;
   bool _regexIgnoreCase = false;
   // True if the str function was applied to the left side.
   bool _lhsAsString = false;

--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -9,7 +9,7 @@
 
 const std::string SparqlToken::TYPE_NAMES[] = {
     "IRI",       "WS",         "KEYWORD", "VARIABLE", "SYMBOL",
-    "AGGREGATE", "RDFLITERAL", "INTEGER", "FLOAT"};
+    "AGGREGATE", "RDFLITERAL", "INTEGER", "FLOAT",    "LOGICAL_OR"};
 
 const std::string SparqlLexer::LANGTAG = "@[a-zA-Z]+(-[a-zA-Z0-9]+)*";
 const std::string SparqlLexer::IRIREF =
@@ -65,6 +65,8 @@ const std::string SparqlLexer::STRING_LITERAL =
 const std::string SparqlLexer::RDFLITERAL =
     STRING_LITERAL + "((" + LANGTAG + ")|(\\^\\^" + IRI + "))?";
 
+const std::string SparqlLexer::LOGICAL_OR = "(\\|\\|)";
+
 const re2::RE2 SparqlLexer::RE_IRI = re2::RE2(IRI);
 const re2::RE2 SparqlLexer::RE_WS = re2::RE2("(" + WS + "+)");
 const re2::RE2 SparqlLexer::RE_KEYWORD = re2::RE2(KEYWORD);
@@ -74,6 +76,7 @@ const re2::RE2 SparqlLexer::RE_AGGREGATE = re2::RE2(AGGREGATE);
 const re2::RE2 SparqlLexer::RE_RDFLITERAL = re2::RE2("(" + RDFLITERAL + ")");
 const re2::RE2 SparqlLexer::RE_INTEGER = re2::RE2(INTEGER);
 const re2::RE2 SparqlLexer::RE_FLOAT = re2::RE2(FLOAT);
+const re2::RE2 SparqlLexer::RE_LOGICAL_OR = re2::RE2(LOGICAL_OR);
 
 SparqlLexer::SparqlLexer(const std::string& sparql)
     : _sparql(sparql), _re_string(_sparql) {
@@ -95,6 +98,8 @@ void SparqlLexer::readNext() {
     } else if (re2::RE2::Consume(&_re_string, RE_KEYWORD, &raw)) {
       _next.type = SparqlToken::Type::KEYWORD;
       raw = ad_utility::getLowercaseUtf8(raw);
+    } else if (re2::RE2::Consume(&_re_string, RE_LOGICAL_OR, &raw)) {
+      _next.type = SparqlToken::Type::LOGICAL_OR;
     } else if (re2::RE2::Consume(&_re_string, RE_VARIABLE, &raw)) {
       _next.type = SparqlToken::Type::VARIABLE;
     } else if (re2::RE2::Consume(&_re_string, RE_IRI, &raw)) {

--- a/src/parser/SparqlLexer.h
+++ b/src/parser/SparqlLexer.h
@@ -16,7 +16,8 @@ struct SparqlToken {
     AGGREGATE,
     RDFLITERAL,
     INTEGER,
-    FLOAT
+    FLOAT,
+    LOGICAL_OR
   };
   static const std::string TYPE_NAMES[];
 
@@ -55,6 +56,7 @@ class SparqlLexer {
   static const std::string PNAME_LN;
   static const std::string INTEGER;
   static const std::string FLOAT;
+  static const std::string LOGICAL_OR;
 
   static const re2::RE2 RE_IRI;
   static const re2::RE2 RE_WS;
@@ -65,6 +67,7 @@ class SparqlLexer {
   static const re2::RE2 RE_RDFLITERAL;
   static const re2::RE2 RE_INTEGER;
   static const re2::RE2 RE_FLOAT;
+  static const re2::RE2 RE_LOGICAL_OR;
 
  public:
   SparqlLexer(const std::string& sparql);

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -618,19 +618,87 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
 bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
                                bool failOnNoFilter,
                                ParsedQuery::GraphPattern* pattern) {
-  if (_lexer.accept("(")) {
-    if (_lexer.accept("lang")) {
-      _lexer.expect("(");
-      _lexer.expect(SparqlToken::Type::VARIABLE);
-      std::string lhs = _lexer.current().raw;
+  size_t numParentheses = 0;
+  while (_lexer.accept("(")) {
+    numParentheses++;
+  }
+  auto expectClose = [numParentheses, this]() mutable {
+    while (numParentheses) {
       _lexer.expect(")");
-      _lexer.expect("=");
-      _lexer.expect(SparqlToken::Type::RDFLITERAL);
-      std::string rhs = _lexer.current().raw;
-      _lexer.expect(")");
-      addLangFilter(lhs, rhs, pattern);
-      return true;
+      numParentheses--;
     }
+  };
+  if (_lexer.accept("lang") && numParentheses) {
+    _lexer.expect("(");
+    _lexer.expect(SparqlToken::Type::VARIABLE);
+    std::string lhs = _lexer.current().raw;
+    _lexer.expect(")");
+    _lexer.expect("=");
+    _lexer.expect(SparqlToken::Type::RDFLITERAL);
+    std::string rhs = _lexer.current().raw;
+    expectClose();
+    addLangFilter(lhs, rhs, pattern);
+    return true;
+  } else if (_lexer.accept("langmatches")) {
+    _lexer.expect("(");
+    _lexer.expect("lang");
+    _lexer.expect("(");
+    _lexer.expect(SparqlToken::Type::VARIABLE);
+    std::string lhs = _lexer.current().raw;
+    _lexer.expect(")");
+    _lexer.expect(",");
+    _lexer.expect(SparqlToken::Type::RDFLITERAL);
+    std::string rhs = _lexer.current().raw;
+    expectClose();
+    addLangFilter(lhs, rhs, pattern);
+    return true;
+  } else if (_lexer.accept("regex")) {
+    std::vector<SparqlFilter> v;
+    v.push_back(parseRegexFilter(false));
+    if (numParentheses) {
+      while (_lexer.accept(SparqlToken::Type::LOGICAL_OR)) {
+        v.push_back(parseRegexFilter(true));
+      }
+    }
+    if (!(v.size() == 1 || std::all_of(v.begin(), v.end(), [](const auto& f) {
+            return f._type == SparqlFilter::PREFIX;
+          }))) {
+      throw ParseException(
+          "Multiple regex filters concatenated via || must currently all be "
+          "PREFIX filters");
+    }
+    // merge the prefix filters (does nothing in case of a single regex filter
+    for (auto it = v.begin() + 1; it < v.end(); ++it) {
+      v[0]._additionalLhs.push_back(std::move(it->_lhs));
+      v[0]._additionalPrefixes.push_back(std::move(it->_rhs));
+    }
+    _filters->push_back(v[0]);
+    expectClose();
+    return true;
+  } else if (_lexer.accept("prefix")) {
+    _lexer.expect("(");
+    SparqlFilter f1;
+    SparqlFilter f2;
+    f1._type = SparqlFilter::GE;
+    f2._type = SparqlFilter::LT;
+    // Do prefix filtering by using two filters (one testing >=, the other =)
+    _lexer.expect(SparqlToken::Type::VARIABLE);
+    f1._lhs = _lexer.current().raw;
+    f2._lhs = f1._lhs;
+    _lexer.expect(",");
+    _lexer.expect(SparqlToken::Type::RDFLITERAL);
+    f1._rhs = _lexer.current().raw;
+    f2._rhs = f1._lhs;
+    f1._rhs = f1._rhs.substr(0, f1._rhs.size() - 1) + " ";
+    f2._rhs = f2._rhs.substr(0, f2._rhs.size() - 2);
+    f2._rhs += f1._rhs[f1._rhs.size() - 2] + 1;
+    f2._rhs += f1._rhs[f1._rhs.size() - 1];
+    _filters->emplace_back(f1);
+    _filters->emplace_back(f2);
+    _lexer.expect(")");
+    expectClose();
+    return true;
+  } else if (numParentheses) {
     SparqlFilter f;
     if (_lexer.accept("str")) {
       _lexer.expect("(");
@@ -695,122 +763,15 @@ bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
       throw ParseException(_lexer.current().raw +
                            " is not a valid right hand side for a filter.");
     }
-    _lexer.expect(")");
+    expectClose();
     _filters->emplace_back(f);
     return true;
-  } else if (_lexer.accept("langmatches")) {
-    _lexer.expect("(");
-    _lexer.expect("lang");
-    _lexer.expect("(");
-    _lexer.expect(SparqlToken::Type::VARIABLE);
-    std::string lhs = _lexer.current().raw;
-    _lexer.expect(")");
-    _lexer.expect(",");
-    _lexer.expect(SparqlToken::Type::RDFLITERAL);
-    std::string rhs = _lexer.current().raw;
-    _lexer.expect(")");
-    addLangFilter(lhs, rhs, pattern);
-    return true;
-  } else if (_lexer.accept("regex")) {
-    SparqlFilter f;
-    f._type = SparqlFilter::REGEX;
-    _lexer.expect("(");
-    if (_lexer.accept("str")) {
-      _lexer.expect("(");
-      f._lhsAsString = true;
-    }
-    _lexer.expect(SparqlToken::Type::VARIABLE);
-    f._lhs = _lexer.current().raw;
-    if (f._lhsAsString) {
-      _lexer.expect(")");
-    }
-    _lexer.expect(",");
-    _lexer.expect(SparqlToken::Type::RDFLITERAL);
-    f._rhs = _lexer.current().raw;
-    // Remove the enlcosing quotation marks
-    f._rhs = f._rhs.substr(1, f._rhs.size() - 2);
-    if (_lexer.accept(",")) {
-      _lexer.expect("\"i\"");
-      f._regexIgnoreCase = true;
-    }
-    _lexer.expect(")");
-    if (f._rhs[0] == '^' && !f._regexIgnoreCase) {
-      // Check if we can use the more efficient prefix filter instead
-      // of an expensive regex filter.
-      bool isSimple = true;
-      bool escaped = false;
-      std::vector<size_t>
-          escapePositions;  // position of backslashes that are used for
-                            // escaping within the regex
-      // these have to be removed if the regex is simply a prefix filter.
 
-      // Check if the regex is only a prefix regex or also does
-      // anything else.
-      const static string regexControlChars = "[]^$.|?*+()";
-      for (size_t i = 1; isSimple && i < f._rhs.size(); i++) {
-        if (f._rhs[i] == '\\') {
-          if (!escaped) {
-            escapePositions.push_back(i);
-          }
-          escaped = !escaped;  // correctly deal with consecutive backslashes
-          continue;
-        }
-        char c = f._rhs[i];
-        bool isControlChar = regexControlChars.find(c) != string::npos;
-        if (!escaped && isControlChar) {
-          isSimple = false;
-        } else if (escaped && !isControlChar) {
-          const std::string error =
-              "Escaping the character "s + c +
-              " is not allowed in QLever's regex filters. (Regex was " +
-              f._rhs +
-              ") Please note that "
-              "there are two levels of Escaping in place here: One for Sparql "
-              "and one for the regex engine";
-          throw ParseException(error);
-        }
-        escaped = false;
-      }
-      if (isSimple) {
-        // There are no regex special chars apart from the leading '^'
-        // so we can use a prefix filter.
-        f._type = SparqlFilter::PREFIX;
-
-        // we have to remove the escaping backslashes
-        for (auto it = escapePositions.rbegin(); it != escapePositions.rend();
-             ++it) {
-          f._rhs.erase(f._rhs.begin() + *it);
-        }
-      }
-    }
-    _filters->emplace_back(f);
-    return true;
-  } else if (_lexer.accept("prefix")) {
-    _lexer.expect("(");
-    SparqlFilter f1;
-    SparqlFilter f2;
-    f1._type = SparqlFilter::GE;
-    f2._type = SparqlFilter::LT;
-    // Do prefix filtering by using two filters (one testing >=, the other =)
-    _lexer.expect(SparqlToken::Type::VARIABLE);
-    f1._lhs = _lexer.current().raw;
-    f2._lhs = f1._lhs;
-    _lexer.expect(",");
-    _lexer.expect(SparqlToken::Type::RDFLITERAL);
-    f1._rhs = _lexer.current().raw;
-    f2._rhs = f1._lhs;
-    f1._rhs = f1._rhs.substr(0, f1._rhs.size() - 1) + " ";
-    f2._rhs = f2._rhs.substr(0, f2._rhs.size() - 2);
-    f2._rhs += f1._rhs[f1._rhs.size() - 2] + 1;
-    f2._rhs += f1._rhs[f1._rhs.size() - 1];
-    _filters->emplace_back(f1);
-    _filters->emplace_back(f2);
-    _lexer.expect(")");
-    return true;
   } else if (failOnNoFilter) {
     _lexer.accept();
     throw ParseException("Expected a filter but got " + _lexer.current().raw);
   }
+  expectClose();
   return false;
 }
 
@@ -942,6 +903,82 @@ string SparqlParser::parseLiteral(const string& literal, bool isEntireString,
     }
   }
   return out.str();
+}
+SparqlFilter SparqlParser::parseRegexFilter(bool expectKeyword) {
+  if (expectKeyword) {
+    _lexer.expect("regex");
+  }
+  SparqlFilter f;
+  f._type = SparqlFilter::REGEX;
+  _lexer.expect("(");
+  if (_lexer.accept("str")) {
+    _lexer.expect("(");
+    f._lhsAsString = true;
+  }
+  _lexer.expect(SparqlToken::Type::VARIABLE);
+  f._lhs = _lexer.current().raw;
+  if (f._lhsAsString) {
+    _lexer.expect(")");
+  }
+  _lexer.expect(",");
+  _lexer.expect(SparqlToken::Type::RDFLITERAL);
+  f._rhs = _lexer.current().raw;
+  // Remove the enlcosing quotation marks
+  f._rhs = f._rhs.substr(1, f._rhs.size() - 2);
+  if (_lexer.accept(",")) {
+    _lexer.expect("\"i\"");
+    f._regexIgnoreCase = true;
+  }
+  _lexer.expect(")");
+  if (f._rhs[0] == '^' && !f._regexIgnoreCase) {
+    // Check if we can use the more efficient prefix filter instead
+    // of an expensive regex filter.
+    bool isSimple = true;
+    bool escaped = false;
+    std::vector<size_t>
+        escapePositions;  // position of backslashes that are used for
+    // escaping within the regex
+    // these have to be removed if the regex is simply a prefix filter.
+
+    // Check if the regex is only a prefix regex or also does
+    // anything else.
+    const static string regexControlChars = "[]^$.|?*+()";
+    for (size_t i = 1; isSimple && i < f._rhs.size(); i++) {
+      if (f._rhs[i] == '\\') {
+        if (!escaped) {
+          escapePositions.push_back(i);
+        }
+        escaped = !escaped;  // correctly deal with consecutive backslashes
+        continue;
+      }
+      char c = f._rhs[i];
+      bool isControlChar = regexControlChars.find(c) != string::npos;
+      if (!escaped && isControlChar) {
+        isSimple = false;
+      } else if (escaped && !isControlChar) {
+        const std::string error =
+            "Escaping the character "s + c +
+            " is not allowed in QLever's regex filters. (Regex was " + f._rhs +
+            ") Please note that "
+            "there are two levels of Escaping in place here: One for Sparql "
+            "and one for the regex engine";
+        throw ParseException(error);
+      }
+      escaped = false;
+    }
+    if (isSimple) {
+      // There are no regex special chars apart from the leading '^'
+      // so we can use a prefix filter.
+      f._type = SparqlFilter::PREFIX;
+
+      // we have to remove the escaping backslashes
+      for (auto it = escapePositions.rbegin(); it != escapePositions.rend();
+           ++it) {
+        f._rhs.erase(f._rhs.begin() + *it);
+      }
+    }
+  }
+  return f;
 }
 
 GraphPatternOperation::BasicGraphPattern& SparqlParser::lastBasicPattern(

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -63,4 +63,5 @@ class SparqlParser {
 
   SparqlLexer _lexer;
   string _query;
+  SparqlFilter parseRegexFilter(bool expectKeyword);
 };


### PR DESCRIPTION
All other types of filter disjunctions will currently lead to parse errors since they are harder to properly evaluate and to estimate during planning.