### PR TITLE
Fix code style

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1633,7 +1633,6 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromAlternative(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitive(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-
   std::string innerLeft = toUniqueVariable(innerLeft);
   std::string innerRight = toUniqueVariable(innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =


### PR DESCRIPTION
clang-format-8 doesn’t like this blank line, which breaks the format-check step of the docker build.