### PR TITLE
Removed use of the deprecated icu macro TRUE

### DIFF
--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -87,7 +87,7 @@ class LocaleManager {
     _ignorePunctuationStatus =
         ignorePunctuationAtFirstLevel ? UCOL_SHIFTED : UCOL_NON_IGNORABLE;
 
-    if (_icuLocale.isBogus() == TRUE) {
+    if (_icuLocale.isBogus()) {
       throw std::runtime_error("Could not create locale with language " + lang +
                                " and Country " + country);
     }


### PR DESCRIPTION
The StringComparator was using the TRUE macro from the icu. The macro is deprecated in new icu versions, and no longer defined by default. The icu instead recommends using the builtin true / false.