### PR TITLE
More generic Cache key for Group by

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -46,16 +46,24 @@ void GroupBy::setSubtree(std::shared_ptr<QueryExecutionTree> subtree) {
 }
 
 string GroupBy::asString(size_t indent) const {
+  const auto varMap = getVariableColumns();
+  const auto varMapInput = _subtree->getVariableColumns();
   std::ostringstream os;
   for (size_t i = 0; i < indent; ++i) {
     os << " ";
   }
   os << "GROUP_BY ";
   for (const std::string var : _groupByVariables) {
-    os << var << ", ";
+    os << varMap.at(var) << ", ";
   }
   for (auto p : _aliases) {
-    os << p._function << ", ";
+    os << ParsedQuery::AggregateTypeAsString(p._type);
+    if (p._type == ParsedQuery::AggregateType::GROUP_CONCAT) {
+      os << p._delimiter;
+    }
+
+    os << ' ' << varMapInput.at(p._inVarName) << ' '
+       << varMap.at(p._outVarName);
   }
   os << std::endl;
   os << _subtree->asString(indent);

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "../util/Exception.h"
 #include "../util/HashMap.h"
 #include "../util/StringUtils.h"
 #include "ParseException.h"
@@ -263,6 +264,33 @@ class ParsedQuery {
     SUM,
     AVG
   };
+
+  static std::string AggregateTypeAsString(AggregateType t) {
+    switch (t) {
+      case AggregateType::COUNT:
+        return "COUNT";
+      case AggregateType::GROUP_CONCAT:
+        return "GROUP_CONCAT";
+      case AggregateType::FIRST:
+        return "FIRST";
+      case AggregateType::LAST:
+        return "LAST";
+      case AggregateType::SAMPLE:
+        return "SAMPLE";
+      case AggregateType::MIN:
+        return "MIN";
+      case AggregateType::MAX:
+        return "MAX";
+      case AggregateType::SUM:
+        return "SUM";
+      case AggregateType::AVG:
+        return "AVG";
+      default:
+        AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+                 "Illegal/unimplemented enum value in AggregateTypeAsString. "
+                 "Should never happen, please report this");
+    }
+  }
 
   struct Alias {
     AggregateType _type;


### PR DESCRIPTION
The cache key for group by previously used the variable names instead of the column indices.
This triggered cache misses when the same query was reused with renamed variables.
This PR fixes this issue.