### PR TITLE
Filter = "literal" now ignores language tags in the KB.

### DIFF
--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -249,6 +249,41 @@ void Filter::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
+template <ResultTable::ResultType T, int WIDTH, bool INVERSE>
+void Filter::computeFilterRange(
+    IdTableStatic<WIDTH>* res, size_t lhs, Id rhs_lower, Id rhs_upper,
+    const IdTableStatic<WIDTH>& input,
+    shared_ptr<const ResultTable> subRes) const {
+bool lhs_is_sorted =
+    subRes->_sortedBy.size() > 0 && subRes->_sortedBy[0] == lhs;
+    if (lhs_is_sorted) {
+      // The input data is sorted, use binary search to locate the first
+      // and last element that match rhs and copy the range.
+
+      const auto& lower = std::lower_bound(
+          input.begin(), input.end(), rhs_lower,
+          [lhs](const auto& l, const auto& r) {
+            return ValueReader<T>::get(l[lhs]) < ValueReader<T>::get(r);
+          });
+        const auto& upper = std::lower_bound(
+            lower, input.end(), rhs_upper, [lhs](const auto& l, const auto& r) {
+              return ValueReader<T>::get(l[lhs]) <
+                     ValueReader<T>::get(r);
+            });
+        if constexpr  (!INVERSE) {
+          res->insert(res->end(), lower, upper);
+        } else {
+          res->insert(res->end(), input.begin(), lower);
+          res->insert(res->end(), upper, res->end());
+        }
+    } else {
+      const auto inv = [&](const bool b){return INVERSE? !b : b;};
+      getEngine().filter(
+          input, [lhs, rhs_lower, rhs_upper, &inv](const auto& e) { return inv(ValueReader<T>::get(e[lhs]) >= ValueReader<T>::get(rhs_lower)  && ValueReader<T>::get(e[lhs]) < ValueReader<T>::get(rhs_upper)); }, res);
+    }
+}
+
+// _____________________________________________________________________________
 template <ResultTable::ResultType T, int WIDTH>
 void Filter::computeFilterFixedValue(
     IdTableStatic<WIDTH>* res, size_t lhs, Id rhs,
@@ -508,6 +543,9 @@ void Filter::computeResultFixedValue(
   // interpret the filters right hand side
   size_t lhs = _subtree->getVariableColumn(_lhs);
   Id rhs;
+  Id rhs_upper_for_range;
+  bool apply_range_filter = false;
+  bool range_filter_inverse = false;
   switch (subRes->getResultType(lhs)) {
     case ResultTable::ResultType::KB: {
       std::string rhs_string = _rhs;
@@ -533,9 +571,10 @@ void Filter::computeResultFixedValue(
       // TODO<joka921> which level do we want for these filters
       auto level = TripleComponentComparator::Level::QUARTERNARY;
       if (_type == SparqlFilter::EQ || _type == SparqlFilter::NE) {
-        if (!getIndex().getVocab().getId(rhs_string, &rhs)) {
-          rhs = std::numeric_limits<size_t>::max() - 1;
-        }
+        rhs = getIndex().getVocab().lower_bound(rhs_string, level);
+        rhs_upper_for_range = getIndex().getVocab().upper_bound(rhs_string, level);
+        apply_range_filter = true;
+        range_filter_inverse = _type == SparqlFilter::NE;
       } else if (_type == SparqlFilter::GE) {
         rhs = getIndex().getVocab().getValueIdForGE(rhs_string, level);
       } else if (_type == SparqlFilter::GT) {
@@ -615,33 +654,48 @@ void Filter::computeResultFixedValue(
         "Requested to apply a string based filter on a non string column: " +
             asString());
   }
-  switch (resultType) {
-    case ResultTable::ResultType::KB:
-      computeFilterFixedValue<ResultTable::ResultType::KB>(&result, lhs, rhs,
+
+  if (apply_range_filter) {
+    if (resultType != ResultTable::ResultType::KB) {
+      AD_THROW(ad_semsearch::Exception::BAD_REQUEST,
+               "Applying a range filter where datatype is not KB, this indicates a programming error, please report this");
+    }
+    if (range_filter_inverse) {
+      computeFilterRange<ResultTable::ResultType::KB, WIDTH, true>(&result, lhs, rhs, rhs_upper_for_range,
                                                            input, subRes);
-      break;
-    case ResultTable::ResultType::VERBATIM:
-      computeFilterFixedValue<ResultTable::ResultType::VERBATIM>(
-          &result, lhs, rhs, input, subRes);
-      break;
-    case ResultTable::ResultType::FLOAT:
-      computeFilterFixedValue<ResultTable::ResultType::FLOAT>(&result, lhs, rhs,
-                                                              input, subRes);
-      break;
-    case ResultTable::ResultType::LOCAL_VOCAB:
-      computeFilterFixedValue<ResultTable::ResultType::LOCAL_VOCAB>(
-          &result, lhs, rhs, input, subRes);
-      break;
-    case ResultTable::ResultType::TEXT:
-      computeFilterFixedValue<ResultTable::ResultType::TEXT>(&result, lhs, rhs,
+    } else {
+      computeFilterRange<ResultTable::ResultType::KB, WIDTH, false>(&result, lhs, rhs, rhs_upper_for_range,
+                                                                    input, subRes);
+    }
+  } else {
+    switch (resultType) {
+      case ResultTable::ResultType::KB:
+        computeFilterFixedValue<ResultTable::ResultType::KB>(&result, lhs, rhs,
                                                              input, subRes);
-      break;
-    default:
-      AD_THROW(
-          ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
-          "Tried to compute a filter on an unknown result type " +
-              std::to_string(static_cast<int>(subRes->getResultType(lhs))));
-      break;
+        break;
+      case ResultTable::ResultType::VERBATIM:
+        computeFilterFixedValue<ResultTable::ResultType::VERBATIM>(
+            &result, lhs, rhs, input, subRes);
+        break;
+      case ResultTable::ResultType::FLOAT:
+        computeFilterFixedValue<ResultTable::ResultType::FLOAT>(
+            &result, lhs, rhs, input, subRes);
+        break;
+      case ResultTable::ResultType::LOCAL_VOCAB:
+        computeFilterFixedValue<ResultTable::ResultType::LOCAL_VOCAB>(
+            &result, lhs, rhs, input, subRes);
+        break;
+      case ResultTable::ResultType::TEXT:
+        computeFilterFixedValue<ResultTable::ResultType::TEXT>(
+            &result, lhs, rhs, input, subRes);
+        break;
+      default:
+        AD_THROW(
+            ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
+            "Tried to compute a filter on an unknown result type " +
+                std::to_string(static_cast<int>(subRes->getResultType(lhs))));
+        break;
+    }
   }
   LOG(DEBUG) << "Filter result computation done." << endl;
   resultTable->_data = result.moveToDynamic();

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -138,10 +138,10 @@ class Filter : public Operation {
    * to subRes and store it in res.
    *
    */
-  template <ResultTable::ResultType T, int WIDTH, bool INVERSE=false>
-  void computeFilterRange(IdTableStatic<WIDTH>* res, size_t lhs, Id rhs_lower, Id rhs_upper,
-                               const IdTableStatic<WIDTH>& input,
-                               shared_ptr<const ResultTable> subRes) const;
+  template <ResultTable::ResultType T, int WIDTH, bool INVERSE = false>
+  void computeFilterRange(IdTableStatic<WIDTH>* res, size_t lhs, Id rhs_lower,
+                          Id rhs_upper, const IdTableStatic<WIDTH>& input,
+                          shared_ptr<const ResultTable> subRes) const;
 
   template <int WIDTH>
   void computeResultFixedValue(

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -132,6 +132,16 @@ class Filter : public Operation {
   void computeFilterFixedValue(IdTableStatic<WIDTH>* res, size_t lhs, Id rhs,
                                const IdTableStatic<WIDTH>& input,
                                shared_ptr<const ResultTable> subRes) const;
+  /**
+   * @brief Uses the result type and applies a range filter
+   * ( input[lhs] >= rhs_lower && input[rhs] < rhs_upper)
+   * to subRes and store it in res.
+   *
+   */
+  template <ResultTable::ResultType T, int WIDTH, bool INVERSE=false>
+  void computeFilterRange(IdTableStatic<WIDTH>* res, size_t lhs, Id rhs_lower, Id rhs_upper,
+                               const IdTableStatic<WIDTH>& input,
+                               shared_ptr<const ResultTable> subRes) const;
 
   template <int WIDTH>
   void computeResultFixedValue(

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -344,6 +344,21 @@ class Vocabulary {
     return _caseComparator.getLocaleManager();
   }
 
+  // Wraps std::lower_bound and returns an index instead of an iterator
+  Id lower_bound(const string& word,
+                 const SortLevel level = SortLevel::QUARTERNARY) const {
+    return static_cast<Id>(std::lower_bound(_words.begin(), _words.end(), word,
+                                            getLowerBoundLambda(level)) -
+                           _words.begin());
+  }
+
+  // _______________________________________________________________
+  Id upper_bound(const string& word, const SortLevel level) const {
+    return static_cast<Id>(std::upper_bound(_words.begin(), _words.end(), word,
+                                            getUpperBoundLambda(level)) -
+                           _words.begin());
+  }
+
  private:
   template <class R = std::string>
   auto getLowerBoundLambda(const SortLevel level) const {
@@ -367,20 +382,7 @@ class Vocabulary {
       return getLowerBoundLambda(level);
     }
   }
-  // Wraps std::lower_bound and returns an index instead of an iterator
-  Id lower_bound(const string& word,
-                 const SortLevel level = SortLevel::QUARTERNARY) const {
-    return static_cast<Id>(std::lower_bound(_words.begin(), _words.end(), word,
-                                            getLowerBoundLambda(level)) -
-                           _words.begin());
-  }
 
-  // _______________________________________________________________
-  Id upper_bound(const string& word, const SortLevel level) const {
-    return static_cast<Id>(std::upper_bound(_words.begin(), _words.end(), word,
-                                            getUpperBoundLambda(level)) -
-                           _words.begin());
-  }
 
   // TODO<joka921> these following two members are only used with the
   // compressed vocabulary. They don't use much space if empty, but still it

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -383,7 +383,6 @@ class Vocabulary {
     }
   }
 
-
   // TODO<joka921> these following two members are only used with the
   // compressed vocabulary. They don't use much space if empty, but still it
   // would be cleaner to throw them out when using the uncompressed version


### PR DESCRIPTION
FILTER (?x = "Apple") now also matches "Apple"@en