### PR TITLE
Fix index build for literal "\"^^"@en

### DIFF
--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -604,9 +604,12 @@ inline string removeLeadingZeros(const string& orig) {
 
 // _____________________________________________________________________________
 bool isXsdValue(const string& val) {
-  // starting the search for "^^ at position 1 makes sure it's not in the
-  // quotes as we already checked that the first char is the first quote
-  return !val.empty() && val[0] == '\"' && val.find("\"^^", 1) != string::npos;
+  // Search for the last quote and check if it is followed by ^^.
+  // NOTE: searching for "^^ starting at position 1 (as done previously) fails
+  // for literal "\"^^"@en (which is contained in the RDF dump of DBpedia).
+  size_t posLastQuote = val.rfind("\"");
+  return !val.empty() && val[0] == '\"' && posLastQuote > 0 &&
+         val.find("^^", posLastQuote) != string::npos;
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
Building the index crashes for the full RDF dump of DBpedia, the exact error message is: 
```
ERROR: BAD INPUT STRING (No ':' in non-URL ValueLiteral "\"^^"@en; in /app/src/index/../util/Conversions.h, line 130, function std::__cxx11::string ad_utility::convertValueLiteralToIndexWord(const string&))
```
The reason is that the dump contains the literal ` "\"^^"@en`, which is mistakenly processed as a literal with a XSD datatype. Obviously, it should be processed as a language-tagged string. 