### PR TITLE
Better descriptor for transitive path

### DIFF
--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -43,6 +43,7 @@ class IndexScan : public Operation {
   void setSubject(const string& subject) { _subject = subject; }
 
   void setPredicate(const string& predicate) { _predicate = predicate; }
+  const string& getPredicate() const { return _predicate; }
 
   void setObject(const string& object) {
     if (!ad_utility::isXsdValue(object)) {

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -78,12 +78,9 @@ std::string TransitivePath::getDescriptor() const {
   if (_leftIsVar) {
     os << _leftColName;
   } else {
-    auto optional = getIndex().idToOptionalString(_leftValue);
-    if (optional) {
-      os << optional.value();
-    } else {
-      os << "#" << _leftValue;
-    }
+    os << getIndex()
+              .idToOptionalString(_leftValue)
+              .value_or("#" + std::to_string(_leftValue));
   }
   // The predicate.
   auto scanOperation =
@@ -97,12 +94,9 @@ std::string TransitivePath::getDescriptor() const {
   if (_rightIsVar) {
     os << _rightColName;
   } else {
-    auto optional = getIndex().idToOptionalString(_rightValue);
-    if (optional) {
-      os << optional.value();
-    } else {
-      os << "#" << _rightValue;
-    }
+    os << getIndex()
+              .idToOptionalString(_rightValue)
+              .value_or("#" + std::to_string(_rightValue));
   }
   return os.str();
 }


### PR DESCRIPTION
The previous descriptor was very cryptic. The reason (probably) was that
neither the subject, nor the predicate, not the object, are directly
known by TransitivePath, but need to be obtained via a bit of
acrobatics. See the code for details.