### PR TITLE
Fix block boundary bug introduced by Unicode refactoring

### DIFF
--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -416,6 +416,7 @@ void Index::calculateBlockBoundaries() {
         locManager.compare(currentLenAndPrefix.second, nextLenAndPrefix.second,
                            LocaleManager::Level::PRIMARY) > 0) {
       _blockBoundaries.push_back(i);
+      currentLenAndPrefix = nextLenAndPrefix;
     }
   }
   _blockBoundaries.push_back(_textVocab.size() - 1);


### PR DESCRIPTION
After 45a68f6217e83100dcf0a3a633e6cf64c5d761af, the block boundary computation was no longer correct: there was always one block per word. I stumbled upon this when a freshly build index with text no longer supported the * in the argument of ql:contains-word

It seems to me that there was simply one line missing, please double-check

TODO: add a unit text that checks that the block boundaries are not the trivial boundaries (one block per word)