### PR TITLE
Use a parallel taskloop for the CountPredicates operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN make test
 
 FROM base as runtime
 WORKDIR /app
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1
 
 ARG UID=1000

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -235,9 +235,9 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
  *
  */
 template <typename T>
-class MergeableHashmap : public ad_utility::HashMap<T, size_t> {
+class MergeableHashMap : public ad_utility::HashMap<T, size_t> {
  public:
-  MergeableHashmap& operator%=(const MergeableHashmap& rhs) {
+  MergeableHashMap& operator%=(const MergeableHashMap& rhs) {
     for (const auto& [key, value] : rhs) {
       (*this)[key] += value;
     }

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -245,9 +245,6 @@ class MergeableHashmap : public ad_utility::HashMap<T, size_t> {
   }
 };
 
-using MergeableId = MergeableHashmap<Id>;
-using MergeableSizeT = MergeableHashmap<size_t>;
-
 template <int WIDTH>
 void CountAvailablePredicates::computePatternTrick(
     const IdTable& dynInput, IdTable* dynResult,
@@ -260,13 +257,14 @@ void CountAvailablePredicates::computePatternTrick(
   LOG(DEBUG) << "For " << input.size() << " entities in column "
              << subjectColumn << std::endl;
 
-  MergeableId predicateCounts;
-  MergeableSizeT patternCounts;
+  MergeableHashMap<Id> predicateCounts;
+  MergeableHashMap<size_t> patternCounts;
 
   // declare openmp reductions which aggregate Hashmaps by adding the values for
   // corresponding keys
-#pragma omp declare reduction(MergeHashmapsId:MergeableId : omp_out %= omp_in)
-#pragma omp declare reduction(MergeHashmapsSizeT:MergeableSizeT \
+#pragma omp declare reduction(MergeHashmapsId:MergeableHashMap<Id> \
+                              : omp_out %= omp_in)
+#pragma omp declare reduction(MergeHashmapsSizeT:MergeableHashMap<size_t> \
                               : omp_out %= omp_in)
 
   // These variables are used to gather additional statistics

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -326,7 +326,8 @@ void CountAvailablePredicates::computePatternTrick(
     patternVec.push_back(p);
   }
 
-  LOG(DEBUG) << "Start convertin patterns" << std::endl;
+  LOG(DEBUG) << "Start translating pattern counts to predicate counts"
+             << std::endl;
   if (patternVec.begin() !=
       patternVec.end()) {  // avoid segfaults with OpenMP on GCC
 #pragma omp parallel
@@ -342,7 +343,8 @@ void CountAvailablePredicates::computePatternTrick(
       }
     }
   }
-  LOG(DEBUG) << "Finished converting patterns" << std::endl;
+  LOG(DEBUG) << "Finished translating pattern counts to predicate counts"
+             << std::endl;
   // write the predicate counts to the result
   result.reserve(predicateCounts.size());
   for (const auto& it : predicateCounts) {

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -225,6 +225,29 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
   *dynResult = result.moveToDynamic();
 }
 
+/**
+ * @ brief A Hashmap from T to size_t which additionally supports merging of
+ * Hashmaps
+ *
+ * publicly inherits from ad_utility::HashMap<T, size_t> and additionally
+ * provides operator%= which merges Hashmaps by adding the values for
+ * corresponding keys. This is needed for the parallel pattern trick
+ *
+ */
+template <typename T>
+class MergeableHashmap : public ad_utility::HashMap<T, size_t> {
+ public:
+  MergeableHashmap& operator%=(const MergeableHashmap& rhs) {
+    for (const auto& [key, value] : rhs) {
+      (*this)[key] += value;
+    }
+    return *this;
+  }
+};
+
+using MergeableId = MergeableHashmap<Id>;
+using MergeableSizeT = MergeableHashmap<size_t>;
+
 template <int WIDTH>
 void CountAvailablePredicates::computePatternTrick(
     const IdTable& dynInput, IdTable* dynResult,
@@ -237,68 +260,97 @@ void CountAvailablePredicates::computePatternTrick(
   LOG(DEBUG) << "For " << input.size() << " entities in column "
              << subjectColumn << std::endl;
 
-  ad_utility::HashMap<Id, size_t> predicateCounts;
-  ad_utility::HashMap<size_t, size_t> patternCounts;
-  size_t inputIdx = 0;
+  MergeableId predicateCounts;
+  MergeableSizeT patternCounts;
+
+  // declare openmp reductions which aggregate Hashmaps by adding the values for
+  // corresponding keys
+#pragma omp declare reduction(MergeHashmapsId:MergeableId : omp_out %= omp_in)
+#pragma omp declare reduction(MergeHashmapsSizeT:MergeableSizeT \
+                              : omp_out %= omp_in)
+
   // These variables are used to gather additional statistics
   size_t numEntitiesWithPatterns = 0;
   // the number of distinct predicates in patterns
   size_t numPatternPredicates = 0;
   // the number of predicates counted without patterns
   size_t numListPredicates = 0;
-  Id lastSubject = ID_NO_VALUE;
-  while (inputIdx < input.size()) {
-    // Skip over elements with the same subject (don't count them twice)
-    Id subject = input(inputIdx, subjectColumn);
-    if (subject == lastSubject) {
-      inputIdx++;
-      continue;
-    }
-    lastSubject = subject;
-    if (subject < hasPattern.size() && hasPattern[subject] != NO_PATTERN) {
-      // The subject matches a pattern
-      patternCounts[hasPattern[subject]]++;
-      numEntitiesWithPatterns++;
-    } else if (subject < hasPredicate.size()) {
-      // The subject does not match a pattern
-      size_t numPredicates;
-      const Id* predicateData;
-      std::tie(predicateData, numPredicates) = hasPredicate[subject];
-      numListPredicates += numPredicates;
-      if (numPredicates > 0) {
-        for (size_t i = 0; i < numPredicates; i++) {
-          predicateCounts[predicateData[i]]++;
+
+  if (input.size() > 0) {  // avoid strange OpenMP segfaults on GCC
+#pragma omp parallel
+#pragma omp single
+#pragma omp taskloop grainsize(500000) default(none) reduction(MergeHashmapsId:predicateCounts) reduction(MergeHashmapsSizeT : patternCounts) \
+                                       reduction(+ : numEntitiesWithPatterns) reduction(+: numPatternPredicates) reduction(+: numListPredicates) shared(input, subjectColumn, hasPattern, hasPredicate)
+    for (size_t inputIdx = 0; inputIdx < input.size(); ++inputIdx) {
+      // Skip over elements with the same subject (don't count them twice)
+      Id subject = input(inputIdx, subjectColumn);
+      if (inputIdx > 0 && subject == input(inputIdx - 1, subjectColumn)) {
+        continue;
+      }
+
+      if (subject < hasPattern.size() && hasPattern[subject] != NO_PATTERN) {
+        // The subject matches a pattern
+        patternCounts[hasPattern[subject]]++;
+        numEntitiesWithPatterns++;
+      } else if (subject < hasPredicate.size()) {
+        // The subject does not match a pattern
+        size_t numPredicates;
+        const Id* predicateData;
+        std::tie(predicateData, numPredicates) = hasPredicate[subject];
+        numListPredicates += numPredicates;
+        if (numPredicates > 0) {
+          for (size_t i = 0; i < numPredicates; i++) {
+            predicateCounts[predicateData[i]]++;
+          }
+        } else {
+          LOG(TRACE) << "No pattern or has-relation entry found for entity "
+                     << std::to_string(subject) << std::endl;
         }
       } else {
-        LOG(TRACE) << "No pattern or has-relation entry found for entity "
-                   << std::to_string(subject) << std::endl;
+        LOG(TRACE) << "Subject " << subject
+                   << " does not appear to be an entity "
+                      "(its id is to high)."
+                   << std::endl;
       }
-    } else {
-      LOG(TRACE) << "Subject " << subject
-                 << " does not appear to be an entity "
-                    "(its id is to high)."
-                 << std::endl;
     }
-    inputIdx++;
   }
   LOG(DEBUG) << "Using " << patternCounts.size()
              << " patterns for computing the result." << std::endl;
   // the number of predicates counted with patterns
   size_t numPredicatesSubsumedInPatterns = 0;
   // resolve the patterns to predicate counts
-  for (const auto& it : patternCounts) {
-    const auto& pattern = patterns[it.first];
-    numPatternPredicates += pattern.second;
-    for (size_t i = 0; i < pattern.second; i++) {
-      predicateCounts[pattern.first[i]] += it.second;
-      numPredicatesSubsumedInPatterns += it.second;
+
+  LOG(DEBUG) << "Converting PatternMap to vector" << std::endl;
+  // flatten into a vector, to make iterable
+  std::vector<std::pair<size_t, size_t>> patternVec;
+  patternVec.reserve(patternCounts.size());
+  for (const auto& p : patternCounts) {
+    patternVec.push_back(p);
+  }
+
+  LOG(DEBUG) << "Start convertin patterns" << std::endl;
+  if (patternVec.begin() !=
+      patternVec.end()) {  // avoid segfaults with OpenMP on GCC
+#pragma omp parallel
+#pragma omp single
+#pragma omp taskloop grainsize(100000) default(none) reduction(MergeHashmapsId:predicateCounts) reduction(+ : numPredicatesSubsumedInPatterns) \
+                                       reduction(+ : numEntitiesWithPatterns) reduction(+: numPatternPredicates) reduction(+: numListPredicates) shared( patternVec, patterns)
+    for (auto it = patternVec.begin(); it != patternVec.end(); ++it) {
+      const auto& pattern = patterns[it->first];
+      numPatternPredicates += pattern.second;
+      for (size_t i = 0; i < pattern.second; i++) {
+        predicateCounts[pattern.first[i]] += it->second;
+        numPredicatesSubsumedInPatterns += it->second;
+      }
     }
   }
+  LOG(DEBUG) << "Finished converting patterns" << std::endl;
   // write the predicate counts to the result
   result.reserve(predicateCounts.size());
   for (const auto& it : predicateCounts) {
     result.push_back({it.first, static_cast<Id>(it.second)});
   }
+  LOG(DEBUG) << "Finished writing results" << std::endl;
 
   // Print interesting statistics about the pattern trick
   double ratioHasPatterns =

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -605,7 +605,7 @@ class TripleComponentComparator {
       std::string_view s, const Level level) const {
     AD_CHECK(level == Level::PRIMARY)
     auto transformed = extractAndTransformComparable(s, Level::PRIMARY);
-    // The `firstOriginalChar` is either " or < or @ 
+    // The `firstOriginalChar` is either " or < or @
     AD_CHECK(static_cast<unsigned char>(transformed.firstOriginalChar) <
              std::numeric_limits<unsigned char>::max())
     if (transformed.transformedVal.get().empty()) {

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -110,11 +110,14 @@ class Log {
   static void imbue(const std::locale& locale) { std::cout.imbue(locale); }
 
   static string getTimeStamp() {
+    using namespace std::chrono;
     auto now = std::chrono::system_clock::now();
     auto in_time_t = std::chrono::system_clock::to_time_t(now);
-
+    auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
     std::stringstream ss;
-    ss << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %X");
+
+    ss << std::put_time(std::localtime(&in_time_t), "%Y-%m-%d %X") << '.'
+       << std::setw(3) << std::setfill('0') << ms.count();
     return ss.str();
   }
 


### PR DESCRIPTION
The CountPredicates operation ("Pattern Trick") can be easily parallelized by
counting the predicates for subsets of the input and later adding/merging them.
This PR delivers a first implementation of this parallelization using OpenMP

TODO:
- make the degree of parallelism configurable (we currently use taskloops, so the behavior under load should still be fine)
- the merging in the end is currently done linearly instead of a binary tree. This is due to the behavior of OpenMP
  which does the final step in the reduction linearly (at least in the current GCC implementation), because this is 
  typically a simple operation (addition) but in our case it is a  merging of hash maps which can take some time.