### PR TITLE
Implement a rough memory Limit for the IdTables

### DIFF
--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -149,7 +149,11 @@ int main(int argc, char** argv) {
       index.addTextFromOnDiskIndex();
     }
 
-    QueryExecutionContext qec(index, engine, &cache, &pinnedSizes);
+    ad_utility::AllocatorWithLimit<Id> allocator{
+        ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+            DEFAULT_MEM_FOR_QUERIES_IN_GB)};
+
+    QueryExecutionContext qec(index, engine, &cache, &pinnedSizes, allocator);
     if (costFactosFileName.size() > 0) {
       qec.readCostFactorsFromTSVFile(costFactosFileName);
     }

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -89,7 +89,10 @@ int main(int argc, char** argv) {
     Engine engine;
     SubtreeCache cache(NOF_SUBTREES_TO_CACHE);
     PinnedSizes pinnedSizes;
-    QueryExecutionContext qec(index, engine, &cache, &pinnedSizes);
+    ad_utility::AllocatorWithLimit<Id> allocator{
+        ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+            DEFAULT_MEM_FOR_QUERIES_IN_GB)};
+    QueryExecutionContext qec(index, engine, &cache, &pinnedSizes, allocator);
     ParsedQuery q;
     if (!freebase) {
       q = SparqlParser("SELECT ?x WHERE {?x <is-a> <Scientist>}").parse();

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -152,7 +152,7 @@ void CountAvailablePredicates::computeResult(ResultTable* result) {
     // If the entity exists return the all predicates for that entitity,
     // otherwise return an empty result.
     if (getIndex().getVocab().getId(_subjectEntityName.value(), &entityId)) {
-      IdTable input(1);
+      IdTable input(1, _executionContext->getAllocator());
       input.push_back({entityId});
       int width = input.cols();
       CALL_FIXED_SIZE_1(width, CountAvailablePredicates::computePatternTrick,

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -268,7 +268,7 @@ void Filter::computeResult(ResultTable* result) {
 template <ResultTable::ResultType T, int WIDTH, bool INVERSE>
 void Filter::computeFilterRange(IdTableStatic<WIDTH>* res, size_t lhs,
                                 Id rhs_lower, Id rhs_upper,
-                                const IdTableStatic<WIDTH>& input,
+                                const IdTableView<WIDTH>& input,
                                 shared_ptr<const ResultTable> subRes) const {
   bool lhs_is_sorted =
       subRes->_sortedBy.size() > 0 && subRes->_sortedBy[0] == lhs;

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -144,7 +144,7 @@ class Filter : public Operation {
    */
   template <ResultTable::ResultType T, int WIDTH, bool INVERSE = false>
   void computeFilterRange(IdTableStatic<WIDTH>* res, size_t lhs, Id rhs_lower,
-                          Id rhs_upper, const IdTableStatic<WIDTH>& input,
+                          Id rhs_upper, const IdTableView<WIDTH>& input,
                           shared_ptr<const ResultTable> subRes) const;
 
   template <int WIDTH>

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -335,7 +335,7 @@ void Join::doComputeJoinWithFullScanDummyLeft(const IdTable& ndr,
     } else {
       // Do a scan.
       LOG(TRACE) << "Inner scan with ID: " << currentJoinId << endl;
-      IdTable jr(2);
+      IdTable jr(2, _executionContext->getAllocator());
       scan(currentJoinId, &jr);
       LOG(TRACE) << "Got #items: " << jr.size() << endl;
       // Build the cross product.
@@ -348,7 +348,7 @@ void Join::doComputeJoinWithFullScanDummyLeft(const IdTable& ndr,
   }
   // Do the scan for the final element.
   LOG(TRACE) << "Inner scan with ID: " << currentJoinId << endl;
-  IdTable jr(2);
+  IdTable jr(2, _executionContext->getAllocator());
   scan(currentJoinId, &jr);
   LOG(TRACE) << "Got #items: " << jr.size() << endl;
   // Build the cross product.
@@ -376,7 +376,7 @@ void Join::doComputeJoinWithFullScanDummyRight(const IdTable& ndr,
     } else {
       // Do a scan.
       LOG(TRACE) << "Inner scan with ID: " << currentJoinId << endl;
-      IdTable jr(2);
+      IdTable jr(2, _executionContext->getAllocator());
       scan(currentJoinId, &jr);
       LOG(TRACE) << "Got #items: " << jr.size() << endl;
       // Build the cross product.
@@ -389,7 +389,7 @@ void Join::doComputeJoinWithFullScanDummyRight(const IdTable& ndr,
   }
   // Do the scan for the final element.
   LOG(TRACE) << "Inner scan with ID: " << currentJoinId << endl;
-  IdTable jr(2);
+  IdTable jr(2, _executionContext->getAllocator());
   scan(currentJoinId, &jr);
   LOG(TRACE) << "Got #items: " << jr.size() << endl;
   // Build the cross product.

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -6,8 +6,9 @@
 #include <cassert>
 
 // _____________________________________________________________________________
-ResultTable::ResultTable()
+ResultTable::ResultTable(ad_utility::AllocatorWithLimit<Id> allocator)
     : _sortedBy(),
+      _data(std::move(allocator)),
       _resultTypes(),
       _localVocab(std::make_shared<std::vector<std::string>>()),
       _status(ResultTable::IN_PROGRESS) {}

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -65,7 +65,7 @@ class ResultTable {
   //          the _localVocab of a subresult.
   std::shared_ptr<vector<string>> _localVocab;
 
-  ResultTable();
+  ResultTable(ad_utility::AllocatorWithLimit<Id> allocator);
 
   ResultTable(const ResultTable& other) = delete;
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -190,7 +190,7 @@ void Server::process(Socket* client) {
       pq.expandPrefixes();
 
       QueryExecutionContext qec(_index, _engine, &_cache, &_pinnedSizes,
-                                pinSubtrees, pinResult);
+                                _allocator, pinSubtrees, pinResult);
       QueryPlanner qp(&qec);
       qp.setEnablePatternTrick(_enablePatternTrick);
       QueryExecutionTree qet = qp.createExecutionTree(pq);

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -11,6 +11,7 @@
 #include "../index/Index.h"
 #include "../parser/ParseException.h"
 #include "../parser/SparqlParser.h"
+#include "../util/AllocatorWithLimit.h"
 #include "../util/Socket.h"
 #include "../util/Timer.h"
 #include "./QueryExecutionContext.h"
@@ -24,11 +25,14 @@ using ad_utility::Socket;
 //! The HTTP Sever used.
 class Server {
  public:
-  explicit Server(const int port, const int numThreads)
+  explicit Server(const int port, const int numThreads, size_t maxMemInBytes)
       : _numThreads(numThreads),
         _serverSocket(),
         _port(port),
         _cache(NOF_SUBTREES_TO_CACHE),
+        _allocator(ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+            maxMemInBytes)),
+
         _index(),
         _engine(),
         _initialized(false) {}
@@ -51,6 +55,7 @@ class Server {
   int _port;
   SubtreeCache _cache;
   PinnedSizes _pinnedSizes;
+  ad_utility::AllocatorWithLimit<Id> _allocator;
   Index _index;
   Engine _engine;
 

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -10,6 +10,8 @@ static const size_t STXXL_MEMORY_TO_USE = 1024L * 1024L * 1024L * 2L;
 static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000 * 1000;
 static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 
+static constexpr size_t DEFAULT_MEM_FOR_QUERIES_IN_GB = 80;
+
 static const size_t NOF_SUBTREES_TO_CACHE = 1000;
 static const size_t MAX_NOF_ROWS_IN_RESULT = 100000;
 static const size_t MIN_WORD_PREFIX_SIZE = 4;

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -737,7 +737,9 @@ void Index::getFilteredECListForWords(const string& words,
       Id eid = filter(i, filterColumn);
       auto it = fMap.find(eid);
       if (it == fMap.end()) {
-        it = fMap.insert(std::make_pair(eid, IdTable(filter.cols()))).first;
+        it = fMap.insert(std::make_pair(eid, IdTable(filter.cols(),
+                                                     filter.getAllocator())))
+                 .first;
       }
       it->second.push_back(filter, i);
     }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -443,7 +443,7 @@ class Index {
         } else {
           // If we don't have blocks, scan the whole relation and filter /
           // restrict.
-          IdTable fullRelation(2);
+          IdTable fullRelation(2, result->getAllocator());
           fullRelation.resize(rmd.getNofElements());
           p._file.read(fullRelation.data(),
                        rmd.getNofElements() * 2 * sizeof(Id),

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -1,0 +1,182 @@
+//
+// Created by johannes on 27.04.20.
+//
+
+#ifndef QLEVER_ALLOCATORWITHLIMIT_H
+#define QLEVER_ALLOCATORWITHLIMIT_H
+
+#include <atomic>
+#include "Synchronized.h"
+
+namespace ad_utility {
+
+namespace detail {
+
+// An Exception to be thrown when trying to allocate more memory than was
+// specified as a limit
+class AllocationExceedsLimitException : public std::exception {
+ public:
+  AllocationExceedsLimitException(size_t requestedBytes, size_t freeBytes)
+      : _message{
+            "Tried to allocate " + std::to_string(requestedBytes >> 20) +
+            "MB, but only " + std::to_string(freeBytes >> 20) +
+            "MB  were free." +
+            "the cache or allowing more memory for QLever during startup"} {};
+
+ private:
+  const char* what() const noexcept override { return _message.c_str(); }
+  const std::string _message;
+};
+
+// Class to keep track of the amount of memory that is left for allocation. When
+// not enough memory is left, an AllocationExceedsLimitException is thrown. Note
+// that need a separate class for this because there can be many Allocation
+// objects at the same time (hence the wrapper class and the synchronization
+// below).
+class AllocationMemoryLeft {
+  size_t free_;  // the number of free bytes
+                 // throw AllocationExceedsLimitException on failure
+ public:
+  AllocationMemoryLeft(size_t n) : free_(n) {}
+
+  // Called before memory is allocated.
+  void decrease_if_enough_left(size_t n) {
+    if (n <= free_) {
+      free_ -= n;
+    } else {
+      throw AllocationExceedsLimitException{n, free_};
+    }
+  }
+
+  // Called after memory is deallocated.
+  void increase(size_t n) { free_ += n; }
+  [[nodiscard]] size_t numFreeBytes() const { return free_; }
+};
+
+/*
+ * Threadsafe Wrapper around AllocationMemoryLeft.
+ * Copies of objects of this class will refer to the same AllocationMemoryLeft
+ * object Concurrent access is handled via ad_utility::Synchronized.
+ */
+class AllocationMemoryLeftThreadsafe {
+ public:
+  AllocationMemoryLeftThreadsafe() = delete;
+  using T =
+      std::shared_ptr<ad_utility::Synchronized<AllocationMemoryLeft, SpinLock>>;
+  explicit AllocationMemoryLeftThreadsafe(T ptr) : ptr_{std::move(ptr)} {}
+  T& ptr() { return ptr_; }
+  const T& ptr() const { return ptr_; }
+
+  friend bool operator==(const AllocationMemoryLeftThreadsafe& a,
+                         const AllocationMemoryLeftThreadsafe& b) {
+    return a.ptr_ == b.ptr_;
+  }
+
+ private:
+  T ptr_;
+};
+}  // namespace detail
+
+// setup a shared Allocation state. For the usage see documentation of the
+// Limited Allocator class
+inline detail::AllocationMemoryLeftThreadsafe
+makeAllocationMemoryLeftThreadsafeObject(size_t n) {
+  return detail::AllocationMemoryLeftThreadsafe{std::make_shared<
+      ad_utility::Synchronized<detail::AllocationMemoryLeft, SpinLock>>(n)};
+}
+
+/**
+ * @brief Class to concurrently allocate memory up to a specified limit on the
+ * total amount of memory allocated. The actual allocation is done by
+ * std::allocator, but only when the limit is not exceeded.
+ *
+ * Memory allocated by copies of an Allocator will also count towards the limit
+ * To use it, construct a first allocator by calling
+ * AllocatorWithLimit{makeAllocationMemoryLeftThreadsafeObject(limit)} and then
+ * pass copies of this allocator to your containers. You can also Create
+ * Allocators for different types respecting the same total memory pool size,
+ * e.g.
+ *
+ * auto memoryLeft = makeAllocationMemoryLeftThreadsafeObject(limitInBytes);
+ * auto allocInt = AllocatorWithLimit<int>{memoryLeft};
+ * auto limitedIntVec = std::vector<int, AllocatorWithLimit<int>>{allocInt};
+ * auto allocString = AllocatorWithLimit<string>{memoryLeft};
+ * auto limitedStringVec = std::vector<string,
+ * AllocatorWithLimit<string>>{allocString};
+ *
+ * // now the total amount of memory allocated by limitedIntVec and
+ * limitedStringVec may never exceed limitInBytes
+ *
+ * @tparam T the type of Elements that this allocator allocates
+ */
+template <typename T>
+class AllocatorWithLimit {
+ public:
+  using value_type = T;
+
+  // These special type aliases are necessary for using this allocator with
+  // the STL. We always want it to be propagated to the target of copy and move
+  // operations, s.T. the copy also counts towards the Limit.
+  using propagate_on_container_copy_assignment = std::true_type;
+  using propagate_on_container_move_assignment = std::true_type;
+  using propagate_on_container_swap = std::true_type;
+
+ private:
+  detail::AllocationMemoryLeftThreadsafe
+      memoryLeft_;  // shared number of free bytes
+  std::allocator<T> allocator_;
+
+ public:
+  /// obtain an AllocationMemoryLeftThreadsafe by calls to
+  /// makeAllocationMemoryLeftThreadsafeObject()
+  explicit AllocatorWithLimit(detail::AllocationMemoryLeftThreadsafe ml)
+      : memoryLeft_(std::move(ml)) {}
+  AllocatorWithLimit() = delete;
+
+  // An allocator must have a function "allocate" with exactly this signature.
+  // TODO<C++20> : the exact signature of allocate changes
+  T* allocate(std::size_t n) {
+    // Subtract the amount of memory we want to allocate from the amount of
+    // memory left. This will throw an exception if not enough memory is left.
+    memoryLeft_.ptr()->wlock()->decrease_if_enough_left(n * sizeof(T));
+    // the actual allocation
+    return allocator_.allocate(n);
+  }
+
+  // An allocator must have a function "deallocate" with exactly this signature.
+  void deallocate(T* p, std::size_t n) {
+    // free the memory
+    allocator_.deallocate(p, n);
+    // Update the amount of memory left.
+    memoryLeft_.ptr()->wlock()->increase(n * sizeof(T));
+  }
+
+  /// Return the number of bytes, that this allocator and all of its copies
+  /// currently have available
+  [[nodiscard]] size_t numFreeBytes() const {
+    // casting is ok, because the actual numFreeBytes call
+    // is const, and everything else is locking
+    return const_cast<AllocatorWithLimit*>(this)
+        ->memoryLeft_.ptr()
+        ->wlock()
+        ->numFreeBytes();
+  }
+
+  // The STL needs two allocators to be equal if and only they refer to the same
+  // memory pool. For us, they are hence equal if they use the same
+  // AllocationMemoryLeft object.00
+  template <typename U, typename V>
+  friend bool operator==(const AllocatorWithLimit<U>& u,
+                         const AllocatorWithLimit<V>& v) {
+    return u.memoryLeft_ == v.memoryLeft_;
+  }
+  template <typename U, typename V>
+  friend bool operator!=(const AllocatorWithLimit<U>& u,
+                         const AllocatorWithLimit<V>& v) {
+    return !(u == v);
+  }
+};
+
+}  // namespace ad_utility
+
+#endif  // QLEVER_ALLOCATORWITHLIMIT_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,3 +141,7 @@ target_link_libraries(PriorityQueueTest gtest_main absl::flat_hash_map ${CMAKE_T
 add_executable(SynchronizedTest SynchronizedTest.cpp)
 add_test(SynchronizedTest SynchronizedTest)
 target_link_libraries(SynchronizedTest gtest_main ${CMAKE_THREAD_LIBS_INIT})
+
+add_executable(LimitedAllocatorTest LimitedAllocatorTest.cpp)
+add_test(LimitedAllocatorTest LimitedAllocatorTest)
+target_link_libraries(LimitedAllocatorTest gtest_main ${CMAKE_THREAD_LIBS_INIT})

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -10,19 +10,26 @@
 #include "../src/engine/Join.h"
 #include "../src/engine/OptionalJoin.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+
 TEST(EngineTest, joinTest) {
-  IdTable a(2);
+  IdTable a(2, allocator());
   a.push_back({1, 1});
   a.push_back({1, 3});
   a.push_back({2, 1});
   a.push_back({2, 2});
   a.push_back({4, 1});
-  IdTable b(2);
+  IdTable b(2, allocator());
   b.push_back({1, 3});
   b.push_back({1, 8});
   b.push_back({3, 1});
   b.push_back({4, 2});
-  IdTable res(3);
+  IdTable res(3, allocator());
   int lwidth = a.cols();
   int rwidth = b.cols();
   int reswidth = a.cols() + b.cols() - 1;
@@ -82,7 +89,7 @@ TEST(EngineTest, joinTest) {
   b.clear();
   res.clear();
 
-  IdTable c(1);
+  IdTable c(1, allocator());
   c.push_back({0});
 
   b.push_back({0, 1});
@@ -94,7 +101,7 @@ TEST(EngineTest, joinTest) {
   rwidth = c.cols();
   reswidth = b.cols() + c.cols() - 1;
   // reset the IdTable.
-  res = IdTable(reswidth);
+  res = IdTable(reswidth, allocator());
   CALL_FIXED_SIZE_3(lwidth, rwidth, reswidth, Join::join, b, 0, c, 0, &res);
 
   ASSERT_EQ(2u, res.size());
@@ -107,18 +114,18 @@ TEST(EngineTest, joinTest) {
 };
 
 TEST(EngineTest, optionalJoinTest) {
-  IdTable a(3);
+  IdTable a(3, allocator());
   a.push_back({4, 1, 2});
   a.push_back({2, 1, 3});
   a.push_back({1, 1, 4});
   a.push_back({2, 2, 1});
   a.push_back({1, 3, 1});
-  IdTable b(3);
+  IdTable b(3, allocator());
   b.push_back({3, 3, 1});
   b.push_back({1, 8, 1});
   b.push_back({4, 2, 2});
   b.push_back({1, 1, 3});
-  IdTable res(4);
+  IdTable res(4, allocator());
   vector<array<Id, 2>> jcls;
   jcls.push_back(array<Id, 2>{{1, 2}});
   jcls.push_back(array<Id, 2>{{2, 1}});
@@ -159,17 +166,17 @@ TEST(EngineTest, optionalJoinTest) {
   ASSERT_EQ(1u, res(4, 3));
 
   // Test the optional join with variable sized data.
-  IdTable va(6);
+  IdTable va(6, allocator());
   va.push_back({1, 2, 3, 4, 5, 6});
   va.push_back({1, 2, 3, 7, 5, 6});
   va.push_back({7, 6, 5, 4, 3, 2});
 
-  IdTable vb(3);
+  IdTable vb(3, allocator());
   vb.push_back({2, 3, 4});
   vb.push_back({2, 3, 5});
   vb.push_back({6, 7, 4});
 
-  IdTable vres(7);
+  IdTable vres(7, allocator());
   jcls.clear();
   jcls.push_back(array<Id, 2>{{1, 0}});
   jcls.push_back(array<Id, 2>{{2, 1}});
@@ -206,8 +213,8 @@ TEST(EngineTest, optionalJoinTest) {
 }
 
 TEST(EngineTest, distinctTest) {
-  IdTable inp(4);
-  IdTable res(4);
+  IdTable inp(4, allocator());
+  IdTable res(4, allocator());
 
   inp.push_back({1, 1, 3, 7});
   inp.push_back({6, 1, 3, 6});

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -7,6 +7,13 @@
 #include "../src/engine/CallFixedSize.h"
 #include "../src/engine/GroupBy.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+
 // This fixture is used to create an Index for the tests.
 // The full index creation is required for initialization of the vocabularies.
 class GroupByTest : public ::testing::Test {
@@ -88,12 +95,12 @@ TEST_F(GroupByTest, doGroupBy) {
   vocab.push_back(ad_utility::convertFloatStringToIndexWord("17"));
 
   // create an input result table with a local vocabulary
-  ResultTable inTable;
+  ResultTable inTable{allocator()};
   inTable._localVocab->push_back("<local1>");
   inTable._localVocab->push_back("<local2>");
   inTable._localVocab->push_back("<local3>");
 
-  IdTable inputData(6);
+  IdTable inputData(6, allocator());
   // The input data types are
   //                   KB, KB, VERBATIM, TEXT, FLOAT,           STRING
   inputData.push_back({1, 4, 123, 0, floatBuffers[0], 0});
@@ -157,7 +164,7 @@ TEST_F(GroupByTest, doGroupBy) {
       {ParsedQuery::AggregateType::AVG, 3, 22, nullptr},
       {ParsedQuery::AggregateType::AVG, 4, 23, nullptr}};
 
-  ResultTable outTable;
+  ResultTable outTable{allocator()};
 
   // This is normally done when calling computeResult in the GroupBy
   // operation.

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -9,6 +9,12 @@
 #include "../src/engine/CountAvailablePredicates.h"
 #include "../src/engine/HasPredicateScan.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
 // used to test HasRelationScan with a subtree
 class DummyOperation : public Operation {
  public:
@@ -60,7 +66,7 @@ class DummyOperation : public Operation {
 
 TEST(HasPredicateScan, freeS) {
   // Used to store the result.
-  ResultTable resultTable;
+  ResultTable resultTable{allocator()};
   resultTable._data.setCols(1);
   // Maps entities to their patterns. If an entity id is higher than the lists
   // length the hasRelation relation is used instead.
@@ -100,7 +106,7 @@ TEST(HasPredicateScan, freeS) {
 
 TEST(HasPredicateScan, freeO) {
   // Used to store the result.
-  ResultTable resultTable;
+  ResultTable resultTable{allocator()};
   resultTable._data.setCols(1);
   // Maps entities to their patterns. If an entity id is higher than the lists
   // length the hasRelation relation is used instead.
@@ -142,7 +148,7 @@ TEST(HasPredicateScan, freeO) {
 
 TEST(HasPredicateScan, fullScan) {
   // Used to store the result.
-  ResultTable resultTable;
+  ResultTable resultTable{allocator()};
   resultTable._data.setCols(2);
   // Maps entities to their patterns. If an entity id is higher than the lists
   // length the hasRelation relation is used instead.
@@ -204,7 +210,7 @@ TEST(HasPredicateScan, fullScan) {
 
 TEST(HasPredicateScan, subtreeS) {
   // Used to store the result.
-  ResultTable resultTable;
+  ResultTable resultTable{allocator()};
   resultTable._data.setCols(3);
   // Maps entities to their patterns. If an entity id is higher than the lists
   // length the hasRelation relation is used instead.
@@ -225,7 +231,7 @@ TEST(HasPredicateScan, subtreeS) {
   Engine engine;
   SubtreeCache cache(NOF_SUBTREES_TO_CACHE);
   PinnedSizes pinnedSizes;
-  QueryExecutionContext ctx(index, engine, &cache, &pinnedSizes);
+  QueryExecutionContext ctx(index, engine, &cache, &pinnedSizes, allocator());
 
   // create the subtree operation
   std::shared_ptr<QueryExecutionTree> subtree =
@@ -288,12 +294,12 @@ TEST(HasPredicateScan, subtreeS) {
 
 TEST(CountAvailablePredicates, patternTrickTest) {
   // The input table containing entity ids
-  IdTable input(1);
+  IdTable input(1, allocator());
   for (Id i = 0; i < 8; i++) {
     input.push_back({i});
   }
   // Used to store the result.
-  IdTable result(2);
+  IdTable result(2, allocator());
   // Maps entities to their patterns. If an entity id is higher than the lists
   // length the hasRelation relation is used instead.
   vector<PatternID> hasPattern = {0, NO_PATTERN, NO_PATTERN, 1, 0};

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -11,11 +11,18 @@
 #include "../src/engine/IdTable.h"
 #include "../src/global/Id.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+
 TEST(IdTableTest, push_back_and_assign) {
   constexpr size_t NUM_ROWS = 30;
   constexpr size_t NUM_COLS = 4;
 
-  IdTable t1(NUM_COLS);
+  IdTable t1{NUM_COLS, allocator()};
   // Fill the rows with numbers counting up from 1
   for (size_t i = 0; i < NUM_ROWS; i++) {
     t1.push_back({i * NUM_COLS + 1, i * NUM_COLS + 2, i * NUM_COLS + 3,
@@ -42,11 +49,11 @@ TEST(IdTableTest, push_back_and_assign) {
 }
 
 TEST(IdTableTest, insert) {
-  IdTable t1(4);
+  IdTable t1{4, allocator()};
   t1.push_back({7, 2, 4, 1});
   t1.push_back({0, 22, 1, 4});
 
-  IdTable init(4);
+  IdTable init(4, allocator());
   init.push_back({1, 0, 6, 3});
   init.push_back({3, 1, 8, 2});
   init.push_back({0, 6, 8, 5});
@@ -92,7 +99,7 @@ TEST(IdTableTest, reserve_and_resize) {
   constexpr size_t NUM_COLS = 20;
 
   // Test a reserve call before insertions
-  IdTable t1(NUM_COLS);
+  IdTable t1(NUM_COLS, allocator());
   t1.reserve(NUM_ROWS);
 
   // Fill the rows with numbers counting up from 1
@@ -112,7 +119,7 @@ TEST(IdTableTest, reserve_and_resize) {
   }
 
   // Test a resize call instead of insertions
-  IdTable t2(NUM_COLS);
+  IdTable t2(NUM_COLS, allocator());
   t2.resize(NUM_ROWS);
 
   // Fill the rows with numbers counting up from 1
@@ -133,7 +140,7 @@ TEST(IdTableTest, copyAndMove) {
   constexpr size_t NUM_ROWS = 100;
   constexpr size_t NUM_COLS = 4;
 
-  IdTable t1(NUM_COLS);
+  IdTable t1(NUM_COLS, allocator());
   // Fill the rows with numbers counting up from 1
   for (size_t i = 0; i < NUM_ROWS; i++) {
     t1.push_back({i * NUM_COLS + 1, i * NUM_COLS + 2, i * NUM_COLS + 3,
@@ -176,7 +183,7 @@ TEST(IdTableTest, erase) {
   constexpr size_t NUM_ROWS = 12;
   constexpr size_t NUM_COLS = 4;
 
-  IdTable t1(NUM_COLS);
+  IdTable t1(NUM_COLS, allocator());
   // Fill the rows with numbers counting up from 1
   for (size_t j = 0; j < 2 * NUM_ROWS; j++) {
     size_t i = j / 2;
@@ -204,7 +211,7 @@ TEST(IdTableTest, iterating) {
   constexpr size_t NUM_ROWS = 42;
   constexpr size_t NUM_COLS = 17;
 
-  IdTable t1(NUM_COLS);
+  IdTable t1(NUM_COLS, allocator());
   // Fill the rows with numbers counting up from 1
   for (size_t i = 0; i < NUM_ROWS; i++) {
     t1.push_back();
@@ -231,7 +238,7 @@ TEST(IdTableTest, iterating) {
 }
 
 TEST(IdTableTest, sortTest) {
-  IdTable test(2);
+  IdTable test(2, allocator());
   test.push_back({3, 1});
   test.push_back({8, 9});
   test.push_back({1, 5});
@@ -287,7 +294,7 @@ TEST(IdTableStaticTest, push_back_and_assign) {
   constexpr size_t NUM_ROWS = 30;
   constexpr size_t NUM_COLS = 4;
 
-  IdTableStatic<NUM_COLS> t1;
+  IdTableStatic<NUM_COLS> t1{allocator()};
   // Fill the rows with numbers counting up from 1
   for (size_t i = 0; i < NUM_ROWS; i++) {
     t1.push_back({i * NUM_COLS + 1, i * NUM_COLS + 2, i * NUM_COLS + 3,
@@ -314,11 +321,11 @@ TEST(IdTableStaticTest, push_back_and_assign) {
 }
 
 TEST(IdTableStaticTest, insert) {
-  IdTableStatic<4> t1;
+  IdTableStatic<4> t1{allocator()};
   t1.push_back({7, 2, 4, 1});
   t1.push_back({0, 22, 1, 4});
 
-  IdTableStatic<4> init;
+  IdTableStatic<4> init{allocator()};
   init.push_back({1, 0, 6, 3});
   init.push_back({3, 1, 8, 2});
   init.push_back({0, 6, 8, 5});
@@ -366,7 +373,7 @@ TEST(IdTableStaticTest, reserve_and_resize) {
   constexpr size_t NUM_COLS = 20;
 
   // Test a reserve call before insertions
-  IdTableStatic<NUM_COLS> t1;
+  IdTableStatic<NUM_COLS> t1{allocator()};
   t1.reserve(NUM_ROWS);
 
   // Fill the rows with numbers counting up from 1
@@ -386,7 +393,7 @@ TEST(IdTableStaticTest, reserve_and_resize) {
   }
 
   // Test a resize call instead of insertions
-  IdTableStatic<NUM_COLS> t2;
+  IdTableStatic<NUM_COLS> t2{allocator()};
   t2.resize(NUM_ROWS);
 
   // Fill the rows with numbers counting up from 1
@@ -407,7 +414,7 @@ TEST(IdTableStaticTest, copyAndMove) {
   constexpr size_t NUM_ROWS = 100;
   constexpr size_t NUM_COLS = 4;
 
-  IdTableStatic<NUM_COLS> t1;
+  IdTableStatic<NUM_COLS> t1{allocator()};
   // Fill the rows with numbers counting up from 1
   for (size_t i = 0; i < NUM_ROWS; i++) {
     t1.push_back({i * NUM_COLS + 1, i * NUM_COLS + 2, i * NUM_COLS + 3,
@@ -450,7 +457,7 @@ TEST(IdTableStaticTest, erase) {
   constexpr size_t NUM_ROWS = 12;
   constexpr size_t NUM_COLS = 4;
 
-  IdTableStatic<NUM_COLS> t1;
+  IdTableStatic<NUM_COLS> t1{allocator()};
   // Fill the rows with numbers counting up from 1
   for (size_t j = 0; j < 2 * NUM_ROWS; j++) {
     size_t i = j / 2;
@@ -478,7 +485,7 @@ TEST(IdTableStaticTest, iterating) {
   constexpr size_t NUM_ROWS = 42;
   constexpr size_t NUM_COLS = 17;
 
-  IdTableStatic<NUM_COLS> t1;
+  IdTableStatic<NUM_COLS> t1{allocator()};
   // Fill the rows with numbers counting up from 1
   for (size_t i = 0; i < NUM_ROWS; i++) {
     t1.push_back();
@@ -508,7 +515,7 @@ TEST(IdTableStaticTest, iterating) {
 // Conversion Tests
 // =============================================================================
 TEST(IdTableTest, conversion) {
-  IdTable table(3);
+  IdTable table(3, allocator());
   table.push_back({4, 1, 0});
   table.push_back({1, 7, 8});
   table.push_back({7, 12, 2});
@@ -545,7 +552,7 @@ TEST(IdTableTest, conversion) {
   }
 
   // Test with more than 5 columns
-  IdTable tableVar(6);
+  IdTable tableVar(6, allocator());
   tableVar.push_back({1, 2, 3, 6, 5, 9});
   tableVar.push_back({0, 4, 3, 4, 5, 3});
   tableVar.push_back({3, 2, 3, 2, 5, 6});

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -8,6 +8,13 @@
 #include "../src/global/Pattern.h"
 #include "../src/index/Index.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+
 string getStxxlConfigFileName(const string& location) {
   std::ostringstream os;
   os << location << ".stxxl";
@@ -511,8 +518,8 @@ TEST(IndexTest, scanTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
-    IdTable wol(1);
-    IdTable wtl(2);
+    IdTable wol(1, allocator());
+    IdTable wtl(2, allocator());
 
     index.scan("b", &wtl, index._PSO);
     ASSERT_EQ(2u, wtl.size());
@@ -595,8 +602,8 @@ TEST(IndexTest, scanTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
-    IdTable wol(1);
-    IdTable wtl(2);
+    IdTable wol(1, allocator());
+    IdTable wtl(2, allocator());
 
     index.scan("is-a", &wtl, index._PSO);
     ASSERT_EQ(7u, wtl.size());

--- a/test/LimitedAllocatorTest.cpp
+++ b/test/LimitedAllocatorTest.cpp
@@ -1,0 +1,52 @@
+//
+// Created by johannes on 27.04.20.
+//
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../src/util/AllocatorWithLimit.h"
+
+using ad_utility::AllocatorWithLimit;
+using ad_utility::makeAllocationMemoryLeftThreadsafeObject;
+
+using V = std::vector<int, AllocatorWithLimit<int>>;
+TEST(AllocatorWithLimit, initial) {
+  AllocatorWithLimit<int> all{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(25)};
+  static_assert(sizeof(int) == 4);
+  [[maybe_unused]] auto ptr = all.allocate(6);
+  ASSERT_THROW(all.allocate(1),
+               ad_utility::detail::AllocationExceedsLimitException);
+}
+
+TEST(AllocatorWithLimit, vector) {
+  V v{AllocatorWithLimit<int>(makeAllocationMemoryLeftThreadsafeObject(18))};
+  v.push_back(5);  // allocate 4 bytes -> works
+  ASSERT_EQ(v.size(), 1u);
+  ASSERT_EQ(v[0], 5);
+
+  v.push_back(4);  // allocate 8 bytes, then free 4, works (10 bytes free)
+  ASSERT_EQ(v.size(), 2u);
+  ASSERT_EQ(v[1], 4);
+
+  // allocate 16 bytes, FAILS (first allocate, then copy, then free 8)
+  ASSERT_THROW(v.push_back(1),
+               ad_utility::detail::AllocationExceedsLimitException);
+}
+
+TEST(AllocatorWithLimit, vectorShared) {
+  AllocatorWithLimit<int> allocator(
+      makeAllocationMemoryLeftThreadsafeObject(18));
+  V v{allocator};
+  V u{allocator};
+  v.push_back(5);  // allocate 4 bytes -> works
+  u.push_back(5);
+  v.push_back(4);  // allocate 8 bytes, then free 4, works (10 bytes free)
+  ASSERT_EQ(v.size(), 2u);
+  ASSERT_EQ(v[1], 4);
+
+  ASSERT_THROW(u.push_back(1),
+               ad_utility::detail::AllocationExceedsLimitException);
+}

--- a/test/MultiColumnJoinTest.cpp
+++ b/test/MultiColumnJoinTest.cpp
@@ -3,28 +3,35 @@
 // Author: Florian Kramer (florian.kramer@netpun.uni-freiburg.de)
 
 #include <array>
+
 #include <vector>
 
 #include <gtest/gtest.h>
 #include "../src/engine/CallFixedSize.h"
 #include "../src/engine/MultiColumnJoin.h"
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
 
 TEST(EngineTest, multiColumnJoinTest) {
   using std::array;
   using std::vector;
 
-  IdTable a(3);
+  IdTable a(3, allocator());
   a.push_back({4, 1, 2});
   a.push_back({2, 1, 3});
   a.push_back({1, 1, 4});
   a.push_back({2, 2, 1});
   a.push_back({1, 3, 1});
-  IdTable b(3);
+  IdTable b(3, allocator());
   b.push_back({3, 3, 1});
   b.push_back({1, 8, 1});
   b.push_back({4, 2, 2});
   b.push_back({1, 1, 3});
-  IdTable res(4);
+  IdTable res(4, allocator());
   vector<array<Id, 2>> jcls;
   jcls.push_back(array<Id, 2>{{1, 2}});
   jcls.push_back(array<Id, 2>{{2, 1}});
@@ -50,17 +57,17 @@ TEST(EngineTest, multiColumnJoinTest) {
   ASSERT_EQ(1u, res[1][3]);
 
   // Test the multi column join with variable sized data.
-  IdTable va(6);
+  IdTable va(6, allocator());
   va.push_back({1, 2, 3, 4, 5, 6});
   va.push_back({1, 2, 3, 7, 5, 6});
   va.push_back({7, 6, 5, 4, 3, 2});
 
-  IdTable vb(3);
+  IdTable vb(3, allocator());
   vb.push_back({2, 3, 4});
   vb.push_back({2, 3, 5});
   vb.push_back({6, 7, 4});
 
-  IdTable vres(7);
+  IdTable vres(7, allocator());
   jcls.clear();
   jcls.push_back({1, 0});
   jcls.push_back({2, 1});
@@ -77,7 +84,7 @@ TEST(EngineTest, multiColumnJoinTest) {
   ASSERT_EQ(4u, vres.size());
   ASSERT_EQ(7u, vres.cols());
 
-  IdTable wantedRes(7);
+  IdTable wantedRes(7, allocator());
   wantedRes.push_back({1, 2, 3, 4, 5, 6, 4});
   wantedRes.push_back({1, 2, 3, 4, 5, 6, 5});
   wantedRes.push_back({1, 2, 3, 7, 5, 6, 4});

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -10,8 +10,15 @@
 #include "../src/engine/TransitivePath.h"
 #include "../src/global/Id.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+
 TEST(TransitivePathTest, computeTransitivePath) {
-  IdTable sub(2);
+  IdTable sub(2, allocator());
   sub.push_back({0, 2});
   sub.push_back({2, 4});
   sub.push_back({4, 7});
@@ -21,9 +28,9 @@ TEST(TransitivePathTest, computeTransitivePath) {
   // Disconnected component.
   sub.push_back({10, 11});
 
-  IdTable result(2);
+  IdTable result(2, allocator());
 
-  IdTable expected(2);
+  IdTable expected(2, allocator());
   expected.push_back({0, 2});
   expected.push_back({0, 4});
   expected.push_back({0, 7});
@@ -46,6 +53,12 @@ TEST(TransitivePathTest, computeTransitivePath) {
   TransitivePath::computeTransitivePath<2>(&result, sub, true, true, 0, 1, 0, 0,
                                            1,
                                            std::numeric_limits<size_t>::max());
+
+  auto cmp = [](const auto& a, const auto& b) {
+    return a[0] != b[0] ? a[0] < b[0] : a[1] < b[1];
+  };
+  std::sort(expected.begin(), expected.end(), cmp);
+  std::sort(result.begin(), result.end(), cmp);
   ASSERT_EQ(expected, result);
 
   result.clear();
@@ -66,6 +79,8 @@ TEST(TransitivePathTest, computeTransitivePath) {
 
   TransitivePath::computeTransitivePath<2>(&result, sub, true, true, 0, 1, 0, 0,
                                            1, 2);
+  std::sort(expected.begin(), expected.end(), cmp);
+  std::sort(result.begin(), result.end(), cmp);
   ASSERT_EQ(expected, result);
 
   result.clear();
@@ -76,6 +91,8 @@ TEST(TransitivePathTest, computeTransitivePath) {
 
   TransitivePath::computeTransitivePath<2>(&result, sub, false, true, 0, 1, 7,
                                            0, 1, 2);
+  std::sort(expected.begin(), expected.end(), cmp);
+  std::sort(result.begin(), result.end(), cmp);
   ASSERT_EQ(expected, result);
 
   result.clear();
@@ -85,5 +102,7 @@ TEST(TransitivePathTest, computeTransitivePath) {
 
   TransitivePath::computeTransitivePath<2>(&result, sub, true, false, 0, 1, 0,
                                            2, 1, 2);
+  std::sort(expected.begin(), expected.end(), cmp);
+  std::sort(result.begin(), result.end(), cmp);
   ASSERT_EQ(expected, result);
 }

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -11,17 +11,24 @@
 #include "../src/engine/Union.h"
 #include "../src/global/Id.h"
 
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+
 TEST(UnionTest, computeUnion) {
-  IdTable left(1);
+  IdTable left(1, allocator());
   left.push_back({1});
   left.push_back({2});
   left.push_back({3});
 
-  IdTable right(2);
+  IdTable right(2, allocator());
   right.push_back({4, 5});
   right.push_back({6, 7});
 
-  IdTable result(2);
+  IdTable result(2, allocator());
 
   const std::vector<std::array<size_t, 2>> columnOrigins = {
       {0, 1}, {Union::NO_COLUMN, 0}};
@@ -45,16 +52,16 @@ TEST(UnionTest, computeUnion) {
 
 TEST(UnionTest, computeUnionOptimized) {
   // the left and right data vectors will be deleted by the result tables
-  IdTable left(2);
+  IdTable left(2, allocator());
   left.push_back({1, 2});
   left.push_back({2, 3});
   left.push_back({3, 4});
 
-  IdTable right(2);
+  IdTable right(2, allocator());
   right.push_back({4, 5});
   right.push_back({6, 7});
 
-  IdTable result(2);
+  IdTable result(2, allocator());
 
   const std::vector<std::array<size_t, 2>> columnOrigins = {{0, 0}, {1, 1}};
   int leftWidth = left.cols();


### PR DESCRIPTION
Allows limiting the size of all IdTables that are used at the same time by using a stateful allocator.

Exceeding the limit will cause an exception.
We currently have no automatic cleanup mechanism etc. , clearing the cache
is the only possibility to get out of the OOM state under heavy load.

However, this is very useful nonetheless because it prevents most `std::bad_alloc` (or even worse OOM or silent)
crashes. 

TODO:

- Some operations use other data structures (e.g. hash maps) which still have to be integrated here
- better handle large immediate results by streaming or externalizing them.