### PR TITLE
In a regex Filter, prefixes are no longer expanded.

### DIFF
--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -253,7 +253,10 @@ void ParsedQuery::expandPrefixes() {
 
   for (auto& f : _rootGraphPattern._filters) {
     expandPrefix(f._lhs, prefixMap);
-    expandPrefix(f._rhs, prefixMap);
+    // TODO<joka921>: proper type system for variable/regex/iri/etc
+    if (f._type != SparqlFilter::REGEX) {
+      expandPrefix(f._rhs, prefixMap);
+    }
   }
 
   vector<GraphPattern*> graphPatterns;


### PR DESCRIPTION
- Previously FILTER regex(?x, "wd:b") the "wd:b" was expanded to "http://wikidata...." which is obviouslyu wrong.