### PR TITLE
Updated abseil for support of gcc 10.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,15 @@ set(CMAKE_CXX_FLAGS_ASAN
         CACHE STRING "Flags used by the C++ compiler during AddressSanitizer builds."
         FORCE)
 
+# Add colored output for Ninja
+if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+     add_compile_options (-fdiagnostics-color=always)
+  elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+     add_compile_options (-fcolor-diagnostics)
+  endif ()
+endif()
+
 ###############################################################################
 ##### Essential settings #####
 ###############################################################################

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1633,7 +1633,6 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromAlternative(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitive(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-
   std::string innerLeft = toUniqueVariable(innerLeft);
   std::string innerRight = toUniqueVariable(innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1434,7 +1434,7 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromPropertyPath(
   AD_THROW(
       ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
       "No implementation for creating a seed from a property path of type " +
-          std::to_string((int)path._operation));
+          std::to_string(static_cast<int>(path._operation)));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1633,8 +1633,8 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromAlternative(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitive(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-  std::string innerLeft = toUniqueVariable(innerLeft);
-  std::string innerRight = toUniqueVariable(innerRight);
+  std::string innerLeft = generateUniqueVarName();
+  std::string innerRight = generateUniqueVarName();
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =
       seedFromPropertyPath(innerLeft, path._children[0], innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> p =
@@ -1655,8 +1655,8 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitive(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitiveMin(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-  std::string innerLeft = toUniqueVariable(innerLeft);
-  std::string innerRight = toUniqueVariable(innerRight);
+  std::string innerLeft = generateUniqueVarName();
+  std::string innerRight = generateUniqueVarName();
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =
       seedFromPropertyPath(innerLeft, path._children[0], innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> p =
@@ -1677,8 +1677,8 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitiveMin(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitiveMax(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-  std::string innerLeft = toUniqueVariable(innerLeft);
-  std::string innerRight = toUniqueVariable(innerRight);
+  std::string innerLeft = generateUniqueVarName();
+  std::string innerRight = generateUniqueVarName();
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =
       seedFromPropertyPath(innerLeft, path._children[0], innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> p =
@@ -1735,10 +1735,6 @@ ParsedQuery::GraphPattern QueryPlanner::uniteGraphPatterns(
 // _____________________________________________________________________________
 std::string QueryPlanner::generateUniqueVarName() {
   return "?:" + std::to_string(_internalVarCount++);
-}
-
-std::string QueryPlanner::toUniqueVariable(const string& entity) {
-  return ad_utility::startsWith(entity, "?") ? generateUniqueVarName() : entity;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1434,7 +1434,7 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromPropertyPath(
   AD_THROW(
       ad_semsearch::Exception::NOT_YET_IMPLEMENTED,
       "No implementation for creating a seed from a property path of type " +
-          ((int)path._operation));
+          std::to_string((int)path._operation));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -246,7 +246,6 @@ class QueryPlanner {
       const std::string& right);
 
   std::string generateUniqueVarName();
-  std::string toUniqueVariable(const string& entity);
 
   // Creates a tree of unions with the given patterns as the trees leaves
   ParsedQuery::GraphPattern uniteGraphPatterns(

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 #pragma once
 
+#include <stdexcept>
 #include <string>
 
 static const size_t STXXL_MEMORY_TO_USE = 1024L * 1024L * 1024L * 2L;


### PR DESCRIPTION
abseil fails to build using gcc 10.2.0 on archlinux. The bug was disscussed [here](https://www.gitmemory.com/issue/abseil/abseil-cpp/774/685978551) and fixed in a newer version. Using the master version of abseil fixes this problem. 