### PR TITLE
Unbound variables are now written in the correct order

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -92,7 +92,7 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out,
   // They may trigger computation (but does not have to).
   shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
-  vector<pair<size_t, ResultTable::ResultType>> validIndices;
+  vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices;
   for (auto var : selectVars) {
     if (ad_utility::startsWith(var, "TEXT(")) {
       var = var.substr(5, var.rfind(')') - 5);
@@ -101,6 +101,8 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out,
     if (it != getVariableColumns().end()) {
       validIndices.push_back(pair<size_t, ResultTable::ResultType>(
           it->second, res->getResultType(it->second)));
+    } else {
+      validIndices.push_back(std::nullopt);
     }
   }
   if (validIndices.size() == 0) {
@@ -120,7 +122,7 @@ nlohmann::json QueryExecutionTree::writeResultAsJson(
   // They may trigger computation (but does not have to).
   shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
-  vector<pair<size_t, ResultTable::ResultType>> validIndices;
+  vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices;
   for (auto var : selectVars) {
     if (ad_utility::startsWith(var, "TEXT(")) {
       var = var.substr(5, var.rfind(')') - 5);
@@ -129,6 +131,8 @@ nlohmann::json QueryExecutionTree::writeResultAsJson(
     if (vc != getVariableColumns().end()) {
       validIndices.push_back(pair<size_t, ResultTable::ResultType>(
           vc->second, res->getResultType(vc->second)));
+    } else {
+      validIndices.push_back(std::nullopt);
     }
   }
   if (validIndices.size() == 0) {
@@ -195,7 +199,8 @@ void QueryExecutionTree::readFromCache() {
 // __________________________________________________________________________________________________________
 nlohmann::json QueryExecutionTree::writeJsonTable(
     const IdTable& data, size_t from, size_t limit,
-    const vector<pair<size_t, ResultTable::ResultType>>& validIndices) const {
+    const vector<std::optional<pair<size_t, ResultTable::ResultType>>>&
+        validIndices) const {
   shared_ptr<const ResultTable> res = getResult();
   nlohmann::json json = nlohmann::json::parse("[]");
   auto optToJson = [](const auto& opt) -> nlohmann::json {
@@ -210,7 +215,12 @@ nlohmann::json QueryExecutionTree::writeJsonTable(
   for (size_t i = from; i < upperBound; ++i) {
     json.emplace_back();
     auto& row = json.back();
-    for (const auto& idx : validIndices) {
+    for (const auto& opt : validIndices) {
+      if (!opt) {
+        row.emplace_back(optToJson(std::optional<string>{}));
+        continue;
+      }
+      const auto& idx = *opt;
       const auto& currentId = data(i, idx.first);
       switch (idx.second) {
         case ResultTable::ResultType::KB: {
@@ -256,45 +266,46 @@ nlohmann::json QueryExecutionTree::writeJsonTable(
 // _________________________________________________________________________________________________________
 void QueryExecutionTree::writeTable(
     const IdTable& data, char sep, size_t from, size_t upperBound,
-    const vector<pair<size_t, ResultTable::ResultType>>& validIndices,
+    const vector<std::optional<pair<size_t, ResultTable::ResultType>>>&
+        validIndices,
     std::ostream& out) const {
   shared_ptr<const ResultTable> res = getResult();
   for (size_t i = from; i < upperBound; ++i) {
     for (size_t j = 0; j < validIndices.size(); ++j) {
-      switch (validIndices[j].second) {
-        case ResultTable::ResultType::KB: {
-          string entity =
-              _qec->getIndex()
-                  .idToOptionalString(data(i, validIndices[j].first))
-                  .value_or("");
-          if (ad_utility::startsWith(entity, VALUE_PREFIX)) {
-            out << ad_utility::convertIndexWordToValueLiteral(entity);
-          } else {
-            out << entity;
+      if (!validIndices[j]) {
+        const auto& val = *validIndices[j];
+        switch (val.second) {
+          case ResultTable::ResultType::KB: {
+            string entity = _qec->getIndex()
+                                .idToOptionalString(data(i, val.first))
+                                .value_or("");
+            if (ad_utility::startsWith(entity, VALUE_PREFIX)) {
+              out << ad_utility::convertIndexWordToValueLiteral(entity);
+            } else {
+              out << entity;
+            }
+            break;
           }
-          break;
+          case ResultTable::ResultType::VERBATIM:
+            out << data(i, val.first);
+            break;
+          case ResultTable::ResultType::TEXT:
+            out << _qec->getIndex().getTextExcerpt(data(i, val.first));
+            break;
+          case ResultTable::ResultType::FLOAT: {
+            float f;
+            std::memcpy(&f, &data(i, val.first), sizeof(float));
+            out << f;
+            break;
+          }
+          case ResultTable::ResultType::LOCAL_VOCAB: {
+            out << res->idToOptionalString(data(i, val.first)).value_or("");
+            break;
+          }
+          default:
+            AD_THROW(ad_semsearch::Exception::INVALID_PARAMETER_VALUE,
+                     "Cannot deduce output type.");
         }
-        case ResultTable::ResultType::VERBATIM:
-          out << data(i, validIndices[j].first);
-          break;
-        case ResultTable::ResultType::TEXT:
-          out << _qec->getIndex().getTextExcerpt(
-              data(i, validIndices[j].first));
-          break;
-        case ResultTable::ResultType::FLOAT: {
-          float f;
-          std::memcpy(&f, &data(i, validIndices[j].first), sizeof(float));
-          out << f;
-          break;
-        }
-        case ResultTable::ResultType::LOCAL_VOCAB: {
-          out << res->idToOptionalString(data(i, validIndices[j].first))
-                     .value_or("");
-          break;
-        }
-        default:
-          AD_THROW(ad_semsearch::Exception::INVALID_PARAMETER_VALUE,
-                   "Cannot deduce output type.");
       }
       out << (j + 1 < validIndices.size() ? sep : '\n');
     }

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -272,7 +272,7 @@ void QueryExecutionTree::writeTable(
   shared_ptr<const ResultTable> res = getResult();
   for (size_t i = from; i < upperBound; ++i) {
     for (size_t j = 0; j < validIndices.size(); ++j) {
-      if (!validIndices[j]) {
+      if (validIndices[j]) {
         const auto& val = *validIndices[j];
         switch (val.second) {
           case ResultTable::ResultType::KB: {

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -217,7 +217,7 @@ nlohmann::json QueryExecutionTree::writeJsonTable(
     auto& row = json.back();
     for (const auto& opt : validIndices) {
       if (!opt) {
-        row.emplace_back(optToJson(std::optional<string>{}));
+        row.emplace_back(nullptr);
         continue;
       }
       const auto& idx = *opt;

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -189,10 +189,12 @@ class QueryExecutionTree {
    */
   nlohmann::json writeJsonTable(
       const IdTable& data, size_t from, size_t limit,
-      const vector<pair<size_t, ResultTable::ResultType>>& validIndices) const;
+      const vector<std::optional<pair<size_t, ResultTable::ResultType>>>&
+          validIndices) const;
 
   void writeTable(
       const IdTable& data, char sep, size_t from, size_t upperBound,
-      const vector<pair<size_t, ResultTable::ResultType>>& validIndices,
+      const vector<std::optional<pair<size_t, ResultTable::ResultType>>>&
+          validIndices,
       std::ostream& out) const;
 };


### PR DESCRIPTION
When writing a query result, the "NULL" columns representing unbound but selected variables
were wrongly moved to the end making the naming and the content of the columns inconsistent (aka wront). This is now fixed for JSON, TSV and all other kinds of output types. Fixes #329 