### PR TITLE
Working Pimpl-Version of Index

### DIFF
--- a/src/SparqlEngineMain.cpp
+++ b/src/SparqlEngineMain.cpp
@@ -6,6 +6,7 @@
 #include <libgen.h>
 #include <stdlib.h>
 
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <string>

--- a/src/WriteIndexListsMain.cpp
+++ b/src/WriteIndexListsMain.cpp
@@ -9,6 +9,7 @@
 #include <libgen.h>
 #include <stdlib.h>
 
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <string>

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -3,6 +3,8 @@
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 #pragma once
 
+#include <gtest/gtest.h>
+
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -270,7 +270,7 @@ void IndexScan::computePSOboundS(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_predicate, _subject, &result->_data, idx._PSO);
+  idx.scan(_predicate, _subject, &result->_data, Index::Permutation::PSO);
 }
 
 // _____________________________________________________________________________
@@ -280,7 +280,7 @@ void IndexScan::computePSOfreeS(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0, 1};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_predicate, &result->_data, idx._PSO, _timeoutTimer);
+  idx.scan(_predicate, &result->_data, Index::Permutation::PSO, _timeoutTimer);
 }
 
 // _____________________________________________________________________________
@@ -289,7 +289,7 @@ void IndexScan::computePOSboundO(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_predicate, _object, &result->_data, idx._POS);
+  idx.scan(_predicate, _object, &result->_data, Index::Permutation::POS);
 }
 
 // _____________________________________________________________________________
@@ -299,7 +299,7 @@ void IndexScan::computePOSfreeO(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0, 1};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_predicate, &result->_data, idx._POS, _timeoutTimer);
+  idx.scan(_predicate, &result->_data, Index::Permutation::POS, _timeoutTimer);
 }
 
 // _____________________________________________________________________________
@@ -338,7 +338,7 @@ void IndexScan::computeSPOfreeP(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0, 1};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_subject, &result->_data, idx._SPO, _timeoutTimer);
+  idx.scan(_subject, &result->_data, Index::Permutation::SPO, _timeoutTimer);
 }
 
 // _____________________________________________________________________________
@@ -347,7 +347,7 @@ void IndexScan::computeSOPboundO(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_subject, _object, &result->_data, idx._SOP);
+  idx.scan(_subject, _object, &result->_data, Index::Permutation::SOP);
 }
 
 // _____________________________________________________________________________
@@ -357,7 +357,7 @@ void IndexScan::computeSOPfreeO(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0, 1};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_subject, &result->_data, idx._SOP, _timeoutTimer);
+  idx.scan(_subject, &result->_data, Index::Permutation::SOP, _timeoutTimer);
 }
 
 // _____________________________________________________________________________
@@ -367,7 +367,7 @@ void IndexScan::computeOPSfreeP(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0, 1};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_object, &result->_data, idx._OPS);
+  idx.scan(_object, &result->_data, Index::Permutation::OPS);
 }
 
 // _____________________________________________________________________________
@@ -377,7 +377,7 @@ void IndexScan::computeOSPfreeS(ResultTable* result) const {
   result->_resultTypes.push_back(ResultTable::ResultType::KB);
   result->_sortedBy = {0, 1};
   const auto& idx = _executionContext->getIndex();
-  idx.scan(_object, &result->_data, idx._OSP, _timeoutTimer);
+  idx.scan(_object, &result->_data, Index::Permutation::OSP, _timeoutTimer);
 }
 
 // _____________________________________________________________________________
@@ -388,42 +388,43 @@ void IndexScan::determineMultiplicities() {
       _multiplicity.emplace_back(1);
     } else {
       const auto& idx = getIndex();
+      using P = Index::Permutation;
       switch (_type) {
         case PSO_FREE_S:
-          _multiplicity = idx.getMultiplicities(_predicate, idx._PSO);
+          _multiplicity = idx.getMultiplicities(_predicate, P::PSO);
           break;
         case POS_FREE_O:
-          _multiplicity = idx.getMultiplicities(_predicate, idx._POS);
+          _multiplicity = idx.getMultiplicities(_predicate, P::POS);
           break;
         case SPO_FREE_P:
-          _multiplicity = idx.getMultiplicities(_subject, idx._SPO);
+          _multiplicity = idx.getMultiplicities(_subject, P::SPO);
           break;
         case SOP_FREE_O:
-          _multiplicity = idx.getMultiplicities(_subject, idx._SOP);
+          _multiplicity = idx.getMultiplicities(_subject, P::SOP);
           break;
         case OSP_FREE_S:
-          _multiplicity = idx.getMultiplicities(_object, idx._OSP);
+          _multiplicity = idx.getMultiplicities(_object, P::OSP);
           break;
         case OPS_FREE_P:
-          _multiplicity = idx.getMultiplicities(_object, idx._OPS);
+          _multiplicity = idx.getMultiplicities(_object, P::OPS);
           break;
         case FULL_INDEX_SCAN_SPO:
-          _multiplicity = idx.getMultiplicities(idx._SPO);
+          _multiplicity = idx.getMultiplicities(P::SPO);
           break;
         case FULL_INDEX_SCAN_SOP:
-          _multiplicity = idx.getMultiplicities(idx._SOP);
+          _multiplicity = idx.getMultiplicities(P::SPO);
           break;
         case FULL_INDEX_SCAN_PSO:
-          _multiplicity = idx.getMultiplicities(idx._PSO);
+          _multiplicity = idx.getMultiplicities(P::PSO);
           break;
         case FULL_INDEX_SCAN_POS:
-          _multiplicity = idx.getMultiplicities(idx._POS);
+          _multiplicity = idx.getMultiplicities(P::POS);
           break;
         case FULL_INDEX_SCAN_OSP:
-          _multiplicity = idx.getMultiplicities(idx._OSP);
+          _multiplicity = idx.getMultiplicities(P::OSP);
           break;
         case FULL_INDEX_SCAN_OPS:
-          _multiplicity = idx.getMultiplicities(idx._OPS);
+          _multiplicity = idx.getMultiplicities(P::OPS);
           break;
         default:
           AD_THROW(ad_semsearch::Exception::ASSERT_FAILED,

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -284,7 +284,7 @@ Join::ScanMethodType Join::getScanMethod(
   const auto& idx = _executionContext->getIndex();
   const auto scanLambda = [&idx](const Index::Permutation perm) {
     return
-        [&idx, &perm](Id id, IdTable* idTable) { idx.scan(id, idTable, perm); };
+        [&idx, perm](Id id, IdTable* idTable) { idx.scan(id, idTable, perm); };
   };
 
   using P = Index::Permutation;

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -282,29 +282,30 @@ Join::ScanMethodType Join::getScanMethod(
   // this works because the join operations execution Context never changes
   // during its lifetime
   const auto& idx = _executionContext->getIndex();
-  const auto scanLambda = [&idx](const auto& perm) {
+  const auto scanLambda = [&idx](const Index::Permutation perm) {
     return
         [&idx, &perm](Id id, IdTable* idTable) { idx.scan(id, idTable, perm); };
   };
 
+  using P = Index::Permutation;
   switch (scan.getType()) {
     case IndexScan::FULL_INDEX_SCAN_SPO:
-      scanMethod = scanLambda(idx._SPO);
+      scanMethod = scanLambda(P::SPO);
       break;
     case IndexScan::FULL_INDEX_SCAN_SOP:
-      scanMethod = scanLambda(idx._SOP);
+      scanMethod = scanLambda(P::SOP);
       break;
     case IndexScan::FULL_INDEX_SCAN_PSO:
-      scanMethod = scanLambda(idx._PSO);
+      scanMethod = scanLambda(P::PSO);
       break;
     case IndexScan::FULL_INDEX_SCAN_POS:
-      scanMethod = scanLambda(idx._POS);
+      scanMethod = scanLambda(P::POS);
       break;
     case IndexScan::FULL_INDEX_SCAN_OSP:
-      scanMethod = scanLambda(idx._OSP);
+      scanMethod = scanLambda(P::OSP);
       break;
     case IndexScan::FULL_INDEX_SCAN_OPS:
-      scanMethod = scanLambda(idx._OPS);
+      scanMethod = scanLambda(P::OPS);
       break;
     default:
       AD_THROW(ad_semsearch::Exception::CHECK_FAILED,

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "../util/Exception.h"
@@ -14,6 +15,8 @@
 #include "QueryExecutionContext.h"
 #include "ResultTable.h"
 #include "RuntimeInformation.h"
+
+using namespace std::string_literals;
 
 using std::endl;
 using std::pair;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -2,8 +2,11 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold <buchholb>
 
+#include "./Server.h"
+
 #include <algorithm>
 #include <cstring>
+#include <fstream>
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
@@ -13,7 +16,6 @@
 #include "../parser/ParseException.h"
 #include "../util/Log.h"
 #include "../util/StringUtils.h"
-#include "./Server.h"
 #include "QueryPlanner.h"
 
 // _____________________________________________________________________________

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
@@ -22,6 +23,8 @@ using std::string;
 using std::vector;
 
 using ad_utility::Socket;
+
+using nlohmann::json;
 
 //! The HTTP Sever used.
 class Server {

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -56,10 +56,18 @@ double SortPerformanceEstimator::measureSortingTimeInSeconds(
 }
 
 SortPerformanceEstimator::SortPerformanceEstimator(
-    const ad_utility::AllocatorWithLimit<Id>& allocator)
+    const ad_utility::AllocatorWithLimit<Id>& passedAllocator)
     : _samples{} {
   static_assert(isSorted(sampleValuesCols));
   static_assert(isSorted(sampleValuesRows));
+
+#if NDEBUG
+  const auto& allocator = passedAllocator;
+#else
+  (void)passedAllocator;
+  ad_utility::AllocatorWithLimit<Id> allocator{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(50 * (1ull << 20))};
+#endif
 
   LOG(INFO) << "Sorting some random result tables to estimate the sorting "
                "performance of this machine. This might take several minutes"

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_library(index
         Index.h Index.cpp
         IndexImpl.h IndexImpl.cpp IndexImpl.Text.cpp
-        Vocabulary.h Vocabulary.cpp
+        Vocabulary.h VocabularyImpl.h
         VocabularyGenerator.h VocabularyGeneratorImpl.h
         ConstantsIndexCreation.h
         ExternalVocabulary.h ExternalVocabulary.cpp

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -3,8 +3,6 @@ add_library(index
         Index.h Index.cpp
         IndexImpl.h IndexImpl.cpp IndexImpl.Text.cpp
         Vocabulary.h Vocabulary.cpp
-        Index.h Index.cpp Index.Text.cpp
-        Vocabulary.h Vocabulary.cpp
         VocabularyGenerator.h VocabularyGeneratorImpl.h
         ConstantsIndexCreation.h
         ExternalVocabulary.h ExternalVocabulary.cpp

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -1,7 +1,8 @@
 
 add_library(index
-        Index.h Index.cpp Index.Text.cpp
-        Vocabulary.h VocabularyImpl.h
+        Index.h Index.cpp
+        IndexImpl.h IndexImpl.cpp IndexImpl.Text.cpp
+        Vocabulary.h Vocabulary.cpp
         VocabularyGenerator.h VocabularyGeneratorImpl.h
         ConstantsIndexCreation.h
         ExternalVocabulary.h ExternalVocabulary.cpp

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -2,128 +2,23 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
-#include <algorithm>
-#include <cmath>
-#include <cstdio>
-#include <future>
-#include <optional>
-#include <stxxl/algorithm>
-#include <stxxl/map>
-#include <unordered_map>
-
-#include "../parser/NTriplesParser.h"
-#include "../parser/ParallelParseBuffer.h"
-#include "../parser/TsvParser.h"
-#include "../util/BatchedPipeline.h"
-#include "../util/Conversions.h"
-#include "../util/HashMap.h"
-#include "../util/TupleHelpers.h"
 #include "./Index.h"
-#include "./PrefixHeuristic.h"
-#include "./VocabularyGenerator.h"
-#include "MetaDataIterator.h"
+
+#include "./IndexImpl.h"
 
 using std::array;
 
-const uint32_t Index::PATTERNS_FILE_VERSION = 0;
-
 // _____________________________________________________________________________
-Index::Index()
-    : _usePatterns(false),
-      _maxNumPatterns(std::numeric_limits<PatternID>::max() - 2) {}
+Index::Index() : _pimpl{std::make_unique<IndexImpl>()} {}
 
-// _____________________________________________________________________________________________
-template <class Parser>
-VocabularyData Index::createIdTriplesAndVocab(const string& ntFile) {
-  auto vocabData =
-      passFileForVocabulary<Parser>(ntFile, _numTriplesPerPartialVocab);
-  // first save the total number of words, this is needed to initialize the
-  // dense IndexMetaData variants
-  _totalVocabularySize = vocabData.nofWords;
-  LOG(INFO) << "total size of vocabulary (internal and external) is "
-            << _totalVocabularySize << std::endl;
-
-  if (_onDiskLiterals) {
-    _vocab.externalizeLiteralsFromTextFile(
-        _onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME,
-        _onDiskBase + ".literals-index");
-  }
-  deleteTemporaryFile(_onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME);
-  // clear vocabulary to save ram (only information from partial binary files
-  // used from now on). This will preserve information about externalized
-  // Prefixes etc.
-  _vocab.clear();
-  convertPartialToGlobalIds(*vocabData.idTriples, vocabData.actualPartialSizes,
-                            NUM_TRIPLES_PER_PARTIAL_VOCAB);
-
-  return vocabData;
-}
+// ____________________________________________________________________________
+Index::~Index() = default;
 
 // _____________________________________________________________________________
 template <class Parser>
 void Index::createFromFile(const string& filename) {
-  string indexFilename = _onDiskBase + ".index";
-  _configurationJson["external-literals"] = _onDiskLiterals;
-
-  initializeVocabularySettingsBuild<Parser>();
-
-  VocabularyData vocabData;
-  if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserDummy>) {
-    if (_onlyAsciiTurtlePrefixes) {
-      LOG(INFO) << "Using the CTRE library for Tokenization\n";
-      vocabData =
-          createIdTriplesAndVocab<TurtleStreamParser<TokenizerCtre>>(filename);
-    } else {
-      LOG(INFO) << "Using the Google Re2 library for Tokenization\n";
-      vocabData =
-          createIdTriplesAndVocab<TurtleStreamParser<Tokenizer>>(filename);
-    }
-
-  } else {
-    vocabData = createIdTriplesAndVocab<Parser>(filename);
-  }
-
-  // also perform unique for first permutation
-  createPermutationPair<IndexMetaDataHmapDispatcher>(&vocabData, _PSO, _POS,
-                                                     true);
-  // also create Patterns after the Spo permutation if specified
-  createPermutationPair<IndexMetaDataMmapDispatcher>(&vocabData, _SPO, _SOP,
-                                                     false, _usePatterns);
-  createPermutationPair<IndexMetaDataMmapDispatcher>(&vocabData, _OSP, _OPS);
-
-  // if we have no compression, this will also copy the whole vocabulary.
-  // but since we expect compression to be the default case, this  should not
-  // hurt
-  string vocabFile = _onDiskBase + ".vocabulary";
-  string vocabFileTmp = _onDiskBase + ".vocabularyTmp";
-  std::vector<string> prefixes;
-  if (_vocabPrefixCompressed) {
-    // we have to use the "normally" sorted vocabulary for the prefix
-    // compression;
-    std::string vocabFileForPrefixCalculation =
-        _onDiskBase + TMP_BASENAME_COMPRESSION + ".vocabulary";
-    prefixes = calculatePrefixes(vocabFileForPrefixCalculation,
-                                 NUM_COMPRESSION_PREFIXES, 1, true);
-    std::ofstream prefixFile(_onDiskBase + PREFIX_FILE);
-    AD_CHECK(prefixFile.is_open());
-    for (const auto& prefix : prefixes) {
-      prefixFile << prefix << '\n';
-    }
-  }
-  _configurationJson["prefixes"] = _vocabPrefixCompressed;
-  Vocabulary<CompressedString, TripleComponentComparator>::prefixCompressFile(
-      vocabFile, vocabFileTmp, prefixes);
-
-  // TODO<joka921> maybe move this to its own function
-  if (std::rename(vocabFileTmp.c_str(), vocabFile.c_str())) {
-    LOG(INFO) << "Error: Rename the prefixed vocab file " << vocabFileTmp
-              << " to " << vocabFile << " set errno to " << errno
-              << ". Terminating...\n";
-    AD_CHECK(false);
-  }
-  writeConfiguration();
+  return _pimpl->template createFromFile<Parser>(filename);
 }
-
 // explicit instantiations
 template void Index::createFromFile<TsvParser>(const string& filename);
 template void Index::createFromFile<NTriplesParser>(const string& filename);
@@ -134,1444 +29,292 @@ template void Index::createFromFile<TurtleMmapParser<Tokenizer>>(
 template void Index::createFromFile<TurtleParserDummy>(const string& filename);
 
 // _____________________________________________________________________________
-template <class Parser>
-VocabularyData Index::passFileForVocabulary(const string& filename,
-                                            size_t linesPerPartial) {
-  auto parser = std::make_shared<Parser>(filename);
-  std::unique_ptr<TripleVec> idTriples(new TripleVec());
-  TripleVec::bufwriter_type writer(*idTriples);
-  bool parserExhausted = false;
-
-  size_t i = 0;
-  // already count the numbers of triples that will be used for the language
-  // filter
-  size_t numFiles = 0;
-
-  // we add extra triples
-  std::vector<size_t> actualPartialSizes;
-
-  std::future<void> sortFuture;
-  while (!parserExhausted) {
-    size_t actualCurrentPartialSize = 0;
-
-    std::unique_ptr<TripleVec> localIdTriples(new TripleVec());
-    TripleVec::bufwriter_type localWriter(*localIdTriples);
-
-    std::array<ItemMapManager, NUM_PARALLEL_ITEM_MAPS> itemArray;
-
-    {
-      auto p = ad_pipeline::setupParallelPipeline<1, NUM_PARALLEL_ITEM_MAPS>(
-          _parserBatchSize,
-          // when called, returns an optional to the next triple. If
-          // <linexPerPartial> triples were parsed, return std::nullopt. when
-          // the parser is unable to deliver triples, set parserExhausted to
-          // true and return std::nullopt. this is exactly the behavior we need,
-          // as a first step in the parallel Pipeline.
-          ParserBatcher(parser, linesPerPartial,
-                        [&]() { parserExhausted = true; }),
-          // convert each triple to the internal representation (e.g. special
-          // values for Numbers, externalized literals, etc.)
-          [this](Triple&& t) {
-            return tripleToInternalRepresentation(std::move(t));
-          },
-
-          // get the Ids for the original triple and the possibly added language
-          // Tag triples using the provided HashMaps via itemArray. See
-          // documentation of the function for more details
-          getIdMapLambdas<NUM_PARALLEL_ITEM_MAPS>(
-              &itemArray, linesPerPartial, &(_vocab.getCaseComparator())));
-
-      while (auto opt = p.getNextValue()) {
-        i++;
-        for (const auto& innerOpt : opt.value()) {
-          if (innerOpt) {
-            actualCurrentPartialSize++;
-            localWriter << innerOpt.value();
-          }
-        }
-        if (i % 10000000 == 0) {
-          LOG(INFO) << "Lines (from KB-file) processed: " << i << '\n';
-        }
-      }
-      LOG(INFO) << "WaitTimes for Pipeline in msecs\n";
-      for (const auto& t : p.getWaitingTime()) {
-        LOG(INFO) << t << " msecs\n";
-      }
-    }
-
-    localWriter.finish();
-    // wait until sorting the last partial vocabulary has finished
-    // to control the number of threads and the amount of memory used at the
-    // same time. typically sorting is finished before we reach again here so
-    // it is not a bottleneck.
-    if (sortFuture.valid()) {
-      sortFuture.get();
-    }
-    std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS> convertedMaps;
-    for (size_t j = 0; j < NUM_PARALLEL_ITEM_MAPS; ++j) {
-      convertedMaps[j] = std::move(itemArray[j]).moveMap();
-    }
-    auto oldItemPtr =
-        std::make_shared<const std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS>>(
-            std::move(convertedMaps));
-    sortFuture = writeNextPartialVocabulary(
-        i, numFiles, actualCurrentPartialSize, oldItemPtr,
-        std::move(localIdTriples), &writer);
-    numFiles++;
-    // Save the information how many triples this partial vocabulary actually
-    // deals with we will use this later for mapping from partial to global
-    // ids
-    actualPartialSizes.push_back(actualCurrentPartialSize);
-  }
-  if (sortFuture.valid()) {
-    sortFuture.get();
-  }
-  writer.finish();
-  LOG(INFO) << "Pass done." << endl;
-
-  if (_vocabPrefixCompressed) {
-    LOG(INFO) << "Merging temporary vocabulary for prefix compression";
-    {
-      VocabularyMerger m;
-      m.mergeVocabulary(_onDiskBase + TMP_BASENAME_COMPRESSION, numFiles,
-                        std::less<>());
-      LOG(INFO) << "Finished merging additional Vocabulary.";
-    }
-  }
-
-  LOG(INFO) << "Merging vocabulary\n";
-  const VocabularyMerger::VocMergeRes mergeRes = [&]() {
-    VocabularyMerger v;
-    auto sortPred = [cmp = &(_vocab.getCaseComparator())](std::string_view a,
-                                                          std::string_view b) {
-      return (*cmp)(a, b, decltype(_vocab)::SortLevel::TOTAL);
-    };
-
-    return v.mergeVocabulary(_onDiskBase, numFiles, sortPred);
-  }();
-  LOG(INFO) << "Finished Merging Vocabulary.\n";
-  VocabularyData res;
-  res.nofWords = mergeRes._numWordsTotal;
-  res.langPredLowerBound = mergeRes._langPredLowerBound;
-  res.langPredUpperBound = mergeRes._langPredUpperBound;
-
-  res.idTriples = std::move(idTriples);
-  res.actualPartialSizes = std::move(actualPartialSizes);
-
-  for (size_t n = 0; n < numFiles; ++n) {
-    string partialFilename =
-        _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(n);
-    deleteTemporaryFile(partialFilename);
-    if (_vocabPrefixCompressed) {
-      partialFilename = _onDiskBase + TMP_BASENAME_COMPRESSION +
-                        PARTIAL_VOCAB_FILE_NAME + std::to_string(n);
-      deleteTemporaryFile(partialFilename);
-    }
-  }
-
-  return res;
-}
-
-// _____________________________________________________________________________
-void Index::convertPartialToGlobalIds(
-    TripleVec& data, const vector<size_t>& actualLinesPerPartial,
-    size_t linesPerPartial) {
-  LOG(INFO) << "Updating Ids in stxxl vector to global Ids.\n";
-
-  size_t i = 0;
-  // iterate over all partial vocabularies
-  for (size_t partialNum = 0; partialNum < actualLinesPerPartial.size();
-       partialNum++) {
-    LOG(INFO) << "Lines processed: " << i << '\n';
-    LOG(INFO) << "Corresponding number of statements in original knowledgeBase:"
-              << linesPerPartial * partialNum << '\n';
-
-    std::string mmapFilename(_onDiskBase + PARTIAL_MMAP_IDS +
-                             std::to_string(partialNum));
-    LOG(INFO) << "Reading IdMap from " << mmapFilename << " ...\n";
-    ad_utility::HashMap<Id, Id> idMap = IdMapFromPartialIdMapFile(mmapFilename);
-    LOG(INFO) << "Done reading idMap\n";
-    // Delete the temporary file in which we stored this map
-    deleteTemporaryFile(mmapFilename);
-
-    // update the triples for which this partial vocabulary was responsible
-    for (size_t tmpNum = 0; tmpNum < actualLinesPerPartial[partialNum];
-         ++tmpNum) {
-      std::array<Id, 3> curTriple = data[i];
-
-      // for all triple elements find their mapping from partial to global ids
-      ad_utility::HashMap<Id, Id>::iterator iterators[3];
-      for (size_t k = 0; k < 3; ++k) {
-        iterators[k] = idMap.find(curTriple[k]);
-        if (iterators[k] == idMap.end()) {
-          LOG(INFO) << "not found in partial Vocab: " << curTriple[k] << '\n';
-          AD_CHECK(false);
-        }
-      }
-
-      // update the Element
-      data[i] = array<Id, 3>{
-          {iterators[0]->second, iterators[1]->second, iterators[2]->second}};
-
-      ++i;
-      if (i % 10000000 == 0) {
-        LOG(INFO) << "Lines processed: " << i << '\n';
-      }
-    }
-  }
-  LOG(INFO) << "Lines processed: " << i << '\n';
-  LOG(INFO) << "Pass done.\n";
-}
-
-pair<FullRelationMetaData, BlockBasedRelationMetaData> Index::writeSwitchedRel(
-    ad_utility::File* out, off_t lastOffset, Id currentRel,
-    ad_utility::BufferedVector<array<Id, 2>>* bufPtr) {
-  // sort according to the "switched" relation.
-  auto& buffer = *bufPtr;
-
-  for (auto& el : buffer) {
-    std::swap(el[0], el[1]);
-  }
-  std::sort(buffer.begin(), buffer.end(), [](const auto& a, const auto& b) {
-    return a[0] == b[0] ? a[1] < b[1] : a[0] < b[0];
-  });
-
-  Id lastLhs = std::numeric_limits<Id>::max();
-
-  bool functional = true;
-  size_t distinctC1 = 0;
-  for (const auto& el : buffer) {
-    if (el[0] == lastLhs) {
-      functional = false;
-    } else {
-      distinctC1++;
-    }
-    lastLhs = el[0];
-  }
-
-  return writeRel(*out, lastOffset, currentRel, buffer, distinctC1, functional);
-}
-
-// _____________________________________________________________________________
-template <class MetaDataDispatcher>
-std::optional<std::pair<typename MetaDataDispatcher::WriteType,
-                        typename MetaDataDispatcher::WriteType>>
-Index::createPermutationPairImpl(const string& fileName1,
-                                 const string& fileName2,
-                                 const Index::TripleVec& vec, size_t c0,
-                                 size_t c1, size_t c2) {
-  typename MetaDataDispatcher::WriteType metaData1;
-  typename MetaDataDispatcher::WriteType metaData2;
-  if constexpr (metaData1._isMmapBased) {
-    metaData1.setup(_totalVocabularySize, FullRelationMetaData::empty,
-                    fileName1 + MMAP_FILE_SUFFIX);
-    metaData2.setup(_totalVocabularySize, FullRelationMetaData::empty,
-                    fileName2 + MMAP_FILE_SUFFIX);
-  }
-
-  if (vec.size() == 0) {
-    LOG(WARN) << "Attempt to write an empty index!" << std::endl;
-    return std::nullopt;
-  }
-  ad_utility::File out1(fileName1, "w");
-  ad_utility::File out2(fileName2, "w");
-
-  LOG(INFO) << "Creating a pair of on-disk index permutation of " << vec.size()
-            << " elements / facts." << std::endl;
-  // Iterate over the vector and identify relation boundaries
-  size_t from = 0;
-  Id currentRel = vec[0][c0];
-  off_t lastOffset1 = 0;
-  off_t lastOffset2 = 0;
-  ad_utility::BufferedVector<array<Id, 2>> buffer(
-      THRESHOLD_RELATION_CREATION, fileName1 + ".tmp.MmapBuffer");
-  bool functional = true;
-  size_t distinctC1 = 1;
-  size_t sizeOfRelation = 0;
-  Id lastLhs = std::numeric_limits<Id>::max();
-  for (TripleVec::bufreader_type reader(vec); !reader.empty(); ++reader) {
-    if ((*reader)[c0] != currentRel) {
-      auto md = writeRel(out1, lastOffset1, currentRel, buffer, distinctC1,
-                         functional);
-      metaData1.add(md.first, md.second);
-      auto md2 = writeSwitchedRel(&out2, lastOffset2, currentRel, &buffer);
-      metaData2.add(md2.first, md2.second);
-      buffer.clear();
-      distinctC1 = 1;
-      lastOffset1 = metaData1.getOffsetAfter();
-      lastOffset2 = metaData2.getOffsetAfter();
-      currentRel = (*reader)[c0];
-      functional = true;
-    } else {
-      sizeOfRelation++;
-      if ((*reader)[c1] == lastLhs) {
-        functional = false;
-      } else {
-        distinctC1++;
-      }
-    }
-    buffer.push_back(array<Id, 2>{{(*reader)[c1], (*reader)[c2]}});
-    lastLhs = (*reader)[c1];
-  }
-  if (from < vec.size()) {
-    auto md =
-        writeRel(out1, lastOffset1, currentRel, buffer, distinctC1, functional);
-    metaData1.add(md.first, md.second);
-
-    auto md2 = writeSwitchedRel(&out2, lastOffset2, currentRel, &buffer);
-    metaData2.add(md2.first, md2.second);
-  }
-
-  LOG(INFO) << "Done creating index permutation." << std::endl;
-  LOG(INFO) << "Calculating statistics for these permutation.\n";
-  metaData1.calculateExpensiveStatistics();
-  metaData2.calculateExpensiveStatistics();
-  LOG(INFO) << "Writing statistics for this permutation:\n"
-            << metaData1.statistics() << std::endl;
-  LOG(INFO) << "Writing statistics for this permutation:\n"
-            << metaData2.statistics() << std::endl;
-
-  out1.close();
-  out2.close();
-  LOG(INFO) << "Permutation done.\n";
-  return std::make_pair(std::move(metaData1), std::move(metaData2));
-}
-
-// ________________________________________________________________________
-template <class MetaDataDispatcher, class Comparator1, class Comparator2>
-std::optional<std::pair<typename MetaDataDispatcher::WriteType,
-                        typename MetaDataDispatcher::WriteType>>
-Index::createPermutations(
-    TripleVec* vec,
-    const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
-        p1,
-    const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
-        p2,
-    bool performUnique) {
-  LOG(INFO) << "Sorting for " << p1._readableName << " permutation..."
-            << std::endl;
-  stxxl::sort(begin(*vec), end(*vec), p1._comp, STXXL_MEMORY_TO_USE);
-  LOG(INFO) << "Sort done." << std::endl;
-
-  if (performUnique) {
-    // this only has to be done for the first permutation (PSO)
-    LOG(INFO) << "Removing duplicate triples as these are not supported in RDF"
-              << std::endl;
-    LOG(INFO) << "Size before: " << vec->size() << std::endl;
-    auto last = std::unique(begin(*vec), end(*vec));
-    vec->resize(size_t(last - vec->begin()));
-    LOG(INFO) << "Done: unique." << std::endl;
-    LOG(INFO) << "Size after: " << vec->size() << std::endl;
-  }
-
-  return createPermutationPairImpl<MetaDataDispatcher>(
-      _onDiskBase + ".index" + p1._fileSuffix,
-      _onDiskBase + ".index" + p2._fileSuffix, *vec, p1._keyOrder[0],
-      p1._keyOrder[1], p1._keyOrder[2]);
-}
-
-// ________________________________________________________________________
-template <class MetaDataDispatcher, class Comparator1, class Comparator2>
-void Index::createPermutationPair(
-    VocabularyData* vocabData,
-    const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
-        p1,
-    const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
-        p2,
-    bool performUnique, bool createPatternsAfterFirst) {
-  auto metaData = createPermutations<MetaDataDispatcher>(
-      &(*vocabData->idTriples), p1, p2, performUnique);
-  if (createPatternsAfterFirst) {
-    // the second permutation does not alter the original triple vector,
-    // so this does still work.
-    createPatterns(true, vocabData);
-  }
-  if (metaData) {
-    LOG(INFO) << "Exchanging Multiplicities for " << p1._readableName << " and "
-              << p2._readableName << '\n';
-    exchangeMultiplicities(&(metaData.value().first),
-                           &(metaData.value().second));
-    LOG(INFO) << "Done" << '\n';
-    LOG(INFO) << "Writing MetaData for " << p1._readableName << " and "
-              << p2._readableName << '\n';
-    ad_utility::File f1(_onDiskBase + ".index" + p1._fileSuffix, "r+");
-    metaData.value().first.appendToFile(&f1);
-    ad_utility::File f2(_onDiskBase + ".index" + p2._fileSuffix, "r+");
-    metaData.value().second.appendToFile(&f2);
-    LOG(INFO) << "Done" << '\n';
-  }
-}
-
-// _________________________________________________________________________
-template <class MetaData>
-void Index::exchangeMultiplicities(MetaData* m1, MetaData* m2) {
-  for (auto it = m1->data().begin(); it != m1->data().end(); ++it) {
-    const FullRelationMetaData& constRmd = it->second;
-    // our MetaData classes have a read-only interface because normally the
-    // FuullRelationMetaData are created separately and then added and never
-    // changed. This function forms an exception to this pattern
-    // because calculation the 2nd column multiplicity separately for each
-    // permutation is inefficient. So it is fine to use const_cast here as an
-    // exception: we delibarately write to a read-only data structure and are
-    // knowing what we are doing
-    FullRelationMetaData& rmd = const_cast<FullRelationMetaData&>(constRmd);
-    m2->data()[it->first].setCol2LogMultiplicity(rmd.getCol1LogMultiplicity());
-    rmd.setCol2LogMultiplicity(m2->data()[it->first].getCol1LogMultiplicity());
-  }
-}
-
-// _____________________________________________________________________________
 void Index::addPatternsToExistingIndex() {
-  auto [langPredLowerBound, langPredUpperBound] = _vocab.prefix_range("@");
-  createPatternsImpl<MetaDataIterator<IndexMetaDataMmapView>,
-                     IndexMetaDataMmapView, ad_utility::File>(
-      _onDiskBase + ".index.patterns", _hasPredicate, _hasPattern, _patterns,
-      _fullHasPredicateMultiplicityEntities,
-      _fullHasPredicateMultiplicityPredicates, _fullHasPredicateSize,
-      _maxNumPatterns, langPredLowerBound, langPredUpperBound, _SPO.metaData(),
-      _SPO._file);
-}
-
-// _____________________________________________________________________________
-void Index::createPatterns(bool vecAlreadySorted, VocabularyData* vocabData) {
-  if (vecAlreadySorted) {
-    LOG(INFO) << "Vector already sorted for pattern creation." << std::endl;
-  } else {
-    LOG(INFO) << "Sorting for pattern creation..." << std::endl;
-    stxxl::sort(begin(*vocabData->idTriples), end(*vocabData->idTriples),
-                SortBySPO(), STXXL_MEMORY_TO_USE);
-    LOG(INFO) << "Sort done." << std::endl;
-  }
-  createPatternsImpl<TripleVec::bufreader_type>(
-      _onDiskBase + ".index.patterns", _hasPredicate, _hasPattern, _patterns,
-      _fullHasPredicateMultiplicityEntities,
-      _fullHasPredicateMultiplicityPredicates, _fullHasPredicateSize,
-      _maxNumPatterns, vocabData->langPredLowerBound,
-      vocabData->langPredUpperBound, *vocabData->idTriples);
-}
-
-// _____________________________________________________________________________
-template <typename VecReaderType, typename... Args>
-void Index::createPatternsImpl(const string& fileName,
-                               CompactStringVector<Id, Id>& hasPredicate,
-                               std::vector<PatternID>& hasPattern,
-                               CompactStringVector<size_t, Id>& patterns,
-                               double& fullHasPredicateMultiplicityEntities,
-                               double& fullHasPredicateMultiplicityPredicates,
-                               size_t& fullHasPredicateSize,
-                               const size_t maxNumPatterns,
-                               const Id langPredLowerBound,
-                               const Id langPredUpperBound,
-                               const Args&... vecReaderArgs) {
-  IndexMetaDataHmap meta;
-  using PatternsCountMap = ad_utility::HashMap<Pattern, size_t>;
-
-  LOG(INFO) << "Creating patterns file..." << std::endl;
-  VecReaderType reader(vecReaderArgs...);
-  if (reader.empty()) {
-    LOG(WARN) << "Triple vector was empty, no patterns created" << std::endl;
-    return;
-  }
-
-  PatternsCountMap patternCounts;
-  // determine the most common patterns
-  Pattern pattern;
-
-  size_t numValidPatterns = 0;
-  Id currentSubj = (*reader)[0];
-
-  for (; !reader.empty(); ++reader) {
-    auto triple = *reader;
-    if (triple[0] != currentSubj) {
-      currentSubj = triple[0];
-      numValidPatterns++;
-      patternCounts[pattern]++;
-      pattern.clear();
-    }
-    // don't list predicates twice
-    if (pattern.empty() || pattern.back() != triple[1]) {
-      // Ignore @..@ type language predicates
-      if (triple[1] < langPredLowerBound || triple[1] >= langPredUpperBound) {
-        pattern.push_back(triple[1]);
-      }
-    }
-  }
-  // process the last entry
-  patternCounts[pattern]++;
-  LOG(INFO) << "Counted patterns and found " << patternCounts.size()
-            << " distinct patterns." << std::endl;
-  LOG(INFO) << "Patterns were found for " << numValidPatterns << " entities."
-            << std::endl;
-
-  // stores patterns sorted by their number of occurences
-  size_t actualNumPatterns = patternCounts.size() < maxNumPatterns
-                                 ? patternCounts.size()
-                                 : maxNumPatterns;
-  LOG(INFO) << "Using " << actualNumPatterns << " of the "
-            << patternCounts.size() << " patterns that were found in the data."
-            << std::endl;
-  std::vector<std::pair<Pattern, size_t>> sortedPatterns;
-  sortedPatterns.reserve(actualNumPatterns);
-  auto comparePatternCounts =
-      [](const std::pair<Pattern, size_t>& first,
-         const std::pair<Pattern, size_t>& second) -> bool {
-    return first.second > second.second ||
-           (first.second == second.second && first.first > second.first);
-  };
-  for (auto& it : patternCounts) {
-    if (sortedPatterns.size() < maxNumPatterns) {
-      sortedPatterns.push_back(it);
-      if (sortedPatterns.size() == maxNumPatterns) {
-        LOG(DEBUG) << "Sorting patterns after initial insertions." << std::endl;
-        // actuall sort the sorted patterns
-        std::sort(sortedPatterns.begin(), sortedPatterns.end(),
-                  comparePatternCounts);
-      }
-    } else {
-      if (comparePatternCounts(it, sortedPatterns.back())) {
-        // The new element is larger than the smallest element in the vector.
-        // Insert it into the correct position in the vector using binary
-        // search.
-        sortedPatterns.pop_back();
-        auto sortedIt =
-            std::lower_bound(sortedPatterns.begin(), sortedPatterns.end(), it,
-                             comparePatternCounts);
-        sortedPatterns.insert(sortedIt, it);
-      }
-    }
-  }
-  if (sortedPatterns.size() < maxNumPatterns) {
-    LOG(DEBUG) << "Sorting patterns after all insertions." << std::endl;
-    // actuall sort the sorted patterns
-    std::sort(sortedPatterns.begin(), sortedPatterns.end(),
-              comparePatternCounts);
-  }
-
-  LOG(DEBUG) << "Number of sorted patterns: " << sortedPatterns.size()
-             << std::endl;
-
-  // store the actual patterns
-  std::vector<std::vector<Id>> buffer;
-  buffer.reserve(sortedPatterns.size());
-  for (const auto& p : sortedPatterns) {
-    buffer.push_back(p.first._data);
-  }
-  patterns.build(buffer);
-
-  std::unordered_map<Pattern, Id> patternSet;
-  patternSet.reserve(sortedPatterns.size());
-  for (size_t i = 0; i < sortedPatterns.size(); i++) {
-    patternSet.insert(std::pair<Pattern, Id>(sortedPatterns[i].first, i));
-  }
-
-  LOG(DEBUG) << "Pattern set size: " << patternSet.size() << std::endl;
-
-  // Associate entities with patterns if possible, store has-relation otherwise
-  ad_utility::MmapVectorTmp<std::array<Id, 2>> entityHasPattern(
-      fileName + ".mmap.entityHasPattern.tmp");
-  ad_utility::MmapVectorTmp<std::array<Id, 2>> entityHasPredicate(
-      fileName + ".mmap.entityHasPredicate.tmp");
-
-  size_t numEntitiesWithPatterns = 0;
-  size_t numEntitiesWithoutPatterns = 0;
-  size_t numInvalidEntities = 0;
-
-  // store how many entries there are in the full has-relation relation (after
-  // resolving all patterns) and how may distinct elements there are (for the
-  // multiplicity;
-  fullHasPredicateSize = 0;
-  size_t fullHasPredicateEntitiesDistinctSize = 0;
-  size_t fullHasPredicatePredicatesDistinctSize = 0;
-  // This vector stores if the pattern was already counted toward the distinct
-  // has relation predicates size.
-  std::vector<bool> haveCountedPattern(patternSet.size());
-
-  // the input triple list is in spo order, we only need a hash map for
-  // predicates
-  ad_utility::HashSet<Id> predicateHashSet;
-
-  pattern.clear();
-  currentSubj = (*VecReaderType(vecReaderArgs...))[0];
-  size_t patternIndex = 0;
-  // Create the has-relation and has-pattern predicates
-  for (VecReaderType reader2(vecReaderArgs...); !reader2.empty(); ++reader2) {
-    auto triple = *reader2;
-    if (triple[0] != currentSubj) {
-      // we have arrived at a new entity;
-      fullHasPredicateEntitiesDistinctSize++;
-      auto it = patternSet.find(pattern);
-      // increase the haspredicate size here as every predicate is only
-      // listed once per entity (otherwise it woul always be the same as
-      // vec.size()
-      fullHasPredicateSize += pattern.size();
-      if (it == patternSet.end()) {
-        numEntitiesWithoutPatterns++;
-        // The pattern does not exist, use the has-relation predicate instead
-        for (size_t i = 0; i < patternIndex; i++) {
-          if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
-            predicateHashSet.insert(pattern[i]);
-            fullHasPredicatePredicatesDistinctSize++;
-          }
-          entityHasPredicate.push_back(
-              std::array<Id, 2>{currentSubj, pattern[i]});
-        }
-      } else {
-        numEntitiesWithPatterns++;
-        // The pattern does exist, add an entry to the has-pattern predicate
-        entityHasPattern.push_back(std::array<Id, 2>{currentSubj, it->second});
-        if (!haveCountedPattern[it->second]) {
-          haveCountedPattern[it->second] = true;
-          // iterate over the pattern once to
-          for (size_t i = 0; i < patternIndex; i++) {
-            if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
-              predicateHashSet.insert(pattern[i]);
-              fullHasPredicatePredicatesDistinctSize++;
-            }
-          }
-        }
-      }
-      pattern.clear();
-      currentSubj = triple[0];
-      patternIndex = 0;
-    }
-    // don't list predicates twice
-    if (patternIndex == 0 || pattern[patternIndex - 1] != (triple[1])) {
-      // Ignore @..@ type language predicates
-      if (triple[1] < langPredLowerBound || triple[1] >= langPredUpperBound) {
-        pattern.push_back(triple[1]);
-        patternIndex++;
-      }
-    }
-  }
-  // process the last element
-  fullHasPredicateSize += pattern.size();
-  fullHasPredicateEntitiesDistinctSize++;
-  auto last = patternSet.find(pattern);
-  if (last == patternSet.end()) {
-    numEntitiesWithoutPatterns++;
-    // The pattern does not exist, use the has-relation predicate instead
-    for (size_t i = 0; i < patternIndex; i++) {
-      entityHasPredicate.push_back(std::array<Id, 2>{currentSubj, pattern[i]});
-      if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
-        predicateHashSet.insert(pattern[i]);
-        fullHasPredicatePredicatesDistinctSize++;
-      }
-    }
-  } else {
-    numEntitiesWithPatterns++;
-    // The pattern does exist, add an entry to the has-pattern predicate
-    entityHasPattern.push_back(std::array<Id, 2>{currentSubj, last->second});
-    for (size_t i = 0; i < patternIndex; i++) {
-      if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
-        predicateHashSet.insert(pattern[i]);
-        fullHasPredicatePredicatesDistinctSize++;
-      }
-    }
-  }
-
-  fullHasPredicateMultiplicityEntities =
-      fullHasPredicateSize /
-      static_cast<double>(fullHasPredicateEntitiesDistinctSize);
-  fullHasPredicateMultiplicityPredicates =
-      fullHasPredicateSize /
-      static_cast<double>(fullHasPredicatePredicatesDistinctSize);
-
-  LOG(DEBUG) << "Number of entity-has-pattern entries: "
-             << entityHasPattern.size() << std::endl;
-  LOG(DEBUG) << "Number of entity-has-relation entries: "
-             << entityHasPredicate.size() << std::endl;
-
-  LOG(INFO) << "Found " << patterns.size() << " distinct patterns."
-            << std::endl;
-  LOG(INFO) << numEntitiesWithPatterns
-            << " of the databases entities have been assigned a pattern."
-            << std::endl;
-  LOG(INFO) << numEntitiesWithoutPatterns
-            << " of the databases entities have not been assigned a pattern."
-            << std::endl;
-  LOG(INFO) << "Of these " << numInvalidEntities
-            << " would have to large a pattern." << std::endl;
-
-  LOG(DEBUG) << "Total number of entities: "
-             << (numEntitiesWithoutPatterns + numEntitiesWithPatterns)
-             << std::endl;
-
-  LOG(DEBUG) << "Full has relation size: " << fullHasPredicateSize << std::endl;
-  LOG(DEBUG) << "Full has relation entity multiplicity: "
-             << fullHasPredicateMultiplicityEntities << std::endl;
-  LOG(DEBUG) << "Full has relation predicate multiplicity: "
-             << fullHasPredicateMultiplicityPredicates << std::endl;
-
-  // Store all data in the file
-  ad_utility::File file(fileName, "w");
-
-  // Write a byte of ones to make it less likely that an unversioned file is
-  // read as a versioned one (unversioned files begin with the id of the lowest
-  // entity that has a pattern).
-  // Then write the version, both multiplicitires and the full size.
-  unsigned char firstByte = 255;
-  file.write(&firstByte, sizeof(char));
-  file.write(&PATTERNS_FILE_VERSION, sizeof(uint32_t));
-  file.write(&fullHasPredicateMultiplicityEntities, sizeof(double));
-  file.write(&fullHasPredicateMultiplicityPredicates, sizeof(double));
-  file.write(&fullHasPredicateSize, sizeof(size_t));
-
-  // write the entityHasPatterns vector
-  size_t numHasPatterns = entityHasPattern.size();
-  file.write(&numHasPatterns, sizeof(size_t));
-  file.write(entityHasPattern.data(), sizeof(Id) * numHasPatterns * 2);
-
-  // write the entityHasPredicate vector
-  size_t numHasPredicatess = entityHasPredicate.size();
-  file.write(&numHasPredicatess, sizeof(size_t));
-  file.write(entityHasPredicate.data(), sizeof(Id) * numHasPredicatess * 2);
-
-  // write the patterns
-  patterns.write(file);
-  file.close();
-
-  LOG(INFO) << "Done creating patterns file." << std::endl;
-
-  // create the has-relation and has-pattern lookup vectors
-  if (entityHasPattern.size() > 0) {
-    hasPattern.resize(entityHasPattern.back()[0] + 1);
-    size_t pos = 0;
-    for (size_t i = 0; i < entityHasPattern.size(); i++) {
-      while (entityHasPattern[i][0] > pos) {
-        hasPattern[pos] = NO_PATTERN;
-        pos++;
-      }
-      hasPattern[pos] = entityHasPattern[i][1];
-      pos++;
-    }
-  }
-
-  vector<vector<Id>> hasPredicateTmp;
-  if (entityHasPredicate.size() > 0) {
-    hasPredicateTmp.resize(entityHasPredicate.back()[0] + 1);
-    size_t pos = 0;
-    for (size_t i = 0; i < entityHasPredicate.size(); i++) {
-      Id current = entityHasPredicate[i][0];
-      while (current > pos) {
-        pos++;
-      }
-      while (i < entityHasPredicate.size() &&
-             entityHasPredicate[i][0] == current) {
-        hasPredicateTmp.back().push_back(entityHasPredicate[i][1]);
-        i++;
-      }
-      pos++;
-    }
-  }
-  hasPredicate.build(hasPredicateTmp);
-}
-
-// _____________________________________________________________________________
-pair<FullRelationMetaData, BlockBasedRelationMetaData> Index::writeRel(
-    ad_utility::File& out, off_t currentOffset, Id relId,
-    const ad_utility::BufferedVector<array<Id, 2>>& data, size_t distinctC1,
-    bool functional) {
-  LOG(TRACE) << "Writing a relation ...\n";
-  AD_CHECK_GT(data.size(), 0);
-  LOG(TRACE) << "Calculating multiplicities ...\n";
-  double multC1 = functional ? 1.0 : data.size() / double(distinctC1);
-  // Dummy value that will be overwritten later
-  double multC2 = 42.42;
-  LOG(TRACE) << "Done calculating multiplicities.\n";
-  FullRelationMetaData rmd(
-      relId, currentOffset, data.size(), multC1, multC2, functional,
-      !functional && data.size() > USE_BLOCKS_INDEX_SIZE_TRESHOLD);
-
-  // Write the full pair index.
-  out.write(data.data(), data.size() * 2 * sizeof(Id));
-  pair<FullRelationMetaData, BlockBasedRelationMetaData> ret;
-  ret.first = rmd;
-
-  if (functional) {
-    writeFunctionalRelation(data, ret);
-  } else {
-    writeNonFunctionalRelation(out, data, ret);
-  };
-  LOG(TRACE) << "Done writing relation.\n";
-  return ret;
-}
-
-// _____________________________________________________________________________
-void Index::writeFunctionalRelation(
-    const BufferedVector<array<Id, 2>>& data,
-    pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd) {
-  // Only has to do something if there are blocks.
-  if (rmd.first.hasBlocks()) {
-    LOG(TRACE) << "Writing part for functional relation ...\n";
-    // Do not write extra LHS and RHS lists.
-    rmd.second._startRhs =
-        rmd.first._startFullIndex + rmd.first.getNofBytesForFulltextIndex();
-    // Since the relation is functional, there are no lhs lists and thus this
-    // is trivial.
-    rmd.second._offsetAfter = rmd.second._startRhs;
-    // Create the block data for the meta data.
-    // Blocks are offsets into the full pair index for functional relations.
-    size_t nofDistinctLhs = 0;
-    Id lastLhs = std::numeric_limits<Id>::max();
-    for (size_t i = 0; i < data.size(); ++i) {
-      if (data[i][0] != lastLhs) {
-        if (nofDistinctLhs % DISTINCT_LHS_PER_BLOCK == 0) {
-          rmd.second._blocks.emplace_back(BlockMetaData(
-              data[i][0], rmd.first._startFullIndex + i * 2 * sizeof(Id)));
-        }
-        ++nofDistinctLhs;
-      }
-    }
-  }
-}
-
-// _____________________________________________________________________________
-void Index::writeNonFunctionalRelation(
-    ad_utility::File& out, const BufferedVector<array<Id, 2>>& data,
-    pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd) {
-  // Only has to do something if there are blocks.
-  if (rmd.first.hasBlocks()) {
-    LOG(TRACE) << "Writing part for non-functional relation ...\n";
-    // Make a pass over the data and extract a RHS list for each LHS.
-    // Prepare both in buffers.
-    // TODO: add compression - at least to RHS.
-    pair<Id, off_t>* bufLhs = new pair<Id, off_t>[data.size()];
-    Id* bufRhs = new Id[data.size()];
-    size_t nofDistinctLhs = 0;
-    Id lastLhs = std::numeric_limits<Id>::max();
-    size_t nofRhsDone = 0;
-    for (; nofRhsDone < data.size(); ++nofRhsDone) {
-      if (data[nofRhsDone][0] != lastLhs) {
-        bufLhs[nofDistinctLhs++] =
-            pair<Id, off_t>(data[nofRhsDone][0], nofRhsDone * sizeof(Id));
-        lastLhs = data[nofRhsDone][0];
-      }
-      bufRhs[nofRhsDone] = data[nofRhsDone][1];
-    }
-
-    // Go over the Lhs data once more and adjust the offsets.
-    off_t startRhs = rmd.first.getStartOfLhs() +
-                     nofDistinctLhs * (sizeof(Id) + sizeof(off_t));
-
-    for (size_t i = 0; i < nofDistinctLhs; ++i) {
-      bufLhs[i].second += startRhs;
-    }
-
-    // Write to file.
-    out.write(bufLhs, nofDistinctLhs * (sizeof(Id) + sizeof(off_t)));
-    out.write(bufRhs, data.size() * sizeof(Id));
-
-    // Update meta data.
-    rmd.second._startRhs = startRhs;
-    rmd.second._offsetAfter =
-        startRhs + rmd.first.getNofElements() * sizeof(Id);
-
-    // Create the block data for the FullRelationMetaData.
-    // Block are offsets into the LHS list for non-functional relations.
-    for (size_t i = 0; i < nofDistinctLhs; ++i) {
-      if (i % DISTINCT_LHS_PER_BLOCK == 0) {
-        rmd.second._blocks.emplace_back(BlockMetaData(
-            bufLhs[i].first,
-            rmd.first.getStartOfLhs() + i * (sizeof(Id) + sizeof(off_t))));
-      }
-    }
-    delete[] bufLhs;
-    delete[] bufRhs;
-  }
+  _pimpl->addPatternsToExistingIndex();
 }
 
 // _____________________________________________________________________________
 void Index::createFromOnDiskIndex(const string& onDiskBase) {
-  setOnDiskBase(onDiskBase);
-  readConfiguration();
-  _vocab.readFromFile(_onDiskBase + ".vocabulary",
-                      _onDiskLiterals ? _onDiskBase + ".literals-index" : "");
-
-  _totalVocabularySize = _vocab.size() + _vocab.getExternalVocab().size();
-  LOG(INFO) << "total vocab size is " << _totalVocabularySize << std::endl;
-  _PSO.loadFromDisk(_onDiskBase);
-  _POS.loadFromDisk(_onDiskBase);
-  _OPS.loadFromDisk(_onDiskBase);
-  _OSP.loadFromDisk(_onDiskBase);
-  _SPO.loadFromDisk(_onDiskBase);
-  _SOP.loadFromDisk(_onDiskBase);
-
-  if (_usePatterns) {
-    // Read the pattern info from the patterns file
-    std::string patternsFilePath = _onDiskBase + ".index.patterns";
-    ad_utility::File patternsFile;
-    patternsFile.open(patternsFilePath, "r");
-    AD_CHECK(patternsFile.isOpen());
-    off_t off = 0;
-    unsigned char firstByte;
-    patternsFile.read(&firstByte, sizeof(char), off);
-    off++;
-    uint32_t version;
-    patternsFile.read(&version, sizeof(uint32_t), off);
-    off += sizeof(uint32_t);
-    if (version != PATTERNS_FILE_VERSION || firstByte != 255) {
-      version = firstByte == 255 ? version : -1;
-      _usePatterns = false;
-      patternsFile.close();
-      std::ostringstream oss;
-      oss << "The patterns file " << patternsFilePath << " version of "
-          << version << " does not match the programs pattern file "
-          << "version of " << PATTERNS_FILE_VERSION << ". Rebuild the index"
-          << " or start the query engine without pattern support." << std::endl;
-      throw std::runtime_error(oss.str());
-    } else {
-      patternsFile.read(&_fullHasPredicateMultiplicityEntities, sizeof(double),
-                        off);
-      off += sizeof(double);
-      patternsFile.read(&_fullHasPredicateMultiplicityPredicates,
-                        sizeof(double), off);
-      off += sizeof(double);
-      patternsFile.read(&_fullHasPredicateSize, sizeof(size_t), off);
-      off += sizeof(size_t);
-
-      // read the entity has patterns vector
-      size_t hasPatternSize;
-      patternsFile.read(&hasPatternSize, sizeof(size_t), off);
-      off += sizeof(size_t);
-      std::vector<array<Id, 2>> entityHasPattern(hasPatternSize);
-      patternsFile.read(entityHasPattern.data(),
-                        hasPatternSize * sizeof(Id) * 2, off);
-      off += hasPatternSize * sizeof(Id) * 2;
-
-      // read the entity has relation vector
-      size_t hasPredicateSize;
-      patternsFile.read(&hasPredicateSize, sizeof(size_t), off);
-      off += sizeof(size_t);
-      std::vector<array<Id, 2>> entityHasPredicate(hasPredicateSize);
-      patternsFile.read(entityHasPredicate.data(),
-                        hasPredicateSize * sizeof(Id) * 2, off);
-      off += hasPredicateSize * sizeof(Id) * 2;
-
-      // read the patterns
-      _patterns.load(patternsFile, off);
-
-      // create the has-relation and has-pattern lookup vectors
-      if (entityHasPattern.size() > 0) {
-        _hasPattern.resize(entityHasPattern.back()[0] + 1);
-        size_t pos = 0;
-        for (size_t i = 0; i < entityHasPattern.size(); i++) {
-          while (entityHasPattern[i][0] > pos) {
-            _hasPattern[pos] = NO_PATTERN;
-            pos++;
-          }
-          _hasPattern[pos] = entityHasPattern[i][1];
-          pos++;
-        }
-      }
-
-      vector<vector<Id>> hasPredicateTmp;
-      if (entityHasPredicate.size() > 0) {
-        hasPredicateTmp.resize(entityHasPredicate.back()[0] + 1);
-        size_t pos = 0;
-        for (size_t i = 0; i < entityHasPredicate.size(); i++) {
-          Id current = entityHasPredicate[i][0];
-          while (current > pos) {
-            pos++;
-          }
-          while (i < entityHasPredicate.size() &&
-                 entityHasPredicate[i][0] == current) {
-            hasPredicateTmp.back().push_back(entityHasPredicate[i][1]);
-            i++;
-          }
-          pos++;
-        }
-      }
-      _hasPredicate.build(hasPredicateTmp);
-    }
-  }
-}
-
-// _____________________________________________________________________________
-void Index::throwExceptionIfNoPatterns() const {
-  if (!_usePatterns) {
-    AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-             "The requested feature requires a loaded patterns file ("
-             "do not specify the --no-patterns option for this to work)");
-  }
+  _pimpl->createFromOnDiskIndex(onDiskBase);
 }
 
 // _____________________________________________________________________________
 const vector<PatternID>& Index::getHasPattern() const {
-  throwExceptionIfNoPatterns();
-  return _hasPattern;
+  return _pimpl->getHasPattern();
 }
 
 // _____________________________________________________________________________
 const CompactStringVector<Id, Id>& Index::getHasPredicate() const {
-  throwExceptionIfNoPatterns();
-  return _hasPredicate;
+  return _pimpl->getHasPredicate();
 }
 
 // _____________________________________________________________________________
 const CompactStringVector<size_t, Id>& Index::getPatterns() const {
-  throwExceptionIfNoPatterns();
-  return _patterns;
+  return _pimpl->getPatterns();
 }
 
 // _____________________________________________________________________________
 double Index::getHasPredicateMultiplicityEntities() const {
-  throwExceptionIfNoPatterns();
-  return _fullHasPredicateMultiplicityEntities;
+  return _pimpl->getHasPredicateMultiplicityEntities();
 }
 
 // _____________________________________________________________________________
 double Index::getHasPredicateMultiplicityPredicates() const {
-  throwExceptionIfNoPatterns();
-  return _fullHasPredicateMultiplicityPredicates;
+  return _pimpl->getHasPredicateMultiplicityPredicates();
 }
 
 // _____________________________________________________________________________
 size_t Index::getHasPredicateFullSize() const {
-  throwExceptionIfNoPatterns();
-  return _fullHasPredicateSize;
-}
-
-// _____________________________________________________________________________
-void Index::scanFunctionalRelation(const pair<off_t, size_t>& blockOff,
-                                   Id lhsId, ad_utility::File& indexFile,
-                                   IdTable* result) const {
-  if (blockOff.second == 0) {
-    // TODO<joka921> this check should be in the callers, but for that I want to
-    // refactor the code duplication there first
-    // nothing to do if the result is empty
-    return;
-  }
-  LOG(TRACE) << "Scanning functional relation ...\n";
-  WidthTwoList block;
-  block.resize(blockOff.second / (2 * sizeof(Id)));
-  indexFile.read(block.data(), blockOff.second, blockOff.first);
-  auto it = std::lower_bound(
-      block.begin(), block.end(), lhsId,
-      [](const array<Id, 2>& elem, Id key) { return elem[0] < key; });
-  if ((*it)[0] == lhsId) {
-    result->push_back({(*it)[1]});
-  }
-  LOG(TRACE) << "Read " << result->size() << " RHS.\n";
-}
-
-// _____________________________________________________________________________
-void Index::scanNonFunctionalRelation(const pair<off_t, size_t>& blockOff,
-                                      const pair<off_t, size_t>& followBlock,
-                                      Id lhsId, ad_utility::File& indexFile,
-                                      off_t upperBound, IdTable* result) const {
-  LOG(TRACE) << "Scanning non-functional relation ...\n";
-
-  if (blockOff.second == 0) {
-    // TODO<joka921> this check should be in the callers, but for that I want to
-    // refactor the code duplication there first
-    // nothing to do if the result is empty
-    return;
-  }
-  vector<pair<Id, off_t>> block;
-  block.resize(blockOff.second / (sizeof(Id) + sizeof(off_t)));
-  indexFile.read(block.data(), blockOff.second, blockOff.first);
-  auto it = std::lower_bound(
-      block.begin(), block.end(), lhsId,
-      [](const pair<Id, off_t>& elem, Id key) { return elem.first < key; });
-  if (it->first == lhsId) {
-    size_t nofBytes = 0;
-    if ((it + 1) != block.end()) {
-      LOG(TRACE) << "Obtained upper bound from same block!\n";
-      nofBytes = static_cast<size_t>((it + 1)->second - it->second);
-    } else {
-      // Look at the follow block to determine the upper bound / nofBytes.
-      if (followBlock.first == blockOff.first) {
-        LOG(TRACE) << "Last block of relation, using rel upper bound!\n";
-        nofBytes = static_cast<size_t>(upperBound - it->second);
-      } else {
-        LOG(TRACE) << "Special case: extra scan of follow block!\n";
-        pair<Id, off_t> follower;
-        indexFile.read(&follower, sizeof(follower), followBlock.first);
-        nofBytes = static_cast<size_t>(follower.second - it->second);
-      }
-    }
-    result->resize(nofBytes / sizeof(Id));
-    indexFile.read(result->data(), nofBytes, it->second);
-  } else {
-    LOG(TRACE) << "Could not find LHS in block. Result will be empty.\n";
-  }
+  return _pimpl->getHasPredicateFullSize();
 }
 
 // _____________________________________________________________________________
 size_t Index::relationCardinality(const string& relationName) const {
-  if (relationName == INTERNAL_TEXT_MATCH_PREDICATE) {
-    return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
-  }
-  Id relId;
-  if (_vocab.getId(relationName, &relId)) {
-    if (this->_PSO.metaData().relationExists(relId)) {
-      return this->_PSO.metaData().getRmd(relId).getNofElements();
-    }
-  }
-  return 0;
+  return _pimpl->relationCardinality(relationName);
 }
 
 // _____________________________________________________________________________
 size_t Index::subjectCardinality(const string& sub) const {
-  Id relId;
-  if (_vocab.getId(sub, &relId)) {
-    if (this->_SPO.metaData().relationExists(relId)) {
-      return this->_SPO.metaData().getRmd(relId).getNofElements();
-    }
-  }
-  return 0;
+  return _pimpl->subjectCardinality(sub);
 }
 
 // _____________________________________________________________________________
 size_t Index::objectCardinality(const string& obj) const {
-  Id relId;
-  if (_vocab.getId(obj, &relId)) {
-    if (this->_OSP.metaData().relationExists(relId)) {
-      return this->_OSP.metaData().getRmd(relId).getNofElements();
-    }
-  }
-  return 0;
+  return _pimpl->objectCardinality(obj);
 }
 
 // _____________________________________________________________________________
 size_t Index::sizeEstimate(const string& sub, const string& pred,
                            const string& obj) const {
-  // One or two of the parameters have to be empty strings.
-  // This determines the permutations to use.
-
-  // With only one nonempty string, we can get the exact count.
-  // With two, we can check if the relation is functional (return 1) or not
-  // where we approximate the result size by the block size.
-  if (sub.size() > 0 && pred.size() == 0 && obj.size() == 0) {
-    return subjectCardinality(sub);
-  }
-  if (sub.size() == 0 && pred.size() > 0 && obj.size() == 0) {
-    return relationCardinality(pred);
-  }
-  if (sub.size() == 0 && pred.size() == 0 && obj.size() > 0) {
-    return objectCardinality(obj);
-  }
-  if (sub.size() == 0 && pred.size() == 0 && obj.size() == 0) {
-    return getNofTriples();
-  }
-  AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-           "Index::sizeEsimate called with more then one of S/P/O given. "
-           "This should never be the case anymore, "
-           " since for such SCANs we compute the result "
-           "directly and don't need an estimate anymore!");
+  return _pimpl->sizeEstimate(sub, pred, obj);
 }
 
 // _____________________________________________________________________________
-template <class T>
-void Index::writeAsciiListFile(const string& filename, const T& ids) const {
-  std::ofstream f(filename);
-
-  for (size_t i = 0; i < ids.size(); ++i) {
-    f << ids[i] << ' ';
-  }
-  f.close();
-}
-
-template void Index::writeAsciiListFile<vector<Id>>(
-    const string& filename, const vector<Id>& ids) const;
-
-template void Index::writeAsciiListFile<vector<Score>>(
-    const string& filename, const vector<Score>& ids) const;
-
-// _____________________________________________________________________________
-bool Index::isLiteral(const string& object) {
-  return decltype(_vocab)::isLiteral(object);
-}
-
-// _____________________________________________________________________________
-bool Index::shouldBeExternalized(const string& object) {
-  return _vocab.shouldBeExternalized(object);
-}
-
-// _____________________________________________________________________________
-void Index::setKbName(const string& name) {
-  _POS.setKbName(name);
-  _PSO.setKbName(name);
-  _SOP.setKbName(name);
-  _SPO.setKbName(name);
-  _OPS.setKbName(name);
-  _OSP.setKbName(name);
-}
+void Index::setKbName(const string& name) { return _pimpl->setKbName(name); }
 
 // ____________________________________________________________________________
 void Index::setOnDiskLiterals(bool onDiskLiterals) {
-  _onDiskLiterals = onDiskLiterals;
+  return _pimpl->setOnDiskLiterals(onDiskLiterals);
 }
 
 // ____________________________________________________________________________
 void Index::setOnDiskBase(const std::string& onDiskBase) {
-  _onDiskBase = onDiskBase;
+  return _pimpl->setOnDiskBase(onDiskBase);
 }
 
 // ____________________________________________________________________________
 void Index::setKeepTempFiles(bool keepTempFiles) {
-  _keepTempFiles = keepTempFiles;
+  return _pimpl->setKeepTempFiles(keepTempFiles);
 }
 
 // _____________________________________________________________________________
-void Index::setUsePatterns(bool usePatterns) { _usePatterns = usePatterns; }
+void Index::setUsePatterns(bool usePatterns) {
+  return _pimpl->setUsePatterns(usePatterns);
+}
 
 // ____________________________________________________________________________
 void Index::setSettingsFile(const std::string& filename) {
-  _settingsFileName = filename;
+  return _pimpl->setSettingsFile(filename);
 }
 
 // ____________________________________________________________________________
 void Index::setPrefixCompression(bool compressed) {
-  _vocabPrefixCompressed = compressed;
+  return _pimpl->setPrefixCompression(compressed);
 }
 
 // ____________________________________________________________________________
-void Index::writeConfiguration() const {
-  std::ofstream f(_onDiskBase + CONFIGURATION_FILE);
-  AD_CHECK(f.is_open());
-  f << _configurationJson;
+void Index::addTextFromContextFile(const string& contextFile) {
+  return _pimpl->addTextFromContextFile(contextFile);
+}
+
+// ___________________________________________________________
+void Index::buildDocsDB(const string& docsFile) {
+  return _pimpl->buildDocsDB(docsFile);
 }
 
 // ___________________________________________________________________________
-void Index::readConfiguration() {
-  std::ifstream f(_onDiskBase + CONFIGURATION_FILE);
-  AD_CHECK(f.is_open());
-  f >> _configurationJson;
-  if (_configurationJson.find("external-literals") !=
-      _configurationJson.end()) {
-    _onDiskLiterals = _configurationJson["external-literals"];
-  }
-
-  if (_configurationJson.find("prefixes") != _configurationJson.end()) {
-    if (_configurationJson["prefixes"]) {
-      vector<string> prefixes;
-      std::ifstream prefixFile(_onDiskBase + PREFIX_FILE);
-      AD_CHECK(prefixFile.is_open());
-      for (string prefix; std::getline(prefixFile, prefix);) {
-        prefixes.emplace_back(std::move(prefix));
-      }
-      _vocab.initializePrefixes(prefixes);
-    } else {
-      _vocab.initializePrefixes(std::vector<std::string>());
-    }
-  }
-
-  if (_configurationJson.find("prefixes-external") !=
-      _configurationJson.end()) {
-    _vocab.initializeExternalizePrefixes(
-        _configurationJson["prefixes-external"]);
-  }
-
-  if (_configurationJson.count("ignore-case")) {
-    LOG(ERROR) << ERROR_IGNORE_CASE_UNSUPPORTED << '\n';
-    throw std::runtime_error("Deprecated key \"ignore-case\" in index build");
-  }
-
-  if (_configurationJson.count("locale")) {
-    std::string lang = _configurationJson["locale"]["language"];
-    std::string country = _configurationJson["locale"]["country"];
-    bool ignorePunctuation = _configurationJson["locale"]["ignore-punctuation"];
-    _vocab.setLocale(lang, country, ignorePunctuation);
-    _textVocab.setLocale(lang, country, ignorePunctuation);
-  } else {
-    LOG(ERROR) << "Key \"locale\" is missing in the metadata. This is probably "
-                  "and old index build that is no longer supported by QLever. "
-                  "Please rebuild your index\n";
-    throw std::runtime_error(
-        "Missing required key \"locale\" in index build's metadata");
-  }
-
-  if (_configurationJson.find("languages-internal") !=
-      _configurationJson.end()) {
-    _vocab.initializeInternalizedLangs(
-        _configurationJson["languages-internal"]);
-  }
+void Index::addTextFromOnDiskIndex() {
+  return _pimpl->addTextFromOnDiskIndex();
 }
 
 // ___________________________________________________________________________
-LangtagAndTriple Index::tripleToInternalRepresentation(Triple&& tripleIn) {
-  LangtagAndTriple res{"", std::move(tripleIn)};
-  auto& spo = res._triple;
-  for (auto& el : spo) {
-    el = _vocab.getLocaleManager().normalizeUtf8(el);
-  }
-  size_t upperBound = 3;
-  if (ad_utility::isXsdValue(spo[2])) {
-    spo[2] = ad_utility::convertValueLiteralToIndexWord(spo[2]);
-    upperBound = 2;
-  } else if (isLiteral(spo[2])) {
-    res._langtag = decltype(_vocab)::getLanguage(spo[2]);
-  }
+const RdfsVocabulary& Index::getVocab() const { return _pimpl->getVocab(); }
 
-  for (size_t k = 0; k < upperBound; ++k) {
-    if (_onDiskLiterals && _vocab.shouldBeExternalized(spo[k])) {
-      if (isLiteral(spo[k])) {
-        spo[k][0] = EXTERNALIZED_LITERALS_PREFIX_CHAR;
-      } else {
-        AD_CHECK(spo[k][0] == '<');
-        spo[k][0] = EXTERNALIZED_ENTITIES_PREFIX_CHAR;
-      }
-    }
-  }
-  return res;
+// ____________________________________________________________________________
+const TextVocabulary& Index::getTextVocab() const {
+  return _pimpl->getTextVocab();
 }
 
 // ___________________________________________________________________________
-template <class Parser>
-void Index::initializeVocabularySettingsBuild() {
-  json j;  // if we have no settings, we still have to initialize some default
-           // values
-  if (!_settingsFileName.empty()) {
-    std::ifstream f(_settingsFileName);
-    AD_CHECK(f.is_open());
-    f >> j;
-  }
+void Index::setTextName(const string& name) {
+  return _pimpl->setTextName(name);
+}
 
-  if (j.find("prefixes-external") != j.end()) {
-    _vocab.initializeExternalizePrefixes(j["prefixes-external"]);
-    _configurationJson["prefixes-external"] = j["prefixes-external"];
-    _onDiskLiterals = true;
-    _configurationJson["external-literals"] = true;
-  }
+// ____________________________________________________________________________
+std::optional<string> Index::idToOptionalString(Id id) const {
+  return _pimpl->idToOptionalString(id);
+}
 
-  if (j.count("ignore-case")) {
-    LOG(ERROR) << ERROR_IGNORE_CASE_UNSUPPORTED << '\n';
-    throw std::runtime_error("Deprecated key \"ignore-case\" in settings JSON");
-  }
+// ____________________________________________________________
+const string& Index::getTextName() const { return _pimpl->getTextName(); }
 
-  /**
-   * ICU uses two separate arguments for each Locale, the language ("en" or
-   * "fr"...) and the country ("GB", "CA"...). The encoding has to be known at
-   * compile time for ICU and will always be UTF-8 so it is not part of the
-   * locale setting.
-   */
+// _____________________________________________________________________________
+const string& Index::getKbName() const { return _pimpl->getKbName(); }
 
-  {
-    std::string lang = LOCALE_DEFAULT_LANG;
-    std::string country = LOCALE_DEFAULT_COUNTRY;
-    bool ignorePunctuation = LOCALE_DEFAULT_IGNORE_PUNCTUATION;
-    if (j.count("locale")) {
-      lang = j["locale"]["language"];
-      country = j["locale"]["country"];
-      ignorePunctuation = j["locale"]["ignore-punctuation"];
-    } else {
-      LOG(INFO) << "locale was not specified by the settings JSON, defaulting "
-                   "to en US\n";
-    }
-    LOG(INFO) << "Using Locale " << lang << " " << country
-              << " with ignore-punctuation: " << ignorePunctuation << '\n';
+// _____________________________________________________________________________
+size_t Index::getNofTriples() const { return _pimpl->getNofTriples(); }
 
-    if (lang != LOCALE_DEFAULT_LANG || country != LOCALE_DEFAULT_COUNTRY) {
-      LOG(WARN) << "You are using Locale settings that differ from the default "
-                   "language or country.\n\t"
-                << "This should work but is untested by the QLever team. If "
-                   "you are running into unexpected problems,\n\t"
-                << "Please make sure to also report your used locale when "
-                   "filing a bug report. Also note that changing the\n\t"
-                << "locale requires to completely rebuild the index\n";
-    }
-    _vocab.setLocale(lang, country, ignorePunctuation);
-    _textVocab.setLocale(lang, country, ignorePunctuation);
-    _configurationJson["locale"]["language"] = lang;
-    _configurationJson["locale"]["country"] = country;
-    _configurationJson["locale"]["ignore-punctuation"] = ignorePunctuation;
-  }
+// __________________________________________________________-
+size_t Index::getNofTextRecords() const { return _pimpl->getNofTextRecords(); }
+size_t Index::getNofWordPostings() const {
+  return _pimpl->getNofWordPostings();
+}
+size_t Index::getNofEntityPostings() const {
+  return _pimpl->getNofEntityPostings();
+}
 
-  if (j.find("languages-internal") != j.end()) {
-    _vocab.initializeInternalizedLangs(j["languages-internal"]);
-    _configurationJson["languages-internal"] = j["languages-internal"];
-    _onDiskLiterals = true;
-    _configurationJson["external-literals"] = true;
-  }
-  if (j.count("ascii-prefixes-only")) {
-    if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserDummy>) {
-      bool v = j["ascii-prefixes-only"];
-      if (v) {
-        LOG(WARN) << WARNING_ASCII_ONLY_PREFIXES;
-        _onlyAsciiTurtlePrefixes = true;
-      } else {
-        _onlyAsciiTurtlePrefixes = false;
-      }
-    } else {
-      LOG(WARN) << "You specified the ascii-prefixes-only but a parser that is "
-                   "not the Turtle stream parser. This means that this setting "
-                   "is ignored\n";
-    }
-  }
+// _____________________________________________________________________________
+size_t Index::getNofSubjects() const { return _pimpl->getNofSubjects(); }
+size_t Index::getNofObjects() const { return _pimpl->getNofObjects(); }
+size_t Index::getNofPredicates() const { return _pimpl->getNofPredicates(); }
 
-  if (j.count("num-triples-per-partial-vocab")) {
-    _numTriplesPerPartialVocab = j["num-triples-per-partial-vocab"];
-    LOG(INFO) << "Overriding setting num-triples-per-partial-vocab to "
-              << _numTriplesPerPartialVocab
-              << " This might influence performance / memory usage during "
-                 "index build\n";
-  }
+// _____________________________________________________________________________
+bool Index::hasAllPermutations() const { return _pimpl->hasAllPermutations(); }
 
-  if (j.count("parser-batch-size")) {
-    _parserBatchSize = j["parser-batch-size"];
-    LOG(INFO) << "Overriding setting parser-batch-size to " << _parserBatchSize
-              << " This might influence performance during index build\n";
-  }
+// _____________________________________________________________________________
+vector<float> Index::getMultiplicities(const string& key,
+                                       const Permutation p) const {
+  return _pimpl->getMultiplicities(key, p);
+}
+// _____________________________________________________________________________
+
+vector<float> Index::getMultiplicities(const Permutation p) const {
+  return _pimpl->getMultiplicities(p);
+}
+// ______________________________________________________________________________
+void Index::dumpAsciiLists(const vector<string>& lists,
+                           bool decodeGapsFreq) const {
+  return _pimpl->dumpAsciiLists(lists, decodeGapsFreq);
+}
+
+// _____________________________________________________
+const string& Index::wordIdToString(Id id) const {
+  return _pimpl->wordIdToString(id);
+}
+
+// _______________________________________________________
+size_t Index::getSizeEstimate(const string& words) const {
+  return _pimpl->getSizeEstimate(words);
+}
+
+// ________________________________________________________
+void Index::getContextListForWords(const string& words, IdTable* result) const {
+  return _pimpl->getContextListForWords(words, result);
+}
+
+// ________________________________________________________________________
+void Index::getECListForWordsOneVar(const string& words, size_t limit,
+                                    IdTable* result) const {
+  return _pimpl->getECListForWordsOneVar(words, limit, result);
+}
+
+// _____________________________________________________________________________________
+void Index::getECListForWords(const string& words, size_t nofVars, size_t limit,
+                              IdTable* result) const {
+  return _pimpl->getECListForWords(words, nofVars, limit, result);
+}
+
+// __________________________________________________________________________
+void Index::getFilteredECListForWords(const string& words,
+                                      const IdTable& filter,
+                                      size_t filterColumn, size_t nofVars,
+                                      size_t limit, IdTable* result) const {
+  return _pimpl->getFilteredECListForWords(words, filter, filterColumn, nofVars,
+                                           limit, result);
+}
+
+// ____________________________________________________________________________
+void Index::getFilteredECListForWordsWidthOne(const string& words,
+                                              const IdTable& filter,
+                                              size_t nofVars, size_t limit,
+                                              IdTable* result) const {
+  return _pimpl->getFilteredECListForWordsWidthOne(words, filter, nofVars,
+                                                   limit, result);
+}
+
+// _____________________________________________________________________________
+void Index::getContextEntityScoreListsForWords(const string& words,
+                                               vector<Id>& cids,
+                                               vector<Id>& eids,
+                                               vector<Score>& scores) const {
+  return _pimpl->getContextEntityScoreListsForWords(words, cids, eids, scores);
+}
+
+// ____________________________________________________________________________
+template <size_t I>
+void Index::getECListForWordsAndSingleSub(const string& words,
+                                          const vector<array<Id, I>>& subres,
+                                          size_t subResMainCol, size_t limit,
+                                          vector<array<Id, 3 + I>>& res) const {
+  return _pimpl->template getECListForWordsAndSingleSub<I>(
+      words, subres, subResMainCol, limit, res);
+}
+
+// __________________________________________________________________________
+void Index::getECListForWordsAndTwoW1Subs(const string& words,
+                                          const vector<array<Id, 1>>& subres1,
+                                          const vector<array<Id, 1>>& subres2,
+                                          size_t limit,
+                                          vector<array<Id, 5>>& res) const {
+  return _pimpl->getECListForWordsAndTwoW1Subs(words, subres1, subres2, limit,
+                                               res);
 }
 
 // ___________________________________________________________________________
-std::future<void> Index::writeNextPartialVocabulary(
-    size_t numLines, size_t numFiles, size_t actualCurrentPartialSize,
-    std::shared_ptr<const std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS>> items,
-    std::unique_ptr<TripleVec> localIds,
-    TripleVec::bufwriter_type* globalWritePtr) {
-  LOG(INFO) << "Lines (from KB-file) processed: " << numLines << '\n';
-  LOG(INFO) << "Actual number of Triples in this section (include "
-               "langfilter triples): "
-            << actualCurrentPartialSize << '\n';
-  std::future<void> resultFuture;
-  string partialFilename =
-      _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
-  string partialCompressionFilename = _onDiskBase + TMP_BASENAME_COMPRESSION +
-                                      PARTIAL_VOCAB_FILE_NAME +
-                                      std::to_string(numFiles);
+void Index::getECListForWordsAndSubtrees(
+    const string& words,
+    const vector<ad_utility::HashMap<Id, vector<vector<Id>>>>& subResVecs,
+    size_t limit, vector<vector<Id>>& res) const {
+  return _pimpl->getECListForWordsAndSubtrees(words, subResVecs, limit, res);
+}
 
-  auto lambda = [localIds = std::move(localIds), globalWritePtr, items,
-                 vocab = &_vocab, partialFilename, partialCompressionFilename,
-                 vocabPrefixCompressed = _vocabPrefixCompressed]() {
-    auto vec = vocabMapsToVector(items);
-    const auto identicalPred = [& c = vocab->getCaseComparator()](
-                                   const auto& a, const auto& b) {
-      return c(a.second.m_splitVal, b.second.m_splitVal,
-               decltype(_vocab)::SortLevel::TOTAL);
-    };
-    LOG(INFO) << "Start sorting of vocabulary with #elements: " << vec.size()
-              << std::endl;
-    sortVocabVector(&vec, identicalPred, true);
-    LOG(INFO) << "Finished sorting of vocabulary" << std::endl;
-    auto mapping = createInternalMapping(&vec);
-    LOG(INFO) << "Finished creating of Mapping vocabulary" << std::endl;
-    auto sz = vec.size();
-    // since now adjacent duplicates also have the same Ids, it suffices to
-    // compare those
-    vec.erase(std::unique(vec.begin(), vec.end(),
-                          [](const auto& a, const auto& b) {
-                            return a.second.m_id == b.second.m_id;
-                          }),
-              vec.end());
-    LOG(INFO) << "Removed " << sz - vec.size()
-              << " Duplicates from the local partial vocabularies\n";
-    writeMappedIdsToExtVec(*localIds, mapping, globalWritePtr);
-    writePartialVocabularyToFile(vec, partialFilename);
-    if (vocabPrefixCompressed) {
-      // sort according to the actual byte values
-      LOG(INFO) << "Start sorting of vocabulary for prefix compression"
-                << std::endl;
-      sortVocabVector(
-          &vec, [](const auto& a, const auto& b) { return a.first < b.first; },
-          false);
-      LOG(INFO) << "Finished sorting of vocabulary for prefix compression"
-                << std::endl;
-      writePartialVocabularyToFile(vec, partialCompressionFilename);
-    }
-    LOG(INFO) << "Finished writing the partial vocabulary" << std::endl;
-  };
+// ____________________________________________________________________________
+void Index::getWordPostingsForTerm(const string& term, vector<Id>& cids,
+                                   vector<Score>& scores) const {
+  return _pimpl->getWordPostingsForTerm(term, cids, scores);
+}
 
-  return std::async(std::launch::async, std::move(lambda));
+// ____________________________________________________________________________
+void Index::getEntityPostingsForTerm(const string& term, vector<Id>& cids,
+                                     vector<Id>& eids,
+                                     vector<Score>& scores) const {
+  return _pimpl->getEntityPostingsForTerm(term, cids, eids, scores);
+}
+
+// ____________________________________________________________________________
+string Index::getTextExcerpt(Id cid) const {
+  return _pimpl->getTextExcerpt(cid);
+}
+
+// ____________________________________________________________________________
+float Index::getAverageNofEntityContexts() const {
+  return _pimpl->getAverageNofEntityContexts();
+}
+
+// ____________________________________________________________________________
+void Index::scan(Id key, IdTable* result, const Permutation& p,
+                 ad_utility::SharedConcurrentTimeoutTimer timer) const {
+  return _pimpl->scan(key, result, p, std::move(timer));
+}
+
+// ___________________________________________________________________________
+void Index::scan(const string& key, IdTable* result, const Permutation& p,
+                 ad_utility::SharedConcurrentTimeoutTimer timer) const {
+  return _pimpl->scan(key, result, p, std::move(timer));
+}
+
+// _____________________________________________________________________________
+void Index::scan(const string& keyFirst, const string& keySecond,
+                 IdTable* result, const Permutation& p) const {
+  return _pimpl->scan(keyFirst, keySecond, result, p);
 }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -3,60 +3,12 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 #pragma once
 
-#include <array>
-#include <fstream>
-#include <google/sparse_hash_set>
-#include <memory>
-#include <nlohmann/json.hpp>
-#include <optional>
-#include <string>
-#include <stxxl/vector>
-#include <vector>
-#include "../engine/ResultTable.h"
+#include "../engine/IdTable.h"
 #include "../global/Pattern.h"
-#include "../parser/NTriplesParser.h"
-#include "../parser/TsvParser.h"
-#include "../parser/TurtleParser.h"
-#include "../util/BufferedVector.h"
-#include "../util/File.h"
-#include "../util/HashMap.h"
-#include "../util/MmapVector.h"
-#include "../util/Timer.h"
-#include "./ConstantsIndexCreation.h"
-#include "./DocsDB.h"
-#include "./IndexBuilderTypes.h"
-#include "./IndexMetaData.h"
-#include "./Permutations.h"
-#include "./StxxlSortFunctors.h"
-#include "./TextMetaData.h"
 #include "./Vocabulary.h"
 
-using ad_utility::BufferedVector;
-using ad_utility::MmapVector;
-using ad_utility::MmapVectorView;
-using std::array;
-using std::shared_ptr;
-using std::string;
-using std::tuple;
-using std::vector;
-
-using json = nlohmann::json;
-
-// a simple struct for better naming
-struct VocabularyData {
-  using TripleVec = stxxl::vector<array<Id, 3>>;
-  // The total number of distinct words in the complete Vocabulary
-  size_t nofWords;
-  // Id lower and upper bound of @lang@<predicate> predicates
-  Id langPredLowerBound;
-  Id langPredUpperBound;
-  // The number of triples in the idTriples vec that each partial vocabulary is
-  // responsible for (depends on the number of additional language filter
-  // triples)
-  std::vector<size_t> actualPartialSizes;
-  // All the triples as Ids.
-  std::unique_ptr<TripleVec> idTriples;
-};
+// Forward declaration for Pimpl idiom
+class IndexImpl;
 
 /**
  * Used as a Template Argument to the createFromFile method, when we do not yet
@@ -66,10 +18,6 @@ class TurtleParserDummy {};
 
 class Index {
  public:
-  using TripleVec = stxxl::vector<array<Id, 3>>;
-  // Block Id, Context Id, Word Id, Score, entity
-  using TextVec = stxxl::vector<tuple<Id, Id, Id, Score, bool>>;
-  using Posting = std::tuple<Id, Id, Score>;
 
   // Forbid copy and assignment
   Index& operator=(const Index&) = delete;
@@ -77,48 +25,10 @@ class Index {
   Index(const Index&) = delete;
 
   Index();
+  ~Index();
 
-  struct IndexMetaDataMmapDispatcher {
-    using WriteType = IndexMetaDataMmap;
-    using ReadType = IndexMetaDataMmapView;
-  };
+  enum class Permutation { POS, PSO, SPO, SOP, OPS, OSP };
 
-  struct IndexMetaDataHmapDispatcher {
-    using WriteType = IndexMetaDataHmap;
-    using ReadType = IndexMetaDataHmap;
-  };
-
-  template <class A, class B>
-  using PermutationImpl = Permutation::PermutationImpl<A, B>;
-
-  // TODO: make those private and allow only const access
-  // instantiations for the 6 Permutations used in QLever
-  // They simplify the creation of permutations in the index class
-  PermutationImpl<SortByPOS, IndexMetaDataHmap> _POS =
-      Permutation::PermutationImpl<SortByPOS, IndexMetaDataHmap>(
-          SortByPOS(), "POS", ".pos", {1, 2, 0});
-  PermutationImpl<SortByPSO, IndexMetaDataHmap> _PSO =
-      Permutation::PermutationImpl<SortByPSO, IndexMetaDataHmap>(
-          SortByPSO(), "PSO", ".pso", {1, 0, 2});
-  PermutationImpl<SortBySOP, IndexMetaDataMmapView> _SOP =
-      Permutation::PermutationImpl<SortBySOP, IndexMetaDataMmapView>(
-          SortBySOP(), "SOP", ".sop", {0, 2, 1});
-  PermutationImpl<SortBySPO, IndexMetaDataMmapView> _SPO =
-      Permutation::PermutationImpl<SortBySPO, IndexMetaDataMmapView>(
-          SortBySPO(), "SPO", ".spo", {0, 1, 2});
-  PermutationImpl<SortByOPS, IndexMetaDataMmapView> _OPS =
-      Permutation::PermutationImpl<SortByOPS, IndexMetaDataMmapView>(
-          SortByOPS(), "OPS", ".ops", {2, 1, 0});
-  PermutationImpl<SortByOSP, IndexMetaDataMmapView> _OSP =
-      Permutation::PermutationImpl<SortByOSP, IndexMetaDataMmapView>(
-          SortByOSP(), "OSP", ".osp", {2, 0, 1});
-
-  const auto& POS() const { return _POS; }
-  const auto& PSO() const { return _PSO; }
-  const auto& SPO() const { return _SPO; }
-  const auto& SOP() const { return _SOP; }
-  const auto& OPS() const { return _OPS; }
-  const auto& OSP() const { return _OSP; }
 
   // Creates an index from a file. Parameter Parser must be able to split the
   // file's format into triples.
@@ -127,14 +37,6 @@ class Index {
   // by createFromOnDiskIndex after this call.
   template <class Parser>
   void createFromFile(const string& filename);
-
-  /**
-   * @brief create an Index from a turtle file
-   * Determine from the settings, which Tokenizer regex engine (google re2 or
-   * ctre) should be used
-   * @param filename
-   */
-  void createFromTurtleFile(const string& filename);
 
   void addPatternsToExistingIndex();
 
@@ -153,9 +55,9 @@ class Index {
   // Read necessary meta data into memory and opens file handles.
   void addTextFromOnDiskIndex();
 
-  const auto& getVocab() const { return _vocab; };
+  [[nodiscard]] const RdfsVocabulary& getVocab() const;
 
-  const auto& getTextVocab() const { return _textVocab; };
+  [[nodiscard]] const TextVocabulary& getTextVocab() const;
 
   // --------------------------------------------------------------------------
   //  -- RETRIEVAL ---
@@ -170,39 +72,37 @@ class Index {
   // --------------------------------------------------------------------------
   // RDF RETRIEVAL
   // --------------------------------------------------------------------------
-  size_t relationCardinality(const string& relationName) const;
+  [[nodiscard]] size_t relationCardinality(const string& relationName) const;
 
-  size_t subjectCardinality(const string& sub) const;
+  [[nodiscard]] size_t subjectCardinality(const string& sub) const;
 
-  size_t objectCardinality(const string& obj) const;
+  [[nodiscard]] size_t objectCardinality(const string& obj) const;
 
-  size_t sizeEstimate(const string& sub, const string& pred,
-                      const string& obj) const;
+  [[nodiscard]] size_t sizeEstimate(const string& sub, const string& pred,
+                                    const string& obj) const;
 
-  std::optional<string> idToOptionalString(Id id) const {
-    return _vocab.idToOptionalString(id);
-  }
+  [[nodiscard]] std::optional<string> idToOptionalString(Id id) const;
 
-  const vector<PatternID>& getHasPattern() const;
-  const CompactStringVector<Id, Id>& getHasPredicate() const;
-  const CompactStringVector<size_t, Id>& getPatterns() const;
+  [[nodiscard]] const vector<PatternID>& getHasPattern() const;
+  [[nodiscard]] const CompactStringVector<Id, Id>& getHasPredicate() const;
+  [[nodiscard]] const CompactStringVector<size_t, Id>& getPatterns() const;
   /**
    * @return The multiplicity of the Entites column (0) of the full has-relation
    *         relation after unrolling the patterns.
    */
-  double getHasPredicateMultiplicityEntities() const;
+  [[nodiscard]] double getHasPredicateMultiplicityEntities() const;
 
   /**
    * @return The multiplicity of the Predicates column (0) of the full
    * has-relation relation after unrolling the patterns.
    */
-  double getHasPredicateMultiplicityPredicates() const;
+  [[nodiscard]] double getHasPredicateMultiplicityPredicates() const;
 
   /**
    * @return The size of the full has-relation relation after unrolling the
    *         patterns.
    */
-  size_t getHasPredicateFullSize() const;
+  [[nodiscard]] size_t getHasPredicateFullSize() const;
 
   // --------------------------------------------------------------------------
   // TEXT RETRIEVAL
@@ -243,8 +143,8 @@ class Index {
                                      vector<array<Id, 3 + I>>& res) const;
 
   void getECListForWordsAndTwoW1Subs(const string& words,
-                                     const vector<array<Id, 1>> subres1,
-                                     const vector<array<Id, 1>> subres2,
+                                     const vector<array<Id, 1>>& subres1,
+                                     const vector<array<Id, 1>>& subres2,
                                      size_t limit,
                                      vector<array<Id, 5>>& res) const;
 
@@ -259,23 +159,9 @@ class Index {
   void getEntityPostingsForTerm(const string& term, vector<Id>& cids,
                                 vector<Id>& eids, vector<Score>& scores) const;
 
-  string getTextExcerpt(Id cid) const {
-    if (cid == ID_NO_VALUE) {
-      return std::string();
-    } else {
-      return _docsDB.getTextExcerpt(cid);
-    }
-  }
+  string getTextExcerpt(Id cid) const;
 
-  // Only for debug reasons and external encoding tests.
-  // Supply an empty vector to dump all lists above a size threshold.
-  void dumpAsciiLists(const vector<string>& lists, bool decodeGapsFreq) const;
-
-  void dumpAsciiLists(const TextBlockMetaData& tbmd) const;
-
-  float getAverageNofEntityContexts() const {
-    return _textMeta.getAverageNofEntityContexts();
-  };
+  float getAverageNofEntityContexts() const;
 
   void setKbName(const string& name);
 
@@ -293,73 +179,30 @@ class Index {
 
   void setPrefixCompression(bool compressed);
 
-  const string& getTextName() const { return _textMeta.getName(); }
+  const string& getTextName() const;
 
-  const string& getKbName() const { return _PSO.metaData().getName(); }
+  const string& getKbName() const;
 
-  size_t getNofTriples() const { return _PSO.metaData().getNofTriples(); }
+  size_t getNofTriples() const;
 
-  size_t getNofTextRecords() const { return _textMeta.getNofTextRecords(); }
-  size_t getNofWordPostings() const { return _textMeta.getNofWordPostings(); }
-  size_t getNofEntityPostings() const {
-    return _textMeta.getNofEntityPostings();
-  }
+  size_t getNofTextRecords() const;
+  size_t getNofWordPostings() const;
+  size_t getNofEntityPostings() const;
 
-  size_t getNofSubjects() const {
-    if (hasAllPermutations()) {
-      return _SPO.metaData().getNofDistinctC1();
-    } else {
-      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-               "Can only get # distinct subjects if all 6 permutations "
-               "have been registered on sever start (and index build time) "
-               "with the -a option.")
-    }
-  }
+  size_t getNofSubjects() const;
 
-  size_t getNofObjects() const {
-    if (hasAllPermutations()) {
-      return _OSP.metaData().getNofDistinctC1();
-    } else {
-      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-               "Can only get # distinct subjects if all 6 permutations "
-               "have been registered on sever start (and index build time) "
-               "with the -a option.")
-    }
-  }
+  size_t getNofObjects() const;
 
-  size_t getNofPredicates() const { return _PSO.metaData().getNofDistinctC1(); }
+  size_t getNofPredicates() const;
 
-  bool hasAllPermutations() const { return SPO()._file.isOpen(); }
+  bool hasAllPermutations() const;
 
-  // _____________________________________________________________________________
-  template <class PermutationImpl>
-  vector<float> getMultiplicities(const string& key,
-                                  const PermutationImpl& p) const {
-    Id keyId;
-    vector<float> res;
-    if (_vocab.getId(key, &keyId) && p._meta.relationExists(keyId)) {
-      auto rmd = p._meta.getRmd(keyId);
-      auto logM1 = rmd.getCol1LogMultiplicity();
-      res.push_back(static_cast<float>(pow(2, logM1)));
-      auto logM2 = rmd.getCol2LogMultiplicity();
-      res.push_back(static_cast<float>(pow(2, logM2)));
-    } else {
-      res.push_back(1);
-      res.push_back(1);
-    }
-    return res;
-  }
+  vector<float> getMultiplicities(const string& key, const Permutation p) const;
+  vector<float> getMultiplicities(const Permutation p) const;
 
-  // ___________________________________________________________________
-  template <class PermutationImpl>
-  vector<float> getMultiplicities(const PermutationImpl& p) const {
-    std::array<float, 3> m{
-        static_cast<float>(getNofTriples() / getNofSubjects()),
-        static_cast<float>(getNofTriples() / getNofPredicates()),
-        static_cast<float>(getNofTriples() / getNofObjects())};
-
-    return {m[p._keyOrder[0]], m[p._keyOrder[1]], m[p._keyOrder[2]]};
-  }
+  // Only for debug reasons and external encoding tests.
+  // Supply an empty vector to dump all lists above a size threshold.
+  void dumpAsciiLists(const vector<string>& lists, bool decodeGapsFreq) const;
 
   /**
    * @brief Perform a scan for one key i.e. retrieve all YZ from the XYZ
@@ -371,17 +214,8 @@ class Index {
    * @param p The Permutation to use (in particularly POS(), SOP,... members of
    * Index class).
    */
-  template <class Permutation>
   void scan(Id key, IdTable* result, const Permutation& p,
-            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const {
-    if (p._meta.relationExists(key)) {
-      const FullRelationMetaData& rmd = p._meta.getRmd(key)._rmdPairs;
-      result->reserve(rmd.getNofElements() + 2);
-      result->resize(rmd.getNofElements());
-      p._file.read(result->data(), rmd.getNofElements() * 2 * sizeof(Id),
-                   rmd._startFullIndex, std::move(timer));
-    }
-  }
+            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
 
   /**
    * @brief Perform a scan for one key i.e. retrieve all YZ from the XYZ
@@ -393,18 +227,8 @@ class Index {
    * @param p The Permutation to use (in particularly POS(), SOP,... members of
    * Index class).
    */
-  template <class Permutation>
   void scan(const string& key, IdTable* result, const Permutation& p,
-            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const {
-    LOG(DEBUG) << "Performing " << p._readableName
-               << " scan for full list for: " << key << "\n";
-    Id relId;
-    if (_vocab.getId(key, &relId)) {
-      LOG(TRACE) << "Successfully got key ID.\n";
-      scan(relId, result, p, std::move(timer));
-    }
-    LOG(DEBUG) << "Scan done, got " << result->size() << " elements.\n";
-  }
+            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
 
   /**
    * @brief Perform a scan for two keys i.e. retrieve all Z from the XYZ
@@ -421,355 +245,9 @@ class Index {
    * Index class).
    */
   // _____________________________________________________________________________
-  template <class PermutationInfo>
   void scan(const string& keyFirst, const string& keySecond, IdTable* result,
-            const PermutationInfo& p) const {
-    LOG(DEBUG) << "Performing " << p._readableName << "  scan of relation "
-               << keyFirst << " with fixed subject: " << keySecond << "...\n";
-    Id relId;
-    Id subjId;
-    if (_vocab.getId(keyFirst, &relId) && _vocab.getId(keySecond, &subjId)) {
-      if (p._meta.relationExists(relId)) {
-        auto rmd = p._meta.getRmd(relId);
-        if (rmd.hasBlocks()) {
-          pair<off_t, size_t> blockOff =
-              rmd._rmdBlocks->getBlockStartAndNofBytesForLhs(subjId);
-          // Functional relations have blocks point into the pair index,
-          // non-functional relations have them point into lhs lists
-          if (rmd.isFunctional()) {
-            scanFunctionalRelation(blockOff, subjId, p._file, result);
-          } else {
-            pair<off_t, size_t> block2 =
-                rmd._rmdBlocks->getFollowBlockForLhs(subjId);
-            scanNonFunctionalRelation(blockOff, block2, subjId, p._file,
-                                      rmd._rmdBlocks->_offsetAfter, result);
-          }
-        } else {
-          // If we don't have blocks, scan the whole relation and filter /
-          // restrict.
-          IdTable fullRelation(2, result->getAllocator());
-          fullRelation.resize(rmd.getNofElements());
-          p._file.read(fullRelation.data(),
-                       rmd.getNofElements() * 2 * sizeof(Id),
-                       rmd._rmdPairs._startFullIndex);
-          getRhsForSingleLhs(fullRelation, subjId, result);
-        }
-      } else {
-        LOG(DEBUG) << "No such relation.\n";
-      }
-    } else {
-      LOG(DEBUG) << "No such second order key.\n";
-    }
-    LOG(DEBUG) << "Scan done, got " << result->size() << " elements.\n";
-  }
+            const Permutation& p) const;
 
  private:
-  string _onDiskBase;
-  string _settingsFileName;
-  bool _onlyAsciiTurtlePrefixes = false;
-  bool _onDiskLiterals = false;
-  bool _keepTempFiles = false;
-  json _configurationJson;
-  Vocabulary<CompressedString, TripleComponentComparator> _vocab;
-  size_t _totalVocabularySize = 0;
-  bool _vocabPrefixCompressed = true;
-  Vocabulary<std::string, SimpleStringComparator> _textVocab;
-
-  TextMetaData _textMeta;
-  DocsDB _docsDB;
-  vector<Id> _blockBoundaries;
-  off_t _currentoff_t;
-  mutable ad_utility::File _textIndexFile;
-
-  // Pattern trick data
-  static const uint32_t PATTERNS_FILE_VERSION;
-  bool _usePatterns;
-  size_t _maxNumPatterns;
-  double _fullHasPredicateMultiplicityEntities;
-  double _fullHasPredicateMultiplicityPredicates;
-  size_t _fullHasPredicateSize;
-
-  size_t _parserBatchSize = PARSER_BATCH_SIZE;
-  size_t _numTriplesPerPartialVocab = NUM_TRIPLES_PER_PARTIAL_VOCAB;
-  /**
-   * @brief Maps pattern ids to sets of predicate ids.
-   */
-  CompactStringVector<size_t, Id> _patterns;
-  /**
-   * @brief Maps entity ids to pattern ids.
-   */
-  std::vector<PatternID> _hasPattern;
-  /**
-   * @brief Maps entity ids to sets of predicate ids
-   */
-  CompactStringVector<Id, Id> _hasPredicate;
-
-  // Create Vocabulary and directly write it to disk. Create TripleVec with all
-  // the triples converted to id space. This Vec can be used for creating
-  // permutations. Member _vocab will be empty after this because it is not
-  // needed for index creation once the TripleVec is set up and it would be a
-  // waste of RAM.
-  template <class Parser>
-  VocabularyData createIdTriplesAndVocab(const string& ntFile);
-
-  // ___________________________________________________________________
-  template <class Parser>
-  VocabularyData passFileForVocabulary(const string& ntFile,
-                                       size_t linesPerPartial);
-
-  /**
-   * @brief Everything that has to be done when we have seen all the triples
-   * that belong to one partial vocabulary, including Log output used inside
-   * passFileForVocabulary
-   *
-   * @param numLines How many Lines from the KB have we already parsed (only for
-   * Logging)
-   * @param numFiles How many partial vocabularies have we seen before/which is
-   * the index of the voc we are going to write
-   * @param actualCurrentPartialSize How many triples belong to this partition
-   * (including extra langfilter triples)
-   * @param items Contains our unsorted vocabulary. Maps words to their local
-   * ids within this vocabulary.
-   */
-  std::future<void> writeNextPartialVocabulary(
-      size_t numLines, size_t numFiles, size_t actualCurrentPartialSize,
-      std::shared_ptr<const ItemMapArray> items,
-      std::unique_ptr<TripleVec> localIds,
-      TripleVec::bufwriter_type* globalWritePtr);
-
-  void convertPartialToGlobalIds(TripleVec& data,
-                                 const vector<size_t>& actualLinesPerPartial,
-                                 size_t linesPerPartial);
-
-  size_t passContextFileForVocabulary(const string& contextFile);
-
-  void passContextFileIntoVector(const string& contextFile, TextVec& vec);
-
-  template <class MetaDataDispatcher>
-  std::optional<std::pair<typename MetaDataDispatcher::WriteType,
-                          typename MetaDataDispatcher::WriteType>>
-  createPermutationPairImpl(const string& fileName1, const string& fileName2,
-                            const Index::TripleVec& vec, size_t c0, size_t c1,
-                            size_t c2);
-
-  pair<FullRelationMetaData, BlockBasedRelationMetaData> writeSwitchedRel(
-      ad_utility::File* out, off_t lastOffset, Id currentRel,
-      ad_utility::BufferedVector<array<Id, 2>>* buffer);
-
-  // _______________________________________________________________________
-  // Create a pair of permutations. Only works for valid pairs (PSO-POS,
-  // OSP-OPS, SPO-SOP).  First creates the permutation and then exchanges the
-  // multiplicities and also writes the MetaData to disk. So we end up with
-  // fully functional permutations.
-  // performUnique must be set for the first pair created using vec to enforce
-  // RDF standard (no duplicate triples).
-  // createPatternsAfterFirst is only valid when  the pair is SPO-SOP because
-  // the SPO permutation is also needed for patterns (see usage in
-  // Index::createFromFile function)
-  template <class MetaDataDispatcher, class Comparator1, class Comparator2>
-  void createPermutationPair(
-      VocabularyData* vec,
-      const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
-          p1,
-      const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
-          p2,
-      bool performUnique = false, bool createPatternsAfterFirst = false);
-
-  // The pairs of permutations are PSO-POS, OSP-OPS and SPO-SOP
-  // the multiplicity of column 1 in partner 1 of the pair is equal to the
-  // multiplity of column 2 in partner 2
-  // This functions writes the multiplicities of the first column of one
-  // arguments to the 2nd column multiplicities of the other
-  template <class MetaData>
-  void exchangeMultiplicities(MetaData* m1, MetaData* m2);
-
-  // wrapper for createPermutation that saves a lot of code duplications
-  // Writes the permutation that is specified by argument permutation
-  // performs std::unique on arg vec iff arg performUnique is true (normally
-  // done for first permutation that is created using vec).
-  // Will sort vec.
-  // returns the MetaData (MmapBased or HmapBased) for this relation.
-  // Careful: only multiplicities for first column is valid after call, need to
-  // call exchangeMultiplicities as done by createPermutationPair
-  // the optional is std::nullopt if vec and thus the index is empty
-  template <class MetaDataDispatcher, class Comparator1, class Comparator2>
-  std::optional<std::pair<typename MetaDataDispatcher::WriteType,
-                          typename MetaDataDispatcher::WriteType>>
-  createPermutations(
-      TripleVec* vec,
-      const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
-          p1,
-      const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
-          p2,
-      bool performUnique);
-
-  /**
-   * @brief Creates the data required for the "pattern-trick" used for fast
-   *        ql:has-relation evaluation when selection relation counts.
-   * @param fileName The name of the file in which the data should be stored
-   * @param args The arguments that need to be passed to the constructor of
-   *             VecReaderType. VecReaderType should allow for iterating over
-   *             the tuples of the spo permutation after having been constructed
-   *             using args.
-   */
-  template <typename VecReaderType, typename... Args>
-  void createPatternsImpl(const string& fileName,
-                          CompactStringVector<Id, Id>& hasPredicate,
-                          std::vector<PatternID>& hasPattern,
-                          CompactStringVector<size_t, Id>& patterns,
-                          double& fullHasPredicateMultiplicityEntities,
-                          double& fullHasPredicateMultiplicityPredicates,
-                          size_t& fullHasPredicateSize,
-                          const size_t maxNumPatterns,
-                          const Id langPredLowerBound,
-                          const Id langPredUpperBound,
-                          const Args&... vecReaderArgs);
-
-  // wrap the static function using the internal member variables
-  // the bool indicates wether the TripleVec has to be sorted before the pattern
-  // creation
-  void createPatterns(bool vecAlreadySorted, VocabularyData* idTriples);
-
-  void createTextIndex(const string& filename, const TextVec& vec);
-
-  ContextListMetaData writePostings(ad_utility::File& out,
-                                    const vector<Posting>& postings,
-                                    bool skipWordlistIfAllTheSame);
-
-  // Add relation to permutation file. Calculate corresponding metaData
-  // (Mutliplicity of second column will be invalid and has to be set by a
-  // separate call to exchangeMultiplicities)
-  // Args:
-  //   out - permutation file to which we write the relation. Must be open.
-  //   currentOffset - the offset of this relation within the permutation file
-  //   relId - the Id of the 0-th column of this relation (e.g. the 'P' in PSO)
-  //   data - the 1st and 2nd column of this relation (e.g. the "SO" for a fixed
-  //          'P' in PSO. Must be sorted by 1. and then 2. column.
-  //   distinctC1 - the number of distinct elemens in 1. column of data ("S" in
-  //                PSO)
-  //   functional - is this relation functional (only one triple per value for
-  //                1. column)
-  // Returns:
-  //   The Meta Data (Permutation offsets) for this relation,
-  //   Careful: only multiplicity for first column is valid in return value
-  static pair<FullRelationMetaData, BlockBasedRelationMetaData> writeRel(
-      ad_utility::File& out, off_t currentOffset, Id relId,
-      const BufferedVector<array<Id, 2>>& data, size_t distinctC1,
-      bool functional);
-
-  static void writeFunctionalRelation(
-      const BufferedVector<array<Id, 2>>& data,
-      pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd);
-
-  static void writeNonFunctionalRelation(
-      ad_utility::File& out, const BufferedVector<array<Id, 2>>& data,
-      pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd);
-
-  void openTextFileHandle();
-
-  void scanFunctionalRelation(const pair<off_t, size_t>& blockOff, Id lhsId,
-                              ad_utility::File& indexFile,
-                              IdTable* result) const;
-
-  void scanNonFunctionalRelation(const pair<off_t, size_t>& blockOff,
-                                 const pair<off_t, size_t>& followBlock,
-                                 Id lhsId, ad_utility::File& indexFile,
-                                 off_t upperBound, IdTable* result) const;
-
-  void addContextToVector(TextVec::bufwriter_type& writer, Id context,
-                          const ad_utility::HashMap<Id, Score>& words,
-                          const ad_utility::HashMap<Id, Score>& entities);
-
-  template <typename T>
-  void readGapComprList(size_t nofElements, off_t from, size_t nofBytes,
-                        vector<T>& result) const;
-
-  template <typename T>
-  void readFreqComprList(size_t nofElements, off_t from, size_t nofBytes,
-                         vector<T>& result) const;
-
-  size_t getIndexOfBestSuitedElTerm(const vector<string>& terms) const;
-
-  void calculateBlockBoundaries();
-
-  Id getWordBlockId(Id wordId) const;
-
-  Id getEntityBlockId(Id entityId) const;
-
-  bool isEntityBlockId(Id blockId) const;
-
-  //! Writes a list of elements (have to be able to be cast to unit64_t)
-  //! to file.
-  //! Returns the number of bytes written.
-  template <class Numeric>
-  size_t writeList(Numeric* data, size_t nofElements,
-                   ad_utility::File& file) const;
-
-  typedef ad_utility::HashMap<Id, Id> IdCodeMap;
-  typedef ad_utility::HashMap<Score, Score> ScoreCodeMap;
-  typedef vector<Id> IdCodebook;
-  typedef vector<Score> ScoreCodebook;
-
-  //! Creates codebooks for lists that are supposed to be entropy encoded.
-  void createCodebooks(const vector<Posting>& postings, IdCodeMap& wordCodemap,
-                       IdCodebook& wordCodebook, ScoreCodeMap& scoreCodemap,
-                       ScoreCodebook& scoreCodebook) const;
-
-  template <class T>
-  size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file) const;
-
-  // FRIEND TESTS
-  friend class IndexTest_createFromTsvTest_Test;
-  friend class IndexTest_createFromOnDiskIndexTest_Test;
-  friend class CreatePatternsFixture_createPatterns_Test;
-
-  template <class T>
-  void writeAsciiListFile(const string& filename, const T& ids) const;
-
-  void getRhsForSingleLhs(const IdTable& in, Id lhsId, IdTable* result) const;
-
-  bool isLiteral(const string& object);
-
-  bool shouldBeExternalized(const string& object);
-  // convert value literals to internal representation
-  // and add externalization characters if necessary.
-  // Returns the language tag of spo[2] (the object) or ""
-  // if there is none.
-  LangtagAndTriple tripleToInternalRepresentation(Triple&& spo);
-
-  /**
-   * @brief Throws an exception if no patterns are loaded. Should be called from
-   *        whithin any index method that returns data requiring the patterns
-   *        file.
-   */
-  void throwExceptionIfNoPatterns() const;
-
-  void writeConfiguration() const;
-  void readConfiguration();
-
-  // initialize the index-build-time settings for the vocabulary
-  template <class Parser>
-  void initializeVocabularySettingsBuild();
-
-  // Helper function for Debugging during the index build.
-  // ExtVecs are not persistent, so we dump them to a mmapVector in a file with
-  // given filename
-  static void dumpExtVecToMmap(const TripleVec& vec, std::string filename) {
-    LOG(INFO) << "Dumping ext vec to mmap" << std::endl;
-    MmapVector<TripleVec::value_type> mmapVec(vec.size(), filename);
-    for (size_t i = 0; i < vec.size(); ++i) {
-      mmapVec[i] = vec[i];
-    }
-    LOG(INFO) << "Done" << std::endl;
-  }
-
-  /**
-   * Delete a temporary file unless the _keepTempFiles flag is set
-   * @param path
-   */
-  void deleteTemporaryFile(const string& path) {
-    if (!_keepTempFiles) {
-      ad_utility::deleteFile(path);
-    }
-  }
+  std::unique_ptr<IndexImpl> _pimpl;
 };

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -18,7 +18,6 @@ class TurtleParserDummy {};
 
 class Index {
  public:
-
   // Forbid copy and assignment
   Index& operator=(const Index&) = delete;
 
@@ -28,7 +27,6 @@ class Index {
   ~Index();
 
   enum class Permutation { POS, PSO, SPO, SOP, OPS, OSP };
-
 
   // Creates an index from a file. Parameter Parser must be able to split the
   // file's format into triples.

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <getopt.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
@@ -10,9 +11,12 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-
 #include <unordered_set>
+
 #include "../global/Constants.h"
+#include "../parser/NTriplesParser.h"
+#include "../parser/TsvParser.h"
+#include "../parser/TurtleParser.h"
 #include "../util/File.h"
 #include "../util/ReadableNumberFact.h"
 #include "../util/StringUtils.h"

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1676,9 +1676,8 @@ vector<float> IndexImpl::getMultiplicities(const Permutation p) const {
 }
 
 // ___________________________________________________________________________
-template <class PermutationImplementation>
-void IndexImpl::scanImpl(Id key, IdTable* result,
-                         const PermutationImplementation& p,
+template <PermutationConcept P>
+void IndexImpl::scanImpl(Id key, IdTable* result, const P& p,
                          ad_utility::SharedConcurrentTimeoutTimer timer) const {
   if (p._meta.relationExists(key)) {
     const FullRelationMetaData& rmd = p._meta.getRmd(key)._rmdPairs;
@@ -1699,9 +1698,8 @@ void IndexImpl::scan(Id key, IdTable* result, const Permutation& p,
 }
 
 // ____________________________________________________________________________
-template <class PermutationImplementation>
-void IndexImpl::scanImpl(const string& key, IdTable* result,
-                         const PermutationImplementation& p,
+template <PermutationConcept P>
+void IndexImpl::scanImpl(const string& key, IdTable* result, const P& p,
                          ad_utility::SharedConcurrentTimeoutTimer timer) const {
   LOG(DEBUG) << "Performing " << p._readableName
              << " scan for full list for: " << key << "\n";
@@ -1723,10 +1721,9 @@ void IndexImpl::scan(const string& key, IdTable* result, const Permutation& p,
 }
 
 // ____________________________________________________________________________
-template <class PermutationImplementation>
+template <PermutationConcept P>
 void IndexImpl::scanImpl(const string& keyFirst, const string& keySecond,
-                         IdTable* result,
-                         const PermutationImplementation& p) const {
+                         IdTable* result, const P& p) const {
   LOG(DEBUG) << "Performing " << p._readableName << "  scan of relation "
              << keyFirst << " with fixed subject: " << keySecond << "...\n";
   Id relId;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1,0 +1,1775 @@
+// Copyright 2014, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+
+#include "./IndexImpl.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <future>
+#include <optional>
+#include <stxxl/algorithm>
+#include <stxxl/map>
+#include <unordered_map>
+
+#include "../parser/NTriplesParser.h"
+#include "../parser/ParallelParseBuffer.h"
+#include "../parser/TsvParser.h"
+#include "../util/BatchedPipeline.h"
+#include "../util/Conversions.h"
+#include "../util/HashMap.h"
+#include "../util/TupleHelpers.h"
+#include "./Index.h"
+#include "./PrefixHeuristic.h"
+#include "./VocabularyGenerator.h"
+#include "MetaDataIterator.h"
+
+using std::array;
+
+const uint32_t IndexImpl::PATTERNS_FILE_VERSION = 0;
+
+// _____________________________________________________________________________
+IndexImpl::IndexImpl()
+    : _usePatterns(false),
+      _maxNumPatterns(std::numeric_limits<PatternID>::max() - 2) {}
+
+// _____________________________________________________________________________________________
+template <class Parser>
+VocabularyData IndexImpl::createIdTriplesAndVocab(const string& ntFile) {
+  auto vocabData =
+      passFileForVocabulary<Parser>(ntFile, _numTriplesPerPartialVocab);
+  // first save the total number of words, this is needed to initialize the
+  // dense IndexMetaData variants
+  _totalVocabularySize = vocabData.nofWords;
+  LOG(INFO) << "total size of vocabulary (internal and external) is "
+            << _totalVocabularySize << std::endl;
+
+  if (_onDiskLiterals) {
+    _vocab.externalizeLiteralsFromTextFile(
+        _onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME,
+        _onDiskBase + ".literals-index");
+  }
+  deleteTemporaryFile(_onDiskBase + EXTERNAL_LITS_TEXT_FILE_NAME);
+  // clear vocabulary to save ram (only information from partial binary files
+  // used from now on). This will preserve information about externalized
+  // Prefixes etc.
+  _vocab.clear();
+  convertPartialToGlobalIds(*vocabData.idTriples, vocabData.actualPartialSizes,
+                            NUM_TRIPLES_PER_PARTIAL_VOCAB);
+
+  return vocabData;
+}
+
+// _____________________________________________________________________________
+template <class Parser>
+void IndexImpl::createFromFile(const string& filename) {
+  string indexFilename = _onDiskBase + ".index";
+  _configurationJson["external-literals"] = _onDiskLiterals;
+
+  initializeVocabularySettingsBuild<Parser>();
+
+  VocabularyData vocabData;
+  if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserDummy>) {
+    if (_onlyAsciiTurtlePrefixes) {
+      LOG(INFO) << "Using the CTRE library for Tokenization\n";
+      vocabData =
+          createIdTriplesAndVocab<TurtleStreamParser<TokenizerCtre>>(filename);
+    } else {
+      LOG(INFO) << "Using the Google Re2 library for Tokenization\n";
+      vocabData =
+          createIdTriplesAndVocab<TurtleStreamParser<Tokenizer>>(filename);
+    }
+
+  } else {
+    vocabData = createIdTriplesAndVocab<Parser>(filename);
+  }
+
+  // also perform unique for first permutation
+  createPermutationPair<IndexMetaDataHmapDispatcher>(&vocabData, _PSO, _POS,
+                                                     true);
+  // also create Patterns after the Spo permutation if specified
+  createPermutationPair<IndexMetaDataMmapDispatcher>(&vocabData, _SPO, _SOP,
+                                                     false, _usePatterns);
+  createPermutationPair<IndexMetaDataMmapDispatcher>(&vocabData, _OSP, _OPS);
+
+  // if we have no compression, this will also copy the whole vocabulary.
+  // but since we expect compression to be the default case, this  should not
+  // hurt
+  string vocabFile = _onDiskBase + ".vocabulary";
+  string vocabFileTmp = _onDiskBase + ".vocabularyTmp";
+  std::vector<string> prefixes;
+  if (_vocabPrefixCompressed) {
+    // we have to use the "normally" sorted vocabulary for the prefix
+    // compression;
+    std::string vocabFileForPrefixCalculation =
+        _onDiskBase + TMP_BASENAME_COMPRESSION + ".vocabulary";
+    prefixes = calculatePrefixes(vocabFileForPrefixCalculation,
+                                 NUM_COMPRESSION_PREFIXES, 1, true);
+    std::ofstream prefixFile(_onDiskBase + PREFIX_FILE);
+    AD_CHECK(prefixFile.is_open());
+    for (const auto& prefix : prefixes) {
+      prefixFile << prefix << '\n';
+    }
+  }
+  _configurationJson["prefixes"] = _vocabPrefixCompressed;
+  Vocabulary<CompressedString, TripleComponentComparator>::prefixCompressFile(
+      vocabFile, vocabFileTmp, prefixes);
+
+  // TODO<joka921> maybe move this to its own function
+  if (std::rename(vocabFileTmp.c_str(), vocabFile.c_str())) {
+    LOG(INFO) << "Error: Rename the prefixed vocab file " << vocabFileTmp
+              << " to " << vocabFile << " set errno to " << errno
+              << ". Terminating...\n";
+    AD_CHECK(false);
+  }
+  writeConfiguration();
+}
+
+// explicit instantiations
+template void IndexImpl::createFromFile<TsvParser>(const string& filename);
+template void IndexImpl::createFromFile<NTriplesParser>(const string& filename);
+template void IndexImpl::createFromFile<TurtleStreamParser<Tokenizer>>(
+    const string& filename);
+template void IndexImpl::createFromFile<TurtleMmapParser<Tokenizer>>(
+    const string& filename);
+template void IndexImpl::createFromFile<TurtleParserDummy>(
+    const string& filename);
+
+// _____________________________________________________________________________
+template <class Parser>
+VocabularyData IndexImpl::passFileForVocabulary(const string& filename,
+                                                size_t linesPerPartial) {
+  auto parser = std::make_shared<Parser>(filename);
+  std::unique_ptr<TripleVec> idTriples(new TripleVec());
+  TripleVec::bufwriter_type writer(*idTriples);
+  bool parserExhausted = false;
+
+  size_t i = 0;
+  // already count the numbers of triples that will be used for the language
+  // filter
+  size_t numFiles = 0;
+
+  // we add extra triples
+  std::vector<size_t> actualPartialSizes;
+
+  std::future<void> sortFuture;
+  while (!parserExhausted) {
+    size_t actualCurrentPartialSize = 0;
+
+    std::unique_ptr<TripleVec> localIdTriples(new TripleVec());
+    TripleVec::bufwriter_type localWriter(*localIdTriples);
+
+    std::array<ItemMapManager, NUM_PARALLEL_ITEM_MAPS> itemArray;
+
+    {
+      auto p = ad_pipeline::setupParallelPipeline<1, NUM_PARALLEL_ITEM_MAPS>(
+          _parserBatchSize,
+          // when called, returns an optional to the next triple. If
+          // <linexPerPartial> triples were parsed, return std::nullopt. when
+          // the parser is unable to deliver triples, set parserExhausted to
+          // true and return std::nullopt. this is exactly the behavior we need,
+          // as a first step in the parallel Pipeline.
+          ParserBatcher(parser, linesPerPartial,
+                        [&]() { parserExhausted = true; }),
+          // convert each triple to the internal representation (e.g. special
+          // values for Numbers, externalized literals, etc.)
+          [this](Triple&& t) {
+            return tripleToInternalRepresentation(std::move(t));
+          },
+
+          // get the Ids for the original triple and the possibly added language
+          // Tag triples using the provided HashMaps via itemArray. See
+          // documentation of the function for more details
+          getIdMapLambdas<NUM_PARALLEL_ITEM_MAPS>(
+              &itemArray, linesPerPartial, &(_vocab.getCaseComparator())));
+
+      while (auto opt = p.getNextValue()) {
+        i++;
+        for (const auto& innerOpt : opt.value()) {
+          if (innerOpt) {
+            actualCurrentPartialSize++;
+            localWriter << innerOpt.value();
+          }
+        }
+        if (i % 10000000 == 0) {
+          LOG(INFO) << "Lines (from KB-file) processed: " << i << '\n';
+        }
+      }
+      LOG(INFO) << "WaitTimes for Pipeline in msecs\n";
+      for (const auto& t : p.getWaitingTime()) {
+        LOG(INFO) << t << " msecs\n";
+      }
+    }
+
+    localWriter.finish();
+    // wait until sorting the last partial vocabulary has finished
+    // to control the number of threads and the amount of memory used at the
+    // same time. typically sorting is finished before we reach again here so
+    // it is not a bottleneck.
+    if (sortFuture.valid()) {
+      sortFuture.get();
+    }
+    std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS> convertedMaps;
+    for (size_t j = 0; j < NUM_PARALLEL_ITEM_MAPS; ++j) {
+      convertedMaps[j] = std::move(itemArray[j]).moveMap();
+    }
+    auto oldItemPtr =
+        std::make_shared<const std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS>>(
+            std::move(convertedMaps));
+    sortFuture = writeNextPartialVocabulary(
+        i, numFiles, actualCurrentPartialSize, oldItemPtr,
+        std::move(localIdTriples), &writer);
+    numFiles++;
+    // Save the information how many triples this partial vocabulary actually
+    // deals with we will use this later for mapping from partial to global
+    // ids
+    actualPartialSizes.push_back(actualCurrentPartialSize);
+  }
+  if (sortFuture.valid()) {
+    sortFuture.get();
+  }
+  writer.finish();
+  LOG(INFO) << "Pass done." << endl;
+
+  if (_vocabPrefixCompressed) {
+    LOG(INFO) << "Merging temporary vocabulary for prefix compression";
+    {
+      VocabularyMerger m;
+      m.mergeVocabulary(_onDiskBase + TMP_BASENAME_COMPRESSION, numFiles,
+                        std::less<>());
+      LOG(INFO) << "Finished merging additional Vocabulary.";
+    }
+  }
+
+  LOG(INFO) << "Merging vocabulary\n";
+  const VocabularyMerger::VocMergeRes mergeRes = [&]() {
+    VocabularyMerger v;
+    auto sortPred = [cmp = &(_vocab.getCaseComparator())](std::string_view a,
+                                                          std::string_view b) {
+      return (*cmp)(a, b, decltype(_vocab)::SortLevel::TOTAL);
+    };
+
+    return v.mergeVocabulary(_onDiskBase, numFiles, sortPred);
+  }();
+  LOG(INFO) << "Finished Merging Vocabulary.\n";
+  VocabularyData res;
+  res.nofWords = mergeRes._numWordsTotal;
+  res.langPredLowerBound = mergeRes._langPredLowerBound;
+  res.langPredUpperBound = mergeRes._langPredUpperBound;
+
+  res.idTriples = std::move(idTriples);
+  res.actualPartialSizes = std::move(actualPartialSizes);
+
+  for (size_t n = 0; n < numFiles; ++n) {
+    string partialFilename =
+        _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(n);
+    deleteTemporaryFile(partialFilename);
+    if (_vocabPrefixCompressed) {
+      partialFilename = _onDiskBase + TMP_BASENAME_COMPRESSION +
+                        PARTIAL_VOCAB_FILE_NAME + std::to_string(n);
+      deleteTemporaryFile(partialFilename);
+    }
+  }
+
+  return res;
+}
+
+// _____________________________________________________________________________
+void IndexImpl::convertPartialToGlobalIds(
+    TripleVec& data, const vector<size_t>& actualLinesPerPartial,
+    size_t linesPerPartial) {
+  LOG(INFO) << "Updating Ids in stxxl vector to global Ids.\n";
+
+  size_t i = 0;
+  // iterate over all partial vocabularies
+  for (size_t partialNum = 0; partialNum < actualLinesPerPartial.size();
+       partialNum++) {
+    LOG(INFO) << "Lines processed: " << i << '\n';
+    LOG(INFO) << "Corresponding number of statements in original knowledgeBase:"
+              << linesPerPartial * partialNum << '\n';
+
+    std::string mmapFilename(_onDiskBase + PARTIAL_MMAP_IDS +
+                             std::to_string(partialNum));
+    LOG(INFO) << "Reading IdMap from " << mmapFilename << " ...\n";
+    ad_utility::HashMap<Id, Id> idMap = IdMapFromPartialIdMapFile(mmapFilename);
+    LOG(INFO) << "Done reading idMap\n";
+    // Delete the temporary file in which we stored this map
+    deleteTemporaryFile(mmapFilename);
+
+    // update the triples for which this partial vocabulary was responsible
+    for (size_t tmpNum = 0; tmpNum < actualLinesPerPartial[partialNum];
+         ++tmpNum) {
+      std::array<Id, 3> curTriple = data[i];
+
+      // for all triple elements find their mapping from partial to global ids
+      ad_utility::HashMap<Id, Id>::iterator iterators[3];
+      for (size_t k = 0; k < 3; ++k) {
+        iterators[k] = idMap.find(curTriple[k]);
+        if (iterators[k] == idMap.end()) {
+          LOG(INFO) << "not found in partial Vocab: " << curTriple[k] << '\n';
+          AD_CHECK(false);
+        }
+      }
+
+      // update the Element
+      data[i] = array<Id, 3>{
+          {iterators[0]->second, iterators[1]->second, iterators[2]->second}};
+
+      ++i;
+      if (i % 10000000 == 0) {
+        LOG(INFO) << "Lines processed: " << i << '\n';
+      }
+    }
+  }
+  LOG(INFO) << "Lines processed: " << i << '\n';
+  LOG(INFO) << "Pass done.\n";
+}
+
+pair<FullRelationMetaData, BlockBasedRelationMetaData>
+IndexImpl::writeSwitchedRel(ad_utility::File* out, off_t lastOffset,
+                            Id currentRel,
+                            ad_utility::BufferedVector<array<Id, 2>>* bufPtr) {
+  // sort according to the "switched" relation.
+  auto& buffer = *bufPtr;
+
+  for (auto& el : buffer) {
+    std::swap(el[0], el[1]);
+  }
+  std::sort(buffer.begin(), buffer.end(), [](const auto& a, const auto& b) {
+    return a[0] == b[0] ? a[1] < b[1] : a[0] < b[0];
+  });
+
+  Id lastLhs = std::numeric_limits<Id>::max();
+
+  bool functional = true;
+  size_t distinctC1 = 0;
+  for (const auto& el : buffer) {
+    if (el[0] == lastLhs) {
+      functional = false;
+    } else {
+      distinctC1++;
+    }
+    lastLhs = el[0];
+  }
+
+  return writeRel(*out, lastOffset, currentRel, buffer, distinctC1, functional);
+}
+
+// _____________________________________________________________________________
+template <class MetaDataDispatcher>
+std::optional<std::pair<typename MetaDataDispatcher::WriteType,
+                        typename MetaDataDispatcher::WriteType>>
+IndexImpl::createPermutationPairImpl(const string& fileName1,
+                                     const string& fileName2,
+                                     const IndexImpl::TripleVec& vec, size_t c0,
+                                     size_t c1, size_t c2) {
+  typename MetaDataDispatcher::WriteType metaData1;
+  typename MetaDataDispatcher::WriteType metaData2;
+  if constexpr (metaData1._isMmapBased) {
+    metaData1.setup(_totalVocabularySize, FullRelationMetaData::empty,
+                    fileName1 + MMAP_FILE_SUFFIX);
+    metaData2.setup(_totalVocabularySize, FullRelationMetaData::empty,
+                    fileName2 + MMAP_FILE_SUFFIX);
+  }
+
+  if (vec.size() == 0) {
+    LOG(WARN) << "Attempt to write an empty index!" << std::endl;
+    return std::nullopt;
+  }
+  ad_utility::File out1(fileName1, "w");
+  ad_utility::File out2(fileName2, "w");
+
+  LOG(INFO) << "Creating a pair of on-disk index permutation of " << vec.size()
+            << " elements / facts." << std::endl;
+  // Iterate over the vector and identify relation boundaries
+  size_t from = 0;
+  Id currentRel = vec[0][c0];
+  off_t lastOffset1 = 0;
+  off_t lastOffset2 = 0;
+  ad_utility::BufferedVector<array<Id, 2>> buffer(
+      THRESHOLD_RELATION_CREATION, fileName1 + ".tmp.MmapBuffer");
+  bool functional = true;
+  size_t distinctC1 = 1;
+  size_t sizeOfRelation = 0;
+  Id lastLhs = std::numeric_limits<Id>::max();
+  for (TripleVec::bufreader_type reader(vec); !reader.empty(); ++reader) {
+    if ((*reader)[c0] != currentRel) {
+      auto md = writeRel(out1, lastOffset1, currentRel, buffer, distinctC1,
+                         functional);
+      metaData1.add(md.first, md.second);
+      auto md2 = writeSwitchedRel(&out2, lastOffset2, currentRel, &buffer);
+      metaData2.add(md2.first, md2.second);
+      buffer.clear();
+      distinctC1 = 1;
+      lastOffset1 = metaData1.getOffsetAfter();
+      lastOffset2 = metaData2.getOffsetAfter();
+      currentRel = (*reader)[c0];
+      functional = true;
+    } else {
+      sizeOfRelation++;
+      if ((*reader)[c1] == lastLhs) {
+        functional = false;
+      } else {
+        distinctC1++;
+      }
+    }
+    buffer.push_back(array<Id, 2>{{(*reader)[c1], (*reader)[c2]}});
+    lastLhs = (*reader)[c1];
+  }
+  if (from < vec.size()) {
+    auto md =
+        writeRel(out1, lastOffset1, currentRel, buffer, distinctC1, functional);
+    metaData1.add(md.first, md.second);
+
+    auto md2 = writeSwitchedRel(&out2, lastOffset2, currentRel, &buffer);
+    metaData2.add(md2.first, md2.second);
+  }
+
+  LOG(INFO) << "Done creating index permutation." << std::endl;
+  LOG(INFO) << "Calculating statistics for these permutation.\n";
+  metaData1.calculateExpensiveStatistics();
+  metaData2.calculateExpensiveStatistics();
+  LOG(INFO) << "Writing statistics for this permutation:\n"
+            << metaData1.statistics() << std::endl;
+  LOG(INFO) << "Writing statistics for this permutation:\n"
+            << metaData2.statistics() << std::endl;
+
+  out1.close();
+  out2.close();
+  LOG(INFO) << "Permutation done.\n";
+  return std::make_pair(std::move(metaData1), std::move(metaData2));
+}
+
+// ________________________________________________________________________
+template <class MetaDataDispatcher, class Comparator1, class Comparator2>
+std::optional<std::pair<typename MetaDataDispatcher::WriteType,
+                        typename MetaDataDispatcher::WriteType>>
+IndexImpl::createPermutations(
+    TripleVec* vec,
+    const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
+        p1,
+    const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
+        p2,
+    bool performUnique) {
+  LOG(INFO) << "Sorting for " << p1._readableName << " permutation..."
+            << std::endl;
+  stxxl::sort(begin(*vec), end(*vec), p1._comp, STXXL_MEMORY_TO_USE);
+  LOG(INFO) << "Sort done." << std::endl;
+
+  if (performUnique) {
+    // this only has to be done for the first permutation (PSO)
+    LOG(INFO) << "Removing duplicate triples as these are not supported in RDF"
+              << std::endl;
+    LOG(INFO) << "Size before: " << vec->size() << std::endl;
+    auto last = std::unique(begin(*vec), end(*vec));
+    vec->resize(size_t(last - vec->begin()));
+    LOG(INFO) << "Done: unique." << std::endl;
+    LOG(INFO) << "Size after: " << vec->size() << std::endl;
+  }
+
+  return createPermutationPairImpl<MetaDataDispatcher>(
+      _onDiskBase + ".index" + p1._fileSuffix,
+      _onDiskBase + ".index" + p2._fileSuffix, *vec, p1._keyOrder[0],
+      p1._keyOrder[1], p1._keyOrder[2]);
+}
+
+// ________________________________________________________________________
+template <class MetaDataDispatcher, class Comparator1, class Comparator2>
+void IndexImpl::createPermutationPair(
+    VocabularyData* vocabData,
+    const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
+        p1,
+    const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
+        p2,
+    bool performUnique, bool createPatternsAfterFirst) {
+  auto metaData = createPermutations<MetaDataDispatcher>(
+      &(*vocabData->idTriples), p1, p2, performUnique);
+  if (createPatternsAfterFirst) {
+    // the second permutation does not alter the original triple vector,
+    // so this does still work.
+    createPatterns(true, vocabData);
+  }
+  if (metaData) {
+    LOG(INFO) << "Exchanging Multiplicities for " << p1._readableName << " and "
+              << p2._readableName << '\n';
+    exchangeMultiplicities(&(metaData.value().first),
+                           &(metaData.value().second));
+    LOG(INFO) << "Done" << '\n';
+    LOG(INFO) << "Writing MetaData for " << p1._readableName << " and "
+              << p2._readableName << '\n';
+    ad_utility::File f1(_onDiskBase + ".index" + p1._fileSuffix, "r+");
+    metaData.value().first.appendToFile(&f1);
+    ad_utility::File f2(_onDiskBase + ".index" + p2._fileSuffix, "r+");
+    metaData.value().second.appendToFile(&f2);
+    LOG(INFO) << "Done" << '\n';
+  }
+}
+
+// _________________________________________________________________________
+template <class MetaData>
+void IndexImpl::exchangeMultiplicities(MetaData* m1, MetaData* m2) {
+  for (auto it = m1->data().begin(); it != m1->data().end(); ++it) {
+    const FullRelationMetaData& constRmd = it->second;
+    // our MetaData classes have a read-only interface because normally the
+    // FuullRelationMetaData are created separately and then added and never
+    // changed. This function forms an exception to this pattern
+    // because calculation the 2nd column multiplicity separately for each
+    // permutation is inefficient. So it is fine to use const_cast here as an
+    // exception: we delibarately write to a read-only data structure and are
+    // knowing what we are doing
+    FullRelationMetaData& rmd = const_cast<FullRelationMetaData&>(constRmd);
+    m2->data()[it->first].setCol2LogMultiplicity(rmd.getCol1LogMultiplicity());
+    rmd.setCol2LogMultiplicity(m2->data()[it->first].getCol1LogMultiplicity());
+  }
+}
+
+// _____________________________________________________________________________
+void IndexImpl::addPatternsToExistingIndex() {
+  auto [langPredLowerBound, langPredUpperBound] = _vocab.prefix_range("@");
+  createPatternsImpl<MetaDataIterator<IndexMetaDataMmapView>,
+                     IndexMetaDataMmapView, ad_utility::File>(
+      _onDiskBase + ".index.patterns", _hasPredicate, _hasPattern, _patterns,
+      _fullHasPredicateMultiplicityEntities,
+      _fullHasPredicateMultiplicityPredicates, _fullHasPredicateSize,
+      _maxNumPatterns, langPredLowerBound, langPredUpperBound, _SPO.metaData(),
+      _SPO._file);
+}
+
+// _____________________________________________________________________________
+void IndexImpl::createPatterns(bool vecAlreadySorted,
+                               VocabularyData* vocabData) {
+  if (vecAlreadySorted) {
+    LOG(INFO) << "Vector already sorted for pattern creation." << std::endl;
+  } else {
+    LOG(INFO) << "Sorting for pattern creation..." << std::endl;
+    stxxl::sort(begin(*vocabData->idTriples), end(*vocabData->idTriples),
+                SortBySPO(), STXXL_MEMORY_TO_USE);
+    LOG(INFO) << "Sort done." << std::endl;
+  }
+  createPatternsImpl<TripleVec::bufreader_type>(
+      _onDiskBase + ".index.patterns", _hasPredicate, _hasPattern, _patterns,
+      _fullHasPredicateMultiplicityEntities,
+      _fullHasPredicateMultiplicityPredicates, _fullHasPredicateSize,
+      _maxNumPatterns, vocabData->langPredLowerBound,
+      vocabData->langPredUpperBound, *vocabData->idTriples);
+}
+
+// _____________________________________________________________________________
+template <typename VecReaderType, typename... Args>
+void IndexImpl::createPatternsImpl(
+    const string& fileName, CompactStringVector<Id, Id>& hasPredicate,
+    std::vector<PatternID>& hasPattern,
+    CompactStringVector<size_t, Id>& patterns,
+    double& fullHasPredicateMultiplicityEntities,
+    double& fullHasPredicateMultiplicityPredicates,
+    size_t& fullHasPredicateSize, const size_t maxNumPatterns,
+    const Id langPredLowerBound, const Id langPredUpperBound,
+    const Args&... vecReaderArgs) {
+  IndexMetaDataHmap meta;
+  using PatternsCountMap = ad_utility::HashMap<Pattern, size_t>;
+
+  LOG(INFO) << "Creating patterns file..." << std::endl;
+  VecReaderType reader(vecReaderArgs...);
+  if (reader.empty()) {
+    LOG(WARN) << "Triple vector was empty, no patterns created" << std::endl;
+    return;
+  }
+
+  PatternsCountMap patternCounts;
+  // determine the most common patterns
+  Pattern pattern;
+
+  size_t numValidPatterns = 0;
+  Id currentSubj = (*reader)[0];
+
+  for (; !reader.empty(); ++reader) {
+    auto triple = *reader;
+    if (triple[0] != currentSubj) {
+      currentSubj = triple[0];
+      numValidPatterns++;
+      patternCounts[pattern]++;
+      pattern.clear();
+    }
+    // don't list predicates twice
+    if (pattern.empty() || pattern.back() != triple[1]) {
+      // Ignore @..@ type language predicates
+      if (triple[1] < langPredLowerBound || triple[1] >= langPredUpperBound) {
+        pattern.push_back(triple[1]);
+      }
+    }
+  }
+  // process the last entry
+  patternCounts[pattern]++;
+  LOG(INFO) << "Counted patterns and found " << patternCounts.size()
+            << " distinct patterns." << std::endl;
+  LOG(INFO) << "Patterns were found for " << numValidPatterns << " entities."
+            << std::endl;
+
+  // stores patterns sorted by their number of occurences
+  size_t actualNumPatterns = patternCounts.size() < maxNumPatterns
+                                 ? patternCounts.size()
+                                 : maxNumPatterns;
+  LOG(INFO) << "Using " << actualNumPatterns << " of the "
+            << patternCounts.size() << " patterns that were found in the data."
+            << std::endl;
+  std::vector<std::pair<Pattern, size_t>> sortedPatterns;
+  sortedPatterns.reserve(actualNumPatterns);
+  auto comparePatternCounts =
+      [](const std::pair<Pattern, size_t>& first,
+         const std::pair<Pattern, size_t>& second) -> bool {
+    return first.second > second.second ||
+           (first.second == second.second && first.first > second.first);
+  };
+  for (auto& it : patternCounts) {
+    if (sortedPatterns.size() < maxNumPatterns) {
+      sortedPatterns.push_back(it);
+      if (sortedPatterns.size() == maxNumPatterns) {
+        LOG(DEBUG) << "Sorting patterns after initial insertions." << std::endl;
+        // actuall sort the sorted patterns
+        std::sort(sortedPatterns.begin(), sortedPatterns.end(),
+                  comparePatternCounts);
+      }
+    } else {
+      if (comparePatternCounts(it, sortedPatterns.back())) {
+        // The new element is larger than the smallest element in the vector.
+        // Insert it into the correct position in the vector using binary
+        // search.
+        sortedPatterns.pop_back();
+        auto sortedIt =
+            std::lower_bound(sortedPatterns.begin(), sortedPatterns.end(), it,
+                             comparePatternCounts);
+        sortedPatterns.insert(sortedIt, it);
+      }
+    }
+  }
+  if (sortedPatterns.size() < maxNumPatterns) {
+    LOG(DEBUG) << "Sorting patterns after all insertions." << std::endl;
+    // actuall sort the sorted patterns
+    std::sort(sortedPatterns.begin(), sortedPatterns.end(),
+              comparePatternCounts);
+  }
+
+  LOG(DEBUG) << "Number of sorted patterns: " << sortedPatterns.size()
+             << std::endl;
+
+  // store the actual patterns
+  std::vector<std::vector<Id>> buffer;
+  buffer.reserve(sortedPatterns.size());
+  for (const auto& p : sortedPatterns) {
+    buffer.push_back(p.first._data);
+  }
+  patterns.build(buffer);
+
+  std::unordered_map<Pattern, Id> patternSet;
+  patternSet.reserve(sortedPatterns.size());
+  for (size_t i = 0; i < sortedPatterns.size(); i++) {
+    patternSet.insert(std::pair<Pattern, Id>(sortedPatterns[i].first, i));
+  }
+
+  LOG(DEBUG) << "Pattern set size: " << patternSet.size() << std::endl;
+
+  // Associate entities with patterns if possible, store has-relation otherwise
+  ad_utility::MmapVectorTmp<std::array<Id, 2>> entityHasPattern(
+      fileName + ".mmap.entityHasPattern.tmp");
+  ad_utility::MmapVectorTmp<std::array<Id, 2>> entityHasPredicate(
+      fileName + ".mmap.entityHasPredicate.tmp");
+
+  size_t numEntitiesWithPatterns = 0;
+  size_t numEntitiesWithoutPatterns = 0;
+  size_t numInvalidEntities = 0;
+
+  // store how many entries there are in the full has-relation relation (after
+  // resolving all patterns) and how may distinct elements there are (for the
+  // multiplicity;
+  fullHasPredicateSize = 0;
+  size_t fullHasPredicateEntitiesDistinctSize = 0;
+  size_t fullHasPredicatePredicatesDistinctSize = 0;
+  // This vector stores if the pattern was already counted toward the distinct
+  // has relation predicates size.
+  std::vector<bool> haveCountedPattern(patternSet.size());
+
+  // the input triple list is in spo order, we only need a hash map for
+  // predicates
+  ad_utility::HashSet<Id> predicateHashSet;
+
+  pattern.clear();
+  currentSubj = (*VecReaderType(vecReaderArgs...))[0];
+  size_t patternIndex = 0;
+  // Create the has-relation and has-pattern predicates
+  for (VecReaderType reader2(vecReaderArgs...); !reader2.empty(); ++reader2) {
+    auto triple = *reader2;
+    if (triple[0] != currentSubj) {
+      // we have arrived at a new entity;
+      fullHasPredicateEntitiesDistinctSize++;
+      auto it = patternSet.find(pattern);
+      // increase the haspredicate size here as every predicate is only
+      // listed once per entity (otherwise it woul always be the same as
+      // vec.size()
+      fullHasPredicateSize += pattern.size();
+      if (it == patternSet.end()) {
+        numEntitiesWithoutPatterns++;
+        // The pattern does not exist, use the has-relation predicate instead
+        for (size_t i = 0; i < patternIndex; i++) {
+          if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+            predicateHashSet.insert(pattern[i]);
+            fullHasPredicatePredicatesDistinctSize++;
+          }
+          entityHasPredicate.push_back(
+              std::array<Id, 2>{currentSubj, pattern[i]});
+        }
+      } else {
+        numEntitiesWithPatterns++;
+        // The pattern does exist, add an entry to the has-pattern predicate
+        entityHasPattern.push_back(std::array<Id, 2>{currentSubj, it->second});
+        if (!haveCountedPattern[it->second]) {
+          haveCountedPattern[it->second] = true;
+          // iterate over the pattern once to
+          for (size_t i = 0; i < patternIndex; i++) {
+            if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+              predicateHashSet.insert(pattern[i]);
+              fullHasPredicatePredicatesDistinctSize++;
+            }
+          }
+        }
+      }
+      pattern.clear();
+      currentSubj = triple[0];
+      patternIndex = 0;
+    }
+    // don't list predicates twice
+    if (patternIndex == 0 || pattern[patternIndex - 1] != (triple[1])) {
+      // Ignore @..@ type language predicates
+      if (triple[1] < langPredLowerBound || triple[1] >= langPredUpperBound) {
+        pattern.push_back(triple[1]);
+        patternIndex++;
+      }
+    }
+  }
+  // process the last element
+  fullHasPredicateSize += pattern.size();
+  fullHasPredicateEntitiesDistinctSize++;
+  auto last = patternSet.find(pattern);
+  if (last == patternSet.end()) {
+    numEntitiesWithoutPatterns++;
+    // The pattern does not exist, use the has-relation predicate instead
+    for (size_t i = 0; i < patternIndex; i++) {
+      entityHasPredicate.push_back(std::array<Id, 2>{currentSubj, pattern[i]});
+      if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+        predicateHashSet.insert(pattern[i]);
+        fullHasPredicatePredicatesDistinctSize++;
+      }
+    }
+  } else {
+    numEntitiesWithPatterns++;
+    // The pattern does exist, add an entry to the has-pattern predicate
+    entityHasPattern.push_back(std::array<Id, 2>{currentSubj, last->second});
+    for (size_t i = 0; i < patternIndex; i++) {
+      if (predicateHashSet.find(pattern[i]) == predicateHashSet.end()) {
+        predicateHashSet.insert(pattern[i]);
+        fullHasPredicatePredicatesDistinctSize++;
+      }
+    }
+  }
+
+  fullHasPredicateMultiplicityEntities =
+      fullHasPredicateSize /
+      static_cast<double>(fullHasPredicateEntitiesDistinctSize);
+  fullHasPredicateMultiplicityPredicates =
+      fullHasPredicateSize /
+      static_cast<double>(fullHasPredicatePredicatesDistinctSize);
+
+  LOG(DEBUG) << "Number of entity-has-pattern entries: "
+             << entityHasPattern.size() << std::endl;
+  LOG(DEBUG) << "Number of entity-has-relation entries: "
+             << entityHasPredicate.size() << std::endl;
+
+  LOG(INFO) << "Found " << patterns.size() << " distinct patterns."
+            << std::endl;
+  LOG(INFO) << numEntitiesWithPatterns
+            << " of the databases entities have been assigned a pattern."
+            << std::endl;
+  LOG(INFO) << numEntitiesWithoutPatterns
+            << " of the databases entities have not been assigned a pattern."
+            << std::endl;
+  LOG(INFO) << "Of these " << numInvalidEntities
+            << " would have to large a pattern." << std::endl;
+
+  LOG(DEBUG) << "Total number of entities: "
+             << (numEntitiesWithoutPatterns + numEntitiesWithPatterns)
+             << std::endl;
+
+  LOG(DEBUG) << "Full has relation size: " << fullHasPredicateSize << std::endl;
+  LOG(DEBUG) << "Full has relation entity multiplicity: "
+             << fullHasPredicateMultiplicityEntities << std::endl;
+  LOG(DEBUG) << "Full has relation predicate multiplicity: "
+             << fullHasPredicateMultiplicityPredicates << std::endl;
+
+  // Store all data in the file
+  ad_utility::File file(fileName, "w");
+
+  // Write a byte of ones to make it less likely that an unversioned file is
+  // read as a versioned one (unversioned files begin with the id of the lowest
+  // entity that has a pattern).
+  // Then write the version, both multiplicitires and the full size.
+  unsigned char firstByte = 255;
+  file.write(&firstByte, sizeof(char));
+  file.write(&PATTERNS_FILE_VERSION, sizeof(uint32_t));
+  file.write(&fullHasPredicateMultiplicityEntities, sizeof(double));
+  file.write(&fullHasPredicateMultiplicityPredicates, sizeof(double));
+  file.write(&fullHasPredicateSize, sizeof(size_t));
+
+  // write the entityHasPatterns vector
+  size_t numHasPatterns = entityHasPattern.size();
+  file.write(&numHasPatterns, sizeof(size_t));
+  file.write(entityHasPattern.data(), sizeof(Id) * numHasPatterns * 2);
+
+  // write the entityHasPredicate vector
+  size_t numHasPredicatess = entityHasPredicate.size();
+  file.write(&numHasPredicatess, sizeof(size_t));
+  file.write(entityHasPredicate.data(), sizeof(Id) * numHasPredicatess * 2);
+
+  // write the patterns
+  patterns.write(file);
+  file.close();
+
+  LOG(INFO) << "Done creating patterns file." << std::endl;
+
+  // create the has-relation and has-pattern lookup vectors
+  if (entityHasPattern.size() > 0) {
+    hasPattern.resize(entityHasPattern.back()[0] + 1);
+    size_t pos = 0;
+    for (size_t i = 0; i < entityHasPattern.size(); i++) {
+      while (entityHasPattern[i][0] > pos) {
+        hasPattern[pos] = NO_PATTERN;
+        pos++;
+      }
+      hasPattern[pos] = entityHasPattern[i][1];
+      pos++;
+    }
+  }
+
+  vector<vector<Id>> hasPredicateTmp;
+  if (entityHasPredicate.size() > 0) {
+    hasPredicateTmp.resize(entityHasPredicate.back()[0] + 1);
+    size_t pos = 0;
+    for (size_t i = 0; i < entityHasPredicate.size(); i++) {
+      Id current = entityHasPredicate[i][0];
+      while (current > pos) {
+        pos++;
+      }
+      while (i < entityHasPredicate.size() &&
+             entityHasPredicate[i][0] == current) {
+        hasPredicateTmp.back().push_back(entityHasPredicate[i][1]);
+        i++;
+      }
+      pos++;
+    }
+  }
+  hasPredicate.build(hasPredicateTmp);
+}
+
+// _____________________________________________________________________________
+pair<FullRelationMetaData, BlockBasedRelationMetaData> IndexImpl::writeRel(
+    ad_utility::File& out, off_t currentOffset, Id relId,
+    const ad_utility::BufferedVector<array<Id, 2>>& data, size_t distinctC1,
+    bool functional) {
+  LOG(TRACE) << "Writing a relation ...\n";
+  AD_CHECK_GT(data.size(), 0);
+  LOG(TRACE) << "Calculating multiplicities ...\n";
+  double multC1 = functional ? 1.0 : data.size() / double(distinctC1);
+  // Dummy value that will be overwritten later
+  double multC2 = 42.42;
+  LOG(TRACE) << "Done calculating multiplicities.\n";
+  FullRelationMetaData rmd(
+      relId, currentOffset, data.size(), multC1, multC2, functional,
+      !functional && data.size() > USE_BLOCKS_INDEX_SIZE_TRESHOLD);
+
+  // Write the full pair index.
+  out.write(data.data(), data.size() * 2 * sizeof(Id));
+  pair<FullRelationMetaData, BlockBasedRelationMetaData> ret;
+  ret.first = rmd;
+
+  if (functional) {
+    writeFunctionalRelation(data, ret);
+  } else {
+    writeNonFunctionalRelation(out, data, ret);
+  };
+  LOG(TRACE) << "Done writing relation.\n";
+  return ret;
+}
+
+// _____________________________________________________________________________
+void IndexImpl::writeFunctionalRelation(
+    const BufferedVector<array<Id, 2>>& data,
+    pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd) {
+  // Only has to do something if there are blocks.
+  if (rmd.first.hasBlocks()) {
+    LOG(TRACE) << "Writing part for functional relation ...\n";
+    // Do not write extra LHS and RHS lists.
+    rmd.second._startRhs =
+        rmd.first._startFullIndex + rmd.first.getNofBytesForFulltextIndex();
+    // Since the relation is functional, there are no lhs lists and thus this
+    // is trivial.
+    rmd.second._offsetAfter = rmd.second._startRhs;
+    // Create the block data for the meta data.
+    // Blocks are offsets into the full pair index for functional relations.
+    size_t nofDistinctLhs = 0;
+    Id lastLhs = std::numeric_limits<Id>::max();
+    for (size_t i = 0; i < data.size(); ++i) {
+      if (data[i][0] != lastLhs) {
+        if (nofDistinctLhs % DISTINCT_LHS_PER_BLOCK == 0) {
+          rmd.second._blocks.emplace_back(BlockMetaData(
+              data[i][0], rmd.first._startFullIndex + i * 2 * sizeof(Id)));
+        }
+        ++nofDistinctLhs;
+      }
+    }
+  }
+}
+
+// _____________________________________________________________________________
+void IndexImpl::writeNonFunctionalRelation(
+    ad_utility::File& out, const BufferedVector<array<Id, 2>>& data,
+    pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd) {
+  // Only has to do something if there are blocks.
+  if (rmd.first.hasBlocks()) {
+    LOG(TRACE) << "Writing part for non-functional relation ...\n";
+    // Make a pass over the data and extract a RHS list for each LHS.
+    // Prepare both in buffers.
+    // TODO: add compression - at least to RHS.
+    pair<Id, off_t>* bufLhs = new pair<Id, off_t>[data.size()];
+    Id* bufRhs = new Id[data.size()];
+    size_t nofDistinctLhs = 0;
+    Id lastLhs = std::numeric_limits<Id>::max();
+    size_t nofRhsDone = 0;
+    for (; nofRhsDone < data.size(); ++nofRhsDone) {
+      if (data[nofRhsDone][0] != lastLhs) {
+        bufLhs[nofDistinctLhs++] =
+            pair<Id, off_t>(data[nofRhsDone][0], nofRhsDone * sizeof(Id));
+        lastLhs = data[nofRhsDone][0];
+      }
+      bufRhs[nofRhsDone] = data[nofRhsDone][1];
+    }
+
+    // Go over the Lhs data once more and adjust the offsets.
+    off_t startRhs = rmd.first.getStartOfLhs() +
+                     nofDistinctLhs * (sizeof(Id) + sizeof(off_t));
+
+    for (size_t i = 0; i < nofDistinctLhs; ++i) {
+      bufLhs[i].second += startRhs;
+    }
+
+    // Write to file.
+    out.write(bufLhs, nofDistinctLhs * (sizeof(Id) + sizeof(off_t)));
+    out.write(bufRhs, data.size() * sizeof(Id));
+
+    // Update meta data.
+    rmd.second._startRhs = startRhs;
+    rmd.second._offsetAfter =
+        startRhs + rmd.first.getNofElements() * sizeof(Id);
+
+    // Create the block data for the FullRelationMetaData.
+    // Block are offsets into the LHS list for non-functional relations.
+    for (size_t i = 0; i < nofDistinctLhs; ++i) {
+      if (i % DISTINCT_LHS_PER_BLOCK == 0) {
+        rmd.second._blocks.emplace_back(BlockMetaData(
+            bufLhs[i].first,
+            rmd.first.getStartOfLhs() + i * (sizeof(Id) + sizeof(off_t))));
+      }
+    }
+    delete[] bufLhs;
+    delete[] bufRhs;
+  }
+}
+
+// _____________________________________________________________________________
+void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
+  setOnDiskBase(onDiskBase);
+  readConfiguration();
+  _vocab.readFromFile(_onDiskBase + ".vocabulary",
+                      _onDiskLiterals ? _onDiskBase + ".literals-index" : "");
+
+  _totalVocabularySize = _vocab.size() + _vocab.getExternalVocab().size();
+  LOG(INFO) << "total vocab size is " << _totalVocabularySize << std::endl;
+  _PSO.loadFromDisk(_onDiskBase);
+  _POS.loadFromDisk(_onDiskBase);
+  _OPS.loadFromDisk(_onDiskBase);
+  _OSP.loadFromDisk(_onDiskBase);
+  _SPO.loadFromDisk(_onDiskBase);
+  _SOP.loadFromDisk(_onDiskBase);
+
+  if (_usePatterns) {
+    // Read the pattern info from the patterns file
+    std::string patternsFilePath = _onDiskBase + ".index.patterns";
+    ad_utility::File patternsFile;
+    patternsFile.open(patternsFilePath, "r");
+    AD_CHECK(patternsFile.isOpen());
+    off_t off = 0;
+    unsigned char firstByte;
+    patternsFile.read(&firstByte, sizeof(char), off);
+    off++;
+    uint32_t version;
+    patternsFile.read(&version, sizeof(uint32_t), off);
+    off += sizeof(uint32_t);
+    if (version != PATTERNS_FILE_VERSION || firstByte != 255) {
+      version = firstByte == 255 ? version : -1;
+      _usePatterns = false;
+      patternsFile.close();
+      std::ostringstream oss;
+      oss << "The patterns file " << patternsFilePath << " version of "
+          << version << " does not match the programs pattern file "
+          << "version of " << PATTERNS_FILE_VERSION << ". Rebuild the index"
+          << " or start the query engine without pattern support." << std::endl;
+      throw std::runtime_error(oss.str());
+    } else {
+      patternsFile.read(&_fullHasPredicateMultiplicityEntities, sizeof(double),
+                        off);
+      off += sizeof(double);
+      patternsFile.read(&_fullHasPredicateMultiplicityPredicates,
+                        sizeof(double), off);
+      off += sizeof(double);
+      patternsFile.read(&_fullHasPredicateSize, sizeof(size_t), off);
+      off += sizeof(size_t);
+
+      // read the entity has patterns vector
+      size_t hasPatternSize;
+      patternsFile.read(&hasPatternSize, sizeof(size_t), off);
+      off += sizeof(size_t);
+      std::vector<array<Id, 2>> entityHasPattern(hasPatternSize);
+      patternsFile.read(entityHasPattern.data(),
+                        hasPatternSize * sizeof(Id) * 2, off);
+      off += hasPatternSize * sizeof(Id) * 2;
+
+      // read the entity has relation vector
+      size_t hasPredicateSize;
+      patternsFile.read(&hasPredicateSize, sizeof(size_t), off);
+      off += sizeof(size_t);
+      std::vector<array<Id, 2>> entityHasPredicate(hasPredicateSize);
+      patternsFile.read(entityHasPredicate.data(),
+                        hasPredicateSize * sizeof(Id) * 2, off);
+      off += hasPredicateSize * sizeof(Id) * 2;
+
+      // read the patterns
+      _patterns.load(patternsFile, off);
+
+      // create the has-relation and has-pattern lookup vectors
+      if (entityHasPattern.size() > 0) {
+        _hasPattern.resize(entityHasPattern.back()[0] + 1);
+        size_t pos = 0;
+        for (size_t i = 0; i < entityHasPattern.size(); i++) {
+          while (entityHasPattern[i][0] > pos) {
+            _hasPattern[pos] = NO_PATTERN;
+            pos++;
+          }
+          _hasPattern[pos] = entityHasPattern[i][1];
+          pos++;
+        }
+      }
+
+      vector<vector<Id>> hasPredicateTmp;
+      if (entityHasPredicate.size() > 0) {
+        hasPredicateTmp.resize(entityHasPredicate.back()[0] + 1);
+        size_t pos = 0;
+        for (size_t i = 0; i < entityHasPredicate.size(); i++) {
+          Id current = entityHasPredicate[i][0];
+          while (current > pos) {
+            pos++;
+          }
+          while (i < entityHasPredicate.size() &&
+                 entityHasPredicate[i][0] == current) {
+            hasPredicateTmp.back().push_back(entityHasPredicate[i][1]);
+            i++;
+          }
+          pos++;
+        }
+      }
+      _hasPredicate.build(hasPredicateTmp);
+    }
+  }
+}
+
+// _____________________________________________________________________________
+void IndexImpl::throwExceptionIfNoPatterns() const {
+  if (!_usePatterns) {
+    AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+             "The requested feature requires a loaded patterns file ("
+             "do not specify the --no-patterns option for this to work)");
+  }
+}
+
+// _____________________________________________________________________________
+const vector<PatternID>& IndexImpl::getHasPattern() const {
+  throwExceptionIfNoPatterns();
+  return _hasPattern;
+}
+
+// _____________________________________________________________________________
+const CompactStringVector<Id, Id>& IndexImpl::getHasPredicate() const {
+  throwExceptionIfNoPatterns();
+  return _hasPredicate;
+}
+
+// _____________________________________________________________________________
+const CompactStringVector<size_t, Id>& IndexImpl::getPatterns() const {
+  throwExceptionIfNoPatterns();
+  return _patterns;
+}
+
+// _____________________________________________________________________________
+double IndexImpl::getHasPredicateMultiplicityEntities() const {
+  throwExceptionIfNoPatterns();
+  return _fullHasPredicateMultiplicityEntities;
+}
+
+// _____________________________________________________________________________
+double IndexImpl::getHasPredicateMultiplicityPredicates() const {
+  throwExceptionIfNoPatterns();
+  return _fullHasPredicateMultiplicityPredicates;
+}
+
+// _____________________________________________________________________________
+size_t IndexImpl::getHasPredicateFullSize() const {
+  throwExceptionIfNoPatterns();
+  return _fullHasPredicateSize;
+}
+
+// _____________________________________________________________________________
+void IndexImpl::scanFunctionalRelation(const pair<off_t, size_t>& blockOff,
+                                       Id lhsId, ad_utility::File& indexFile,
+                                       IdTable* result) const {
+  if (blockOff.second == 0) {
+    // TODO<joka921> this check should be in the callers, but for that I want to
+    // refactor the code duplication there first
+    // nothing to do if the result is empty
+    return;
+  }
+  LOG(TRACE) << "Scanning functional relation ...\n";
+  WidthTwoList block;
+  block.resize(blockOff.second / (2 * sizeof(Id)));
+  indexFile.read(block.data(), blockOff.second, blockOff.first);
+  auto it = std::lower_bound(
+      block.begin(), block.end(), lhsId,
+      [](const array<Id, 2>& elem, Id key) { return elem[0] < key; });
+  if ((*it)[0] == lhsId) {
+    result->push_back({(*it)[1]});
+  }
+  LOG(TRACE) << "Read " << result->size() << " RHS.\n";
+}
+
+// _____________________________________________________________________________
+void IndexImpl::scanNonFunctionalRelation(
+    const pair<off_t, size_t>& blockOff, const pair<off_t, size_t>& followBlock,
+    Id lhsId, ad_utility::File& indexFile, off_t upperBound,
+    IdTable* result) const {
+  LOG(TRACE) << "Scanning non-functional relation ...\n";
+
+  if (blockOff.second == 0) {
+    // TODO<joka921> this check should be in the callers, but for that I want to
+    // refactor the code duplication there first
+    // nothing to do if the result is empty
+    return;
+  }
+  vector<pair<Id, off_t>> block;
+  block.resize(blockOff.second / (sizeof(Id) + sizeof(off_t)));
+  indexFile.read(block.data(), blockOff.second, blockOff.first);
+  auto it = std::lower_bound(
+      block.begin(), block.end(), lhsId,
+      [](const pair<Id, off_t>& elem, Id key) { return elem.first < key; });
+  if (it->first == lhsId) {
+    size_t nofBytes = 0;
+    if ((it + 1) != block.end()) {
+      LOG(TRACE) << "Obtained upper bound from same block!\n";
+      nofBytes = static_cast<size_t>((it + 1)->second - it->second);
+    } else {
+      // Look at the follow block to determine the upper bound / nofBytes.
+      if (followBlock.first == blockOff.first) {
+        LOG(TRACE) << "Last block of relation, using rel upper bound!\n";
+        nofBytes = static_cast<size_t>(upperBound - it->second);
+      } else {
+        LOG(TRACE) << "Special case: extra scan of follow block!\n";
+        pair<Id, off_t> follower;
+        indexFile.read(&follower, sizeof(follower), followBlock.first);
+        nofBytes = static_cast<size_t>(follower.second - it->second);
+      }
+    }
+    result->resize(nofBytes / sizeof(Id));
+    indexFile.read(result->data(), nofBytes, it->second);
+  } else {
+    LOG(TRACE) << "Could not find LHS in block. Result will be empty.\n";
+  }
+}
+
+// _____________________________________________________________________________
+size_t IndexImpl::relationCardinality(const string& relationName) const {
+  if (relationName == INTERNAL_TEXT_MATCH_PREDICATE) {
+    return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
+  }
+  Id relId;
+  if (_vocab.getId(relationName, &relId)) {
+    if (this->_PSO.metaData().relationExists(relId)) {
+      return this->_PSO.metaData().getRmd(relId).getNofElements();
+    }
+  }
+  return 0;
+}
+
+// _____________________________________________________________________________
+size_t IndexImpl::subjectCardinality(const string& sub) const {
+  Id relId;
+  if (_vocab.getId(sub, &relId)) {
+    if (this->_SPO.metaData().relationExists(relId)) {
+      return this->_SPO.metaData().getRmd(relId).getNofElements();
+    }
+  }
+  return 0;
+}
+
+// _____________________________________________________________________________
+size_t IndexImpl::objectCardinality(const string& obj) const {
+  Id relId;
+  if (_vocab.getId(obj, &relId)) {
+    if (this->_OSP.metaData().relationExists(relId)) {
+      return this->_OSP.metaData().getRmd(relId).getNofElements();
+    }
+  }
+  return 0;
+}
+
+// _____________________________________________________________________________
+size_t IndexImpl::sizeEstimate(const string& sub, const string& pred,
+                               const string& obj) const {
+  // One or two of the parameters have to be empty strings.
+  // This determines the permutations to use.
+
+  // With only one nonempty string, we can get the exact count.
+  // With two, we can check if the relation is functional (return 1) or not
+  // where we approximate the result size by the block size.
+  if (sub.size() > 0 && pred.size() == 0 && obj.size() == 0) {
+    return subjectCardinality(sub);
+  }
+  if (sub.size() == 0 && pred.size() > 0 && obj.size() == 0) {
+    return relationCardinality(pred);
+  }
+  if (sub.size() == 0 && pred.size() == 0 && obj.size() > 0) {
+    return objectCardinality(obj);
+  }
+  if (sub.size() == 0 && pred.size() == 0 && obj.size() == 0) {
+    return getNofTriples();
+  }
+  AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+           "IndexImpl::sizeEsimate called with more then one of S/P/O given. "
+           "This should never be the case anymore, "
+           " since for such SCANs we compute the result "
+           "directly and don't need an estimate anymore!");
+}
+
+// _____________________________________________________________________________
+template <class T>
+void IndexImpl::writeAsciiListFile(const string& filename, const T& ids) const {
+  std::ofstream f(filename);
+
+  for (size_t i = 0; i < ids.size(); ++i) {
+    f << ids[i] << ' ';
+  }
+  f.close();
+}
+
+template void IndexImpl::writeAsciiListFile<vector<Id>>(
+    const string& filename, const vector<Id>& ids) const;
+
+template void IndexImpl::writeAsciiListFile<vector<Score>>(
+    const string& filename, const vector<Score>& ids) const;
+
+// _____________________________________________________________________________
+bool IndexImpl::isLiteral(const string& object) {
+  return decltype(_vocab)::isLiteral(object);
+}
+
+// _____________________________________________________________________________
+bool IndexImpl::shouldBeExternalized(const string& object) {
+  return _vocab.shouldBeExternalized(object);
+}
+
+// _____________________________________________________________________________
+void IndexImpl::setKbName(const string& name) {
+  _POS.setKbName(name);
+  _PSO.setKbName(name);
+  _SOP.setKbName(name);
+  _SPO.setKbName(name);
+  _OPS.setKbName(name);
+  _OSP.setKbName(name);
+}
+
+// ____________________________________________________________________________
+void IndexImpl::setOnDiskLiterals(bool onDiskLiterals) {
+  _onDiskLiterals = onDiskLiterals;
+}
+
+// ____________________________________________________________________________
+void IndexImpl::setOnDiskBase(const std::string& onDiskBase) {
+  _onDiskBase = onDiskBase;
+}
+
+// ____________________________________________________________________________
+void IndexImpl::setKeepTempFiles(bool keepTempFiles) {
+  _keepTempFiles = keepTempFiles;
+}
+
+// _____________________________________________________________________________
+void IndexImpl::setUsePatterns(bool usePatterns) { _usePatterns = usePatterns; }
+
+// ____________________________________________________________________________
+void IndexImpl::setSettingsFile(const std::string& filename) {
+  _settingsFileName = filename;
+}
+
+// ____________________________________________________________________________
+void IndexImpl::setPrefixCompression(bool compressed) {
+  _vocabPrefixCompressed = compressed;
+}
+
+// ____________________________________________________________________________
+void IndexImpl::writeConfiguration() const {
+  std::ofstream f(_onDiskBase + CONFIGURATION_FILE);
+  AD_CHECK(f.is_open());
+  f << _configurationJson;
+}
+
+// ___________________________________________________________________________
+void IndexImpl::readConfiguration() {
+  std::ifstream f(_onDiskBase + CONFIGURATION_FILE);
+  AD_CHECK(f.is_open());
+  f >> _configurationJson;
+  if (_configurationJson.find("external-literals") !=
+      _configurationJson.end()) {
+    _onDiskLiterals = _configurationJson["external-literals"];
+  }
+
+  if (_configurationJson.find("prefixes") != _configurationJson.end()) {
+    if (_configurationJson["prefixes"]) {
+      vector<string> prefixes;
+      std::ifstream prefixFile(_onDiskBase + PREFIX_FILE);
+      AD_CHECK(prefixFile.is_open());
+      for (string prefix; std::getline(prefixFile, prefix);) {
+        prefixes.emplace_back(std::move(prefix));
+      }
+      _vocab.initializePrefixes(prefixes);
+    } else {
+      _vocab.initializePrefixes(std::vector<std::string>());
+    }
+  }
+
+  if (_configurationJson.find("prefixes-external") !=
+      _configurationJson.end()) {
+    _vocab.initializeExternalizePrefixes(
+        _configurationJson["prefixes-external"]);
+  }
+
+  if (_configurationJson.count("ignore-case")) {
+    LOG(ERROR) << ERROR_IGNORE_CASE_UNSUPPORTED << '\n';
+    throw std::runtime_error("Deprecated key \"ignore-case\" in index build");
+  }
+
+  if (_configurationJson.count("locale")) {
+    std::string lang = _configurationJson["locale"]["language"];
+    std::string country = _configurationJson["locale"]["country"];
+    bool ignorePunctuation = _configurationJson["locale"]["ignore-punctuation"];
+    _vocab.setLocale(lang, country, ignorePunctuation);
+    _textVocab.setLocale(lang, country, ignorePunctuation);
+  } else {
+    LOG(ERROR) << "Key \"locale\" is missing in the metadata. This is probably "
+                  "and old index build that is no longer supported by QLever. "
+                  "Please rebuild your index\n";
+    throw std::runtime_error(
+        "Missing required key \"locale\" in index build's metadata");
+  }
+
+  if (_configurationJson.find("languages-internal") !=
+      _configurationJson.end()) {
+    _vocab.initializeInternalizedLangs(
+        _configurationJson["languages-internal"]);
+  }
+}
+
+// ___________________________________________________________________________
+LangtagAndTriple IndexImpl::tripleToInternalRepresentation(Triple&& tripleIn) {
+  LangtagAndTriple res{"", std::move(tripleIn)};
+  auto& spo = res._triple;
+  for (auto& el : spo) {
+    el = _vocab.getLocaleManager().normalizeUtf8(el);
+  }
+  size_t upperBound = 3;
+  if (ad_utility::isXsdValue(spo[2])) {
+    spo[2] = ad_utility::convertValueLiteralToIndexWord(spo[2]);
+    upperBound = 2;
+  } else if (isLiteral(spo[2])) {
+    res._langtag = decltype(_vocab)::getLanguage(spo[2]);
+  }
+
+  for (size_t k = 0; k < upperBound; ++k) {
+    if (_onDiskLiterals && _vocab.shouldBeExternalized(spo[k])) {
+      if (isLiteral(spo[k])) {
+        spo[k][0] = EXTERNALIZED_LITERALS_PREFIX_CHAR;
+      } else {
+        AD_CHECK(spo[k][0] == '<');
+        spo[k][0] = EXTERNALIZED_ENTITIES_PREFIX_CHAR;
+      }
+    }
+  }
+  return res;
+}
+
+// ___________________________________________________________________________
+template <class Parser>
+void IndexImpl::initializeVocabularySettingsBuild() {
+  json j;  // if we have no settings, we still have to initialize some default
+  // values
+  if (!_settingsFileName.empty()) {
+    std::ifstream f(_settingsFileName);
+    AD_CHECK(f.is_open());
+    f >> j;
+  }
+
+  if (j.find("prefixes-external") != j.end()) {
+    _vocab.initializeExternalizePrefixes(j["prefixes-external"]);
+    _configurationJson["prefixes-external"] = j["prefixes-external"];
+    _onDiskLiterals = true;
+    _configurationJson["external-literals"] = true;
+  }
+
+  if (j.count("ignore-case")) {
+    LOG(ERROR) << ERROR_IGNORE_CASE_UNSUPPORTED << '\n';
+    throw std::runtime_error("Deprecated key \"ignore-case\" in settings JSON");
+  }
+
+  /**
+   * ICU uses two separate arguments for each Locale, the language ("en" or
+   * "fr"...) and the country ("GB", "CA"...). The encoding has to be known at
+   * compile time for ICU and will always be UTF-8 so it is not part of the
+   * locale setting.
+   */
+
+  {
+    std::string lang = LOCALE_DEFAULT_LANG;
+    std::string country = LOCALE_DEFAULT_COUNTRY;
+    bool ignorePunctuation = LOCALE_DEFAULT_IGNORE_PUNCTUATION;
+    if (j.count("locale")) {
+      lang = j["locale"]["language"];
+      country = j["locale"]["country"];
+      ignorePunctuation = j["locale"]["ignore-punctuation"];
+    } else {
+      LOG(INFO) << "locale was not specified by the settings JSON, defaulting "
+                   "to en US\n";
+    }
+    LOG(INFO) << "Using Locale " << lang << " " << country
+              << " with ignore-punctuation: " << ignorePunctuation << '\n';
+
+    if (lang != LOCALE_DEFAULT_LANG || country != LOCALE_DEFAULT_COUNTRY) {
+      LOG(WARN) << "You are using Locale settings that differ from the default "
+                   "language or country.\n\t"
+                << "This should work but is untested by the QLever team. If "
+                   "you are running into unexpected problems,\n\t"
+                << "Please make sure to also report your used locale when "
+                   "filing a bug report. Also note that changing the\n\t"
+                << "locale requires to completely rebuild the index\n";
+    }
+    _vocab.setLocale(lang, country, ignorePunctuation);
+    _textVocab.setLocale(lang, country, ignorePunctuation);
+    _configurationJson["locale"]["language"] = lang;
+    _configurationJson["locale"]["country"] = country;
+    _configurationJson["locale"]["ignore-punctuation"] = ignorePunctuation;
+  }
+
+  if (j.find("languages-internal") != j.end()) {
+    _vocab.initializeInternalizedLangs(j["languages-internal"]);
+    _configurationJson["languages-internal"] = j["languages-internal"];
+    _onDiskLiterals = true;
+    _configurationJson["external-literals"] = true;
+  }
+  if (j.count("ascii-prefixes-only")) {
+    if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserDummy>) {
+      bool v = j["ascii-prefixes-only"];
+      if (v) {
+        LOG(WARN) << WARNING_ASCII_ONLY_PREFIXES;
+        _onlyAsciiTurtlePrefixes = true;
+      } else {
+        _onlyAsciiTurtlePrefixes = false;
+      }
+    } else {
+      LOG(WARN) << "You specified the ascii-prefixes-only but a parser that is "
+                   "not the Turtle stream parser. This means that this setting "
+                   "is ignored\n";
+    }
+  }
+
+  if (j.count("num-triples-per-partial-vocab")) {
+    _numTriplesPerPartialVocab = j["num-triples-per-partial-vocab"];
+    LOG(INFO) << "Overriding setting num-triples-per-partial-vocab to "
+              << _numTriplesPerPartialVocab
+              << " This might influence performance / memory usage during "
+                 "index build\n";
+  }
+
+  if (j.count("parser-batch-size")) {
+    _parserBatchSize = j["parser-batch-size"];
+    LOG(INFO) << "Overriding setting parser-batch-size to " << _parserBatchSize
+              << " This might influence performance during index build\n";
+  }
+}
+
+// ___________________________________________________________________________
+std::future<void> IndexImpl::writeNextPartialVocabulary(
+    size_t numLines, size_t numFiles, size_t actualCurrentPartialSize,
+    std::shared_ptr<const std::array<ItemMap, NUM_PARALLEL_ITEM_MAPS>> items,
+    std::unique_ptr<TripleVec> localIds,
+    TripleVec::bufwriter_type* globalWritePtr) {
+  LOG(INFO) << "Lines (from KB-file) processed: " << numLines << '\n';
+  LOG(INFO) << "Actual number of Triples in this section (include "
+               "langfilter triples): "
+            << actualCurrentPartialSize << '\n';
+  std::future<void> resultFuture;
+  string partialFilename =
+      _onDiskBase + PARTIAL_VOCAB_FILE_NAME + std::to_string(numFiles);
+  string partialCompressionFilename = _onDiskBase + TMP_BASENAME_COMPRESSION +
+                                      PARTIAL_VOCAB_FILE_NAME +
+                                      std::to_string(numFiles);
+
+  auto lambda = [localIds = std::move(localIds), globalWritePtr, items,
+                 vocab = &_vocab, partialFilename, partialCompressionFilename,
+                 vocabPrefixCompressed = _vocabPrefixCompressed]() {
+    auto vec = vocabMapsToVector(items);
+    const auto identicalPred = [&c = vocab->getCaseComparator()](
+                                   const auto& a, const auto& b) {
+      return c(a.second.m_splitVal, b.second.m_splitVal,
+               decltype(_vocab)::SortLevel::TOTAL);
+    };
+    LOG(INFO) << "Start sorting of vocabulary with #elements: " << vec.size()
+              << std::endl;
+    sortVocabVector(&vec, identicalPred, true);
+    LOG(INFO) << "Finished sorting of vocabulary" << std::endl;
+    auto mapping = createInternalMapping(&vec);
+    LOG(INFO) << "Finished creating of Mapping vocabulary" << std::endl;
+    auto sz = vec.size();
+    // since now adjacent duplicates also have the same Ids, it suffices to
+    // compare those
+    vec.erase(std::unique(vec.begin(), vec.end(),
+                          [](const auto& a, const auto& b) {
+                            return a.second.m_id == b.second.m_id;
+                          }),
+              vec.end());
+    LOG(INFO) << "Removed " << sz - vec.size()
+              << " Duplicates from the local partial vocabularies\n";
+    writeMappedIdsToExtVec(*localIds, mapping, globalWritePtr);
+    writePartialVocabularyToFile(vec, partialFilename);
+    if (vocabPrefixCompressed) {
+      // sort according to the actual byte values
+      LOG(INFO) << "Start sorting of vocabulary for prefix compression"
+                << std::endl;
+      sortVocabVector(
+          &vec, [](const auto& a, const auto& b) { return a.first < b.first; },
+          false);
+      LOG(INFO) << "Finished sorting of vocabulary for prefix compression"
+                << std::endl;
+      writePartialVocabularyToFile(vec, partialCompressionFilename);
+    }
+    LOG(INFO) << "Finished writing the partial vocabulary" << std::endl;
+  };
+
+  return std::async(std::launch::async, std::move(lambda));
+}
+
+template <typename F, typename... Args>
+auto IndexImpl::applyForPermutation(Permutation p, F f, Args&&... args) {
+  auto fLifted = [&](auto&& permutationImpl) {
+    return f(permutationImpl, std::forward<Args>(args)...);
+  };
+
+  switch (p) {
+    case Permutation::POS:
+      return fLifted(POS());
+    case Permutation::PSO:
+      return fLifted(PSO());
+    case Permutation::SOP:
+      return fLifted(SOP());
+    case Permutation::SPO:
+      return fLifted(SPO());
+    case Permutation::OSP:
+      return fLifted(OSP());
+    case Permutation::OPS:
+      return fLifted(OPS());
+    default:
+      AD_CHECK(false);
+  }
+}
+
+template <typename F, typename... Args>
+auto IndexImpl::applyForPermutation(Permutation p, F f, Args&&... args) const {
+  auto fLifted = [&](auto&& permutationImpl) {
+    return f(permutationImpl, std::forward<Args>(args)...);
+  };
+
+  switch (p) {
+    case Permutation::POS:
+      return fLifted(POS());
+    case Permutation::PSO:
+      return fLifted(PSO());
+    case Permutation::SOP:
+      return fLifted(SOP());
+    case Permutation::SPO:
+      return fLifted(SPO());
+    case Permutation::OSP:
+      return fLifted(OSP());
+    case Permutation::OPS:
+      return fLifted(OPS());
+    default:
+      AD_CHECK(false);
+  }
+}
+
+// _____________________________________________________________________________
+template <class PermutationImplementation>
+vector<float> IndexImpl::getMultiplicitiesImpl(
+    const PermutationImplementation& p, const string& key) const {
+  Id keyId;
+  vector<float> res;
+  if (_vocab.getId(key, &keyId) && p._meta.relationExists(keyId)) {
+    auto rmd = p._meta.getRmd(keyId);
+    auto logM1 = rmd.getCol1LogMultiplicity();
+    res.push_back(static_cast<float>(pow(2, logM1)));
+    auto logM2 = rmd.getCol2LogMultiplicity();
+    res.push_back(static_cast<float>(pow(2, logM2)));
+  } else {
+    res.push_back(1);
+    res.push_back(1);
+  }
+  return res;
+}
+
+// _____________________________________________________________________________________________
+vector<float> IndexImpl::getMultiplicities(const string& key,
+                                           const Permutation p) const {
+  auto f = [&](const auto& permutationImpl) {
+    return getMultiplicitiesImpl(permutationImpl, key);
+  };
+  return applyForPermutation(p, f);
+}
+
+// ___________________________________________________________________
+template <class PermutationImplementation>
+vector<float> IndexImpl::getMultiplicitiesImpl(
+    const PermutationImplementation& p) const {
+  std::array<float, 3> m{
+      static_cast<float>(getNofTriples() / getNofSubjects()),
+      static_cast<float>(getNofTriples() / getNofPredicates()),
+      static_cast<float>(getNofTriples() / getNofObjects())};
+
+  return {m[p._keyOrder[0]], m[p._keyOrder[1]], m[p._keyOrder[2]]};
+}
+
+// _____________________________________________________________________________
+vector<float> IndexImpl::getMultiplicities(const Permutation p) const {
+  auto f = [this](const auto& permutationImpl) {
+    return getMultiplicitiesImpl(permutationImpl);
+  };
+  return applyForPermutation(p, f);
+}
+
+// ___________________________________________________________________________
+template <class PermutationImplementation>
+void IndexImpl::scanImpl(Id key, IdTable* result,
+                         const PermutationImplementation& p,
+                         ad_utility::SharedConcurrentTimeoutTimer timer) const {
+  if (p._meta.relationExists(key)) {
+    const FullRelationMetaData& rmd = p._meta.getRmd(key)._rmdPairs;
+    result->reserve(rmd.getNofElements() + 2);
+    result->resize(rmd.getNofElements());
+    p._file.read(result->data(), rmd.getNofElements() * 2 * sizeof(Id),
+                 rmd._startFullIndex, std::move(timer));
+  }
+}
+
+// ___________________________________________________________________________
+void IndexImpl::scan(Id key, IdTable* result, const Permutation& p,
+                     ad_utility::SharedConcurrentTimeoutTimer timer) const {
+  auto f = [&](const auto& permutationImpl) {
+    return scanImpl(key, result, permutationImpl, timer);
+  };
+  return applyForPermutation(p, f);
+}
+
+// ____________________________________________________________________________
+template <class PermutationImplementation>
+void IndexImpl::scanImpl(const string& key, IdTable* result,
+                         const PermutationImplementation& p,
+                         ad_utility::SharedConcurrentTimeoutTimer timer) const {
+  LOG(DEBUG) << "Performing " << p._readableName
+             << " scan for full list for: " << key << "\n";
+  Id relId;
+  if (_vocab.getId(key, &relId)) {
+    LOG(TRACE) << "Successfully got key ID.\n";
+    scanImpl(relId, result, p, std::move(timer));
+  }
+  LOG(DEBUG) << "Scan done, got " << result->size() << " elements.\n";
+}
+
+// ____________________________________________________________________________
+void IndexImpl::scan(const string& key, IdTable* result, const Permutation& p,
+                     ad_utility::SharedConcurrentTimeoutTimer timer) const {
+  auto f = [&](const auto& permutationImpl) {
+    return scanImpl(key, result, permutationImpl, timer);
+  };
+  return applyForPermutation(p, f);
+}
+
+// ____________________________________________________________________________
+template <class PermutationImplementation>
+void IndexImpl::scanImpl(const string& keyFirst, const string& keySecond,
+                         IdTable* result,
+                         const PermutationImplementation& p) const {
+  LOG(DEBUG) << "Performing " << p._readableName << "  scan of relation "
+             << keyFirst << " with fixed subject: " << keySecond << "...\n";
+  Id relId;
+  Id subjId;
+  if (_vocab.getId(keyFirst, &relId) && _vocab.getId(keySecond, &subjId)) {
+    if (p._meta.relationExists(relId)) {
+      auto rmd = p._meta.getRmd(relId);
+      if (rmd.hasBlocks()) {
+        pair<off_t, size_t> blockOff =
+            rmd._rmdBlocks->getBlockStartAndNofBytesForLhs(subjId);
+        // Functional relations have blocks point into the pair index,
+        // non-functional relations have them point into lhs lists
+        if (rmd.isFunctional()) {
+          scanFunctionalRelation(blockOff, subjId, p._file, result);
+        } else {
+          pair<off_t, size_t> block2 =
+              rmd._rmdBlocks->getFollowBlockForLhs(subjId);
+          scanNonFunctionalRelation(blockOff, block2, subjId, p._file,
+                                    rmd._rmdBlocks->_offsetAfter, result);
+        }
+      } else {
+        // If we don't have blocks, scan the whole relation and filter /
+        // restrict.
+        IdTable fullRelation(2, result->getAllocator());
+        fullRelation.resize(rmd.getNofElements());
+        p._file.read(fullRelation.data(), rmd.getNofElements() * 2 * sizeof(Id),
+                     rmd._rmdPairs._startFullIndex);
+        getRhsForSingleLhs(fullRelation, subjId, result);
+      }
+    } else {
+      LOG(DEBUG) << "No such relation.\n";
+    }
+  } else {
+    LOG(DEBUG) << "No such second order key.\n";
+  }
+  LOG(DEBUG) << "Scan done, got " << result->size() << " elements.\n";
+}
+
+// _________________________________________________________________________
+void IndexImpl::scan(const string& keyFirst, const string& keySecond,
+                     IdTable* result, const Permutation p) const {
+  auto f = [&](const auto& permutationImpl) {
+    return scanImpl(keyFirst, keySecond, result, permutationImpl);
+  };
+  return applyForPermutation(p, f);
+}

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1539,7 +1539,7 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
                  vocab = &_vocab, partialFilename, partialCompressionFilename,
                  vocabPrefixCompressed = _vocabPrefixCompressed]() {
     auto vec = vocabMapsToVector(items);
-    const auto identicalPred = [&c = vocab->getCaseComparator()](
+    const auto identicalPred = [& c = vocab->getCaseComparator()](
                                    const auto& a, const auto& b) {
       return c(a.second.m_splitVal, b.second.m_splitVal,
                decltype(_vocab)::SortLevel::TOTAL);

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1581,7 +1581,7 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
 
 template <typename F, typename... Args>
 auto IndexImpl::applyForPermutation(Permutation p, F f, Args&&... args) {
-  auto fLifted = [&](auto&& permutationImpl) {
+  auto fLifted = [&](const auto& permutationImpl) {
     return f(permutationImpl, std::forward<Args>(args)...);
   };
 
@@ -1605,7 +1605,7 @@ auto IndexImpl::applyForPermutation(Permutation p, F f, Args&&... args) {
 
 template <typename F, typename... Args>
 auto IndexImpl::applyForPermutation(Permutation p, F f, Args&&... args) const {
-  auto fLifted = [&](auto&& permutationImpl) {
+  auto fLifted = [&](const auto& permutationImpl) {
     return f(permutationImpl, std::forward<Args>(args)...);
   };
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -1,0 +1,722 @@
+// Copyright 2015, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+#pragma once
+
+#include <array>
+#include <fstream>
+#include <google/sparse_hash_set>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <stxxl/vector>
+#include <vector>
+
+#include "../engine/ResultTable.h"
+#include "../global/Pattern.h"
+#include "../parser/NTriplesParser.h"
+#include "../parser/TsvParser.h"
+#include "../parser/TurtleParser.h"
+#include "../util/BufferedVector.h"
+#include "../util/File.h"
+#include "../util/HashMap.h"
+#include "../util/MmapVector.h"
+#include "../util/Timer.h"
+#include "./ConstantsIndexCreation.h"
+#include "./DocsDB.h"
+#include "./Index.h"
+#include "./IndexBuilderTypes.h"
+#include "./IndexMetaData.h"
+#include "./Permutations.h"
+#include "./StxxlSortFunctors.h"
+#include "./TextMetaData.h"
+#include "./Vocabulary.h"
+
+using ad_utility::BufferedVector;
+using ad_utility::MmapVector;
+using ad_utility::MmapVectorView;
+using std::array;
+using std::shared_ptr;
+using std::string;
+using std::tuple;
+using std::vector;
+
+using json = nlohmann::json;
+
+// a simple struct for better naming
+struct VocabularyData {
+  using TripleVec = stxxl::vector<array<Id, 3>>;
+  // The total number of distinct words in the complete Vocabulary
+  size_t nofWords;
+  // Id lower and upper bound of @lang@<predicate> predicates
+  Id langPredLowerBound;
+  Id langPredUpperBound;
+  // The number of triples in the idTriples vec that each partial vocabulary is
+  // responsible for (depends on the number of additional language filter
+  // triples)
+  std::vector<size_t> actualPartialSizes;
+  // All the triples as Ids.
+  std::unique_ptr<TripleVec> idTriples;
+};
+
+class IndexImpl {
+ public:
+  using TripleVec = stxxl::vector<array<Id, 3>>;
+  // Block Id, Context Id, Word Id, Score, entity
+  using TextVec = stxxl::vector<tuple<Id, Id, Id, Score, bool>>;
+  using Posting = std::tuple<Id, Id, Score>;
+
+  // Forbid copy and assignment
+  IndexImpl& operator=(const IndexImpl&) = delete;
+
+  IndexImpl(const IndexImpl&) = delete;
+
+  IndexImpl();
+
+  struct IndexMetaDataMmapDispatcher {
+    using WriteType = IndexMetaDataMmap;
+    using ReadType = IndexMetaDataMmapView;
+  };
+
+  struct IndexMetaDataHmapDispatcher {
+    using WriteType = IndexMetaDataHmap;
+    using ReadType = IndexMetaDataHmap;
+  };
+
+  using Permutation = Index::Permutation;
+
+  template <class A, class B>
+  using PermutationImpl = PermutationImpl::PermutationImpl<A, B>;
+
+  // TODO: make those private and allow only const access
+  // instantiations for the 6 Permutations used in QLever
+  // They simplify the creation of permutations in the index class
+  PermutationImpl<SortByPOS, IndexMetaDataHmap> _POS =
+      PermutationImpl<SortByPOS, IndexMetaDataHmap>(SortByPOS(), "POS", ".pos",
+                                                    {1, 2, 0});
+  PermutationImpl<SortByPSO, IndexMetaDataHmap> _PSO =
+      PermutationImpl<SortByPSO, IndexMetaDataHmap>(SortByPSO(), "PSO", ".pso",
+                                                    {1, 0, 2});
+  PermutationImpl<SortBySOP, IndexMetaDataMmapView> _SOP =
+      PermutationImpl<SortBySOP, IndexMetaDataMmapView>(SortBySOP(), "SOP",
+                                                        ".sop", {0, 2, 1});
+  PermutationImpl<SortBySPO, IndexMetaDataMmapView> _SPO =
+      PermutationImpl<SortBySPO, IndexMetaDataMmapView>(SortBySPO(), "SPO",
+                                                        ".spo", {0, 1, 2});
+  PermutationImpl<SortByOPS, IndexMetaDataMmapView> _OPS =
+      PermutationImpl<SortByOPS, IndexMetaDataMmapView>(SortByOPS(), "OPS",
+                                                        ".ops", {2, 1, 0});
+  PermutationImpl<SortByOSP, IndexMetaDataMmapView> _OSP =
+      PermutationImpl<SortByOSP, IndexMetaDataMmapView>(SortByOSP(), "OSP",
+                                                        ".osp", {2, 0, 1});
+
+  const auto& POS() const { return _POS; }
+  const auto& PSO() const { return _PSO; }
+  const auto& SPO() const { return _SPO; }
+  const auto& SOP() const { return _SOP; }
+  const auto& OPS() const { return _OPS; }
+  const auto& OSP() const { return _OSP; }
+
+  template <typename F, typename... Args>
+  auto applyForPermutation(Permutation p, F f, Args&&... args);
+
+  template <typename F, typename... Args>
+  auto applyForPermutation(Permutation p, F f, Args&&... args) const;
+
+  // Creates an index from a file. Parameter Parser must be able to split the
+  // file's format into triples.
+  // Will write vocabulary and on-disk index data.
+  // !! The index can not directly be used after this call, but has to be setup
+  // by createFromOnDiskIndex after this call.
+  template <class Parser>
+  void createFromFile(const string& filename);
+
+  /**
+   * @brief create an IndexImpl from a turtle file
+   * Determine from the settings, which Tokenizer regex engine (google re2 or
+   * ctre) should be used
+   * @param filename
+   */
+  void createFromTurtleFile(const string& filename);
+
+  void addPatternsToExistingIndex();
+
+  // Creates an index object from an on disk index
+  // that has previously been constructed.
+  // Read necessary meta data into memory and opens file handles.
+  void createFromOnDiskIndex(const string& onDiskBase);
+
+  // Adds a text index to a fully initialized KB index.
+  // Reads a context file and builds the index for the first time.
+  void addTextFromContextFile(const string& contextFile);
+
+  void buildDocsDB(const string& docsFile);
+
+  // Adds text index from on disk index that has previously been constructed.
+  // Read necessary meta data into memory and opens file handles.
+  void addTextFromOnDiskIndex();
+
+  const auto& getVocab() const { return _vocab; };
+
+  const auto& getTextVocab() const { return _textVocab; };
+
+  // --------------------------------------------------------------------------
+  //  -- RETRIEVAL ---
+  // --------------------------------------------------------------------------
+  typedef vector<array<Id, 1>> WidthOneList;
+  typedef vector<array<Id, 2>> WidthTwoList;
+  typedef vector<array<Id, 3>> WidthThreeList;
+  typedef vector<array<Id, 4>> WidthFourList;
+  typedef vector<array<Id, 5>> WidthFiveList;
+  typedef vector<vector<Id>> VarWidthList;
+
+  // --------------------------------------------------------------------------
+  // RDF RETRIEVAL
+  // --------------------------------------------------------------------------
+  size_t relationCardinality(const string& relationName) const;
+
+  size_t subjectCardinality(const string& sub) const;
+
+  size_t objectCardinality(const string& obj) const;
+
+  size_t sizeEstimate(const string& sub, const string& pred,
+                      const string& obj) const;
+
+  std::optional<string> idToOptionalString(Id id) const {
+    return _vocab.idToOptionalString(id);
+  }
+
+  const vector<PatternID>& getHasPattern() const;
+  const CompactStringVector<Id, Id>& getHasPredicate() const;
+  const CompactStringVector<size_t, Id>& getPatterns() const;
+  /**
+   * @return The multiplicity of the Entites column (0) of the full has-relation
+   *         relation after unrolling the patterns.
+   */
+  double getHasPredicateMultiplicityEntities() const;
+
+  /**
+   * @return The multiplicity of the Predicates column (0) of the full
+   * has-relation relation after unrolling the patterns.
+   */
+  double getHasPredicateMultiplicityPredicates() const;
+
+  /**
+   * @return The size of the full has-relation relation after unrolling the
+   *         patterns.
+   */
+  size_t getHasPredicateFullSize() const;
+
+  // --------------------------------------------------------------------------
+  // TEXT RETRIEVAL
+  // --------------------------------------------------------------------------
+  const string& wordIdToString(Id id) const;
+
+  size_t getSizeEstimate(const string& words) const;
+
+  void getContextListForWords(const string& words, IdTable* result) const;
+
+  void getECListForWordsOneVar(const string& words, size_t limit,
+                               IdTable* result) const;
+
+  // With two or more variables.
+  void getECListForWords(const string& words, size_t nofVars, size_t limit,
+                         IdTable* result) const;
+
+  // With filtering. Needs many template instantiations but
+  // only nofVars truly makes a difference. Others are just data types
+  // of result tables.
+  void getFilteredECListForWords(const string& words, const IdTable& filter,
+                                 size_t filterColumn, size_t nofVars,
+                                 size_t limit, IdTable* result) const;
+
+  // Special cast with a width-one filter.
+  void getFilteredECListForWordsWidthOne(const string& words,
+                                         const IdTable& filter, size_t nofVars,
+                                         size_t limit, IdTable* result) const;
+
+  void getContextEntityScoreListsForWords(const string& words, vector<Id>& cids,
+                                          vector<Id>& eids,
+                                          vector<Score>& scores) const;
+
+  template <size_t I>
+  void getECListForWordsAndSingleSub(const string& words,
+                                     const vector<array<Id, I>>& subres,
+                                     size_t subResMainCol, size_t limit,
+                                     vector<array<Id, 3 + I>>& res) const;
+
+  void getECListForWordsAndTwoW1Subs(const string& words,
+                                     const vector<array<Id, 1>> subres1,
+                                     const vector<array<Id, 1>> subres2,
+                                     size_t limit,
+                                     vector<array<Id, 5>>& res) const;
+
+  void getECListForWordsAndSubtrees(
+      const string& words,
+      const vector<ad_utility::HashMap<Id, vector<vector<Id>>>>& subResVecs,
+      size_t limit, vector<vector<Id>>& res) const;
+
+  void getWordPostingsForTerm(const string& term, vector<Id>& cids,
+                              vector<Score>& scores) const;
+
+  void getEntityPostingsForTerm(const string& term, vector<Id>& cids,
+                                vector<Id>& eids, vector<Score>& scores) const;
+
+  string getTextExcerpt(Id cid) const {
+    if (cid == ID_NO_VALUE) {
+      return std::string();
+    } else {
+      return _docsDB.getTextExcerpt(cid);
+    }
+  }
+
+  // Only for debug reasons and external encoding tests.
+  // Supply an empty vector to dump all lists above a size threshold.
+  void dumpAsciiLists(const vector<string>& lists, bool decodeGapsFreq) const;
+
+  void dumpAsciiLists(const TextBlockMetaData& tbmd) const;
+
+  float getAverageNofEntityContexts() const {
+    return _textMeta.getAverageNofEntityContexts();
+  };
+
+  void setKbName(const string& name);
+
+  void setTextName(const string& name);
+
+  void setUsePatterns(bool usePatterns);
+
+  void setOnDiskLiterals(bool onDiskLiterals);
+
+  void setKeepTempFiles(bool keepTempFiles);
+
+  void setOnDiskBase(const std::string& onDiskBase);
+
+  void setSettingsFile(const std::string& filename);
+
+  void setPrefixCompression(bool compressed);
+
+  const string& getTextName() const { return _textMeta.getName(); }
+
+  const string& getKbName() const { return _PSO.metaData().getName(); }
+
+  size_t getNofTriples() const { return _PSO.metaData().getNofTriples(); }
+
+  size_t getNofTextRecords() const { return _textMeta.getNofTextRecords(); }
+  size_t getNofWordPostings() const { return _textMeta.getNofWordPostings(); }
+  size_t getNofEntityPostings() const {
+    return _textMeta.getNofEntityPostings();
+  }
+
+  size_t getNofSubjects() const {
+    if (hasAllPermutations()) {
+      return _SPO.metaData().getNofDistinctC1();
+    } else {
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+               "Can only get # distinct subjects if all 6 permutations "
+               "have been registered on sever start (and index build time) "
+               "with the -a option.")
+    }
+  }
+
+  size_t getNofObjects() const {
+    if (hasAllPermutations()) {
+      return _OSP.metaData().getNofDistinctC1();
+    } else {
+      AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
+               "Can only get # distinct subjects if all 6 permutations "
+               "have been registered on sever start (and index build time) "
+               "with the -a option.")
+    }
+  }
+
+  size_t getNofPredicates() const { return _PSO.metaData().getNofDistinctC1(); }
+
+  bool hasAllPermutations() const { return SPO()._file.isOpen(); }
+
+ private:
+  // _____________________________________________________________________________
+  template <class PermutationImplementation>
+  vector<float> getMultiplicitiesImpl(const PermutationImplementation& p,
+                                      const string& key) const;
+
+  // ___________________________________________________________________
+  template <class PermutationImplementation>
+  vector<float> getMultiplicitiesImpl(const PermutationImplementation& p) const;
+
+ public:
+  vector<float> getMultiplicities(const string& key, const Permutation p) const;
+  vector<float> getMultiplicities(const Permutation p) const;
+
+  /**
+   * @brief Perform a scan for one key i.e. retrieve all YZ from the XYZ
+   * permutation for a specific key value of X
+   * @tparam PermutationImplementation The permutations IndexImpl::POS()... have
+   * different types
+   * @param key The key (in Id space) for which to search, e.g. fixed value for
+   * O in OSP permutation.
+   * @param result The Id table to which we will write. Must have 2 columns.
+   * @param p The Permutation to use (in particularly POS(), SOP,... members of
+   * IndexImpl class).
+   */
+  template <class PermutationImplementation>
+  void scanImpl(Id key, IdTable* result, const PermutationImplementation& p,
+                ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+  void scan(Id key, IdTable* result, const Permutation& p,
+            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+  /**
+   * @brief Perform a scan for one key i.e. retrieve all YZ from the XYZ
+   * permutation for a specific key value of X
+   * @tparam PermutationImplementation The permutations IndexImpl::POS()... have
+   * different types
+   * @param key The key (as a raw string that is yet to be transformed to index
+   * space) for which to search, e.g. fixed value for O in OSP permutation.
+   * @param result The Id table to which we will write. Must have 2 columns.
+   * @param p The Permutation to use (in particularly POS(), SOP,... members of
+   * IndexImpl class).
+   */
+  template <class PermutationImplementation>
+  void scanImpl(const string& key, IdTable* result,
+                const PermutationImplementation& p,
+                ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+  void scan(const string& key, IdTable* result, const Permutation& p,
+            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+  /**
+   * @brief Perform a scan for two keys i.e. retrieve all Z from the XYZ
+   * permutation for specific key values of X and Y.
+   * @tparam PermutationImplementation The permutations IndexImpl::POS()... have
+   * different types
+   * @param keyFirst The first key (as a raw string that is yet to be
+   * transformed to index space) for which to search, e.g. fixed value for O in
+   * OSP permutation.
+   * @param keySecond The second key (as a raw string that is yet to be
+   * transformed to index space) for which to search, e.g. fixed value for S in
+   * OSP permutation.
+   * @param result The Id table to which we will write. Must have 2 columns.
+   * @param p The Permutation to use (in particularly POS(), SOP,... members of
+   * IndexImpl class).
+   */
+  // _____________________________________________________________________________
+  template <class PermutationImplementation>
+  void scanImpl(const string& keyFirst, const string& keySecond,
+                IdTable* result, const PermutationImplementation& p) const;
+
+  // _________________________________________________________________________
+  void scan(const string& keyFirst, const string& keySecond, IdTable* result,
+            const Permutation p) const;
+
+ private:
+  string _onDiskBase;
+  string _settingsFileName;
+  bool _onlyAsciiTurtlePrefixes = false;
+  bool _onDiskLiterals = false;
+  bool _keepTempFiles = false;
+  json _configurationJson;
+  Vocabulary<CompressedString, TripleComponentComparator> _vocab;
+  size_t _totalVocabularySize = 0;
+  bool _vocabPrefixCompressed = true;
+  Vocabulary<std::string, SimpleStringComparator> _textVocab;
+
+  TextMetaData _textMeta;
+  DocsDB _docsDB;
+  vector<Id> _blockBoundaries;
+  off_t _currentoff_t;
+  mutable ad_utility::File _textIndexFile;
+
+  // Pattern trick data
+  static const uint32_t PATTERNS_FILE_VERSION;
+  bool _usePatterns;
+  size_t _maxNumPatterns;
+  double _fullHasPredicateMultiplicityEntities;
+  double _fullHasPredicateMultiplicityPredicates;
+  size_t _fullHasPredicateSize;
+
+  size_t _parserBatchSize = PARSER_BATCH_SIZE;
+  size_t _numTriplesPerPartialVocab = NUM_TRIPLES_PER_PARTIAL_VOCAB;
+  /**
+   * @brief Maps pattern ids to sets of predicate ids.
+   */
+  CompactStringVector<size_t, Id> _patterns;
+  /**
+   * @brief Maps entity ids to pattern ids.
+   */
+  std::vector<PatternID> _hasPattern;
+  /**
+   * @brief Maps entity ids to sets of predicate ids
+   */
+  CompactStringVector<Id, Id> _hasPredicate;
+
+  // Create Vocabulary and directly write it to disk. Create TripleVec with all
+  // the triples converted to id space. This Vec can be used for creating
+  // permutations. Member _vocab will be empty after this because it is not
+  // needed for index creation once the TripleVec is set up and it would be a
+  // waste of RAM.
+  template <class Parser>
+  VocabularyData createIdTriplesAndVocab(const string& ntFile);
+
+  // ___________________________________________________________________
+  template <class Parser>
+  VocabularyData passFileForVocabulary(const string& ntFile,
+                                       size_t linesPerPartial);
+
+  /**
+   * @brief Everything that has to be done when we have seen all the triples
+   * that belong to one partial vocabulary, including Log output used inside
+   * passFileForVocabulary
+   *
+   * @param numLines How many Lines from the KB have we already parsed (only for
+   * Logging)
+   * @param numFiles How many partial vocabularies have we seen before/which is
+   * the index of the voc we are going to write
+   * @param actualCurrentPartialSize How many triples belong to this partition
+   * (including extra langfilter triples)
+   * @param items Contains our unsorted vocabulary. Maps words to their local
+   * ids within this vocabulary.
+   */
+  std::future<void> writeNextPartialVocabulary(
+      size_t numLines, size_t numFiles, size_t actualCurrentPartialSize,
+      std::shared_ptr<const ItemMapArray> items,
+      std::unique_ptr<TripleVec> localIds,
+      TripleVec::bufwriter_type* globalWritePtr);
+
+  void convertPartialToGlobalIds(TripleVec& data,
+                                 const vector<size_t>& actualLinesPerPartial,
+                                 size_t linesPerPartial);
+
+  size_t passContextFileForVocabulary(const string& contextFile);
+
+  void passContextFileIntoVector(const string& contextFile, TextVec& vec);
+
+  template <class MetaDataDispatcher>
+  std::optional<std::pair<typename MetaDataDispatcher::WriteType,
+                          typename MetaDataDispatcher::WriteType>>
+  createPermutationPairImpl(const string& fileName1, const string& fileName2,
+                            const IndexImpl::TripleVec& vec, size_t c0,
+                            size_t c1, size_t c2);
+
+  pair<FullRelationMetaData, BlockBasedRelationMetaData> writeSwitchedRel(
+      ad_utility::File* out, off_t lastOffset, Id currentRel,
+      ad_utility::BufferedVector<array<Id, 2>>* buffer);
+
+  // _______________________________________________________________________
+  // Create a pair of permutations. Only works for valid pairs (PSO-POS,
+  // OSP-OPS, SPO-SOP).  First creates the permutation and then exchanges the
+  // multiplicities and also writes the MetaData to disk. So we end up with
+  // fully functional permutations.
+  // performUnique must be set for the first pair created using vec to enforce
+  // RDF standard (no duplicate triples).
+  // createPatternsAfterFirst is only valid when  the pair is SPO-SOP because
+  // the SPO permutation is also needed for patterns (see usage in
+  // IndexImpl::createFromFile function)
+  template <class MetaDataDispatcher, class Comparator1, class Comparator2>
+  void createPermutationPair(
+      VocabularyData* vec,
+      const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
+          p1,
+      const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
+          p2,
+      bool performUnique = false, bool createPatternsAfterFirst = false);
+
+  // The pairs of permutations are PSO-POS, OSP-OPS and SPO-SOP
+  // the multiplicity of column 1 in partner 1 of the pair is equal to the
+  // multiplity of column 2 in partner 2
+  // This functions writes the multiplicities of the first column of one
+  // arguments to the 2nd column multiplicities of the other
+  template <class MetaData>
+  void exchangeMultiplicities(MetaData* m1, MetaData* m2);
+
+  // wrapper for createPermutation that saves a lot of code duplications
+  // Writes the permutation that is specified by argument permutation
+  // performs std::unique on arg vec iff arg performUnique is true (normally
+  // done for first permutation that is created using vec).
+  // Will sort vec.
+  // returns the MetaData (MmapBased or HmapBased) for this relation.
+  // Careful: only multiplicities for first column is valid after call, need to
+  // call exchangeMultiplicities as done by createPermutationPair
+  // the optional is std::nullopt if vec and thus the index is empty
+  template <class MetaDataDispatcher, class Comparator1, class Comparator2>
+  std::optional<std::pair<typename MetaDataDispatcher::WriteType,
+                          typename MetaDataDispatcher::WriteType>>
+  createPermutations(
+      TripleVec* vec,
+      const PermutationImpl<Comparator1, typename MetaDataDispatcher::ReadType>&
+          p1,
+      const PermutationImpl<Comparator2, typename MetaDataDispatcher::ReadType>&
+          p2,
+      bool performUnique);
+
+  /**
+   * @brief Creates the data required for the "pattern-trick" used for fast
+   *        ql:has-relation evaluation when selection relation counts.
+   * @param fileName The name of the file in which the data should be stored
+   * @param args The arguments that need to be passed to the constructor of
+   *             VecReaderType. VecReaderType should allow for iterating over
+   *             the tuples of the spo permutation after having been constructed
+   *             using args.
+   */
+  template <typename VecReaderType, typename... Args>
+  void createPatternsImpl(const string& fileName,
+                          CompactStringVector<Id, Id>& hasPredicate,
+                          std::vector<PatternID>& hasPattern,
+                          CompactStringVector<size_t, Id>& patterns,
+                          double& fullHasPredicateMultiplicityEntities,
+                          double& fullHasPredicateMultiplicityPredicates,
+                          size_t& fullHasPredicateSize,
+                          const size_t maxNumPatterns,
+                          const Id langPredLowerBound,
+                          const Id langPredUpperBound,
+                          const Args&... vecReaderArgs);
+
+  // wrap the static function using the internal member variables
+  // the bool indicates wether the TripleVec has to be sorted before the pattern
+  // creation
+  void createPatterns(bool vecAlreadySorted, VocabularyData* idTriples);
+
+  void createTextIndex(const string& filename, const TextVec& vec);
+
+  ContextListMetaData writePostings(ad_utility::File& out,
+                                    const vector<Posting>& postings,
+                                    bool skipWordlistIfAllTheSame);
+
+  // Add relation to permutation file. Calculate corresponding metaData
+  // (Mutliplicity of second column will be invalid and has to be set by a
+  // separate call to exchangeMultiplicities)
+  // Args:
+  //   out - permutation file to which we write the relation. Must be open.
+  //   currentOffset - the offset of this relation within the permutation file
+  //   relId - the Id of the 0-th column of this relation (e.g. the 'P' in PSO)
+  //   data - the 1st and 2nd column of this relation (e.g. the "SO" for a fixed
+  //          'P' in PSO. Must be sorted by 1. and then 2. column.
+  //   distinctC1 - the number of distinct elemens in 1. column of data ("S" in
+  //                PSO)
+  //   functional - is this relation functional (only one triple per value for
+  //                1. column)
+  // Returns:
+  //   The Meta Data (Permutation offsets) for this relation,
+  //   Careful: only multiplicity for first column is valid in return value
+  static pair<FullRelationMetaData, BlockBasedRelationMetaData> writeRel(
+      ad_utility::File& out, off_t currentOffset, Id relId,
+      const BufferedVector<array<Id, 2>>& data, size_t distinctC1,
+      bool functional);
+
+  static void writeFunctionalRelation(
+      const BufferedVector<array<Id, 2>>& data,
+      pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd);
+
+  static void writeNonFunctionalRelation(
+      ad_utility::File& out, const BufferedVector<array<Id, 2>>& data,
+      pair<FullRelationMetaData, BlockBasedRelationMetaData>& rmd);
+
+  void openTextFileHandle();
+
+  void scanFunctionalRelation(const pair<off_t, size_t>& blockOff, Id lhsId,
+                              ad_utility::File& indexFile,
+                              IdTable* result) const;
+
+  void scanNonFunctionalRelation(const pair<off_t, size_t>& blockOff,
+                                 const pair<off_t, size_t>& followBlock,
+                                 Id lhsId, ad_utility::File& indexFile,
+                                 off_t upperBound, IdTable* result) const;
+
+  void addContextToVector(TextVec::bufwriter_type& writer, Id context,
+                          const ad_utility::HashMap<Id, Score>& words,
+                          const ad_utility::HashMap<Id, Score>& entities);
+
+  template <typename T>
+  void readGapComprList(size_t nofElements, off_t from, size_t nofBytes,
+                        vector<T>& result) const;
+
+  template <typename T>
+  void readFreqComprList(size_t nofElements, off_t from, size_t nofBytes,
+                         vector<T>& result) const;
+
+  size_t getIndexOfBestSuitedElTerm(const vector<string>& terms) const;
+
+  void calculateBlockBoundaries();
+
+  Id getWordBlockId(Id wordId) const;
+
+  Id getEntityBlockId(Id entityId) const;
+
+  bool isEntityBlockId(Id blockId) const;
+
+  //! Writes a list of elements (have to be able to be cast to unit64_t)
+  //! to file.
+  //! Returns the number of bytes written.
+  template <class Numeric>
+  size_t writeList(Numeric* data, size_t nofElements,
+                   ad_utility::File& file) const;
+
+  typedef ad_utility::HashMap<Id, Id> IdCodeMap;
+  typedef ad_utility::HashMap<Score, Score> ScoreCodeMap;
+  typedef vector<Id> IdCodebook;
+  typedef vector<Score> ScoreCodebook;
+
+  //! Creates codebooks for lists that are supposed to be entropy encoded.
+  void createCodebooks(const vector<Posting>& postings, IdCodeMap& wordCodemap,
+                       IdCodebook& wordCodebook, ScoreCodeMap& scoreCodemap,
+                       ScoreCodebook& scoreCodebook) const;
+
+  template <class T>
+  size_t writeCodebook(const vector<T>& codebook, ad_utility::File& file) const;
+
+  // FRIEND TESTS
+  friend class IndexTest_createFromTsvTest_Test;
+  friend class IndexTest_createFromOnDiskIndexTest_Test;
+  friend class CreatePatternsFixture_createPatterns_Test;
+
+  template <class T>
+  void writeAsciiListFile(const string& filename, const T& ids) const;
+
+  void getRhsForSingleLhs(const IdTable& in, Id lhsId, IdTable* result) const;
+
+  bool isLiteral(const string& object);
+
+  bool shouldBeExternalized(const string& object);
+  // convert value literals to internal representation
+  // and add externalization characters if necessary.
+  // Returns the language tag of spo[2] (the object) or ""
+  // if there is none.
+  LangtagAndTriple tripleToInternalRepresentation(Triple&& spo);
+
+  /**
+   * @brief Throws an exception if no patterns are loaded. Should be called from
+   *        whithin any index method that returns data requiring the patterns
+   *        file.
+   */
+  void throwExceptionIfNoPatterns() const;
+
+  void writeConfiguration() const;
+  void readConfiguration();
+
+  // initialize the index-build-time settings for the vocabulary
+  template <class Parser>
+  void initializeVocabularySettingsBuild();
+
+  // Helper function for Debugging during the index build.
+  // ExtVecs are not persistent, so we dump them to a mmapVector in a file with
+  // given filename
+  static void dumpExtVecToMmap(const TripleVec& vec, std::string filename) {
+    LOG(INFO) << "Dumping ext vec to mmap" << std::endl;
+    MmapVector<TripleVec::value_type> mmapVec(vec.size(), filename);
+    for (size_t i = 0; i < vec.size(); ++i) {
+      mmapVec[i] = vec[i];
+    }
+    LOG(INFO) << "Done" << std::endl;
+  }
+
+  /**
+   * Delete a temporary file unless the _keepTempFiles flag is set
+   * @param path
+   */
+  void deleteTemporaryFile(const string& path) {
+    if (!_keepTempFiles) {
+      ad_utility::deleteFile(path);
+    }
+  }
+};

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -118,9 +118,12 @@ class IndexImpl {
   const auto& OPS() const { return _OPS; }
   const auto& OSP() const { return _OSP; }
 
+  // Converts the Permutation p to the corresponding PermutationImpl permImpl
+  // (Permutation::POS -> POS()) and then calls f(permImpl, args...)
   template <typename F, typename... Args>
   auto applyForPermutation(Permutation p, F f, Args&&... args);
 
+  // Const overload of applyForPermutation
   template <typename F, typename... Args>
   auto applyForPermutation(Permutation p, F f, Args&&... args) const;
 
@@ -360,13 +363,16 @@ class IndexImpl {
    * @param p The Permutation to use (in particularly POS(), SOP,... members of
    * IndexImpl class).
    */
-  template <class PermutationImplementation>
-  void scanImpl(Id key, IdTable* result, const PermutationImplementation& p,
-                ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
-
   void scan(Id key, IdTable* result, const Permutation& p,
             ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
 
+ private:
+  // _____________________________________________________________________
+  template <PermutationConcept P>
+  void scanImpl(Id key, IdTable* result, const P& p,
+                ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+ public:
   /**
    * @brief Perform a scan for one key i.e. retrieve all YZ from the XYZ
    * permutation for a specific key value of X
@@ -378,14 +384,16 @@ class IndexImpl {
    * @param p The Permutation to use (in particularly POS(), SOP,... members of
    * IndexImpl class).
    */
-  template <class PermutationImplementation>
-  void scanImpl(const string& key, IdTable* result,
-                const PermutationImplementation& p,
-                ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
-
   void scan(const string& key, IdTable* result, const Permutation& p,
             ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
 
+ private:
+  // ________________________________________________________________________
+  template <PermutationConcept P>
+  void scanImpl(const string& key, IdTable* result, const P& p,
+                ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+ public:
   /**
    * @brief Perform a scan for two keys i.e. retrieve all Z from the XYZ
    * permutation for specific key values of X and Y.
@@ -402,13 +410,14 @@ class IndexImpl {
    * IndexImpl class).
    */
   // _____________________________________________________________________________
-  template <class PermutationImplementation>
-  void scanImpl(const string& keyFirst, const string& keySecond,
-                IdTable* result, const PermutationImplementation& p) const;
-
-  // _________________________________________________________________________
   void scan(const string& keyFirst, const string& keySecond, IdTable* result,
             const Permutation p) const;
+
+ private:
+  // _________________________________________________________________________
+  template <PermutationConcept P>
+  void scanImpl(const string& keyFirst, const string& keySecond,
+                IdTable* result, const P& p) const;
 
  private:
   string _onDiskBase;

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -67,4 +67,25 @@ class PermutationImpl {
   mutable ad_utility::File _file;
 };
 
+// PermutationConceptBool<T> == true if and only if T is an instantiation of the
+// PermutationImpl<> template.
+namespace detail {
+template <typename T>
+constexpr bool PermutationConceptBool = false;
+
+template <typename C, typename M>
+constexpr bool PermutationConceptBool<PermutationImpl<C, M>> = true;
+}  // namespace detail
+
 }  // namespace PermutationImpl
+
+/**
+ * Set up a concept for the PermutationImpls (new C++20 feature). Allows us to
+ * write functions like
+ *
+ * // P must be a type that is a PermutationImpl, otherwise an other overload is
+ * chosen or we get a ->readable<- error message template <PermutationConcept P>
+ * void doSomething();
+ */
+template <typename T>
+concept PermutationConcept = PermutationImpl::detail::PermutationConceptBool<T>;

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -67,4 +67,4 @@ class PermutationImpl {
   mutable ad_utility::File _file;
 };
 
-}  // namespace Permutation
+}  // namespace PermutationImpl

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -10,7 +10,7 @@
 #include "../util/Log.h"
 #include "./StxxlSortFunctors.h"
 
-namespace Permutation {
+namespace PermutationImpl {
 using std::array;
 using std::string;
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -3,9 +3,12 @@
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <cstdio>
+
 #include "../src/engine/CallFixedSize.h"
 #include "../src/engine/GroupBy.h"
+#include "../src/parser/NTriplesParser.h"
 
 ad_utility::AllocatorWithLimit<Id>& allocator() {
   static ad_utility::AllocatorWithLimit<Id> a{


### PR DESCRIPTION
The Index class is rather expensive to compile and needs Access to many datatypes that aren't needed elsewhere.
This commit restructures the Index class to use the Pimpl (Pointer to implementation) idiom, s.t. we can change
the Index implementation without retriggering the expensive compilation of all different Operations.