### PR TITLE
Update the CTRE library

### DIFF
--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -100,7 +100,6 @@ enum class TokId : int {
  * Caveat: The Prefix names are currently restricted to ascii values.
  */
 struct TurtleTokenCtre {
-
   static constexpr auto TurtlePrefix = grp(fixed_string("@prefix"));
   // TODO: this is actually case-insensitive
   static constexpr auto SparqlPrefix = grp(fixed_string("PREFIX"));

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -16,16 +16,17 @@ using namespace std::string_literals;
 
 /// Helper function for ctre: concatenation of fixed_strings
 template <size_t A, size_t B>
-constexpr ctll::fixed_string<A + B - 1> operator+(
-    const ctll::fixed_string<A>& a, const ctll::fixed_string<B>& b) {
-  char32_t comb[A + B - 1] = {};
-  for (size_t i = 0; i < A - 1;
-       ++i) {  // omit the trailing 0 of the first string
+constexpr ctll::fixed_string<A + B> operator+(const ctll::fixed_string<A>& a,
+                                              const ctll::fixed_string<B>& b) {
+  char32_t comb[A + B + 1] = {};
+  for (size_t i = 0; i < A; ++i) {  // omit the trailing 0 of the first string
     comb[i] = a.content[i];
   }
   for (size_t i = 0; i < B; ++i) {
-    comb[i + A - 1] = b.content[i];
+    comb[i + A] = b.content[i];
   }
+  // the input array must be zero-terminated
+  comb[A + B] = '\0';
   return ctll::fixed_string(comb);
 }
 
@@ -63,7 +64,7 @@ static constexpr auto cls(const ctll::fixed_string<N>& s) {
 /// Create a ctll::fixed string from a compile time character constant. The
 /// short name helps keep the overview when assembling long regexes.
 template <typename T, size_t N>
-constexpr fixed_string<N> fs(const T (&input)[N]) noexcept {
+constexpr auto fs(const T (&input)[N]) noexcept {
   return fixed_string(input);
 }
 

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -61,13 +61,6 @@ static constexpr auto cls(const ctll::fixed_string<N>& s) {
   return fixed_string("[") + s + fixed_string("]");
 }
 
-/// Create a ctll::fixed string from a compile time character constant. The
-/// short name helps keep the overview when assembling long regexes.
-template <typename T, size_t N>
-constexpr auto fs(const T (&input)[N]) noexcept {
-  return fixed_string(input);
-}
-
 /// One entry for each Token in the Turtle Grammar. Used to create a unified
 /// Interface to the two different Tokenizers
 enum class TokId : int {
@@ -107,8 +100,6 @@ enum class TokId : int {
  * Caveat: The Prefix names are currently restricted to ascii values.
  */
 struct TurtleTokenCtre {
-  template <size_t N>
-  using STR = ctll::fixed_string<N>;
 
   static constexpr auto TurtlePrefix = grp(fixed_string("@prefix"));
   // TODO: this is actually case-insensitive
@@ -134,31 +125,32 @@ struct TurtleTokenCtre {
   static constexpr auto ExponentString = fixed_string("[eE][\\+\\-]?[0-9]+");
   static constexpr auto Exponent = grp(ExponentString);
 
-  static constexpr auto DoubleString = fs("[\\+\\-]?([0-9]+\\.[0-9]*") +
-                                       ExponentString + "|" + ExponentString +
-                                       ")";
+  static constexpr auto DoubleString =
+      fixed_string("[\\+\\-]?([0-9]+\\.[0-9]*") + ExponentString + "|" +
+      ExponentString + ")";
 
   static constexpr auto Double = grp(DoubleString);
 
-  static constexpr auto HexString = fs("0-9A-Fa-f");
+  static constexpr auto HexString = fixed_string("0-9A-Fa-f");
   static constexpr auto UcharString =
-      fs("\\\\u[0-9a-fA-f]{4}|\\\\U[0-9a-fA-f]{8}");
+      fixed_string("\\\\u[0-9a-fA-f]{4}|\\\\U[0-9a-fA-f]{8}");
 
-  static constexpr auto EcharString = fs("\\\\[tbnrf\"\'\\\\]");
+  static constexpr auto EcharString = fixed_string("\\\\[tbnrf\"\'\\\\]");
 
   static constexpr auto StringLiteralQuoteString =
-      fs("\"([^\\x22\\x5C\\x0A\\x0D]|") + EcharString + "|" + UcharString +
-      ")*\"";
+      fixed_string("\"([^\\x22\\x5C\\x0A\\x0D]|") + EcharString + "|" +
+      UcharString + ")*\"";
 
   static constexpr auto StringLiteralSingleQuoteString =
-      fs("'([^\\x27\\x5C\\x0A\\x0D]|") + EcharString + "|" + UcharString +
-      ")*'";
+      fixed_string("'([^\\x27\\x5C\\x0A\\x0D]|") + EcharString + "|" +
+      UcharString + ")*'";
   static constexpr auto StringLiteralLongSingleQuoteString =
-      fs("'''((''|')?([^'\\\\]|") + EcharString + "|" + UcharString + "))*'''";
+      fixed_string("'''((''|')?([^'\\\\]|") + EcharString + "|" + UcharString +
+      "))*'''";
 
   static constexpr auto StringLiteralLongQuoteString =
-      fs("\"\"\"((\"\"|\")?([^\"\\\\]|") + EcharString + "|" + UcharString +
-      "))*\"\"\"";
+      fixed_string("\"\"\"((\"\"|\")?([^\"\\\\]|") + EcharString + "|" +
+      UcharString + "))*\"\"\"";
 
   // TODO: fix this!
   static constexpr auto IrirefString =
@@ -219,7 +211,7 @@ struct TurtleTokenCtre {
       grp(PnameNSString) + grp(PnLocalString);
 
   static constexpr fixed_string BlankNodeLabelString =
-      fs("_:") + cls(PnCharsUString + "0-9") +
+      fixed_string("_:") + cls(PnCharsUString + "0-9") +
       grp("\\.*" + cls(PnCharsString)) + "*";
 
   static constexpr fixed_string WsSingleString = "\\x20\\x09\\x0D\\x0A";

--- a/third_party/ctre/include/ctre/ctre.h
+++ b/third_party/ctre/include/ctre/ctre.h
@@ -218,6 +218,9 @@ prospectively choose to deem waived or otherwise exclude such Section(s) of
 the License, but only in their entirety and only with respect to the Combined
 Software.
 */
+#ifndef CTRE_V2__CTRE_UNICODE__HPP
+#define CTRE_V2__CTRE_UNICODE__HPP
+
 #ifndef CTRE_V2__CTRE__HPP
 #define CTRE_V2__CTRE__HPP
 
@@ -241,209 +244,211 @@ Software.
 namespace ctll {
 
 struct length_value_t {
-  uint32_t value;
-  uint8_t length;
+uint32_t value;
+uint8_t length;
 };
 
 constexpr length_value_t length_and_value_of_utf8_code_point(uint8_t first_unit) noexcept {
-  if ((first_unit & 0b1000'0000) == 0b0000'0000) return {static_cast<uint32_t>(first_unit), 1};
-  else if ((first_unit & 0b1110'0000) == 0b1100'0000) return {static_cast<uint32_t>(first_unit & 0b0001'1111), 2};
-  else if ((first_unit & 0b1111'0000) == 0b1110'0000) return {static_cast<uint32_t>(first_unit & 0b0000'1111), 3};
-  else if ((first_unit & 0b1111'1000) == 0b1111'0000) return {static_cast<uint32_t>(first_unit & 0b0000'0111), 4};
-  else if ((first_unit & 0b1111'1100) == 0b1111'1000) return {static_cast<uint32_t>(first_unit & 0b0000'0011), 5};
-  else if ((first_unit & 0b1111'1100) == 0b1111'1100) return {static_cast<uint32_t>(first_unit & 0b0000'0001), 6};
-  else return {0, 0};
+if ((first_unit & 0b1000'0000) == 0b0000'0000) return {static_cast<uint32_t>(first_unit), 1};
+else if ((first_unit & 0b1110'0000) == 0b1100'0000) return {static_cast<uint32_t>(first_unit & 0b0001'1111), 2};
+else if ((first_unit & 0b1111'0000) == 0b1110'0000) return {static_cast<uint32_t>(first_unit & 0b0000'1111), 3};
+else if ((first_unit & 0b1111'1000) == 0b1111'0000) return {static_cast<uint32_t>(first_unit & 0b0000'0111), 4};
+else if ((first_unit & 0b1111'1100) == 0b1111'1000) return {static_cast<uint32_t>(first_unit & 0b0000'0011), 5};
+else if ((first_unit & 0b1111'1100) == 0b1111'1100) return {static_cast<uint32_t>(first_unit & 0b0000'0001), 6};
+else return {0, 0};
 }
 
 constexpr char32_t value_of_trailing_utf8_code_point(uint8_t unit, bool & correct) noexcept {
-  if ((unit & 0b1100'0000) == 0b1000'0000) return unit & 0b0011'1111;
-  else {
-    correct = false;
-    return 0;
-  }
+if ((unit & 0b1100'0000) == 0b1000'0000) return unit & 0b0011'1111;
+else {
+correct = false;
+return 0;
+}
 }
 
 constexpr length_value_t length_and_value_of_utf16_code_point(uint16_t first_unit) noexcept {
-  if ((first_unit & 0b1111110000000000) == 0b1101'1000'0000'0000) return {static_cast<uint32_t>(first_unit & 0b0000001111111111), 2};
-  else return {first_unit, 1};
+if ((first_unit & 0b1111110000000000) == 0b1101'1000'0000'0000) return {static_cast<uint32_t>(first_unit & 0b0000001111111111), 2};
+else return {first_unit, 1};
 }
 
 template <size_t N> struct fixed_string {
-  char32_t content[N] = {};
-  size_t real_size{0};
-  bool correct_flag{true};
-
-  template <typename T> constexpr fixed_string(const T (&input)[N]) noexcept {
-    if constexpr (std::is_same_v<T, char>) {
+char32_t content[N] = {};
+size_t real_size{0};
+bool correct_flag{true};
+template <typename T> constexpr fixed_string(const T (&input)[N+1]) noexcept {
+if constexpr (std::is_same_v<T, char>) {
 #if CTRE_STRING_IS_UTF8
-      size_t out{0};
-				for (size_t i{0}; i < N; ++i) {
-					if ((i == (N-1)) && (input[i] == 0)) break;
-					length_value_t info = length_and_value_of_utf8_code_point(input[i]);
-					switch (info.length) {
-						case 6:
-							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-							[[fallthrough]];
-						case 5:
-							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-							[[fallthrough]];
-						case 4:
-							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-							[[fallthrough]];
-						case 3:
-							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-							[[fallthrough]];
-						case 2:
-							if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-							[[fallthrough]];
-						case 1:
-							content[out++] = static_cast<char32_t>(info.value);
-							real_size++;
-							break;
-						default:
-							correct_flag = false;
-							return;
-					}
-				}
+size_t out{0};
+for (size_t i{0}; i < N; ++i) {
+if ((i == (N-1)) && (input[i] == 0)) break;
+length_value_t info = length_and_value_of_utf8_code_point(input[i]);
+switch (info.length) {
+case 6:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 5:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 4:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 3:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 2:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 1:
+content[out++] = static_cast<char32_t>(info.value);
+real_size++;
+break;
+default:
+correct_flag = false;
+return;
+}
+}
 #else
-      for (size_t i{0}; i < N; ++i) {
-        content[i] = static_cast<uint8_t>(input[i]);
-        if ((i == (N-1)) && (input[i] == 0)) break;
-        real_size++;
-      }
+for (size_t i{0}; i < N; ++i) {
+content[i] = static_cast<uint8_t>(input[i]);
+if ((i == (N-1)) && (input[i] == 0)) break;
+real_size++;
+}
 #endif
 #if __cpp_char8_t
-      } else if constexpr (std::is_same_v<T, char8_t>) {
-			size_t out{0};
-			for (size_t i{0}; i < N; ++i) {
-				if ((i == (N-1)) && (input[i] == 0)) break;
-				length_value_t info = length_and_value_of_utf8_code_point(input[i]);
-				switch (info.length) {
-					case 6:
-						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-						[[fallthrough]];
-					case 5:
-						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-						[[fallthrough]];
-					case 4:
-						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-						[[fallthrough]];
-					case 3:
-						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-						[[fallthrough]];
-					case 2:
-						if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
-						[[fallthrough]];
-					case 1:
-						content[out++] = static_cast<char32_t>(info.value);
-						real_size++;
-						break;
-					default:
-						correct_flag = false;
-						return;
-				}
-			}
+} else if constexpr (std::is_same_v<T, char8_t>) {
+size_t out{0};
+for (size_t i{0}; i < N; ++i) {
+if ((i == (N-1)) && (input[i] == 0)) break;
+length_value_t info = length_and_value_of_utf8_code_point(input[i]);
+switch (info.length) {
+case 6:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 5:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 4:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 3:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 2:
+if (++i < N) info.value = (info.value << 6) | value_of_trailing_utf8_code_point(input[i], correct_flag);
+[[fallthrough]];
+case 1:
+content[out++] = static_cast<char32_t>(info.value);
+real_size++;
+break;
+default:
+correct_flag = false;
+return;
+}
+}
 #endif
-    } else if constexpr (std::is_same_v<T, char16_t>) {
-      size_t out{0};
-      for (size_t i{0}; i < N; ++i) {
-        length_value_t info = length_and_value_of_utf16_code_point(input[i]);
-        if (info.length == 2) {
-          if (++i < N) {
-            if ((input[i] & 0b1111'1100'0000'0000) == 0b1101'1100'0000'0000) {
-              content[out++] = (info.value << 10) | (input[i] & 0b0000'0011'1111'1111);
-            } else {
-              correct_flag = false;
-              break;
-            }
-          }
-        } else {
-          if ((i == (N-1)) && (input[i] == 0)) break;
-          content[out++] = info.value;
-        }
-      }
-      real_size = out;
-    } else if constexpr (std::is_same_v<T, wchar_t> || std::is_same_v<T, char32_t>) {
-      for (size_t i{0}; i < N; ++i) {
-        content[i] = input[i];
-        if ((i == (N-1)) && (input[i] == 0)) break;
-        real_size++;
-      }
-    }
-  }
-  constexpr fixed_string(const fixed_string & other) noexcept {
-    for (size_t i{0}; i < N; ++i) {
-      content[i] = other.content[i];
-    }
-    real_size = other.real_size;
-    correct_flag = other.correct_flag;
-  }
-  constexpr bool correct() const noexcept {
-    return correct_flag;
-  }
-  constexpr size_t size() const noexcept {
-    return real_size;
-  }
-  constexpr const char32_t * begin() const noexcept {
-    return content;
-  }
-  constexpr const char32_t * end() const noexcept {
-    return content + size();
-  }
-  constexpr char32_t operator[](size_t i) const noexcept {
-    return content[i];
-  }
-  template <size_t M> constexpr bool is_same_as(const fixed_string<M> & rhs) const noexcept {
-    if (real_size != rhs.size()) return false;
-    for (size_t i{0}; i != real_size; ++i) {
-      if (content[i] != rhs[i]) return false;
-    }
-    return true;
-  }
+} else if constexpr (std::is_same_v<T, char16_t>) {
+size_t out{0};
+for (size_t i{0}; i < N; ++i) {
+length_value_t info = length_and_value_of_utf16_code_point(input[i]);
+if (info.length == 2) {
+if (++i < N) {
+if ((input[i] & 0b1111'1100'0000'0000) == 0b1101'1100'0000'0000) {
+content[out++] = (info.value << 10) | (input[i] & 0b0000'0011'1111'1111);
+} else {
+correct_flag = false;
+break;
+}
+}
+} else {
+if ((i == (N-1)) && (input[i] == 0)) break;
+content[out++] = info.value;
+}
+}
+real_size = out;
+} else if constexpr (std::is_same_v<T, wchar_t> || std::is_same_v<T, char32_t>) {
+for (size_t i{0}; i < N; ++i) {
+content[i] = input[i];
+if ((i == (N-1)) && (input[i] == 0)) break;
+real_size++;
+}
+}
+}
+constexpr fixed_string(const fixed_string & other) noexcept {
+for (size_t i{0}; i < N; ++i) {
+content[i] = other.content[i];
+}
+real_size = other.real_size;
+correct_flag = other.correct_flag;
+}
+constexpr bool correct() const noexcept {
+return correct_flag;
+}
+constexpr size_t size() const noexcept {
+return real_size;
+}
+constexpr const char32_t * begin() const noexcept {
+return content;
+}
+constexpr const char32_t * end() const noexcept {
+return content + size();
+}
+constexpr char32_t operator[](size_t i) const noexcept {
+return content[i];
+}
+template <size_t M> constexpr bool is_same_as(const fixed_string<M> & rhs) const noexcept {
+if (real_size != rhs.size()) return false;
+for (size_t i{0}; i != real_size; ++i) {
+if (content[i] != rhs[i]) return false;
+}
+return true;
+}
+constexpr operator std::basic_string_view<char32_t>() const noexcept {
+return std::basic_string_view<char32_t>{content, size()};
+}
 };
 
 template <> class fixed_string<0> {
-  static constexpr char32_t __empty[1] = {0};
- public:
-  template <typename T> constexpr fixed_string(const T *) noexcept {
-
-  }
-  constexpr fixed_string(std::initializer_list<char32_t>) noexcept {
-
-  }
-  constexpr fixed_string(const fixed_string &) noexcept {
-
-  }
-  constexpr bool correct() const noexcept {
-    return true;
-  }
-  constexpr size_t size() const noexcept {
-    return 0;
-  }
-  constexpr const char32_t * begin() const noexcept {
-    return __empty;
-  }
-  constexpr const char32_t * end() const noexcept {
-    return __empty + size();
-  }
-  constexpr char32_t operator[](size_t) const noexcept {
-    return 0;
-  }
-};
-
-template <typename CharT, size_t N> fixed_string(const CharT (&)[N]) -> fixed_string<N>;
-template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
-
-template <typename T, size_t N> class basic_fixed_string: public fixed_string<N> {
-  using parent = fixed_string<N>;
- public:
-  template <typename... Args> constexpr basic_fixed_string(Args && ... args) noexcept: parent(std::forward<Args>(args)...) { }
-};
-
-template <typename CharT, size_t N> basic_fixed_string(const CharT (&)[N]) -> basic_fixed_string<CharT, N>;
-template <typename CharT, size_t N> basic_fixed_string(basic_fixed_string<CharT, N>) -> basic_fixed_string<CharT, N>;
+static constexpr char32_t empty[1] = {0};
+public:
+template <typename T> constexpr fixed_string(const T *) noexcept {
 
 }
+constexpr fixed_string(std::initializer_list<char32_t>) noexcept {
+
+}
+constexpr fixed_string(const fixed_string &) noexcept {
+
+}
+constexpr bool correct() const noexcept {
+return true;
+}
+constexpr size_t size() const noexcept {
+return 0;
+}
+constexpr const char32_t * begin() const noexcept {
+return empty;
+}
+constexpr const char32_t * end() const noexcept {
+return empty + size();
+}
+constexpr char32_t operator[](size_t) const noexcept {
+return 0;
+}
+constexpr operator std::basic_string_view<char32_t>() const noexcept {
+return std::basic_string_view<char32_t>{empty, 0};
+}
+};
+
+template <typename CharT, size_t N> fixed_string(const CharT (&)[N]) -> fixed_string<N-1>;
+template <size_t N> fixed_string(fixed_string<N>) -> fixed_string<N>;
+
+}
+
+#if CTLL_CNTTP_COMPILER_CHECK
+#define CTLL_FIXED_STRING ctll::fixed_string
+#else
+#define CTLL_FIXED_STRING const auto &
+#endif
 
 #endif
 
@@ -454,6 +459,8 @@ template <typename CharT, size_t N> basic_fixed_string(basic_fixed_string<CharT,
 #define CTLL__UTILITIES__HPP
 
 #include <type_traits>
+
+#define CTLL_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || (__cpp_nontype_template_args >= 201411L && __clang_major__ >= 12))
 
 #ifdef _MSC_VER
 #define CTLL_FORCE_INLINE __forceinline
@@ -466,11 +473,11 @@ namespace ctll {
 template <bool> struct conditional_helper;
 
 template <> struct conditional_helper<true> {
-  template <typename A, typename> using type = A;
+template <typename A, typename> using type = A;
 };
 
 template <> struct conditional_helper<false> {
-  template <typename, typename B> using type = B;
+template <typename, typename B> using type = B;
 };
 
 template <bool V, typename A, typename B> using conditional = typename conditional_helper<V>::template type<A,B>;
@@ -507,9 +514,9 @@ constexpr auto pop_front(empty_list) -> empty_list;
 
 // pop element from the front of a list and return new typelist too
 template <typename Front, typename List> struct list_pop_pair {
-  Front front{};
-  List list{};
-  constexpr list_pop_pair() = default;
+Front front{};
+List list{};
+constexpr list_pop_pair() = default;
 };
 
 template <typename Head, typename... As, typename T = _nothing> constexpr auto pop_and_get_front(list<Head, As...>, T = T()) noexcept -> list_pop_pair<Head, list<As...>> { return {}; }
@@ -518,6 +525,38 @@ template <typename T = _nothing> constexpr auto pop_and_get_front(empty_list, T 
 // return front of the list
 template <typename Head, typename... As, typename T = _nothing> constexpr auto front(list<Head, As...>, T = T()) noexcept -> Head { return {}; }
 template <typename T = _nothing> constexpr auto front(empty_list, T = T()) noexcept -> T { return {}; }
+
+// set operations
+template <typename T> struct item_matcher {
+struct not_selected {
+template <typename... Ts> friend constexpr auto operator+(list<Ts...>, not_selected) -> list<Ts...>;
+};
+template <typename Y> struct wrapper {
+template <typename... Ts> friend constexpr auto operator+(list<Ts...>, wrapper<Y>) -> list<Ts...,Y>;
+};
+
+static constexpr auto check(T) { return std::true_type{}; }
+static constexpr auto check(...) { return std::false_type{}; }
+static constexpr auto select(T) { return not_selected{}; }
+template <typename Y> static constexpr auto select(Y) { return wrapper<Y>{}; }
+};
+
+template <typename T, typename... Ts> constexpr bool exists_in(T, list<Ts...>) noexcept {
+return (item_matcher<T>::check(Ts{}) || ... || false);
+}
+
+template <typename T, typename... Ts> constexpr auto add_item(T item, list<Ts...> l) noexcept {
+if constexpr (exists_in(item, l)) {
+return l;
+} else {
+return list<Ts..., T>{};
+}
+}
+
+template <typename T, typename... Ts> constexpr auto remove_item(T, list<Ts...>) noexcept {
+item_matcher<T> matcher;
+return decltype((list<>{} + ... + matcher.select(Ts{}))){};
+}
 
 }
 
@@ -530,13 +569,13 @@ namespace ctll {
 
 // terminal type representing symbol / character of any type
 template <auto v> struct term {
-  static constexpr auto value = v;
+static constexpr auto value = v;
 };
 
 // epsilon = nothing on input tape
 // also used as an command for parsing means "do nothing"
 struct epsilon {
-  static constexpr auto value = '-';
+static constexpr auto value = '-';
 };
 
 // empty_stack_symbol = nothing on stack
@@ -551,12 +590,12 @@ struct reject { constexpr explicit operator bool() noexcept { return false; } };
 
 // action type, every action item in grammar must inherit from
 struct action {
-  struct action_tag { };
+struct action_tag { };
 };
 
 // move one character forward and pop it from stack command
 struct pop_input {
-  struct pop_input_tag { };
+struct pop_input_tag { };
 };
 
 // additional overloads for type list
@@ -567,73 +606,73 @@ template <typename... Ts> constexpr auto push_front(epsilon, list<Ts...>) -> lis
 template <typename... As, typename... Bs> constexpr auto push_front(list<As...>, list<Bs...>) -> list<As..., Bs...> { return {}; }
 
 template <typename T, typename... As> constexpr auto pop_front_and_push_front(T item, list<As...> l) {
-  return push_front(item, pop_front(l));
+return push_front(item, pop_front(l));
 }
 
 // SPECIAL matching types for nicer grammars
 
 // match any term
 struct anything {
-  constexpr inline anything() noexcept { }
-  template <auto V> constexpr anything(term<V>) noexcept;
+constexpr inline anything() noexcept { }
+template <auto V> constexpr anything(term<V>) noexcept;
 };
 
 // match range of term A-B
 template <auto A, decltype(A) B> struct range {
-  constexpr inline range() noexcept { }
-  //template <auto V> constexpr range(term<V>) noexcept requires (A <= V) && (V <= B);
-  template <auto V, typename = std::enable_if_t<(A <= V) && (V <= B)>> constexpr inline range(term<V>) noexcept;
+constexpr inline range() noexcept { }
+//template <auto V> constexpr range(term<V>) noexcept requires (A <= V) && (V <= B);
+template <auto V, typename = std::enable_if_t<(A <= V) && (V <= B)>> constexpr inline range(term<V>) noexcept;
 };
 
 #ifdef __EDG__
 template <auto V, auto... Set> struct contains {
-	static constexpr bool value = ((Set == V) || ... || false);
+static constexpr bool value = ((Set == V) || ... || false);
 };
 #endif
 
 // match terms defined in set
 template <auto... Def> struct set {
-  constexpr inline set() noexcept { }
+constexpr inline set() noexcept { }
 #ifdef __EDG__
-  template <auto V, typename = std::enable_if_t<contains<V, Def...>::value>> constexpr inline set(term<V>) noexcept;
+template <auto V, typename = std::enable_if_t<contains<V, Def...>::value>> constexpr inline set(term<V>) noexcept;
 #else
-  template <auto V, typename = std::enable_if_t<((Def == V) || ... || false)>> constexpr inline set(term<V>) noexcept;
+template <auto V, typename = std::enable_if_t<((Def == V) || ... || false)>> constexpr inline set(term<V>) noexcept;
 #endif
 };
 
 // match terms not defined in set
 template <auto... Def> struct neg_set {
-  constexpr inline neg_set() noexcept { }
+constexpr inline neg_set() noexcept { }
 
 #ifdef __EDG__
-  template <auto V, typename = std::enable_if_t<!contains<V, Def...>::value>> constexpr inline neg_set(term<V>) noexcept;
+template <auto V, typename = std::enable_if_t<!contains<V, Def...>::value>> constexpr inline neg_set(term<V>) noexcept;
 #else
-  template <auto V, typename = std::enable_if_t<!((Def == V) || ... || false)>> constexpr inline neg_set(term<V>) noexcept;
+template <auto V, typename = std::enable_if_t<!((Def == V) || ... || false)>> constexpr inline neg_set(term<V>) noexcept;
 #endif
 };
 
 // AUGMENTED grammar which completes user-defined grammar for all other cases
 template <typename Grammar> struct augment_grammar: public Grammar {
-  // start nonterminal is defined in parent type
-  using typename Grammar::_start;
+// start nonterminal is defined in parent type
+using typename Grammar::_start;
 
-  // grammar rules are inherited from Grammar parent type
-  using Grammar::rule;
+// grammar rules are inherited from Grammar parent type
+using Grammar::rule;
 
-  // term on stack and on input means pop_input;
-  template <auto A> static constexpr auto rule(term<A>, term<A>) -> ctll::pop_input;
+// term on stack and on input means pop_input;
+template <auto A> static constexpr auto rule(term<A>, term<A>) -> ctll::pop_input;
 
-  // if the type on stack (range, set, neg_set, anything) is constructible from the terminal => pop_input
-  template <typename Expected, auto V> static constexpr auto rule(Expected, term<V>) -> std::enable_if_t<std::is_constructible_v<Expected, term<V>>, ctll::pop_input>;
+// if the type on stack (range, set, neg_set, anything) is constructible from the terminal => pop_input
+template <typename Expected, auto V> static constexpr auto rule(Expected, term<V>) -> std::enable_if_t<std::is_constructible_v<Expected, term<V>>, ctll::pop_input>;
 
-  // empty stack and empty input means we are accepting
-  static constexpr auto rule(empty_stack_symbol, epsilon) -> ctll::accept;
+// empty stack and empty input means we are accepting
+static constexpr auto rule(empty_stack_symbol, epsilon) -> ctll::accept;
 
-  // not matching anything else => reject
-  static constexpr auto rule(...) -> ctll::reject;
+// not matching anything else => reject
+static constexpr auto rule(...) -> ctll::reject;
 
-  // start stack is just a list<Grammar::_start>;
-  using start_stack = list<typename Grammar::_start>;
+// start stack is just a list<Grammar::_start>;
+using start_stack = list<typename Grammar::_start>;
 };
 
 }
@@ -647,24 +686,24 @@ namespace ctll {
 struct empty_subject { };
 
 struct empty_actions {
-  // dummy operator so using Actions::operator() later will not give error
-  template <typename Action, typename InputSymbol, typename Subject> static constexpr auto apply(Action, InputSymbol, Subject subject) {
-    return subject;
-  }
+// dummy operator so using Actions::operator() later will not give error
+template <typename Action, typename InputSymbol, typename Subject> static constexpr auto apply(Action, InputSymbol, Subject subject) {
+return subject;
+}
 };
 
 template <typename Actions> struct identity: public Actions {
-  using Actions::apply;
-  // allow empty_subject to exists
-  template <typename Action, auto V> constexpr static auto apply(Action, term<V>, empty_subject) -> empty_subject { return {}; }
-  template <typename Action> constexpr static auto apply(Action, epsilon, empty_subject) -> empty_subject { return {}; }
+using Actions::apply;
+// allow empty_subject to exists
+template <typename Action, auto V> constexpr static auto apply(Action, term<V>, empty_subject) -> empty_subject { return {}; }
+template <typename Action> constexpr static auto apply(Action, epsilon, empty_subject) -> empty_subject { return {}; }
 };
 
 template <typename Actions> struct ignore_unknown: public Actions {
-  using Actions::apply;
-  // allow flow thru unknown actions
-  template <typename Action, auto V, typename Subject> constexpr static auto apply(Action, term<V>, Subject) -> Subject { return {}; }
-  template <typename Action, typename Subject> constexpr static auto apply(Action, epsilon, Subject) -> Subject { return {}; }
+using Actions::apply;
+// allow flow thru unknown actions
+template <typename Action, auto V, typename Subject> constexpr static auto apply(Action, term<V>, Subject) -> Subject { return {}; }
+template <typename Action, typename Subject> constexpr static auto apply(Action, epsilon, Subject) -> Subject { return {}; }
 };
 }
 
@@ -675,170 +714,170 @@ template <typename Actions> struct ignore_unknown: public Actions {
 namespace ctll {
 
 enum class decision {
-  reject,
-  accept,
-  undecided
+reject,
+accept,
+undecided
 };
 
 struct placeholder { };
 
 template <size_t> using index_placeholder = placeholder;
 
-#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
+#if CTLL_CNTTP_COMPILER_CHECK
 template <typename Grammar, ctll::fixed_string input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser { // in c++20
 #else
 template <typename Grammar, const auto & input, typename ActionSelector = empty_actions, bool IgnoreUnknownActions = false> struct parser {
 #endif
 
 #ifdef __GNUC__ // workaround to GCC bug
-#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
-  static constexpr auto _input = input;  // c++20 mode
+#if CTLL_CNTTP_COMPILER_CHECK
+static constexpr auto _input = input;  // c++20 mode
 #else
-  static constexpr auto & _input = input; // c++17 mode
+static constexpr auto & _input = input; // c++17 mode
 #endif
 #else
-  static constexpr auto _input = input; // everyone else
+static constexpr auto _input = input; // everyone else
 #endif
 
-  using Actions = ctll::conditional<IgnoreUnknownActions, ignore_unknown<ActionSelector>, identity<ActionSelector>>;
-  using grammar = augment_grammar<Grammar>;
+using Actions = ctll::conditional<IgnoreUnknownActions, ignore_unknown<ActionSelector>, identity<ActionSelector>>;
+using grammar = augment_grammar<Grammar>;
 
-  template <size_t Pos, typename Stack, typename Subject, decision Decision> struct results {
-    constexpr inline CTLL_FORCE_INLINE operator bool() const noexcept {
-      return Decision == decision::accept;
-    }
+template <size_t Pos, typename Stack, typename Subject, decision Decision> struct results {
+constexpr inline CTLL_FORCE_INLINE operator bool() const noexcept {
+return Decision == decision::accept;
+}
 
 #ifdef __GNUC__ // workaround to GCC bug
-#if ((__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L)) || (__cpp_nontype_template_args >= 201911L))
-    static constexpr auto _input = input;  // c++20 mode
+#if CTLL_CNTTP_COMPILER_CHECK
+static constexpr auto _input = input;  // c++20 mode
 #else
-    static constexpr auto & _input = input; // c++17 mode
+static constexpr auto & _input = input; // c++17 mode
 #endif
 #else
-    static constexpr auto _input = input; // everyone else
+static constexpr auto _input = input; // everyone else
 #endif
 
-    using output_type = Subject;
+using output_type = Subject;
 
-    constexpr auto operator+(placeholder) const noexcept {
-      if constexpr (Decision == decision::undecided) {
-        // parse for current char (RPos) with previous stack and subject :)
-        return parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template decide<Pos, Stack, Subject>({}, {});
-      } else {
-        // if there is decision already => just push it to the end of fold expression
-        return *this;
-      }
-    }
-  };
+constexpr auto operator+(placeholder) const noexcept {
+if constexpr (Decision == decision::undecided) {
+// parse for current char (RPos) with previous stack and subject :)
+return parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template decide<Pos, Stack, Subject>({}, {});
+} else {
+// if there is decision already => just push it to the end of fold expression
+return *this;
+}
+}
+};
 
-  template <size_t Pos> static constexpr auto get_current_term() noexcept {
-    if constexpr (Pos < input.size()) {
-      constexpr auto value = input[Pos];
-      if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
-        return term<static_cast<char>(value)>{};
-      } else {
-        return term<input[Pos]>{};
-      }
+template <size_t Pos> static constexpr auto get_current_term() noexcept {
+if constexpr (Pos < input.size()) {
+constexpr auto value = input[Pos];
+if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
+return term<static_cast<char>(value)>{};
+} else {
+return term<value>{};
+}
 
-    } else {
-      // return epsilon if we are past the input
-      return epsilon{};
-    }
-  }
-  template <size_t Pos> static constexpr auto get_previous_term() noexcept {
-    if constexpr (Pos == 0) {
-      // there is no previous character on input if we are on start
-      return epsilon{};
-    } else if constexpr ((Pos-1) < input.size()) {
-      constexpr auto value = input[Pos-1];
-      if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
-        return term<static_cast<char>(value)>{};
-      } else {
-        return term<value>{};
-      }
-    } else {
-      return epsilon{};
-    }
-  }
-  // if rule is accept => return true and subject
-  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
-  static constexpr auto move(ctll::accept, Terminal, Stack, Subject) noexcept {
-    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::accept>();
-  }
-  // if rule is reject => return false and subject
-  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
-  static constexpr auto move(ctll::reject, Terminal, Stack, Subject) noexcept {
-    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
-  }
-  // if rule is pop_input => move to next character
-  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
-  static constexpr auto move(ctll::pop_input, Terminal, Stack, Subject) noexcept {
-    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, Stack, Subject, decision::undecided>();
-  }
-  // if rule is string => push it to the front of stack
-  template <size_t Pos, typename... Content, typename Terminal, typename Stack, typename Subject>
-  static constexpr auto move(push<Content...> string, Terminal, Stack stack, Subject subject) noexcept {
-    return decide<Pos>(push_front(string, stack), subject);
-  }
-  // if rule is epsilon (empty string) => continue
-  template <size_t Pos, typename Terminal, typename Stack, typename Subject>
-  static constexpr auto move(epsilon, Terminal, Stack stack, Subject subject) noexcept {
-    return decide<Pos>(stack, subject);
-  }
-  // if rule is string with current character at the beginning (term<V>) => move to next character
-  // and push string without the character (quick LL(1))
-  template <size_t Pos, auto V, typename... Content, typename Stack, typename Subject>
-  static constexpr auto move(push<term<V>, Content...>, term<V>, Stack stack, Subject) noexcept {
-    constexpr auto _input = input;
-    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
-  }
-  // if rule is string with any character at the beginning (compatible with current term<T>) => move to next character
-  // and push string without the character (quick LL(1))
-  template <size_t Pos, auto V, typename... Content, auto T, typename Stack, typename Subject>
-  static constexpr auto move(push<anything, Content...>, term<T>, Stack stack, Subject) noexcept {
-    constexpr auto _input = input;
-    return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
-  }
-  // decide if we need to take action or move
-  template <size_t Pos, typename Stack, typename Subject> static constexpr auto decide(Stack previous_stack, Subject previous_subject) noexcept {
-    // each call means we pop something from stack
-    auto top_symbol = decltype(ctll::front(previous_stack, empty_stack_symbol()))();
-    // gcc pedantic warning
-    [[maybe_unused]] auto stack = decltype(ctll::pop_front(previous_stack))();
+} else {
+// return epsilon if we are past the input
+return epsilon{};
+}
+}
+template <size_t Pos> static constexpr auto get_previous_term() noexcept {
+if constexpr (Pos == 0) {
+// there is no previous character on input if we are on start
+return epsilon{};
+} else if constexpr ((Pos-1) < input.size()) {
+constexpr auto value = input[Pos-1];
+if constexpr (value <= static_cast<decltype(value)>(std::numeric_limits<char>::max())) {
+return term<static_cast<char>(value)>{};
+} else {
+return term<value>{};
+}
+} else {
+return epsilon{};
+}
+}
+// if rule is accept => return true and subject
+template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+static constexpr auto move(ctll::accept, Terminal, Stack, Subject) noexcept {
+return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::accept>();
+}
+// if rule is reject => return false and subject
+template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+static constexpr auto move(ctll::reject, Terminal, Stack, Subject) noexcept {
+return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
+}
+// if rule is pop_input => move to next character
+template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+static constexpr auto move(ctll::pop_input, Terminal, Stack, Subject) noexcept {
+return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, Stack, Subject, decision::undecided>();
+}
+// if rule is string => push it to the front of stack
+template <size_t Pos, typename... Content, typename Terminal, typename Stack, typename Subject>
+static constexpr auto move(push<Content...> string, Terminal, Stack stack, Subject subject) noexcept {
+return decide<Pos>(push_front(string, stack), subject);
+}
+// if rule is epsilon (empty string) => continue
+template <size_t Pos, typename Terminal, typename Stack, typename Subject>
+static constexpr auto move(epsilon, Terminal, Stack stack, Subject subject) noexcept {
+return decide<Pos>(stack, subject);
+}
+// if rule is string with current character at the beginning (term<V>) => move to next character
+// and push string without the character (quick LL(1))
+template <size_t Pos, auto V, typename... Content, typename Stack, typename Subject>
+static constexpr auto move(push<term<V>, Content...>, term<V>, Stack stack, Subject) noexcept {
+constexpr auto _input = input;
+return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
+}
+// if rule is string with any character at the beginning (compatible with current term<T>) => move to next character
+// and push string without the character (quick LL(1))
+template <size_t Pos, auto V, typename... Content, auto T, typename Stack, typename Subject>
+static constexpr auto move(push<anything, Content...>, term<T>, Stack stack, Subject) noexcept {
+constexpr auto _input = input;
+return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos+1, decltype(push_front(list<Content...>(), stack)), Subject, decision::undecided>();
+}
+// decide if we need to take action or move
+template <size_t Pos, typename Stack, typename Subject> static constexpr auto decide(Stack previous_stack, Subject previous_subject) noexcept {
+// each call means we pop something from stack
+auto top_symbol = decltype(ctll::front(previous_stack, empty_stack_symbol()))();
+// gcc pedantic warning
+[[maybe_unused]] auto stack = decltype(ctll::pop_front(previous_stack))();
 
-    // in case top_symbol is action type (apply it on previous subject and get new one)
-    if constexpr (std::is_base_of_v<ctll::action, decltype(top_symbol)>) {
-      auto subject = Actions::apply(top_symbol, get_previous_term<Pos>(), previous_subject);
+// in case top_symbol is action type (apply it on previous subject and get new one)
+if constexpr (std::is_base_of_v<ctll::action, decltype(top_symbol)>) {
+auto subject = Actions::apply(top_symbol, get_previous_term<Pos>(), previous_subject);
 
-      // in case that semantic action is error => reject input
-      if constexpr (std::is_same_v<ctll::reject, decltype(subject)>) {
-        return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
-      } else {
-        return decide<Pos>(stack, subject);
-      }
-    } else {
-      // all other cases are ordinary for LL(1) parser
-      auto current_term = get_current_term<Pos>();
-      auto rule = decltype(grammar::rule(top_symbol,current_term))();
-      return move<Pos>(rule, current_term, stack, previous_subject);
-    }
-  }
+// in case that semantic action is error => reject input
+if constexpr (std::is_same_v<ctll::reject, decltype(subject)>) {
+return typename parser<Grammar, _input, ActionSelector, IgnoreUnknownActions>::template results<Pos, Stack, Subject, decision::reject>();
+} else {
+return decide<Pos>(stack, subject);
+}
+} else {
+// all other cases are ordinary for LL(1) parser
+auto current_term = get_current_term<Pos>();
+auto rule = decltype(grammar::rule(top_symbol,current_term))();
+return move<Pos>(rule, current_term, stack, previous_subject);
+}
+}
 
-  // trampolines with folded expression
-  template <typename Subject, size_t... Pos> static constexpr auto trampoline_decide(Subject, std::index_sequence<Pos...>) noexcept {
-    // parse everything for first char and than for next and next ...
-    // Pos+1 is needed as we want to finish calculation with epsilons on stack
-    auto v = (decide<0, typename grammar::start_stack, Subject>({}, {}) + ... + index_placeholder<Pos+1>());
-    return v;
-  }
+// trampolines with folded expression
+template <typename Subject, size_t... Pos> static constexpr auto trampoline_decide(Subject, std::index_sequence<Pos...>) noexcept {
+// parse everything for first char and than for next and next ...
+// Pos+1 is needed as we want to finish calculation with epsilons on stack
+auto v = (decide<0, typename grammar::start_stack, Subject>({}, {}) + ... + index_placeholder<Pos+1>());
+return v;
+}
 
-  template <typename Subject = empty_subject> static constexpr auto trampoline_decide(Subject subject = {}) noexcept {
-    // there will be no recursion, just sequence long as the input
-    return trampoline_decide(subject, std::make_index_sequence<input.size()>());
-  }
+template <typename Subject = empty_subject> static constexpr auto trampoline_decide(Subject subject = {}) noexcept {
+// there will be no recursion, just sequence long as the input
+return trampoline_decide(subject, std::make_index_sequence<input.size()>());
+}
 
-  template <typename Subject = empty_subject> using output = decltype(trampoline_decide<Subject>());
-  template <typename Subject = empty_subject> static inline constexpr bool correct_with = trampoline_decide<Subject>();
+template <typename Subject = empty_subject> using output = decltype(trampoline_decide<Subject>());
+template <typename Subject = empty_subject> static inline constexpr bool correct_with = trampoline_decide<Subject>();
 
 };
 
@@ -861,402 +900,426 @@ namespace ctre {
 struct pcre {
 
 // NONTERMINALS:
-  struct a {};
-  struct b {};
-  struct backslash {};
-  struct backslash_range {};
-  struct block {};
-  struct block_name2 {};
-  struct block_name {};
-  struct c {};
-  struct class_named_name {};
-  struct content2 {};
-  struct content_in_capture {};
-  struct d {};
-  struct e {};
-  struct f {};
-  struct g {};
-  struct h {};
-  struct hexdec_repeat {};
-  struct i {};
-  struct j {};
-  struct k {};
-  struct l {};
-  struct m {};
-  struct mod {};
-  struct mod_opt {};
-  struct n {};
-  struct number2 {};
-  struct number {};
-  struct o {};
-  struct p {};
-  struct property_name2 {};
-  struct property_name {};
-  struct property_value2 {};
-  struct property_value {};
-  struct q {};
-  struct range {};
-  struct repeat {};
-  struct s {}; using _start = s;
-  struct set2a {};
-  struct set2b {};
-  struct string2 {};
+struct a {};
+struct b {};
+struct backslash {};
+struct backslash_range {};
+struct block {};
+struct block_name2 {};
+struct block_name {};
+struct c {};
+struct class_named_name {};
+struct content2 {};
+struct content {};
+struct content_in_capture {};
+struct d {};
+struct e {};
+struct f {};
+struct g {};
+struct h {};
+struct hexdec_repeat {};
+struct i {};
+struct j {};
+struct k {};
+struct l {};
+struct m {};
+struct mod {};
+struct mod_opt {};
+struct n {};
+struct number2 {};
+struct number {};
+struct o {};
+struct property_name2 {};
+struct property_name {};
+struct property_value2 {};
+struct property_value {};
+struct range {};
+struct repeat {};
+struct s {}; using _start = s;
+struct set2a {};
+struct set2b {};
+struct string2 {};
 
 // 'action' types:
-  struct class_digit: ctll::action {};
-  struct class_named_alnum: ctll::action {};
-  struct class_named_alpha: ctll::action {};
-  struct class_named_ascii: ctll::action {};
-  struct class_named_blank: ctll::action {};
-  struct class_named_cntrl: ctll::action {};
-  struct class_named_digit: ctll::action {};
-  struct class_named_graph: ctll::action {};
-  struct class_named_lower: ctll::action {};
-  struct class_named_print: ctll::action {};
-  struct class_named_punct: ctll::action {};
-  struct class_named_space: ctll::action {};
-  struct class_named_upper: ctll::action {};
-  struct class_named_word: ctll::action {};
-  struct class_named_xdigit: ctll::action {};
-  struct class_nondigit: ctll::action {};
-  struct class_nonnewline: ctll::action {};
-  struct class_nonspace: ctll::action {};
-  struct class_nonword: ctll::action {};
-  struct class_space: ctll::action {};
-  struct class_word: ctll::action {};
-  struct create_hexdec: ctll::action {};
-  struct create_number: ctll::action {};
-  struct finish_hexdec: ctll::action {};
-  struct look_finish: ctll::action {};
-  struct make_alternate: ctll::action {};
-  struct make_back_reference: ctll::action {};
-  struct make_capture: ctll::action {};
-  struct make_capture_with_name: ctll::action {};
-  struct make_lazy: ctll::action {};
-  struct make_optional: ctll::action {};
-  struct make_possessive: ctll::action {};
-  struct make_property: ctll::action {};
-  struct make_property_negative: ctll::action {};
-  struct make_range: ctll::action {};
-  struct make_relative_back_reference: ctll::action {};
-  struct make_sequence: ctll::action {};
-  struct negate_class_named: ctll::action {};
-  struct prepare_capture: ctll::action {};
-  struct push_assert_begin: ctll::action {};
-  struct push_assert_end: ctll::action {};
-  struct push_character: ctll::action {};
-  struct push_character_alarm: ctll::action {};
-  struct push_character_anything: ctll::action {};
-  struct push_character_escape: ctll::action {};
-  struct push_character_formfeed: ctll::action {};
-  struct push_character_newline: ctll::action {};
-  struct push_character_null: ctll::action {};
-  struct push_character_return_carriage: ctll::action {};
-  struct push_character_tab: ctll::action {};
-  struct push_empty: ctll::action {};
-  struct push_hexdec: ctll::action {};
-  struct push_name: ctll::action {};
-  struct push_number: ctll::action {};
-  struct push_property_name: ctll::action {};
-  struct push_property_value: ctll::action {};
-  struct repeat_ab: ctll::action {};
-  struct repeat_at_least: ctll::action {};
-  struct repeat_exactly: ctll::action {};
-  struct repeat_plus: ctll::action {};
-  struct repeat_star: ctll::action {};
-  struct reset_capture: ctll::action {};
-  struct set_combine: ctll::action {};
-  struct set_make: ctll::action {};
-  struct set_make_negative: ctll::action {};
-  struct set_start: ctll::action {};
-  struct start_lookahead_negative: ctll::action {};
-  struct start_lookahead_positive: ctll::action {};
+struct class_digit: ctll::action {};
+struct class_horizontal_space: ctll::action {};
+struct class_named_alnum: ctll::action {};
+struct class_named_alpha: ctll::action {};
+struct class_named_ascii: ctll::action {};
+struct class_named_blank: ctll::action {};
+struct class_named_cntrl: ctll::action {};
+struct class_named_digit: ctll::action {};
+struct class_named_graph: ctll::action {};
+struct class_named_lower: ctll::action {};
+struct class_named_print: ctll::action {};
+struct class_named_punct: ctll::action {};
+struct class_named_space: ctll::action {};
+struct class_named_upper: ctll::action {};
+struct class_named_word: ctll::action {};
+struct class_named_xdigit: ctll::action {};
+struct class_non_horizontal_space: ctll::action {};
+struct class_non_vertical_space: ctll::action {};
+struct class_nondigit: ctll::action {};
+struct class_nonnewline: ctll::action {};
+struct class_nonspace: ctll::action {};
+struct class_nonword: ctll::action {};
+struct class_space: ctll::action {};
+struct class_vertical_space: ctll::action {};
+struct class_word: ctll::action {};
+struct create_hexdec: ctll::action {};
+struct create_number: ctll::action {};
+struct finish_hexdec: ctll::action {};
+struct look_finish: ctll::action {};
+struct make_alternate: ctll::action {};
+struct make_atomic: ctll::action {};
+struct make_back_reference: ctll::action {};
+struct make_capture: ctll::action {};
+struct make_capture_with_name: ctll::action {};
+struct make_lazy: ctll::action {};
+struct make_optional: ctll::action {};
+struct make_possessive: ctll::action {};
+struct make_property: ctll::action {};
+struct make_property_negative: ctll::action {};
+struct make_range: ctll::action {};
+struct make_relative_back_reference: ctll::action {};
+struct make_sequence: ctll::action {};
+struct negate_class_named: ctll::action {};
+struct prepare_capture: ctll::action {};
+struct push_assert_begin: ctll::action {};
+struct push_assert_end: ctll::action {};
+struct push_assert_subject_begin: ctll::action {};
+struct push_assert_subject_end: ctll::action {};
+struct push_assert_subject_end_with_lineend: ctll::action {};
+struct push_character: ctll::action {};
+struct push_character_alarm: ctll::action {};
+struct push_character_anything: ctll::action {};
+struct push_character_escape: ctll::action {};
+struct push_character_formfeed: ctll::action {};
+struct push_character_newline: ctll::action {};
+struct push_character_null: ctll::action {};
+struct push_character_return_carriage: ctll::action {};
+struct push_character_tab: ctll::action {};
+struct push_empty: ctll::action {};
+struct push_hexdec: ctll::action {};
+struct push_name: ctll::action {};
+struct push_not_word_boundary: ctll::action {};
+struct push_number: ctll::action {};
+struct push_property_name: ctll::action {};
+struct push_property_value: ctll::action {};
+struct push_word_boundary: ctll::action {};
+struct repeat_ab: ctll::action {};
+struct repeat_at_least: ctll::action {};
+struct repeat_exactly: ctll::action {};
+struct repeat_plus: ctll::action {};
+struct repeat_star: ctll::action {};
+struct reset_capture: ctll::action {};
+struct set_combine: ctll::action {};
+struct set_make: ctll::action {};
+struct set_make_negative: ctll::action {};
+struct set_start: ctll::action {};
+struct start_atomic: ctll::action {};
+struct start_lookahead_negative: ctll::action {};
+struct start_lookahead_positive: ctll::action {};
 
 // (q)LL1 function:
-  using _others = ctll::neg_set<'!','$','\x28','\x29','*','+',',','-','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','0','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>;
-  static constexpr auto rule(s, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
-  static constexpr auto rule(s, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
-  static constexpr auto rule(s, ctll::epsilon) -> ctll::push<push_empty>;
-  static constexpr auto rule(s, ctll::set<'\x29','*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+using _others = ctll::neg_set<'!','$','\x28','\x29','*','+',',','-','.','/',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','0','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>;
+static constexpr auto rule(s, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::set<'!',',','-','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+static constexpr auto rule(s, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
+static constexpr auto rule(s, ctll::term<'|'>) -> ctll::push<ctll::anything, push_empty, content, make_alternate>;
+static constexpr auto rule(s, ctll::epsilon) -> ctll::push<push_empty>;
+static constexpr auto rule(s, ctll::set<'\x29','*','+','?','\x7B','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(a, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2, make_alternate>;
-  static constexpr auto rule(a, ctll::term<'\x29'>) -> ctll::push<push_empty, make_alternate>;
-  static constexpr auto rule(a, ctll::epsilon) -> ctll::push<push_empty, make_alternate>;
-  static constexpr auto rule(a, ctll::set<'*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+static constexpr auto rule(a, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::set<'!',',','-','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2, make_alternate>;
+static constexpr auto rule(a, ctll::term<'\x29'>) -> ctll::push<push_empty, make_alternate>;
+static constexpr auto rule(a, ctll::epsilon) -> ctll::push<push_empty, make_alternate>;
+static constexpr auto rule(a, ctll::set<'*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(b, ctll::term<','>) -> ctll::push<ctll::anything, n>;
-  static constexpr auto rule(b, ctll::term<'\x7D'>) -> ctll::push<repeat_exactly, ctll::anything>;
+static constexpr auto rule(b, ctll::term<','>) -> ctll::push<ctll::anything, n>;
+static constexpr auto rule(b, ctll::term<'\x7D'>) -> ctll::push<repeat_exactly, ctll::anything>;
 
-  static constexpr auto rule(backslash, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
-  static constexpr auto rule(backslash, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
-  static constexpr auto rule(backslash, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
-  static constexpr auto rule(backslash, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
-  static constexpr auto rule(backslash, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
-  static constexpr auto rule(backslash, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
-  static constexpr auto rule(backslash, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
-  static constexpr auto rule(backslash, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
-  static constexpr auto rule(backslash, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, m>;
-  static constexpr auto rule(backslash, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
-  static constexpr auto rule(backslash, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
-  static constexpr auto rule(backslash, ctll::term<'u'>) -> ctll::push<ctll::anything, k>;
-  static constexpr auto rule(backslash, ctll::term<'x'>) -> ctll::push<ctll::anything, l>;
-  static constexpr auto rule(backslash, ctll::set<'$','\x28','\x29','*','+','-','.','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
-  static constexpr auto rule(backslash, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm>;
-  static constexpr auto rule(backslash, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape>;
-  static constexpr auto rule(backslash, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed>;
-  static constexpr auto rule(backslash, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline>;
-  static constexpr auto rule(backslash, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null>;
-  static constexpr auto rule(backslash, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage>;
-  static constexpr auto rule(backslash, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab>;
+static constexpr auto rule(backslash, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
+static constexpr auto rule(backslash, ctll::term<'h'>) -> ctll::push<ctll::anything, class_horizontal_space>;
+static constexpr auto rule(backslash, ctll::term<'H'>) -> ctll::push<ctll::anything, class_non_horizontal_space>;
+static constexpr auto rule(backslash, ctll::term<'V'>) -> ctll::push<ctll::anything, class_non_vertical_space>;
+static constexpr auto rule(backslash, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
+static constexpr auto rule(backslash, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
+static constexpr auto rule(backslash, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
+static constexpr auto rule(backslash, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
+static constexpr auto rule(backslash, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
+static constexpr auto rule(backslash, ctll::term<'v'>) -> ctll::push<ctll::anything, class_vertical_space>;
+static constexpr auto rule(backslash, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
+static constexpr auto rule(backslash, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
+static constexpr auto rule(backslash, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, m>;
+static constexpr auto rule(backslash, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
+static constexpr auto rule(backslash, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
+static constexpr auto rule(backslash, ctll::term<'u'>) -> ctll::push<ctll::anything, k>;
+static constexpr auto rule(backslash, ctll::term<'x'>) -> ctll::push<ctll::anything, l>;
+static constexpr auto rule(backslash, ctll::term<'A'>) -> ctll::push<ctll::anything, push_assert_subject_begin>;
+static constexpr auto rule(backslash, ctll::term<'z'>) -> ctll::push<ctll::anything, push_assert_subject_end>;
+static constexpr auto rule(backslash, ctll::term<'Z'>) -> ctll::push<ctll::anything, push_assert_subject_end_with_lineend>;
+static constexpr auto rule(backslash, ctll::set<'$','\x28','\x29','*','+','-','.','/','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
+static constexpr auto rule(backslash, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm>;
+static constexpr auto rule(backslash, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape>;
+static constexpr auto rule(backslash, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed>;
+static constexpr auto rule(backslash, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline>;
+static constexpr auto rule(backslash, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null>;
+static constexpr auto rule(backslash, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage>;
+static constexpr auto rule(backslash, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab>;
+static constexpr auto rule(backslash, ctll::term<'B'>) -> ctll::push<ctll::anything, push_not_word_boundary>;
+static constexpr auto rule(backslash, ctll::term<'b'>) -> ctll::push<ctll::anything, push_word_boundary>;
 
-  static constexpr auto rule(backslash_range, ctll::term<'u'>) -> ctll::push<ctll::anything, k>;
-  static constexpr auto rule(backslash_range, ctll::term<'x'>) -> ctll::push<ctll::anything, l>;
-  static constexpr auto rule(backslash_range, ctll::term<'-'>) -> ctll::push<ctll::anything, push_character>;
-  static constexpr auto rule(backslash_range, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm>;
-  static constexpr auto rule(backslash_range, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape>;
-  static constexpr auto rule(backslash_range, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed>;
-  static constexpr auto rule(backslash_range, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline>;
-  static constexpr auto rule(backslash_range, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null>;
-  static constexpr auto rule(backslash_range, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage>;
-  static constexpr auto rule(backslash_range, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab>;
+static constexpr auto rule(backslash_range, ctll::term<'u'>) -> ctll::push<ctll::anything, k>;
+static constexpr auto rule(backslash_range, ctll::term<'x'>) -> ctll::push<ctll::anything, l>;
+static constexpr auto rule(backslash_range, ctll::set<'$','\x28','\x29','*','+','-','.','/','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
+static constexpr auto rule(backslash_range, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm>;
+static constexpr auto rule(backslash_range, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape>;
+static constexpr auto rule(backslash_range, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed>;
+static constexpr auto rule(backslash_range, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline>;
+static constexpr auto rule(backslash_range, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null>;
+static constexpr auto rule(backslash_range, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage>;
+static constexpr auto rule(backslash_range, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab>;
 
-  static constexpr auto rule(block, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::term<'?'>) -> ctll::push<ctll::anything, d>;
-  static constexpr auto rule(block, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(block, ctll::term<'\x29'>) -> ctll::push<push_empty, make_capture, ctll::anything>;
-  static constexpr auto rule(block, ctll::set<'*','+','\x7B','|','\x7D'>) -> ctll::reject;
+static constexpr auto rule(block, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'?'>) -> ctll::push<ctll::anything, d>;
+static constexpr auto rule(block, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::set<'!',',','-','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'|'>) -> ctll::push<ctll::anything, push_empty, content, make_alternate, make_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(block, ctll::term<'\x29'>) -> ctll::push<push_empty, make_capture, ctll::anything>;
+static constexpr auto rule(block, ctll::set<'*','+','\x7B','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(block_name2, ctll::set<'>','\x7D'>) -> ctll::epsilon;
-  static constexpr auto rule(block_name2, ctll::set<'0','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_name, block_name2>;
+static constexpr auto rule(block_name2, ctll::set<'>','\x7D'>) -> ctll::epsilon;
+static constexpr auto rule(block_name2, ctll::set<'0','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_name, block_name2>;
 
-  static constexpr auto rule(block_name, ctll::set<'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'>) -> ctll::push<ctll::anything, push_name, block_name2>;
+static constexpr auto rule(block_name, ctll::set<'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'>) -> ctll::push<ctll::anything, push_name, block_name2>;
 
-  static constexpr auto rule(c, ctll::term<'['>) -> ctll::push<ctll::anything, ctll::term<':'>, i, range, set_start, set2b, set_make, ctll::term<']'>>;
-  static constexpr auto rule(c, ctll::term<'\\'>) -> ctll::push<ctll::anything, e, set_start, set2b, set_make, ctll::term<']'>>;
-  static constexpr auto rule(c, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
-  static constexpr auto rule(c, _others) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
-  static constexpr auto rule(c, ctll::term<'^'>) -> ctll::push<ctll::anything, set2a, set_make_negative, ctll::term<']'>>;
-  static constexpr auto rule(c, ctll::set<'-',']','|'>) -> ctll::reject;
+static constexpr auto rule(c, ctll::term<'['>) -> ctll::push<ctll::anything, ctll::term<':'>, i, range, set_start, set2b, set_make, ctll::term<']'>>;
+static constexpr auto rule(c, ctll::term<'\\'>) -> ctll::push<ctll::anything, e, set_start, set2b, set_make, ctll::term<']'>>;
+static constexpr auto rule(c, ctll::set<'!','$','\x28','\x29','*','+',',','.','/',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','0','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
+static constexpr auto rule(c, _others) -> ctll::push<ctll::anything, push_character, range, set_start, set2b, set_make, ctll::term<']'>>;
+static constexpr auto rule(c, ctll::term<'^'>) -> ctll::push<ctll::anything, set2a, set_make_negative, ctll::term<']'>>;
+static constexpr auto rule(c, ctll::set<'-',']'>) -> ctll::reject;
 
-  static constexpr auto rule(class_named_name, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit>;
-  static constexpr auto rule(class_named_name, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit>;
-  static constexpr auto rule(class_named_name, ctll::term<'b'>) -> ctll::push<ctll::anything, ctll::term<'l'>, ctll::term<'a'>, ctll::term<'n'>, ctll::term<'k'>, class_named_blank>;
-  static constexpr auto rule(class_named_name, ctll::term<'c'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'t'>, ctll::term<'r'>, ctll::term<'l'>, class_named_cntrl>;
-  static constexpr auto rule(class_named_name, ctll::term<'w'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'r'>, ctll::term<'d'>, class_named_word>;
-  static constexpr auto rule(class_named_name, ctll::term<'l'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'w'>, ctll::term<'e'>, ctll::term<'r'>, class_named_lower>;
-  static constexpr auto rule(class_named_name, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'a'>, ctll::term<'c'>, ctll::term<'e'>, class_named_space>;
-  static constexpr auto rule(class_named_name, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'p'>, ctll::term<'e'>, ctll::term<'r'>, class_named_upper>;
-  static constexpr auto rule(class_named_name, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'r'>, ctll::term<'a'>, ctll::term<'p'>, ctll::term<'h'>, class_named_graph>;
-  static constexpr auto rule(class_named_name, ctll::term<'a'>) -> ctll::push<ctll::anything, g>;
-  static constexpr auto rule(class_named_name, ctll::term<'p'>) -> ctll::push<ctll::anything, h>;
+static constexpr auto rule(class_named_name, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit>;
+static constexpr auto rule(class_named_name, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit>;
+static constexpr auto rule(class_named_name, ctll::term<'b'>) -> ctll::push<ctll::anything, ctll::term<'l'>, ctll::term<'a'>, ctll::term<'n'>, ctll::term<'k'>, class_named_blank>;
+static constexpr auto rule(class_named_name, ctll::term<'c'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'t'>, ctll::term<'r'>, ctll::term<'l'>, class_named_cntrl>;
+static constexpr auto rule(class_named_name, ctll::term<'w'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'r'>, ctll::term<'d'>, class_named_word>;
+static constexpr auto rule(class_named_name, ctll::term<'l'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'w'>, ctll::term<'e'>, ctll::term<'r'>, class_named_lower>;
+static constexpr auto rule(class_named_name, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'a'>, ctll::term<'c'>, ctll::term<'e'>, class_named_space>;
+static constexpr auto rule(class_named_name, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'p'>, ctll::term<'e'>, ctll::term<'r'>, class_named_upper>;
+static constexpr auto rule(class_named_name, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'r'>, ctll::term<'a'>, ctll::term<'p'>, ctll::term<'h'>, class_named_graph>;
+static constexpr auto rule(class_named_name, ctll::term<'a'>) -> ctll::push<ctll::anything, g>;
+static constexpr auto rule(class_named_name, ctll::term<'p'>) -> ctll::push<ctll::anything, h>;
 
-  static constexpr auto rule(content2, ctll::term<'\x29'>) -> ctll::epsilon;
-  static constexpr auto rule(content2, ctll::epsilon) -> ctll::epsilon;
-  static constexpr auto rule(content2, ctll::term<'|'>) -> ctll::push<ctll::anything, a>;
+static constexpr auto rule(content2, ctll::term<'\x29'>) -> ctll::epsilon;
+static constexpr auto rule(content2, ctll::epsilon) -> ctll::epsilon;
+static constexpr auto rule(content2, ctll::term<'|'>) -> ctll::push<ctll::anything, a>;
 
-  static constexpr auto rule(content_in_capture, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
-  static constexpr auto rule(content_in_capture, ctll::term<'\x29'>) -> ctll::push<push_empty>;
-  static constexpr auto rule(content_in_capture, ctll::set<'*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
+static constexpr auto rule(content, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::set<'!',',','-','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+static constexpr auto rule(content, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
+static constexpr auto rule(content, ctll::set<'\x29','*','+','?','\x7B','|','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(d, ctll::term<'<'>) -> ctll::push<ctll::anything, block_name, ctll::term<'>'>, content_in_capture, make_capture_with_name, ctll::term<'\x29'>>;
-  static constexpr auto rule(d, ctll::term<':'>) -> ctll::push<reset_capture, ctll::anything, content_in_capture, ctll::term<'\x29'>>;
-  static constexpr auto rule(d, ctll::term<'!'>) -> ctll::push<reset_capture, ctll::anything, start_lookahead_negative, content_in_capture, look_finish, ctll::term<'\x29'>>;
-  static constexpr auto rule(d, ctll::term<'='>) -> ctll::push<reset_capture, ctll::anything, start_lookahead_positive, content_in_capture, look_finish, ctll::term<'\x29'>>;
+static constexpr auto rule(content_in_capture, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::set<'!',',','-','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, content2>;
+static constexpr auto rule(content_in_capture, ctll::term<'|'>) -> ctll::push<ctll::anything, push_empty, content, make_alternate>;
+static constexpr auto rule(content_in_capture, ctll::term<'\x29'>) -> ctll::push<push_empty>;
+static constexpr auto rule(content_in_capture, ctll::set<'*','+','?','\x7B','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(e, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
-  static constexpr auto rule(e, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
-  static constexpr auto rule(e, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
-  static constexpr auto rule(e, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
-  static constexpr auto rule(e, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
-  static constexpr auto rule(e, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
-  static constexpr auto rule(e, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
-  static constexpr auto rule(e, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
-  static constexpr auto rule(e, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
-  static constexpr auto rule(e, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
-  static constexpr auto rule(e, ctll::term<'u'>) -> ctll::push<ctll::anything, k, range>;
-  static constexpr auto rule(e, ctll::term<'x'>) -> ctll::push<ctll::anything, l, range>;
-  static constexpr auto rule(e, ctll::term<'-'>) -> ctll::push<ctll::anything, p>;
-  static constexpr auto rule(e, ctll::set<'$','\x28','\x29','*','+','.','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
-  static constexpr auto rule(e, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm, range>;
-  static constexpr auto rule(e, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape, range>;
-  static constexpr auto rule(e, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed, range>;
-  static constexpr auto rule(e, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline, range>;
-  static constexpr auto rule(e, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null, range>;
-  static constexpr auto rule(e, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage, range>;
-  static constexpr auto rule(e, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab, range>;
+static constexpr auto rule(d, ctll::term<'<'>) -> ctll::push<ctll::anything, block_name, ctll::term<'>'>, content_in_capture, make_capture_with_name, ctll::term<'\x29'>>;
+static constexpr auto rule(d, ctll::term<':'>) -> ctll::push<reset_capture, ctll::anything, content_in_capture, ctll::term<'\x29'>>;
+static constexpr auto rule(d, ctll::term<'>'>) -> ctll::push<reset_capture, ctll::anything, start_atomic, content_in_capture, make_atomic, ctll::term<'\x29'>>;
+static constexpr auto rule(d, ctll::term<'!'>) -> ctll::push<reset_capture, ctll::anything, start_lookahead_negative, content_in_capture, look_finish, ctll::term<'\x29'>>;
+static constexpr auto rule(d, ctll::term<'='>) -> ctll::push<reset_capture, ctll::anything, start_lookahead_positive, content_in_capture, look_finish, ctll::term<'\x29'>>;
 
-  static constexpr auto rule(f, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
-  static constexpr auto rule(f, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
-  static constexpr auto rule(f, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
-  static constexpr auto rule(f, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
-  static constexpr auto rule(f, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
-  static constexpr auto rule(f, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
-  static constexpr auto rule(f, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
-  static constexpr auto rule(f, ctll::set<'1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, make_back_reference>;
-  static constexpr auto rule(f, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
-  static constexpr auto rule(f, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
-  static constexpr auto rule(f, ctll::term<'u'>) -> ctll::push<ctll::anything, k, range>;
-  static constexpr auto rule(f, ctll::term<'x'>) -> ctll::push<ctll::anything, l, range>;
-  static constexpr auto rule(f, ctll::set<'$','\x28','\x29','*','+','.','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character>;
-  static constexpr auto rule(f, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm, range>;
-  static constexpr auto rule(f, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape, range>;
-  static constexpr auto rule(f, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed, range>;
-  static constexpr auto rule(f, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline, range>;
-  static constexpr auto rule(f, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null, range>;
-  static constexpr auto rule(f, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage, range>;
-  static constexpr auto rule(f, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab, range>;
-  static constexpr auto rule(f, ctll::term<'-'>) -> ctll::push<ctll::anything, q>;
+static constexpr auto rule(e, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
+static constexpr auto rule(e, ctll::term<'h'>) -> ctll::push<ctll::anything, class_horizontal_space>;
+static constexpr auto rule(e, ctll::term<'H'>) -> ctll::push<ctll::anything, class_non_horizontal_space>;
+static constexpr auto rule(e, ctll::term<'V'>) -> ctll::push<ctll::anything, class_non_vertical_space>;
+static constexpr auto rule(e, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
+static constexpr auto rule(e, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
+static constexpr auto rule(e, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
+static constexpr auto rule(e, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
+static constexpr auto rule(e, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
+static constexpr auto rule(e, ctll::term<'v'>) -> ctll::push<ctll::anything, class_vertical_space>;
+static constexpr auto rule(e, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
+static constexpr auto rule(e, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
+static constexpr auto rule(e, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
+static constexpr auto rule(e, ctll::term<'u'>) -> ctll::push<ctll::anything, k, range>;
+static constexpr auto rule(e, ctll::term<'x'>) -> ctll::push<ctll::anything, l, range>;
+static constexpr auto rule(e, ctll::set<'$','\x28','\x29','*','+','-','.','/','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character, range>;
+static constexpr auto rule(e, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm, range>;
+static constexpr auto rule(e, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape, range>;
+static constexpr auto rule(e, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed, range>;
+static constexpr auto rule(e, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline, range>;
+static constexpr auto rule(e, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null, range>;
+static constexpr auto rule(e, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage, range>;
+static constexpr auto rule(e, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab, range>;
 
-  static constexpr auto rule(g, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'c'>, ctll::term<'i'>, ctll::term<'i'>, class_named_ascii>;
-  static constexpr auto rule(g, ctll::term<'l'>) -> ctll::push<ctll::anything, o>;
+static constexpr auto rule(f, ctll::term<'d'>) -> ctll::push<ctll::anything, class_digit>;
+static constexpr auto rule(f, ctll::term<'h'>) -> ctll::push<ctll::anything, class_horizontal_space>;
+static constexpr auto rule(f, ctll::term<'H'>) -> ctll::push<ctll::anything, class_non_horizontal_space>;
+static constexpr auto rule(f, ctll::term<'V'>) -> ctll::push<ctll::anything, class_non_vertical_space>;
+static constexpr auto rule(f, ctll::term<'D'>) -> ctll::push<ctll::anything, class_nondigit>;
+static constexpr auto rule(f, ctll::term<'N'>) -> ctll::push<ctll::anything, class_nonnewline>;
+static constexpr auto rule(f, ctll::term<'S'>) -> ctll::push<ctll::anything, class_nonspace>;
+static constexpr auto rule(f, ctll::term<'W'>) -> ctll::push<ctll::anything, class_nonword>;
+static constexpr auto rule(f, ctll::term<'s'>) -> ctll::push<ctll::anything, class_space>;
+static constexpr auto rule(f, ctll::term<'v'>) -> ctll::push<ctll::anything, class_vertical_space>;
+static constexpr auto rule(f, ctll::term<'w'>) -> ctll::push<ctll::anything, class_word>;
+static constexpr auto rule(f, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property>;
+static constexpr auto rule(f, ctll::term<'P'>) -> ctll::push<ctll::anything, ctll::term<'\x7B'>, property_name, ctll::term<'\x7D'>, make_property_negative>;
+static constexpr auto rule(f, ctll::term<'u'>) -> ctll::push<ctll::anything, k, range>;
+static constexpr auto rule(f, ctll::term<'x'>) -> ctll::push<ctll::anything, l, range>;
+static constexpr auto rule(f, ctll::set<'$','\x28','\x29','*','+','-','.','/','?','[','\\',']','^','\x7B','|','\x7D'>) -> ctll::push<ctll::anything, push_character, range>;
+static constexpr auto rule(f, ctll::term<'a'>) -> ctll::push<ctll::anything, push_character_alarm, range>;
+static constexpr auto rule(f, ctll::term<'e'>) -> ctll::push<ctll::anything, push_character_escape, range>;
+static constexpr auto rule(f, ctll::term<'f'>) -> ctll::push<ctll::anything, push_character_formfeed, range>;
+static constexpr auto rule(f, ctll::term<'n'>) -> ctll::push<ctll::anything, push_character_newline, range>;
+static constexpr auto rule(f, ctll::term<'0'>) -> ctll::push<ctll::anything, push_character_null, range>;
+static constexpr auto rule(f, ctll::term<'r'>) -> ctll::push<ctll::anything, push_character_return_carriage, range>;
+static constexpr auto rule(f, ctll::term<'t'>) -> ctll::push<ctll::anything, push_character_tab, range>;
 
-  static constexpr auto rule(h, ctll::term<'r'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'n'>, ctll::term<'t'>, class_named_print>;
-  static constexpr auto rule(h, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'c'>, ctll::term<'t'>, class_named_punct>;
+static constexpr auto rule(g, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'c'>, ctll::term<'i'>, ctll::term<'i'>, class_named_ascii>;
+static constexpr auto rule(g, ctll::term<'l'>) -> ctll::push<ctll::anything, o>;
 
-  static constexpr auto rule(hexdec_repeat, ctll::term<'\x7D'>) -> ctll::epsilon;
-  static constexpr auto rule(hexdec_repeat, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_hexdec, hexdec_repeat>;
+static constexpr auto rule(h, ctll::term<'r'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'n'>, ctll::term<'t'>, class_named_print>;
+static constexpr auto rule(h, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'c'>, ctll::term<'t'>, class_named_punct>;
 
-  static constexpr auto rule(i, ctll::term<'^'>) -> ctll::push<ctll::anything, class_named_name, negate_class_named, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'b'>) -> ctll::push<ctll::anything, ctll::term<'l'>, ctll::term<'a'>, ctll::term<'n'>, ctll::term<'k'>, class_named_blank, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'c'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'t'>, ctll::term<'r'>, ctll::term<'l'>, class_named_cntrl, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'w'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'r'>, ctll::term<'d'>, class_named_word, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'l'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'w'>, ctll::term<'e'>, ctll::term<'r'>, class_named_lower, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'a'>, ctll::term<'c'>, ctll::term<'e'>, class_named_space, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'p'>, ctll::term<'e'>, ctll::term<'r'>, class_named_upper, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'r'>, ctll::term<'a'>, ctll::term<'p'>, ctll::term<'h'>, class_named_graph, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'a'>) -> ctll::push<ctll::anything, g, ctll::term<':'>, ctll::term<']'>>;
-  static constexpr auto rule(i, ctll::term<'p'>) -> ctll::push<ctll::anything, h, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(hexdec_repeat, ctll::term<'\x7D'>) -> ctll::epsilon;
+static constexpr auto rule(hexdec_repeat, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_hexdec, hexdec_repeat>;
 
-  static constexpr auto rule(j, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash_range, make_range>;
-  static constexpr auto rule(j, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, make_range>;
-  static constexpr auto rule(j, _others) -> ctll::push<ctll::anything, push_character, make_range>;
-  static constexpr auto rule(j, ctll::set<'-','[',']','^','|'>) -> ctll::reject;
+static constexpr auto rule(i, ctll::term<'^'>) -> ctll::push<ctll::anything, class_named_name, negate_class_named, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'x'>) -> ctll::push<ctll::anything, ctll::term<'d'>, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_xdigit, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'d'>) -> ctll::push<ctll::anything, ctll::term<'i'>, ctll::term<'g'>, ctll::term<'i'>, ctll::term<'t'>, class_named_digit, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'b'>) -> ctll::push<ctll::anything, ctll::term<'l'>, ctll::term<'a'>, ctll::term<'n'>, ctll::term<'k'>, class_named_blank, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'c'>) -> ctll::push<ctll::anything, ctll::term<'n'>, ctll::term<'t'>, ctll::term<'r'>, ctll::term<'l'>, class_named_cntrl, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'w'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'r'>, ctll::term<'d'>, class_named_word, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'l'>) -> ctll::push<ctll::anything, ctll::term<'o'>, ctll::term<'w'>, ctll::term<'e'>, ctll::term<'r'>, class_named_lower, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'s'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'a'>, ctll::term<'c'>, ctll::term<'e'>, class_named_space, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'u'>) -> ctll::push<ctll::anything, ctll::term<'p'>, ctll::term<'p'>, ctll::term<'e'>, ctll::term<'r'>, class_named_upper, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'g'>) -> ctll::push<ctll::anything, ctll::term<'r'>, ctll::term<'a'>, ctll::term<'p'>, ctll::term<'h'>, class_named_graph, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'a'>) -> ctll::push<ctll::anything, g, ctll::term<':'>, ctll::term<']'>>;
+static constexpr auto rule(i, ctll::term<'p'>) -> ctll::push<ctll::anything, h, ctll::term<':'>, ctll::term<']'>>;
 
-  static constexpr auto rule(k, ctll::term<'\x7B'>) -> ctll::push<create_hexdec, ctll::anything, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, hexdec_repeat, ctll::term<'\x7D'>, finish_hexdec>;
-  static constexpr auto rule(k, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<create_hexdec, ctll::anything, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, finish_hexdec>;
+static constexpr auto rule(j, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash_range, make_range>;
+static constexpr auto rule(j, ctll::set<'!','$','\x28','\x29','*','+',',','.','/',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','0','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, make_range>;
+static constexpr auto rule(j, _others) -> ctll::push<ctll::anything, push_character, make_range>;
+static constexpr auto rule(j, ctll::set<'-','[',']'>) -> ctll::reject;
 
-  static constexpr auto rule(l, ctll::term<'\x7B'>) -> ctll::push<create_hexdec, ctll::anything, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, hexdec_repeat, ctll::term<'\x7D'>, finish_hexdec>;
-  static constexpr auto rule(l, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<create_hexdec, ctll::anything, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, finish_hexdec>;
+static constexpr auto rule(k, ctll::term<'\x7B'>) -> ctll::push<create_hexdec, ctll::anything, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, hexdec_repeat, ctll::term<'\x7D'>, finish_hexdec>;
+static constexpr auto rule(k, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<create_hexdec, ctll::anything, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, finish_hexdec>;
 
-  static constexpr auto rule(m, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2, ctll::term<'\x7D'>, make_back_reference>;
-  static constexpr auto rule(m, ctll::term<'-'>) -> ctll::push<ctll::anything, number, ctll::term<'\x7D'>, make_relative_back_reference>;
-  static constexpr auto rule(m, ctll::set<'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'>) -> ctll::push<ctll::anything, push_name, block_name2, ctll::term<'\x7D'>, make_back_reference>;
+static constexpr auto rule(l, ctll::term<'\x7B'>) -> ctll::push<create_hexdec, ctll::anything, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, hexdec_repeat, ctll::term<'\x7D'>, finish_hexdec>;
+static constexpr auto rule(l, ctll::set<'0','A','B','C','D','E','F','a','b','c','d','e','f','1','2','3','4','5','6','7','8','9'>) -> ctll::push<create_hexdec, ctll::anything, push_hexdec, ctll::set<'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F','a','b','c','d','e','f'>, push_hexdec, finish_hexdec>;
 
-  static constexpr auto rule(mod, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
-  static constexpr auto rule(mod, ctll::epsilon) -> ctll::epsilon;
-  static constexpr auto rule(mod, _others) -> ctll::epsilon;
-  static constexpr auto rule(mod, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
-  static constexpr auto rule(mod, ctll::term<'+'>) -> ctll::push<ctll::anything, make_possessive>;
-  static constexpr auto rule(mod, ctll::set<'*','\x7B','\x7D'>) -> ctll::reject;
+static constexpr auto rule(m, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2, ctll::term<'\x7D'>, make_back_reference>;
+static constexpr auto rule(m, ctll::term<'-'>) -> ctll::push<ctll::anything, number, ctll::term<'\x7D'>, make_relative_back_reference>;
+static constexpr auto rule(m, ctll::set<'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z'>) -> ctll::push<ctll::anything, push_name, block_name2, ctll::term<'\x7D'>, make_back_reference>;
 
-  static constexpr auto rule(mod_opt, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
-  static constexpr auto rule(mod_opt, ctll::epsilon) -> ctll::epsilon;
-  static constexpr auto rule(mod_opt, _others) -> ctll::epsilon;
-  static constexpr auto rule(mod_opt, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
-  static constexpr auto rule(mod_opt, ctll::set<'*','+','\x7B','\x7D'>) -> ctll::reject;
+static constexpr auto rule(mod, ctll::set<'!','$','\x28','\x29',',','-','.','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+static constexpr auto rule(mod, ctll::epsilon) -> ctll::epsilon;
+static constexpr auto rule(mod, _others) -> ctll::epsilon;
+static constexpr auto rule(mod, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
+static constexpr auto rule(mod, ctll::term<'+'>) -> ctll::push<ctll::anything, make_possessive>;
+static constexpr auto rule(mod, ctll::set<'*','\x7B','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(n, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2, repeat_ab, ctll::term<'\x7D'>, mod>;
-  static constexpr auto rule(n, ctll::term<'\x7D'>) -> ctll::push<repeat_at_least, ctll::anything, mod>;
+static constexpr auto rule(mod_opt, ctll::set<'!','$','\x28','\x29',',','-','.','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+static constexpr auto rule(mod_opt, ctll::epsilon) -> ctll::epsilon;
+static constexpr auto rule(mod_opt, _others) -> ctll::epsilon;
+static constexpr auto rule(mod_opt, ctll::term<'?'>) -> ctll::push<ctll::anything, make_lazy>;
+static constexpr auto rule(mod_opt, ctll::set<'*','+','\x7B','\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(number2, ctll::set<',','\x7D'>) -> ctll::epsilon;
-  static constexpr auto rule(number2, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_number, number2>;
+static constexpr auto rule(n, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2, repeat_ab, ctll::term<'\x7D'>, mod>;
+static constexpr auto rule(n, ctll::term<'\x7D'>) -> ctll::push<repeat_at_least, ctll::anything, mod>;
 
-  static constexpr auto rule(number, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2>;
+static constexpr auto rule(number2, ctll::set<',','\x7D'>) -> ctll::epsilon;
+static constexpr auto rule(number2, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_number, number2>;
 
-  static constexpr auto rule(o, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'h'>, ctll::term<'a'>, class_named_alpha>;
-  static constexpr auto rule(o, ctll::term<'n'>) -> ctll::push<ctll::anything, ctll::term<'u'>, ctll::term<'m'>, class_named_alnum>;
+static constexpr auto rule(number, ctll::set<'0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, create_number, number2>;
 
-  static constexpr auto rule(p, ctll::term<'-'>) -> ctll::push<push_character, ctll::anything, j>;
-  static constexpr auto rule(p, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<push_character>;
-  static constexpr auto rule(p, ctll::epsilon) -> ctll::push<push_character>;
-  static constexpr auto rule(p, _others) -> ctll::push<push_character>;
-  static constexpr auto rule(p, ctll::term<'|'>) -> ctll::reject;
+static constexpr auto rule(o, ctll::term<'p'>) -> ctll::push<ctll::anything, ctll::term<'h'>, ctll::term<'a'>, class_named_alpha>;
+static constexpr auto rule(o, ctll::term<'n'>) -> ctll::push<ctll::anything, ctll::term<'u'>, ctll::term<'m'>, class_named_alnum>;
 
-  static constexpr auto rule(property_name2, ctll::term<'\x7D'>) -> ctll::epsilon;
-  static constexpr auto rule(property_name2, ctll::term<'='>) -> ctll::push<ctll::anything, property_value>;
-  static constexpr auto rule(property_name2, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_name, property_name2>;
+static constexpr auto rule(property_name2, ctll::term<'\x7D'>) -> ctll::epsilon;
+static constexpr auto rule(property_name2, ctll::term<'='>) -> ctll::push<ctll::anything, property_value>;
+static constexpr auto rule(property_name2, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_name, property_name2>;
 
-  static constexpr auto rule(property_name, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_name, property_name2>;
+static constexpr auto rule(property_name, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_name, property_name2>;
 
-  static constexpr auto rule(property_value2, ctll::term<'\x7D'>) -> ctll::epsilon;
-  static constexpr auto rule(property_value2, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_value, property_value2>;
+static constexpr auto rule(property_value2, ctll::term<'\x7D'>) -> ctll::epsilon;
+static constexpr auto rule(property_value2, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_value, property_value2>;
 
-  static constexpr auto rule(property_value, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_value, property_value2>;
+static constexpr auto rule(property_value, ctll::set<'0','.','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_property_value, property_value2>;
 
-  static constexpr auto rule(q, ctll::term<'-'>) -> ctll::push<push_character, ctll::anything, j>;
-  static constexpr auto rule(q, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::push<push_character>;
-  static constexpr auto rule(q, ctll::epsilon) -> ctll::push<push_character>;
-  static constexpr auto rule(q, _others) -> ctll::push<push_character>;
-  static constexpr auto rule(q, ctll::term<'|'>) -> ctll::reject;
+static constexpr auto rule(range, ctll::set<'!','$','\x28','\x29','*','+',',','.','/',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','|','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+static constexpr auto rule(range, ctll::epsilon) -> ctll::epsilon;
+static constexpr auto rule(range, _others) -> ctll::epsilon;
+static constexpr auto rule(range, ctll::term<'-'>) -> ctll::push<ctll::anything, j>;
 
-  static constexpr auto rule(range, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','\x7B','\x7D','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
-  static constexpr auto rule(range, ctll::epsilon) -> ctll::epsilon;
-  static constexpr auto rule(range, _others) -> ctll::epsilon;
-  static constexpr auto rule(range, ctll::term<'-'>) -> ctll::push<ctll::anything, j>;
-  static constexpr auto rule(range, ctll::term<'|'>) -> ctll::reject;
+static constexpr auto rule(repeat, ctll::set<'!','$','\x28','\x29',',','-','.','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
+static constexpr auto rule(repeat, ctll::epsilon) -> ctll::epsilon;
+static constexpr auto rule(repeat, _others) -> ctll::epsilon;
+static constexpr auto rule(repeat, ctll::term<'?'>) -> ctll::push<ctll::anything, make_optional, mod_opt>;
+static constexpr auto rule(repeat, ctll::term<'\x7B'>) -> ctll::push<ctll::anything, number, b>;
+static constexpr auto rule(repeat, ctll::term<'+'>) -> ctll::push<ctll::anything, repeat_plus, mod>;
+static constexpr auto rule(repeat, ctll::term<'*'>) -> ctll::push<ctll::anything, repeat_star, mod>;
+static constexpr auto rule(repeat, ctll::term<'\x7D'>) -> ctll::reject;
 
-  static constexpr auto rule(repeat, ctll::set<'!','$','\x28','\x29',',','-','.',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','[','\\',']','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','|','0','1','2','3','4','5','6','7','8','9'>) -> ctll::epsilon;
-  static constexpr auto rule(repeat, ctll::epsilon) -> ctll::epsilon;
-  static constexpr auto rule(repeat, _others) -> ctll::epsilon;
-  static constexpr auto rule(repeat, ctll::term<'?'>) -> ctll::push<ctll::anything, make_optional, mod_opt>;
-  static constexpr auto rule(repeat, ctll::term<'\x7B'>) -> ctll::push<ctll::anything, number, b>;
-  static constexpr auto rule(repeat, ctll::term<'+'>) -> ctll::push<ctll::anything, repeat_plus, mod>;
-  static constexpr auto rule(repeat, ctll::term<'*'>) -> ctll::push<ctll::anything, repeat_star, mod>;
-  static constexpr auto rule(repeat, ctll::term<'\x7D'>) -> ctll::reject;
+static constexpr auto rule(set2a, ctll::term<']'>) -> ctll::epsilon;
+static constexpr auto rule(set2a, ctll::term<'['>) -> ctll::push<ctll::anything, ctll::term<':'>, i, range, set_start, set2b>;
+static constexpr auto rule(set2a, ctll::term<'\\'>) -> ctll::push<ctll::anything, f, set_start, set2b>;
+static constexpr auto rule(set2a, ctll::set<'!','$','\x28','\x29','*','+',',','.','/',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','0','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range, set_start, set2b>;
+static constexpr auto rule(set2a, _others) -> ctll::push<ctll::anything, push_character, range, set_start, set2b>;
+static constexpr auto rule(set2a, ctll::term<'-'>) -> ctll::reject;
 
-  static constexpr auto rule(set2a, ctll::term<']'>) -> ctll::epsilon;
-  static constexpr auto rule(set2a, ctll::term<'['>) -> ctll::push<ctll::anything, ctll::term<':'>, i, range, set_start, set2b>;
-  static constexpr auto rule(set2a, ctll::term<'\\'>) -> ctll::push<ctll::anything, f, set_start, set2b>;
-  static constexpr auto rule(set2a, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range, set_start, set2b>;
-  static constexpr auto rule(set2a, _others) -> ctll::push<ctll::anything, push_character, range, set_start, set2b>;
-  static constexpr auto rule(set2a, ctll::set<'-','|'>) -> ctll::reject;
+static constexpr auto rule(set2b, ctll::term<']'>) -> ctll::epsilon;
+static constexpr auto rule(set2b, ctll::term<'['>) -> ctll::push<ctll::anything, ctll::term<':'>, i, range, set_combine, set2b>;
+static constexpr auto rule(set2b, ctll::term<'\\'>) -> ctll::push<ctll::anything, f, set_combine, set2b>;
+static constexpr auto rule(set2b, ctll::set<'!','$','\x28','\x29','*','+',',','.','/',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','0','t','u','v','w','x','y','z','\x7B','|','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range, set_combine, set2b>;
+static constexpr auto rule(set2b, _others) -> ctll::push<ctll::anything, push_character, range, set_combine, set2b>;
+static constexpr auto rule(set2b, ctll::term<'-'>) -> ctll::reject;
 
-  static constexpr auto rule(set2b, ctll::term<']'>) -> ctll::epsilon;
-  static constexpr auto rule(set2b, ctll::term<'['>) -> ctll::push<ctll::anything, ctll::term<':'>, i, range, set_combine, set2b>;
-  static constexpr auto rule(set2b, ctll::term<'\\'>) -> ctll::push<ctll::anything, f, set_combine, set2b>;
-  static constexpr auto rule(set2b, ctll::set<'!','$','\x28','\x29','*','+',',','.',':','<','=','>','?','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z','^','_','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','0','s','t','u','v','w','x','y','z','\x7B','\x7D','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, range, set_combine, set2b>;
-  static constexpr auto rule(set2b, _others) -> ctll::push<ctll::anything, push_character, range, set_combine, set2b>;
-  static constexpr auto rule(set2b, ctll::set<'-','|'>) -> ctll::reject;
-
-  static constexpr auto rule(string2, ctll::set<'\x29','|'>) -> ctll::epsilon;
-  static constexpr auto rule(string2, ctll::epsilon) -> ctll::epsilon;
-  static constexpr auto rule(string2, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::set<'!',',','-',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, make_sequence>;
-  static constexpr auto rule(string2, ctll::set<'*','+','?','\x7B','\x7D'>) -> ctll::reject;
+static constexpr auto rule(string2, ctll::set<'\x29','|'>) -> ctll::epsilon;
+static constexpr auto rule(string2, ctll::epsilon) -> ctll::epsilon;
+static constexpr auto rule(string2, ctll::term<'\\'>) -> ctll::push<ctll::anything, backslash, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::term<'['>) -> ctll::push<ctll::anything, c, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::term<'\x28'>) -> ctll::push<ctll::anything, prepare_capture, block, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::term<'^'>) -> ctll::push<ctll::anything, push_assert_begin, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::term<'$'>) -> ctll::push<ctll::anything, push_assert_end, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::set<'!',',','-','/',':','<','=','>','A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',']','_','0','U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','1','2','3','4','5','6','7','8','9'>) -> ctll::push<ctll::anything, push_character, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, _others) -> ctll::push<ctll::anything, push_character, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::term<'.'>) -> ctll::push<ctll::anything, push_character_anything, repeat, string2, make_sequence>;
+static constexpr auto rule(string2, ctll::set<'*','+','?','\x7B','\x7D'>) -> ctll::reject;
 
 };
 
@@ -1267,63 +1330,30 @@ struct pcre {
 #ifndef CTRE__ATOMS__HPP
 #define CTRE__ATOMS__HPP
 
-#include <cstdint>
-
-namespace ctre {
-
-// special helpers for matching
-struct accept { };
-struct reject { };
-struct start_mark { };
-struct end_mark { };
-struct end_cycle_mark { };
-struct end_lookahead_mark { };
-template <size_t Id> struct numeric_mark { };
-
-// actual AST of regexp
-template <auto... Str> struct string { };
-template <typename... Opts> struct select { };
-template <typename... Content> struct optional { };
-template <typename... Content> struct lazy_optional { };
-template <typename... Content> struct sequence { };
-struct empty { };
-
-template <typename... Content> struct plus { };
-template <typename... Content> struct star { };
-template <size_t a, size_t b, typename... Content> struct repeat { };
-
-template <typename... Content> struct lazy_plus { };
-template <typename... Content> struct lazy_star { };
-template <size_t a, size_t b, typename... Content> struct lazy_repeat { };
-
-template <typename... Content> struct possessive_plus { };
-template <typename... Content> struct possessive_star { };
-template <size_t a, size_t b, typename... Content> struct possessive_repeat { };
-
-template <size_t Index, typename... Content> struct capture { };
-
-template <size_t Index, typename Name, typename... Content> struct capture_with_name { };
-
-template <size_t Index> struct back_reference { };
-template <typename Name> struct back_reference_with_name { };
-
-template <typename Type> struct look_start { };
-
-template <typename... Content> struct lookahead_positive { };
-template <typename... Content> struct lookahead_negative { };
-
-struct assert_begin { };
-struct assert_end { };
-
-}
-
-#endif
-
 #ifndef CTRE__ATOMS_CHARACTERS__HPP
 #define CTRE__ATOMS_CHARACTERS__HPP
 
 #ifndef CTRE__UTILITY__HPP
 #define CTRE__UTILITY__HPP
+
+#define CTRE_CNTTP_COMPILER_CHECK (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L) || (__cpp_nontype_template_args >= 201411L && __clang_major__ >= 12))
+
+#if __GNUC__ > 9
+#if __has_cpp_attribute(likely)
+#define CTRE_LIKELY [[likely]]
+#else
+#define CTRE_LIKELY
+#endif
+
+#if __has_cpp_attribute(unlikely)
+#define CTRE_UNLIKELY [[unlikely]]
+#else
+#define CTRE_UNLIKELY
+#endif
+#else
+#define CTRE_LIKELY
+#define CTRE_UNLIKELY
+#endif
 
 #ifdef _MSC_VER
 #define CTRE_FORCE_INLINE __forceinline
@@ -1342,51 +1372,79 @@ namespace ctre {
 // sfinae check for types here
 
 template <typename T> class MatchesCharacter {
-  template <typename Y, typename CharT> static auto test(CharT c) -> decltype(Y::match_char(c), std::true_type());
-  template <typename> static auto test(...) -> std::false_type;
- public:
-  template <typename CharT> static inline constexpr bool value = decltype(test<T>(std::declval<CharT>()))();
+template <typename Y, typename CharT> static auto test(CharT c) -> decltype(Y::match_char(c), std::true_type());
+template <typename> static auto test(...) -> std::false_type;
+public:
+template <typename CharT> static inline constexpr bool value = decltype(test<T>(std::declval<CharT>()))();
 };
 
 template <auto V> struct character {
-  template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
-    return value == V;
-  }
-};
-
-struct any {
-  template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT) noexcept { return true; }
+template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+return value == V;
+}
 };
 
 template <typename... Content> struct negative_set {
-  template <typename CharT> inline static constexpr bool match_char(CharT value) noexcept {
-    return !(Content::match_char(value) || ... || false);
-  }
+template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+return !(Content::match_char(value) || ... || false);
+}
 };
 
 template <typename... Content> struct set {
-  template <typename CharT> inline static constexpr bool match_char(CharT value) noexcept {
-    return (Content::match_char(value) || ... || false);
-  }
+template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+return (Content::match_char(value) || ... || false);
+}
 };
 
 template <auto... Cs> struct enumeration : set<character<Cs>...> { };
 
 template <typename... Content> struct negate {
-  template <typename CharT> inline static constexpr bool match_char(CharT value) noexcept {
-    return !(Content::match_char(value) || ... || false);
-  }
+template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+return !(Content::match_char(value) || ... || false);
+}
 };
 
 template <auto A, auto B> struct char_range {
-  template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
-    return (value >= A) && (value <= B);
-  }
+template <typename CharT> CTRE_FORCE_INLINE static constexpr bool match_char(CharT value) noexcept {
+return (value >= A) && (value <= B);
+}
 };
 
 using word_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'>, character<'_'> >;
 
 using space_chars = enumeration<' ', '\t', '\n', '\v', '\f', '\r'>;
+
+using vertical_space_chars = enumeration<
+(char)0x000A, // Linefeed (LF)
+(char)0x000B, // Vertical tab (VT)
+(char)0x000C, // Form feed (FF)
+(char)0x000D, // Carriage return (CR)
+(char32_t)0x0085, // Next line (NEL)
+(char32_t)0x2028, // Line separator
+(char32_t)0x2029 // Paragraph separator
+>;
+
+using horizontal_space_chars = enumeration<
+(char)0x0009, // Horizontal tab (HT)
+(char)0x0020, // Space
+(char32_t)0x00A0, // Non-break space
+(char32_t)0x1680, // Ogham space mark
+(char32_t)0x180E, // Mongolian vowel separator
+(char32_t)0x2000, // En quad
+(char32_t)0x2001, // Em quad
+(char32_t)0x2002, // En space
+(char32_t)0x2003, // Em space
+(char32_t)0x2004, // Three-per-em space
+(char32_t)0x2005, // Four-per-em space
+(char32_t)0x2006, // Six-per-em space
+(char32_t)0x2007, // Figure space
+(char32_t)0x2008, // Punctuation space
+(char32_t)0x2009, // Thin space
+(char32_t)0x200A, // Hair space
+(char32_t)0x202F, // Narrow no-break space
+(char32_t)0x205F, // Medium mathematical space
+(char32_t)0x3000 // Ideographic space
+>;
 
 using alphanum_chars = set<char_range<'A','Z'>, char_range<'a','z'>, char_range<'0','9'> >;
 
@@ -1396,8 +1454,8 @@ using xdigit_chars = set<char_range<'A','F'>, char_range<'a','f'>, char_range<'0
 
 using punct_chars
 = enumeration<'!', '"', '#', '$', '%', '&', '\'', '(', ')', '*', ',', '-',
-    '.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']',
-    '^', '_', '`', '{', '|', '}', '~'>;
+'.', '/', ':', ';', '<', '=', '>', '?', '@', '[', '\\', ']',
+'^', '_', '`', '{', '|', '}', '~'>;
 
 using digit_chars = char_range<'0','9'>;
 
@@ -1407,12 +1465,176 @@ using ascii_chars = char_range<'\x00','\x7F'>;
 
 #endif
 
+#include <cstdint>
+
+namespace ctre {
+
+// special helpers for matching
+struct accept { };
+struct reject { };
+struct start_mark { };
+struct end_mark { };
+struct end_cycle_mark { };
+struct end_lookahead_mark { };
+template <size_t Id> struct numeric_mark { };
+
+struct any { };
+
+// actual AST of regexp
+template <auto... Str> struct string { };
+template <typename... Opts> struct select { };
+template <typename... Content> struct sequence { };
+struct empty { };
+
+template <size_t a, size_t b, typename... Content> struct repeat { };
+template <typename... Content> using plus = repeat<1,0,Content...>;
+template <typename... Content> using star = repeat<0,0,Content...>;
+
+template <size_t a, size_t b, typename... Content> struct lazy_repeat { };
+template <typename... Content> using lazy_plus = lazy_repeat<1,0,Content...>;
+template <typename... Content> using lazy_star = lazy_repeat<0,0,Content...>;
+
+template <size_t a, size_t b, typename... Content> struct possessive_repeat { };
+template <typename... Content> using possessive_plus = possessive_repeat<1,0,Content...>;
+template <typename... Content> using possessive_star = possessive_repeat<0,0,Content...>;
+
+template <typename... Content> using optional = repeat<0,1,Content...>;
+template <typename... Content> using lazy_optional = lazy_repeat<0,1,Content...>;
+
+template <size_t Index, typename... Content> struct capture { };
+
+template <size_t Index, typename Name, typename... Content> struct capture_with_name { };
+
+template <size_t Index> struct back_reference { };
+template <typename Name> struct back_reference_with_name { };
+
+template <typename Type> struct look_start { };
+
+template <typename... Content> struct lookahead_positive { };
+template <typename... Content> struct lookahead_negative { };
+
+struct atomic_start { };
+
+template <typename... Content> struct atomic_group { };
+
+template <typename... Content> struct boundary { };
+template <typename... Content> struct not_boundary { };
+
+using word_boundary = boundary<word_chars>;
+using not_word_boundary = not_boundary<word_chars>;
+
+struct assert_subject_begin { };
+struct assert_subject_end { };
+struct assert_subject_end_line{ };
+struct assert_line_begin { };
+struct assert_line_end { };
+
+}
+
+#endif
+
 #ifndef CTRE__ATOMS_UNICODE__HPP
 #define CTRE__ATOMS_UNICODE__HPP
 
 // master branch is not including unicode db (for now)
-// #include "../unicode-db/unicode.hpp"
-#include <array>
+#ifndef H_COR3NTIN_UNICODE_SYNOPSYS
+#define H_COR3NTIN_UNICODE_SYNOPSYS
+
+#include <string_view>
+
+namespace uni
+{
+enum class category;
+enum class property;
+enum class version : unsigned char;
+enum class script ;
+enum class block;
+
+struct script_extensions_view {
+constexpr script_extensions_view(char32_t c);
+
+struct sentinel {};
+struct iterator {
+
+constexpr iterator(char32_t c);
+constexpr script operator*() const;
+
+constexpr iterator& operator++(int);
+
+constexpr iterator operator++();
+
+constexpr bool operator==(sentinel) const;
+constexpr bool operator!=(sentinel) const;
+
+private:
+char32_t m_c;
+script m_script;
+int idx = 1;
+};
+
+constexpr iterator begin() const;
+constexpr sentinel end() const;
+
+private:
+char32_t c;
+};
+
+struct numeric_value {
+
+constexpr double value() const;
+constexpr long long numerator() const;
+constexpr int denominator() const;
+constexpr bool is_valid() const;
+
+protected:
+constexpr numeric_value() = default;
+constexpr numeric_value(long long n, int16_t d);
+
+long long _n = 0;
+int16_t _d = 0;
+friend constexpr numeric_value cp_numeric_value(char32_t cp);
+};
+
+constexpr category cp_category(char32_t cp);
+constexpr script cp_script(char32_t cp);
+constexpr script_extensions_view cp_script_extensions(char32_t cp);
+constexpr version cp_age(char32_t cp);
+constexpr block cp_block(char32_t cp);
+constexpr bool cp_is_valid(char32_t cp);
+constexpr bool cp_is_assigned(char32_t cp);
+constexpr bool cp_is_ascii(char32_t cp);
+constexpr numeric_value cp_numeric_value(char32_t cp);
+
+template<script>
+constexpr bool cp_is(char32_t);
+template<property>
+constexpr bool cp_is(char32_t);
+template<category>
+constexpr bool cp_is(char32_t);
+
+namespace detail
+{
+enum class binary_prop;
+constexpr int propnamecomp(std::string_view sa, std::string_view sb);
+constexpr binary_prop binary_prop_from_string(std::string_view s);
+
+template<binary_prop p>
+constexpr bool get_binary_prop(char32_t) = delete;
+
+constexpr script   script_from_string(std::string_view s);
+constexpr block    block_from_string(std::string_view s);
+constexpr version  age_from_string(std::string_view a);
+constexpr category category_from_string(std::string_view a);
+
+constexpr bool is_unassigned(category cat);
+constexpr bool is_unknown(script s);
+constexpr bool is_unknown(block b);
+constexpr bool is_unassigned(version v);
+constexpr bool is_unknown(binary_prop s);
+}
+}
+
+#endif
 
 namespace ctre {
 
@@ -1421,8 +1643,8 @@ namespace ctre {
 template <auto... Str> struct property_name { };
 template <auto... Str> struct property_value { };
 
-template <size_t Sz> constexpr std::string_view get_string_view(const std::array<char, Sz> & arr) noexcept {
-  return std::string_view(arr.data(), arr.size());
+template <size_t Sz> constexpr std::string_view get_string_view(const char (& arr)[Sz]) noexcept {
+return std::string_view(arr, Sz);
 }
 
 // basic support for binary and type-value properties
@@ -1431,131 +1653,131 @@ template <auto Name> struct binary_property;
 template <auto Name, auto Value> struct property;
 
 // unicode TS#18 level 1.2 general_category
-//template <uni::__binary_prop Property> struct binary_property<Property> {
-//	template <typename CharT> inline static constexpr bool match_char(CharT) noexcept {
-//		return uni::__get_binary_prop<Property>(c);
-//	}
-//};
+template <uni::detail::binary_prop Property> struct binary_property<Property> {
+template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+return uni::detail::get_binary_prop<Property>(c);
+}
+};
 
 // unicode TS#18 level 1.2.2
 
 enum class property_type {
-  script, script_extension, age, block, unknown
+script, script_extension, age, block, unknown
 };
 
 // unicode TS#18 level 1.2.2
 
-//template <uni::script Script> struct binary_property<Script> {
-//	template <typename CharT> inline static constexpr bool match_char(CharT) noexcept {
-//		return uni::cp_script(c) == Script;
-//	}
-//};
-//
-//template <uni::script Script> struct property<property_type::script_extension, Script> {
-//	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
-//		for (uni::script sc: uni::cp_script_extensions(c)) {
-//			if (sc == Script) return true;
-//		}
-//		return false;
-//	}
-//};
+template <uni::script Script> struct binary_property<Script> {
+template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+return uni::cp_script(c) == Script;
+}
+};
 
-//template <uni::version Age> struct binary_property<Age> {
-//	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
-//		return uni::cp_age(c) <= Age;
-//	}
-//};
-//
-//template <uni::block Block> struct binary_property<Block> {
-//	template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
-//		return uni::cp_block(c) == Block;
-//	}
-//};
+template <uni::script Script> struct property<property_type::script_extension, Script> {
+template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+for (uni::script sc: uni::cp_script_extensions(c)) {
+if (sc == Script) return true;
+}
+return false;
+}
+};
+
+template <uni::version Age> struct binary_property<Age> {
+template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+return uni::cp_age(c) <= Age;
+}
+};
+
+template <uni::block Block> struct binary_property<Block> {
+template <typename CharT> inline static constexpr bool match_char(CharT c) noexcept {
+return uni::cp_block(c) == Block;
+}
+};
 
 // nonbinary properties
 
-constexpr property_type property_type_from_name(std::string_view) noexcept {
-  return property_type::unknown;
-  //using namespace std::string_view_literals;
-  //if (uni::__pronamecomp(str, "script"sv) == 0 || uni::__pronamecomp(str, "sc"sv) == 0) {
-  //	return property_type::script;
-  //} else if (uni::__pronamecomp(str, "script_extension"sv) == 0 || uni::__pronamecomp(str, "scx"sv) == 0) {
-  //	return property_type::script_extension;
-  //} else if (uni::__pronamecomp(str, "age"sv) == 0) {
-  //	return property_type::age;
-  //} else if (uni::__pronamecomp(str, "block"sv) == 0) {
-  //	return property_type::block;
-  //} else {
-  //	return property_type::unknown;
-  //}
+template <typename = void> // Make it always a template as propnamecomp isn't defined yet
+constexpr property_type property_type_from_name(std::string_view str) noexcept {
+using namespace std::string_view_literals;
+if (uni::detail::propnamecomp(str, "script"sv) == 0 || uni::detail::propnamecomp(str, "sc"sv) == 0) {
+return property_type::script;
+} else if (uni::detail::propnamecomp(str, "script_extension"sv) == 0 || uni::detail::propnamecomp(str, "scx"sv) == 0) {
+return property_type::script_extension;
+} else if (uni::detail::propnamecomp(str, "age"sv) == 0) {
+return property_type::age;
+} else if (uni::detail::propnamecomp(str, "block"sv) == 0) {
+return property_type::block;
+} else {
+return property_type::unknown;
+}
 }
 
 template <property_type Property> struct property_type_builder {
-  template <auto... Value> static constexpr auto get() {
-    return ctll::reject{};
-  }
+template <auto... Value> static constexpr auto get() {
+return ctll::reject{};
+}
 };
 
 template <auto... Name> struct property_builder {
-  static constexpr std::array<char, sizeof...(Name)> name{static_cast<char>(Name)...};
-  static constexpr property_type type = property_type_from_name(get_string_view(name));
+static constexpr char name[sizeof...(Name)]{static_cast<char>(Name)...};
+static constexpr property_type type = property_type_from_name(get_string_view(name));
 
-  using helper = property_type_builder<type>;
+using helper = property_type_builder<type>;
 
-  template <auto... Value> static constexpr auto get() {
-    return helper::template get<Value...>();
-  }
+template <auto... Value> static constexpr auto get() {
+return helper::template get<Value...>();
+}
 };
 
 // unicode TS#18 level 1.2.2 script support
 
-//template <> struct property_type_builder<property_type::script> {
-//	template <auto... Value> static constexpr auto get() {
-//		constexpr std::array<char, sizeof...(Value)> value{Value...};
-//		constexpr auto sc = uni::__script_from_string(get_string_view(value));
-//		if constexpr (sc == uni::script::unknown) {
-//			return ctll::reject{};
-//		} else {
-//			return binary_property<sc>();
-//		}
-//	}
-//};
-//
-//template <> struct property_type_builder<property_type::script_extension> {
-//	template <auto... Value> static constexpr auto get() {
-//		constexpr std::array<char, sizeof...(Value)> value{Value...};
-//		constexpr auto sc = uni::__script_from_string(get_string_view(value));
-//		if constexpr (sc == uni::script::unknown) {
-//			return ctll::reject{};
-//		} else {
-//			return property<property_type::script_extension, sc>();
-//		}
-//	}
-//};
-//
-//template <> struct property_type_builder<property_type::age> {
-//	template <auto... Value> static constexpr auto get() {
-//		constexpr std::array<char, sizeof...(Value)> value{Value...};
-//		constexpr auto age = uni::__age_from_string(get_string_view(value));
-//		if constexpr (age == uni::version::unassigned) {
-//			return ctll::reject{};
-//		} else {
-//			return binary_property<age>();
-//		}
-//	}
-//};
-//
-//template <> struct property_type_builder<property_type::block> {
-//	template <auto... Value> static constexpr auto get() {
-//		constexpr std::array<char, sizeof...(Value)> value{Value...};
-//		constexpr auto block = uni::__block_from_string(get_string_view(value));
-//		if constexpr (block == uni::block::no_block) {
-//			return ctll::reject{};
-//		} else {
-//			return binary_property<block>();
-//		}
-//	}
-//};
+template <> struct property_type_builder<property_type::script> {
+template <auto... Value> static constexpr auto get() {
+constexpr char value[sizeof...(Value)]{static_cast<char>(Value)...};
+constexpr auto sc = uni::detail::script_from_string(get_string_view(value));
+if constexpr (uni::detail::is_unknown(sc)) {
+return ctll::reject{};
+} else {
+return binary_property<sc>();
+}
+}
+};
+
+template <> struct property_type_builder<property_type::script_extension> {
+template <auto... Value> static constexpr auto get() {
+constexpr char value[sizeof...(Value)]{static_cast<char>(Value)...};
+constexpr auto sc = uni::detail::script_from_string(get_string_view(value));
+if constexpr (uni::detail::is_unknown(sc)) {
+return ctll::reject{};
+} else {
+return property<property_type::script_extension, sc>();
+}
+}
+};
+
+template <> struct property_type_builder<property_type::age> {
+template <auto... Value> static constexpr auto get() {
+constexpr char value[sizeof...(Value)]{static_cast<char>(Value)...};
+constexpr auto age = uni::detail::age_from_string(get_string_view(value));
+if constexpr (uni::detail::is_unassigned(age)) {
+return ctll::reject{};
+} else {
+return binary_property<age>();
+}
+}
+};
+
+template <> struct property_type_builder<property_type::block> {
+template <auto... Value> static constexpr auto get() {
+constexpr char value[sizeof...(Value)]{static_cast<char>(Value)...};
+constexpr auto block = uni::detail::block_from_string(get_string_view(value));
+if constexpr (uni::detail::is_unknown(block)) {
+return ctll::reject{};
+} else {
+return binary_property<block>();
+}
+}
+};
 
 }
 
@@ -1569,14 +1791,16 @@ template <auto... Name> struct property_builder {
 namespace ctre {
 
 template <auto... Name> struct id {
-  static constexpr auto name = ctll::fixed_string<sizeof...(Name)>{{Name...}};
+static constexpr auto name = ctll::fixed_string<sizeof...(Name)>{{Name...}};
+
+friend constexpr auto operator==(id<Name...>, id<Name...>) noexcept -> std::true_type { return {}; }
+
+template <auto... Other> friend constexpr auto operator==(id<Name...>, id<Other...>) noexcept -> std::false_type { return {}; }
+
+template <typename T> friend constexpr auto operator==(id<Name...>, T) noexcept -> std::false_type { return {}; }
+
+template <typename T> friend constexpr auto operator==(T, id<Name...>) noexcept -> std::false_type { return {}; }
 };
-
-template <auto... Name> constexpr auto operator==(id<Name...>, id<Name...>) noexcept -> std::true_type { return {}; }
-
-template <auto... Name1, auto... Name2> constexpr auto operator==(id<Name1...>, id<Name2...>) noexcept -> std::false_type { return {}; }
-
-template <auto... Name, typename T> constexpr auto operator==(id<Name...>, T) noexcept -> std::false_type { return {}; }
 
 }
 
@@ -1588,16 +1812,16 @@ template <auto... Name, typename T> constexpr auto operator==(id<Name...>, T) no
 namespace ctre {
 
 template <size_t Counter> struct pcre_parameters {
-  static constexpr size_t current_counter = Counter;
+static constexpr size_t current_counter = Counter;
 };
 
 template <typename Stack = ctll::list<>, typename Parameters = pcre_parameters<0>> struct pcre_context {
-  using stack_type = Stack;
-  using parameters_type = Parameters;
-  static constexpr inline auto stack = stack_type();
-  static constexpr inline auto parameters = parameters_type();
-  constexpr pcre_context() noexcept { }
-  constexpr pcre_context(Stack, Parameters) noexcept { }
+using stack_type = Stack;
+using parameters_type = Parameters;
+static constexpr inline auto stack = stack_type();
+static constexpr inline auto parameters = parameters_type();
+constexpr pcre_context() noexcept { }
+constexpr pcre_context(Stack, Parameters) noexcept { }
 };
 
 template <typename... Content, typename Parameters> pcre_context(ctll::list<Content...>, Parameters) -> pcre_context<ctll::list<Content...>, Parameters>;
@@ -1612,14 +1836,49 @@ struct pcre_actions {
 #define CTRE__ACTIONS__ASSERTS__HPP
 
 // push_assert_begin
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_begin, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(assert_begin(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_begin, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(assert_line_begin(), subject.stack), subject.parameters};
+}
 
 // push_assert_end
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_end, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(assert_end(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_end, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(assert_line_end(), subject.stack), subject.parameters};
+}
+
+// push_assert_begin
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_subject_begin, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(assert_subject_begin(), subject.stack), subject.parameters};
+}
+
+// push_assert_subject_end
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_subject_end, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(assert_subject_end(), subject.stack), subject.parameters};
+}
+
+// push_assert_subject_end_with_lineend
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_assert_subject_end_with_lineend, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(assert_subject_end_line(), subject.stack), subject.parameters};
+}
+
+#endif
+
+#ifndef CTRE__ACTIONS__ATOMIC_GROUP__HPP
+#define CTRE__ACTIONS__ATOMIC_GROUP__HPP
+
+// atomic start
+template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_atomic, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<atomic_start, Ts...>(), pcre_parameters<Counter>()};
+}
+
+// atomic
+template <auto V, typename Atomic, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_atomic, ctll::term<V>, pcre_context<ctll::list<Atomic, atomic_start, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<atomic_group<Atomic>, Ts...>(), pcre_parameters<Counter>()};
+}
+
+// atomic sequence
+template <auto V, typename... Atomic, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_atomic, ctll::term<V>, pcre_context<ctll::list<sequence<Atomic...>, atomic_start, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<atomic_group<Atomic...>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 #endif
 
@@ -1627,30 +1886,45 @@ struct pcre_actions {
 #define CTRE__ACTIONS__BACKREFERENCE__HPP
 
 // backreference with name
-  template <auto... Str, auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_back_reference, ctll::term<V>, pcre_context<ctll::list<id<Str...>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::push_front(back_reference_with_name<id<Str...>>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-  }
+template <auto... Str, auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_back_reference, ctll::term<V>, pcre_context<ctll::list<id<Str...>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::push_front(back_reference_with_name<id<Str...>>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
 
 // with just a number
-  template <auto V, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_back_reference, ctll::term<V>, pcre_context<ctll::list<number<Id>, Ts...>, pcre_parameters<Counter>>) {
-    // if we are looking outside of existing list of Ids ... reject input during parsing
-    if constexpr (Counter < Id) {
-      return ctll::reject{};
-    } else {
-      return pcre_context{ctll::push_front(back_reference<Id>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-    }
-  }
+template <auto V, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_back_reference, ctll::term<V>, pcre_context<ctll::list<number<Id>, Ts...>, pcre_parameters<Counter>>) {
+// if we are looking outside of existing list of Ids ... reject input during parsing
+if constexpr (Counter < Id) {
+return ctll::reject{};
+} else {
+return pcre_context{ctll::push_front(back_reference<Id>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
+}
 
 // relative backreference
-  template <auto V, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_relative_back_reference, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<number<Id>, Ts...>, pcre_parameters<Counter>>) {
-    // if we are looking outside of existing list of Ids ... reject input during parsing
-    if constexpr (Counter < Id) {
-      return ctll::reject{};
-    } else {
-      constexpr size_t absolute_id = (Counter + 1) - Id;
-      return pcre_context{ctll::push_front(back_reference<absolute_id>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-    }
-  }
+template <auto V, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_relative_back_reference, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<number<Id>, Ts...>, pcre_parameters<Counter>>) {
+// if we are looking outside of existing list of Ids ... reject input during parsing
+if constexpr (Counter < Id) {
+return ctll::reject{};
+} else {
+constexpr size_t absolute_id = (Counter + 1) - Id;
+return pcre_context{ctll::push_front(back_reference<absolute_id>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
+}
+
+#endif
+
+#ifndef CTRE__ACTIONS__BOUNDARIES__HPP
+#define CTRE__ACTIONS__BOUNDARIES__HPP
+
+// push_word_boundary
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_word_boundary, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(boundary<word_chars>(), subject.stack), subject.parameters};
+}
+
+// push_not_word_boundary
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_not_word_boundary, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(boundary<negative_set<word_chars>>(), subject.stack), subject.parameters};
+}
 
 #endif
 
@@ -1658,39 +1932,39 @@ struct pcre_actions {
 #define CTRE__ACTIONS__CAPTURE__HPP
 
 // prepare_capture
-  template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::prepare_capture, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::push_front(capture_id<Counter+1>(), ctll::list<Ts...>()), pcre_parameters<Counter+1>()};
-  }
+template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::prepare_capture, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::push_front(capture_id<Counter+1>(), ctll::list<Ts...>()), pcre_parameters<Counter+1>()};
+}
 
 // reset_capture
-  template <auto V, typename... Ts, size_t Id, size_t Counter> static constexpr auto apply(pcre::reset_capture, ctll::term<V>, pcre_context<ctll::list<capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<Ts...>(), pcre_parameters<Counter-1>()};
-  }
+template <auto V, typename... Ts, size_t Id, size_t Counter> static constexpr auto apply(pcre::reset_capture, ctll::term<V>, pcre_context<ctll::list<capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<Ts...>(), pcre_parameters<Counter-1>()};
+}
 
 // capture
-  template <auto V, typename A, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture, ctll::term<V>, pcre_context<ctll::list<A, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::push_front(capture<Id, A>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-  }
+template <auto V, typename A, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture, ctll::term<V>, pcre_context<ctll::list<A, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::push_front(capture<Id, A>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
 // capture (sequence)
-  template <auto V, typename... Content, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::push_front(capture<Id, Content...>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-  }
+template <auto V, typename... Content, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::push_front(capture<Id, Content...>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
 // push_name
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_name, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(id<V>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_name, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(id<V>(), subject.stack), subject.parameters};
+}
 // push_name (concat)
-  template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_name, ctll::term<V>, pcre_context<ctll::list<id<Str...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(id<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_name, ctll::term<V>, pcre_context<ctll::list<id<Str...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(id<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
+}
 // capture with name
-  template <auto... Str, auto V, typename A, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture_with_name, ctll::term<V>, pcre_context<ctll::list<A, id<Str...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::push_front(capture_with_name<Id, id<Str...>, A>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-  }
+template <auto... Str, auto V, typename A, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture_with_name, ctll::term<V>, pcre_context<ctll::list<A, id<Str...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::push_front(capture_with_name<Id, id<Str...>, A>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
 // capture with name (sequence)
-  template <auto... Str, auto V, typename... Content, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture_with_name, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, id<Str...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::push_front(capture_with_name<Id, id<Str...>, Content...>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
-  }
+template <auto... Str, auto V, typename... Content, size_t Id, typename... Ts, size_t Counter> static constexpr auto apply(pcre::make_capture_with_name, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, id<Str...>, capture_id<Id>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::push_front(capture_with_name<Id, id<Str...>, Content...>(), ctll::list<Ts...>()), pcre_parameters<Counter>()};
+}
 
 #endif
 
@@ -1698,41 +1972,41 @@ struct pcre_actions {
 #define CTRE__ACTIONS__CHARACTERS__HPP
 
 // push character
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<V>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<V>(), subject.stack), subject.parameters};
+}
 // push_any_character
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_anything, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(any(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_anything, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(any(), subject.stack), subject.parameters};
+}
 // character_alarm
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_alarm, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\x07'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_alarm, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\x07'>(), subject.stack), subject.parameters};
+}
 // character_escape
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_escape, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\x14'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_escape, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\x14'>(), subject.stack), subject.parameters};
+}
 // character_formfeed
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_formfeed, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\x0C'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_formfeed, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\x0C'>(), subject.stack), subject.parameters};
+}
 // push_character_newline
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_newline, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\x0A'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_newline, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\x0A'>(), subject.stack), subject.parameters};
+}
 // push_character_null
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_null, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\0'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_null, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\0'>(), subject.stack), subject.parameters};
+}
 // push_character_return_carriage
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_return_carriage, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\x0D'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_return_carriage, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\x0D'>(), subject.stack), subject.parameters};
+}
 // push_character_tab
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_tab, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(character<'\x09'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_character_tab, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(character<'\x09'>(), subject.stack), subject.parameters};
+}
 
 #endif
 
@@ -1740,33 +2014,122 @@ struct pcre_actions {
 #define CTRE__ACTIONS__CLASS__HPP
 
 // class_digit
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_digit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::set<ctre::digit_chars>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_digit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::set<ctre::digit_chars>(), subject.stack), subject.parameters};
+}
 // class_non_digit
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nondigit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::negative_set<ctre::digit_chars>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nondigit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::negative_set<ctre::digit_chars>(), subject.stack), subject.parameters};
+}
 // class_space
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::set<ctre::space_chars>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::set<ctre::space_chars>(), subject.stack), subject.parameters};
+}
 // class_nonspace
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonspace, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::negative_set<ctre::space_chars>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonspace, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::negative_set<ctre::space_chars>(), subject.stack), subject.parameters};
+}
+
+// class_horizontal_space
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_horizontal_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::set<ctre::horizontal_space_chars>(), subject.stack), subject.parameters};
+}
+// class_horizontal_nonspace
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_non_horizontal_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::negative_set<ctre::horizontal_space_chars>(), subject.stack), subject.parameters};
+}
+// class_vertical_space
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_vertical_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::set<ctre::vertical_space_chars>(), subject.stack), subject.parameters};
+}
+// class_vertical_nonspace
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_non_vertical_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::negative_set<ctre::vertical_space_chars>(), subject.stack), subject.parameters};
+}
+
 // class_word
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_word, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::set<ctre::word_chars>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_word, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::set<ctre::word_chars>(), subject.stack), subject.parameters};
+}
 // class_nonword
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonword, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::negative_set<ctre::word_chars>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonword, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::negative_set<ctre::word_chars>(), subject.stack), subject.parameters};
+}
 // class_nonnewline
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonnewline, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::negative_set<character<'\n'>>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_nonnewline, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::negative_set<character<'\n'>>(), subject.stack), subject.parameters};
+}
+
+#endif
+
+#ifndef CTRE__ACTIONS__FUSION__HPP
+#define CTRE__ACTIONS__FUSION__HPP
+
+static constexpr size_t combine_max_repeat_length(size_t A, size_t B) {
+if (A && B) return A+B;
+else return 0;
+}
+
+template <size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content> static constexpr auto combine_repeat(repeat<MinA, MaxA, Content...>, repeat<MinB, MaxB, Content...>) {
+return repeat<MinA + MinB, combine_max_repeat_length(MaxA, MaxB), Content...>();
+}
+
+template <size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content> static constexpr auto combine_repeat(lazy_repeat<MinA, MaxA, Content...>, lazy_repeat<MinB, MaxB, Content...>) {
+return lazy_repeat<MinA + MinB, combine_max_repeat_length(MaxA, MaxB), Content...>();
+}
+
+template <size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content> static constexpr auto combine_repeat(possessive_repeat<MinA, MaxA, Content...>, possessive_repeat<MinB, MaxB, Content...>) {
+[[maybe_unused]] constexpr bool first_is_unbounded = (MaxA == 0);
+[[maybe_unused]] constexpr bool second_is_nonempty = (MinB > 0);
+[[maybe_unused]] constexpr bool second_can_be_empty = (MinB == 0);
+
+if constexpr (first_is_unbounded && second_is_nonempty) {
+// will always reject, but I keep the content, so I have some amount of captures
+return sequence<reject, Content...>();
+} else if constexpr (first_is_unbounded) {
+return possessive_repeat<MinA, MaxA, Content...>();
+} else if constexpr (second_can_be_empty) {
+return possessive_repeat<MinA, combine_max_repeat_length(MaxA, MaxB), Content...>();
+} else {
+return possessive_repeat<MaxA + MinB, combine_max_repeat_length(MaxA, MaxB), Content...>();
+}
+}
+
+// concat repeat sequences
+template <auto V, size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<repeat<MinB, MaxB, Content...>, repeat<MinA, MaxA, Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(combine_repeat(repeat<MinA, MaxA, Content...>(), repeat<MinB, MaxB, Content...>()), ctll::list<Ts...>()), subject.parameters};
+}
+
+// concat lazy repeat sequences
+template <auto V, size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<lazy_repeat<MinB, MaxB, Content...>, lazy_repeat<MinA, MaxA, Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(combine_repeat(lazy_repeat<MinA, MaxA, Content...>(), lazy_repeat<MinB, MaxB, Content...>()), ctll::list<Ts...>()), subject.parameters};
+}
+
+// concat possessive repeat seqeunces
+template <auto V, size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<possessive_repeat<MinB, MaxB, Content...>, possessive_repeat<MinA, MaxA, Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(combine_repeat(possessive_repeat<MinA, MaxA, Content...>(), possessive_repeat<MinB, MaxB, Content...>()), ctll::list<Ts...>()), subject.parameters};
+}
+
+// concat repeat sequences into sequence
+template <auto V, size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content, typename... As, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<repeat<MinB, MaxB, Content...>, As...>,repeat<MinA, MaxA, Content...>,Ts...>, Parameters> subject) {
+using result = decltype(combine_repeat(repeat<MinB, MaxB, Content...>(), repeat<MinA, MaxA, Content...>()));
+
+return pcre_context{ctll::push_front(sequence<result,As...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// concat lazy repeat sequences into sequence
+template <auto V, size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content, typename... As, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<lazy_repeat<MinB, MaxB, Content...>, As...>,lazy_repeat<MinA, MaxA, Content...>,Ts...>, Parameters> subject) {
+using result = decltype(combine_repeat(lazy_repeat<MinB, MaxB, Content...>(), lazy_repeat<MinA, MaxA, Content...>()));
+
+return pcre_context{ctll::push_front(sequence<result,As...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// concat possessive repeat sequences into sequence
+template <auto V, size_t MinA, size_t MaxA, size_t MinB, size_t MaxB, typename... Content, typename... As, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<possessive_repeat<MinB, MaxB, Content...>, As...>,possessive_repeat<MinA, MaxA, Content...>,Ts...>, Parameters> subject) {
+using result = decltype(combine_repeat(possessive_repeat<MinB, MaxB, Content...>(), possessive_repeat<MinA, MaxA, Content...>()));
+
+return pcre_context{ctll::push_front(sequence<result,As...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 #endif
 
@@ -1774,28 +2137,29 @@ struct pcre_actions {
 #define CTRE__ACTIONS__HEXDEC__HPP
 
 // hexdec character support (seed)
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::create_hexdec, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(number<0ull>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::create_hexdec, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(number<0ull>(), subject.stack), subject.parameters};
+}
 // hexdec character support (push value)
-  template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
-    constexpr auto previous = N << 4ull;
-    if constexpr (V >= 'a' && V <= 'f') {
-      return pcre_context{ctll::push_front(number<(previous + (V - 'a' + 10))>(), ctll::list<Ts...>()), subject.parameters};
-    } else if constexpr (V >= 'A' && V <= 'F') {
-      return pcre_context{ctll::push_front(number<(previous + (V - 'A' + 10))>(), ctll::list<Ts...>()), subject.parameters};
-    } else {
-      return pcre_context{ctll::push_front(number<(previous + (V - '0'))>(), ctll::list<Ts...>()), subject.parameters};
-    }
-  }
+template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
+constexpr auto previous = N << 4ull;
+if constexpr (V >= 'a' && V <= 'f') {
+return pcre_context{ctll::push_front(number<(previous + (V - 'a' + 10))>(), ctll::list<Ts...>()), subject.parameters};
+} else if constexpr (V >= 'A' && V <= 'F') {
+return pcre_context{ctll::push_front(number<(previous + (V - 'A' + 10))>(), ctll::list<Ts...>()), subject.parameters};
+} else {
+return pcre_context{ctll::push_front(number<(previous + (V - '0'))>(), ctll::list<Ts...>()), subject.parameters};
+}
+}
 // hexdec character support (convert to character)
-  template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::finish_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
-    if constexpr (N <= std::numeric_limits<unsigned char>::max()) {
-      return pcre_context{ctll::push_front(character<(char)N>(), ctll::list<Ts...>()), subject.parameters};
-    } else {
-      return pcre_context{ctll::push_front(character<N>(), ctll::list<Ts...>()), subject.parameters};
-    }
-  }
+template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::finish_hexdec, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
+constexpr size_t max_char = std::numeric_limits<char>::max();
+if constexpr (N <= max_char) {
+return pcre_context{ctll::push_front(character<(char)N>(), ctll::list<Ts...>()), subject.parameters};
+} else {
+return pcre_context{ctll::push_front(character<(char32_t)N>(), ctll::list<Ts...>()), subject.parameters};
+}
+}
 
 #endif
 
@@ -1803,34 +2167,34 @@ struct pcre_actions {
 #define CTRE__ACTIONS__LOOKAHEAD__HPP
 
 // lookahead positive start
-  template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_lookahead_positive, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<look_start<lookahead_positive<>>, Ts...>(), pcre_parameters<Counter>()};
-  }
+template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_lookahead_positive, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<look_start<lookahead_positive<>>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 // lookahead positive end
-  template <auto V, typename Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<Look, look_start<lookahead_positive<>>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<lookahead_positive<Look>, Ts...>(), pcre_parameters<Counter>()};
-  }
+template <auto V, typename Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<Look, look_start<lookahead_positive<>>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<lookahead_positive<Look>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 // lookahead positive end (sequence)
-  template <auto V, typename... Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<ctre::sequence<Look...>, look_start<lookahead_positive<>>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<lookahead_positive<Look...>, Ts...>(), pcre_parameters<Counter>()};
-  }
+template <auto V, typename... Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<ctre::sequence<Look...>, look_start<lookahead_positive<>>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<lookahead_positive<Look...>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 // lookahead negative start
-  template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_lookahead_negative, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<look_start<lookahead_negative<>>, Ts...>(), pcre_parameters<Counter>()};
-  }
+template <auto V, typename... Ts, size_t Counter> static constexpr auto apply(pcre::start_lookahead_negative, ctll::term<V>, pcre_context<ctll::list<Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<look_start<lookahead_negative<>>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 // lookahead negative end
-  template <auto V, typename Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<Look, look_start<lookahead_negative<>>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<lookahead_negative<Look>, Ts...>(), pcre_parameters<Counter>()};
-  }
+template <auto V, typename Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<Look, look_start<lookahead_negative<>>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<lookahead_negative<Look>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 // lookahead negative end (sequence)
-  template <auto V, typename... Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<ctre::sequence<Look...>, look_start<lookahead_negative<>>, Ts...>, pcre_parameters<Counter>>) {
-    return pcre_context{ctll::list<lookahead_negative<Look...>, Ts...>(), pcre_parameters<Counter>()};
-  }
+template <auto V, typename... Look, typename... Ts, size_t Counter> static constexpr auto apply(pcre::look_finish, ctll::term<V>, pcre_context<ctll::list<ctre::sequence<Look...>, look_start<lookahead_negative<>>, Ts...>, pcre_parameters<Counter>>) {
+return pcre_context{ctll::list<lookahead_negative<Look...>, Ts...>(), pcre_parameters<Counter>()};
+}
 
 #endif
 
@@ -1838,61 +2202,61 @@ struct pcre_actions {
 #define CTRE__ACTIONS__NAMED_CLASS__HPP
 
 // class_named_alnum
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_alnum, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::alphanum_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_alnum, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::alphanum_chars(), subject.stack), subject.parameters};
+}
 // class_named_alpha
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_alpha, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::alpha_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_alpha, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::alpha_chars(), subject.stack), subject.parameters};
+}
 // class_named_digit
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_digit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::digit_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_digit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::digit_chars(), subject.stack), subject.parameters};
+}
 // class_named_ascii
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_ascii, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::ascii_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_ascii, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::ascii_chars(), subject.stack), subject.parameters};
+}
 // class_named_blank
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_blank, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::enumeration<' ','\t'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_blank, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::enumeration<' ','\t'>(), subject.stack), subject.parameters};
+}
 // class_named_cntrl
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_cntrl, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::set<ctre::char_range<'\x00','\x1F'>, ctre::character<'\x7F'>>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_cntrl, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::set<ctre::char_range<'\x00','\x1F'>, ctre::character<'\x7F'>>(), subject.stack), subject.parameters};
+}
 // class_named_graph
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_graph, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::char_range<'\x21','\x7E'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_graph, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::char_range<'\x21','\x7E'>(), subject.stack), subject.parameters};
+}
 // class_named_lower
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_lower, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::char_range<'a','z'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_lower, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::char_range<'a','z'>(), subject.stack), subject.parameters};
+}
 // class_named_upper
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_upper, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::char_range<'A','Z'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_upper, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::char_range<'A','Z'>(), subject.stack), subject.parameters};
+}
 // class_named_print
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_print, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(ctre::char_range<'\x20','\x7E'>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_print, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(ctre::char_range<'\x20','\x7E'>(), subject.stack), subject.parameters};
+}
 // class_named_space
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(space_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_space, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(space_chars(), subject.stack), subject.parameters};
+}
 // class_named_word
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_word, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(word_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_word, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(word_chars(), subject.stack), subject.parameters};
+}
 // class_named_punct
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_punct, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(punct_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_punct, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(punct_chars(), subject.stack), subject.parameters};
+}
 // class_named_xdigit
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_xdigit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(xdigit_chars(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::class_named_xdigit, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(xdigit_chars(), subject.stack), subject.parameters};
+}
 
 #endif
 
@@ -1900,37 +2264,125 @@ struct pcre_actions {
 #define CTRE__ACTIONS__OPTIONS__HPP
 
 // empty option for alternate
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_empty, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(empty(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_empty, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(empty(), subject.stack), subject.parameters};
+}
 
 // empty option for empty regex
-  template <typename Parameters> static constexpr auto apply(pcre::push_empty, ctll::epsilon, pcre_context<ctll::list<>, Parameters> subject) {
-    return pcre_context{ctll::push_front(empty(), subject.stack), subject.parameters};
-  }
+template <typename Parameters> static constexpr auto apply(pcre::push_empty, ctll::epsilon, pcre_context<ctll::list<>, Parameters> subject) {
+return pcre_context{ctll::push_front(empty(), subject.stack), subject.parameters};
+}
 
 // make_alternate (A|B)
-  template <auto V, typename A, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_alternate, ctll::term<V>, pcre_context<ctll::list<B, A, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(select<A,B>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_alternate, ctll::term<V>, pcre_context<ctll::list<B, A, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(select<A,B>(), ctll::list<Ts...>()), subject.parameters};
+}
 // make_alternate (As..)|B => (As..|B)
-  template <auto V, typename A, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_alternate, ctll::term<V>, pcre_context<ctll::list<ctre::select<Bs...>, A, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(select<A,Bs...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_alternate, ctll::term<V>, pcre_context<ctll::list<ctre::select<Bs...>, A, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(select<A,Bs...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_optional
-  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(optional<A>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(optional<A>(), ctll::list<Ts...>()), subject.parameters};
+}
 
-  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(optional<Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(optional<Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// prevent from creating wrapped optionals
+template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<optional<A>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(optional<A>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// in case inner optional is lazy, result should be lazy too
+template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_optional, ctll::term<V>, pcre_context<ctll::list<lazy_optional<A>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(lazy_optional<A>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_lazy (optional)
-  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<optional<Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(lazy_optional<Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<optional<Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(lazy_optional<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// if you already got a lazy optional, make_lazy is no-op
+template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<lazy_optional<Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(lazy_optional<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+#endif
+
+#ifndef CTRE__ACTIONS__PROPERTIES__HPP
+#define CTRE__ACTIONS__PROPERTIES__HPP
+
+// push_property_name
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_name, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(property_name<V>(), subject.stack), subject.parameters};
+}
+// push_property_name (concat)
+template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_name, ctll::term<V>, pcre_context<ctll::list<property_name<Str...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(property_name<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// push_property_value
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_value, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(property_value<V>(), subject.stack), subject.parameters};
+}
+// push_property_value (concat)
+template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_value, ctll::term<V>, pcre_context<ctll::list<property_value<Str...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(property_value<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// make_property
+template <auto V, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_name<Name...>, Ts...>, Parameters> subject) {
+//return ctll::reject{};
+constexpr char name[sizeof...(Name)]{static_cast<char>(Name)...};
+constexpr auto p = uni::detail::binary_prop_from_string(get_string_view(name));
+
+if constexpr (uni::detail::is_unknown(p)) {
+return ctll::reject{};
+} else {
+return pcre_context{ctll::push_front(binary_property<p>(), ctll::list<Ts...>()), subject.parameters};
+}
+}
+
+// make_property
+template <auto V, auto... Value, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_value<Value...>, property_name<Name...>, Ts...>, Parameters> subject) {
+//return ctll::reject{};
+constexpr auto prop = property_builder<Name...>::template get<Value...>();
+
+if constexpr (std::is_same_v<decltype(prop), ctll::reject>) {
+return ctll::reject{};
+} else {
+return pcre_context{ctll::push_front(prop, ctll::list<Ts...>()), subject.parameters};
+}
+}
+
+// make_property_negative
+template <auto V, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property_negative, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_name<Name...>, Ts...>, Parameters> subject) {
+//return ctll::reject{};
+constexpr char name[sizeof...(Name)]{static_cast<char>(Name)...};
+constexpr auto p = uni::detail::binary_prop_from_string(get_string_view(name));
+
+if constexpr (uni::detail::is_unknown(p)) {
+return ctll::reject{};
+} else {
+return pcre_context{ctll::push_front(negate<binary_property<p>>(), ctll::list<Ts...>()), subject.parameters};
+}
+}
+
+// make_property_negative
+template <auto V, auto... Value, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property_negative, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_value<Value...>, property_name<Name...>, Ts...>, Parameters> subject) {
+//return ctll::reject{};
+constexpr auto prop = property_builder<Name...>::template get<Value...>();
+
+if constexpr (std::is_same_v<decltype(prop), ctll::reject>) {
+return ctll::reject{};
+} else {
+return pcre_context{ctll::push_front(negate<decltype(prop)>(), ctll::list<Ts...>()), subject.parameters};
+}
+}
 
 #endif
 
@@ -1938,89 +2390,89 @@ struct pcre_actions {
 #define CTRE__ACTIONS__REPEAT__HPP
 
 // repeat 1..N
-  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_plus, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(plus<A>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_plus, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(plus<A>(), ctll::list<Ts...>()), subject.parameters};
+}
 // repeat 1..N (sequence)
-  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_plus, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(plus<Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_plus, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(plus<Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // repeat 0..N
-  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_star, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(star<A>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_star, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(star<A>(), ctll::list<Ts...>()), subject.parameters};
+}
 // repeat 0..N (sequence)
-  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_star, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(star<Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_star, ctll::term<V>, pcre_context<ctll::list<sequence<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(star<Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // create_number (seed)
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::create_number, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(number<static_cast<size_t>(V - '0')>(), subject.stack), subject.parameters};
-  }
+template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::create_number, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(number<static_cast<size_t>(V - '0')>(), subject.stack), subject.parameters};
+}
 // push_number
-  template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_number, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
-    constexpr size_t previous = N * 10ull;
-    return pcre_context{ctll::push_front(number<(previous + (V - '0'))>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, size_t N, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_number, ctll::term<V>, pcre_context<ctll::list<number<N>, Ts...>, Parameters> subject) {
+constexpr size_t previous = N * 10ull;
+return pcre_context{ctll::push_front(number<(previous + (V - '0'))>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // repeat A..B
-  template <auto V, typename Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_ab, ctll::term<V>, pcre_context<ctll::list<number<B>, number<A>, Subject, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(repeat<A,B,Subject>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_ab, ctll::term<V>, pcre_context<ctll::list<number<B>, number<A>, Subject, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(repeat<A,B,Subject>(), ctll::list<Ts...>()), subject.parameters};
+}
 // repeat A..B (sequence)
-  template <auto V, typename... Content, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_ab, ctll::term<V>, pcre_context<ctll::list<number<B>, number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(repeat<A,B,Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_ab, ctll::term<V>, pcre_context<ctll::list<number<B>, number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(repeat<A,B,Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // repeat_exactly
-  template <auto V, typename Subject, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_exactly, ctll::term<V>, pcre_context<ctll::list<number<A>, Subject, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(repeat<A,A,Subject>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename Subject, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_exactly, ctll::term<V>, pcre_context<ctll::list<number<A>, Subject, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(repeat<A,A,Subject>(), ctll::list<Ts...>()), subject.parameters};
+}
 // repeat_exactly A..B (sequence)
-  template <auto V, typename... Content, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_exactly, ctll::term<V>, pcre_context<ctll::list<number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(repeat<A,A,Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_exactly, ctll::term<V>, pcre_context<ctll::list<number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(repeat<A,A,Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // repeat_at_least (A+)
-  template <auto V, typename Subject, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_at_least, ctll::term<V>, pcre_context<ctll::list<number<A>, Subject, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(repeat<A,0,Subject>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename Subject, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_at_least, ctll::term<V>, pcre_context<ctll::list<number<A>, Subject, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(repeat<A,0,Subject>(), ctll::list<Ts...>()), subject.parameters};
+}
 // repeat_at_least (A+) (sequence)
-  template <auto V, typename... Content, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_at_least, ctll::term<V>, pcre_context<ctll::list<number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(repeat<A,0,Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, size_t A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::repeat_at_least, ctll::term<V>, pcre_context<ctll::list<number<A>, sequence<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(repeat<A,0,Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_lazy (plus)
-  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<plus<Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(lazy_plus<Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<plus<Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(lazy_plus<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_lazy (star)
-  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<star<Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(lazy_star<Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<star<Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(lazy_star<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_lazy (repeat<A,B>)
-  template <auto V, typename... Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<repeat<A,B,Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(lazy_repeat<A,B,Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_lazy, ctll::term<V>, pcre_context<ctll::list<repeat<A,B,Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(lazy_repeat<A,B,Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_possessive (plus)
-  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<plus<Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(possessive_plus<Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<plus<Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(possessive_plus<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_possessive (star)
-  template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<star<Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(possessive_star<Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<star<Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(possessive_star<Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // make_possessive (repeat<A,B>)
-  template <auto V, typename... Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<repeat<A,B,Subject...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(possessive_repeat<A,B,Subject...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Subject, size_t A, size_t B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_possessive, ctll::term<V>, pcre_context<ctll::list<repeat<A,B,Subject...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(possessive_repeat<A,B,Subject...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 #endif
 
@@ -2028,21 +2480,31 @@ struct pcre_actions {
 #define CTRE__ACTIONS__SEQUENCE__HPP
 
 // make_sequence
-  template <auto V, typename A, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<B,A,Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(sequence<A,B>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<B,A,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(sequence<A,B>(), ctll::list<Ts...>()), subject.parameters};
+}
 // make_sequence (concat)
-  template <auto V, typename... As, typename B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<As...>,B,Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(sequence<B,As...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<Bs...>,A,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(sequence<A,Bs...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
 // make_sequence (make string)
-  template <auto V, auto A, auto B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>,Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(string<A,B>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, auto A, auto B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(string<A,B>(), ctll::list<Ts...>()), subject.parameters};
+}
 // make_sequence (concat string)
-  template <auto V, auto... As, auto B, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<string<As...>,character<B>,Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(string<B,As...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, auto A, auto... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<string<Bs...>,character<A>,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(string<A,Bs...>(), ctll::list<Ts...>()), subject.parameters};
+}
+
+// make_sequence (make string in front of different items)
+template <auto V, auto A, auto B, typename... Sq, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<character<B>,Sq...>,character<A>,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(sequence<string<A,B>,Sq...>(), ctll::list<Ts...>()), subject.parameters};
+}
+// make_sequence (concat string in front of different items)
+template <auto V, auto A, auto... Bs, typename... Sq, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_sequence, ctll::term<V>, pcre_context<ctll::list<sequence<string<Bs...>,Sq...>,character<A>,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(sequence<string<A,Bs...>,Sq...>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 #endif
 
@@ -2051,7 +2513,7 @@ struct pcre_actions {
 
 // UTILITY
 // add into set if not exists
-  template <template <typename...> typename SetType, typename T, typename... As, bool Exists = (std::is_same_v<T, As> || ... || false)> static constexpr auto push_back_into_set(T, SetType<As...>) -> ctll::conditional<Exists, SetType<As...>, SetType<As...,T>> { return {}; }
+template <template <typename...> typename SetType, typename T, typename... As, bool Exists = (std::is_same_v<T, As> || ... || false)> static constexpr auto push_back_into_set(T, SetType<As...>) -> ctll::conditional<Exists, SetType<As...>, SetType<As...,T>> { return {}; }
 
 //template <template <typename...> typename SetType, typename A, typename BHead, typename... Bs> struct set_merge_helper {
 //	using step = decltype(push_back_into_set<SetType>(BHead(), A()));
@@ -2066,22 +2528,22 @@ struct pcre_actions {
 // END OF UTILITY
 
 // set_start
-  template <auto V, typename A,typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_start, ctll::term<V>, pcre_context<ctll::list<A,Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(set<A>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A,typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_start, ctll::term<V>, pcre_context<ctll::list<A,Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(set<A>(), ctll::list<Ts...>()), subject.parameters};
+}
 // set_make
-  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_make, ctll::term<V>, pcre_context<ctll::list<set<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(set<Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_make, ctll::term<V>, pcre_context<ctll::list<set<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(set<Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 // set_make_negative
-  template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_make_negative, ctll::term<V>, pcre_context<ctll::list<set<Content...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(negative_set<Content...>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_make_negative, ctll::term<V>, pcre_context<ctll::list<set<Content...>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(negative_set<Content...>(), ctll::list<Ts...>()), subject.parameters};
+}
 // set{A...} + B = set{A,B}
-  template <auto V, typename A, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<A,set<Content...>,Ts...>, Parameters> subject) {
-    auto new_set = push_back_into_set<set>(A(), set<Content...>());
-    return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<A,set<Content...>,Ts...>, Parameters> subject) {
+auto new_set = push_back_into_set<set>(A(), set<Content...>());
+return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
+}
 // TODO checkme
 //// set{A...} + set{B...} = set{A...,B...}
 //template <auto V, typename... As, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<set<As...>,set<Bs...>,Ts...>, Parameters> subject) {
@@ -2090,10 +2552,10 @@ struct pcre_actions {
 //}
 
 // negative_set{A...} + B = negative_set{A,B}
-  template <auto V, typename A, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<A,negative_set<Content...>,Ts...>, Parameters> subject) {
-    auto new_set = push_back_into_set<set>(A(), set<Content...>());
-    return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Content, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<A,negative_set<Content...>,Ts...>, Parameters> subject) {
+auto new_set = push_back_into_set<set>(A(), set<Content...>());
+return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
+}
 // TODO checkme
 //// negative_set{A...} + negative_set{B...} = negative_set{A...,B...}
 //template <auto V, typename... As, typename... Bs, typename... Ts, typename Parameters> static constexpr auto apply(pcre::set_combine, ctll::term<V>, pcre_context<ctll::list<negative_set<As...>,negative_set<Bs...>,Ts...>, Parameters> subject) {
@@ -2101,87 +2563,14 @@ struct pcre_actions {
 //	return pcre_context{ctll::push_front(new_set, ctll::list<Ts...>()), subject.parameters};
 //}
 // negate_class_named: [[^:digit:]] = [^[:digit:]]
-  template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::negate_class_named, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(negate<A>(), ctll::list<Ts...>()), subject.parameters};
-  }
+template <auto V, typename A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::negate_class_named, ctll::term<V>, pcre_context<ctll::list<A, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(negate<A>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 // add range to set
-  template <auto V, auto B, auto A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_range, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(char_range<A,B>(), ctll::list<Ts...>()), subject.parameters};
-  }
-
-#endif
-
-#ifndef CTRE__ACTIONS__PROPERTIES__HPP
-#define CTRE__ACTIONS__PROPERTIES__HPP
-
-// push_property_name
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_name, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(property_name<V>(), subject.stack), subject.parameters};
-  }
-// push_property_name (concat)
-  template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_name, ctll::term<V>, pcre_context<ctll::list<property_name<Str...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(property_name<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
-  }
-
-// push_property_value
-  template <auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_value, ctll::term<V>, pcre_context<ctll::list<Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(property_value<V>(), subject.stack), subject.parameters};
-  }
-// push_property_value (concat)
-  template <auto... Str, auto V, typename... Ts, typename Parameters> static constexpr auto apply(pcre::push_property_value, ctll::term<V>, pcre_context<ctll::list<property_value<Str...>, Ts...>, Parameters> subject) {
-    return pcre_context{ctll::push_front(property_value<Str..., V>(), ctll::list<Ts...>()), subject.parameters};
-  }
-
-// make_property
-  template <auto V, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_name<Name...>, Ts...>, Parameters> subject) {
-    return ctll::reject{};
-    //constexpr std::array<char, sizeof...(Name)> name{static_cast<char>(Name)...};
-    //constexpr auto p = uni::__binary_prop_from_string(get_string_view(name));
-    //
-    //if constexpr (p == uni::__binary_prop::unknown) {
-    //	return ctll::reject{};
-    //} else {
-    //	return pcre_context{ctll::push_front(binary_property<p>(), ctll::list<Ts...>()), subject.parameters};
-    //}
-  }
-
-// make_property
-  template <auto V, auto... Value, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_value<Value...>, property_name<Name...>, Ts...>, Parameters> subject) {
-    return ctll::reject{};
-    //constexpr auto prop = property_builder<Name...>::template get<Value...>();
-    //
-    //if constexpr (std::is_same_v<decltype(prop), ctll::reject>) {
-    //	return ctll::reject{};
-    //} else {
-    //	return pcre_context{ctll::push_front(prop, ctll::list<Ts...>()), subject.parameters};
-    //}
-  }
-
-// make_property_negative
-  template <auto V, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property_negative, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_name<Name...>, Ts...>, Parameters> subject) {
-    return ctll::reject{};
-    //constexpr std::array<char, sizeof...(Name)> name{static_cast<char>(Name)...};
-    //constexpr auto p = uni::__binary_prop_from_string(get_string_view(name));
-    //
-    //if constexpr (p == uni::__binary_prop::unknown) {
-    //	return ctll::reject{};
-    //} else {
-    //	return pcre_context{ctll::push_front(negate<binary_property<p>>(), ctll::list<Ts...>()), subject.parameters};
-    //}
-  }
-
-// make_property_negative
-  template <auto V, auto... Value, auto... Name, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_property_negative, ctll::term<V>, [[maybe_unused]] pcre_context<ctll::list<property_value<Value...>, property_name<Name...>, Ts...>, Parameters> subject) {
-    return ctll::reject{};
-    //constexpr auto prop = property_builder<Name...>::template get<Value...>();
-    //
-    //if constexpr (std::is_same_v<decltype(prop), ctll::reject>) {
-    //	return ctll::reject{};
-    //} else {
-    //	return pcre_context{ctll::push_front(negate<decltype(prop)>(), ctll::list<Ts...>()), subject.parameters};
-    //}
-  }
+template <auto V, auto B, auto A, typename... Ts, typename Parameters> static constexpr auto apply(pcre::make_range, ctll::term<V>, pcre_context<ctll::list<character<B>,character<A>, Ts...>, Parameters> subject) {
+return pcre_context{ctll::push_front(char_range<A,B>(), ctll::list<Ts...>()), subject.parameters};
+}
 
 #endif
 
@@ -2194,94 +2583,466 @@ struct pcre_actions {
 #ifndef CTRE__EVALUATION__HPP
 #define CTRE__EVALUATION__HPP
 
+#ifndef CTRE_V2__CTRE__FLAGS_AND_MODES__HPP
+#define CTRE_V2__CTRE__FLAGS_AND_MODES__HPP
+
+namespace ctre {
+
+struct singleline { };
+struct multiline { };
+
+struct flags {
+bool block_empty_match = false;
+bool multiline = false;
+constexpr CTRE_FORCE_INLINE flags(ctre::singleline) { }
+constexpr CTRE_FORCE_INLINE flags(ctre::multiline): multiline{true} { }
+};
+
+constexpr CTRE_FORCE_INLINE auto not_empty_match(flags f) {
+f.block_empty_match = true;
+return f;
+}
+
+constexpr CTRE_FORCE_INLINE auto consumed_something(flags f, bool condition = true) {
+if (condition) f.block_empty_match = false;
+return f;
+}
+
+constexpr CTRE_FORCE_INLINE bool cannot_be_empty_match(flags f) {
+return f.block_empty_match;
+}
+
+constexpr CTRE_FORCE_INLINE bool multiline_mode(flags f) {
+return f.multiline;
+}
+
+} // namespace ctre
+
+#endif
+
+#ifndef CTRE__STARTS_WITH_ANCHOR__HPP
+#define CTRE__STARTS_WITH_ANCHOR__HPP
+
+namespace ctre {
+
+template <typename... Content>
+constexpr bool starts_with_anchor(const flags &, ctll::list<Content...>) noexcept {
+return false;
+}
+
+template <typename... Content>
+constexpr bool starts_with_anchor(const flags &, ctll::list<assert_subject_begin, Content...>) noexcept {
+// yes! start subject anchor is here
+return true;
+}
+
+template <typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<assert_line_begin, Content...>) noexcept {
+// yes! start line anchor is here
+return !ctre::multiline_mode(f) || starts_with_anchor(f, ctll::list<Content...>{});
+}
+
+template <typename CharLike, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<boundary<CharLike>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Content...>{});
+}
+
+template <typename... Options, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<select<Options...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return (starts_with_anchor(f, ctll::list<Options, Content...>{}) && ... && true);
+}
+
+template <typename... Optional, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<optional<Optional...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Optional..., Content...>{}) && starts_with_anchor(f, ctll::list<Content...>{});
+}
+
+template <typename... Optional, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<lazy_optional<Optional...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Optional..., Content...>{}) && starts_with_anchor(f, ctll::list<Content...>{});
+}
+
+template <typename... Seq, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<sequence<Seq...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Seq..., Content...>{});
+}
+
+template <size_t A, size_t B, typename... Seq, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<repeat<A, B, Seq...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Seq..., Content...>{});
+}
+
+template <size_t A, size_t B, typename... Seq, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<lazy_repeat<A, B, Seq...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Seq..., Content...>{});
+}
+
+template <size_t A, size_t B, typename... Seq, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<possessive_repeat<A, B, Seq...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Seq..., Content...>{});
+}
+
+template <size_t Index, typename... Seq, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<capture<Index, Seq...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Seq..., Content...>{});
+}
+
+template <size_t Index, typename... Seq, typename... Content>
+constexpr bool starts_with_anchor(const flags & f, ctll::list<capture_with_name<Index, Seq...>, Content...>) noexcept {
+// check if all options starts with anchor or if they are empty, there is an anchor behind them
+return starts_with_anchor(f, ctll::list<Seq..., Content...>{});
+}
+
+}
+
+#endif
+
 #ifndef CTRE__RETURN_TYPE__HPP
 #define CTRE__RETURN_TYPE__HPP
 
+#ifndef CTRE__UTF8__HPP
+#define CTRE__UTF8__HPP
+
+#if __cpp_char8_t >= 201811
+
+#include <string_view>
+#include <iterator>
+
+namespace ctre {
+
+struct utf8_iterator {
+using self_type = utf8_iterator;
+using value_type = char8_t;
+using reference = char8_t;
+using pointer = const char8_t *;
+using iterator_category = std::bidirectional_iterator_tag;
+using difference_type = int;
+
+struct sentinel {
+
+};
+
+const char8_t * ptr{nullptr};
+const char8_t * end{nullptr};
+
+constexpr friend bool operator!=(const utf8_iterator & lhs, sentinel) {
+return lhs.ptr < lhs.end;
+}
+
+constexpr friend bool operator!=(sentinel, const utf8_iterator & rhs) {
+return rhs.ptr < rhs.end;
+}
+
+constexpr friend bool operator!=(const utf8_iterator & lhs, const utf8_iterator & rhs) {
+return lhs.ptr != rhs.ptr;
+}
+
+constexpr friend bool operator==(const utf8_iterator & lhs, sentinel) {
+return lhs.ptr >= lhs.end;
+}
+
+constexpr friend bool operator==(sentinel, const utf8_iterator & rhs) {
+return rhs.ptr >= rhs.end;
+}
+
+constexpr utf8_iterator & operator=(const char8_t * rhs) {
+ptr = rhs;
+return *this;
+}
+
+constexpr operator const char8_t *() const noexcept {
+return ptr;
+}
+
+constexpr utf8_iterator & operator++() noexcept {
+// the contant is mapping from first 5 bits of first code unit to length of UTF8 code point -1
+// xxxxx -> yy (5 bits to 2 bits)
+// 5 bits are 32 combination, and for each I need 2 bits, hence 64 bit constant
+// (*ptr >> 2) & 0b111110 look at the left 5 bits ignoring the least significant
+// & 0b11u  selects only needed two bits
+// +1  because each iteration is at least one code unit forward
+
+ptr += ((0x3A55000000000000ull >> ((*ptr >> 2) & 0b111110u)) & 0b11u) + 1;
+return *this;
+}
+
+constexpr utf8_iterator & operator--() noexcept {
+if (ptr > end) {
+ptr = end-1;
+} else {
+--ptr;
+}
+
+while ((*ptr & 0b11000000u) == 0b10'000000) {
+--ptr;
+}
+
+return *this;
+}
+
+constexpr utf8_iterator operator--(int) noexcept {
+auto self = *this;
+this->operator--();
+return self;
+}
+
+constexpr utf8_iterator operator++(int) noexcept {
+auto self = *this;
+this->operator++();
+return self;
+}
+
+constexpr utf8_iterator operator+(unsigned step) const noexcept {
+utf8_iterator result = *this;
+while (step > 0) {
+++result;
+step--;
+}
+return result;
+}
+
+constexpr utf8_iterator operator-(unsigned step) const noexcept {
+utf8_iterator result = *this;
+while (step > 0) {
+--result;
+step--;
+}
+return result;
+}
+
+constexpr char32_t operator*() const noexcept {
+constexpr char32_t mojibake = 0xFFFDull;
+
+// quickpath
+if (!(*ptr & 0b1000'0000u)) CTRE_LIKELY {
+return *ptr;
+}
+
+// calculate length based on first 5 bits
+const unsigned length = ((0x3A55000000000000ull >> ((*ptr >> 2) & 0b111110u)) & 0b11u);
+
+// actual length is number + 1 bytes
+
+// length 0 here means it's a bad front unit
+if (!length) CTRE_UNLIKELY {
+return mojibake;
+}
+
+// if part of the utf-8 sequence is past the end
+if (((ptr + length) >= end)) CTRE_UNLIKELY {
+return mojibake;
+}
+
+if ((ptr[1] & 0b1100'0000u) != 0b1000'0000) CTRE_UNLIKELY {
+return mojibake;
+}
+
+const char8_t mask = (0b0011'1111u >> length);
+
+// length = 1 (2 bytes) mask = 0b0001'1111u
+// length = 2 (3 bytes) mask = 0b0000'1111u
+// length = 3 (4 bytes) mask = 0b0000'0111u
+
+// remove utf8 front bits, get only significant part
+// and add first trailing unit
+
+char32_t result = ((ptr[0] & mask) << 6) | (ptr[1] & 0b0011'1111u);
+
+// add rest of trailing units
+if (length == 1) CTRE_LIKELY {
+return result;
+}
+
+if ((ptr[2] & 0b1100'0000u) != 0b1000'0000) CTRE_UNLIKELY {
+return mojibake;
+}
+
+result = (result << 6) | (ptr[2] & 0b0011'1111u);
+
+if (length == 2) CTRE_LIKELY {
+return result;
+}
+
+if ((ptr[3] & 0b1100'0000u) != 0b1000'0000) CTRE_UNLIKELY {
+return mojibake;
+}
+
+return (result << 6) | (ptr[3] & 0b0011'1111u);
+}
+};
+
+struct utf8_range {
+std::u8string_view range;
+constexpr utf8_range(std::u8string_view r) noexcept: range{r} { }
+
+constexpr auto begin() const noexcept {
+return utf8_iterator{range.data(), range.data() + range.size()};
+}
+constexpr auto end() const noexcept {
+return utf8_iterator::sentinel{};
+}
+};
+
+}
+
+#endif
+
+#endif
 #include <type_traits>
 #include <tuple>
 #include <string_view>
 #include <string>
+#include <iterator>
+#include <iosfwd>
 
 namespace ctre {
+
+constexpr bool is_random_accessible(const std::random_access_iterator_tag &) { return true; }
+constexpr bool is_random_accessible(...) { return false; }
 
 struct not_matched_tag_t { };
 
 static constexpr inline auto not_matched = not_matched_tag_t{};
 
 template <size_t Id, typename Name = void> struct captured_content {
-  template <typename Iterator> class storage {
-    Iterator _begin{};
-    Iterator _end{};
+template <typename Iterator> class storage {
+Iterator _begin{};
+Iterator _end{};
 
-    bool _matched{false};
-   public:
-    using char_type = typename std::iterator_traits<Iterator>::value_type;
+bool _matched{false};
+public:
+using char_type = typename std::iterator_traits<Iterator>::value_type;
 
-    using name = Name;
+using name = Name;
 
-    constexpr CTRE_FORCE_INLINE storage() noexcept {}
+constexpr CTRE_FORCE_INLINE storage() noexcept {}
 
-    constexpr CTRE_FORCE_INLINE void matched() noexcept {
-      _matched = true;
-    }
-    constexpr CTRE_FORCE_INLINE void unmatch() noexcept {
-      _matched = false;
-    }
-    constexpr CTRE_FORCE_INLINE void set_start(Iterator pos) noexcept {
-      _begin = pos;
-    }
-    constexpr CTRE_FORCE_INLINE storage & set_end(Iterator pos) noexcept {
-      _end = pos;
-      return *this;
-    }
-    constexpr CTRE_FORCE_INLINE Iterator get_end() const noexcept {
-      return _end;
-    }
+constexpr CTRE_FORCE_INLINE void matched() noexcept {
+_matched = true;
+}
+constexpr CTRE_FORCE_INLINE void unmatch() noexcept {
+_matched = false;
+}
+constexpr CTRE_FORCE_INLINE void set_start(Iterator pos) noexcept {
+_begin = pos;
+}
+constexpr CTRE_FORCE_INLINE storage & set_end(Iterator pos) noexcept {
+_end = pos;
+return *this;
+}
+constexpr CTRE_FORCE_INLINE Iterator get_end() const noexcept {
+return _end;
+}
 
 
-    constexpr auto begin() const noexcept {
-      return _begin;
-    }
-    constexpr auto end() const noexcept {
-      return _end;
-    }
+constexpr auto begin() const noexcept {
+return _begin;
+}
+constexpr auto end() const noexcept {
+return _end;
+}
 
-    constexpr CTRE_FORCE_INLINE operator bool() const noexcept {
-      return _matched;
-    }
+// TODO explicit
+constexpr CTRE_FORCE_INLINE operator bool() const noexcept {
+return _matched;
+}
 
-    constexpr CTRE_FORCE_INLINE auto size() const noexcept {
-      return static_cast<size_t>(std::distance(_begin, _end));
-    }
+constexpr CTRE_FORCE_INLINE const auto * data_unsafe() const noexcept {
+#if __cpp_char8_t >= 201811
+if constexpr (std::is_same_v<Iterator, utf8_iterator>) {
+return _begin.ptr;
+} else {
+return &*_begin;
+}
+#else
+return &*_begin;
+#endif
+}
 
-    constexpr CTRE_FORCE_INLINE auto to_view() const noexcept {
-      return std::basic_string_view<char_type>(&*_begin, static_cast<size_t>(std::distance(_begin, _end)));
-    }
+constexpr CTRE_FORCE_INLINE const auto * data() const noexcept {
+constexpr bool must_be_contiguous_iterator = is_random_accessible(typename std::iterator_traits<Iterator>::iterator_category{});
 
-    constexpr CTRE_FORCE_INLINE auto to_string() const noexcept {
-      return std::basic_string<char_type>(begin(), end());
-    }
+static_assert(must_be_contiguous_iterator, "To access result as a pointer you need to provide a random access iterator/range to regex.");
 
-    constexpr CTRE_FORCE_INLINE auto view() const noexcept {
-      return std::basic_string_view<char_type>(&*_begin, static_cast<size_t>(std::distance(_begin, _end)));
-    }
+return data_unsafe();
+}
 
-    constexpr CTRE_FORCE_INLINE auto str() const noexcept {
-      return std::basic_string<char_type>(begin(), end());
-    }
+constexpr CTRE_FORCE_INLINE auto size() const noexcept {
+return static_cast<size_t>(std::distance(begin(), end()));
+}
 
-    constexpr CTRE_FORCE_INLINE operator std::basic_string_view<char_type>() const noexcept {
-      return to_view();
-    }
+constexpr CTRE_FORCE_INLINE size_t unit_size() const noexcept {
+#if __cpp_char8_t >= 201811
+if constexpr (std::is_same_v<Iterator, utf8_iterator>) {
+return static_cast<size_t>(std::distance(_begin.ptr, _end.ptr));
+}
+#endif
+return static_cast<size_t>(std::distance(begin(), end()));
+}
 
-    constexpr CTRE_FORCE_INLINE explicit operator std::basic_string<char_type>() const noexcept {
-      return to_string();
-    }
+template <typename It = Iterator> constexpr CTRE_FORCE_INLINE auto to_view() const noexcept {
+// random access, because C++ (waving hands around)
+constexpr bool must_be_contiguous_iterator = is_random_accessible(typename std::iterator_traits<std::remove_const_t<It>>::iterator_category{});
 
-    constexpr CTRE_FORCE_INLINE static size_t get_id() noexcept {
-      return Id;
-    }
-  };
+static_assert(must_be_contiguous_iterator, "To convert capture into a basic_string_view you need to provide a pointer or a contiguous iterator/range to regex.");
+
+return std::basic_string_view<char_type>(data_unsafe(), static_cast<size_t>(unit_size()));
+}
+
+constexpr CTRE_FORCE_INLINE std::basic_string<char_type> to_string() const noexcept {
+#if __cpp_char8_t >= 201811
+if constexpr (std::is_same_v<Iterator, utf8_iterator>) {
+return std::basic_string<char_type>(data_unsafe(), static_cast<size_t>(unit_size()));
+}
+#endif
+return std::basic_string<char_type>(begin(), end());
+}
+
+constexpr CTRE_FORCE_INLINE auto view() const noexcept {
+return to_view();
+}
+
+constexpr CTRE_FORCE_INLINE auto str() const noexcept {
+return to_string();
+}
+
+constexpr CTRE_FORCE_INLINE operator std::basic_string_view<char_type>() const noexcept {
+return to_view();
+}
+
+constexpr CTRE_FORCE_INLINE explicit operator std::basic_string<char_type>() const noexcept {
+return to_string();
+}
+
+constexpr CTRE_FORCE_INLINE static size_t get_id() noexcept {
+return Id;
+}
+
+friend CTRE_FORCE_INLINE constexpr bool operator==(const storage & lhs, std::basic_string_view<char_type> rhs) noexcept {
+return bool(lhs) ? lhs.view() == rhs : false;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator!=(const storage & lhs, std::basic_string_view<char_type> rhs) noexcept {
+return bool(lhs) ? lhs.view() != rhs : false;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator==(std::basic_string_view<char_type> lhs, const storage & rhs) noexcept {
+return bool(rhs) ? lhs == rhs.view() : false;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator!=(std::basic_string_view<char_type> lhs, const storage & rhs) noexcept {
+return bool(rhs) ? lhs != rhs.view() : false;
+}
+friend CTRE_FORCE_INLINE std::ostream & operator<<(std::ostream & str, const storage & rhs) {
+return str << rhs.view();
+}
+};
 };
 
 struct capture_not_exists_tag { };
@@ -2291,197 +3052,222 @@ static constexpr inline auto capture_not_exists = capture_not_exists_tag{};
 template <typename... Captures> struct captures;
 
 template <typename Head, typename... Tail> struct captures<Head, Tail...>: captures<Tail...> {
-  Head head{};
-  constexpr CTRE_FORCE_INLINE captures() noexcept { }
-  template <size_t id> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
-    if constexpr (id == Head::get_id()) {
-      return true;
-    } else {
-      return captures<Tail...>::template exists<id>();
-    }
-  }
-  template <typename Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
-    if constexpr (std::is_same_v<Name, typename Head::name>) {
-      return true;
-    } else {
-      return captures<Tail...>::template exists<Name>();
-    }
-  }
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-  template <ctll::fixed_string Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+Head head{};
+constexpr CTRE_FORCE_INLINE captures() noexcept { }
+template <size_t id> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+if constexpr (id == Head::get_id()) {
+return true;
+} else {
+return captures<Tail...>::template exists<id>();
+}
+}
+template <typename Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+if constexpr (std::is_same_v<Name, typename Head::name>) {
+return true;
+} else {
+return captures<Tail...>::template exists<Name>();
+}
+}
+#if CTRE_CNTTP_COMPILER_CHECK
+template <ctll::fixed_string Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
 #else
-  template <const auto & Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+template <const auto & Name> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
 #endif
-    if constexpr (std::is_same_v<typename Head::name, void>) {
-      return captures<Tail...>::template exists<Name>();
-    } else {
-      if constexpr (Head::name::name.is_same_as(Name)) {
-        return true;
-      } else {
-        return captures<Tail...>::template exists<Name>();
-      }
-    }
-  }
-  template <size_t id> CTRE_FORCE_INLINE constexpr auto & select() noexcept {
-    if constexpr (id == Head::get_id()) {
-      return head;
-    } else {
-      return captures<Tail...>::template select<id>();
-    }
-  }
-  template <typename Name> CTRE_FORCE_INLINE constexpr auto & select() noexcept {
-    if constexpr (std::is_same_v<Name, typename Head::name>) {
-      return head;
-    } else {
-      return captures<Tail...>::template select<Name>();
-    }
-  }
-  template <size_t id> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
-    if constexpr (id == Head::get_id()) {
-      return head;
-    } else {
-      return captures<Tail...>::template select<id>();
-    }
-  }
-  template <typename Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
-    if constexpr (std::is_same_v<Name, typename Head::name>) {
-      return head;
-    } else {
-      return captures<Tail...>::template select<Name>();
-    }
-  }
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-  template <ctll::fixed_string Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+if constexpr (std::is_same_v<typename Head::name, void>) {
+return captures<Tail...>::template exists<Name>();
+} else {
+if constexpr (Head::name::name.is_same_as(Name)) {
+return true;
+} else {
+return captures<Tail...>::template exists<Name>();
+}
+}
+}
+template <size_t id> CTRE_FORCE_INLINE constexpr auto & select() noexcept {
+if constexpr (id == Head::get_id()) {
+return head;
+} else {
+return captures<Tail...>::template select<id>();
+}
+}
+template <typename Name> CTRE_FORCE_INLINE constexpr auto & select() noexcept {
+if constexpr (std::is_same_v<Name, typename Head::name>) {
+return head;
+} else {
+return captures<Tail...>::template select<Name>();
+}
+}
+template <size_t id> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+if constexpr (id == Head::get_id()) {
+return head;
+} else {
+return captures<Tail...>::template select<id>();
+}
+}
+template <typename Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+if constexpr (std::is_same_v<Name, typename Head::name>) {
+return head;
+} else {
+return captures<Tail...>::template select<Name>();
+}
+}
+#if CTRE_CNTTP_COMPILER_CHECK
+template <ctll::fixed_string Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
 #else
-  template <const auto & Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+template <const auto & Name> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
 #endif
-    if constexpr (std::is_same_v<typename Head::name, void>) {
-      return captures<Tail...>::template select<Name>();
-    } else {
-      if constexpr (Head::name::name.is_same_as(Name)) {
-        return head;
-      } else {
-        return captures<Tail...>::template select<Name>();
-      }
-    }
-  }
+if constexpr (std::is_same_v<typename Head::name, void>) {
+return captures<Tail...>::template select<Name>();
+} else {
+if constexpr (Head::name::name.is_same_as(Name)) {
+return head;
+} else {
+return captures<Tail...>::template select<Name>();
+}
+}
+}
 };
 
 template <> struct captures<> {
-  constexpr CTRE_FORCE_INLINE captures() noexcept { }
-  template <size_t> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
-    return false;
-  }
-  template <typename> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
-    return false;
-  }
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-  template <ctll::fixed_string> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+constexpr CTRE_FORCE_INLINE captures() noexcept { }
+template <size_t> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+return false;
+}
+template <typename> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+return false;
+}
+#if CTRE_CNTTP_COMPILER_CHECK
+template <ctll::fixed_string> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
 #else
-  template <const auto &> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
+template <const auto &> CTRE_FORCE_INLINE static constexpr bool exists() noexcept {
 #endif
-    return false;
-  }
-  template <size_t> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
-    return capture_not_exists;
-  }
-  template <typename> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
-    return capture_not_exists;
-  }
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-  template <ctll::fixed_string> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+return false;
+}
+template <size_t> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+return capture_not_exists;
+}
+template <typename> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+return capture_not_exists;
+}
+#if CTRE_CNTTP_COMPILER_CHECK
+template <ctll::fixed_string> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
 #else
-  template <const auto &> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
+template <const auto &> CTRE_FORCE_INLINE constexpr auto & select() const noexcept {
 #endif
-    return capture_not_exists;
-  }
+return capture_not_exists;
+}
 };
 
 template <typename Iterator, typename... Captures> class regex_results {
-  captures<captured_content<0>::template storage<Iterator>, typename Captures::template storage<Iterator>...> _captures{};
- public:
-  using char_type = typename std::iterator_traits<Iterator>::value_type;
+captures<captured_content<0>::template storage<Iterator>, typename Captures::template storage<Iterator>...> _captures{};
+public:
+using char_type = typename std::iterator_traits<Iterator>::value_type;
 
-  constexpr CTRE_FORCE_INLINE regex_results() noexcept { }
-  constexpr CTRE_FORCE_INLINE regex_results(not_matched_tag_t) noexcept { }
+constexpr CTRE_FORCE_INLINE regex_results() noexcept { }
+constexpr CTRE_FORCE_INLINE regex_results(not_matched_tag_t) noexcept { }
 
-  // special constructor for deducting
-  constexpr CTRE_FORCE_INLINE regex_results(Iterator, ctll::list<Captures...>) noexcept { }
+// special constructor for deducting
+constexpr CTRE_FORCE_INLINE regex_results(Iterator, ctll::list<Captures...>) noexcept { }
 
-  template <size_t Id, typename = std::enable_if_t<decltype(_captures)::template exists<Id>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
-    return _captures.template select<Id>();
-  }
-  template <typename Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
-    return _captures.template select<Name>();
-  }
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-  template <ctll::fixed_string Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+template <size_t Id, typename = std::enable_if_t<decltype(_captures)::template exists<Id>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+return _captures.template select<Id>();
+}
+template <typename Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+return _captures.template select<Name>();
+}
+#if CTRE_CNTTP_COMPILER_CHECK
+template <ctll::fixed_string Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
 #else
-  template <const auto & Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
+template <const auto & Name, typename = std::enable_if_t<decltype(_captures)::template exists<Name>()>> CTRE_FORCE_INLINE constexpr auto get() const noexcept {
 #endif
-    return _captures.template select<Name>();
-  }
-  static constexpr size_t size() noexcept {
-    return sizeof...(Captures) + 1;
-  }
-  constexpr CTRE_FORCE_INLINE regex_results & matched() noexcept {
-    _captures.template select<0>().matched();
-    return *this;
-  }
-  constexpr CTRE_FORCE_INLINE regex_results & unmatch() noexcept {
-    _captures.template select<0>().unmatch();
-    return *this;
-  }
-  constexpr CTRE_FORCE_INLINE operator bool() const noexcept {
-    return bool(_captures.template select<0>());
-  }
+return _captures.template select<Name>();
+}
+static constexpr size_t count() noexcept {
+return sizeof...(Captures) + 1;
+}
+constexpr CTRE_FORCE_INLINE regex_results & matched() noexcept {
+_captures.template select<0>().matched();
+return *this;
+}
+constexpr CTRE_FORCE_INLINE regex_results & unmatch() noexcept {
+_captures.template select<0>().unmatch();
+return *this;
+}
+constexpr CTRE_FORCE_INLINE operator bool() const noexcept {
+return bool(_captures.template select<0>());
+}
 
-  constexpr CTRE_FORCE_INLINE operator std::basic_string_view<char_type>() const noexcept {
-    return to_view();
-  }
+constexpr CTRE_FORCE_INLINE operator std::basic_string_view<char_type>() const noexcept {
+return to_view();
+}
 
-  constexpr CTRE_FORCE_INLINE explicit operator std::basic_string<char_type>() const noexcept {
-    return to_string();
-  }
+constexpr CTRE_FORCE_INLINE explicit operator std::basic_string<char_type>() const noexcept {
+return to_string();
+}
 
-  constexpr CTRE_FORCE_INLINE auto to_view() const noexcept {
-    return _captures.template select<0>().to_view();
-  }
+constexpr CTRE_FORCE_INLINE auto to_view() const noexcept {
+return _captures.template select<0>().to_view();
+}
 
-  constexpr CTRE_FORCE_INLINE auto to_string() const noexcept {
-    return _captures.template select<0>().to_string();
-  }
+constexpr CTRE_FORCE_INLINE auto to_string() const noexcept {
+return _captures.template select<0>().to_string();
+}
 
-  constexpr CTRE_FORCE_INLINE auto view() const noexcept {
-    return _captures.template select<0>().view();
-  }
+constexpr CTRE_FORCE_INLINE auto view() const noexcept {
+return _captures.template select<0>().view();
+}
 
-  constexpr CTRE_FORCE_INLINE auto str() const noexcept {
-    return _captures.template select<0>().to_string();
-  }
+constexpr CTRE_FORCE_INLINE auto str() const noexcept {
+return _captures.template select<0>().to_string();
+}
 
-  constexpr CTRE_FORCE_INLINE regex_results & set_start_mark(Iterator pos) noexcept {
-    _captures.template select<0>().set_start(pos);
-    return *this;
-  }
-  constexpr CTRE_FORCE_INLINE regex_results & set_end_mark(Iterator pos) noexcept {
-    _captures.template select<0>().set_end(pos);
-    return *this;
-  }
-  constexpr CTRE_FORCE_INLINE Iterator get_end_position() const noexcept {
-    return _captures.template select<0>().get_end();
-  }
-  template <size_t Id> CTRE_FORCE_INLINE constexpr regex_results & start_capture(Iterator pos) noexcept {
-    _captures.template select<Id>().set_start(pos);
-    return *this;
-  }
-  template <size_t Id> CTRE_FORCE_INLINE constexpr regex_results & end_capture(Iterator pos) noexcept {
-    _captures.template select<Id>().set_end(pos).matched();
-    return *this;
-  }
+constexpr CTRE_FORCE_INLINE size_t size() const noexcept {
+return _captures.template select<0>().size();
+}
+
+constexpr CTRE_FORCE_INLINE const auto * data() const noexcept {
+return _captures.template select<0>().data();
+}
+
+constexpr CTRE_FORCE_INLINE regex_results & set_start_mark(Iterator pos) noexcept {
+_captures.template select<0>().set_start(pos);
+return *this;
+}
+constexpr CTRE_FORCE_INLINE regex_results & set_end_mark(Iterator pos) noexcept {
+_captures.template select<0>().set_end(pos);
+return *this;
+}
+constexpr CTRE_FORCE_INLINE Iterator get_end_position() const noexcept {
+return _captures.template select<0>().get_end();
+}
+template <size_t Id> CTRE_FORCE_INLINE constexpr regex_results & start_capture(Iterator pos) noexcept {
+_captures.template select<Id>().set_start(pos);
+return *this;
+}
+template <size_t Id> CTRE_FORCE_INLINE constexpr regex_results & end_capture(Iterator pos) noexcept {
+_captures.template select<Id>().set_end(pos).matched();
+return *this;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator==(const regex_results & lhs, std::basic_string_view<char_type> rhs) noexcept {
+return bool(lhs) ? lhs.view() == rhs : false;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator!=(const regex_results & lhs, std::basic_string_view<char_type> rhs) noexcept {
+return bool(lhs) ? lhs.view() != rhs : true;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator==(std::basic_string_view<char_type> lhs, const regex_results & rhs) noexcept {
+return bool(rhs) ? lhs == rhs.view() : false;
+}
+friend CTRE_FORCE_INLINE constexpr bool operator!=(std::basic_string_view<char_type> lhs, const regex_results & rhs) noexcept {
+return bool(rhs) ? lhs != rhs.view() : true;
+}
+friend CTRE_FORCE_INLINE std::ostream & operator<<(std::ostream & str, const regex_results & rhs) {
+return str << rhs.view();
+}
 };
 
 template <typename Iterator, typename... Captures> regex_results(Iterator, ctll::list<Captures...>) -> regex_results<Iterator, Captures...>;
+
+template <typename ResultIterator, typename Pattern> using return_type = decltype(regex_results(std::declval<ResultIterator>(), find_captures(Pattern{})));
 
 }
 
@@ -2494,13 +3280,13 @@ template <typename Iterator, typename... Captures> regex_results(Iterator, ctll:
 #endif
 
 namespace std {
-template <typename... Captures> struct tuple_size<ctre::regex_results<Captures...>> : public std::integral_constant<size_t, ctre::regex_results<Captures...>::size()> { };
+template <typename... Captures> struct tuple_size<ctre::regex_results<Captures...>> : public std::integral_constant<size_t, ctre::regex_results<Captures...>::count()> { };
 
 template <size_t N, typename... Captures> struct tuple_element<N, ctre::regex_results<Captures...>> {
- public:
-  using type = decltype(
-  std::declval<const ctre::regex_results<Captures...> &>().template get<N>()
-  );
+public:
+using type = decltype(
+std::declval<const ctre::regex_results<Captures...> &>().template get<N>()
+);
 };
 }
 
@@ -2517,100 +3303,100 @@ template <size_t N, typename... Captures> struct tuple_element<N, ctre::regex_re
 namespace ctre {
 
 template <typename Pattern> constexpr auto find_captures(Pattern) noexcept {
-  return find_captures(ctll::list<Pattern>(), ctll::list<>());
+return find_captures(ctll::list<Pattern>(), ctll::list<>());
 }
 
 template <typename... Output> constexpr auto find_captures(ctll::list<>, ctll::list<Output...> output) noexcept {
-  return output;
+return output;
 }
 
 template <auto... String, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<string<String...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Tail...>(), output);
+return find_captures(ctll::list<Tail...>(), output);
 }
 
 template <typename... Options, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<select<Options...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Options..., Tail...>(), output);
+return find_captures(ctll::list<Options..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<optional<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_optional<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<sequence<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<empty, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Tail...>(), output);
+return find_captures(ctll::list<Tail...>(), output);
 }
 
-template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<assert_begin, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Tail...>(), output);
+template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<assert_subject_begin, Tail...>, Output output) noexcept {
+return find_captures(ctll::list<Tail...>(), output);
 }
 
-template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<assert_end, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Tail...>(), output);
+template <typename... Tail, typename Output> constexpr auto find_captures(ctll::list<assert_subject_end, Tail...>, Output output) noexcept {
+return find_captures(ctll::list<Tail...>(), output);
 }
 
 // , typename = std::enable_if_t<(MatchesCharacter<CharacterLike>::template value<char>)
 template <typename CharacterLike, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<CharacterLike, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Tail...>(), output);
+return find_captures(ctll::list<Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<plus<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<star<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <size_t A, size_t B, typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<repeat<A,B,Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_plus<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_star<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <size_t A, size_t B, typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lazy_repeat<A,B,Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<possessive_plus<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<possessive_star<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <size_t A, size_t B, typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<possessive_repeat<A,B,Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lookahead_positive<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <typename... Content, typename... Tail, typename Output> constexpr auto find_captures(ctll::list<lookahead_negative<Content...>, Tail...>, Output output) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), output);
+return find_captures(ctll::list<Content..., Tail...>(), output);
 }
 
 template <size_t Id, typename... Content, typename... Tail, typename... Output> constexpr auto find_captures(ctll::list<capture<Id,Content...>, Tail...>, ctll::list<Output...>) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), ctll::list<Output..., captured_content<Id>>());
+return find_captures(ctll::list<Content..., Tail...>(), ctll::list<Output..., captured_content<Id>>());
 }
 
 template <size_t Id, typename Name, typename... Content, typename... Tail, typename... Output> constexpr auto find_captures(ctll::list<capture_with_name<Id,Name,Content...>, Tail...>, ctll::list<Output...>) noexcept {
-  return find_captures(ctll::list<Content..., Tail...>(), ctll::list<Output..., captured_content<Id, Name>>());
+return find_captures(ctll::list<Content..., Tail...>(), ctll::list<Output..., captured_content<Id, Name>>());
 }
 
 }
@@ -2627,466 +3413,513 @@ struct can_be_anything {};
 
 template <typename... Content>
 constexpr auto first(ctll::list<Content...> l, ctll::list<>) noexcept {
-  return l;
+return l;
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<accept, Tail...>) noexcept {
-  return l;
+return l;
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<end_mark, Tail...>) noexcept {
-  return l;
+return l;
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<end_cycle_mark, Tail...>) noexcept {
-  return l;
+return l;
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<end_lookahead_mark, Tail...>) noexcept {
-  return l;
+return l;
 }
 
 template <typename... Content, size_t Id, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<numeric_mark<Id>, Tail...>) noexcept {
-  return first(l, ctll::list<Tail...>{});
+return first(l, ctll::list<Tail...>{});
 }
 
 // empty
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<empty, Tail...>) noexcept {
-  return first(l, ctll::list<Tail...>{});
+return first(l, ctll::list<Tail...>{});
+}
+
+// boundary
+template <typename... Content, typename CharLike, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<boundary<CharLike>, Tail...>) noexcept {
+return first(l, ctll::list<Tail...>{});
 }
 
 // asserts
 template <typename... Content, typename... Tail>
-constexpr auto first(ctll::list<Content...> l, ctll::list<assert_begin, Tail...>) noexcept {
-  return first(l, ctll::list<Tail...>{});
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_subject_begin, Tail...>) noexcept {
+return first(l, ctll::list<Tail...>{});
 }
 
 template <typename... Content, typename... Tail>
-constexpr auto first(ctll::list<Content...> l, ctll::list<assert_end, Tail...>) noexcept {
-  return l;
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_subject_end, Tail...>) noexcept {
+return l;
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_subject_end_line, Tail...>) noexcept {
+// FIXME allow endline here
+return l;
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_line_begin, Tail...>) noexcept {
+// FIXME line begin is a bit different than subject begin
+return first(l, ctll::list<Tail...>{});
+}
+
+template <typename... Content, typename... Tail>
+constexpr auto first(ctll::list<Content...> l, ctll::list<assert_line_end, Tail...>) noexcept {
+// FIXME line end is a bit different than subject begin
+return l;
 }
 
 // sequence
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<sequence<Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 // plus
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<plus<Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 // lazy_plus
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_plus<Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 // possessive_plus
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_plus<Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 // star
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<star<Seq...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
 }
 
 // lazy_star
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_star<Seq...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
 }
 
 // possessive_star
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_star<Seq...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
 }
 
 // lazy_repeat
 template <typename... Content, size_t A, size_t B, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_repeat<A, B, Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 template <typename... Content, size_t B, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_repeat<0, B, Seq...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
 }
 
 // possessive_repeat
 template <typename... Content, size_t A, size_t B, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_repeat<A, B, Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 template <typename... Content, size_t B, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<possessive_repeat<0, B, Seq...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
 }
 
 // repeat
 template <typename... Content, size_t A, size_t B, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<repeat<A, B, Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 template <typename... Content, size_t B, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<repeat<0, B, Seq...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
+return first(first(l, ctll::list<Tail...>{}), ctll::list<Seq..., Tail...>{});
 }
 
 // lookahead_positive
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<lookahead_positive<Seq...>, Tail...>) noexcept {
-  return ctll::list<can_be_anything>{};
+return ctll::list<can_be_anything>{};
 }
 
 // lookahead_negative TODO fixme
 template <typename... Content, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<lookahead_negative<Seq...>, Tail...>) noexcept {
-  return ctll::list<can_be_anything>{};
+return ctll::list<can_be_anything>{};
 }
 
 // capture
 template <typename... Content, size_t Id, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<capture<Id, Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 template <typename... Content, size_t Id, typename Name, typename... Seq, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<capture_with_name<Id, Name, Seq...>, Tail...>) noexcept {
-  return first(l, ctll::list<Seq..., Tail...>{});
+return first(l, ctll::list<Seq..., Tail...>{});
 }
 
 // backreference
 template <typename... Content, size_t Id, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<back_reference<Id>, Tail...>) noexcept {
-  return ctll::list<can_be_anything>{};
+return ctll::list<can_be_anything>{};
 }
 
 template <typename... Content, typename Name, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<back_reference_with_name<Name>, Tail...>) noexcept {
-  return ctll::list<can_be_anything>{};
+return ctll::list<can_be_anything>{};
 }
 
 // string First extraction
 template <typename... Content, auto First, auto... String, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<string<First, String...>, Tail...>) noexcept {
-  return ctll::list<Content..., character<First>>{};
+return ctll::list<Content..., character<First>>{};
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<string<>, Tail...>) noexcept {
-  return first(l, ctll::list<Tail...>{});
+return first(l, ctll::list<Tail...>{});
 }
 
 // optional
 template <typename... Content, typename... Opt, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<optional<Opt...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Opt..., Tail...>{}), ctll::list<Tail...>{});
+return first(first(l, ctll::list<Opt..., Tail...>{}), ctll::list<Tail...>{});
 }
 
 template <typename... Content, typename... Opt, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<lazy_optional<Opt...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<Opt..., Tail...>{}), ctll::list<Tail...>{});
+return first(first(l, ctll::list<Opt..., Tail...>{}), ctll::list<Tail...>{});
 }
 
 // select (alternation)
 template <typename... Content, typename SHead, typename... STail, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<select<SHead, STail...>, Tail...>) noexcept {
-  return first(first(l, ctll::list<SHead, Tail...>{}), ctll::list<select<STail...>, Tail...>{});
+return first(first(l, ctll::list<SHead, Tail...>{}), ctll::list<select<STail...>, Tail...>{});
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...> l, ctll::list<select<>, Tail...>) noexcept {
-  return l;
+return l;
+}
+
+// unicode property => anything
+template <typename... Content, auto Property, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<ctre::binary_property<Property>, Tail...>) noexcept {
+return ctll::list<can_be_anything>{};
+}
+
+template <typename... Content, auto Property, auto Value, typename... Tail>
+constexpr auto first(ctll::list<Content...>, ctll::list<ctre::property<Property, Value>, Tail...>) noexcept {
+return ctll::list<can_be_anything>{};
 }
 
 // characters / sets
 
 template <typename... Content, auto V, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<character<V>, Tail...>) noexcept {
-  return ctll::list<Content..., character<V>>{};
+return ctll::list<Content..., character<V>>{};
 }
 
 template <typename... Content, auto... Values, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<enumeration<Values...>, Tail...>) noexcept {
-  return ctll::list<Content..., character<Values>...>{};
+return ctll::list<Content..., character<Values>...>{};
 }
 
 template <typename... Content, typename... SetContent, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<set<SetContent...>, Tail...>) noexcept {
-  return ctll::list<Content..., SetContent...>{};
+return ctll::list<Content..., SetContent...>{};
 }
 
 template <typename... Content, auto A, auto B, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<char_range<A,B>, Tail...>) noexcept {
-  return ctll::list<Content..., char_range<A,B>>{};
+return ctll::list<Content..., char_range<A,B>>{};
 }
 
 template <typename... Content, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<any, Tail...>) noexcept {
-  return ctll::list<can_be_anything>{};
+return ctll::list<can_be_anything>{};
 }
 
 // negative
 template <typename... Content, typename... SetContent, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<negate<SetContent...>, Tail...>) noexcept {
-  return ctll::list<Content..., negative_set<SetContent...>>{};
+return ctll::list<Content..., negative_set<SetContent...>>{};
 }
 
 template <typename... Content, typename... SetContent, typename... Tail>
 constexpr auto first(ctll::list<Content...>, ctll::list<negative_set<SetContent...>, Tail...>) noexcept {
-  return ctll::list<Content..., negative_set<SetContent...>>{};
+return ctll::list<Content..., negative_set<SetContent...>>{};
 }
 
 // user facing interface
 template <typename... Content> constexpr auto calculate_first(Content...) noexcept {
-  return first(ctll::list<>{}, ctll::list<Content...>{});
+return first(ctll::list<>{}, ctll::list<Content...>{});
 }
 
 // calculate mutual exclusivity
 template <typename... Content> constexpr size_t calculate_size_of_first(ctre::negative_set<Content...>) {
-  return 1 + 1 * sizeof...(Content);
+return 1 + 1 * sizeof...(Content);
 }
 
 template <auto... V> constexpr size_t calculate_size_of_first(ctre::enumeration<V...>) {
-  return sizeof...(V);
+return sizeof...(V);
 }
 
 constexpr size_t calculate_size_of_first(...) {
-  return 1;
+return 1;
 }
 
 template <typename... Content> constexpr size_t calculate_size_of_first(ctll::list<Content...>) {
-  return (calculate_size_of_first(Content{}) + ... + 0);
+return (calculate_size_of_first(Content{}) + ... + 0);
 }
 
 template <typename... Content> constexpr size_t calculate_size_of_first(ctre::set<Content...>) {
-  return (calculate_size_of_first(Content{}) + ... + 0);
+return (calculate_size_of_first(Content{}) + ... + 0);
 }
 
 template <auto A, typename CB> constexpr int64_t negative_helper(ctre::character<A>, CB & cb, int64_t start) {
-  if (A != std::numeric_limits<int64_t>::min()) {
-    if (start < A) {
-      cb(start, A-1);
-    }
-  }
-  if (A != std::numeric_limits<int64_t>::max()) {
-    return A+1;
-  } else {
-    return A;
-  }
+if (A != std::numeric_limits<int64_t>::min()) {
+if (start < A) {
+cb(start, A-1);
+}
+}
+if (A != std::numeric_limits<int64_t>::max()) {
+return A+1;
+} else {
+return A;
+}
 }
 
 template <auto A, auto B, typename CB> constexpr int64_t negative_helper(ctre::char_range<A,B>, CB & cb, int64_t start) {
-  if (A != std::numeric_limits<int64_t>::min()) {
-    if (start < A) {
-      cb(start, A-1);
-    }
-  }
-  if (B != std::numeric_limits<int64_t>::max()) {
-    return B+1;
-  } else {
-    return B;
-  }
+if (A != std::numeric_limits<int64_t>::min()) {
+if (start < A) {
+cb(start, A-1);
+}
+}
+if (B != std::numeric_limits<int64_t>::max()) {
+return B+1;
+} else {
+return B;
+}
 }
 
 template <auto Head, auto... Tail, typename CB> constexpr int64_t negative_helper(ctre::enumeration<Head, Tail...>, CB & cb, int64_t start) {
-  int64_t nstart = negative_helper(ctre::character<Head>{}, cb, start);
-  return negative_helper(ctre::enumeration<Tail...>{}, cb, nstart);
+int64_t nstart = negative_helper(ctre::character<Head>{}, cb, start);
+return negative_helper(ctre::enumeration<Tail...>{}, cb, nstart);
 }
 
 template <typename CB> constexpr int64_t negative_helper(ctre::enumeration<>, CB &, int64_t start) {
-  return start;
+return start;
 }
 
 template <typename CB> constexpr int64_t negative_helper(ctre::set<>, CB &, int64_t start) {
-  return start;
+return start;
+}
+
+template <auto Property, typename CB>
+constexpr auto negative_helper(ctre::binary_property<Property>, CB &&, int64_t start) {
+return start;
+}
+
+template <auto Property, auto Value, typename CB>
+constexpr auto negative_helper(ctre::property<Property, Value>, CB &&, int64_t start) {
+return start;
 }
 
 template <typename Head, typename... Rest, typename CB> constexpr int64_t negative_helper(ctre::set<Head, Rest...>, CB & cb, int64_t start) {
-  start = negative_helper(Head{}, cb, start);
-  return negative_helper(ctre::set<Rest...>{}, cb, start);
+start = negative_helper(Head{}, cb, start);
+return negative_helper(ctre::set<Rest...>{}, cb, start);
 }
 
 template <typename Head, typename... Rest, typename CB> constexpr void negative_helper(ctre::negative_set<Head, Rest...>, CB && cb, int64_t start = std::numeric_limits<int64_t>::min()) {
-  start = negative_helper(Head{}, cb, start);
-  negative_helper(ctre::negative_set<Rest...>{}, std::forward<CB>(cb), start);
+start = negative_helper(Head{}, cb, start);
+negative_helper(ctre::negative_set<Rest...>{}, std::forward<CB>(cb), start);
 }
 
 template <typename CB> constexpr void negative_helper(ctre::negative_set<>, CB && cb, int64_t start = std::numeric_limits<int64_t>::min()) {
-  if (start < std::numeric_limits<int64_t>::max()) {
-    cb(start, std::numeric_limits<int64_t>::max());
-  }
+if (start < std::numeric_limits<int64_t>::max()) {
+cb(start, std::numeric_limits<int64_t>::max());
+}
 }
 
 // simple fixed set
 // TODO: this needs some optimizations
 template <size_t Capacity> class point_set {
-  struct point {
-    int64_t low{};
-    int64_t high{};
-    constexpr bool operator<(const point & rhs) const {
-      return low < rhs.low;
-    }
-    constexpr point() { }
-    constexpr point(int64_t l, int64_t h): low{l}, high{h} { }
-  };
-  point points[Capacity+1]{};
-  size_t used{0};
-  constexpr point * begin() {
-    return points;
-  }
-  constexpr point * begin() const {
-    return points;
-  }
-  constexpr point * end() {
-    return points + used;
-  }
-  constexpr point * end() const {
-    return points + used;
-  }
-  constexpr point * lower_bound(point obj) {
-    auto first = begin();
-    auto last = end();
-    auto it = first;
-    size_t count = std::distance(first, last);
-    while (count > 0) {
-      it = first;
-      size_t step = count / 2;
-      std::advance(it, step);
-      if (*it < obj) {
-        first = ++it;
-        count -= step + 1;
-      } else {
-        count = step;
-      }
-    }
-    return it;
-  }
-  constexpr point * insert_point(int64_t position, int64_t other) {
-    point obj{position, other};
-    auto it = lower_bound(obj);
-    if (it == end()) {
-      *it = obj;
-      used++;
-      return it;
-    } else {
-      auto out = it;
-      auto e = end();
-      while (it != e) {
-        auto tmp = *it;
-        *it = obj;
-        obj = tmp;
-        //std::swap(*it, obj);
-        it++;
-      }
-      auto tmp = *it;
-      *it = obj;
-      obj = tmp;
-      //std::swap(*it, obj);
+struct point {
+int64_t low{};
+int64_t high{};
+constexpr bool operator<(const point & rhs) const {
+return low < rhs.low;
+}
+constexpr point() { }
+constexpr point(int64_t l, int64_t h): low{l}, high{h} { }
+};
+point points[Capacity+1]{};
+size_t used{0};
+constexpr point * begin() {
+return points;
+}
+constexpr point * begin() const {
+return points;
+}
+constexpr point * end() {
+return points + used;
+}
+constexpr point * end() const {
+return points + used;
+}
+constexpr point * lower_bound(point obj) {
+auto first = begin();
+auto last = end();
+auto it = first;
+size_t count = std::distance(first, last);
+while (count > 0) {
+it = first;
+size_t step = count / 2;
+std::advance(it, step);
+if (*it < obj) {
+first = ++it;
+count -= step + 1;
+} else {
+count = step;
+}
+}
+return it;
+}
+constexpr point * insert_point(int64_t position, int64_t other) {
+point obj{position, other};
+auto it = lower_bound(obj);
+if (it == end()) {
+*it = obj;
+used++;
+return it;
+} else {
+auto out = it;
+auto e = end();
+while (it != e) {
+auto tmp = *it;
+*it = obj;
+obj = tmp;
+//std::swap(*it, obj);
+it++;
+}
+auto tmp = *it;
+*it = obj;
+obj = tmp;
+//std::swap(*it, obj);
 
-      used++;
-      return out;
-    }
-  }
- public:
-  constexpr point_set() { }
-  constexpr void insert(int64_t low, int64_t high) {
-    insert_point(low, high);
-    //insert_point(high, low);
-  }
-  constexpr bool check(int64_t low, int64_t high) {
-    for (auto r: *this) {
-      if (r.low <= low && low <= r.high) {
-        return true;
-      } else if (r.low <= high && high <= r.high) {
-        return true;
-      } else if (low <= r.low && r.low <= high) {
-        return true;
-      } else if (low <= r.high && r.high <= high) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-
-  template <auto V> constexpr bool check(ctre::character<V>) {
-    return check(V,V);
-  }
-  template <auto A, auto B> constexpr bool check(ctre::char_range<A,B>) {
-    return check(A,B);
-  }
-  constexpr bool check(can_be_anything) {
-    return used > 0;
-  }
-  template <typename... Content> constexpr bool check(ctre::negative_set<Content...> nset) {
-    bool collision = false;
-    negative_helper(nset, [&](int64_t low, int64_t high){
-      collision |= this->check(low, high);
-    });
-    return collision;
-  }
-  template <auto... V> constexpr bool check(ctre::enumeration<V...>) {
-
-    return (check(V,V) || ... || false);
-  }
-  template <typename... Content> constexpr bool check(ctll::list<Content...>) {
-    return (check(Content{}) || ... || false);
-  }
-  template <typename... Content> constexpr bool check(ctre::set<Content...>) {
-    return (check(Content{}) || ... || false);
-  }
+used++;
+return out;
+}
+}
+public:
+constexpr point_set() { }
+constexpr void insert(int64_t low, int64_t high) {
+insert_point(low, high);
+//insert_point(high, low);
+}
+constexpr bool check(int64_t low, int64_t high) {
+for (auto r: *this) {
+if (r.low <= low && low <= r.high) {
+return true;
+} else if (r.low <= high && high <= r.high) {
+return true;
+} else if (low <= r.low && r.low <= high) {
+return true;
+} else if (low <= r.high && r.high <= high) {
+return true;
+}
+}
+return false;
+}
 
 
-  template <auto V> constexpr void populate(ctre::character<V>) {
-    insert(V,V);
-  }
-  template <auto A, auto B> constexpr void populate(ctre::char_range<A,B>) {
-    insert(A,B);
-  }
-  constexpr void populate(can_be_anything) {
-    insert(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
-  }
-  template <typename... Content> constexpr void populate(ctre::negative_set<Content...> nset) {
-    negative_helper(nset, [&](int64_t low, int64_t high){
-      this->insert(low, high);
-    });
-  }
-  template <typename... Content> constexpr void populate(ctre::set<Content...>) {
-    (populate(Content{}), ...);
-  }
-  template <typename... Content> constexpr void populate(ctll::list<Content...>) {
-    (populate(Content{}), ...);
-  }
+template <auto V> constexpr bool check(ctre::character<V>) {
+return check(V,V);
+}
+template <auto A, auto B> constexpr bool check(ctre::char_range<A,B>) {
+return check(A,B);
+}
+constexpr bool check(can_be_anything) {
+return used > 0;
+}
+template <typename... Content> constexpr bool check(ctre::negative_set<Content...> nset) {
+bool collision = false;
+negative_helper(nset, [&](int64_t low, int64_t high){
+collision |= this->check(low, high);
+});
+return collision;
+}
+template <auto... V> constexpr bool check(ctre::enumeration<V...>) {
+
+return (check(V,V) || ... || false);
+}
+template <typename... Content> constexpr bool check(ctll::list<Content...>) {
+return (check(Content{}) || ... || false);
+}
+template <typename... Content> constexpr bool check(ctre::set<Content...>) {
+return (check(Content{}) || ... || false);
+}
+
+
+template <auto V> constexpr void populate(ctre::character<V>) {
+insert(V,V);
+}
+template <auto A, auto B> constexpr void populate(ctre::char_range<A,B>) {
+insert(A,B);
+}
+constexpr void populate(can_be_anything) {
+insert(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+}
+template <typename... Content> constexpr void populate(ctre::negative_set<Content...> nset) {
+negative_helper(nset, [&](int64_t low, int64_t high){
+this->insert(low, high);
+});
+}
+template <typename... Content> constexpr void populate(ctre::set<Content...>) {
+(populate(Content{}), ...);
+}
+template <typename... Content> constexpr void populate(ctll::list<Content...>) {
+(populate(Content{}), ...);
+}
 };
 
 template <typename... A, typename... B> constexpr bool collides(ctll::list<A...> rhs, ctll::list<B...> lhs) {
-  constexpr size_t capacity = calculate_size_of_first(rhs);
+constexpr size_t capacity = calculate_size_of_first(rhs);
 
-  point_set<capacity> set;
-  set.populate(rhs);
+point_set<capacity> set;
+set.populate(rhs);
 
-  return set.check(lhs);
+return set.check(lhs);
 }
 
 }
 
 #endif
+
+#include <iterator>
 
 // remove me when MSVC fix the constexpr bug
 #ifdef _MSC_VER
@@ -3097,428 +3930,505 @@ template <typename... A, typename... B> constexpr bool collides(ctll::list<A...>
 
 namespace ctre {
 
-// calling with pattern prepare stack and triplet of iterators
-template <typename Iterator, typename EndIterator, typename Pattern>
-constexpr inline auto match_re(const Iterator begin, const EndIterator end, Pattern pattern) noexcept {
-  using return_type = decltype(regex_results(std::declval<Iterator>(), find_captures(pattern)));
-  return evaluate(begin, begin, end, return_type{}, ctll::list<start_mark, Pattern, assert_end, end_mark, accept>());
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than_or_infinite(size_t i) {
+if constexpr (Limit == 0) {
+// infinite
+return true;
+} else {
+return i < Limit;
+}
 }
 
-template <typename Iterator, typename EndIterator, typename Pattern>
-constexpr inline auto search_re(const Iterator begin, const EndIterator end, Pattern pattern) noexcept {
-  using return_type = decltype(regex_results(std::declval<Iterator>(), find_captures(pattern)));
-
-  auto it = begin;
-  for (; end != it; ++it) {
-    if (auto out = evaluate(begin, it, end, return_type{}, ctll::list<start_mark, Pattern, end_mark, accept>())) {
-      return out;
-    }
-  }
-
-  // in case the RE is empty
-  return evaluate(begin, it, end, return_type{}, ctll::list<start_mark, Pattern, end_mark, accept>());
+template <size_t Limit> constexpr CTRE_FORCE_INLINE bool less_than(size_t i) {
+if constexpr (Limit == 0) {
+// infinite
+return false;
+} else {
+return i < Limit;
 }
+}
+
+constexpr bool is_bidirectional(const std::bidirectional_iterator_tag &) { return true; }
+constexpr bool is_bidirectional(...) { return false; }
 
 // sink for making the errors shorter
 template <typename R, typename Iterator, typename EndIterator>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R, ...) noexcept {
-  return R{};
-}
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, flags, R, ...) noexcept = delete;
 
 // if we found "accept" object on stack => ACCEPT
 template <typename R, typename Iterator, typename EndIterator>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R captures, ctll::list<accept>) noexcept {
-  return captures.matched();
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, flags, R captures, ctll::list<accept>) noexcept {
+return captures.matched();
 }
 
 // if we found "reject" object on stack => REJECT
 template <typename R, typename... Rest, typename Iterator, typename EndIterator>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R, ctll::list<reject, Rest...>) noexcept {
-  return R{}; // just return not matched return type
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, flags, R, ctll::list<reject, Rest...>) noexcept {
+return not_matched;
 }
 
 // mark start of outer capture
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<start_mark, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures.set_start_mark(current), ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<start_mark, Tail...>) noexcept {
+return evaluate(begin, current, end, f, captures.set_start_mark(current), ctll::list<Tail...>());
 }
 
 // mark end of outer capture
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<end_mark, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures.set_end_mark(current), ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<end_mark, Tail...>) noexcept {
+return evaluate(begin, current, end, f, captures.set_end_mark(current), ctll::list<Tail...>());
 }
 
 // mark end of cycle
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator current, const EndIterator, R captures, ctll::list<end_cycle_mark>) noexcept {
-  return captures.set_end_mark(current).matched();
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator current, const EndIterator, [[maybe_unused]] const flags & f, R captures, ctll::list<end_cycle_mark>) noexcept {
+if (cannot_be_empty_match(f)) {
+return not_matched;
+}
+
+return captures.set_end_mark(current).matched();
 }
 
 // matching everything which behave as a one character matcher
 
 template <typename R, typename Iterator, typename EndIterator, typename CharacterLike, typename... Tail, typename = std::enable_if_t<(MatchesCharacter<CharacterLike>::template value<decltype(*std::declval<Iterator>())>)>>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<CharacterLike, Tail...>) noexcept {
-  if (end == current) return not_matched;
-  if (!CharacterLike::match_char(*current)) return not_matched;
-  return evaluate(begin, current+1, end, captures, ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<CharacterLike, Tail...>) noexcept {
+if (current == end) return not_matched;
+if (!CharacterLike::match_char(*current)) return not_matched;
+
+return evaluate(begin, ++current, end, consumed_something(f), captures, ctll::list<Tail...>());
+}
+
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<any, Tail...>) noexcept {
+if (current == end) return not_matched;
+
+if (multiline_mode(f)) {
+// TODO add support for different line ending and unicode (in a future unicode mode)
+if (*current == '\n') return not_matched;
+}
+return evaluate(begin, ++current, end, consumed_something(f), captures, ctll::list<Tail...>());
 }
 
 // matching strings in patterns
 
 template <typename Iterator> struct string_match_result {
-  Iterator current;
-  bool match;
+Iterator position;
+bool match;
 };
 
-template <auto Head, auto... String, typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> evaluate_match_string(Iterator current, const EndIterator end) noexcept {
-  if ((end != current) && (Head == *current)) {
-    if constexpr (sizeof...(String) > 0) {
-      return evaluate_match_string<String...>(++current, end);
-    } else {
-      return {++current, true};
-    }
-  } else {
-    return {current, false}; // not needed but will optimize
-  }
+template <typename CharT, typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE bool compare_character(CharT c, Iterator & it, const EndIterator & end) {
+if (it != end) {
+using char_type = decltype(*it);
+return *it++ == static_cast<char_type>(c);
+}
+return false;
+}
+
+template <auto... String, size_t... Idx, typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> evaluate_match_string(Iterator current, [[maybe_unused]] const EndIterator end, std::index_sequence<Idx...>) noexcept {
+
+bool same = (compare_character(String, current, end) && ... && true);
+
+return {current, same};
 }
 
 template <typename R, typename Iterator, typename EndIterator, auto... String, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<string<String...>, Tail...>) noexcept {
-  if constexpr (sizeof...(String) == 0) {
-    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
-  } else if (auto tmp = evaluate_match_string<String...>(current, end); tmp.match) {
-    return evaluate(begin, tmp.current, end, captures, ctll::list<Tail...>());
-  } else {
-    return not_matched;
-  }
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, [[maybe_unused]] const flags & f, R captures, ctll::list<string<String...>, Tail...>) noexcept {
+auto result = evaluate_match_string<String...>(current, end, std::make_index_sequence<sizeof...(String)>());
+
+if (!result.match) {
+return not_matched;
+}
+
+return evaluate(begin, result.position, end, consumed_something(f, sizeof...(String) > 0), captures, ctll::list<Tail...>());
 }
 
 // matching select in patterns
 template <typename R, typename Iterator, typename EndIterator, typename HeadOptions, typename... TailOptions, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<select<HeadOptions, TailOptions...>, Tail...>) noexcept {
-  if (auto r = evaluate(begin, current, end, captures, ctll::list<HeadOptions, Tail...>())) {
-    return r;
-  } else {
-    return evaluate(begin, current, end, captures, ctll::list<select<TailOptions...>, Tail...>());
-  }
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<select<HeadOptions, TailOptions...>, Tail...>) noexcept {
+if (auto r = evaluate(begin, current, end, f, captures, ctll::list<HeadOptions, Tail...>())) {
+return r;
+} else {
+return evaluate(begin, current, end, f, captures, ctll::list<select<TailOptions...>, Tail...>());
+}
 }
 
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R, ctll::list<select<>, Tail...>) noexcept {
-  // no previous option was matched => REJECT
-  return not_matched;
-}
-
-// matching optional in patterns
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<optional<Content...>, Tail...>) noexcept {
-  if (auto r1 = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, Tail...>())) {
-    return r1;
-  } else if (auto r2 = evaluate(begin, current, end, captures, ctll::list<Tail...>())) {
-    return r2;
-  } else {
-    return not_matched;
-  }
-}
-
-// lazy optional
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_optional<Content...>, Tail...>) noexcept {
-  if (auto r1 = evaluate(begin, current, end, captures, ctll::list<Tail...>())) {
-    return r1;
-  } else if (auto r2 = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, Tail...>())) {
-    return r2;
-  } else {
-    return not_matched;
-  }
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, flags, R, ctll::list<select<>, Tail...>) noexcept {
+// no previous option was matched => REJECT
+return not_matched;
 }
 
 // matching sequence in patterns
 template <typename R, typename Iterator, typename EndIterator, typename HeadContent, typename... TailContent, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<sequence<HeadContent, TailContent...>, Tail...>) noexcept {
-  if constexpr (sizeof...(TailContent) > 0) {
-    return evaluate(begin, current, end, captures, ctll::list<HeadContent, sequence<TailContent...>, Tail...>());
-  } else {
-    return evaluate(begin, current, end, captures, ctll::list<HeadContent, Tail...>());
-  }
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<sequence<HeadContent, TailContent...>, Tail...>) noexcept {
+if constexpr (sizeof...(TailContent) > 0) {
+return evaluate(begin, current, end, f, captures, ctll::list<HeadContent, sequence<TailContent...>, Tail...>());
+} else {
+return evaluate(begin, current, end, f, captures, ctll::list<HeadContent, Tail...>());
+}
 }
 
 // matching empty in patterns
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<empty, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<empty, Tail...>) noexcept {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
 }
 
 // matching asserts
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<assert_begin, Tail...>) noexcept {
-  if (begin != current) {
-    return not_matched;
-  }
-  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<assert_subject_begin, Tail...>) noexcept {
+if (begin != current) {
+return not_matched;
+}
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
 }
 
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<assert_end, Tail...>) noexcept {
-  if (end != current) {
-    return not_matched;
-  }
-  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<assert_subject_end, Tail...>) noexcept {
+if (end != current) {
+return not_matched;
+}
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+}
+
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<assert_subject_end_line, Tail...>) noexcept {
+if (multiline_mode(f)) {
+if (end == current) {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else if (*current == '\n' && std::next(current) == end) {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else {
+return not_matched;
+}
+} else {
+if (end != current) {
+return not_matched;
+}
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+}
+}
+
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<assert_line_begin, Tail...>) noexcept {
+if (multiline_mode(f)) {
+if (begin == current) {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else if (*std::prev(current) == '\n') {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else {
+return not_matched;
+}
+} else {
+if (begin != current) {
+return not_matched;
+}
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+}
+}
+
+template <typename R, typename Iterator, typename EndIterator, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<assert_line_end, Tail...>) noexcept {
+if (multiline_mode(f)) {
+if (end == current) {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else if (*current == '\n') {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else {
+return not_matched;
+}
+} else {
+if (end != current) {
+return not_matched;
+}
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+}
+
+// TODO properly match line end
+if (end != current) {
+return not_matched;
+}
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+}
+
+// matching boundary
+template <typename R, typename Iterator, typename EndIterator, typename CharacterLike, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<boundary<CharacterLike>, Tail...>) noexcept {
+
+// reason why I need bidirectional iterators or some clever hack
+bool before = false;
+bool after = false;
+
+static_assert(is_bidirectional(typename std::iterator_traits<Iterator>::iterator_category{}), "To use boundary in regex you need to provide bidirectional iterator or range.");
+
+if (end != current) {
+after = CharacterLike::match_char(*current);
+}
+if (begin != current) {
+before = CharacterLike::match_char(*std::prev(current));
+}
+
+if (before == after) return not_matched;
+
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+}
+
+// matching not_boundary
+template <typename R, typename Iterator, typename EndIterator, typename CharacterLike, typename... Tail>
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<not_boundary<CharacterLike>, Tail...>) noexcept {
+
+// reason why I need bidirectional iterators or some clever hack
+bool before = false;
+bool after = false;
+
+static_assert(is_bidirectional(typename std::iterator_traits<Iterator>::iterator_category{}), "To use boundary in regex you need to provide bidirectional iterator or range.");
+
+if (end != current) {
+after = CharacterLike::match_char(*current);
+}
+if (begin != current) {
+before = CharacterLike::match_char(*std::prev(current));
+}
+
+if (before != after) return not_matched;
+
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
 }
 
 // lazy repeat
 template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_repeat<A,B,Content...>, Tail...>) noexcept {
-  // A..B
-  size_t i{0};
-  for (; i < A && (A != 0); ++i) {
-    if (auto outer_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
-      captures = outer_result.unmatch();
-      current = outer_result.get_end_position();
-    } else {
-      return not_matched;
-    }
-  }
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, [[maybe_unused]] const flags & f, R captures, ctll::list<lazy_repeat<A,B,Content...>, Tail...>) noexcept {
 
-  if (auto outer_result = evaluate(begin, current, end, captures, ctll::list<Tail...>())) {
-    return outer_result;
-  } else {
-    for (; (i < B) || (B == 0); ++i) {
-      if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
-        if (auto outer_result = evaluate(begin, inner_result.get_end_position(), end, inner_result.unmatch(), ctll::list<Tail...>())) {
-          return outer_result;
-        } else {
-          captures = inner_result.unmatch();
-          current = inner_result.get_end_position();
-          continue;
-        }
-      } else {
-        return not_matched;
-      }
-    }
-    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
-  }
+if constexpr (B != 0 && A > B) {
+return not_matched;
+}
+
+const Iterator backup_current = current;
+
+size_t i{0};
+
+while (less_than<A>(i)) {
+auto outer_result = evaluate(begin, current, end, not_empty_match(f), captures, ctll::list<Content..., end_cycle_mark>());
+
+if (!outer_result) return not_matched;
+
+captures = outer_result.unmatch();
+current = outer_result.get_end_position();
+
+++i;
+}
+
+if (auto outer_result = evaluate(begin, current, end, consumed_something(f, backup_current != current), captures, ctll::list<Tail...>())) {
+return outer_result;
+}
+
+while (less_than_or_infinite<B>(i)) {
+auto inner_result = evaluate(begin, current, end, not_empty_match(f), captures, ctll::list<Content..., end_cycle_mark>());
+
+if (!inner_result) return not_matched;
+
+auto outer_result = evaluate(begin, inner_result.get_end_position(), end, consumed_something(f), inner_result.unmatch(), ctll::list<Tail...>());
+
+if (outer_result) {
+return outer_result;
+}
+
+captures = inner_result.unmatch();
+current = inner_result.get_end_position();
+
+++i;
+}
+
+// rest of regex
+return evaluate(begin, current, end, consumed_something(f), captures, ctll::list<Tail...>());
 }
 
 // possessive repeat
 template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<possessive_repeat<A,B,Content...>, Tail...>) noexcept {
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, [[maybe_unused]] const flags & f, R captures, ctll::list<possessive_repeat<A,B,Content...>, Tail...>) noexcept {
 
-  for (size_t i{0}; (i < B) || (B == 0); ++i) {
-    // try as many of inner as possible and then try outer once
-    if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
-      captures = inner_result.unmatch();
-      current = inner_result.get_end_position();
-    } else {
-      if (i < A && (A != 0)) return not_matched;
-      else return evaluate(begin, current, end, captures, ctll::list<Tail...>());
-    }
-  }
+if constexpr ((B != 0) && (A > B)) {
+return not_matched;
+}
 
-  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+const auto backup_current = current;
+
+for (size_t i{0}; less_than_or_infinite<B>(i); ++i) {
+// try as many of inner as possible and then try outer once
+auto inner_result = evaluate(begin, current, end, not_empty_match(f), captures, ctll::list<Content..., end_cycle_mark>());
+
+if (!inner_result) {
+if (!less_than<A>(i)) break;
+return not_matched;
+}
+
+captures = inner_result.unmatch();
+current = inner_result.get_end_position();
+}
+
+return evaluate(begin, current, end, consumed_something(f, backup_current != current), captures, ctll::list<Tail...>());
 }
 
 // (gready) repeat
 template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
 #ifdef CTRE_MSVC_GREEDY_WORKAROUND
-constexpr inline void evaluate_recursive(R & result, size_t i, const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<repeat<A,B,Content...>, Tail...> stack) {
+constexpr inline void evaluate_recursive(R & result, size_t i, const Iterator begin, Iterator current, const EndIterator end, [[maybe_unused]] const flags & f, R captures, ctll::list<repeat<A,B,Content...>, Tail...> stack) {
 #else
-constexpr inline R evaluate_recursive(size_t i, const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<repeat<A,B,Content...>, Tail...> stack) {
+constexpr inline R evaluate_recursive(size_t i, const Iterator begin, Iterator current, const EndIterator end, [[maybe_unused]] const flags & f, R captures, ctll::list<repeat<A,B,Content...>, Tail...> stack) {
 #endif
-  if ((B == 0) || (i < B)) {
+if (less_than_or_infinite<B>(i)) {
 
-    // a*ab
-    // aab
+// a*ab
+// aab
 
-    if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
-      // TODO MSVC issue:
-      // if I uncomment this return it will not fail in constexpr (but the matching result will not be correct)
-      //  return inner_result
-      // I tried to add all constructors to R but without any success
+if (auto inner_result = evaluate(begin, current, end, not_empty_match(f), captures, ctll::list<Content..., end_cycle_mark>())) {
+// TODO MSVC issue:
+// if I uncomment this return it will not fail in constexpr (but the matching result will not be correct)
+//  return inner_result
+// I tried to add all constructors to R but without any success
+auto tmp_current = current;
+tmp_current = inner_result.get_end_position();
 #ifdef CTRE_MSVC_GREEDY_WORKAROUND
-      evaluate_recursive(result, i+1, begin, inner_result.get_end_position(), end, inner_result.unmatch(), stack);
-			if (result) {
-				return;
-			}
+evaluate_recursive(result, i+1, begin, tmp_current, end, f, inner_result.unmatch(), stack);
+if (result) {
+return;
+}
 #else
-      if (auto rec_result = evaluate_recursive(i+1, begin, inner_result.get_end_position(), end, inner_result.unmatch(), stack)) {
-        return rec_result;
-      }
-#endif
-    }
-  }
-#ifdef CTRE_MSVC_GREEDY_WORKAROUND
-  result = evaluate(begin, current, end, captures, ctll::list<Tail...>());
-#else
-  return evaluate(begin, current, end, captures, ctll::list<Tail...>());
+if (auto rec_result = evaluate_recursive(i+1, begin, tmp_current, end, f, inner_result.unmatch(), stack)) {
+return rec_result;
+}
 #endif
 }
-
-// (gready) repeat optimization
-// basic one, if you are at the end of RE, just change it into possessive
-// TODO do the same if there is no collision with rest of the RE
-template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<repeat<A,B,Content...>,assert_end, Tail...>) {
-  return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<A,B,Content...>, assert_end, Tail...>());
 }
-
-template <typename... T> struct identify_type;
+#ifdef CTRE_MSVC_GREEDY_WORKAROUND
+result = evaluate(begin, current, end, consumed_something(f), captures, ctll::list<Tail...>());
+#else
+return evaluate(begin, current, end, consumed_something(f), captures, ctll::list<Tail...>());
+#endif
+}
 
 // (greedy) repeat
 template <typename R, typename Iterator, typename EndIterator, size_t A, size_t B, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, [[maybe_unused]] ctll::list<repeat<A,B,Content...>, Tail...> stack) {
-  // check if it can be optimized
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, [[maybe_unused]] const flags & f, R captures, [[maybe_unused]] ctll::list<repeat<A,B,Content...>, Tail...> stack) {
+
+if constexpr ((B != 0) && (A > B)) {
+return not_matched;
+}
+
 #ifndef CTRE_DISABLE_GREEDY_OPT
-  if constexpr (collides(calculate_first(Content{}...), calculate_first(Tail{}...))) {
+if constexpr (!collides(calculate_first(Content{}...), calculate_first(Tail{}...))) {
+return evaluate(begin, current, end, f, captures, ctll::list<possessive_repeat<A,B,Content...>, Tail...>());
+}
 #endif
-    // A..B
-    size_t i{0};
-    for (; i < A && (A != 0); ++i) {
-      if (auto inner_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_cycle_mark>())) {
-        captures = inner_result.unmatch();
-        current = inner_result.get_end_position();
-      } else {
-        return not_matched;
-      }
-    }
+
+// A..B
+size_t i{0};
+while (less_than<A>(i)) {
+auto inner_result = evaluate(begin, current, end, not_empty_match(f), captures, ctll::list<Content..., end_cycle_mark>());
+
+if (!inner_result) return not_matched;
+
+captures = inner_result.unmatch();
+current = inner_result.get_end_position();
+
+++i;
+}
+
 #ifdef CTRE_MSVC_GREEDY_WORKAROUND
-    R result;
-		evaluate_recursive(result, i, begin, current, end, captures, stack);
-		return result;
+R result;
+evaluate_recursive(result, i, begin, current, end, f, captures, stack);
+return result;
 #else
-    return evaluate_recursive(i, begin, current, end, captures, stack);
-#endif
-#ifndef CTRE_DISABLE_GREEDY_OPT
-  } else {
-    // if there is no collision we can go possessive
-    return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<A,B,Content...>, Tail...>());
-  }
+return evaluate_recursive(i, begin, current, end, f, captures, stack);
 #endif
 
-}
-
-// repeat lazy_star
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_star<Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<lazy_repeat<0,0,Content...>, Tail...>());
-}
-
-// repeat (lazy_plus)
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lazy_plus<Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<lazy_repeat<1,0,Content...>, Tail...>());
-}
-
-// repeat (possessive_star)
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<possessive_star<Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<0,0,Content...>, Tail...>());
-}
-
-// repeat (possessive_plus)
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<possessive_plus<Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<possessive_repeat<1,0,Content...>, Tail...>());
-}
-
-// repeat (greedy) star
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<star<Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<repeat<0,0,Content...>, Tail...>());
-}
-
-// repeat (greedy) plus
-template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<plus<Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures, ctll::list<repeat<1,0,Content...>, Tail...>());
 }
 
 // capture (numeric ID)
 template <typename R, typename Iterator, typename EndIterator, size_t Id, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<capture<Id, Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures.template start_capture<Id>(current), ctll::list<sequence<Content...>, numeric_mark<Id>, Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<capture<Id, Content...>, Tail...>) noexcept {
+return evaluate(begin, current, end, f, captures.template start_capture<Id>(current), ctll::list<sequence<Content...>, numeric_mark<Id>, Tail...>());
 }
 
 // capture end mark (numeric and string ID)
 template <typename R, typename Iterator, typename EndIterator, size_t Id, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<numeric_mark<Id>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures.template end_capture<Id>(current), ctll::list<Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<numeric_mark<Id>, Tail...>) noexcept {
+return evaluate(begin, current, end, f, captures.template end_capture<Id>(current), ctll::list<Tail...>());
 }
 
 // capture (string ID)
 template <typename R, typename Iterator, typename EndIterator, size_t Id, typename Name, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<capture_with_name<Id, Name, Content...>, Tail...>) noexcept {
-  return evaluate(begin, current, end, captures.template start_capture<Id>(current), ctll::list<sequence<Content...>, numeric_mark<Id>, Tail...>());
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<capture_with_name<Id, Name, Content...>, Tail...>) noexcept {
+return evaluate(begin, current, end, f, captures.template start_capture<Id>(current), ctll::list<sequence<Content...>, numeric_mark<Id>, Tail...>());
 }
 
 // backreference support (match agains content of iterators)
-template <typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> match_against_range(Iterator current, const EndIterator end, Iterator range_current, const Iterator range_end) noexcept {
-  while (end != current && range_end != range_current) {
-    if (*current == *range_current) {
-      current++;
-      range_current++;
-    } else {
-      return {current, false};
-    }
-  }
-  return {current, range_current == range_end};
+template <typename Iterator, typename EndIterator> constexpr CTRE_FORCE_INLINE string_match_result<Iterator> match_against_range(Iterator current, const EndIterator end, Iterator range_current, const Iterator range_end, flags) noexcept {
+while (end != current && range_end != range_current) {
+if (*current == *range_current) {
+current++;
+range_current++;
+} else {
+return {current, false};
+}
+}
+return {current, range_current == range_end};
 }
 
 // backreference with name
 template <typename R, typename Id, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<back_reference_with_name<Id>, Tail...>) noexcept {
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<back_reference_with_name<Id>, Tail...>) noexcept {
 
-  if (const auto ref = captures.template get<Id>()) {
-    if (auto tmp = match_against_range(current, end, ref.begin(), ref.end()); tmp.match) {
-      return evaluate(begin, tmp.current, end, captures, ctll::list<Tail...>());
-    }
-  }
-  return not_matched;
+if (const auto ref = captures.template get<Id>()) {
+if (auto result = match_against_range(current, end, ref.begin(), ref.end(), f); result.match) {
+return evaluate(begin, result.position, end, consumed_something(f, ref.begin() != ref.end()), captures, ctll::list<Tail...>());
+}
+}
+return not_matched;
 }
 
 // backreference
 template <typename R, size_t Id, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<back_reference<Id>, Tail...>) noexcept {
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<back_reference<Id>, Tail...>) noexcept {
 
-  if (const auto ref = captures.template get<Id>()) {
-    if (auto tmp = match_against_range(current, end, ref.begin(), ref.end()); tmp.match) {
-      return evaluate(begin, tmp.current, end, captures, ctll::list<Tail...>());
-    }
-  }
-  return not_matched;
+if (const auto ref = captures.template get<Id>()) {
+if (auto result = match_against_range(current, end, ref.begin(), ref.end(), f); result.match) {
+return evaluate(begin, result.position, end, consumed_something(f, ref.begin() != ref.end()), captures, ctll::list<Tail...>());
+}
+}
+return not_matched;
 }
 
 // end of lookahead
 template <typename R, typename Iterator, typename EndIterator, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, R captures, ctll::list<end_lookahead_mark>) noexcept {
-  return captures.matched();
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator, Iterator, const EndIterator, flags, R captures, ctll::list<end_lookahead_mark>) noexcept {
+// TODO check interaction with non-empty flag
+return captures.matched();
 }
 
 // lookahead positive
 template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lookahead_positive<Content...>, Tail...>) noexcept {
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<lookahead_positive<Content...>, Tail...>) noexcept {
 
-  if (auto lookahead_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_lookahead_mark>())) {
-    captures = lookahead_result.unmatch();
-    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
-  } else {
-    return not_matched;
-  }
+if (auto lookahead_result = evaluate(begin, current, end, f, captures, ctll::list<sequence<Content...>, end_lookahead_mark>())) {
+captures = lookahead_result.unmatch();
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
+} else {
+return not_matched;
+}
 }
 
 // lookahead negative
 template <typename R, typename Iterator, typename EndIterator, typename... Content, typename... Tail>
-constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, R captures, ctll::list<lookahead_negative<Content...>, Tail...>) noexcept {
+constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, const EndIterator end, const flags & f, R captures, ctll::list<lookahead_negative<Content...>, Tail...>) noexcept {
 
-  if (auto lookahead_result = evaluate(begin, current, end, captures, ctll::list<sequence<Content...>, end_lookahead_mark>())) {
-    return not_matched;
-  } else {
-    return evaluate(begin, current, end, captures, ctll::list<Tail...>());
-  }
+if (auto lookahead_result = evaluate(begin, current, end, f, captures, ctll::list<sequence<Content...>, end_lookahead_mark>())) {
+return not_matched;
+} else {
+return evaluate(begin, current, end, f, captures, ctll::list<Tail...>());
 }
-
-// property matching
+}
 
 }
 
@@ -3527,106 +4437,643 @@ constexpr CTRE_FORCE_INLINE R evaluate(const Iterator begin, Iterator current, c
 #ifndef CTRE__WRAPPER__HPP
 #define CTRE__WRAPPER__HPP
 
-#include <string_view>
-#include <string>
+#ifndef CTRE_V2__CTRE__RANGE__HPP
+#define CTRE_V2__CTRE__RANGE__HPP
+
+#ifndef CTRE_V2__CTRE__ITERATOR__HPP
+#define CTRE_V2__CTRE__ITERATOR__HPP
+
+#include <cstddef>
 
 namespace ctre {
 
+// TODO make proper iterator traits here
+
+struct regex_end_iterator {
+constexpr regex_end_iterator() noexcept { }
+};
+
+template <typename BeginIterator, typename EndIterator, typename RE, typename ResultIterator = BeginIterator> struct regex_iterator {
+using value_type = decltype(RE::template exec_with_result_iterator<ResultIterator>(std::declval<BeginIterator>(), std::declval<EndIterator>()));
+using iterator_category = std::forward_iterator_tag;
+using pointer = void;
+using reference = const value_type &;
+using difference_type = int;
+
+BeginIterator orig_begin{};
+BeginIterator current{};
+EndIterator end{};
+value_type current_match{};
+
+constexpr CTRE_FORCE_INLINE regex_iterator() noexcept = default;
+constexpr CTRE_FORCE_INLINE regex_iterator(const regex_iterator &) noexcept = default;
+constexpr CTRE_FORCE_INLINE regex_iterator(regex_iterator &&) noexcept = default;
+
+constexpr CTRE_FORCE_INLINE regex_iterator(BeginIterator begin, EndIterator end) noexcept: orig_begin{begin}, current{begin}, end{end}, current_match{RE::template exec_with_result_iterator<ResultIterator>(current, end)} {
+if (current_match) {
+current = current_match.template get<0>().end();
+}
+}
+
+constexpr CTRE_FORCE_INLINE regex_iterator & operator=(const regex_iterator &) noexcept = default;
+constexpr CTRE_FORCE_INLINE regex_iterator & operator=(regex_iterator &&) noexcept = default;
+
+constexpr CTRE_FORCE_INLINE const value_type & operator*() const noexcept {
+return current_match;
+}
+constexpr CTRE_FORCE_INLINE regex_iterator & operator++() noexcept {
+if (current == end) {
+current_match = decltype(current_match){};
+return *this;
+}
+
+current_match = RE::template exec_with_result_iterator<ResultIterator>(orig_begin, current, end);
+
+if (current_match) {
+current = current_match.template get<0>().end();
+}
+return *this;
+}
+constexpr CTRE_FORCE_INLINE regex_iterator operator++(int) noexcept {
+auto previous = *this;
+this->operator++();
+return previous;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current == right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return !(left.current == right.current);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator<(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current < right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator>(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current > right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator<=(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current <= right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator>=(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current >= right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, regex_end_iterator) noexcept {
+return !bool(left.current_match);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(regex_end_iterator, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return !bool(right.current_match);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, regex_end_iterator) noexcept {
+return bool(left.current_match);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(regex_end_iterator, const regex_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return bool(right.current_match);
+}
+};
+
+template <typename BeginIterator, typename EndIterator, typename RE, typename ResultIterator = BeginIterator> struct regex_split_iterator {
+using value_type = decltype(RE::template exec_with_result_iterator<ResultIterator>(std::declval<BeginIterator>(), std::declval<EndIterator>()));
+using iterator_category = std::forward_iterator_tag;
+using pointer = void;
+using reference = const value_type &;
+using difference_type = int;
+
+BeginIterator orig_begin{};
+BeginIterator current{};
+EndIterator end{};
+value_type current_match{};
+bool last_match{false};
+
+constexpr CTRE_FORCE_INLINE void modify_match() {
+auto tmp = current_match.template get<0>().end();
+current_match.set_end_mark(current_match.template get<0>().begin());
+current_match.set_start_mark(current);
+current = tmp;
+}
+
+constexpr CTRE_FORCE_INLINE void match_rest() {
+// the end is there set by search_method
+current_match.set_start_mark(current);
+current_match.matched();
+current = current_match.template get<0>().end();
+last_match = true;
+}
+
+constexpr CTRE_FORCE_INLINE regex_split_iterator() noexcept = default;
+constexpr CTRE_FORCE_INLINE regex_split_iterator(const regex_split_iterator &) noexcept = default;
+constexpr CTRE_FORCE_INLINE regex_split_iterator(regex_split_iterator &&) noexcept = default;
+
+constexpr CTRE_FORCE_INLINE regex_split_iterator(BeginIterator begin, EndIterator end) noexcept: orig_begin{begin}, current{begin}, end{end}, current_match{RE::template exec_with_result_iterator<ResultIterator>(current, end)} {
+if (current_match) {
+modify_match();
+} else {
+match_rest();
+}
+}
+
+constexpr CTRE_FORCE_INLINE regex_split_iterator & operator=(const regex_split_iterator &) noexcept = default;
+constexpr CTRE_FORCE_INLINE regex_split_iterator & operator=(regex_split_iterator &&) noexcept = default;
+
+constexpr CTRE_FORCE_INLINE const value_type & operator*() const noexcept {
+return current_match;
+}
+constexpr CTRE_FORCE_INLINE regex_split_iterator & operator++() noexcept {
+if (current == end && last_match) {
+current_match = decltype(current_match){};
+return *this;
+}
+
+current_match = RE::template exec_with_result_iterator<ResultIterator>(orig_begin, current, end);
+
+if (current_match) {
+modify_match();
+} else {
+match_rest();
+}
+return *this;
+}
+constexpr CTRE_FORCE_INLINE regex_split_iterator operator++(int) noexcept {
+auto previous = *this;
+this->operator++();
+return previous;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current == right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return !(left.current == right.current);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator<(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current < right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator>(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current > right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator<=(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current <= right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator>=(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return left.current >= right.current;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, regex_end_iterator) noexcept {
+return !bool(left.current_match);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(regex_end_iterator, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return !bool(right.current_match);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & left, regex_end_iterator) noexcept {
+return bool(left.current_match);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(regex_end_iterator, const regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator> & right) noexcept {
+return bool(right.current_match);
+}
+};
+
+} // ctre
+
+#endif
+
+namespace ctre {
+
+template <typename> constexpr bool is_range = false;
+
+template <typename BeginIterator, typename EndIterator, typename RE, typename ResultIterator = BeginIterator> struct regex_range {
+BeginIterator _begin;
+EndIterator _end;
+
+constexpr CTRE_FORCE_INLINE regex_range(BeginIterator begin, EndIterator end) noexcept: _begin{begin}, _end{end} { }
+
+constexpr CTRE_FORCE_INLINE auto begin() const noexcept {
+return regex_iterator<BeginIterator, EndIterator, RE, ResultIterator>(_begin, _end);
+}
+constexpr CTRE_FORCE_INLINE auto end() const noexcept {
+return regex_end_iterator{};
+}
+};
+
+template <typename... Ts> constexpr bool is_range<regex_range<Ts...>> = true;
+
+template <typename BeginIterator, typename EndIterator, typename RE, typename ResultIterator = BeginIterator> struct regex_split_range {
+BeginIterator _begin;
+EndIterator _end;
+
+constexpr CTRE_FORCE_INLINE regex_split_range(BeginIterator begin, EndIterator end) noexcept: _begin{begin}, _end{end} { }
+
+constexpr CTRE_FORCE_INLINE auto begin() const noexcept {
+return regex_split_iterator<BeginIterator, EndIterator, RE, ResultIterator>(_begin, _end);
+}
+constexpr CTRE_FORCE_INLINE auto end() const noexcept {
+return regex_end_iterator{};
+}
+};
+
+template <typename... Ts> constexpr bool is_range<regex_split_range<Ts...>> = true;
+
+template <typename Range, typename RE> struct multi_subject_range {
+struct end_iterator { };
+
+using first_type = decltype(std::declval<Range>().begin());
+using last_type = decltype(std::declval<Range>().end());
+
+struct iterator {
+using value_type = decltype(RE::exec(std::declval<typename std::iterator_traits<first_type>::value_type>()));
+using iterator_category = std::forward_iterator_tag;
+using pointer = void;
+using reference = const value_type &;
+using difference_type = int;
+
+first_type first{};
+last_type last{};
+value_type current_result{};
+
+constexpr CTRE_FORCE_INLINE iterator() noexcept = default;
+constexpr CTRE_FORCE_INLINE iterator(first_type f, last_type l) noexcept: first{f}, last{l}, current_result{find_first()} { }
+
+constexpr CTRE_FORCE_INLINE value_type find_first() noexcept {
+while (first != last) {
+if (auto res = RE::exec(*first)) return res;
+else ++first;
+}
+return {};
+}
+
+constexpr CTRE_FORCE_INLINE const value_type & operator*() const noexcept {
+return current_result;
+}
+
+constexpr CTRE_FORCE_INLINE iterator & operator++() noexcept {
+++first;
+current_result = find_first();
+return *this;
+}
+constexpr CTRE_FORCE_INLINE iterator operator++(int) noexcept {
+auto previous = *this;
+this->operator++();
+return previous;
+}
+
+friend constexpr CTRE_FORCE_INLINE bool operator==(const iterator & left, const iterator & right) noexcept {
+return left.first == right.first;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(const iterator & left, const iterator & right) noexcept {
+return !(left.first == right.first);
+}
+friend constexpr CTRE_FORCE_INLINE bool operator<(const iterator & left, const iterator & right) noexcept {
+return left.first < right.first;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator>(const iterator & left, const iterator & right) noexcept {
+return left.first > right.first;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator<=(const iterator & left, const iterator & right) noexcept {
+return left.first <= right.first;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator>=(const iterator & left, const iterator & right) noexcept {
+return left.first >= right.first;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(const iterator & left, end_iterator) noexcept {
+return left.first == left.last;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator==(end_iterator, const iterator & right) noexcept {
+return right.first == right.last;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(const iterator & left, end_iterator) noexcept {
+return left.first != left.last;
+}
+friend constexpr CTRE_FORCE_INLINE bool operator!=(end_iterator, const iterator & right) noexcept {
+return right.first == right.last;
+}
+};
+
+Range range{};
+
+constexpr CTRE_FORCE_INLINE multi_subject_range() noexcept = default;
+constexpr CTRE_FORCE_INLINE multi_subject_range(Range r) noexcept:  range{r} { }
+
+constexpr CTRE_FORCE_INLINE auto begin() const noexcept {
+return iterator{range.begin(), range.end()};
+}
+constexpr CTRE_FORCE_INLINE auto end() const noexcept {
+return end_iterator{};
+}
+};
+
+// this is not regex range!
+template <typename... Ts> constexpr bool is_range<multi_subject_range<Ts...>> = true;
+
+}
+
+#if __cpp_lib_ranges >= 201911
+namespace std::ranges {
+
+template <typename... Ts> inline constexpr bool enable_borrowed_range<::ctre::regex_range<Ts...>> = true;
+template <typename... Ts> inline constexpr bool enable_borrowed_range<::ctre::regex_split_range<Ts...>> = true;
+template <typename Range, typename RE> inline constexpr bool enable_borrowed_range<::ctre::multi_subject_range<Range, RE>> = enable_borrowed_range<Range>;
+template <typename Range, typename RE> inline constexpr bool enable_view<::ctre::multi_subject_range<Range, RE>> = true;
+
+}
+#endif
+
+#endif
+
+#include <string_view>
+
+namespace ctre {
+
+template <typename RE, typename Method = void, typename Modifier = singleline> struct regular_expression;
+
 struct zero_terminated_string_end_iterator {
-  constexpr inline zero_terminated_string_end_iterator() = default;
-  constexpr CTRE_FORCE_INLINE bool operator==(const char * ptr) const noexcept {
-    return *ptr == '\0';
-  }
-  constexpr CTRE_FORCE_INLINE bool operator==(const wchar_t * ptr) const noexcept {
-    return *ptr == 0;
-  }
-  constexpr CTRE_FORCE_INLINE bool operator!=(const char * ptr) const noexcept {
-    return *ptr != '\0';
-  }
-  constexpr CTRE_FORCE_INLINE bool operator!=(const wchar_t * ptr) const noexcept {
-    return *ptr != 0;
-  }
+constexpr CTRE_FORCE_INLINE friend bool operator==(const char * ptr, zero_terminated_string_end_iterator) noexcept {
+return *ptr == '\0';
+}
+constexpr CTRE_FORCE_INLINE friend bool operator==(const wchar_t * ptr, zero_terminated_string_end_iterator) noexcept {
+return *ptr == 0;
+}
+constexpr CTRE_FORCE_INLINE friend bool operator!=(const char * ptr, zero_terminated_string_end_iterator) noexcept {
+return *ptr != '\0';
+}
+constexpr CTRE_FORCE_INLINE friend bool operator!=(const wchar_t * ptr, zero_terminated_string_end_iterator) noexcept {
+return *ptr != 0;
+}
+constexpr CTRE_FORCE_INLINE friend bool operator==(zero_terminated_string_end_iterator, const char * ptr) noexcept {
+return *ptr == '\0';
+}
+constexpr CTRE_FORCE_INLINE friend bool operator==(zero_terminated_string_end_iterator, const wchar_t * ptr) noexcept {
+return *ptr == 0;
+}
+constexpr CTRE_FORCE_INLINE friend bool operator!=(zero_terminated_string_end_iterator, const char * ptr) noexcept {
+return *ptr != '\0';
+}
+constexpr CTRE_FORCE_INLINE friend bool operator!=(zero_terminated_string_end_iterator, const wchar_t * ptr) noexcept {
+return *ptr != 0;
+}
 };
 
 template <typename T> class RangeLikeType {
-  template <typename Y> static auto test(Y *) -> decltype(std::declval<const Y &>().begin(), std::declval<const Y &>().end(), std::true_type());
-  template <typename> static auto test(...) -> std::false_type;
- public:
-  static inline constexpr bool value = decltype(test<std::remove_reference_t<std::remove_const_t<T>>>( nullptr ))::value;
+template <typename Y> static auto test(Y *) -> decltype(std::declval<const Y &>().begin(), std::declval<const Y &>().end(), std::true_type());
+template <typename> static auto test(...) -> std::false_type;
+public:
+static inline constexpr bool value = decltype(test<std::remove_reference_t<std::remove_const_t<T>>>( nullptr ))::value;
 };
 
-template <typename RE> struct regular_expression {
-  template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto match_2(IteratorBegin begin, IteratorEnd end) noexcept {
-    return match_re(begin, end, RE());
-  }
-  template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto search_2(IteratorBegin begin, IteratorEnd end) noexcept {
-    return search_re(begin, end, RE());
-  }
-  constexpr CTRE_FORCE_INLINE regular_expression() noexcept { }
-  constexpr CTRE_FORCE_INLINE regular_expression(RE) noexcept { }
-  template <typename Iterator> constexpr CTRE_FORCE_INLINE static auto match(Iterator begin, Iterator end) noexcept {
-    return match_re(begin, end, RE());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(const char * s) noexcept {
-    return match_2(s, zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(const wchar_t * s) noexcept {
-    return match_2(s, zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(const std::string & s) noexcept {
-    return match_2(s.c_str(), zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(const std::wstring & s) noexcept {
-    return match_2(s.c_str(), zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(std::string_view sv) noexcept {
-    return match(sv.begin(), sv.end());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(std::wstring_view sv) noexcept {
-    return match(sv.begin(), sv.end());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(std::u16string_view sv) noexcept {
-    return match(sv.begin(), sv.end());
-  }
-  static constexpr CTRE_FORCE_INLINE auto match(std::u32string_view sv) noexcept {
-    return match(sv.begin(), sv.end());
-  }
-  template <typename Range, typename = typename std::enable_if<RangeLikeType<Range>::value>::type> static constexpr CTRE_FORCE_INLINE auto match(Range && range) noexcept {
-    return match(std::begin(range), std::end(range));
-  }
-  template <typename Iterator> constexpr CTRE_FORCE_INLINE static auto search(Iterator begin, Iterator end) noexcept {
-    return search_re(begin, end, RE());
-  }
-  constexpr CTRE_FORCE_INLINE static auto search(const char * s) noexcept {
-    return search_2(s, zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(const wchar_t * s) noexcept {
-    return search_2(s, zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(const std::string & s) noexcept {
-    return search_2(s.c_str(), zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(const std::wstring & s) noexcept {
-    return search_2(s.c_str(), zero_terminated_string_end_iterator());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(std::string_view sv) noexcept {
-    return search(sv.begin(), sv.end());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(std::wstring_view sv) noexcept {
-    return search(sv.begin(), sv.end());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(std::u16string_view sv) noexcept {
-    return search(sv.begin(), sv.end());
-  }
-  static constexpr CTRE_FORCE_INLINE auto search(std::u32string_view sv) noexcept {
-    return search(sv.begin(), sv.end());
-  }
-  template <typename Range> static constexpr CTRE_FORCE_INLINE auto search(Range && range) noexcept {
-    return search(std::begin(range), std::end(range));
-  }
+struct match_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+
+return evaluate(orig_begin, begin, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, RE, assert_subject_end, end_mark, accept>());
+}
+
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+return exec<Modifier, ResultIterator>(begin, begin, end, RE{});
+}
 };
 
-template <typename RE> regular_expression(RE) -> regular_expression<RE>;
+struct search_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+
+constexpr bool fixed = starts_with_anchor(Modifier{}, ctll::list<RE>{});
+
+auto it = begin;
+
+for (; end != it && !fixed; ++it) {
+if (auto out = evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, RE, end_mark, accept>())) {
+return out;
+}
+}
+
+// in case the RE is empty or fixed
+auto out = evaluate(orig_begin, it, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, RE, end_mark, accept>());
+
+// ALERT: ugly hack
+// propagate end even if it didn't match (this is needed for split function)
+if (!out) out.set_end_mark(it);
+return out;
+}
+
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+return exec<Modifier, ResultIterator>(begin, begin, end, RE{});
+}
+};
+
+struct starts_with_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+return evaluate(orig_begin, begin, end, Modifier{}, return_type<result_iterator, RE>{}, ctll::list<start_mark, RE, end_mark, accept>());
+}
+
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+return exec<Modifier, ResultIterator>(begin, begin, end, RE{});
+}
+};
+
+// wrapper which calls search on input
+struct range_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+using wrapped_regex = regular_expression<RE, search_method, Modifier>;
+
+return regex_range<IteratorBegin, IteratorEnd, wrapped_regex, result_iterator>(begin, end);
+}
+};
+
+struct tokenize_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+using wrapped_regex = regular_expression<RE, starts_with_method, Modifier>;
+
+return regex_range<IteratorBegin, IteratorEnd, wrapped_regex, result_iterator>(begin, end);
+}
+};
+
+struct split_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+using wrapped_regex = regular_expression<RE, search_method, Modifier>;
+
+return regex_split_range<IteratorBegin, IteratorEnd, wrapped_regex, result_iterator>(begin, end);
+}
+};
+
+struct iterator_method {
+template <typename Modifier = singleline, typename ResultIterator = void, typename RE, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end, RE) noexcept {
+using result_iterator = std::conditional_t<std::is_same_v<ResultIterator, void>, IteratorBegin, ResultIterator>;
+using wrapped_regex = regular_expression<RE, search_method, Modifier>;
+
+return regex_iterator<IteratorBegin, IteratorEnd, wrapped_regex, result_iterator>(begin, end);
+}
+constexpr CTRE_FORCE_INLINE static auto exec() noexcept {
+return regex_end_iterator{};
+}
+};
+
+template <typename RE, typename Method, typename Modifier> struct regular_expression {
+constexpr CTRE_FORCE_INLINE regular_expression() noexcept { }
+constexpr CTRE_FORCE_INLINE regular_expression(RE) noexcept { }
+
+template <typename ResultIterator, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec_with_result_iterator(IteratorBegin orig_begin, IteratorBegin begin, IteratorEnd end) noexcept {
+return Method::template exec<Modifier, ResultIterator>(orig_begin, begin, end, RE{});
+}
+template <typename ResultIterator, typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec_with_result_iterator(IteratorBegin begin, IteratorEnd end) noexcept {
+return Method::template exec<Modifier, ResultIterator>(begin, end, RE{});
+}
+template <typename Range> constexpr CTRE_FORCE_INLINE static auto multi_exec(Range && range) noexcept {
+return multi_subject_range<Range, regular_expression>{std::forward<Range>(range)};
+}
+constexpr CTRE_FORCE_INLINE static auto exec() noexcept {
+return Method::template exec();
+}
+template <typename IteratorBegin, typename IteratorEnd> constexpr CTRE_FORCE_INLINE static auto exec(IteratorBegin begin, IteratorEnd end) noexcept {
+return Method::template exec<Modifier>(begin, end, RE{});
+}
+static constexpr CTRE_FORCE_INLINE auto exec(const char * s) noexcept {
+return Method::template exec<Modifier>(s, zero_terminated_string_end_iterator(), RE{});
+}
+static constexpr CTRE_FORCE_INLINE auto exec(const wchar_t * s) noexcept {
+return Method::template exec<Modifier>(s, zero_terminated_string_end_iterator(), RE{});
+}
+static constexpr CTRE_FORCE_INLINE auto exec(std::string_view sv) noexcept {
+return exec(sv.begin(), sv.end());
+}
+static constexpr CTRE_FORCE_INLINE auto exec(std::wstring_view sv) noexcept {
+return exec(sv.begin(), sv.end());
+}
+#if __cpp_char8_t >= 201811
+static constexpr CTRE_FORCE_INLINE auto exec(std::u8string_view sv) noexcept {
+return exec_with_result_iterator<const char8_t *>(utf8_range(sv).begin(), utf8_range(sv).end());
+}
+#endif
+static constexpr CTRE_FORCE_INLINE auto exec(std::u16string_view sv) noexcept {
+return exec(sv.begin(), sv.end());
+}
+static constexpr CTRE_FORCE_INLINE auto exec(std::u32string_view sv) noexcept {
+return exec(sv.begin(), sv.end());
+}
+template <typename Range, typename = typename std::enable_if<RangeLikeType<Range>::value>::type> static constexpr CTRE_FORCE_INLINE auto exec(Range && range) noexcept {
+return exec(std::begin(range), std::end(range));
+}
+
+// another api
+template <typename... Args> CTRE_FORCE_INLINE constexpr auto operator()(Args && ... args) const noexcept {
+return exec(std::forward<Args>(args)...);
+}
+// api for pattern matching
+template <typename... Args> CTRE_FORCE_INLINE constexpr auto try_extract(Args && ... args) const noexcept {
+return exec(std::forward<Args>(args)...);
+}
+
+// for compatibility with _ctre literal
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto match(Args && ... args) noexcept {
+return regular_expression<RE, match_method, singleline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto search(Args && ... args) noexcept {
+return regular_expression<RE, search_method, singleline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto starts_with(Args && ... args) noexcept {
+return regular_expression<RE, starts_with_method, singleline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto range(Args && ... args) noexcept {
+return regular_expression<RE, range_method, singleline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto split(Args && ... args) noexcept {
+return regular_expression<RE, split_method, singleline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto tokenize(Args && ... args) noexcept {
+return regular_expression<RE, tokenize_method, singleline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto iterator(Args && ... args) noexcept {
+return regular_expression<RE, iterator_method, singleline>::exec(std::forward<Args>(args)...);
+}
+
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_match(Args && ... args) noexcept {
+return regular_expression<RE, match_method, multiline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_search(Args && ... args) noexcept {
+return regular_expression<RE, search_method, multiline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_starts_with(Args && ... args) noexcept {
+return regular_expression<RE, starts_with_method, multiline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_range(Args && ... args) noexcept {
+return regular_expression<RE, range_method, multiline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_split(Args && ... args) noexcept {
+return regular_expression<RE, split_method, multiline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_tokenize(Args && ... args) noexcept {
+return regular_expression<RE, tokenize_method, multiline>::exec(std::forward<Args>(args)...);
+}
+template <typename... Args> static constexpr CTRE_FORCE_INLINE auto multiline_iterator(Args && ... args) noexcept {
+return regular_expression<RE, iterator_method, multiline>::exec(std::forward<Args>(args)...);
+}
+};
+
+// range style API support for tokenize/range/split operations
+template <typename Range, typename RE, typename Modifier> constexpr auto operator|(Range && range, regular_expression<RE, range_method, Modifier> re) noexcept {
+return re.exec(std::forward<Range>(range));
+}
+
+template <typename Range, typename RE, typename Modifier> constexpr auto operator|(Range && range, regular_expression<RE, tokenize_method, Modifier> re) noexcept {
+return re.exec(std::forward<Range>(range));
+}
+
+template <typename Range, typename RE, typename Modifier> constexpr auto operator|(Range && range, regular_expression<RE, split_method, Modifier> re) noexcept {
+return re.exec(std::forward<Range>(range));
+}
+
+template <typename Range, typename RE, typename Modifier> constexpr auto operator|(Range && range, regular_expression<RE, iterator_method, Modifier> re) noexcept = delete;
+
+template <typename Range, typename RE, typename Method, typename Modifier> constexpr auto operator|(Range && range, regular_expression<RE, Method, Modifier> re) noexcept {
+return re.multi_exec(std::forward<Range>(range));
+}
+
+#if CTRE_CNTTP_COMPILER_CHECK
+#define CTRE_REGEX_INPUT_TYPE ctll::fixed_string
+template <auto input> struct regex_builder {
+static constexpr auto _input = input;
+using _tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+static_assert(_tmp(), "Regular Expression contains syntax error.");
+using type = ctll::conditional<(bool)(_tmp()), decltype(ctll::front(typename _tmp::output_type::stack_type())), ctll::list<reject>>;
+};
+#else
+#define CTRE_REGEX_INPUT_TYPE const auto &
+template <const auto & input> struct regex_builder {
+using _tmp = typename ctll::parser<ctre::pcre, input, ctre::pcre_actions>::template output<pcre_context<>>;
+static_assert(_tmp(), "Regular Expression contains syntax error.");
+using type = ctll::conditional<(bool)(_tmp()), decltype(ctll::front(typename _tmp::output_type::stack_type())), ctll::list<reject>>;
+};
+#endif
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto match = regular_expression<typename regex_builder<input>::type, match_method, singleline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto search = regular_expression<typename regex_builder<input>::type, search_method, singleline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto starts_with = regular_expression<typename regex_builder<input>::type, starts_with_method, singleline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto range = regular_expression<typename regex_builder<input>::type, range_method, singleline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto split = regular_expression<typename regex_builder<input>::type, split_method, singleline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto tokenize = regular_expression<typename regex_builder<input>::type, tokenize_method, singleline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto iterator = regular_expression<typename regex_builder<input>::type, iterator_method, singleline>();
+
+static constexpr inline auto sentinel = regex_end_iterator();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_match = regular_expression<typename regex_builder<input>::type, match_method, multiline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_search = regular_expression<typename regex_builder<input>::type, search_method, multiline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_starts_with = regular_expression<typename regex_builder<input>::type, starts_with_method, multiline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_range = regular_expression<typename regex_builder<input>::type, range_method, multiline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_split = regular_expression<typename regex_builder<input>::type, split_method, multiline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_tokenize = regular_expression<typename regex_builder<input>::type, tokenize_method, multiline>();
+
+template <CTRE_REGEX_INPUT_TYPE input> static constexpr inline auto multiline_iterator = regular_expression<typename regex_builder<input>::type, iterator_method, multiline>();
+
+static constexpr inline auto multiline_sentinel = regex_end_iterator();
 
 }
 
@@ -3639,7 +5086,7 @@ namespace ctre {
 // in C++17 (clang & gcc with gnu extension) we need translate character pack into ctll::fixed_string
 // in C++20 we have `class nontype template parameters`
 
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 template <typename CharT, CharT... input> static inline constexpr auto _fixed_string_reference = ctll::fixed_string< sizeof...(input)>({input...});
 #endif
 
@@ -3656,8 +5103,14 @@ namespace literals {
 #ifdef __INTEL_COMPILER
 // not enable literals
 #elif defined __GNUC__
-#if not(__GNUC__ == 9)
+#if __GNUC__ < 9
 #define CTRE_ENABLE_LITERALS
+#elif __GNUC__ >= 10
+#if !CTRE_CNTTP_COMPILER_CHECK
+// newer versions of GCC will give error when trying to use GNU extension
+#else
+#define CTRE_ENABLE_LITERALS
+#endif
 #endif
 #endif
 
@@ -3666,27 +5119,27 @@ namespace literals {
 // add this when we will have concepts
 // requires ctll::parser<ctre::pcre, _fixed_string_reference<CharT, charpack...>, ctre::pcre_actions>::template correct_with<pcre_context<>>
 
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre() noexcept {
-	constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
 #else
 template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre() noexcept {
-	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+constexpr auto _input = input; // workaround for GCC 9 bug 88092
 #endif
-	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(tmp(), "Regular Expression contains syntax error.");
-	if constexpr (tmp()) {
-		using re = decltype(front(typename tmp::output_type::stack_type()));
-		return ctre::regular_expression(re());
-	} else {
-		return ctre::regular_expression(reject());
-	}
+using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+static_assert(tmp(), "Regular Expression contains syntax error.");
+if constexpr (tmp()) {
+using re = decltype(front(typename tmp::output_type::stack_type()));
+return ctre::regular_expression(re());
+} else {
+return ctre::regular_expression(reject());
+}
 }
 
 // this will need to be fixed with C++20
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre_id() noexcept {
-	return id<charpack...>();
+return id<charpack...>();
 }
 #endif
 
@@ -3698,36 +5151,36 @@ namespace test_literals {
 
 #ifdef CTRE_ENABLE_LITERALS
 
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr inline auto operator""_ctre_test() noexcept {
-	constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
 #else
 template <ctll::fixed_string input> CTRE_FLATTEN constexpr inline auto operator""_ctre_test() noexcept {
-	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+constexpr auto _input = input; // workaround for GCC 9 bug 88092
 #endif
-	return ctll::parser<ctre::pcre, _input>::template correct_with<>;
+return ctll::parser<ctre::pcre, _input>::template correct_with<>;
 }
 
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr inline auto operator""_ctre_gen() noexcept {
-	constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
 #else
 template <ctll::fixed_string input> CTRE_FLATTEN constexpr inline auto operator""_ctre_gen() noexcept {
-	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+constexpr auto _input = input; // workaround for GCC 9 bug 88092
 #endif
-	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(tmp(), "Regular Expression contains syntax error.");
-	return typename tmp::output_type::stack_type();
+using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+static_assert(tmp(), "Regular Expression contains syntax error.");
+return typename tmp::output_type::stack_type();
 }
 
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 template <typename CharT, CharT... charpack> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre_syntax() noexcept {
-	constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
+constexpr auto & _input = _fixed_string_reference<CharT, charpack...>;
 #else
 template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto operator""_ctre_syntax() noexcept {
-	constexpr auto _input = input; // workaround for GCC 9 bug 88092
+constexpr auto _input = input; // workaround for GCC 9 bug 88092
 #endif
-	return ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template correct_with<pcre_context<>>;
+return ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template correct_with<pcre_context<>>;
 }
 
 #endif
@@ -3749,236 +5202,39 @@ template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE aut
 
 namespace ctre {
 
-#if !(__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
+#if !CTRE_CNTTP_COMPILER_CHECK
 // avoiding CTAD limitation in C++17
 template <typename CharT, size_t N> class pattern: public ctll::fixed_string<N> {
-  using parent = ctll::fixed_string<N>;
- public:
-  constexpr pattern(const CharT (&input)[N]) noexcept: parent(input) { }
+using parent = ctll::fixed_string<N>;
+public:
+constexpr pattern(const CharT (&input)[N]) noexcept: parent(input) { }
 };
 
 template <typename CharT, size_t N> pattern(const CharT (&)[N]) -> pattern<CharT, N>;
 
 // for better examples
 template <typename CharT, size_t N> class fixed_string: public ctll::fixed_string<N> {
-  using parent = ctll::fixed_string<N>;
- public:
-  constexpr fixed_string(const CharT (&input)[N]) noexcept: parent(input) { }
+using parent = ctll::fixed_string<N>;
+public:
+constexpr fixed_string(const CharT (&input)[N]) noexcept: parent(input) { }
 };
 
 template <typename CharT, size_t N> fixed_string(const CharT (&)[N]) -> fixed_string<CharT, N>;
 #endif
 
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-template <ctll::fixed_string input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto re() noexcept {
+#if CTRE_CNTTP_COMPILER_CHECK
+template <ctll::fixed_string input, typename Modifier = void> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto re() noexcept {
 constexpr auto _input = input; // workaround for GCC 9 bug 88092
 #else
-template <auto & input> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto re() noexcept {
-  constexpr auto & _input = input;
+template <auto & input, typename Modifier = void> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto re() noexcept {
+constexpr auto & _input = input;
 #endif
 
-  using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-  static_assert(tmp(), "Regular Expression contains syntax error.");
-  using re = decltype(front(typename tmp::output_type::stack_type()));
-  return ctre::regular_expression(re());
+using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
+static_assert(tmp(), "Regular Expression contains syntax error.");
+using regex = decltype(front(typename tmp::output_type::stack_type()));
+return ctre::regular_expression<regex, Modifier, singleline>();
 }
-
-// in moment when we get C++20 support this will start to work :)
-
-template <typename RE> struct regex_match_t {
-  template <typename... Args> CTRE_FORCE_INLINE constexpr auto operator()(Args && ... args) const noexcept {
-    auto re_obj = ctre::regular_expression<RE>();
-    return re_obj.match(std::forward<Args>(args)...);
-  }
-  template <typename... Args> CTRE_FORCE_INLINE constexpr auto try_extract(Args && ... args) const noexcept {
-    return operator()(std::forward<Args>(args)...);
-  }
-};
-
-template <typename RE> struct regex_search_t {
-  template <typename... Args> CTRE_FORCE_INLINE constexpr auto operator()(Args && ... args) const noexcept {
-    auto re_obj = ctre::regular_expression<RE>();
-    return re_obj.search(std::forward<Args>(args)...);
-  }
-  template <typename... Args> CTRE_FORCE_INLINE constexpr auto try_extract(Args && ... args) const noexcept {
-    return operator()(std::forward<Args>(args)...);
-  }
-};
-
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-
-template <auto input> struct regex_builder {
-	static constexpr auto _input = input;
-	using _tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(_tmp(), "Regular Expression contains syntax error.");
-	using type = ctll::conditional<(bool)(_tmp()), decltype(ctll::front(typename _tmp::output_type::stack_type())), ctll::list<reject>>;
-};
-
-template <ctll::fixed_string input> static constexpr inline auto match = regex_match_t<typename regex_builder<input>::type>();
-
-template <ctll::fixed_string input> static constexpr inline auto search = regex_search_t<typename regex_builder<input>::type>();
-
-#else
-
-template <auto & input> struct regex_builder {
-  using _tmp = typename ctll::parser<ctre::pcre, input, ctre::pcre_actions>::template output<pcre_context<>>;
-  static_assert(_tmp(), "Regular Expression contains syntax error.");
-  using type = ctll::conditional<(bool)(_tmp()), decltype(ctll::front(typename _tmp::output_type::stack_type())), ctll::list<reject>>;
-};
-
-template <auto & input> static constexpr inline auto match = regex_match_t<typename regex_builder<input>::type>();
-
-template <auto & input> static constexpr inline auto search = regex_search_t<typename regex_builder<input>::type>();
-
-#endif
-
-}
-
-#endif
-
-#ifndef CTRE_V2__CTRE__ITERATOR__HPP
-#define CTRE_V2__CTRE__ITERATOR__HPP
-
-namespace ctre {
-
-struct regex_end_iterator {
-  constexpr regex_end_iterator() noexcept { }
-};
-
-template <typename BeginIterator, typename EndIterator, typename RE> struct regex_iterator {
-  BeginIterator current;
-  const EndIterator end;
-  decltype(RE::search_2(std::declval<BeginIterator>(), std::declval<EndIterator>())) current_match;
-
-  constexpr regex_iterator(BeginIterator begin, EndIterator end) noexcept: current{begin}, end{end}, current_match{RE::search_2(current, end)} {
-    if (current_match) {
-      current = current_match.template get<0>().end();
-    }
-  }
-  constexpr const auto & operator*() const noexcept {
-    return current_match;
-  }
-  constexpr regex_iterator & operator++() noexcept {
-    current_match = RE::search_2(current, end);
-    if (current_match) {
-      current = current_match.template get<0>().end();
-    }
-    return *this;
-  }
-  constexpr regex_iterator operator++(int) noexcept {
-    auto previous = *this;
-    current_match = RE::search_2(current, end);
-    if (current_match) {
-      current = current_match.template get<0>().end();
-    }
-    return previous;
-  }
-};
-
-template <typename BeginIterator, typename EndIterator, typename RE> constexpr bool operator!=(const regex_iterator<BeginIterator, EndIterator, RE> & left, regex_end_iterator) {
-  return bool(left.current_match);
-}
-
-template <typename BeginIterator, typename EndIterator, typename RE> constexpr bool operator!=(regex_end_iterator, const regex_iterator<BeginIterator, EndIterator, RE> & right) {
-  return bool(right.current_match);
-}
-
-template <typename BeginIterator, typename EndIterator, typename RE> constexpr auto iterator(BeginIterator begin, EndIterator end, RE) noexcept {
-  return regex_iterator<BeginIterator, EndIterator, RE>(begin, end);
-}
-
-constexpr auto iterator() noexcept {
-  return regex_end_iterator{};
-}
-
-template <typename Subject, typename RE> constexpr auto iterator(const Subject & subject, RE re) noexcept {
-  return iterator(subject.begin(), subject.end(), re);
-}
-
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-template <ctll::fixed_string input, typename BeginIterator, typename EndIterator> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto iterator(BeginIterator begin, EndIterator end) noexcept {
-	constexpr auto _input = input;
-	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(tmp(), "Regular Expression contains syntax error.");
-	using re = decltype(front(typename tmp::output_type::stack_type()));
-	return iterator(begin, end, re());
-}
-#endif
-
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-template <ctll::fixed_string input, typename Subject> CTRE_FLATTEN constexpr CTRE_FORCE_INLINE auto iterator(const Subject & subject) noexcept {
-	constexpr auto _input = input;
-	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(tmp(), "Regular Expression contains syntax error.");
-	using re = decltype(front(typename tmp::output_type::stack_type()));
-	return iterator(subject.begin(), subject.end(), re());
-}
-#endif
-
-} // ctre
-
-#endif
-
-#ifndef CTRE_V2__CTRE__RANGE__HPP
-#define CTRE_V2__CTRE__RANGE__HPP
-
-namespace ctre {
-
-template <typename BeginIterator, typename EndIterator, typename RE> struct regex_range {
-  BeginIterator _begin;
-  const EndIterator _end;
-  constexpr regex_range(BeginIterator begin, EndIterator end) noexcept: _begin{begin}, _end{end} { }
-
-  constexpr auto begin() const noexcept {
-    return regex_iterator<BeginIterator, EndIterator, RE>(_begin, _end);
-  }
-  constexpr auto end() const noexcept {
-    return regex_end_iterator{};
-  }
-};
-
-template <typename BeginIterator, typename EndIterator, typename RE> constexpr auto range(BeginIterator begin, EndIterator end, RE) noexcept {
-  return regex_range<BeginIterator, EndIterator, RE>(begin, end);
-}
-
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-template <ctll::fixed_string input, typename BeginIterator, typename EndIterator> constexpr auto range(BeginIterator begin, EndIterator end) noexcept {
-	constexpr auto _input = input;
-	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(tmp(), "Regular Expression contains syntax error.");
-	using re = decltype(front(typename tmp::output_type::stack_type()));
-	auto re_obj = ctre::regular_expression(re());
-	return range(begin, end, re_obj);
-}
-#endif
-
-template <typename Subject, typename RE> constexpr auto range(const Subject & subject, RE re) noexcept {
-  return range(subject.begin(), subject.end(), re);
-}
-
-template <typename RE> constexpr auto range(const char * subject, RE re) noexcept {
-  return range(subject, zero_terminated_string_end_iterator(), re);
-}
-
-#if (__cpp_nontype_template_parameter_class || (__cpp_nontype_template_args >= 201911L))
-template <ctll::fixed_string input, typename Subject> constexpr auto range(const Subject & subject) noexcept {
-	constexpr auto _input = input;
-	using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-	static_assert(tmp(), "Regular Expression contains syntax error.");
-	using re = decltype(front(typename tmp::output_type::stack_type()));
-	auto re_obj = ctre::regular_expression(re());
-	return range(subject.begin(), subject.end(), re_obj);
-}
-#else
-template <auto & input, typename Subject> constexpr auto range(const Subject & subject) noexcept {
-  constexpr auto & _input = input;
-  using tmp = typename ctll::parser<ctre::pcre, _input, ctre::pcre_actions>::template output<pcre_context<>>;
-  static_assert(tmp(), "Regular Expression contains syntax error.");
-  using re = decltype(front(typename tmp::output_type::stack_type()));
-  auto re_obj = ctre::regular_expression(re());
-  return range(subject.begin(), subject.end(), re_obj);
-}
-#endif
 
 }
 
@@ -3988,12 +5244,9325 @@ template <auto & input, typename Subject> constexpr auto range(const Subject & s
 #define CTRE_V2__CTRE__OPERATORS__HPP
 
 template <typename A, typename B> constexpr auto operator|(ctre::regular_expression<A>, ctre::regular_expression<B>) -> ctre::regular_expression<ctre::select<A,B>> {
-  return {};
+return {};
 }
 
 template <typename A, typename B> constexpr auto operator>>(ctre::regular_expression<A>, ctre::regular_expression<B>) -> ctre::regular_expression<ctre::sequence<A,B>> {
-  return {};
+return {};
 }
+
+#endif
+
+#endif
+
+#ifndef CTRE_V2__UNICODE_CODE_DB__HPP
+#define CTRE_V2__UNICODE_CODE_DB__HPP
+
+#define UNI_SINGLE_HEADER
+#ifndef H_COR3NTIN_UNICODE_SYNOPSYS
+#define H_COR3NTIN_UNICODE_SYNOPSYS
+
+#include <string_view>
+
+namespace uni
+{
+enum class category;
+enum class property;
+enum class version : unsigned char;
+enum class script ;
+enum class block;
+
+struct script_extensions_view {
+constexpr script_extensions_view(char32_t c);
+
+struct sentinel {};
+struct iterator {
+
+constexpr iterator(char32_t c);
+constexpr script operator*() const;
+
+constexpr iterator& operator++(int);
+
+constexpr iterator operator++();
+
+constexpr bool operator==(sentinel) const;
+constexpr bool operator!=(sentinel) const;
+
+private:
+char32_t m_c;
+script m_script;
+int idx = 1;
+};
+
+constexpr iterator begin() const;
+constexpr sentinel end() const;
+
+private:
+char32_t c;
+};
+
+struct numeric_value {
+
+constexpr double value() const;
+constexpr long long numerator() const;
+constexpr int denominator() const;
+constexpr bool is_valid() const;
+
+protected:
+constexpr numeric_value() = default;
+constexpr numeric_value(long long n, int16_t d);
+
+long long _n = 0;
+int16_t _d = 0;
+friend constexpr numeric_value cp_numeric_value(char32_t cp);
+};
+
+constexpr category cp_category(char32_t cp);
+constexpr script cp_script(char32_t cp);
+constexpr script_extensions_view cp_script_extensions(char32_t cp);
+constexpr version cp_age(char32_t cp);
+constexpr block cp_block(char32_t cp);
+constexpr bool cp_is_valid(char32_t cp);
+constexpr bool cp_is_assigned(char32_t cp);
+constexpr bool cp_is_ascii(char32_t cp);
+constexpr numeric_value cp_numeric_value(char32_t cp);
+
+template<script>
+constexpr bool cp_is(char32_t);
+template<property>
+constexpr bool cp_is(char32_t);
+template<category>
+constexpr bool cp_is(char32_t);
+
+namespace detail
+{
+enum class binary_prop;
+constexpr int propnamecomp(std::string_view sa, std::string_view sb);
+constexpr binary_prop binary_prop_from_string(std::string_view s);
+
+template<binary_prop p>
+constexpr bool get_binary_prop(char32_t) = delete;
+
+constexpr script   script_from_string(std::string_view s);
+constexpr block    block_from_string(std::string_view s);
+constexpr version  age_from_string(std::string_view a);
+constexpr category category_from_string(std::string_view a);
+
+constexpr bool is_unassigned(category cat);
+constexpr bool is_unknown(script s);
+constexpr bool is_unknown(block b);
+constexpr bool is_unassigned(version v);
+constexpr bool is_unknown(binary_prop s);
+}
+}
+
+#endif
+#include <cstdint>
+#include <algorithm>
+#include <string_view>
+
+namespace uni::detail {
+
+template<class ForwardIt, class T, class Compare>
+constexpr ForwardIt upper_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp) {
+ForwardIt it = first;
+typename std::iterator_traits<ForwardIt>::difference_type count = std::distance(first, last);
+typename std::iterator_traits<ForwardIt>::difference_type step = count / 2;
+
+while(count > 0) {
+it = first;
+step = count / 2;
+std::advance(it, step);
+if(!comp(value, *it)) {
+first = ++it;
+count -= step + 1;
+} else
+count = step;
+}
+return first;
+}
+
+template<class ForwardIt, class T, class Compare>
+constexpr ForwardIt lower_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp) {
+ForwardIt it = first;
+typename std::iterator_traits<ForwardIt>::difference_type count = std::distance(first, last);
+typename std::iterator_traits<ForwardIt>::difference_type step = count / 2;
+
+while(count > 0) {
+it = first;
+step = count / 2;
+std::advance(it, step);
+if(comp(*it, value)) {
+first = ++it;
+count -= step + 1;
+} else
+count = step;
+}
+return first;
+}
+
+template<class ForwardIt, class T>
+constexpr ForwardIt lower_bound(ForwardIt first, ForwardIt last, const T& value) {
+ForwardIt it = first;
+typename std::iterator_traits<ForwardIt>::difference_type count = std::distance(first, last);
+typename std::iterator_traits<ForwardIt>::difference_type step = count / 2;
+
+while(count > 0) {
+it = first;
+step = count / 2;
+std::advance(it, step);
+if(*it < value) {
+first = ++it;
+count -= step + 1;
+} else
+count = step;
+}
+return first;
+}
+
+template<class ForwardIt, class T>
+constexpr bool binary_search(ForwardIt first, ForwardIt last, const T& value) {
+first = detail::lower_bound(first, last, value);
+return (!(first == last) && !(value < *first));
+}
+template<typename T, auto N>
+struct compact_range {
+std::uint32_t _data[N];
+constexpr T value(char32_t cp, T default_value) const {
+const auto end = std::end(_data);
+auto it = detail::upper_bound(std::begin(_data), end, cp, [](char32_t cp, uint32_t v) {
+char32_t c = (v >> 8);
+return cp < c;
+});
+if(it == end)
+return default_value;
+it--;
+return *(it)&0xFF;
+}
+};
+template<class T, class... U>
+compact_range(T, U...) -> compact_range<T, sizeof...(U) + 1>;
+
+template<typename T, auto N>
+struct compact_list {
+std::uint32_t _data[N];
+constexpr T value(char32_t cp, T default_value) const {
+const auto end = std::end(_data);
+auto it = detail::lower_bound(std::begin(_data), end, cp, [](uint32_t v, char32_t cp) {
+char32_t c = (v >> 8);
+return c < cp;
+});
+if(it == end || ((*it) >> 8) != cp)
+return default_value;
+return *(it)&0xFF;
+}
+};
+template<class T, class... U>
+compact_list(T, U...)-> compact_list<T, sizeof...(U) + 1>;
+
+template <typename T, std::size_t N>
+struct array {
+using type = T[N];
+};
+
+template <typename T>
+struct array<T, 0> {
+using type = T*;
+};
+
+template <typename T, std::size_t N>
+using array_t = typename array<T, N>::type;
+
+template<std::size_t r1_s, std::size_t r2_s, int16_t r2_t_f, int16_t r2_t_b, std::size_t r3_s,
+std::size_t r4_s, int16_t r4_t_f, int16_t r4_t_b, std::size_t r5_s, int16_t r5_t_f,
+int16_t r5_t_b, std::size_t r6_s>
+struct bool_trie {
+
+// not tries, just bitmaps for all code points 0..0x7FF (UTF-8 1- and 2-byte sequences)
+std::uint64_t r1[32];
+
+// trie for code points 0x800..0xFFFF (UTF-8 3-byte sequences, aka rest of BMP)
+
+uint8_t r2[r2_s];
+array_t<std::uint64_t, r3_s> r3;    // leaves can be shared, so size isn't fixed
+
+// trie for 0x10000..0x10FFFF (UTF-8 4-byte sequences, aka non-BMP code points)
+array_t<std::uint8_t, r4_s> r4;
+array_t<std::uint8_t, r5_s> r5;   // two level to exploit sparseness of non-BMP
+array_t<std::uint64_t, r6_s> r6;  // again, leaves are shared
+
+constexpr bool lookup(char32_t u) const {
+std::uint32_t c = u;
+if(c < 0x800) {
+if constexpr(r1_s == 0) {
+return false;
+} else {
+return trie_range_leaf(c, r1[c >> 6]);
+}
+} else if(c < 0x10000) {
+if constexpr(r3_s == 0) {
+return false;
+} else {
+std::size_t i = ((c >> 6) - 0x20);
+auto child = 0;
+if(i >= r2_t_f && i < r2_t_f + r2_s)
+child = r2[i - r2_t_f];
+return trie_range_leaf(c, r3[child]);
+}
+} else {
+if constexpr(r6_s == 0) {
+return false;
+}
+std::size_t i4 = (c >> 12) - 0x10;
+auto child = 0;
+if constexpr(r4_s > 0) {
+if(i4 >= r4_t_f && i4 < r4_t_f + r4_s) {
+child = r4[i4 - r4_t_f];
+}
+}
+
+std::size_t i5 = (child << 6) + ((c >> 6) & 0x3f);
+auto leaf = 0;
+if constexpr(r5_s > 0) {
+if(i5 >= r5_t_f && i5 < r5_t_f + r5_s) {
+leaf = r5[i5 - r5_t_f];
+}
+}
+return trie_range_leaf(c, r6[leaf]);
+}
+}
+
+constexpr bool trie_range_leaf(std::uint32_t c, std::uint64_t chunk) const {
+return (chunk >> (c & 0b111111)) & 0b1;
+}
+};
+
+template<std::size_t size>
+struct flat_array {
+char32_t data[size];
+constexpr bool lookup(char32_t u) const {
+if constexpr(size < 20) {
+for(auto it = std::begin(data); it != std::end(data); ++it) {
+if(*it == u)
+return true;
+if(it == std::end(data))
+return false;
+}
+} else {
+return detail::binary_search(std::begin(data), std::end(data), u);
+}
+return false;
+}
+};
+
+template<auto N>
+struct range_array {
+std::uint32_t _data[N];
+constexpr bool lookup(char32_t cp) const {
+const auto end = std::end(_data);
+auto it = detail::upper_bound(std::begin(_data), end, cp, [](char32_t cp, uint32_t v) {
+char32_t c = (v >> 8);
+return cp < c;
+});
+if(it == end)
+return false;
+it--;
+return (*it) & 0xFF;
+}
+};
+
+template<class... U>
+range_array(U...)->range_array<sizeof...(U)>;
+
+constexpr char propcharnorm(char a) {
+if(a >= 'A' && a <= 'Z')
+return a + 32;
+if(a == ' ' || a == '-')
+return '_';
+return a;
+}
+
+constexpr int propcharcomp(char a, char b) {
+a = propcharnorm(a);
+b = propcharnorm(b);
+if(a == b)
+return 0;
+if(a < b)
+return -1;
+return 1;
+}
+
+constexpr int propnamecomp(std::string_view sa, std::string_view sb) {
+// workaround, iterators in std::string_view are not constexpr in libc++ (for now)
+const char* a = sa.begin();
+const char* b = sb.begin();
+
+const char* ae = sa.end();
+const char* be = sb.end();
+
+for(; a != ae && b != be; a++, b++) {
+auto res = propcharcomp(*a, *b);
+if(res != 0)
+return res;
+}
+if(sa.size() < sb.size())
+return -1;
+else if(sb.size() < sa.size())
+return 1;
+return 0;
+}
+
+template <typename A, typename B>
+struct pair
+{
+A first;
+B second;
+};
+
+template <typename A, typename B>
+pair(A, B) -> pair<A, B>;
+
+struct string_with_idx { const char* name; uint32_t value; };
+
+}    // namespace uni::detail
+
+namespace uni {
+
+constexpr double numeric_value::value() const {
+return numerator() / double(_d);
+}
+
+constexpr long long numeric_value::numerator() const {
+return _n;
+}
+
+constexpr int numeric_value::denominator() const {
+return _d;
+}
+
+constexpr bool numeric_value::is_valid() const {
+return _d != 0;
+}
+
+constexpr numeric_value::numeric_value(long long n, int16_t d) : _n(n), _d(d) {}
+
+}    // namespace uni
+
+namespace uni {
+enum class version : uint8_t {
+unassigned,
+v1_1,
+v2_0,
+v2_1,
+v3_0,
+v3_1,
+v3_2,
+v4_0,
+v4_1,
+v5_0,
+v5_1,
+v5_2,
+v6_0,
+v6_1,
+v6_2,
+v6_3,
+v7_0,
+v8_0,
+v9_0,
+v10_0,
+v11_0,
+v12_0,
+v12_1,
+v13_0,
+latest_version = v13_0
+};
+enum class category {
+c,
+other = c,
+cc,
+control = cc,
+cf,
+format = cf,
+cn,
+unassigned = cn,
+co,
+private_use = co,
+cs,
+surrogate = cs,
+l,
+letter = l,
+lc,
+cased_letter = lc,
+ll,
+lowercase_letter = ll,
+lm,
+modifier_letter = lm,
+lo,
+other_letter = lo,
+lt,
+titlecase_letter = lt,
+lu,
+uppercase_letter = lu,
+m,
+mark = m,
+mc,
+spacing_mark = mc,
+me,
+enclosing_mark = me,
+mn,
+nonspacing_mark = mn,
+n,
+number = n,
+nd,
+decimal_number = nd,
+nl,
+letter_number = nl,
+no,
+other_number = no,
+p,
+punctuation = p,
+pc,
+connector_punctuation = pc,
+pd,
+dash_punctuation = pd,
+pe,
+close_punctuation = pe,
+pf,
+final_punctuation = pf,
+pi,
+initial_punctuation = pi,
+po,
+other_punctuation = po,
+ps,
+open_punctuation = ps,
+s,
+symbol = s,
+sc,
+currency_symbol = sc,
+sk,
+modifier_symbol = sk,
+sm,
+math_symbol = sm,
+so,
+other_symbol = so,
+z,
+separator = z,
+zl,
+line_separator = zl,
+zp,
+paragraph_separator = zp,
+zs,
+space_separator = zs,
+max
+};
+enum class block {
+no_block,    // 0
+nb = no_block,
+basic_latin,    // 1
+ascii = basic_latin,
+latin_1_supplement,    // 2
+latin_1_sup = latin_1_supplement,
+latin_extended_a,    // 3
+latin_ext_a = latin_extended_a,
+latin_extended_b,    // 4
+latin_ext_b = latin_extended_b,
+ipa_extensions,    // 5
+ipa_ext = ipa_extensions,
+spacing_modifier_letters,    // 6
+modifier_letters = spacing_modifier_letters,
+combining_diacritical_marks,    // 7
+diacriticals = combining_diacritical_marks,
+greek_and_coptic,    // 8
+greek = greek_and_coptic,
+cyrillic,               // 9
+cyrillic_supplement,    // 10
+cyrillic_sup = cyrillic_supplement,
+armenian,             // 11
+hebrew,               // 12
+arabic,               // 13
+syriac,               // 14
+arabic_supplement,    // 15
+arabic_sup = arabic_supplement,
+thaana,               // 16
+nko,                  // 17
+samaritan,            // 18
+mandaic,              // 19
+syriac_supplement,    // 20
+syriac_sup = syriac_supplement,
+arabic_extended_a,    // 21
+arabic_ext_a = arabic_extended_a,
+devanagari,     // 22
+bengali,        // 23
+gurmukhi,       // 24
+gujarati,       // 25
+oriya,          // 26
+tamil,          // 27
+telugu,         // 28
+kannada,        // 29
+malayalam,      // 30
+sinhala,        // 31
+thai,           // 32
+lao,            // 33
+tibetan,        // 34
+myanmar,        // 35
+georgian,       // 36
+hangul_jamo,    // 37
+jamo = hangul_jamo,
+ethiopic,               // 38
+ethiopic_supplement,    // 39
+ethiopic_sup = ethiopic_supplement,
+cherokee,                                 // 40
+unified_canadian_aboriginal_syllabics,    // 41
+ucas = unified_canadian_aboriginal_syllabics,
+ogham,                                             // 42
+runic,                                             // 43
+tagalog,                                           // 44
+hanunoo,                                           // 45
+buhid,                                             // 46
+tagbanwa,                                          // 47
+khmer,                                             // 48
+mongolian,                                         // 49
+unified_canadian_aboriginal_syllabics_extended,    // 50
+ucas_ext = unified_canadian_aboriginal_syllabics_extended,
+limbu,                                   // 51
+tai_le,                                  // 52
+new_tai_lue,                             // 53
+khmer_symbols,                           // 54
+buginese,                                // 55
+tai_tham,                                // 56
+combining_diacritical_marks_extended,    // 57
+diacriticals_ext = combining_diacritical_marks_extended,
+balinese,               // 58
+sundanese,              // 59
+batak,                  // 60
+lepcha,                 // 61
+ol_chiki,               // 62
+cyrillic_extended_c,    // 63
+cyrillic_ext_c = cyrillic_extended_c,
+georgian_extended,    // 64
+georgian_ext = georgian_extended,
+sundanese_supplement,    // 65
+sundanese_sup = sundanese_supplement,
+vedic_extensions,    // 66
+vedic_ext = vedic_extensions,
+phonetic_extensions,    // 67
+phonetic_ext = phonetic_extensions,
+phonetic_extensions_supplement,    // 68
+phonetic_ext_sup = phonetic_extensions_supplement,
+combining_diacritical_marks_supplement,    // 69
+diacriticals_sup = combining_diacritical_marks_supplement,
+latin_extended_additional,    // 70
+latin_ext_additional = latin_extended_additional,
+greek_extended,    // 71
+greek_ext = greek_extended,
+general_punctuation,    // 72
+punctuation = general_punctuation,
+superscripts_and_subscripts,    // 73
+super_and_sub = superscripts_and_subscripts,
+currency_symbols,                           // 74
+combining_diacritical_marks_for_symbols,    // 75
+diacriticals_for_symbols = combining_diacritical_marks_for_symbols,
+letterlike_symbols,        // 76
+number_forms,              // 77
+arrows,                    // 78
+mathematical_operators,    // 79
+math_operators = mathematical_operators,
+miscellaneous_technical,    // 80
+misc_technical = miscellaneous_technical,
+control_pictures,                 // 81
+optical_character_recognition,    // 82
+ocr = optical_character_recognition,
+enclosed_alphanumerics,    // 83
+enclosed_alphanum = enclosed_alphanumerics,
+box_drawing,              // 84
+block_elements,           // 85
+geometric_shapes,         // 86
+miscellaneous_symbols,    // 87
+misc_symbols = miscellaneous_symbols,
+dingbats,                                // 88
+miscellaneous_mathematical_symbols_a,    // 89
+misc_math_symbols_a = miscellaneous_mathematical_symbols_a,
+supplemental_arrows_a,    // 90
+sup_arrows_a = supplemental_arrows_a,
+braille_patterns,    // 91
+braille = braille_patterns,
+supplemental_arrows_b,    // 92
+sup_arrows_b = supplemental_arrows_b,
+miscellaneous_mathematical_symbols_b,    // 93
+misc_math_symbols_b = miscellaneous_mathematical_symbols_b,
+supplemental_mathematical_operators,    // 94
+sup_math_operators = supplemental_mathematical_operators,
+miscellaneous_symbols_and_arrows,    // 95
+misc_arrows = miscellaneous_symbols_and_arrows,
+glagolitic,          // 96
+latin_extended_c,    // 97
+latin_ext_c = latin_extended_c,
+coptic,                 // 98
+georgian_supplement,    // 99
+georgian_sup = georgian_supplement,
+tifinagh,             // 100
+ethiopic_extended,    // 101
+ethiopic_ext = ethiopic_extended,
+cyrillic_extended_a,    // 102
+cyrillic_ext_a = cyrillic_extended_a,
+supplemental_punctuation,    // 103
+sup_punctuation = supplemental_punctuation,
+cjk_radicals_supplement,    // 104
+cjk_radicals_sup = cjk_radicals_supplement,
+kangxi_radicals,    // 105
+kangxi = kangxi_radicals,
+ideographic_description_characters,    // 106
+idc = ideographic_description_characters,
+cjk_symbols_and_punctuation,    // 107
+cjk_symbols = cjk_symbols_and_punctuation,
+hiragana,                     // 108
+katakana,                     // 109
+bopomofo,                     // 110
+hangul_compatibility_jamo,    // 111
+compat_jamo = hangul_compatibility_jamo,
+kanbun,               // 112
+bopomofo_extended,    // 113
+bopomofo_ext = bopomofo_extended,
+cjk_strokes,                     // 114
+katakana_phonetic_extensions,    // 115
+katakana_ext = katakana_phonetic_extensions,
+enclosed_cjk_letters_and_months,    // 116
+enclosed_cjk = enclosed_cjk_letters_and_months,
+cjk_compatibility,    // 117
+cjk_compat = cjk_compatibility,
+cjk_unified_ideographs_extension_a,    // 118
+cjk_ext_a = cjk_unified_ideographs_extension_a,
+yijing_hexagram_symbols,    // 119
+yijing = yijing_hexagram_symbols,
+cjk_unified_ideographs,    // 120
+cjk = cjk_unified_ideographs,
+yi_syllables,           // 121
+yi_radicals,            // 122
+lisu,                   // 123
+vai,                    // 124
+cyrillic_extended_b,    // 125
+cyrillic_ext_b = cyrillic_extended_b,
+bamum,                    // 126
+modifier_tone_letters,    // 127
+latin_extended_d,         // 128
+latin_ext_d = latin_extended_d,
+syloti_nagri,                 // 129
+common_indic_number_forms,    // 130
+indic_number_forms = common_indic_number_forms,
+phags_pa,               // 131
+saurashtra,             // 132
+devanagari_extended,    // 133
+devanagari_ext = devanagari_extended,
+kayah_li,                  // 134
+rejang,                    // 135
+hangul_jamo_extended_a,    // 136
+jamo_ext_a = hangul_jamo_extended_a,
+javanese,              // 137
+myanmar_extended_b,    // 138
+myanmar_ext_b = myanmar_extended_b,
+cham,                  // 139
+myanmar_extended_a,    // 140
+myanmar_ext_a = myanmar_extended_a,
+tai_viet,                   // 141
+meetei_mayek_extensions,    // 142
+meetei_mayek_ext = meetei_mayek_extensions,
+ethiopic_extended_a,    // 143
+ethiopic_ext_a = ethiopic_extended_a,
+latin_extended_e,    // 144
+latin_ext_e = latin_extended_e,
+cherokee_supplement,    // 145
+cherokee_sup = cherokee_supplement,
+meetei_mayek,        // 146
+hangul_syllables,    // 147
+hangul = hangul_syllables,
+hangul_jamo_extended_b,    // 148
+jamo_ext_b = hangul_jamo_extended_b,
+high_surrogates,                // 149
+high_private_use_surrogates,    // 150
+high_pu_surrogates = high_private_use_surrogates,
+low_surrogates,      // 151
+private_use_area,    // 152
+pua = private_use_area,
+cjk_compatibility_ideographs,    // 153
+cjk_compat_ideographs = cjk_compatibility_ideographs,
+alphabetic_presentation_forms,    // 154
+alphabetic_pf = alphabetic_presentation_forms,
+arabic_presentation_forms_a,    // 155
+arabic_pf_a = arabic_presentation_forms_a,
+variation_selectors,    // 156
+vs = variation_selectors,
+vertical_forms,          // 157
+combining_half_marks,    // 158
+half_marks = combining_half_marks,
+cjk_compatibility_forms,    // 159
+cjk_compat_forms = cjk_compatibility_forms,
+small_form_variants,    // 160
+small_forms = small_form_variants,
+arabic_presentation_forms_b,    // 161
+arabic_pf_b = arabic_presentation_forms_b,
+halfwidth_and_fullwidth_forms,    // 162
+half_and_full_forms = halfwidth_and_fullwidth_forms,
+specials,                 // 163
+linear_b_syllabary,       // 164
+linear_b_ideograms,       // 165
+aegean_numbers,           // 166
+ancient_greek_numbers,    // 167
+ancient_symbols,          // 168
+phaistos_disc,            // 169
+phaistos = phaistos_disc,
+lycian,                    // 170
+carian,                    // 171
+coptic_epact_numbers,      // 172
+old_italic,                // 173
+gothic,                    // 174
+old_permic,                // 175
+ugaritic,                  // 176
+old_persian,               // 177
+deseret,                   // 178
+shavian,                   // 179
+osmanya,                   // 180
+osage,                     // 181
+elbasan,                   // 182
+caucasian_albanian,        // 183
+linear_a,                  // 184
+cypriot_syllabary,         // 185
+imperial_aramaic,          // 186
+palmyrene,                 // 187
+nabataean,                 // 188
+hatran,                    // 189
+phoenician,                // 190
+lydian,                    // 191
+meroitic_hieroglyphs,      // 192
+meroitic_cursive,          // 193
+kharoshthi,                // 194
+old_south_arabian,         // 195
+old_north_arabian,         // 196
+manichaean,                // 197
+avestan,                   // 198
+inscriptional_parthian,    // 199
+inscriptional_pahlavi,     // 200
+psalter_pahlavi,           // 201
+old_turkic,                // 202
+old_hungarian,             // 203
+hanifi_rohingya,           // 204
+rumi_numeral_symbols,      // 205
+rumi = rumi_numeral_symbols,
+yezidi,                     // 206
+old_sogdian,                // 207
+sogdian,                    // 208
+chorasmian,                 // 209
+elymaic,                    // 210
+brahmi,                     // 211
+kaithi,                     // 212
+sora_sompeng,               // 213
+chakma,                     // 214
+mahajani,                   // 215
+sharada,                    // 216
+sinhala_archaic_numbers,    // 217
+khojki,                     // 218
+multani,                    // 219
+khudawadi,                  // 220
+grantha,                    // 221
+newa,                       // 222
+tirhuta,                    // 223
+siddham,                    // 224
+modi,                       // 225
+mongolian_supplement,       // 226
+mongolian_sup = mongolian_supplement,
+takri,               // 227
+ahom,                // 228
+dogra,               // 229
+warang_citi,         // 230
+dives_akuru,         // 231
+nandinagari,         // 232
+zanabazar_square,    // 233
+soyombo,             // 234
+pau_cin_hau,         // 235
+bhaiksuki,           // 236
+marchen,             // 237
+masaram_gondi,       // 238
+gunjala_gondi,       // 239
+makasar,             // 240
+lisu_supplement,     // 241
+lisu_sup = lisu_supplement,
+tamil_supplement,    // 242
+tamil_sup = tamil_supplement,
+cuneiform,                            // 243
+cuneiform_numbers_and_punctuation,    // 244
+cuneiform_numbers = cuneiform_numbers_and_punctuation,
+early_dynastic_cuneiform,               // 245
+egyptian_hieroglyphs,                   // 246
+egyptian_hieroglyph_format_controls,    // 247
+anatolian_hieroglyphs,                  // 248
+bamum_supplement,                       // 249
+bamum_sup = bamum_supplement,
+mro,                                    // 250
+bassa_vah,                              // 251
+pahawh_hmong,                           // 252
+medefaidrin,                            // 253
+miao,                                   // 254
+ideographic_symbols_and_punctuation,    // 255
+ideographic_symbols = ideographic_symbols_and_punctuation,
+tangut,                 // 256
+tangut_components,      // 257
+khitan_small_script,    // 258
+tangut_supplement,      // 259
+tangut_sup = tangut_supplement,
+kana_supplement,    // 260
+kana_sup = kana_supplement,
+kana_extended_a,    // 261
+kana_ext_a = kana_extended_a,
+small_kana_extension,    // 262
+small_kana_ext = small_kana_extension,
+nushu,                        // 263
+duployan,                     // 264
+shorthand_format_controls,    // 265
+byzantine_musical_symbols,    // 266
+byzantine_music = byzantine_musical_symbols,
+musical_symbols,    // 267
+music = musical_symbols,
+ancient_greek_musical_notation,    // 268
+ancient_greek_music = ancient_greek_musical_notation,
+mayan_numerals,           // 269
+tai_xuan_jing_symbols,    // 270
+tai_xuan_jing = tai_xuan_jing_symbols,
+counting_rod_numerals,    // 271
+counting_rod = counting_rod_numerals,
+mathematical_alphanumeric_symbols,    // 272
+math_alphanum = mathematical_alphanumeric_symbols,
+sutton_signwriting,       // 273
+glagolitic_supplement,    // 274
+glagolitic_sup = glagolitic_supplement,
+nyiakeng_puachue_hmong,                    // 275
+wancho,                                    // 276
+mende_kikakui,                             // 277
+adlam,                                     // 278
+indic_siyaq_numbers,                       // 279
+ottoman_siyaq_numbers,                     // 280
+arabic_mathematical_alphabetic_symbols,    // 281
+arabic_math = arabic_mathematical_alphabetic_symbols,
+mahjong_tiles,    // 282
+mahjong = mahjong_tiles,
+domino_tiles,    // 283
+domino = domino_tiles,
+playing_cards,                       // 284
+enclosed_alphanumeric_supplement,    // 285
+enclosed_alphanum_sup = enclosed_alphanumeric_supplement,
+enclosed_ideographic_supplement,    // 286
+enclosed_ideographic_sup = enclosed_ideographic_supplement,
+miscellaneous_symbols_and_pictographs,    // 287
+misc_pictographs = miscellaneous_symbols_and_pictographs,
+emoticons,                    // 288
+ornamental_dingbats,          // 289
+transport_and_map_symbols,    // 290
+transport_and_map = transport_and_map_symbols,
+alchemical_symbols,    // 291
+alchemical = alchemical_symbols,
+geometric_shapes_extended,    // 292
+geometric_shapes_ext = geometric_shapes_extended,
+supplemental_arrows_c,    // 293
+sup_arrows_c = supplemental_arrows_c,
+supplemental_symbols_and_pictographs,    // 294
+sup_symbols_and_pictographs = supplemental_symbols_and_pictographs,
+chess_symbols,                         // 295
+symbols_and_pictographs_extended_a,    // 296
+symbols_and_pictographs_ext_a = symbols_and_pictographs_extended_a,
+symbols_for_legacy_computing,          // 297
+cjk_unified_ideographs_extension_b,    // 298
+cjk_ext_b = cjk_unified_ideographs_extension_b,
+cjk_unified_ideographs_extension_c,    // 299
+cjk_ext_c = cjk_unified_ideographs_extension_c,
+cjk_unified_ideographs_extension_d,    // 300
+cjk_ext_d = cjk_unified_ideographs_extension_d,
+cjk_unified_ideographs_extension_e,    // 301
+cjk_ext_e = cjk_unified_ideographs_extension_e,
+cjk_unified_ideographs_extension_f,    // 302
+cjk_ext_f = cjk_unified_ideographs_extension_f,
+cjk_compatibility_ideographs_supplement,    // 303
+cjk_compat_ideographs_sup = cjk_compatibility_ideographs_supplement,
+cjk_unified_ideographs_extension_g,    // 304
+cjk_ext_g = cjk_unified_ideographs_extension_g,
+tags,                              // 305
+variation_selectors_supplement,    // 306
+vs_sup = variation_selectors_supplement,
+supplementary_private_use_area_a,    // 307
+sup_pua_a = supplementary_private_use_area_a,
+supplementary_private_use_area_b,    // 308
+sup_pua_b = supplementary_private_use_area_b,
+__max
+};
+enum class script {
+adlm,    // 0
+adlam = adlm,
+aghb,    // 1
+caucasian_albanian = aghb,
+ahom,    // 2
+arab,    // 3
+arabic = arab,
+armi,    // 4
+imperial_aramaic = armi,
+armn,    // 5
+armenian = armn,
+avst,    // 6
+avestan = avst,
+bali,    // 7
+balinese = bali,
+bamu,    // 8
+bamum = bamu,
+bass,    // 9
+bassa_vah = bass,
+batk,    // 10
+batak = batk,
+beng,    // 11
+bengali = beng,
+bhks,    // 12
+bhaiksuki = bhks,
+bopo,    // 13
+bopomofo = bopo,
+brah,    // 14
+brahmi = brah,
+brai,    // 15
+braille = brai,
+bugi,    // 16
+buginese = bugi,
+buhd,    // 17
+buhid = buhd,
+cakm,    // 18
+chakma = cakm,
+cans,    // 19
+canadian_aboriginal = cans,
+cari,    // 20
+carian = cari,
+cham,    // 21
+cher,    // 22
+cherokee = cher,
+chrs,    // 23
+chorasmian = chrs,
+copt,    // 24
+coptic = copt,
+cprt,    // 25
+cypriot = cprt,
+cyrl,    // 26
+cyrillic = cyrl,
+deva,    // 27
+devanagari = deva,
+diak,    // 28
+dives_akuru = diak,
+dogr,    // 29
+dogra = dogr,
+dsrt,    // 30
+deseret = dsrt,
+dupl,    // 31
+duployan = dupl,
+egyp,    // 32
+egyptian_hieroglyphs = egyp,
+elba,    // 33
+elbasan = elba,
+elym,    // 34
+elymaic = elym,
+ethi,    // 35
+ethiopic = ethi,
+geor,    // 36
+georgian = geor,
+glag,    // 37
+glagolitic = glag,
+gong,    // 38
+gunjala_gondi = gong,
+gonm,    // 39
+masaram_gondi = gonm,
+goth,    // 40
+gothic = goth,
+gran,    // 41
+grantha = gran,
+grek,    // 42
+greek = grek,
+gujr,    // 43
+gujarati = gujr,
+guru,    // 44
+gurmukhi = guru,
+hang,    // 45
+hangul = hang,
+hani,    // 46
+han = hani,
+hano,    // 47
+hanunoo = hano,
+hatr,    // 48
+hatran = hatr,
+hebr,    // 49
+hebrew = hebr,
+hira,    // 50
+hiragana = hira,
+hluw,    // 51
+anatolian_hieroglyphs = hluw,
+hmng,    // 52
+pahawh_hmong = hmng,
+hmnp,    // 53
+nyiakeng_puachue_hmong = hmnp,
+hrkt,    // 54
+katakana_or_hiragana = hrkt,
+hung,    // 55
+old_hungarian = hung,
+ital,    // 56
+old_italic = ital,
+java,    // 57
+javanese = java,
+kali,    // 58
+kayah_li = kali,
+kana,    // 59
+katakana = kana,
+khar,    // 60
+kharoshthi = khar,
+khmr,    // 61
+khmer = khmr,
+khoj,    // 62
+khojki = khoj,
+kits,    // 63
+khitan_small_script = kits,
+knda,    // 64
+kannada = knda,
+kthi,    // 65
+kaithi = kthi,
+lana,    // 66
+tai_tham = lana,
+laoo,    // 67
+lao = laoo,
+latn,    // 68
+latin = latn,
+lepc,    // 69
+lepcha = lepc,
+limb,    // 70
+limbu = limb,
+lina,    // 71
+linear_a = lina,
+linb,    // 72
+linear_b = linb,
+lisu,    // 73
+lyci,    // 74
+lycian = lyci,
+lydi,    // 75
+lydian = lydi,
+mahj,    // 76
+mahajani = mahj,
+maka,    // 77
+makasar = maka,
+mand,    // 78
+mandaic = mand,
+mani,    // 79
+manichaean = mani,
+marc,    // 80
+marchen = marc,
+medf,    // 81
+medefaidrin = medf,
+mend,    // 82
+mende_kikakui = mend,
+merc,    // 83
+meroitic_cursive = merc,
+mero,    // 84
+meroitic_hieroglyphs = mero,
+mlym,    // 85
+malayalam = mlym,
+modi,    // 86
+mong,    // 87
+mongolian = mong,
+mroo,    // 88
+mro = mroo,
+mtei,    // 89
+meetei_mayek = mtei,
+mult,    // 90
+multani = mult,
+mymr,    // 91
+myanmar = mymr,
+nand,    // 92
+nandinagari = nand,
+narb,    // 93
+old_north_arabian = narb,
+nbat,    // 94
+nabataean = nbat,
+newa,    // 95
+nkoo,    // 96
+nko = nkoo,
+nshu,    // 97
+nushu = nshu,
+ogam,    // 98
+ogham = ogam,
+olck,    // 99
+ol_chiki = olck,
+orkh,    // 100
+old_turkic = orkh,
+orya,    // 101
+oriya = orya,
+osge,    // 102
+osage = osge,
+osma,    // 103
+osmanya = osma,
+palm,    // 104
+palmyrene = palm,
+pauc,    // 105
+pau_cin_hau = pauc,
+perm,    // 106
+old_permic = perm,
+phag,    // 107
+phags_pa = phag,
+phli,    // 108
+inscriptional_pahlavi = phli,
+phlp,    // 109
+psalter_pahlavi = phlp,
+phnx,    // 110
+phoenician = phnx,
+plrd,    // 111
+miao = plrd,
+prti,    // 112
+inscriptional_parthian = prti,
+rjng,    // 113
+rejang = rjng,
+rohg,    // 114
+hanifi_rohingya = rohg,
+runr,    // 115
+runic = runr,
+samr,    // 116
+samaritan = samr,
+sarb,    // 117
+old_south_arabian = sarb,
+saur,    // 118
+saurashtra = saur,
+sgnw,    // 119
+signwriting = sgnw,
+shaw,    // 120
+shavian = shaw,
+shrd,    // 121
+sharada = shrd,
+sidd,    // 122
+siddham = sidd,
+sind,    // 123
+khudawadi = sind,
+sinh,    // 124
+sinhala = sinh,
+sogd,    // 125
+sogdian = sogd,
+sogo,    // 126
+old_sogdian = sogo,
+sora,    // 127
+sora_sompeng = sora,
+soyo,    // 128
+soyombo = soyo,
+sund,    // 129
+sundanese = sund,
+sylo,    // 130
+syloti_nagri = sylo,
+syrc,    // 131
+syriac = syrc,
+tagb,    // 132
+tagbanwa = tagb,
+takr,    // 133
+takri = takr,
+tale,    // 134
+tai_le = tale,
+talu,    // 135
+new_tai_lue = talu,
+taml,    // 136
+tamil = taml,
+tang,    // 137
+tangut = tang,
+tavt,    // 138
+tai_viet = tavt,
+telu,    // 139
+telugu = telu,
+tfng,    // 140
+tifinagh = tfng,
+tglg,    // 141
+tagalog = tglg,
+thaa,    // 142
+thaana = thaa,
+thai,    // 143
+tibt,    // 144
+tibetan = tibt,
+tirh,    // 145
+tirhuta = tirh,
+ugar,    // 146
+ugaritic = ugar,
+vaii,    // 147
+vai = vaii,
+wara,    // 148
+warang_citi = wara,
+wcho,    // 149
+wancho = wcho,
+xpeo,    // 150
+old_persian = xpeo,
+xsux,    // 151
+cuneiform = xsux,
+yezi,    // 152
+yezidi = yezi,
+yiii,    // 153
+yi = yiii,
+zanb,    // 154
+zanabazar_square = zanb,
+zinh,    // 155
+inherited = zinh,
+zyyy,    // 156
+common = zyyy,
+zzzz,    // 157
+unknown = zzzz,
+max
+};
+namespace detail::tables {
+static constexpr const char* age_strings[] = {
+"unassigned", "1.1", "2.0", "2.1",  "3.0",  "3.1",  "3.2",  "4.0",
+"4.1",        "5.0", "5.1", "5.2",  "6.0",  "6.1",  "6.2",  "6.3",
+"7.0",        "8.0", "9.0", "10.0", "11.0", "12.0", "12.1", "13.0"};
+static constexpr compact_range age_data = {
+0x00000001, 0x0001F604, 0x0001FA01, 0x00021804, 0x00022006, 0x00022107, 0x00022204,
+0x00023407, 0x00023708, 0x00024209, 0x00025001, 0x0002A904, 0x0002AE07, 0x0002B001,
+0x0002DF04, 0x0002E001, 0x0002EA04, 0x0002EF07, 0x00030001, 0x00034604, 0x00034F06,
+0x00035007, 0x00035808, 0x00035D07, 0x00036001, 0x00036204, 0x00036306, 0x0003700A,
+0x00037401, 0x0003760A, 0x00037800, 0x00037A01, 0x00037B09, 0x00037E01, 0x00037F10,
+0x00038000, 0x00038401, 0x00038B00, 0x00038C01, 0x00038D00, 0x00038E01, 0x0003A200,
+0x0003A301, 0x0003CF0A, 0x0003D001, 0x0003D704, 0x0003D806, 0x0003DA01, 0x0003DB04,
+0x0003DC01, 0x0003DD04, 0x0003DE01, 0x0003DF04, 0x0003E001, 0x0003E104, 0x0003E201,
+0x0003F405, 0x0003F606, 0x0003F707, 0x0003FC08, 0x00040004, 0x00040101, 0x00040D04,
+0x00040E01, 0x00045004, 0x00045101, 0x00045D04, 0x00045E01, 0x0004870A, 0x00048804,
+0x00048A06, 0x00048C04, 0x00049001, 0x0004C506, 0x0004C701, 0x0004C906, 0x0004CB01,
+0x0004CD06, 0x0004CF09, 0x0004D001, 0x0004EC04, 0x0004EE01, 0x0004F608, 0x0004F801,
+0x0004FA09, 0x00050006, 0x00051009, 0x0005140A, 0x0005240B, 0x0005260C, 0x00052810,
+0x00053000, 0x00053101, 0x00055700, 0x00055901, 0x00056014, 0x00056101, 0x00058814,
+0x00058901, 0x00058A04, 0x00058B00, 0x00058D10, 0x00058F0D, 0x00059000, 0x00059102,
+0x0005A208, 0x0005A302, 0x0005B001, 0x0005BA09, 0x0005BB01, 0x0005C402, 0x0005C508,
+0x0005C800, 0x0005D001, 0x0005EB00, 0x0005EF14, 0x0005F001, 0x0005F500, 0x00060007,
+0x0006040D, 0x00060510, 0x0006060A, 0x00060B08, 0x00060C01, 0x00060D07, 0x0006160A,
+0x00061B01, 0x00061C0F, 0x00061D00, 0x00061E08, 0x00061F01, 0x0006200C, 0x00062101,
+0x00063B0A, 0x00064001, 0x00065304, 0x00065607, 0x00065908, 0x00065F0C, 0x00066001,
+0x00066E06, 0x00067001, 0x0006B804, 0x0006BA01, 0x0006BF04, 0x0006C001, 0x0006CF04,
+0x0006D001, 0x0006EE07, 0x0006F001, 0x0006FA04, 0x0006FF07, 0x00070004, 0x00070E00,
+0x00070F04, 0x00072D07, 0x00073004, 0x00074B00, 0x00074D07, 0x00075008, 0x00076E0A,
+0x00078004, 0x0007B106, 0x0007B200, 0x0007C009, 0x0007FB00, 0x0007FD14, 0x0008000B,
+0x00082E00, 0x0008300B, 0x00083F00, 0x0008400C, 0x00085C00, 0x00085E0C, 0x00085F00,
+0x00086013, 0x00086B00, 0x0008A00D, 0x0008A110, 0x0008A20D, 0x0008AD10, 0x0008B311,
+0x0008B500, 0x0008B612, 0x0008BE17, 0x0008C800, 0x0008D314, 0x0008D412, 0x0008E311,
+0x0008E40D, 0x0008FF10, 0x0009000B, 0x00090101, 0x00090407, 0x00090501, 0x00093A0C,
+0x00093C01, 0x00094E0B, 0x00094F0C, 0x00095001, 0x0009550B, 0x0009560C, 0x00095801,
+0x0009710A, 0x0009730C, 0x00097810, 0x0009790B, 0x00097B09, 0x00097D08, 0x00097E09,
+0x00098010, 0x00098101, 0x00098400, 0x00098501, 0x00098D00, 0x00098F01, 0x00099100,
+0x00099301, 0x0009A900, 0x0009AA01, 0x0009B100, 0x0009B201, 0x0009B300, 0x0009B601,
+0x0009BA00, 0x0009BC01, 0x0009BD07, 0x0009BE01, 0x0009C500, 0x0009C701, 0x0009C900,
+0x0009CB01, 0x0009CE08, 0x0009CF00, 0x0009D701, 0x0009D800, 0x0009DC01, 0x0009DE00,
+0x0009DF01, 0x0009E400, 0x0009E601, 0x0009FB0B, 0x0009FC13, 0x0009FE14, 0x0009FF00,
+0x000A0107, 0x000A0201, 0x000A0307, 0x000A0400, 0x000A0501, 0x000A0B00, 0x000A0F01,
+0x000A1100, 0x000A1301, 0x000A2900, 0x000A2A01, 0x000A3100, 0x000A3201, 0x000A3400,
+0x000A3501, 0x000A3700, 0x000A3801, 0x000A3A00, 0x000A3C01, 0x000A3D00, 0x000A3E01,
+0x000A4300, 0x000A4701, 0x000A4900, 0x000A4B01, 0x000A4E00, 0x000A510A, 0x000A5200,
+0x000A5901, 0x000A5D00, 0x000A5E01, 0x000A5F00, 0x000A6601, 0x000A750A, 0x000A7614,
+0x000A7700, 0x000A8101, 0x000A8400, 0x000A8501, 0x000A8C07, 0x000A8D01, 0x000A8E00,
+0x000A8F01, 0x000A9200, 0x000A9301, 0x000AA900, 0x000AAA01, 0x000AB100, 0x000AB201,
+0x000AB400, 0x000AB501, 0x000ABA00, 0x000ABC01, 0x000AC600, 0x000AC701, 0x000ACA00,
+0x000ACB01, 0x000ACE00, 0x000AD001, 0x000AD100, 0x000AE001, 0x000AE107, 0x000AE400,
+0x000AE601, 0x000AF00D, 0x000AF107, 0x000AF200, 0x000AF911, 0x000AFA13, 0x000B0000,
+0x000B0101, 0x000B0400, 0x000B0501, 0x000B0D00, 0x000B0F01, 0x000B1100, 0x000B1301,
+0x000B2900, 0x000B2A01, 0x000B3100, 0x000B3201, 0x000B3400, 0x000B3507, 0x000B3601,
+0x000B3A00, 0x000B3C01, 0x000B440A, 0x000B4500, 0x000B4701, 0x000B4900, 0x000B4B01,
+0x000B4E00, 0x000B5517, 0x000B5601, 0x000B5800, 0x000B5C01, 0x000B5E00, 0x000B5F01,
+0x000B620A, 0x000B6400, 0x000B6601, 0x000B7107, 0x000B720C, 0x000B7800, 0x000B8201,
+0x000B8400, 0x000B8501, 0x000B8B00, 0x000B8E01, 0x000B9100, 0x000B9201, 0x000B9600,
+0x000B9901, 0x000B9B00, 0x000B9C01, 0x000B9D00, 0x000B9E01, 0x000BA000, 0x000BA301,
+0x000BA500, 0x000BA801, 0x000BAB00, 0x000BAE01, 0x000BB608, 0x000BB701, 0x000BBA00,
+0x000BBE01, 0x000BC300, 0x000BC601, 0x000BC900, 0x000BCA01, 0x000BCE00, 0x000BD00A,
+0x000BD100, 0x000BD701, 0x000BD800, 0x000BE608, 0x000BE701, 0x000BF307, 0x000BFB00,
+0x000C0010, 0x000C0101, 0x000C0414, 0x000C0501, 0x000C0D00, 0x000C0E01, 0x000C1100,
+0x000C1201, 0x000C2900, 0x000C2A01, 0x000C3410, 0x000C3501, 0x000C3A00, 0x000C3D0A,
+0x000C3E01, 0x000C4500, 0x000C4601, 0x000C4900, 0x000C4A01, 0x000C4E00, 0x000C5501,
+0x000C5700, 0x000C580A, 0x000C5A11, 0x000C5B00, 0x000C6001, 0x000C620A, 0x000C6400,
+0x000C6601, 0x000C7000, 0x000C7715, 0x000C780A, 0x000C8012, 0x000C8110, 0x000C8201,
+0x000C8414, 0x000C8501, 0x000C8D00, 0x000C8E01, 0x000C9100, 0x000C9201, 0x000CA900,
+0x000CAA01, 0x000CB400, 0x000CB501, 0x000CBA00, 0x000CBC07, 0x000CBE01, 0x000CC500,
+0x000CC601, 0x000CC900, 0x000CCA01, 0x000CCE00, 0x000CD501, 0x000CD700, 0x000CDE01,
+0x000CDF00, 0x000CE001, 0x000CE209, 0x000CE400, 0x000CE601, 0x000CF000, 0x000CF109,
+0x000CF300, 0x000D0013, 0x000D0110, 0x000D0201, 0x000D0417, 0x000D0501, 0x000D0D00,
+0x000D0E01, 0x000D1100, 0x000D1201, 0x000D290C, 0x000D2A01, 0x000D3A0C, 0x000D3B13,
+0x000D3D0A, 0x000D3E01, 0x000D440A, 0x000D4500, 0x000D4601, 0x000D4900, 0x000D4A01,
+0x000D4E0C, 0x000D4F12, 0x000D5000, 0x000D5412, 0x000D5701, 0x000D5812, 0x000D5F11,
+0x000D6001, 0x000D620A, 0x000D6400, 0x000D6601, 0x000D700A, 0x000D7612, 0x000D790A,
+0x000D8000, 0x000D8117, 0x000D8204, 0x000D8400, 0x000D8504, 0x000D9700, 0x000D9A04,
+0x000DB200, 0x000DB304, 0x000DBC00, 0x000DBD04, 0x000DBE00, 0x000DC004, 0x000DC700,
+0x000DCA04, 0x000DCB00, 0x000DCF04, 0x000DD500, 0x000DD604, 0x000DD700, 0x000DD804,
+0x000DE000, 0x000DE610, 0x000DF000, 0x000DF204, 0x000DF500, 0x000E0101, 0x000E3B00,
+0x000E3F01, 0x000E5C00, 0x000E8101, 0x000E8300, 0x000E8401, 0x000E8500, 0x000E8615,
+0x000E8701, 0x000E8915, 0x000E8A01, 0x000E8B00, 0x000E8C15, 0x000E8D01, 0x000E8E15,
+0x000E9401, 0x000E9815, 0x000E9901, 0x000EA015, 0x000EA101, 0x000EA400, 0x000EA501,
+0x000EA600, 0x000EA701, 0x000EA815, 0x000EAA01, 0x000EAC15, 0x000EAD01, 0x000EBA15,
+0x000EBB01, 0x000EBE00, 0x000EC001, 0x000EC500, 0x000EC601, 0x000EC700, 0x000EC801,
+0x000ECE00, 0x000ED001, 0x000EDA00, 0x000EDC01, 0x000EDE0D, 0x000EE000, 0x000F0002,
+0x000F4800, 0x000F4902, 0x000F6A04, 0x000F6B0A, 0x000F6D00, 0x000F7102, 0x000F8C0C,
+0x000F9002, 0x000F9604, 0x000F9702, 0x000F9800, 0x000F9902, 0x000FAE04, 0x000FB102,
+0x000FB804, 0x000FB902, 0x000FBA04, 0x000FBD00, 0x000FBE04, 0x000FCD00, 0x000FCE0A,
+0x000FCF04, 0x000FD008, 0x000FD20A, 0x000FD50B, 0x000FD90C, 0x000FDB00, 0x00100004,
+0x0010220A, 0x00102304, 0x0010280A, 0x00102904, 0x00102B0A, 0x00102C04, 0x0010330A,
+0x00103604, 0x00103A0A, 0x00104004, 0x00105A0A, 0x00109A0B, 0x00109E0A, 0x0010A001,
+0x0010C600, 0x0010C70D, 0x0010C800, 0x0010CD0D, 0x0010CE00, 0x0010D001, 0x0010F706,
+0x0010F908, 0x0010FB01, 0x0010FC08, 0x0010FD0D, 0x00110001, 0x00115A0B, 0x00115F01,
+0x0011A30B, 0x0011A801, 0x0011FA0B, 0x00120004, 0x00120708, 0x00120804, 0x00124708,
+0x00124804, 0x00124900, 0x00124A04, 0x00124E00, 0x00125004, 0x00125700, 0x00125804,
+0x00125900, 0x00125A04, 0x00125E00, 0x00126004, 0x00128708, 0x00128804, 0x00128900,
+0x00128A04, 0x00128E00, 0x00129004, 0x0012AF08, 0x0012B004, 0x0012B100, 0x0012B204,
+0x0012B600, 0x0012B804, 0x0012BF00, 0x0012C004, 0x0012C100, 0x0012C204, 0x0012C600,
+0x0012C804, 0x0012CF08, 0x0012D004, 0x0012D700, 0x0012D804, 0x0012EF08, 0x0012F004,
+0x00130F08, 0x00131004, 0x00131100, 0x00131204, 0x00131600, 0x00131804, 0x00131F08,
+0x00132004, 0x00134708, 0x00134804, 0x00135B00, 0x00135D0C, 0x00135F08, 0x00136104,
+0x00137D00, 0x00138008, 0x00139A00, 0x0013A004, 0x0013F511, 0x0013F600, 0x0013F811,
+0x0013FE00, 0x0014000B, 0x00140104, 0x0016770B, 0x00168004, 0x00169D00, 0x0016A004,
+0x0016F110, 0x0016F900, 0x00170006, 0x00170D00, 0x00170E06, 0x00171500, 0x00172006,
+0x00173700, 0x00174006, 0x00175400, 0x00176006, 0x00176D00, 0x00176E06, 0x00177100,
+0x00177206, 0x00177400, 0x00178004, 0x0017DD07, 0x0017DE00, 0x0017E004, 0x0017EA00,
+0x0017F007, 0x0017FA00, 0x00180004, 0x00180F00, 0x00181004, 0x00181A00, 0x00182004,
+0x00187814, 0x00187900, 0x00188004, 0x0018AA0A, 0x0018AB00, 0x0018B00B, 0x0018F600,
+0x00190007, 0x00191D10, 0x00191F00, 0x00192007, 0x00192C00, 0x00193007, 0x00193C00,
+0x00194007, 0x00194100, 0x00194407, 0x00196E00, 0x00197007, 0x00197500, 0x00198008,
+0x0019AA0B, 0x0019AC00, 0x0019B008, 0x0019CA00, 0x0019D008, 0x0019DA0B, 0x0019DB00,
+0x0019DE08, 0x0019E007, 0x001A0008, 0x001A1C00, 0x001A1E08, 0x001A200B, 0x001A5F00,
+0x001A600B, 0x001A7D00, 0x001A7F0B, 0x001A8A00, 0x001A900B, 0x001A9A00, 0x001AA00B,
+0x001AAE00, 0x001AB010, 0x001ABF17, 0x001AC100, 0x001B0009, 0x001B4C00, 0x001B5009,
+0x001B7D00, 0x001B800A, 0x001BAB0D, 0x001BAE0A, 0x001BBA0D, 0x001BC00C, 0x001BF400,
+0x001BFC0C, 0x001C000A, 0x001C3800, 0x001C3B0A, 0x001C4A00, 0x001C4D0A, 0x001C8012,
+0x001C8900, 0x001C9014, 0x001CBB00, 0x001CBD14, 0x001CC00D, 0x001CC800, 0x001CD00B,
+0x001CF30D, 0x001CF713, 0x001CF810, 0x001CFA15, 0x001CFB00, 0x001D0007, 0x001D6C08,
+0x001DC409, 0x001DCB0A, 0x001DE710, 0x001DF613, 0x001DFA00, 0x001DFB12, 0x001DFC0C,
+0x001DFD0B, 0x001DFE09, 0x001E0001, 0x001E9B02, 0x001E9C0A, 0x001EA001, 0x001EFA0A,
+0x001F0001, 0x001F1600, 0x001F1801, 0x001F1E00, 0x001F2001, 0x001F4600, 0x001F4801,
+0x001F4E00, 0x001F5001, 0x001F5800, 0x001F5901, 0x001F5A00, 0x001F5B01, 0x001F5C00,
+0x001F5D01, 0x001F5E00, 0x001F5F01, 0x001F7E00, 0x001F8001, 0x001FB500, 0x001FB601,
+0x001FC500, 0x001FC601, 0x001FD400, 0x001FD601, 0x001FDC00, 0x001FDD01, 0x001FF000,
+0x001FF201, 0x001FF500, 0x001FF601, 0x001FFF00, 0x00200001, 0x00202F04, 0x00203001,
+0x00204706, 0x00204804, 0x00204E06, 0x00205307, 0x00205508, 0x00205706, 0x00205808,
+0x00205F06, 0x0020640A, 0x00206500, 0x0020660F, 0x00206A01, 0x00207106, 0x00207200,
+0x00207401, 0x00208F00, 0x00209008, 0x0020950C, 0x00209D00, 0x0020A001, 0x0020AB02,
+0x0020AC03, 0x0020AD04, 0x0020B006, 0x0020B208, 0x0020B60B, 0x0020B90C, 0x0020BA0E,
+0x0020BB10, 0x0020BE11, 0x0020BF13, 0x0020C000, 0x0020D001, 0x0020E204, 0x0020E406,
+0x0020EB08, 0x0020EC09, 0x0020F00A, 0x0020F100, 0x00210001, 0x00213904, 0x00213B07,
+0x00213C08, 0x00213D06, 0x00214C08, 0x00214D09, 0x00214F0A, 0x0021500B, 0x00215301,
+0x00218304, 0x00218409, 0x0021850A, 0x0021890B, 0x00218A11, 0x00218C00, 0x00219001,
+0x0021EB04, 0x0021F406, 0x00220001, 0x0022F206, 0x00230001, 0x00230104, 0x00230201,
+0x00237B04, 0x00237C06, 0x00237D04, 0x00239B06, 0x0023CF07, 0x0023D108, 0x0023DC09,
+0x0023E80B, 0x0023E90C, 0x0023F410, 0x0023FB12, 0x0023FF13, 0x00240001, 0x00242504,
+0x00242700, 0x00244001, 0x00244B00, 0x00246001, 0x0024EB06, 0x0024FF07, 0x00250001,
+0x00259606, 0x0025A001, 0x0025F004, 0x0025F806, 0x00260001, 0x00261407, 0x00261606,
+0x00261808, 0x00261904, 0x00261A01, 0x00267004, 0x00267206, 0x00267E08, 0x00268006,
+0x00268A07, 0x00269208, 0x00269D0A, 0x00269E0B, 0x0026A007, 0x0026A208, 0x0026B209,
+0x0026B30A, 0x0026BD0B, 0x0026C00A, 0x0026C40B, 0x0026CE0C, 0x0026CF0B, 0x0026E20C,
+0x0026E30B, 0x0026E40C, 0x0026E80B, 0x00270010, 0x00270101, 0x0027050C, 0x00270601,
+0x00270A0C, 0x00270C01, 0x0027280C, 0x00272901, 0x00274C0C, 0x00274D01, 0x00274E0C,
+0x00274F01, 0x0027530C, 0x00275601, 0x0027570B, 0x00275801, 0x00275F0C, 0x00276101,
+0x00276806, 0x00277601, 0x0027950C, 0x00279801, 0x0027B00C, 0x0027B101, 0x0027BF0C,
+0x0027C008, 0x0027C709, 0x0027CB0D, 0x0027CC0A, 0x0027CD0D, 0x0027CE0C, 0x0027D006,
+0x0027EC0A, 0x0027F006, 0x00280004, 0x00290006, 0x002B0007, 0x002B0E08, 0x002B1409,
+0x002B1B0A, 0x002B2009, 0x002B240A, 0x002B4D10, 0x002B500A, 0x002B550B, 0x002B5A10,
+0x002B7400, 0x002B7610, 0x002B9600, 0x002B9717, 0x002B9810, 0x002BBA14, 0x002BBD10,
+0x002BC915, 0x002BCA10, 0x002BD213, 0x002BD314, 0x002BEC11, 0x002BF014, 0x002BFF15,
+0x002C0008, 0x002C2F00, 0x002C3008, 0x002C5F00, 0x002C6009, 0x002C6D0A, 0x002C700B,
+0x002C710A, 0x002C7409, 0x002C780A, 0x002C7E0B, 0x002C8008, 0x002CEB0B, 0x002CF20D,
+0x002CF400, 0x002CF908, 0x002D2600, 0x002D270D, 0x002D2800, 0x002D2D0D, 0x002D2E00,
+0x002D3008, 0x002D660D, 0x002D6800, 0x002D6F08, 0x002D700C, 0x002D7100, 0x002D7F0C,
+0x002D8008, 0x002D9700, 0x002DA008, 0x002DA700, 0x002DA808, 0x002DAF00, 0x002DB008,
+0x002DB700, 0x002DB808, 0x002DBF00, 0x002DC008, 0x002DC700, 0x002DC808, 0x002DCF00,
+0x002DD008, 0x002DD700, 0x002DD808, 0x002DDF00, 0x002DE00A, 0x002E0008, 0x002E180A,
+0x002E1C08, 0x002E1E0A, 0x002E310B, 0x002E320D, 0x002E3C10, 0x002E4312, 0x002E4513,
+0x002E4A14, 0x002E4F15, 0x002E5017, 0x002E5300, 0x002E8004, 0x002E9A00, 0x002E9B04,
+0x002EF400, 0x002F0004, 0x002FD600, 0x002FF004, 0x002FFC00, 0x00300001, 0x00303804,
+0x00303B06, 0x00303E04, 0x00303F01, 0x00304000, 0x00304101, 0x00309506, 0x00309700,
+0x00309901, 0x00309F06, 0x0030A101, 0x0030FF06, 0x00310000, 0x00310501, 0x00312D0A,
+0x00312E13, 0x00312F14, 0x00313000, 0x00313101, 0x00318F00, 0x00319001, 0x0031A004,
+0x0031B80C, 0x0031BB17, 0x0031C008, 0x0031D00A, 0x0031E400, 0x0031F006, 0x00320001,
+0x00321D07, 0x00321F00, 0x00322001, 0x0032440B, 0x00325007, 0x00325106, 0x00326001,
+0x00327C07, 0x00327E08, 0x00327F01, 0x0032B106, 0x0032C001, 0x0032CC07, 0x0032D001,
+0x0032FF16, 0x00330001, 0x00337707, 0x00337B01, 0x0033DE07, 0x0033E001, 0x0033FF07,
+0x00340004, 0x004DB617, 0x004DC007, 0x004E0001, 0x009FA608, 0x009FBC0A, 0x009FC40B,
+0x009FCC0D, 0x009FCD11, 0x009FD613, 0x009FEB14, 0x009FF017, 0x009FFD00, 0x00A00004,
+0x00A48D00, 0x00A49004, 0x00A4A206, 0x00A4A404, 0x00A4B406, 0x00A4B504, 0x00A4C106,
+0x00A4C204, 0x00A4C506, 0x00A4C604, 0x00A4C700, 0x00A4D00B, 0x00A5000A, 0x00A62C00,
+0x00A6400A, 0x00A6600C, 0x00A6620A, 0x00A6740D, 0x00A67C0A, 0x00A69810, 0x00A69E11,
+0x00A69F0D, 0x00A6A00B, 0x00A6F800, 0x00A70008, 0x00A71709, 0x00A71B0A, 0x00A72009,
+0x00A7220A, 0x00A78D0C, 0x00A78F11, 0x00A7900C, 0x00A7920D, 0x00A79410, 0x00A7A00C,
+0x00A7AA0D, 0x00A7AB10, 0x00A7AE12, 0x00A7AF14, 0x00A7B010, 0x00A7B211, 0x00A7B814,
+0x00A7BA15, 0x00A7C000, 0x00A7C215, 0x00A7C717, 0x00A7CB00, 0x00A7F517, 0x00A7F710,
+0x00A7F80D, 0x00A7FA0C, 0x00A7FB0A, 0x00A80008, 0x00A82C17, 0x00A82D00, 0x00A8300B,
+0x00A83A00, 0x00A84009, 0x00A87800, 0x00A8800A, 0x00A8C512, 0x00A8C600, 0x00A8CE0A,
+0x00A8DA00, 0x00A8E00B, 0x00A8FC11, 0x00A8FE14, 0x00A9000A, 0x00A95400, 0x00A95F0A,
+0x00A9600B, 0x00A97D00, 0x00A9800B, 0x00A9CE00, 0x00A9CF0B, 0x00A9DA00, 0x00A9DE0B,
+0x00A9E010, 0x00A9FF00, 0x00AA000A, 0x00AA3700, 0x00AA400A, 0x00AA4E00, 0x00AA500A,
+0x00AA5A00, 0x00AA5C0A, 0x00AA600B, 0x00AA7C10, 0x00AA800B, 0x00AAC300, 0x00AADB0B,
+0x00AAE00D, 0x00AAF700, 0x00AB010C, 0x00AB0700, 0x00AB090C, 0x00AB0F00, 0x00AB110C,
+0x00AB1700, 0x00AB200C, 0x00AB2700, 0x00AB280C, 0x00AB2F00, 0x00AB3010, 0x00AB6011,
+0x00AB6410, 0x00AB6615, 0x00AB6817, 0x00AB6C00, 0x00AB7011, 0x00ABC00B, 0x00ABEE00,
+0x00ABF00B, 0x00ABFA00, 0x00AC0002, 0x00D7A400, 0x00D7B00B, 0x00D7C700, 0x00D7CB0B,
+0x00D7FC00, 0x00D80002, 0x00E00001, 0x00FA2E0D, 0x00FA3006, 0x00FA6B0B, 0x00FA6E00,
+0x00FA7008, 0x00FADA00, 0x00FB0001, 0x00FB0700, 0x00FB1301, 0x00FB1800, 0x00FB1D04,
+0x00FB1E01, 0x00FB3700, 0x00FB3801, 0x00FB3D00, 0x00FB3E01, 0x00FB3F00, 0x00FB4001,
+0x00FB4200, 0x00FB4301, 0x00FB4500, 0x00FB4601, 0x00FBB20C, 0x00FBC200, 0x00FBD301,
+0x00FD4000, 0x00FD5001, 0x00FD9000, 0x00FD9201, 0x00FDC800, 0x00FDF001, 0x00FDFC06,
+0x00FDFD07, 0x00FDFE00, 0x00FE0006, 0x00FE1008, 0x00FE1A00, 0x00FE2001, 0x00FE240A,
+0x00FE2710, 0x00FE2E11, 0x00FE3001, 0x00FE4506, 0x00FE4707, 0x00FE4901, 0x00FE5300,
+0x00FE5401, 0x00FE6700, 0x00FE6801, 0x00FE6C00, 0x00FE7001, 0x00FE7306, 0x00FE7401,
+0x00FE7500, 0x00FE7601, 0x00FEFD00, 0x00FEFF01, 0x00FF0000, 0x00FF0101, 0x00FF5F06,
+0x00FF6101, 0x00FFBF00, 0x00FFC201, 0x00FFC800, 0x00FFCA01, 0x00FFD000, 0x00FFD201,
+0x00FFD800, 0x00FFDA01, 0x00FFDD00, 0x00FFE001, 0x00FFE700, 0x00FFE801, 0x00FFEF00,
+0x00FFF904, 0x00FFFC03, 0x00FFFD01, 0x00FFFE00, 0x01000007, 0x01000C00, 0x01000D07,
+0x01002700, 0x01002807, 0x01003B00, 0x01003C07, 0x01003E00, 0x01003F07, 0x01004E00,
+0x01005007, 0x01005E00, 0x01008007, 0x0100FB00, 0x01010007, 0x01010300, 0x01010707,
+0x01013400, 0x01013707, 0x01014008, 0x01018B10, 0x01018D12, 0x01018F00, 0x0101900A,
+0x01019C17, 0x01019D00, 0x0101A010, 0x0101A100, 0x0101D00A, 0x0101FE00, 0x0102800A,
+0x01029D00, 0x0102A00A, 0x0102D100, 0x0102E010, 0x0102FC00, 0x01030005, 0x01031F10,
+0x01032005, 0x01032400, 0x01032D13, 0x01033005, 0x01034B00, 0x01035010, 0x01037B00,
+0x01038007, 0x01039E00, 0x01039F07, 0x0103A008, 0x0103C400, 0x0103C808, 0x0103D600,
+0x01040005, 0x01042607, 0x01042805, 0x01044E07, 0x01049E00, 0x0104A007, 0x0104AA00,
+0x0104B012, 0x0104D400, 0x0104D812, 0x0104FC00, 0x01050010, 0x01052800, 0x01053010,
+0x01056400, 0x01056F10, 0x01057000, 0x01060010, 0x01073700, 0x01074010, 0x01075600,
+0x01076010, 0x01076800, 0x01080007, 0x01080600, 0x01080807, 0x01080900, 0x01080A07,
+0x01083600, 0x01083707, 0x01083900, 0x01083C07, 0x01083D00, 0x01083F07, 0x0108400B,
+0x01085600, 0x0108570B, 0x01086010, 0x01089F00, 0x0108A710, 0x0108B000, 0x0108E011,
+0x0108F300, 0x0108F411, 0x0108F600, 0x0108FB11, 0x01090009, 0x01091A0B, 0x01091C00,
+0x01091F09, 0x0109200A, 0x01093A00, 0x01093F0A, 0x01094000, 0x0109800D, 0x0109B800,
+0x0109BC11, 0x0109BE0D, 0x0109C011, 0x0109D000, 0x0109D211, 0x010A0008, 0x010A0400,
+0x010A0508, 0x010A0700, 0x010A0C08, 0x010A1400, 0x010A1508, 0x010A1800, 0x010A1908,
+0x010A3414, 0x010A3600, 0x010A3808, 0x010A3B00, 0x010A3F08, 0x010A4814, 0x010A4900,
+0x010A5008, 0x010A5900, 0x010A600B, 0x010A8010, 0x010AA000, 0x010AC010, 0x010AE700,
+0x010AEB10, 0x010AF700, 0x010B000B, 0x010B3600, 0x010B390B, 0x010B5600, 0x010B580B,
+0x010B7300, 0x010B780B, 0x010B8010, 0x010B9200, 0x010B9910, 0x010B9D00, 0x010BA910,
+0x010BB000, 0x010C000B, 0x010C4900, 0x010C8011, 0x010CB300, 0x010CC011, 0x010CF300,
+0x010CFA11, 0x010D0014, 0x010D2800, 0x010D3014, 0x010D3A00, 0x010E600B, 0x010E7F00,
+0x010E8017, 0x010EAA00, 0x010EAB17, 0x010EAE00, 0x010EB017, 0x010EB200, 0x010F0014,
+0x010F2800, 0x010F3014, 0x010F5A00, 0x010FB017, 0x010FCC00, 0x010FE015, 0x010FF700,
+0x0110000C, 0x01104E00, 0x0110520C, 0x01107000, 0x01107F10, 0x0110800B, 0x0110C200,
+0x0110CD14, 0x0110CE00, 0x0110D00D, 0x0110E900, 0x0110F00D, 0x0110FA00, 0x0111000D,
+0x01113500, 0x0111360D, 0x01114414, 0x01114717, 0x01114800, 0x01115010, 0x01117700,
+0x0111800D, 0x0111C911, 0x0111CD10, 0x0111CE17, 0x0111D00D, 0x0111DA10, 0x0111DB11,
+0x0111E000, 0x0111E110, 0x0111F500, 0x01120010, 0x01121200, 0x01121310, 0x01123E12,
+0x01123F00, 0x01128011, 0x01128700, 0x01128811, 0x01128900, 0x01128A11, 0x01128E00,
+0x01128F11, 0x01129E00, 0x01129F11, 0x0112AA00, 0x0112B010, 0x0112EB00, 0x0112F010,
+0x0112FA00, 0x01130011, 0x01130110, 0x01130400, 0x01130510, 0x01130D00, 0x01130F10,
+0x01131100, 0x01131310, 0x01132900, 0x01132A10, 0x01133100, 0x01133210, 0x01133400,
+0x01133510, 0x01133A00, 0x01133B14, 0x01133C10, 0x01134500, 0x01134710, 0x01134900,
+0x01134B10, 0x01134E00, 0x01135011, 0x01135100, 0x01135710, 0x01135800, 0x01135D10,
+0x01136400, 0x01136610, 0x01136D00, 0x01137010, 0x01137500, 0x01140012, 0x01145A17,
+0x01145B12, 0x01145C00, 0x01145D12, 0x01145E14, 0x01145F15, 0x01146017, 0x01146200,
+0x01148010, 0x0114C800, 0x0114D010, 0x0114DA00, 0x01158010, 0x0115B600, 0x0115B810,
+0x0115CA11, 0x0115DE00, 0x01160010, 0x01164500, 0x01165010, 0x01165A00, 0x01166012,
+0x01166D00, 0x0116800D, 0x0116B815, 0x0116B900, 0x0116C00D, 0x0116CA00, 0x01170011,
+0x01171A14, 0x01171B00, 0x01171D11, 0x01172C00, 0x01173011, 0x01174000, 0x01180014,
+0x01183C00, 0x0118A010, 0x0118F300, 0x0118FF10, 0x01190017, 0x01190700, 0x01190917,
+0x01190A00, 0x01190C17, 0x01191400, 0x01191517, 0x01191700, 0x01191817, 0x01193600,
+0x01193717, 0x01193900, 0x01193B17, 0x01194700, 0x01195017, 0x01195A00, 0x0119A015,
+0x0119A800, 0x0119AA15, 0x0119D800, 0x0119DA15, 0x0119E500, 0x011A0013, 0x011A4800,
+0x011A5013, 0x011A8415, 0x011A8613, 0x011A9D14, 0x011A9E13, 0x011AA300, 0x011AC010,
+0x011AF900, 0x011C0012, 0x011C0900, 0x011C0A12, 0x011C3700, 0x011C3812, 0x011C4600,
+0x011C5012, 0x011C6D00, 0x011C7012, 0x011C9000, 0x011C9212, 0x011CA800, 0x011CA912,
+0x011CB700, 0x011D0013, 0x011D0700, 0x011D0813, 0x011D0A00, 0x011D0B13, 0x011D3700,
+0x011D3A13, 0x011D3B00, 0x011D3C13, 0x011D3E00, 0x011D3F13, 0x011D4800, 0x011D5013,
+0x011D5A00, 0x011D6014, 0x011D6600, 0x011D6714, 0x011D6900, 0x011D6A14, 0x011D8F00,
+0x011D9014, 0x011D9200, 0x011D9314, 0x011D9900, 0x011DA014, 0x011DAA00, 0x011EE014,
+0x011EF900, 0x011FB017, 0x011FB100, 0x011FC015, 0x011FF200, 0x011FFF15, 0x01200009,
+0x01236F10, 0x01239911, 0x01239A00, 0x01240009, 0x01246310, 0x01246F00, 0x01247009,
+0x01247410, 0x01247500, 0x01248011, 0x01254400, 0x0130000B, 0x01342F00, 0x01343015,
+0x01343900, 0x01440011, 0x01464700, 0x0168000C, 0x016A3900, 0x016A4010, 0x016A5F00,
+0x016A6010, 0x016A6A00, 0x016A6E10, 0x016A7000, 0x016AD010, 0x016AEE00, 0x016AF010,
+0x016AF600, 0x016B0010, 0x016B4600, 0x016B5010, 0x016B5A00, 0x016B5B10, 0x016B6200,
+0x016B6310, 0x016B7800, 0x016B7D10, 0x016B9000, 0x016E4014, 0x016E9B00, 0x016F000D,
+0x016F4515, 0x016F4B00, 0x016F4F15, 0x016F500D, 0x016F7F15, 0x016F8800, 0x016F8F0D,
+0x016FA000, 0x016FE012, 0x016FE113, 0x016FE215, 0x016FE417, 0x016FE500, 0x016FF017,
+0x016FF200, 0x01700012, 0x0187ED14, 0x0187F215, 0x0187F800, 0x01880012, 0x018AF317,
+0x018CD600, 0x018D0017, 0x018D0900, 0x01B0000C, 0x01B00213, 0x01B11F00, 0x01B15015,
+0x01B15300, 0x01B16415, 0x01B16800, 0x01B17013, 0x01B2FC00, 0x01BC0010, 0x01BC6B00,
+0x01BC7010, 0x01BC7D00, 0x01BC8010, 0x01BC8900, 0x01BC9010, 0x01BC9A00, 0x01BC9C10,
+0x01BCA400, 0x01D00005, 0x01D0F600, 0x01D10005, 0x01D12700, 0x01D1290A, 0x01D12A05,
+0x01D1DE11, 0x01D1E900, 0x01D20008, 0x01D24600, 0x01D2E014, 0x01D2F400, 0x01D30007,
+0x01D35700, 0x01D36009, 0x01D37214, 0x01D37900, 0x01D40005, 0x01D45500, 0x01D45605,
+0x01D49D00, 0x01D49E05, 0x01D4A000, 0x01D4A205, 0x01D4A300, 0x01D4A505, 0x01D4A700,
+0x01D4A905, 0x01D4AD00, 0x01D4AE05, 0x01D4BA00, 0x01D4BB05, 0x01D4BC00, 0x01D4BD05,
+0x01D4C107, 0x01D4C205, 0x01D4C400, 0x01D4C505, 0x01D50600, 0x01D50705, 0x01D50B00,
+0x01D50D05, 0x01D51500, 0x01D51605, 0x01D51D00, 0x01D51E05, 0x01D53A00, 0x01D53B05,
+0x01D53F00, 0x01D54005, 0x01D54500, 0x01D54605, 0x01D54700, 0x01D54A05, 0x01D55100,
+0x01D55205, 0x01D6A408, 0x01D6A600, 0x01D6A805, 0x01D7CA09, 0x01D7CC00, 0x01D7CE05,
+0x01D80011, 0x01DA8C00, 0x01DA9B11, 0x01DAA000, 0x01DAA111, 0x01DAB000, 0x01E00012,
+0x01E00700, 0x01E00812, 0x01E01900, 0x01E01B12, 0x01E02200, 0x01E02312, 0x01E02500,
+0x01E02612, 0x01E02B00, 0x01E10015, 0x01E12D00, 0x01E13015, 0x01E13E00, 0x01E14015,
+0x01E14A00, 0x01E14E15, 0x01E15000, 0x01E2C015, 0x01E2FA00, 0x01E2FF15, 0x01E30000,
+0x01E80010, 0x01E8C500, 0x01E8C710, 0x01E8D700, 0x01E90012, 0x01E94B15, 0x01E94C00,
+0x01E95012, 0x01E95A00, 0x01E95E12, 0x01E96000, 0x01EC7114, 0x01ECB500, 0x01ED0115,
+0x01ED3E00, 0x01EE000D, 0x01EE0400, 0x01EE050D, 0x01EE2000, 0x01EE210D, 0x01EE2300,
+0x01EE240D, 0x01EE2500, 0x01EE270D, 0x01EE2800, 0x01EE290D, 0x01EE3300, 0x01EE340D,
+0x01EE3800, 0x01EE390D, 0x01EE3A00, 0x01EE3B0D, 0x01EE3C00, 0x01EE420D, 0x01EE4300,
+0x01EE470D, 0x01EE4800, 0x01EE490D, 0x01EE4A00, 0x01EE4B0D, 0x01EE4C00, 0x01EE4D0D,
+0x01EE5000, 0x01EE510D, 0x01EE5300, 0x01EE540D, 0x01EE5500, 0x01EE570D, 0x01EE5800,
+0x01EE590D, 0x01EE5A00, 0x01EE5B0D, 0x01EE5C00, 0x01EE5D0D, 0x01EE5E00, 0x01EE5F0D,
+0x01EE6000, 0x01EE610D, 0x01EE6300, 0x01EE640D, 0x01EE6500, 0x01EE670D, 0x01EE6B00,
+0x01EE6C0D, 0x01EE7300, 0x01EE740D, 0x01EE7800, 0x01EE790D, 0x01EE7D00, 0x01EE7E0D,
+0x01EE7F00, 0x01EE800D, 0x01EE8A00, 0x01EE8B0D, 0x01EE9C00, 0x01EEA10D, 0x01EEA400,
+0x01EEA50D, 0x01EEAA00, 0x01EEAB0D, 0x01EEBC00, 0x01EEF00D, 0x01EEF200, 0x01F0000A,
+0x01F02C00, 0x01F0300A, 0x01F09400, 0x01F0A00C, 0x01F0AF00, 0x01F0B10C, 0x01F0BF10,
+0x01F0C000, 0x01F0C10C, 0x01F0D000, 0x01F0D10C, 0x01F0E010, 0x01F0F600, 0x01F1000B,
+0x01F10B10, 0x01F10D17, 0x01F1100B, 0x01F12F14, 0x01F1300C, 0x01F1310B, 0x01F1320C,
+0x01F13D0B, 0x01F13E0C, 0x01F13F0B, 0x01F1400C, 0x01F1420B, 0x01F1430C, 0x01F1460B,
+0x01F1470C, 0x01F14A0B, 0x01F14F0C, 0x01F1570B, 0x01F1580C, 0x01F15F0B, 0x01F1600C,
+0x01F16A0D, 0x01F16C15, 0x01F16D17, 0x01F1700C, 0x01F1790B, 0x01F17A0C, 0x01F17B0B,
+0x01F17D0C, 0x01F17F0B, 0x01F1800C, 0x01F18A0B, 0x01F18E0C, 0x01F1900B, 0x01F1910C,
+0x01F19B12, 0x01F1AD17, 0x01F1AE00, 0x01F1E60C, 0x01F2000B, 0x01F2010C, 0x01F20300,
+0x01F2100B, 0x01F2320C, 0x01F23B12, 0x01F23C00, 0x01F2400B, 0x01F24900, 0x01F2500C,
+0x01F25200, 0x01F26013, 0x01F26600, 0x01F3000C, 0x01F32110, 0x01F32D11, 0x01F3300C,
+0x01F33610, 0x01F3370C, 0x01F37D10, 0x01F37E11, 0x01F3800C, 0x01F39410, 0x01F3A00C,
+0x01F3C510, 0x01F3C60C, 0x01F3CB10, 0x01F3CF11, 0x01F3D410, 0x01F3E00C, 0x01F3F110,
+0x01F3F811, 0x01F4000C, 0x01F43F10, 0x01F4400C, 0x01F44110, 0x01F4420C, 0x01F4F810,
+0x01F4F90C, 0x01F4FD10, 0x01F4FF11, 0x01F5000C, 0x01F53E10, 0x01F5400D, 0x01F54410,
+0x01F54B11, 0x01F5500C, 0x01F56810, 0x01F57A12, 0x01F57B10, 0x01F5A412, 0x01F5A510,
+0x01F5FB0C, 0x01F6000D, 0x01F6010C, 0x01F6110D, 0x01F6120C, 0x01F6150D, 0x01F6160C,
+0x01F6170D, 0x01F6180C, 0x01F6190D, 0x01F61A0C, 0x01F61B0D, 0x01F61C0C, 0x01F61F0D,
+0x01F6200C, 0x01F6260D, 0x01F6280C, 0x01F62C0D, 0x01F62D0C, 0x01F62E0D, 0x01F6300C,
+0x01F6340D, 0x01F6350C, 0x01F64110, 0x01F64311, 0x01F6450C, 0x01F65010, 0x01F6800C,
+0x01F6C610, 0x01F6D011, 0x01F6D112, 0x01F6D313, 0x01F6D515, 0x01F6D617, 0x01F6D800,
+0x01F6E010, 0x01F6ED00, 0x01F6F010, 0x01F6F412, 0x01F6F713, 0x01F6F914, 0x01F6FA15,
+0x01F6FB17, 0x01F6FD00, 0x01F7000C, 0x01F77400, 0x01F78010, 0x01F7D514, 0x01F7D900,
+0x01F7E015, 0x01F7EC00, 0x01F80010, 0x01F80C00, 0x01F81010, 0x01F84800, 0x01F85010,
+0x01F85A00, 0x01F86010, 0x01F88800, 0x01F89010, 0x01F8AE00, 0x01F8B017, 0x01F8B200,
+0x01F90013, 0x01F90C17, 0x01F90D15, 0x01F91011, 0x01F91912, 0x01F91F13, 0x01F92012,
+0x01F92813, 0x01F93012, 0x01F93113, 0x01F93312, 0x01F93F15, 0x01F94012, 0x01F94C13,
+0x01F94D14, 0x01F95012, 0x01F95F13, 0x01F96C14, 0x01F97115, 0x01F97217, 0x01F97314,
+0x01F97717, 0x01F97900, 0x01F97A14, 0x01F97B15, 0x01F97C14, 0x01F98011, 0x01F98512,
+0x01F99213, 0x01F99814, 0x01F9A317, 0x01F9A515, 0x01F9AB17, 0x01F9AE15, 0x01F9B014,
+0x01F9BA15, 0x01F9C011, 0x01F9C114, 0x01F9C315, 0x01F9CB17, 0x01F9CC00, 0x01F9CD15,
+0x01F9D013, 0x01F9E714, 0x01FA0015, 0x01FA5400, 0x01FA6014, 0x01FA6E00, 0x01FA7015,
+0x01FA7417, 0x01FA7500, 0x01FA7815, 0x01FA7B00, 0x01FA8015, 0x01FA8317, 0x01FA8700,
+0x01FA9015, 0x01FA9617, 0x01FAA900, 0x01FAB017, 0x01FAB700, 0x01FAC017, 0x01FAC300,
+0x01FAD017, 0x01FAD700, 0x01FB0017, 0x01FB9300, 0x01FB9417, 0x01FBCB00, 0x01FBF017,
+0x01FBFA00, 0x02000005, 0x02A6D717, 0x02A6DE00, 0x02A7000B, 0x02B73500, 0x02B7400C,
+0x02B81E00, 0x02B82011, 0x02CEA200, 0x02CEB013, 0x02EBE100, 0x02F80005, 0x02FA1E00,
+0x03000017, 0x03134B00, 0x0E000105, 0x0E000200, 0x0E002005, 0x0E008000, 0x0E010007,
+0x0E01F000, 0x0F000002, 0x0FFFFE00, 0x10000002, 0x10FFFE00, 0xFFFFFFFF};
+static constexpr string_with_idx categories_names[] = {
+string_with_idx{"c", 0},
+string_with_idx{"cased_letter", 7},
+string_with_idx{"cc", 1},
+string_with_idx{"cf", 2},
+string_with_idx{"close_punctuation", 24},
+string_with_idx{"cn", 3},
+string_with_idx{"co", 4},
+string_with_idx{"connector_punctuation", 22},
+string_with_idx{"control", 1},
+string_with_idx{"cs", 5},
+string_with_idx{"currency_symbol", 30},
+string_with_idx{"dash_punctuation", 23},
+string_with_idx{"decimal_number", 18},
+string_with_idx{"enclosing_mark", 15},
+string_with_idx{"final_punctuation", 25},
+string_with_idx{"format", 2},
+string_with_idx{"initial_punctuation", 26},
+string_with_idx{"l", 6},
+string_with_idx{"lc", 7},
+string_with_idx{"letter", 6},
+string_with_idx{"letter_number", 19},
+string_with_idx{"line_separator", 35},
+string_with_idx{"ll", 8},
+string_with_idx{"lm", 9},
+string_with_idx{"lo", 10},
+string_with_idx{"lowercase_letter", 8},
+string_with_idx{"lt", 11},
+string_with_idx{"lu", 12},
+string_with_idx{"m", 13},
+string_with_idx{"mark", 13},
+string_with_idx{"math_symbol", 32},
+string_with_idx{"mc", 14},
+string_with_idx{"me", 15},
+string_with_idx{"mn", 16},
+string_with_idx{"modifier_letter", 9},
+string_with_idx{"modifier_symbol", 31},
+string_with_idx{"n", 17},
+string_with_idx{"nd", 18},
+string_with_idx{"nl", 19},
+string_with_idx{"no", 20},
+string_with_idx{"nonspacing_mark", 16},
+string_with_idx{"number", 17},
+string_with_idx{"open_punctuation", 28},
+string_with_idx{"other", 0},
+string_with_idx{"other_letter", 10},
+string_with_idx{"other_number", 20},
+string_with_idx{"other_punctuation", 27},
+string_with_idx{"other_symbol", 33},
+string_with_idx{"p", 21},
+string_with_idx{"paragraph_separator", 36},
+string_with_idx{"pc", 22},
+string_with_idx{"pd", 23},
+string_with_idx{"pe", 24},
+string_with_idx{"pf", 25},
+string_with_idx{"pi", 26},
+string_with_idx{"po", 27},
+string_with_idx{"private_use", 4},
+string_with_idx{"ps", 28},
+string_with_idx{"punctuation", 21},
+string_with_idx{"s", 29},
+string_with_idx{"sc", 30},
+string_with_idx{"separator", 34},
+string_with_idx{"sk", 31},
+string_with_idx{"sm", 32},
+string_with_idx{"so", 33},
+string_with_idx{"space_separator", 37},
+string_with_idx{"spacing_mark", 14},
+string_with_idx{"surrogate", 5},
+string_with_idx{"symbol", 29},
+string_with_idx{"titlecase_letter", 11},
+string_with_idx{"unassigned", 3},
+string_with_idx{"uppercase_letter", 12},
+string_with_idx{"z", 34},
+string_with_idx{"zl", 35},
+string_with_idx{"zp", 36},
+string_with_idx{"zs", 37}};
+static constexpr range_array cat_cc = {0x00000001, 0x00002000, 0x00007F01, 0x0000A000};
+static constexpr range_array cat_zs = {0x00000000, 0x00002001, 0x00002100, 0x0000A001,
+0x0000A100, 0x00168001, 0x00168100, 0x00200001,
+0x00200B00, 0x00202F01, 0x00203000, 0x00205F01,
+0x00206000, 0x00300001, 0x00300100};
+static constexpr bool_trie<32, 991, 1, 0, 51, 255, 1, 0, 482, 4, 26, 40> cat_po{
+{0x8c00d4ee00000000, 0x0000000010000001, 0x80c0008200000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x4000000000000000, 0x0000000000000080, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x00000000fc000000, 0x0000000000000200, 0x0018000000000049,
+0x00000000c8003600, 0x00003c0000000000, 0x0000000000000000, 0x0000000000100000,
+0x0000000000003fff, 0x0000000000000000, 0x0000000000000000, 0x0380000000000000},
+{1,  2,  2,  2,  3,  2,  4,  2,  5,  2, 6,  2,  2, 2, 2,  2,  7,  8, 2,  2,  2,  2, 9,  2,
+10, 2,  2,  11, 2,  12, 13, 2,  14, 2, 15, 2,  2, 2, 2,  2,  2,  2, 2,  2,  16, 2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  17, 2, 18, 19, 2, 2, 20, 21, 2,  2, 2,  2,  22, 2, 2,  23,
+2,  24, 2,  2,  25, 2,  26, 27, 28, 2, 29, 2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  30,
+31, 2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  32, 2,  6,  2,  2,  33, 34, 2, 2,  2,  2, 2, 2,  35, 2,  2, 15, 2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  28, 2,  2,  2,  2,  36, 37, 2, 38, 2,  2, 2, 2,  2,  39, 2, 40, 41, 42, 2, 43, 2,
+44, 2,  45, 2,  2,  2,  46, 2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2,  2,  2, 2, 2,  2,  2,  2, 2,  2,  2,  2, 2,  47,
+48, 2,  2,  49, 50, 2,  2},
+{0x7fff000000000000, 0x0000000040000000, 0x0000000000000000, 0x0001003000000000,
+0x2000000000000000, 0x0040000000000000, 0x0001000000000000, 0x0080000000000000,
+0x0000000000000010, 0x0010000000000000, 0x000000000c008000, 0x000000000017fff0,
+0x0000000000000020, 0x00000000061f0000, 0x000000000000fc00, 0x0800000000000000,
+0x000001ff00000000, 0x0000400000000000, 0x0000380000000000, 0x0060000000000000,
+0x0000000007700000, 0x00000000000007bf, 0x0000000000000030, 0x00000000c0000000,
+0x00003f7f00000000, 0x00000001fc000000, 0xf000000000000000, 0xf800000000000000,
+0xc000000000000000, 0x00000000000800ff, 0x79ff00ff00c00000, 0x000000007febff8e,
+0xde00000000000000, 0xf3ff7c00cb7fc9c3, 0x000000000004fffa, 0x200000000000000e,
+0x000000000000e000, 0x4008000000000000, 0x00fc000000000000, 0x00f0000000000000,
+0x170000000000c000, 0x0000c00000000000, 0x0000000080000000, 0x00000000c0003ffe,
+0x00000000f0000000, 0x00030000c0000000, 0x0000080000000000, 0x00010000027f0000,
+0x00000d0380f71e60, 0x100000018c00d4ee, 0x0000003200000000},
+{1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 5, 3, 6, 7, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
+{1,  0,  0, 0,  0,  0,  0, 0,  0,  0,  2,  3,  0, 0, 0,  0,  0,  4,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  5, 0,  0,  6,  0,  0,  0, 0, 7,  0,  8,  9,  0, 10, 0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  11, 0, 0, 0,  12, 13, 14, 0, 15, 0,  16, 17,
+0,  18, 0, 0,  0,  0,  0, 0,  19, 0,  20, 0,  0, 0, 21, 0,  22, 0,  0, 23, 0,  0,  0,
+24, 0,  0, 0,  0,  25, 0, 26, 27, 28, 29, 0,  0, 0, 0,  0,  0,  30, 0, 0,  0,  0,  0,
+0,  0,  0, 0,  31, 0,  0, 0,  27, 0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 32, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  33, 0, 34, 35, 36, 0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  37, 0, 0, 0,  0,  26, 0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  2,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  38, 0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0,
+0,  0,  0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0,  39},
+{0x0000000000000000, 0x0000000000000007, 0x0000000080000000, 0x0000000000010000,
+0x0000800000000000, 0x0000000000800000, 0x8000000080000000, 0x8000000001ff0000,
+0x007f000000000000, 0xfe00000000000000, 0x000000001e000000, 0x0000000003e00000,
+0x0000000000003f80, 0xd800000000000000, 0x0000000000000003, 0x003000000000000f,
+0x00000000e80021e0, 0x3f00000000000000, 0x0000020000000000, 0x000000002c00f800,
+0x0000000000000040, 0x0000000000fffffe, 0x00001fff0000000e, 0x7000000000000000,
+0x0800000000000000, 0x0000000000000070, 0x0000000400000000, 0x8000000000000000,
+0x000000000000007f, 0x00000007dc000000, 0x000300000000003e, 0x0180000000000000,
+0x001f000000000000, 0x0000c00000000000, 0x0020000000000000, 0x0f80000000000000,
+0x0000000000000010, 0x0000000007800000, 0x0000000000000f80, 0x00000000c0000000}};
+static constexpr range_array cat_sc = {
+0x00000000, 0x00002401, 0x00002500, 0x0000A201, 0x0000A600, 0x00058F01, 0x00059000,
+0x00060B01, 0x00060C00, 0x0007FE01, 0x00080000, 0x0009F201, 0x0009F400, 0x0009FB01,
+0x0009FC00, 0x000AF101, 0x000AF200, 0x000BF901, 0x000BFA00, 0x000E3F01, 0x000E4000,
+0x0017DB01, 0x0017DC00, 0x0020A001, 0x0020C000, 0x00A83801, 0x00A83900, 0x00FDFC01,
+0x00FDFD00, 0x00FE6901, 0x00FE6A00, 0x00FF0401, 0x00FF0500, 0x00FFE001, 0x00FFE200,
+0x00FFE501, 0x00FFE700, 0x011FDD01, 0x011FE100, 0x01E2FF01, 0x01E30000, 0x01ECB001,
+0x01ECB100};
+static constexpr bool_trie<32, 962, 28, 2, 19, 0, 0, 0, 0, 0, 0, 0> cat_ps{
+{0x0000010000000000, 0x0800000008000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 2, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 3,  4,  5, 0, 0, 0, 0, 0, 0,  0, 0, 0,  6, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  7,  0, 8, 0, 0, 0, 0, 0,  0, 9, 10, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 11, 12, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0,
+14, 0, 0, 0, 15, 16, 0, 0, 17, 18},
+{0x0000000000000000, 0x1400000000000000, 0x0000000008000000, 0x0000000044000000,
+0x2000000000000020, 0x0000000000002000, 0x0000020000000500, 0x0015550000000000,
+0x0000554000000020, 0x0000000000aaaaa8, 0x1000000005000000, 0x0000015400000000,
+0x0000000000000004, 0x0000000025515500, 0x8000000000000000, 0xaaa0000000800000,
+0x000000002a00008a, 0x0800000000000100, 0x0000000488000000},
+{},
+{},
+{}};
+static constexpr bool_trie<32, 962, 28, 2, 17, 0, 0, 0, 0, 0, 0, 0> cat_pe{
+{0x0000020000000000, 0x2000000020000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 2, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  3, 4, 0, 0, 0, 0, 0, 0,  0, 0, 0, 5, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  6, 0, 7, 0, 0, 0, 0, 0,  0, 8, 9, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 11, 0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+0,  0, 0, 0, 0,  0,  0, 0, 0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,
+12, 0, 0, 0, 13, 14, 0, 0, 15, 16},
+{0x0000000000000000, 0x2800000000000000, 0x0000000010000000, 0x4000000000000040,
+0x0000000000004000, 0x0000040000000a00, 0x002aaa0000000000, 0x0000aa8000000040,
+0x0000000001555550, 0x200000000a000000, 0x000002a800000000, 0x00000000caa2aa00,
+0x4000000000000000, 0x5540000001000000, 0x0000000054000115, 0x2000000000000200,
+0x0000000920000000},
+{},
+{},
+{}};
+static constexpr bool_trie<32, 895, 97, 0, 25, 2, 13, 241, 97, 91, 4, 7> cat_sm{
+{0x7000080000000000, 0x5000000000000000, 0x0002100000000000, 0x0080000000800000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0040000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x00000000000001c0, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 2, 0, 3, 4,  5, 6, 7,  7,  7, 7, 8,  9,  10, 11, 0, 0, 0,  0,  0, 0, 12, 13, 0, 14, 0,
+0, 0, 0, 0, 15, 0, 0, 0,  0,  7, 7, 16, 17, 7,  7,  7, 7, 18, 19, 0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,  0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 0,  0, 0, 0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 20, 0,  0, 0, 0,  0,  0, 0,  0,
+0, 0, 0, 0, 21, 0, 0, 22, 23, 0, 24},
+{0x0000000000000000, 0x1c00000000040010, 0x0000000000001c00, 0x0000000001000000,
+0x000000000000081f, 0x000040490c1f0000, 0xfff000000014c000, 0xffffffffffffffff,
+0x0000000300000000, 0x1000000000000000, 0x000ffffff8000000, 0x00000003f0000000,
+0x0080000000000000, 0xff00000000000002, 0x0000800000000000, 0xffff003fffffff9f,
+0xfffffffffe000007, 0xcffffffff0ffffff, 0xffff000000000000, 0x0000000000001f9f,
+0x0000020000000000, 0x0000007400000000, 0x0000000070000800, 0x0000000050000000,
+0x00001e0400000000},
+{1, 2},
+{1, 2, 3, 4, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6},
+{0x0000000000000000, 0x0800000008000002, 0x0020000000200000, 0x0000800000008000,
+0x0000020000000200, 0x0000000000000008, 0x0003000000000000}};
+static constexpr flat_array<25> cat_pd{{0x002D, 0x058A, 0x05BE, 0x1400, 0x1806, 0x2010, 0x2011,
+0x2012, 0x2013, 0x2014, 0x2015, 0x2E17, 0x2E1A, 0x2E3A,
+0x2E3B, 0x2E40, 0x301C, 0x3030, 0x30A0, 0xFE31, 0xFE32,
+0xFE58, 0xFE63, 0xFF0D, 0x10EAD}};
+static constexpr bool_trie<32, 984, 5, 3, 9, 255, 1, 0, 414, 18, 16, 8> cat_nd{
+{0x03ff000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x000003ff00000000, 0x0000000000000000, 0x03ff000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x00000000000003ff},
+{1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 2, 0, 2, 3, 0, 0, 0, 0, 4, 2,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 2,
+0, 0, 0, 0, 5, 0, 2, 0, 0, 6, 0, 0, 2, 7, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 0, 0, 8, 0, 2, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+{0x0000000000000000, 0x0000ffc000000000, 0x0000000003ff0000, 0x000003ff00000000,
+0x00000000000003ff, 0x000000000000ffc0, 0x0000000003ff03ff, 0x03ff000000000000,
+0x03ff000003ff0000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 4, 5, 6, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 2, 4, 0, 0, 5, 0, 0, 0, 2, 0, 0,
+0, 0, 0, 5, 0, 5, 0, 0, 0, 0, 0, 5, 0, 6, 2, 0, 0, 0, 0, 0, 0, 1, 0, 5, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 5, 0, 0, 0, 5, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 1, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+{0x0000000000000000, 0x000003ff00000000, 0x03ff000000000000, 0x0000ffc000000000,
+0xffc0000000000000, 0x0000000003ff0000, 0x00000000000003ff, 0xffffffffffffc000}};
+static constexpr bool_trie<32, 955, 34, 3, 24, 255, 1, 0, 341, 16, 27, 24> cat_lu{
+{0x0000000000000000, 0x0000000007fffffe, 0x0000000000000000, 0x000000007f7fffff,
+0xaa55555555555555, 0x2b555555555554aa, 0x11aed2d5b1dbced6, 0x55d255554aaaa490,
+0x6c05555555555555, 0x000000000000557a, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x8045000000000000, 0x00000ffbfffed740, 0xe6905555551c8000,
+0x0000ffffffffffff, 0x5555555500000000, 0x5555555555555401, 0x5555555555552aab,
+0xfffe555555555555, 0x00000000007fffff, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 2,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 1, 3, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 4, 0, 0, 0,
+0, 0,  5,  5, 6,  5,  7,  8,  9, 10, 0, 0, 0, 0, 11, 12, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  14, 15, 5, 16, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 17, 18, 0, 19, 20, 21, 22, 0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0,  0,  0, 0,  0,  0,  0,  0, 0,  0, 0, 0, 0, 0,  0,  0,  0, 23},
+{0x0000000000000000, 0xffffffff00000000, 0x00000000000020bf, 0x003fffffffffffff,
+0xe7ffffffffff0000, 0x5555555555555555, 0x5555555540155555, 0xff00ff003f00ff00,
+0x0000ff00aa003f00, 0x0f00000000000000, 0x0f001f000f000f00, 0xc00f3d503e273884,
+0x0000000000000020, 0x0000000000000008, 0x00007fffffffffff, 0xc025ea9d00000000,
+0x0004280555555555, 0x0000155555555555, 0x0000000005555555, 0x5554555400000000,
+0x6a00555555555555, 0x555f7d5555452855, 0x00200000000002f4, 0x07fffffe00000000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 4, 5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1, 0, 2, 3, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 4,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 5, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 6, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  23},
+{0x0000000000000000, 0x000000ffffffffff, 0xffff000000000000, 0x00000000000fffff,
+0x0007ffffffffffff, 0xffffffff00000000, 0x00000000ffffffff, 0xfff0000003ffffff,
+0xffffff0000003fff, 0x003fde64d0000003, 0x000003ffffff0000, 0x7b0000001fdfe7b0,
+0xfffff0000001fc5f, 0x03ffffff0000003f, 0x00003ffffff00000, 0xf0000003ffffff00,
+0xffff0000003fffff, 0xffffff00000003ff, 0x07fffffc00000001, 0x001ffffff0000000,
+0x00007fffffc00000, 0x000001ffffff0000, 0x0000000000000400, 0x00000003ffffffff}};
+static constexpr bool_trie<32, 898, 94, 0, 12, 1, 15, 240, 1, 79, 48, 2> cat_sk{
+{0x0000000000000000, 0x0000000140000000, 0x0110810000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0xffffafe0fffc003c,
+0x0000000000000000, 0x0020000000000000, 0x0000000000000030, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 4, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 10, 0, 11},
+{0x0000000000000000, 0xa000000000000000, 0x6000e000e000e003, 0x0000000018000000,
+0x00000003007fffff, 0x0000000000000600, 0x00000c0008000000, 0xfffc000000000000,
+0x0000000000000003, 0x4000000000000000, 0x0000000000000001, 0x0000000800000000},
+{1},
+{1},
+{0x0000000000000000, 0xf800000000000000}};
+static constexpr flat_array<10> cat_pc{
+{0x005F, 0x203F, 0x2040, 0x2054, 0xFE33, 0xFE34, 0xFE4D, 0xFE4E, 0xFE4F, 0xFF3F}};
+static constexpr bool_trie<32, 955, 35, 2, 30, 255, 1, 0, 342, 16, 26, 25> cat_ll{
+{0x0000000000000000, 0x07fffffe00000000, 0x0020000000000000, 0xff7fffff80000000,
+0x55aaaaaaaaaaaaaa, 0xd4aaaaaaaaaaab55, 0xe6512d2a4e243129, 0xaa29aaaab5555240,
+0x93faaaaaaaaaaaaa, 0xffffffffffffaa85, 0x0000ffffffefffff, 0x0000000000000000,
+0x0000000000000000, 0x388a000000000000, 0xfffff00000010000, 0x192faaaaaae37fff,
+0xffff000000000000, 0xaaaaaaaaffffffff, 0xaaaaaaaaaaaaa802, 0xaaaaaaaaaaaad554,
+0x0000aaaaaaaaaaaa, 0xffffffff00000000, 0x00000000000001ff, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 2,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 3, 0,  4,
+5, 6,  0,  7,  7,  8, 7, 9, 10, 11, 12, 0, 0,  0,  0, 13, 14, 15, 0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  16, 17, 7, 18, 19, 0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 20, 21,
+0, 22, 23, 24, 25, 0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  16, 26, 27, 0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  0,  0, 0, 0, 0,  0,  0,  0, 28, 0,  0, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0,
+0, 0,  0,  0,  29},
+{0x0000000000000000, 0xe7ffffffffff0000, 0x3f00000000000000, 0x00000000000001ff,
+0x00000fffffffffff, 0xfefff80000000000, 0x0000000007ffffff, 0xaaaaaaaaaaaaaaaa,
+0xaaaaaaaabfeaaaaa, 0x00ff00ff003f00ff, 0x3fff00ff00ff003f, 0x40df00ff00ff00ff,
+0x00dc00ff00cf00dc, 0x321080000008c400, 0x00000000000043c0, 0x0000000000000010,
+0xffff000000000000, 0x0fda15627fffffff, 0x0008501aaaaaaaaa, 0x000020bfffffffff,
+0x00002aaaaaaaaaaa, 0x000000000aaaaaaa, 0xaaabaaa800000000, 0x95feaaaaaaaaaaaa,
+0xaaa082aaaaba50aa, 0x0440000000000508, 0xffff01ff07ffffff, 0xffffffffffffffff,
+0x0000000000f8007f, 0x0000000007fffffe},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 4, 5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1, 2, 0, 3, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  4,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 5, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 6, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  23, 24},
+{0x0000000000000000, 0xffffff0000000000, 0x000000000000ffff, 0x0fffffffff000000,
+0x0007ffffffffffff, 0x00000000ffffffff, 0xffffffff00000000, 0x000ffffffc000000,
+0x000000ffffdfc000, 0xebc000000ffffffc, 0xfffffc000000ffef, 0x00ffffffc000000f,
+0x00000ffffffc0000, 0xfc000000ffffffc0, 0xffffc000000fffff, 0x0ffffffc000000ff,
+0x0000ffffffc00000, 0x0000003ffffffc00, 0xf0000003f7fffffc, 0xffc000000fdfffff,
+0xffff0000003f7fff, 0xfffffc000000fdff, 0x0000000000000bf7, 0xfffffffc00000000,
+0x000000000000000f}};
+static constexpr bool_trie<32, 985, 7, 0, 53, 255, 1, 0, 492, 4, 16, 48> cat_so{
+{0x0000000000000000, 0x0000000000000000, 0x0001424000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000004, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000006000, 0x0000000000000000,
+0x000000000000c000, 0x0000000000000000, 0x0000000000000000, 0x6000020040000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0040000000000000},
+{1,  0,  0,  0,  0,  0,  2,  0,  3,  0,  4,  0,  0,  0,  5,  0,  0,  0,  0,  0,  0,  6,  0,
+7,  8,  0,  0,  9,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  10, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  11, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  12, 0,  13, 0,  0,  0,  0,
+0,  14, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  15, 16, 17, 18, 0,  0,  0,  0,  19, 20, 21, 22, 23, 24, 25, 26, 27, 27, 28, 29, 27, 30,
+27, 27, 27, 31, 32, 0,  27, 27, 27, 27, 0,  0,  0,  0,  0,  0,  0,  0,  33, 34, 35, 27, 0,
+0,  0,  36, 0,  0,  0,  0,  0,  37, 38, 39, 27, 27, 27, 40, 41, 0,  0,  0,  0,  0,  42, 43,
+44, 45, 46, 27, 27, 27, 27, 27, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  27, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  47, 48,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  49, 0,  0,  0,  0,  0,  0,  0,  0,  50, 0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  51, 0,  0,  0,  0,  0,  0,  0,  52},
+{0x0000000000000000, 0x0400000000000000, 0x0001000000000000, 0x05f8000000000000,
+0x8000000000000000, 0x0200000000008000, 0x01500000fce8000e, 0xc000000000000000,
+0x0000000001e0dfbf, 0x00000000c0000000, 0x0000000003ff0000, 0x0000200000000000,
+0x0000000000000001, 0xffffffffc0000000, 0x1ff007fe00000000, 0x0c0042afc0d0037b,
+0x000000000000b400, 0xffffbfb6f3e00c00, 0x000fffffffeb3fff, 0xfffff9fcfffff0ff,
+0xefffffffffffffff, 0xfff0000007ffffff, 0xfffffffc0fffffff, 0x0000007fffffffff,
+0x00000000000007ff, 0xfffffffff0000000, 0x000003ffffffffff, 0xffffffffffffffff,
+0xff7fffffffffffff, 0x00fffffffffffffd, 0xffff7fffffffffff, 0x000000ffffffffff,
+0xfffffffffff00000, 0x0000ffffffffffff, 0xffcfffffffffe060, 0xffffffffffbfffff,
+0x000007e000000000, 0x0000000000030000, 0xfffffffffbffffff, 0x000fffffffffffff,
+0x0fff0000003fffff, 0xc0c00001000c0010, 0x00000000ffc30000, 0x0000000fffffffff,
+0xfffffc007fffffff, 0xffffffff000100ff, 0x0001fffffffffc00, 0xffffffffffff0000,
+0x000000000000007f, 0x02c00f0000000000, 0x0380000000000000, 0x2000000000000000,
+0x3000611000000000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 4, 2, 5, 6, 7, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1,  2,  3,  4,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  5,  0,  0,  0,  0,  0,  0,  0,  0,  0,  6,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  7,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  8,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  9,  10, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  11, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  12, 12, 12, 13, 14, 15,
+16, 17, 12, 18, 0,  0,  12, 19, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  12, 12, 12, 12, 12, 12, 12, 12, 20, 21, 22, 0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  23, 0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  24, 0,  25, 0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  26, 12, 27, 28, 29, 12, 30, 31, 32, 33, 0,  0,  12, 12, 12, 34,
+12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 35, 12, 36, 12, 37, 38, 39, 40, 0,  12, 41, 12,
+42, 12, 43, 44, 45, 12, 12, 46, 47},
+{0x0000000000000000, 0xff80000000000000, 0xfe00000000000000, 0x000000011fff73ff,
+0x1fffffffffff0000, 0x0180000000000000, 0x0000000000000100, 0x8000000000000000,
+0x0003fffe1fe00000, 0xf000000000000000, 0x0000000000000020, 0x0000000010000000,
+0xffffffffffffffff, 0x003fffffffffffff, 0xfffffe7fffffffff, 0x00001c1fffffffff,
+0xffffc3fffffff018, 0x000001ffffffffff, 0x0000000000000023, 0x00000000007fffff,
+0x0780000000000000, 0xffdfe00000000000, 0x000000000000006f, 0x0000000000008000,
+0x0000100000000000, 0x0000400000000000, 0xffff0fffffffffff, 0xfffe7fff000fffff,
+0x003ffffffffefffe, 0xffffffffffffe000, 0x00003fffffffffff, 0xffffffc000000000,
+0x0fffffffffff0007, 0x0000003f000301ff, 0x07ffffffffffffff, 0x1fff1fff00ffffff,
+0x000fffffffffffff, 0x00000fff01ffffff, 0xffffffffffff0fff, 0xffffffff03ff00ff,
+0x00033fffffff00ff, 0xfdffffffffffffff, 0xffffffffffffefff, 0x071f3fff000fffff,
+0x007f01ffffff007f, 0x00000000007f0007, 0xfffffffffff7ffff, 0x00000000000007ff}};
+static constexpr bool_trie<32, 991, 1, 0, 114, 255, 1, 0, 1087, 1, 0, 95> cat_lo{
+{0x0000000000000000, 0x0000000000000000, 0x0400040000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0800000000000000, 0x000000000000000f,
+0x0000000000000000, 0x0000000000000000, 0x0000000000100000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x000787ffffff0000,
+0xffffffff00000000, 0xfffec000000007fe, 0xffffffffffffffff, 0x9c00c000002fffff,
+0x0000fffffffd0000, 0xffffffffffffe000, 0x0002003fffffffff, 0x000007fffffffc00},
+{1,   2,   3,   4,  5,   6,  7,  8,  9,   10,  11,  12,  13,  14,  15,  16, 17, 18, 19, 20,
+21,  22,  23,  24, 25,  26, 27, 28, 29,  30,  31,  32,  33,  34,  31,  35, 35, 35, 35, 35,
+36,  37,  38,  39, 40,  41, 31, 42, 35,  35,  35,  35,  35,  35,  35,  35, 43, 44, 45, 46,
+47,  48,  49,  50, 51,  52, 53, 54, 55,  56,  57,  58,  59,  31,  31,  60, 61, 62, 63, 64,
+65,  31,  66,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 67,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 68, 69,  70,  71,  31,  31,  31,  31,  31, 31, 31, 31, 72,
+42,  73,  74,  75, 35,  76, 68, 31, 31,  31,  31,  31,  31,  31,  31,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 31, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 77, 78, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  79, 80, 35, 35,  35,  35,  81,  82,  50,  63,  31, 31, 83, 84, 85,
+48,  86,  87,  88, 89,  90, 91, 92, 93,  94,  95,  96,  31,  31,  97,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  35,  35,  35,  35,  35,  35,  35, 35, 35, 35, 35,
+35,  35,  35,  35, 35,  35, 35, 35, 35,  98,  99,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  31, 31,  31, 31, 31, 31,  31,  31,  31,  31,  31,  31,  31, 31, 31, 31, 31,
+31,  31,  31,  35, 35,  35, 35, 35, 100, 35,  101, 102, 103, 104, 105, 35, 35, 35, 35, 106,
+107, 108, 109, 31, 110, 35, 77, 31, 111, 112, 113},
+{0x00000000003fffff, 0x000007ff01ffffff, 0xffdfffff00000000, 0x00000000000000ff,
+0x23fffffffffffff0, 0xfffc0003ff010000, 0x23c5fdfffff99fe1, 0x10030003b0004000,
+0x036dfdfffff987e0, 0x001c00005e000000, 0x23edfdfffffbbfe0, 0x0200000300010000,
+0x23edfdfffff99fe0, 0x00020003b0000000, 0x03ffc718d63dc7e8, 0x0000000000010000,
+0x23fffdfffffddfe0, 0x0000000307000000, 0x23effdfffffddfe1, 0x0006000340000000,
+0x27fffffffffddff0, 0xfc00000380704000, 0x2ffbfffffc7fffe0, 0x000000000000007f,
+0x000dfffffffffffe, 0x000000000000003f, 0x200dffaffffff7d6, 0x00000000f000001f,
+0x0000000000000001, 0x00001ffffffffeff, 0x0000000000001f00, 0x0000000000000000,
+0x800007ffffffffff, 0xffe1c0623c3f0000, 0x0000000000004003, 0xffffffffffffffff,
+0xffffffff3d7f3dff, 0x7f3dffffffff3dff, 0xffffffffff7fff3d, 0xffffffffff3dffff,
+0x0000000007ffffff, 0x000000000000ffff, 0xfffffffffffffffe, 0xffff9fffffffffff,
+0xffffffff07fffffe, 0x01fe07ffffffffff, 0x0003ffff0003dfff, 0x0001dfff0003ffff,
+0x000fffffffffffff, 0x0000000010000000, 0xffffffff00000000, 0x01fffffffffffff7,
+0xffff05ffffffff9f, 0x003fffffffffffff, 0x000000007fffffff, 0x001f3fffffff0000,
+0xffff0fffffffffff, 0x00000000000003ff, 0xffffffff007fffff, 0x00000000001fffff,
+0x000fffffffffffe0, 0x0000000000000fe0, 0xfc00c001fffffff8, 0x0000003fffffffff,
+0x0000000fffffffff, 0x00fffffffc00e000, 0x046fde0000000000, 0x01e0000000000000,
+0xffff000000000000, 0x000000ffffffffff, 0x7f7f7f7f007fffff, 0x000000007f7f7f7f,
+0x1000000000000040, 0xfffffffe807fffff, 0x87ffffffffffffff, 0xfffeffffffffffe0,
+0xffffffff00007fff, 0x1fffffffffffffff, 0xffffffffffdfffff, 0x0000000000001fff,
+0x00ffffffffff0000, 0x00000c00ffff0fff, 0x0000400000000000, 0x0000000000008000,
+0xf880000000000000, 0x00000007fffff7bb, 0x000ffffffffffffc, 0x68fc000000000000,
+0xffff003ffffffc00, 0x1fffffff0000007f, 0x0007fffffffffff0, 0x7c00ff9f00000000,
+0x000001ffffffffff, 0xc47effff00000ff7, 0x3e62ffffffffffff, 0x000407ff18000005,
+0x00007f7f007e7e7e, 0x00000007ffffffff, 0xffff000fffffffff, 0x0ffffffffffff87f,
+0xffff3fffffffffff, 0x0000000003ffffff, 0x5f7ffdffa0000000, 0xffffffffffffffdb,
+0x0003ffffffffffff, 0xfffffffffff80000, 0x3fffffffffffffff, 0xffffffffffff0000,
+0xfffffffffffcffff, 0x0fff0000000000ff, 0xffdf000000000000, 0xfffeffc000000000,
+0x7fffffff3fffffff, 0x000000001cfcfcfc},
+{1,  2,  3, 4,  5,  6, 7,  8, 5, 5, 9, 5, 5, 10, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 11,
+12, 13, 7, 14, 15, 7, 16, 5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5, 5,  5, 5, 5, 5, 5, 5, 5},
+{1,  2,  3,  4,  4,  4,  4,  4,  4,  5,  6,  7,  8,  9,  10, 4,  11, 12, 4,  13, 14, 4,  4,
+2,  2,  2,  2,  15, 16, 4,  4,  17, 18, 19, 20, 21, 4,  22, 4,  23, 24, 25, 26, 27, 28, 29,
+4,  2,  30, 4,  4,  14, 4,  4,  4,  4,  4,  31, 4,  32, 33, 34, 35, 36, 4,  37, 38, 39, 40,
+41, 42, 43, 4,  44, 19, 45, 46, 4,  4,  47, 48, 49, 50, 4,  4,  51, 52, 49, 53, 54, 4,  55,
+4,  4,  4,  56, 4,  4,  57, 58, 59, 60, 61, 62, 63, 64, 65, 4,  4,  4,  4,  66, 67, 68, 4,
+69, 70, 71, 4,  4,  4,  4,  72, 4,  4,  73, 4,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  74, 4,  4,  4,  2,  2,  2,  75, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+51, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  76, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  2,  2,  2,  2,  2,  2,  2,  2,  65, 19, 4,  77, 49, 78, 68, 4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  2,  79, 4,  4,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  80, 2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  81, 30, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+2,  2,  2,  2,  19, 82, 2,  2,  2,  2,  2,  83, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  2,  84, 85, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  86,
+87, 4,  4,  4,  4,  4,  56, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  2,  2,  2,  88, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  89, 90, 91, 4,  4,  4,  4,  4,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  12, 2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  47, 2,  2,  2,  9,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  92, 2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  93,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  2,  2,  2,  2,  2,  2,  2,  2,  12, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  94, 4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,  4,
+4,  4,  4,  4,  4,  4},
+{0xb7ffff7fffffefff, 0x000000003fff3fff, 0xffffffffffffffff, 0x07ffffffffffffff,
+0x0000000000000000, 0xffffffff1fffffff, 0x000000000001ffff, 0xffffe000ffffffff,
+0x003fffffffff03fd, 0xffffffff3fffffff, 0x000000000000ff0f, 0xffffffffffff0000,
+0x000000003fffffff, 0xffff00ffffffffff, 0x0000000fffffffff, 0x007fffffffffffff,
+0x000000ff003fffff, 0x91bffffffffffd3f, 0x007fffff003fffff, 0x000000007fffffff,
+0x0037ffff00000000, 0x03ffffff003fffff, 0xc0ffffffffffffff, 0x003ffffffeef0001,
+0x1fffffff00000000, 0x000000001fffffff, 0x0000001ffffffeff, 0x003fffffffffffff,
+0x0007ffff003fffff, 0x000000000003ffff, 0x00000000000001ff, 0x000303ffffffffff,
+0xffff00801fffffff, 0x000000000000003f, 0xffff000000000000, 0x007fffff0000001f,
+0x00fffffffffffff8, 0x0000fffffffffff8, 0x000001ffffff0000, 0x0000007ffffffff8,
+0x0047ffffffff0090, 0x0007fffffffffff8, 0x000000001400001e, 0x00000ffffffbffff,
+0xffff01ffbfffbd7f, 0x23edfdfffff99fe0, 0x00000003e0010000, 0x001fffffffffffff,
+0x0000000380000780, 0x0000ffffffffffff, 0x00000000000000b0, 0x00007fffffffffff,
+0x000000000f000000, 0x0000000000000010, 0x010007ffffffffff, 0x0000000007ffffff,
+0x00000fffffffffff, 0x8000000000000000, 0x8000ffffff6ff27f, 0x0000000000000002,
+0xfffffcff00000000, 0x0000000a0001ffff, 0x0407fffffffff801, 0xfffffffff0010000,
+0x00000000200003ff, 0x01ffffffffffffff, 0x00007ffffffffdff, 0xfffc000000000001,
+0x000000000000ffff, 0x0001fffffffffb7f, 0xfffffdbf00000040, 0x00000000010003ff,
+0x0007ffff00000000, 0x0001000000000000, 0x0000000003ffffff, 0x000000000000000f,
+0x000000000000007f, 0x00003fffffff0000, 0xe0fffff800000000, 0x00000000000107ff,
+0x00ffffffffffffff, 0x00000000003fffff, 0xffff00f000070000, 0x0fffffffffffffff,
+0x1fff07ffffffffff, 0x0000000003ff01ff, 0x00001fffffffffff, 0x0000000000004000,
+0x000000000000001f, 0x0af7fe96ffffffef, 0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff,
+0xffff0003ffffffff, 0x00000001ffffffff, 0x00000000000007ff}};
+static constexpr flat_array<12> cat_pi{{0x00AB, 0x2018, 0x201B, 0x201C, 0x201F, 0x2039, 0x2E02,
+0x2E04, 0x2E09, 0x2E0C, 0x2E1C, 0x2E20}};
+static constexpr range_array cat_cf = {
+0x00000000, 0x0000AD01, 0x0000AE00, 0x00060001, 0x00060600, 0x00061C01, 0x00061D00,
+0x0006DD01, 0x0006DE00, 0x00070F01, 0x00071000, 0x0008E201, 0x0008E300, 0x00180E01,
+0x00180F00, 0x00200B01, 0x00201000, 0x00202A01, 0x00202F00, 0x00206001, 0x00206500,
+0x00206601, 0x00207000, 0x00FEFF01, 0x00FF0000, 0x00FFF901, 0x00FFFC00, 0x0110BD01,
+0x0110BE00, 0x0110CD01, 0x0110CE00, 0x01343001, 0x01343900, 0x01BCA001, 0x01BCA400,
+0x01D17301, 0x01D17B00, 0x0E000101, 0x0E000200, 0x0E002001, 0x0E008000};
+static constexpr bool_trie<32, 634, 7, 351, 25, 255, 1, 0, 385, 4, 59, 37> cat_no{
+{0x0000000000000000, 0x0000000000000000, 0x720c000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1,  0,  0, 0, 0, 0,  2, 0, 3, 0,  4,  0,  0, 0,  5,  0, 0, 0, 0, 0, 0, 6, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  7,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  8, 0, 0, 0,  0, 0, 0, 0,  9,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 10, 11, 0,  0, 12, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  14, 15,
+16, 0,  0, 0, 0, 0,  0, 0, 0, 0,  17, 18, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 19, 0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0,  21,
+22, 23, 0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0, 0, 0, 0,  0, 0, 0, 0,  0,  0,  24},
+{0x0000000000000000, 0x03f0000000000000, 0x00fc000000000000, 0x0007000000000000,
+0x7f00000000000000, 0x01ff00007f000000, 0x000ffc0000000000, 0x1ffffe0000000000,
+0x03ff000000000000, 0x0000000004000000, 0x03f1000000000000, 0x00000000000003ff,
+0x00000000ffff0000, 0x0000000000000200, 0xffffffff00000000, 0x000000000fffffff,
+0xfffffc0000000000, 0xffc0000000000000, 0x00000000000fffff, 0x2000000000000000,
+0x00000000003c0000, 0x000003ff00000000, 0x00000000fffeff00, 0xfffe0000000003ff,
+0x003f000000000000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 4, 5, 6, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1,  2,  3, 0,  0, 0, 0,  4,  5,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 6,  7,  8,  9, 0,  10, 11, 0,  12, 13, 14, 0,  15, 16, 0,  0,  0,
+0,  17, 0, 0,  0, 0, 0,  18, 0,  0, 19, 20, 0,  21, 0,  22, 0,  0,  0,  0,  0,  23, 0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  24, 0,  0,  0,
+0,  0,  0, 25, 0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  26, 0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  27, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 28, 0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  29, 0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 30, 0,  31, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0, 0,  0, 0, 32, 0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  33, 34, 0,
+35, 0,  0, 0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  36},
+{0x0000000000000000, 0x000fffffffffff80, 0x01e0000000000000, 0x0000000000000c00,
+0x0ffffffe00000000, 0x0000000f00000000, 0xfe000000ff000000, 0x0000ff8000000000,
+0xf800000000000000, 0x000000000fc00000, 0x3000000000000000, 0xfffffffffffcffff,
+0x60000000000001ff, 0x00000000e0000000, 0x0000f80000000000, 0xff000000ff000000,
+0x0000fe0000000000, 0xfc00000000000000, 0x7fffffff00000000, 0x0000007fe0000000,
+0x00000000001e0000, 0x0000000000000fe0, 0x0000003ffffc0000, 0x001ffffe00000000,
+0x0c00000000000000, 0x0007fc0000000000, 0x00001ffffc000000, 0x00000000001fffff,
+0x00000003f8000000, 0x00000000007fffff, 0x000fffff00000000, 0x01ffffff00000000,
+0x000000000000ff80, 0xfffe000000000000, 0x001eefffffffffff, 0x3fffbffffffffffe,
+0x0000000000001fff}};
+static constexpr flat_array<10> cat_pf{
+{0x00BB, 0x2019, 0x201D, 0x203A, 0x2E03, 0x2E05, 0x2E0A, 0x2E0D, 0x2E1D, 0x2E21}};
+static constexpr range_array cat_lt = {
+0x00000000, 0x0001C501, 0x0001C600, 0x0001C801, 0x0001C900, 0x0001CB01, 0x0001CC00,
+0x0001F201, 0x0001F300, 0x001F8801, 0x001F9000, 0x001F9801, 0x001FA000, 0x001FA801,
+0x001FB000, 0x001FBC01, 0x001FBD00, 0x001FCC01, 0x001FCD00, 0x001FFC01, 0x001FFD00};
+static constexpr bool_trie<32, 991, 1, 0, 31, 9, 6, 241, 57, 109, 26, 6> cat_lm{
+{0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0xffff000000000000, 0x0000501f0003ffc3,
+0x0000000000000000, 0x0410000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000002000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000001, 0x0000000000000000, 0x0000006000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0430000000000000},
+{1,  1,  1,  1, 2, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  3,
+1,  3,  1,  1, 1, 1, 1,  1,  1,  4,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  5,  1,  6,  1, 1, 1, 1, 1,  1, 1,  1,  7,  1,
+1,  1,  1,  1, 1, 8, 1,  1,  9,  10, 11, 1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 12, 13, 1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 14, 1, 1,  1,  15, 1,
+1,  15, 1,  1, 1, 1, 1,  1,  1,  16, 1,  17, 18, 1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  19, 1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  8,  1,  1, 1, 1, 20, 21, 22, 1,  23, 24, 25, 26, 1,  1, 1, 1, 1, 1,  1, 27, 1,  24, 1,
+28, 1,  29, 1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1, 1,  1, 1,  1,  1,  1,
+1,  1,  1,  1, 1, 1, 1,  1,  1,  1,  1,  1,  1,  24, 30, 1},
+{0x0000011004000000, 0x0000000000000000, 0x0002000000000000, 0x0000000000000040,
+0x1000000000000000, 0x0000000000800000, 0x0000000000000008, 0x0000008000000000,
+0x3f00000000000000, 0xfffff00000000000, 0x010007ffffffffff, 0xfffffffff8000000,
+0x8002000000000000, 0x000000001fff0000, 0x3000000000000000, 0x0000800000000000,
+0x083e000000000020, 0x0000000060000000, 0x7000000000000000, 0x0000000000200000,
+0x0000000000001000, 0x8000000000000000, 0x0000000030000000, 0x00000000ff800000,
+0x0001000000000000, 0x0000000000000100, 0x0300000000000000, 0x0000004000008000,
+0x0018000020000000, 0x00000200f0000000, 0x00000000c0000000},
+{1, 0, 0, 0, 0, 0, 0, 0, 2},
+{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5},
+{0x0000000000000000, 0x000000000000000f, 0x00000000fff80000, 0x0000000b00000000,
+0x3f80000000000000, 0x0000000000000800}};
+static constexpr bool_trie<32, 991, 1, 0, 74, 255, 1, 0, 449, 7, 56, 61> cat_mn{
+{0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0xffffffffffffffff, 0x0000ffffffffffff, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x00000000000000f8, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0xbffffffffffe0000, 0x00000000000000b6,
+0x0000000007ff0000, 0x00010000fffff800, 0x0000000000000000, 0x00003d9f9fc00000,
+0xffff000000020000, 0x00000000000007ff, 0x0001ffc000000000, 0x200ff80000000000},
+{1,  2,  3,  4,  5,  6,  7,  8,  9,  8,  10, 11, 12, 13, 14, 15, 16, 11, 17, 18, 19, 20, 21,
+22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  33, 2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  34, 35, 36, 37, 38, 2,  39, 2,  40, 2,
+2,  2,  41, 42, 43, 44, 45, 46, 47, 48, 49, 2,  2,  50, 2,  2,  2,  51, 2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  52, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  53, 2,  54, 2,  55, 2,  2,  2,  2,  2,  2,  2,  2,  56, 2,
+57, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  58, 59, 60, 2,  2,  2,  2,  61, 2,  2,  62, 63,
+64, 65, 66, 67, 68, 69, 70, 2,  2,  2,  71, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
+2,  2,  2,  2,  2,  72, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  73, 2,  2,  2,  2,  2,
+2,  2},
+{0x00003eeffbc00000, 0x000000000e000000, 0x0000000000000000, 0xfffffffbfff80000,
+0x1400000000000007, 0x0000000c00fe21fe, 0x1000000000000002, 0x4000000c0000201e,
+0x1000000000000006, 0x0023000000023986, 0xfc00000c000021be, 0x9000000000000002,
+0x0000000c0060201e, 0x0000000000000004, 0x0000000000002001, 0xc000000000000011,
+0x0000000c00603dc1, 0x0000000c00003040, 0x1800000000000003, 0x0000000c0000201e,
+0x0000000000000002, 0x00000000005c0400, 0x07f2000000000000, 0x0000000000007f80,
+0x1ff2000000000000, 0x0000000000003f00, 0x02a0000003000000, 0x7ffe000000000000,
+0x1ffffffffeffe0df, 0x0000000000000040, 0x66fde00000000000, 0x001e0001c3000000,
+0x0000000020002064, 0x00000000e0000000, 0x001c0000001c0000, 0x000c0000000c0000,
+0x3fb0000000000000, 0x00000000200ffe40, 0x0000000000003800, 0x0000020000000060,
+0x0e04018700000000, 0x0000000009800000, 0x9ff81fe57f400000, 0xbfff000000000000,
+0x0000000000000001, 0x17d000000000000f, 0x000ff80000000004, 0x00003b3c00000003,
+0x0003a34000000000, 0x00cff00000000000, 0x031021fdfff70000, 0xfbffffffffffffff,
+0x0001ffe21fff0000, 0x0003800000000000, 0x8000000000000000, 0xffffffff00000000,
+0x00003c0000000000, 0x0000000006000000, 0x3ff0800000000000, 0x00000000c0000000,
+0x0003000000000000, 0x0000106000000844, 0x8003ffff00000030, 0x00003fc000000000,
+0x000000000003ff80, 0x33c8000000000007, 0x0000002000000000, 0x00667e0000000000,
+0x1000000000001008, 0xc19d000000000000, 0x0040300000000002, 0x0000212000000000,
+0x0000000040000000, 0x0000ffff0000ffff},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 4, 2, 5, 6, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 7, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1,  0,  0,  0, 2,  0,  3,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  4,  0,  0,  5,  0,  0,  0,  0,  0,  0,  0,  0,  6,
+0,  0,  0,  0, 0,  7,  0,  0,  8,  0,  0,  9,  10, 11, 0,  12, 13, 14, 15, 16, 0,  0,  17,
+18, 19, 0,  0, 20, 21, 22, 23, 0,  0,  24, 25, 26, 27, 28, 0,  29, 0,  0,  0,  30, 0,  0,
+0,  31, 32, 0, 33, 34, 35, 36, 0,  0,  0,  0,  0,  37, 0,  38, 0,  39, 40, 41, 0,  0,  0,
+0,  42, 0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  43, 44,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  45, 46, 47, 0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+48, 0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  49, 50, 0,  0,
+51, 0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  52, 53, 54, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  55, 0,  0,  0,  44, 0,  0,  0,  0,  0,  0,  56, 0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  57, 0,
+58, 0,  0,  0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+0,  0,  0,  0, 0,  0,  0,  0,  59, 59, 59, 60},
+{0x0000000000000000, 0x2000000000000000, 0x0000000100000000, 0x07c0000000000000,
+0x870000000000f06e, 0x0000006000000000, 0x000000f000000000, 0x0000180000000000,
+0x000000000001ffc0, 0xff00000000000002, 0x800000000000007f, 0x0678000000000003,
+0x001fef8000000007, 0x0008000000000000, 0x7fc0000000000003, 0x0000000000009e00,
+0x40d3800000000000, 0x000007f880000000, 0x1800000000000003, 0x001f1fc000000001,
+0xff00000000000000, 0x000000004000005c, 0x85f8000000000000, 0x000000000000000d,
+0xb03c000000000000, 0x0000000030000001, 0xa7f8000000000000, 0x0000000000000001,
+0x00bf280000000000, 0x00000fbce0000000, 0x06ff800000000000, 0x5800000000000000,
+0x0000000000000008, 0x000000010cf00000, 0x79f80000000007fe, 0x000000000e7e0080,
+0x00000000037ffc00, 0xbf7f000000000000, 0x006dfcfffffc0000, 0xb47e000000000000,
+0x00000000000000bf, 0x0000000000a30000, 0x0018000000000000, 0x001f000000000000,
+0x007f000000000000, 0x0000000000008000, 0x0000000000078000, 0x0000001000000000,
+0x0000000060000000, 0xf800038000000000, 0x00003c0000000fe7, 0x000000000000001c,
+0xf87fffffffffffff, 0x00201fffffffffff, 0x0000fffef8000010, 0x000007dbf9ffff7f,
+0x0000f00000000000, 0x00000000007f0000, 0x00000000000007f0, 0xffffffffffffffff,
+0x0000ffffffffffff}};
+static constexpr range_array cat_me = {0x00000000, 0x00048801, 0x00048A00, 0x001ABE01,
+0x001ABF00, 0x0020DD01, 0x0020E100, 0x0020E201,
+0x0020E500, 0x00A67001, 0x00A67300};
+static constexpr bool_trie<0, 652, 4, 336, 42, 13, 1, 242, 134, 64, 58, 33> cat_mc{
+{},
+{1,  2,  3,  4,  5,  6,  5,  7,  8, 4, 9,  10, 11, 12, 8, 13, 3, 14, 15, 16, 0,  0,  0,
+0,  9,  17, 0,  0,  18, 19, 20, 0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  21, 22, 0, 0,  0, 0,  23, 0,  0,  0,  24,
+25, 0,  0,  26, 27, 28, 29, 30, 0, 0, 31, 0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  32, 0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 33, 0, 34, 35, 0,  36, 37, 6,
+38, 39, 0,  40, 0,  0,  0,  41},
+{0x0000000000000000, 0xc800000000000008, 0x000000000000de01, 0xc00000000000000c,
+0x0000000000801981, 0xc000000000000008, 0x0000000000000001, 0x0000000000001a01,
+0x400000000000000c, 0xc000000000000000, 0x0000000000801dc6, 0x000000000000000e,
+0x000000000000001e, 0x0000000000600d9f, 0x0000000000801dc1, 0x000000000000000c,
+0x000c0000ff038000, 0x8000000000000000, 0x1902180000000000, 0x00003f9c00c00000,
+0x000000001c009f98, 0xc040000000000000, 0x00000000000001bf, 0x01fb0e7800000000,
+0x0000000006000000, 0x0007e01a00a00000, 0xe820000000000010, 0x000000000000001b,
+0x000004c200000004, 0x000c5c8000000000, 0x00300ff000000000, 0x0080000200000000,
+0x0000c00000000000, 0x0000009800000000, 0xfff0000000000003, 0x000000000000000f,
+0x00000000000c0000, 0xcc30000000000008, 0x0019800000000000, 0x2800000000002000,
+0x0020c80000000000, 0x000016d800000000},
+{1, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 3},
+{1, 0,  2,  0,  3,  4,  5, 6, 7,  0,  0,  8,  9,  10, 0, 0, 11, 12, 13, 14, 0, 0, 15,
+0, 16, 0,  17, 0,  18, 0, 0, 0,  19, 0,  0,  0,  20, 1, 0, 21, 22, 23, 24, 0, 0, 0,
+0, 0,  25, 0,  26, 0,  0, 0, 27, 0,  0,  0,  0,  28, 0, 0, 0,  0,  0,  0,  0, 0, 0,
+0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,
+0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0,  0, 0, 0,
+0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  29, 30, 31, 0,  0, 0, 0,  0,  32},
+{0x0000000000000000, 0x0000000000000005, 0x0187000000000004, 0x0000100000000000,
+0x0000000000000060, 0x8038000000000004, 0x0000000000004001, 0x002c700000000000,
+0x0000000700000000, 0xc00000000000000c, 0x0000000c0080399e, 0x00e0000000000000,
+0x0000000000000023, 0x7a07000000000000, 0x0000000000000002, 0x4f03800000000000,
+0x5807000000000000, 0x0040d00000000000, 0x0000004300000000, 0x0100700000000000,
+0x21bf000000000000, 0x00000010f00e0000, 0x0200000000000000, 0x0000000001800000,
+0x0000000000800000, 0x4000800000000000, 0x0012020000000000, 0x0000000000587c00,
+0x0060000000000000, 0xfffffffffffe0000, 0x00000000000000ff, 0x0003000000000000,
+0x0007e06000000000}};
+static constexpr range_array cat_nl = {
+0x00000000, 0x0016EE01, 0x0016F100, 0x00216001, 0x00218300, 0x00218501, 0x00218900,
+0x00300701, 0x00300800, 0x00302101, 0x00302A00, 0x00303801, 0x00303B00, 0x00A6E601,
+0x00A6F000, 0x01014001, 0x01017500, 0x01034101, 0x01034200, 0x01034A01, 0x01034B00,
+0x0103D101, 0x0103D600, 0x01240001, 0x01246F00};
+static constexpr flat_array<1> cat_zl{{0x2028}};
+static constexpr flat_array<1> cat_zp{{0x2029}};
+static constexpr range_array cat_cs = {0x00000000, 0x00D80001, 0x00E00000};
+static constexpr range_array cat_co = {0x00000000, 0x00E00001, 0x00F90000, 0x0F000001,
+0x0FFFFE00, 0x10000001, 0x10FFFE00};
+constexpr category get_category(char32_t c) {
+if(cat_co.lookup(c))
+return category::co;
+if(cat_lo.lookup(c))
+return category::lo;
+if(cat_so.lookup(c))
+return category::so;
+if(cat_ll.lookup(c))
+return category::ll;
+if(cat_cs.lookup(c))
+return category::cs;
+if(cat_mn.lookup(c))
+return category::mn;
+if(cat_lu.lookup(c))
+return category::lu;
+if(cat_sm.lookup(c))
+return category::sm;
+if(cat_no.lookup(c))
+return category::no;
+if(cat_nd.lookup(c))
+return category::nd;
+if(cat_po.lookup(c))
+return category::po;
+if(cat_mc.lookup(c))
+return category::mc;
+if(cat_lm.lookup(c))
+return category::lm;
+if(cat_nl.lookup(c))
+return category::nl;
+if(cat_cf.lookup(c))
+return category::cf;
+if(cat_sk.lookup(c))
+return category::sk;
+if(cat_ps.lookup(c))
+return category::ps;
+if(cat_pe.lookup(c))
+return category::pe;
+if(cat_cc.lookup(c))
+return category::cc;
+if(cat_sc.lookup(c))
+return category::sc;
+if(cat_lt.lookup(c))
+return category::lt;
+if(cat_pd.lookup(c))
+return category::pd;
+if(cat_zs.lookup(c))
+return category::zs;
+if(cat_me.lookup(c))
+return category::me;
+if(cat_pi.lookup(c))
+return category::pi;
+if(cat_pf.lookup(c))
+return category::pf;
+if(cat_pc.lookup(c))
+return category::pc;
+if(cat_zp.lookup(c))
+return category::zp;
+if(cat_zl.lookup(c))
+return category::zl;
+return category::cn;
+}
+}    // namespace detail::tables
+template<>
+constexpr bool cp_is<category::co>(char32_t c) {
+return detail::tables::cat_co.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::lo>(char32_t c) {
+return detail::tables::cat_lo.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::so>(char32_t c) {
+return detail::tables::cat_so.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::ll>(char32_t c) {
+return detail::tables::cat_ll.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::cs>(char32_t c) {
+return detail::tables::cat_cs.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::mn>(char32_t c) {
+return detail::tables::cat_mn.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::lu>(char32_t c) {
+return detail::tables::cat_lu.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::sm>(char32_t c) {
+return detail::tables::cat_sm.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::no>(char32_t c) {
+return detail::tables::cat_no.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::nd>(char32_t c) {
+return detail::tables::cat_nd.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::po>(char32_t c) {
+return detail::tables::cat_po.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::mc>(char32_t c) {
+return detail::tables::cat_mc.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::lm>(char32_t c) {
+return detail::tables::cat_lm.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::nl>(char32_t c) {
+return detail::tables::cat_nl.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::cf>(char32_t c) {
+return detail::tables::cat_cf.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::sk>(char32_t c) {
+return detail::tables::cat_sk.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::ps>(char32_t c) {
+return detail::tables::cat_ps.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::pe>(char32_t c) {
+return detail::tables::cat_pe.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::cc>(char32_t c) {
+return detail::tables::cat_cc.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::sc>(char32_t c) {
+return detail::tables::cat_sc.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::lt>(char32_t c) {
+return detail::tables::cat_lt.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::pd>(char32_t c) {
+return detail::tables::cat_pd.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::zs>(char32_t c) {
+return detail::tables::cat_zs.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::me>(char32_t c) {
+return detail::tables::cat_me.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::pi>(char32_t c) {
+return detail::tables::cat_pi.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::pf>(char32_t c) {
+return detail::tables::cat_pf.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::pc>(char32_t c) {
+return detail::tables::cat_pc.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::zp>(char32_t c) {
+return detail::tables::cat_zp.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::zl>(char32_t c) {
+return detail::tables::cat_zl.lookup(c);
+}
+template<>
+constexpr bool cp_is<category::cased_letter>(char32_t c) {
+if(detail::tables::cat_ll.lookup(c))
+return true;
+if(detail::tables::cat_lu.lookup(c))
+return true;
+if(detail::tables::cat_lt.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::letter>(char32_t c) {
+if(detail::tables::cat_lo.lookup(c))
+return true;
+if(detail::tables::cat_ll.lookup(c))
+return true;
+if(detail::tables::cat_lu.lookup(c))
+return true;
+if(detail::tables::cat_lm.lookup(c))
+return true;
+if(detail::tables::cat_lt.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::mark>(char32_t c) {
+if(detail::tables::cat_mn.lookup(c))
+return true;
+if(detail::tables::cat_mc.lookup(c))
+return true;
+if(detail::tables::cat_me.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::number>(char32_t c) {
+if(detail::tables::cat_no.lookup(c))
+return true;
+if(detail::tables::cat_nd.lookup(c))
+return true;
+if(detail::tables::cat_nl.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::punctuation>(char32_t c) {
+if(detail::tables::cat_po.lookup(c))
+return true;
+if(detail::tables::cat_ps.lookup(c))
+return true;
+if(detail::tables::cat_pe.lookup(c))
+return true;
+if(detail::tables::cat_pd.lookup(c))
+return true;
+if(detail::tables::cat_pi.lookup(c))
+return true;
+if(detail::tables::cat_pf.lookup(c))
+return true;
+if(detail::tables::cat_pc.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::symbol>(char32_t c) {
+if(detail::tables::cat_so.lookup(c))
+return true;
+if(detail::tables::cat_sm.lookup(c))
+return true;
+if(detail::tables::cat_sk.lookup(c))
+return true;
+if(detail::tables::cat_sc.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::separator>(char32_t c) {
+if(detail::tables::cat_zs.lookup(c))
+return true;
+if(detail::tables::cat_zp.lookup(c))
+return true;
+if(detail::tables::cat_zl.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::other>(char32_t c) {
+if(detail::tables::cat_co.lookup(c))
+return true;
+if(detail::tables::cat_cs.lookup(c))
+return true;
+if(detail::tables::cat_cf.lookup(c))
+return true;
+if(detail::tables::cat_cc.lookup(c))
+return true;
+return false;
+}
+template<>
+constexpr bool cp_is<category::unassigned>(char32_t c) {
+return cp_category(c) == category::unassigned;
+}
+namespace detail::tables {
+static constexpr string_with_idx blocks_names[] = {
+string_with_idx{"adlam", 278},
+string_with_idx{"aegean_numbers", 166},
+string_with_idx{"ahom", 228},
+string_with_idx{"alchemical", 291},
+string_with_idx{"alchemical_symbols", 291},
+string_with_idx{"alphabetic_pf", 154},
+string_with_idx{"alphabetic_presentation_forms", 154},
+string_with_idx{"anatolian_hieroglyphs", 248},
+string_with_idx{"ancient_greek_music", 268},
+string_with_idx{"ancient_greek_musical_notation", 268},
+string_with_idx{"ancient_greek_numbers", 167},
+string_with_idx{"ancient_symbols", 168},
+string_with_idx{"arabic", 13},
+string_with_idx{"arabic_ext_a", 21},
+string_with_idx{"arabic_extended_a", 21},
+string_with_idx{"arabic_math", 281},
+string_with_idx{"arabic_mathematical_alphabetic_symbols", 281},
+string_with_idx{"arabic_pf_a", 155},
+string_with_idx{"arabic_pf_b", 161},
+string_with_idx{"arabic_presentation_forms_a", 155},
+string_with_idx{"arabic_presentation_forms_b", 161},
+string_with_idx{"arabic_sup", 15},
+string_with_idx{"arabic_supplement", 15},
+string_with_idx{"armenian", 11},
+string_with_idx{"arrows", 78},
+string_with_idx{"ascii", 1},
+string_with_idx{"avestan", 198},
+string_with_idx{"balinese", 58},
+string_with_idx{"bamum", 126},
+string_with_idx{"bamum_sup", 249},
+string_with_idx{"bamum_supplement", 249},
+string_with_idx{"basic_latin", 1},
+string_with_idx{"bassa_vah", 251},
+string_with_idx{"batak", 60},
+string_with_idx{"bengali", 23},
+string_with_idx{"bhaiksuki", 236},
+string_with_idx{"block_elements", 85},
+string_with_idx{"bopomofo", 110},
+string_with_idx{"bopomofo_ext", 113},
+string_with_idx{"bopomofo_extended", 113},
+string_with_idx{"box_drawing", 84},
+string_with_idx{"brahmi", 211},
+string_with_idx{"braille", 91},
+string_with_idx{"braille_patterns", 91},
+string_with_idx{"buginese", 55},
+string_with_idx{"buhid", 46},
+string_with_idx{"byzantine_music", 266},
+string_with_idx{"byzantine_musical_symbols", 266},
+string_with_idx{"carian", 171},
+string_with_idx{"caucasian_albanian", 183},
+string_with_idx{"chakma", 214},
+string_with_idx{"cham", 139},
+string_with_idx{"cherokee", 40},
+string_with_idx{"cherokee_sup", 145},
+string_with_idx{"cherokee_supplement", 145},
+string_with_idx{"chess_symbols", 295},
+string_with_idx{"chorasmian", 209},
+string_with_idx{"cjk", 120},
+string_with_idx{"cjk_compat", 117},
+string_with_idx{"cjk_compat_forms", 159},
+string_with_idx{"cjk_compat_ideographs", 153},
+string_with_idx{"cjk_compat_ideographs_sup", 303},
+string_with_idx{"cjk_compatibility", 117},
+string_with_idx{"cjk_compatibility_forms", 159},
+string_with_idx{"cjk_compatibility_ideographs", 153},
+string_with_idx{"cjk_compatibility_ideographs_supplement", 303},
+string_with_idx{"cjk_ext_a", 118},
+string_with_idx{"cjk_ext_b", 298},
+string_with_idx{"cjk_ext_c", 299},
+string_with_idx{"cjk_ext_d", 300},
+string_with_idx{"cjk_ext_e", 301},
+string_with_idx{"cjk_ext_f", 302},
+string_with_idx{"cjk_ext_g", 304},
+string_with_idx{"cjk_radicals_sup", 104},
+string_with_idx{"cjk_radicals_supplement", 104},
+string_with_idx{"cjk_strokes", 114},
+string_with_idx{"cjk_symbols", 107},
+string_with_idx{"cjk_symbols_and_punctuation", 107},
+string_with_idx{"cjk_unified_ideographs", 120},
+string_with_idx{"cjk_unified_ideographs_extension_a", 118},
+string_with_idx{"cjk_unified_ideographs_extension_b", 298},
+string_with_idx{"cjk_unified_ideographs_extension_c", 299},
+string_with_idx{"cjk_unified_ideographs_extension_d", 300},
+string_with_idx{"cjk_unified_ideographs_extension_e", 301},
+string_with_idx{"cjk_unified_ideographs_extension_f", 302},
+string_with_idx{"cjk_unified_ideographs_extension_g", 304},
+string_with_idx{"combining_diacritical_marks", 7},
+string_with_idx{"combining_diacritical_marks_extended", 57},
+string_with_idx{"combining_diacritical_marks_for_symbols", 75},
+string_with_idx{"combining_diacritical_marks_supplement", 69},
+string_with_idx{"combining_half_marks", 158},
+string_with_idx{"common_indic_number_forms", 130},
+string_with_idx{"compat_jamo", 111},
+string_with_idx{"control_pictures", 81},
+string_with_idx{"coptic", 98},
+string_with_idx{"coptic_epact_numbers", 172},
+string_with_idx{"counting_rod", 271},
+string_with_idx{"counting_rod_numerals", 271},
+string_with_idx{"cuneiform", 243},
+string_with_idx{"cuneiform_numbers", 244},
+string_with_idx{"cuneiform_numbers_and_punctuation", 244},
+string_with_idx{"currency_symbols", 74},
+string_with_idx{"cypriot_syllabary", 185},
+string_with_idx{"cyrillic", 9},
+string_with_idx{"cyrillic_ext_a", 102},
+string_with_idx{"cyrillic_ext_b", 125},
+string_with_idx{"cyrillic_ext_c", 63},
+string_with_idx{"cyrillic_extended_a", 102},
+string_with_idx{"cyrillic_extended_b", 125},
+string_with_idx{"cyrillic_extended_c", 63},
+string_with_idx{"cyrillic_sup", 10},
+string_with_idx{"cyrillic_supplement", 10},
+string_with_idx{"deseret", 178},
+string_with_idx{"devanagari", 22},
+string_with_idx{"devanagari_ext", 133},
+string_with_idx{"devanagari_extended", 133},
+string_with_idx{"diacriticals", 7},
+string_with_idx{"diacriticals_ext", 57},
+string_with_idx{"diacriticals_for_symbols", 75},
+string_with_idx{"diacriticals_sup", 69},
+string_with_idx{"dingbats", 88},
+string_with_idx{"dives_akuru", 231},
+string_with_idx{"dogra", 229},
+string_with_idx{"domino", 283},
+string_with_idx{"domino_tiles", 283},
+string_with_idx{"duployan", 264},
+string_with_idx{"early_dynastic_cuneiform", 245},
+string_with_idx{"egyptian_hieroglyph_format_controls", 247},
+string_with_idx{"egyptian_hieroglyphs", 246},
+string_with_idx{"elbasan", 182},
+string_with_idx{"elymaic", 210},
+string_with_idx{"emoticons", 288},
+string_with_idx{"enclosed_alphanum", 83},
+string_with_idx{"enclosed_alphanum_sup", 285},
+string_with_idx{"enclosed_alphanumeric_supplement", 285},
+string_with_idx{"enclosed_alphanumerics", 83},
+string_with_idx{"enclosed_cjk", 116},
+string_with_idx{"enclosed_cjk_letters_and_months", 116},
+string_with_idx{"enclosed_ideographic_sup", 286},
+string_with_idx{"enclosed_ideographic_supplement", 286},
+string_with_idx{"ethiopic", 38},
+string_with_idx{"ethiopic_ext", 101},
+string_with_idx{"ethiopic_ext_a", 143},
+string_with_idx{"ethiopic_extended", 101},
+string_with_idx{"ethiopic_extended_a", 143},
+string_with_idx{"ethiopic_sup", 39},
+string_with_idx{"ethiopic_supplement", 39},
+string_with_idx{"general_punctuation", 72},
+string_with_idx{"geometric_shapes", 86},
+string_with_idx{"geometric_shapes_ext", 292},
+string_with_idx{"geometric_shapes_extended", 292},
+string_with_idx{"georgian", 36},
+string_with_idx{"georgian_ext", 64},
+string_with_idx{"georgian_extended", 64},
+string_with_idx{"georgian_sup", 99},
+string_with_idx{"georgian_supplement", 99},
+string_with_idx{"glagolitic", 96},
+string_with_idx{"glagolitic_sup", 274},
+string_with_idx{"glagolitic_supplement", 274},
+string_with_idx{"gothic", 174},
+string_with_idx{"grantha", 221},
+string_with_idx{"greek", 8},
+string_with_idx{"greek_and_coptic", 8},
+string_with_idx{"greek_ext", 71},
+string_with_idx{"greek_extended", 71},
+string_with_idx{"gujarati", 25},
+string_with_idx{"gunjala_gondi", 239},
+string_with_idx{"gurmukhi", 24},
+string_with_idx{"half_and_full_forms", 162},
+string_with_idx{"half_marks", 158},
+string_with_idx{"halfwidth_and_fullwidth_forms", 162},
+string_with_idx{"hangul", 147},
+string_with_idx{"hangul_compatibility_jamo", 111},
+string_with_idx{"hangul_jamo", 37},
+string_with_idx{"hangul_jamo_extended_a", 136},
+string_with_idx{"hangul_jamo_extended_b", 148},
+string_with_idx{"hangul_syllables", 147},
+string_with_idx{"hanifi_rohingya", 204},
+string_with_idx{"hanunoo", 45},
+string_with_idx{"hatran", 189},
+string_with_idx{"hebrew", 12},
+string_with_idx{"high_private_use_surrogates", 150},
+string_with_idx{"high_pu_surrogates", 150},
+string_with_idx{"high_surrogates", 149},
+string_with_idx{"hiragana", 108},
+string_with_idx{"idc", 106},
+string_with_idx{"ideographic_description_characters", 106},
+string_with_idx{"ideographic_symbols", 255},
+string_with_idx{"ideographic_symbols_and_punctuation", 255},
+string_with_idx{"imperial_aramaic", 186},
+string_with_idx{"indic_number_forms", 130},
+string_with_idx{"indic_siyaq_numbers", 279},
+string_with_idx{"inscriptional_pahlavi", 200},
+string_with_idx{"inscriptional_parthian", 199},
+string_with_idx{"ipa_ext", 5},
+string_with_idx{"ipa_extensions", 5},
+string_with_idx{"jamo", 37},
+string_with_idx{"jamo_ext_a", 136},
+string_with_idx{"jamo_ext_b", 148},
+string_with_idx{"javanese", 137},
+string_with_idx{"kaithi", 212},
+string_with_idx{"kana_ext_a", 261},
+string_with_idx{"kana_extended_a", 261},
+string_with_idx{"kana_sup", 260},
+string_with_idx{"kana_supplement", 260},
+string_with_idx{"kanbun", 112},
+string_with_idx{"kangxi", 105},
+string_with_idx{"kangxi_radicals", 105},
+string_with_idx{"kannada", 29},
+string_with_idx{"katakana", 109},
+string_with_idx{"katakana_ext", 115},
+string_with_idx{"katakana_phonetic_extensions", 115},
+string_with_idx{"kayah_li", 134},
+string_with_idx{"kharoshthi", 194},
+string_with_idx{"khitan_small_script", 258},
+string_with_idx{"khmer", 48},
+string_with_idx{"khmer_symbols", 54},
+string_with_idx{"khojki", 218},
+string_with_idx{"khudawadi", 220},
+string_with_idx{"lao", 33},
+string_with_idx{"latin_1_sup", 2},
+string_with_idx{"latin_1_supplement", 2},
+string_with_idx{"latin_ext_a", 3},
+string_with_idx{"latin_ext_additional", 70},
+string_with_idx{"latin_ext_b", 4},
+string_with_idx{"latin_ext_c", 97},
+string_with_idx{"latin_ext_d", 128},
+string_with_idx{"latin_ext_e", 144},
+string_with_idx{"latin_extended_a", 3},
+string_with_idx{"latin_extended_additional", 70},
+string_with_idx{"latin_extended_b", 4},
+string_with_idx{"latin_extended_c", 97},
+string_with_idx{"latin_extended_d", 128},
+string_with_idx{"latin_extended_e", 144},
+string_with_idx{"lepcha", 61},
+string_with_idx{"letterlike_symbols", 76},
+string_with_idx{"limbu", 51},
+string_with_idx{"linear_a", 184},
+string_with_idx{"linear_b_ideograms", 165},
+string_with_idx{"linear_b_syllabary", 164},
+string_with_idx{"lisu", 123},
+string_with_idx{"lisu_sup", 241},
+string_with_idx{"lisu_supplement", 241},
+string_with_idx{"low_surrogates", 151},
+string_with_idx{"lycian", 170},
+string_with_idx{"lydian", 191},
+string_with_idx{"mahajani", 215},
+string_with_idx{"mahjong", 282},
+string_with_idx{"mahjong_tiles", 282},
+string_with_idx{"makasar", 240},
+string_with_idx{"malayalam", 30},
+string_with_idx{"mandaic", 19},
+string_with_idx{"manichaean", 197},
+string_with_idx{"marchen", 237},
+string_with_idx{"masaram_gondi", 238},
+string_with_idx{"math_alphanum", 272},
+string_with_idx{"math_operators", 79},
+string_with_idx{"mathematical_alphanumeric_symbols", 272},
+string_with_idx{"mathematical_operators", 79},
+string_with_idx{"mayan_numerals", 269},
+string_with_idx{"medefaidrin", 253},
+string_with_idx{"meetei_mayek", 146},
+string_with_idx{"meetei_mayek_ext", 142},
+string_with_idx{"meetei_mayek_extensions", 142},
+string_with_idx{"mende_kikakui", 277},
+string_with_idx{"meroitic_cursive", 193},
+string_with_idx{"meroitic_hieroglyphs", 192},
+string_with_idx{"miao", 254},
+string_with_idx{"misc_arrows", 95},
+string_with_idx{"misc_math_symbols_a", 89},
+string_with_idx{"misc_math_symbols_b", 93},
+string_with_idx{"misc_pictographs", 287},
+string_with_idx{"misc_symbols", 87},
+string_with_idx{"misc_technical", 80},
+string_with_idx{"miscellaneous_mathematical_symbols_a", 89},
+string_with_idx{"miscellaneous_mathematical_symbols_b", 93},
+string_with_idx{"miscellaneous_symbols", 87},
+string_with_idx{"miscellaneous_symbols_and_arrows", 95},
+string_with_idx{"miscellaneous_symbols_and_pictographs", 287},
+string_with_idx{"miscellaneous_technical", 80},
+string_with_idx{"modi", 225},
+string_with_idx{"modifier_letters", 6},
+string_with_idx{"modifier_tone_letters", 127},
+string_with_idx{"mongolian", 49},
+string_with_idx{"mongolian_sup", 226},
+string_with_idx{"mongolian_supplement", 226},
+string_with_idx{"mro", 250},
+string_with_idx{"multani", 219},
+string_with_idx{"music", 267},
+string_with_idx{"musical_symbols", 267},
+string_with_idx{"myanmar", 35},
+string_with_idx{"myanmar_ext_a", 140},
+string_with_idx{"myanmar_ext_b", 138},
+string_with_idx{"myanmar_extended_a", 140},
+string_with_idx{"myanmar_extended_b", 138},
+string_with_idx{"nabataean", 188},
+string_with_idx{"nandinagari", 232},
+string_with_idx{"nb", 0},
+string_with_idx{"new_tai_lue", 53},
+string_with_idx{"newa", 222},
+string_with_idx{"nko", 17},
+string_with_idx{"no_block", 0},
+string_with_idx{"number_forms", 77},
+string_with_idx{"nushu", 263},
+string_with_idx{"nyiakeng_puachue_hmong", 275},
+string_with_idx{"ocr", 82},
+string_with_idx{"ogham", 42},
+string_with_idx{"ol_chiki", 62},
+string_with_idx{"old_hungarian", 203},
+string_with_idx{"old_italic", 173},
+string_with_idx{"old_north_arabian", 196},
+string_with_idx{"old_permic", 175},
+string_with_idx{"old_persian", 177},
+string_with_idx{"old_sogdian", 207},
+string_with_idx{"old_south_arabian", 195},
+string_with_idx{"old_turkic", 202},
+string_with_idx{"optical_character_recognition", 82},
+string_with_idx{"oriya", 26},
+string_with_idx{"ornamental_dingbats", 289},
+string_with_idx{"osage", 181},
+string_with_idx{"osmanya", 180},
+string_with_idx{"ottoman_siyaq_numbers", 280},
+string_with_idx{"pahawh_hmong", 252},
+string_with_idx{"palmyrene", 187},
+string_with_idx{"pau_cin_hau", 235},
+string_with_idx{"phags_pa", 131},
+string_with_idx{"phaistos", 169},
+string_with_idx{"phaistos_disc", 169},
+string_with_idx{"phoenician", 190},
+string_with_idx{"phonetic_ext", 67},
+string_with_idx{"phonetic_ext_sup", 68},
+string_with_idx{"phonetic_extensions", 67},
+string_with_idx{"phonetic_extensions_supplement", 68},
+string_with_idx{"playing_cards", 284},
+string_with_idx{"private_use_area", 152},
+string_with_idx{"psalter_pahlavi", 201},
+string_with_idx{"pua", 152},
+string_with_idx{"punctuation", 72},
+string_with_idx{"rejang", 135},
+string_with_idx{"rumi", 205},
+string_with_idx{"rumi_numeral_symbols", 205},
+string_with_idx{"runic", 43},
+string_with_idx{"samaritan", 18},
+string_with_idx{"saurashtra", 132},
+string_with_idx{"sharada", 216},
+string_with_idx{"shavian", 179},
+string_with_idx{"shorthand_format_controls", 265},
+string_with_idx{"siddham", 224},
+string_with_idx{"sinhala", 31},
+string_with_idx{"sinhala_archaic_numbers", 217},
+string_with_idx{"small_form_variants", 160},
+string_with_idx{"small_forms", 160},
+string_with_idx{"small_kana_ext", 262},
+string_with_idx{"small_kana_extension", 262},
+string_with_idx{"sogdian", 208},
+string_with_idx{"sora_sompeng", 213},
+string_with_idx{"soyombo", 234},
+string_with_idx{"spacing_modifier_letters", 6},
+string_with_idx{"specials", 163},
+string_with_idx{"sundanese", 59},
+string_with_idx{"sundanese_sup", 65},
+string_with_idx{"sundanese_supplement", 65},
+string_with_idx{"sup_arrows_a", 90},
+string_with_idx{"sup_arrows_b", 92},
+string_with_idx{"sup_arrows_c", 293},
+string_with_idx{"sup_math_operators", 94},
+string_with_idx{"sup_pua_a", 307},
+string_with_idx{"sup_pua_b", 308},
+string_with_idx{"sup_punctuation", 103},
+string_with_idx{"sup_symbols_and_pictographs", 294},
+string_with_idx{"super_and_sub", 73},
+string_with_idx{"superscripts_and_subscripts", 73},
+string_with_idx{"supplemental_arrows_a", 90},
+string_with_idx{"supplemental_arrows_b", 92},
+string_with_idx{"supplemental_arrows_c", 293},
+string_with_idx{"supplemental_mathematical_operators", 94},
+string_with_idx{"supplemental_punctuation", 103},
+string_with_idx{"supplemental_symbols_and_pictographs", 294},
+string_with_idx{"supplementary_private_use_area_a", 307},
+string_with_idx{"supplementary_private_use_area_b", 308},
+string_with_idx{"sutton_signwriting", 273},
+string_with_idx{"syloti_nagri", 129},
+string_with_idx{"symbols_and_pictographs_ext_a", 296},
+string_with_idx{"symbols_and_pictographs_extended_a", 296},
+string_with_idx{"symbols_for_legacy_computing", 297},
+string_with_idx{"syriac", 14},
+string_with_idx{"syriac_sup", 20},
+string_with_idx{"syriac_supplement", 20},
+string_with_idx{"tagalog", 44},
+string_with_idx{"tagbanwa", 47},
+string_with_idx{"tags", 305},
+string_with_idx{"tai_le", 52},
+string_with_idx{"tai_tham", 56},
+string_with_idx{"tai_viet", 141},
+string_with_idx{"tai_xuan_jing", 270},
+string_with_idx{"tai_xuan_jing_symbols", 270},
+string_with_idx{"takri", 227},
+string_with_idx{"tamil", 27},
+string_with_idx{"tamil_sup", 242},
+string_with_idx{"tamil_supplement", 242},
+string_with_idx{"tangut", 256},
+string_with_idx{"tangut_components", 257},
+string_with_idx{"tangut_sup", 259},
+string_with_idx{"tangut_supplement", 259},
+string_with_idx{"telugu", 28},
+string_with_idx{"thaana", 16},
+string_with_idx{"thai", 32},
+string_with_idx{"tibetan", 34},
+string_with_idx{"tifinagh", 100},
+string_with_idx{"tirhuta", 223},
+string_with_idx{"transport_and_map", 290},
+string_with_idx{"transport_and_map_symbols", 290},
+string_with_idx{"ucas", 41},
+string_with_idx{"ucas_ext", 50},
+string_with_idx{"ugaritic", 176},
+string_with_idx{"unified_canadian_aboriginal_syllabics", 41},
+string_with_idx{"unified_canadian_aboriginal_syllabics_extended", 50},
+string_with_idx{"vai", 124},
+string_with_idx{"variation_selectors", 156},
+string_with_idx{"variation_selectors_supplement", 306},
+string_with_idx{"vedic_ext", 66},
+string_with_idx{"vedic_extensions", 66},
+string_with_idx{"vertical_forms", 157},
+string_with_idx{"vs", 156},
+string_with_idx{"vs_sup", 306},
+string_with_idx{"wancho", 276},
+string_with_idx{"warang_citi", 230},
+string_with_idx{"yezidi", 206},
+string_with_idx{"yi_radicals", 122},
+string_with_idx{"yi_syllables", 121},
+string_with_idx{"yijing", 119},
+string_with_idx{"yijing_hexagram_symbols", 119},
+string_with_idx{"zanabazar_square", 233}};
+static constexpr const compact_range block_data = {
+0x00000001, 0x00008001, 0x00010001, 0x00018001, 0x00025001, 0x0002B001, 0x00030001,
+0x00037001, 0x00040001, 0x00050001, 0x00053001, 0x00059001, 0x00060001, 0x00070001,
+0x00075001, 0x00078001, 0x0007C001, 0x00080001, 0x00084001, 0x00086001, 0x00087000,
+0x0008A002, 0x00090002, 0x00098002, 0x000A0002, 0x000A8002, 0x000B0002, 0x000B8002,
+0x000C0002, 0x000C8002, 0x000D0002, 0x000D8002, 0x000E0002, 0x000E8002, 0x000F0002,
+0x00100002, 0x0010A002, 0x00110002, 0x00120002, 0x00138002, 0x0013A002, 0x00140002,
+0x00168002, 0x0016A002, 0x00170002, 0x00172002, 0x00174002, 0x00176002, 0x00178002,
+0x00180002, 0x0018B002, 0x00190002, 0x00195002, 0x00198002, 0x0019E002, 0x001A0002,
+0x001A2002, 0x001AB002, 0x001B0002, 0x001B8002, 0x001BC002, 0x001C0002, 0x001C5002,
+0x001C8002, 0x001C9002, 0x001CC002, 0x001CD002, 0x001D0002, 0x001D8002, 0x001DC002,
+0x001E0002, 0x001F0002, 0x00200002, 0x00207002, 0x0020A002, 0x0020D002, 0x00210002,
+0x00215002, 0x00219002, 0x00220002, 0x00230002, 0x00240002, 0x00244002, 0x00246002,
+0x00250002, 0x00258002, 0x0025A002, 0x00260002, 0x00270002, 0x0027C002, 0x0027F002,
+0x00280002, 0x00290002, 0x00298002, 0x002A0002, 0x002B0002, 0x002C0002, 0x002C6002,
+0x002C8002, 0x002D0002, 0x002D3002, 0x002D8002, 0x002DE002, 0x002E0002, 0x002E8002,
+0x002F0002, 0x002FE000, 0x002FF003, 0x00300003, 0x00304003, 0x0030A003, 0x00310003,
+0x00313003, 0x00319003, 0x0031A003, 0x0031C003, 0x0031F003, 0x00320003, 0x00330003,
+0x00340003, 0x004DC003, 0x004E0003, 0x00A00003, 0x00A49003, 0x00A4D003, 0x00A50003,
+0x00A64003, 0x00A6A003, 0x00A70003, 0x00A72003, 0x00A80003, 0x00A83003, 0x00A84003,
+0x00A88003, 0x00A8E003, 0x00A90003, 0x00A93003, 0x00A96003, 0x00A98003, 0x00A9E003,
+0x00AA0003, 0x00AA6003, 0x00AA8003, 0x00AAE003, 0x00AB0003, 0x00AB3003, 0x00AB7003,
+0x00ABC003, 0x00AC0003, 0x00D7B003, 0x00D80003, 0x00DB8003, 0x00DC0003, 0x00E00003,
+0x00F90003, 0x00FB0003, 0x00FB5003, 0x00FE0003, 0x00FE1003, 0x00FE2003, 0x00FE3003,
+0x00FE5003, 0x00FE7003, 0x00FF0003, 0x00FFF003, 0x01000003, 0x01008003, 0x01010003,
+0x01014003, 0x01019003, 0x0101D003, 0x01020000, 0x01028004, 0x0102A004, 0x0102E004,
+0x01030004, 0x01033004, 0x01035004, 0x01038004, 0x0103A004, 0x0103E000, 0x01040005,
+0x01045005, 0x01048005, 0x0104B005, 0x01050005, 0x01053005, 0x01057000, 0x01060006,
+0x01078000, 0x01080007, 0x01084007, 0x01086007, 0x01088007, 0x0108B000, 0x0108E008,
+0x01090008, 0x01092008, 0x01094000, 0x01098009, 0x0109A009, 0x010A0009, 0x010A6009,
+0x010A8009, 0x010AA000, 0x010AC00A, 0x010B000A, 0x010B400A, 0x010B600A, 0x010B800A,
+0x010BB000, 0x010C000B, 0x010C5000, 0x010C800C, 0x010D000C, 0x010D4000, 0x010E600D,
+0x010E800D, 0x010EC000, 0x010F000E, 0x010F300E, 0x010F7000, 0x010FB00F, 0x010FE00F,
+0x0110000F, 0x0110800F, 0x0110D00F, 0x0111000F, 0x0111500F, 0x0111800F, 0x0111E00F,
+0x0112000F, 0x01125000, 0x01128010, 0x0112B010, 0x01130010, 0x01138000, 0x01140011,
+0x01148011, 0x0114E000, 0x01158012, 0x01160012, 0x01166012, 0x01168012, 0x0116D000,
+0x01170013, 0x01174000, 0x01180014, 0x01185000, 0x0118A015, 0x01190015, 0x01196000,
+0x0119A016, 0x011A0016, 0x011A5016, 0x011AB000, 0x011AC017, 0x011B0000, 0x011C0018,
+0x011C7018, 0x011CC000, 0x011D0019, 0x011D6019, 0x011DB000, 0x011EE01A, 0x011F0000,
+0x011FB01B, 0x011FC01B, 0x0120001B, 0x0124001B, 0x0124801B, 0x01255000, 0x0130001C,
+0x0134301C, 0x01344000, 0x0144001D, 0x01468000, 0x0168001E, 0x016A401E, 0x016A7000,
+0x016AD01F, 0x016B001F, 0x016B9000, 0x016E4020, 0x016EA000, 0x016F0021, 0x016FA000,
+0x016FE022, 0x01700022, 0x01880022, 0x018B0022, 0x018D0022, 0x018D9000, 0x01B00023,
+0x01B10023, 0x01B13023, 0x01B17023, 0x01B30000, 0x01BC0024, 0x01BCA024, 0x01BCB000,
+0x01D00025, 0x01D10025, 0x01D20025, 0x01D25000, 0x01D2E026, 0x01D30026, 0x01D36026,
+0x01D38000, 0x01D40027, 0x01D80027, 0x01DAB000, 0x01E00028, 0x01E03000, 0x01E10029,
+0x01E15000, 0x01E2C02A, 0x01E30000, 0x01E8002B, 0x01E8E000, 0x01E9002C, 0x01E96000,
+0x01EC702D, 0x01ECC000, 0x01ED002E, 0x01ED5000, 0x01EE002F, 0x01EF0000, 0x01F00030,
+0x01F03030, 0x01F0A030, 0x01F10030, 0x01F20030, 0x01F30030, 0x01F60030, 0x01F65030,
+0x01F68030, 0x01F70030, 0x01F78030, 0x01F80030, 0x01F90030, 0x01FA0030, 0x01FA7030,
+0x01FB0030, 0x01FC0000, 0x02000031, 0x02A6E000, 0x02A70032, 0x02B74032, 0x02B82032,
+0x02CEB032, 0x02EBF000, 0x02F80033, 0x02FA2000, 0x03000034, 0x03135000, 0x0E000035,
+0x0E008000, 0x0E010036, 0x0E01F000, 0x0F000037, 0x10000037, 0xFFFFFFFF};
+static constexpr string_with_idx scripts_names[] = {
+string_with_idx{"adlam", 0},
+string_with_idx{"adlm", 0},
+string_with_idx{"aghb", 1},
+string_with_idx{"ahom", 2},
+string_with_idx{"anatolian_hieroglyphs", 51},
+string_with_idx{"arab", 3},
+string_with_idx{"arabic", 3},
+string_with_idx{"armenian", 5},
+string_with_idx{"armi", 4},
+string_with_idx{"armn", 5},
+string_with_idx{"avestan", 6},
+string_with_idx{"avst", 6},
+string_with_idx{"bali", 7},
+string_with_idx{"balinese", 7},
+string_with_idx{"bamu", 8},
+string_with_idx{"bamum", 8},
+string_with_idx{"bass", 9},
+string_with_idx{"bassa_vah", 9},
+string_with_idx{"batak", 10},
+string_with_idx{"batk", 10},
+string_with_idx{"beng", 11},
+string_with_idx{"bengali", 11},
+string_with_idx{"bhaiksuki", 12},
+string_with_idx{"bhks", 12},
+string_with_idx{"bopo", 13},
+string_with_idx{"bopomofo", 13},
+string_with_idx{"brah", 14},
+string_with_idx{"brahmi", 14},
+string_with_idx{"brai", 15},
+string_with_idx{"braille", 15},
+string_with_idx{"bugi", 16},
+string_with_idx{"buginese", 16},
+string_with_idx{"buhd", 17},
+string_with_idx{"buhid", 17},
+string_with_idx{"cakm", 18},
+string_with_idx{"canadian_aboriginal", 19},
+string_with_idx{"cans", 19},
+string_with_idx{"cari", 20},
+string_with_idx{"carian", 20},
+string_with_idx{"caucasian_albanian", 1},
+string_with_idx{"chakma", 18},
+string_with_idx{"cham", 21},
+string_with_idx{"cher", 22},
+string_with_idx{"cherokee", 22},
+string_with_idx{"chorasmian", 23},
+string_with_idx{"chrs", 23},
+string_with_idx{"common", 156},
+string_with_idx{"copt", 24},
+string_with_idx{"coptic", 24},
+string_with_idx{"cprt", 25},
+string_with_idx{"cuneiform", 151},
+string_with_idx{"cypriot", 25},
+string_with_idx{"cyrillic", 26},
+string_with_idx{"cyrl", 26},
+string_with_idx{"deseret", 30},
+string_with_idx{"deva", 27},
+string_with_idx{"devanagari", 27},
+string_with_idx{"diak", 28},
+string_with_idx{"dives_akuru", 28},
+string_with_idx{"dogr", 29},
+string_with_idx{"dogra", 29},
+string_with_idx{"dsrt", 30},
+string_with_idx{"dupl", 31},
+string_with_idx{"duployan", 31},
+string_with_idx{"egyp", 32},
+string_with_idx{"egyptian_hieroglyphs", 32},
+string_with_idx{"elba", 33},
+string_with_idx{"elbasan", 33},
+string_with_idx{"elym", 34},
+string_with_idx{"elymaic", 34},
+string_with_idx{"ethi", 35},
+string_with_idx{"ethiopic", 35},
+string_with_idx{"geor", 36},
+string_with_idx{"georgian", 36},
+string_with_idx{"glag", 37},
+string_with_idx{"glagolitic", 37},
+string_with_idx{"gong", 38},
+string_with_idx{"gonm", 39},
+string_with_idx{"goth", 40},
+string_with_idx{"gothic", 40},
+string_with_idx{"gran", 41},
+string_with_idx{"grantha", 41},
+string_with_idx{"greek", 42},
+string_with_idx{"grek", 42},
+string_with_idx{"gujarati", 43},
+string_with_idx{"gujr", 43},
+string_with_idx{"gunjala_gondi", 38},
+string_with_idx{"gurmukhi", 44},
+string_with_idx{"guru", 44},
+string_with_idx{"han", 46},
+string_with_idx{"hang", 45},
+string_with_idx{"hangul", 45},
+string_with_idx{"hani", 46},
+string_with_idx{"hanifi_rohingya", 114},
+string_with_idx{"hano", 47},
+string_with_idx{"hanunoo", 47},
+string_with_idx{"hatr", 48},
+string_with_idx{"hatran", 48},
+string_with_idx{"hebr", 49},
+string_with_idx{"hebrew", 49},
+string_with_idx{"hira", 50},
+string_with_idx{"hiragana", 50},
+string_with_idx{"hluw", 51},
+string_with_idx{"hmng", 52},
+string_with_idx{"hmnp", 53},
+string_with_idx{"hrkt", 54},
+string_with_idx{"hung", 55},
+string_with_idx{"imperial_aramaic", 4},
+string_with_idx{"inherited", 155},
+string_with_idx{"inscriptional_pahlavi", 108},
+string_with_idx{"inscriptional_parthian", 112},
+string_with_idx{"ital", 56},
+string_with_idx{"java", 57},
+string_with_idx{"javanese", 57},
+string_with_idx{"kaithi", 65},
+string_with_idx{"kali", 58},
+string_with_idx{"kana", 59},
+string_with_idx{"kannada", 64},
+string_with_idx{"katakana", 59},
+string_with_idx{"katakana_or_hiragana", 54},
+string_with_idx{"kayah_li", 58},
+string_with_idx{"khar", 60},
+string_with_idx{"kharoshthi", 60},
+string_with_idx{"khitan_small_script", 63},
+string_with_idx{"khmer", 61},
+string_with_idx{"khmr", 61},
+string_with_idx{"khoj", 62},
+string_with_idx{"khojki", 62},
+string_with_idx{"khudawadi", 123},
+string_with_idx{"kits", 63},
+string_with_idx{"knda", 64},
+string_with_idx{"kthi", 65},
+string_with_idx{"lana", 66},
+string_with_idx{"lao", 67},
+string_with_idx{"laoo", 67},
+string_with_idx{"latin", 68},
+string_with_idx{"latn", 68},
+string_with_idx{"lepc", 69},
+string_with_idx{"lepcha", 69},
+string_with_idx{"limb", 70},
+string_with_idx{"limbu", 70},
+string_with_idx{"lina", 71},
+string_with_idx{"linb", 72},
+string_with_idx{"linear_a", 71},
+string_with_idx{"linear_b", 72},
+string_with_idx{"lisu", 73},
+string_with_idx{"lyci", 74},
+string_with_idx{"lycian", 74},
+string_with_idx{"lydi", 75},
+string_with_idx{"lydian", 75},
+string_with_idx{"mahajani", 76},
+string_with_idx{"mahj", 76},
+string_with_idx{"maka", 77},
+string_with_idx{"makasar", 77},
+string_with_idx{"malayalam", 85},
+string_with_idx{"mand", 78},
+string_with_idx{"mandaic", 78},
+string_with_idx{"mani", 79},
+string_with_idx{"manichaean", 79},
+string_with_idx{"marc", 80},
+string_with_idx{"marchen", 80},
+string_with_idx{"masaram_gondi", 39},
+string_with_idx{"medefaidrin", 81},
+string_with_idx{"medf", 81},
+string_with_idx{"meetei_mayek", 89},
+string_with_idx{"mend", 82},
+string_with_idx{"mende_kikakui", 82},
+string_with_idx{"merc", 83},
+string_with_idx{"mero", 84},
+string_with_idx{"meroitic_cursive", 83},
+string_with_idx{"meroitic_hieroglyphs", 84},
+string_with_idx{"miao", 111},
+string_with_idx{"mlym", 85},
+string_with_idx{"modi", 86},
+string_with_idx{"mong", 87},
+string_with_idx{"mongolian", 87},
+string_with_idx{"mro", 88},
+string_with_idx{"mroo", 88},
+string_with_idx{"mtei", 89},
+string_with_idx{"mult", 90},
+string_with_idx{"multani", 90},
+string_with_idx{"myanmar", 91},
+string_with_idx{"mymr", 91},
+string_with_idx{"nabataean", 94},
+string_with_idx{"nand", 92},
+string_with_idx{"nandinagari", 92},
+string_with_idx{"narb", 93},
+string_with_idx{"nbat", 94},
+string_with_idx{"new_tai_lue", 135},
+string_with_idx{"newa", 95},
+string_with_idx{"nko", 96},
+string_with_idx{"nkoo", 96},
+string_with_idx{"nshu", 97},
+string_with_idx{"nushu", 97},
+string_with_idx{"nyiakeng_puachue_hmong", 53},
+string_with_idx{"ogam", 98},
+string_with_idx{"ogham", 98},
+string_with_idx{"ol_chiki", 99},
+string_with_idx{"olck", 99},
+string_with_idx{"old_hungarian", 55},
+string_with_idx{"old_italic", 56},
+string_with_idx{"old_north_arabian", 93},
+string_with_idx{"old_permic", 106},
+string_with_idx{"old_persian", 150},
+string_with_idx{"old_sogdian", 126},
+string_with_idx{"old_south_arabian", 117},
+string_with_idx{"old_turkic", 100},
+string_with_idx{"oriya", 101},
+string_with_idx{"orkh", 100},
+string_with_idx{"orya", 101},
+string_with_idx{"osage", 102},
+string_with_idx{"osge", 102},
+string_with_idx{"osma", 103},
+string_with_idx{"osmanya", 103},
+string_with_idx{"pahawh_hmong", 52},
+string_with_idx{"palm", 104},
+string_with_idx{"palmyrene", 104},
+string_with_idx{"pau_cin_hau", 105},
+string_with_idx{"pauc", 105},
+string_with_idx{"perm", 106},
+string_with_idx{"phag", 107},
+string_with_idx{"phags_pa", 107},
+string_with_idx{"phli", 108},
+string_with_idx{"phlp", 109},
+string_with_idx{"phnx", 110},
+string_with_idx{"phoenician", 110},
+string_with_idx{"plrd", 111},
+string_with_idx{"prti", 112},
+string_with_idx{"psalter_pahlavi", 109},
+string_with_idx{"rejang", 113},
+string_with_idx{"rjng", 113},
+string_with_idx{"rohg", 114},
+string_with_idx{"runic", 115},
+string_with_idx{"runr", 115},
+string_with_idx{"samaritan", 116},
+string_with_idx{"samr", 116},
+string_with_idx{"sarb", 117},
+string_with_idx{"saur", 118},
+string_with_idx{"saurashtra", 118},
+string_with_idx{"sgnw", 119},
+string_with_idx{"sharada", 121},
+string_with_idx{"shavian", 120},
+string_with_idx{"shaw", 120},
+string_with_idx{"shrd", 121},
+string_with_idx{"sidd", 122},
+string_with_idx{"siddham", 122},
+string_with_idx{"signwriting", 119},
+string_with_idx{"sind", 123},
+string_with_idx{"sinh", 124},
+string_with_idx{"sinhala", 124},
+string_with_idx{"sogd", 125},
+string_with_idx{"sogdian", 125},
+string_with_idx{"sogo", 126},
+string_with_idx{"sora", 127},
+string_with_idx{"sora_sompeng", 127},
+string_with_idx{"soyo", 128},
+string_with_idx{"soyombo", 128},
+string_with_idx{"sund", 129},
+string_with_idx{"sundanese", 129},
+string_with_idx{"sylo", 130},
+string_with_idx{"syloti_nagri", 130},
+string_with_idx{"syrc", 131},
+string_with_idx{"syriac", 131},
+string_with_idx{"tagalog", 141},
+string_with_idx{"tagb", 132},
+string_with_idx{"tagbanwa", 132},
+string_with_idx{"tai_le", 134},
+string_with_idx{"tai_tham", 66},
+string_with_idx{"tai_viet", 138},
+string_with_idx{"takr", 133},
+string_with_idx{"takri", 133},
+string_with_idx{"tale", 134},
+string_with_idx{"talu", 135},
+string_with_idx{"tamil", 136},
+string_with_idx{"taml", 136},
+string_with_idx{"tang", 137},
+string_with_idx{"tangut", 137},
+string_with_idx{"tavt", 138},
+string_with_idx{"telu", 139},
+string_with_idx{"telugu", 139},
+string_with_idx{"tfng", 140},
+string_with_idx{"tglg", 141},
+string_with_idx{"thaa", 142},
+string_with_idx{"thaana", 142},
+string_with_idx{"thai", 143},
+string_with_idx{"tibetan", 144},
+string_with_idx{"tibt", 144},
+string_with_idx{"tifinagh", 140},
+string_with_idx{"tirh", 145},
+string_with_idx{"tirhuta", 145},
+string_with_idx{"ugar", 146},
+string_with_idx{"ugaritic", 146},
+string_with_idx{"unknown", 157},
+string_with_idx{"vai", 147},
+string_with_idx{"vaii", 147},
+string_with_idx{"wancho", 149},
+string_with_idx{"wara", 148},
+string_with_idx{"warang_citi", 148},
+string_with_idx{"wcho", 149},
+string_with_idx{"xpeo", 150},
+string_with_idx{"xsux", 151},
+string_with_idx{"yezi", 152},
+string_with_idx{"yezidi", 152},
+string_with_idx{"yi", 153},
+string_with_idx{"yiii", 153},
+string_with_idx{"zanabazar_square", 154},
+string_with_idx{"zanb", 154},
+string_with_idx{"zinh", 155},
+string_with_idx{"zyyy", 156},
+string_with_idx{"zzzz", 157}};
+template<auto N>
+struct script_data;
+template<>
+struct script_data<0> {
+static constexpr const compact_range scripts_data = {
+0x0000009C, 0x00004144, 0x00005B9C, 0x00006144, 0x00007B9C, 0x0000AA44, 0x0000AB9C,
+0x0000BA44, 0x0000BB9C, 0x0000C044, 0x0000D79C, 0x0000D844, 0x0000F79C, 0x0000F844,
+0x0002B99C, 0x0002E044, 0x0002E59C, 0x0002EA0D, 0x0002EC9C, 0x0003009B, 0x0003702A,
+0x0003749C, 0x0003752A, 0x0003789D, 0x00037A2A, 0x00037E9C, 0x00037F2A, 0x0003809D,
+0x0003842A, 0x0003859C, 0x0003862A, 0x0003879C, 0x0003882A, 0x00038B9D, 0x00038C2A,
+0x00038D9D, 0x00038E2A, 0x0003A29D, 0x0003A32A, 0x0003E218, 0x0003F02A, 0x0004001A,
+0x0004859B, 0x0004871A, 0x0005309D, 0x00053105, 0x0005579D, 0x00055905, 0x00058B9D,
+0x00058D05, 0x0005909D, 0x00059131, 0x0005C89D, 0x0005D031, 0x0005EB9D, 0x0005EF31,
+0x0005F59D, 0x00060003, 0x0006059C, 0x00060603, 0x00060C9C, 0x00060D03, 0x00061B9C,
+0x00061C03, 0x00061D9D, 0x00061E03, 0x00061F9C, 0x00062003, 0x0006409C, 0x00064103,
+0x00064B9B, 0x00065603, 0x0006709B, 0x00067103, 0x0006DD9C, 0x0006DE03, 0x00070083,
+0x00070E9D, 0x00070F83, 0x00074B9D, 0x00074D83, 0x00075003, 0x0007808E, 0x0007B29D,
+0x0007C060, 0x0007FB9D, 0x0007FD60, 0x00080074, 0x00082E9D, 0x00083074, 0x00083F9D,
+0x0008404E, 0x00085C9D, 0x00085E4E, 0x00085F9D, 0x00086083, 0x00086B9D, 0x0008A003,
+0x0008B59D, 0x0008B603, 0x0008C89D, 0x0008D303, 0x0008E29C, 0x0008E303, 0x0009001B,
+0x0009519B, 0x0009551B, 0x0009649C, 0x0009661B, 0x0009800B, 0x0009849D, 0x0009850B,
+0x00098D9D, 0x00098F0B, 0x0009919D, 0x0009930B, 0x0009A99D, 0x0009AA0B, 0x0009B19D,
+0x0009B20B, 0x0009B39D, 0x0009B60B, 0x0009BA9D, 0x0009BC0B, 0x0009C59D, 0x0009C70B,
+0x0009C99D, 0x0009CB0B, 0x0009CF9D, 0x0009D70B, 0x0009D89D, 0x0009DC0B, 0x0009DE9D,
+0x0009DF0B, 0x0009E49D, 0x0009E60B, 0x0009FF9D, 0x000A012C, 0x000A049D, 0x000A052C,
+0x000A0B9D, 0x000A0F2C, 0x000A119D, 0x000A132C, 0x000A299D, 0x000A2A2C, 0x000A319D,
+0x000A322C, 0x000A349D, 0x000A352C, 0x000A379D, 0x000A382C, 0x000A3A9D, 0x000A3C2C,
+0x000A3D9D, 0x000A3E2C, 0x000A439D, 0x000A472C, 0x000A499D, 0x000A4B2C, 0x000A4E9D,
+0x000A512C, 0x000A529D, 0x000A592C, 0x000A5D9D, 0x000A5E2C, 0x000A5F9D, 0x000A662C,
+0x000A779D, 0x000A812B, 0x000A849D, 0x000A852B, 0x000A8E9D, 0x000A8F2B, 0x000A929D,
+0x000A932B, 0x000AA99D, 0x000AAA2B, 0x000AB19D, 0x000AB22B, 0x000AB49D, 0x000AB52B,
+0x000ABA9D, 0x000ABC2B, 0x000AC69D, 0x000AC72B, 0x000ACA9D, 0x000ACB2B, 0x000ACE9D,
+0x000AD02B, 0x000AD19D, 0x000AE02B, 0x000AE49D, 0x000AE62B, 0x000AF29D, 0x000AF92B,
+0x000B009D, 0x000B0165, 0x000B049D, 0x000B0565, 0x000B0D9D, 0x000B0F65, 0x000B119D,
+0x000B1365, 0x000B299D, 0x000B2A65, 0x000B319D, 0x000B3265, 0x000B349D, 0x000B3565,
+0x000B3A9D, 0x000B3C65, 0x000B459D, 0x000B4765, 0x000B499D, 0x000B4B65, 0x000B4E9D,
+0x000B5565, 0x000B589D, 0x000B5C65, 0x000B5E9D, 0x000B5F65, 0x000B649D, 0x000B6665,
+0x000B789D, 0x000B8288, 0x000B849D, 0x000B8588, 0x000B8B9D, 0x000B8E88, 0x000B919D,
+0x000B9288, 0x000B969D, 0x000B9988, 0x000B9B9D, 0x000B9C88, 0x000B9D9D, 0x000B9E88,
+0x000BA09D, 0x000BA388, 0x000BA59D, 0x000BA888, 0x000BAB9D, 0x000BAE88, 0x000BBA9D,
+0x000BBE88, 0x000BC39D, 0x000BC688, 0x000BC99D, 0x000BCA88, 0x000BCE9D, 0x000BD088,
+0x000BD19D, 0x000BD788, 0x000BD89D, 0x000BE688, 0x000BFB9D, 0x000C008B, 0x000C0D9D,
+0x000C0E8B, 0x000C119D, 0x000C128B, 0x000C299D, 0x000C2A8B, 0x000C3A9D, 0x000C3D8B,
+0x000C459D, 0x000C468B, 0x000C499D, 0x000C4A8B, 0x000C4E9D, 0x000C558B, 0x000C579D,
+0x000C588B, 0x000C5B9D, 0x000C608B, 0x000C649D, 0x000C668B, 0x000C709D, 0x000C778B,
+0x000C8040, 0x000C8D9D, 0x000C8E40, 0x000C919D, 0x000C9240, 0x000CA99D, 0x000CAA40,
+0x000CB49D, 0x000CB540, 0x000CBA9D, 0x000CBC40, 0x000CC59D, 0x000CC640, 0x000CC99D,
+0x000CCA40, 0x000CCE9D, 0x000CD540, 0x000CD79D, 0x000CDE40, 0x000CDF9D, 0x000CE040,
+0x000CE49D, 0x000CE640, 0x000CF09D, 0x000CF140, 0x000CF39D, 0x000D0055, 0x000D0D9D,
+0x000D0E55, 0x000D119D, 0x000D1255, 0x000D459D, 0x000D4655, 0x000D499D, 0x000D4A55,
+0x000D509D, 0x000D5455, 0x000D649D, 0x000D6655, 0x000D809D, 0x000D817C, 0x000D849D,
+0x000D857C, 0x000D979D, 0x000D9A7C, 0x000DB29D, 0x000DB37C, 0x000DBC9D, 0x000DBD7C,
+0x000DBE9D, 0x000DC07C, 0x000DC79D, 0x000DCA7C, 0x000DCB9D, 0x000DCF7C, 0x000DD59D,
+0x000DD67C, 0x000DD79D, 0x000DD87C, 0x000DE09D, 0x000DE67C, 0x000DF09D, 0x000DF27C,
+0x000DF59D, 0x000E018F, 0x000E3B9D, 0x000E3F9C, 0x000E408F, 0x000E5C9D, 0x000E8143,
+0x000E839D, 0x000E8443, 0x000E859D, 0x000E8643, 0x000E8B9D, 0x000E8C43, 0x000EA49D,
+0x000EA543, 0x000EA69D, 0x000EA743, 0x000EBE9D, 0x000EC043, 0x000EC59D, 0x000EC643,
+0x000EC79D, 0x000EC843, 0x000ECE9D, 0x000ED043, 0x000EDA9D, 0x000EDC43, 0x000EE09D,
+0x000F0090, 0x000F489D, 0x000F4990, 0x000F6D9D, 0x000F7190, 0x000F989D, 0x000F9990,
+0x000FBD9D, 0x000FBE90, 0x000FCD9D, 0x000FCE90, 0x000FD59C, 0x000FD990, 0x000FDB9D,
+0x0010005B, 0x0010A024, 0x0010C69D, 0x0010C724, 0x0010C89D, 0x0010CD24, 0x0010CE9D,
+0x0010D024, 0x0010FB9C, 0x0010FC24, 0x0011002D, 0x00120023, 0x0012499D, 0x00124A23,
+0x00124E9D, 0x00125023, 0x0012579D, 0x00125823, 0x0012599D, 0x00125A23, 0x00125E9D,
+0x00126023, 0x0012899D, 0x00128A23, 0x00128E9D, 0x00129023, 0x0012B19D, 0x0012B223,
+0x0012B69D, 0x0012B823, 0x0012BF9D, 0x0012C023, 0x0012C19D, 0x0012C223, 0x0012C69D,
+0x0012C823, 0x0012D79D, 0x0012D823, 0x0013119D, 0x00131223, 0x0013169D, 0x00131823,
+0x00135B9D, 0x00135D23, 0x00137D9D, 0x00138023, 0x00139A9D, 0x0013A016, 0x0013F69D,
+0x0013F816, 0x0013FE9D, 0x00140013, 0x00168062, 0x00169D9D, 0x0016A073, 0x0016EB9C,
+0x0016EE73, 0x0016F99D, 0x0017008D, 0x00170D9D, 0x00170E8D, 0x0017159D, 0x0017202F,
+0x0017359C, 0x0017379D, 0x00174011, 0x0017549D, 0x00176084, 0x00176D9D, 0x00176E84,
+0x0017719D, 0x00177284, 0x0017749D, 0x0017803D, 0x0017DE9D, 0x0017E03D, 0x0017EA9D,
+0x0017F03D, 0x0017FA9D, 0x00180057, 0x0018029C, 0x00180457, 0x0018059C, 0x00180657,
+0x00180F9D, 0x00181057, 0x00181A9D, 0x00182057, 0x0018799D, 0x00188057, 0x0018AB9D,
+0x0018B013, 0x0018F69D, 0x00190046, 0x00191F9D, 0x00192046, 0x00192C9D, 0x00193046,
+0x00193C9D, 0x00194046, 0x0019419D, 0x00194446, 0x00195086, 0x00196E9D, 0x00197086,
+0x0019759D, 0x00198087, 0x0019AC9D, 0x0019B087, 0x0019CA9D, 0x0019D087, 0x0019DB9D,
+0x0019DE87, 0x0019E03D, 0x001A0010, 0x001A1C9D, 0x001A1E10, 0x001A2042, 0x001A5F9D,
+0x001A6042, 0x001A7D9D, 0x001A7F42, 0x001A8A9D, 0x001A9042, 0x001A9A9D, 0x001AA042,
+0x001AAE9D, 0x001AB09B, 0x001AC19D, 0x001B0007, 0x001B4C9D, 0x001B5007, 0x001B7D9D,
+0x001B8081, 0x001BC00A, 0x001BF49D, 0x001BFC0A, 0x001C0045, 0x001C389D, 0x001C3B45,
+0x001C4A9D, 0x001C4D45, 0x001C5063, 0x001C801A, 0x001C899D, 0x001C9024, 0x001CBB9D,
+0x001CBD24, 0x001CC081, 0x001CC89D, 0x001CD09B, 0x001CD39C, 0x001CD49B, 0x001CE19C,
+0x001CE29B, 0x001CE99C, 0x001CED9B, 0x001CEE9C, 0x001CF49B, 0x001CF59C, 0x001CF89B,
+0x001CFA9C, 0x001CFB9D, 0x001D0044, 0x001D262A, 0x001D2B1A, 0x001D2C44, 0x001D5D2A,
+0x001D6244, 0x001D662A, 0x001D6B44, 0x001D781A, 0x001D7944, 0x001DBF2A, 0x001DC09B,
+0x001DFA9D, 0x001DFB9B, 0x001E0044, 0x001F002A, 0x001F169D, 0x001F182A, 0x001F1E9D,
+0x001F202A, 0x001F469D, 0x001F482A, 0x001F4E9D, 0x001F502A, 0x001F589D, 0x001F592A,
+0x001F5A9D, 0x001F5B2A, 0x001F5C9D, 0x001F5D2A, 0x001F5E9D, 0x001F5F2A, 0x001F7E9D,
+0x001F802A, 0x001FB59D, 0x001FB62A, 0x001FC59D, 0x001FC62A, 0x001FD49D, 0x001FD62A,
+0x001FDC9D, 0x001FDD2A, 0x001FF09D, 0x001FF22A, 0x001FF59D, 0x001FF62A, 0x001FFF9D,
+0x0020009C, 0x00200C9B, 0x00200E9C, 0x0020659D, 0x0020669C, 0x00207144, 0x0020729D,
+0x0020749C, 0x00207F44, 0x0020809C, 0x00208F9D, 0x00209044, 0x00209D9D, 0x0020A09C,
+0x0020C09D, 0x0020D09B, 0x0020F19D, 0x0021009C, 0x0021262A, 0x0021279C, 0x00212A44,
+0x00212C9C, 0x00213244, 0x0021339C, 0x00214E44, 0x00214F9C, 0x00216044, 0x0021899C,
+0x00218C9D, 0x0021909C, 0x0024279D, 0x0024409C, 0x00244B9D, 0x0024609C, 0x0028000F,
+0x0029009C, 0x002B749D, 0x002B769C, 0x002B969D, 0x002B979C, 0x002C0025, 0x002C2F9D,
+0x002C3025, 0x002C5F9D, 0x002C6044, 0x002C8018, 0x002CF49D, 0x002CF918, 0x002D0024,
+0x002D269D, 0x002D2724, 0x002D289D, 0x002D2D24, 0x002D2E9D, 0x002D308C, 0x002D689D,
+0x002D6F8C, 0x002D719D, 0x002D7F8C, 0x002D8023, 0x002D979D, 0x002DA023, 0x002DA79D,
+0x002DA823, 0x002DAF9D, 0x002DB023, 0x002DB79D, 0x002DB823, 0x002DBF9D, 0x002DC023,
+0x002DC79D, 0x002DC823, 0x002DCF9D, 0x002DD023, 0x002DD79D, 0x002DD823, 0x002DDF9D,
+0x002DE01A, 0x002E009C, 0x002E539D, 0x002E802E, 0x002E9A9D, 0x002E9B2E, 0x002EF49D,
+0x002F002E, 0x002FD69D, 0x002FF09C, 0x002FFC9D, 0x0030009C, 0x0030052E, 0x0030069C,
+0x0030072E, 0x0030089C, 0x0030212E, 0x00302A9B, 0x00302E2D, 0x0030309C, 0x0030382E,
+0x00303C9C, 0x0030409D, 0x00304132, 0x0030979D, 0x0030999B, 0x00309B9C, 0x00309D32,
+0x0030A09C, 0x0030A13B, 0x0030FB9C, 0x0030FD3B, 0x0031009D, 0x0031050D, 0x0031309D,
+0x0031312D, 0x00318F9D, 0x0031909C, 0x0031A00D, 0x0031C09C, 0x0031E49D, 0x0031F03B,
+0x0032002D, 0x00321F9D, 0x0032209C, 0x0032602D, 0x00327F9C, 0x0032D03B, 0x0032FF9C,
+0x0033003B, 0x0033589C, 0x0034002E, 0x004DC09C, 0x004E002E, 0x009FFD9D, 0x00A00099,
+0x00A48D9D, 0x00A49099, 0x00A4C79D, 0x00A4D049, 0x00A50093, 0x00A62C9D, 0x00A6401A,
+0x00A6A008, 0x00A6F89D, 0x00A7009C, 0x00A72244, 0x00A7889C, 0x00A78B44, 0x00A7C09D,
+0x00A7C244, 0x00A7CB9D, 0x00A7F544, 0x00A80082, 0x00A82D9D, 0x00A8309C, 0x00A83A9D,
+0x00A8406B, 0x00A8789D, 0x00A88076, 0x00A8C69D, 0x00A8CE76, 0x00A8DA9D, 0x00A8E01B,
+0x00A9003A, 0x00A92E9C, 0x00A92F3A, 0x00A93071, 0x00A9549D, 0x00A95F71, 0x00A9602D,
+0x00A97D9D, 0x00A98039, 0x00A9CE9D, 0x00A9CF9C, 0x00A9D039, 0x00A9DA9D, 0x00A9DE39,
+0x00A9E05B, 0x00A9FF9D, 0x00AA0015, 0x00AA379D, 0x00AA4015, 0x00AA4E9D, 0x00AA5015,
+0x00AA5A9D, 0x00AA5C15, 0x00AA605B, 0x00AA808A, 0x00AAC39D, 0x00AADB8A, 0x00AAE059,
+0x00AAF79D, 0x00AB0123, 0x00AB079D, 0x00AB0923, 0x00AB0F9D, 0x00AB1123, 0x00AB179D,
+0x00AB2023, 0x00AB279D, 0x00AB2823, 0x00AB2F9D, 0x00AB3044, 0x00AB5B9C, 0x00AB5C44,
+0x00AB652A, 0x00AB6644, 0x00AB6A9C, 0x00AB6C9D, 0x00AB7016, 0x00ABC059, 0x00ABEE9D,
+0x00ABF059, 0x00ABFA9D, 0x00AC002D, 0x00D7A49D, 0x00D7B02D, 0x00D7C79D, 0x00D7CB2D,
+0x00D7FC9D, 0x00F9002E, 0x00FA6E9D, 0x00FA702E, 0x00FADA9D, 0x00FB0044, 0x00FB079D,
+0x00FB1305, 0x00FB189D, 0x00FB1D31, 0x00FB379D, 0x00FB3831, 0x00FB3D9D, 0x00FB3E31,
+0x00FB3F9D, 0x00FB4031, 0x00FB429D, 0x00FB4331, 0x00FB459D, 0x00FB4631, 0x00FB5003,
+0x00FBC29D, 0x00FBD303, 0x00FD3E9C, 0x00FD409D, 0x00FD5003, 0x00FD909D, 0x00FD9203,
+0x00FDC89D, 0x00FDF003, 0x00FDFE9D, 0x00FE009B, 0x00FE109C, 0x00FE1A9D, 0x00FE209B,
+0x00FE2E1A, 0x00FE309C, 0x00FE539D, 0x00FE549C, 0x00FE679D, 0x00FE689C, 0x00FE6C9D,
+0x00FE7003, 0x00FE759D, 0x00FE7603, 0x00FEFD9D, 0x00FEFF9C, 0x00FF009D, 0x00FF019C,
+0x00FF2144, 0x00FF3B9C, 0x00FF4144, 0x00FF5B9C, 0x00FF663B, 0x00FF709C, 0x00FF713B,
+0x00FF9E9C, 0x00FFA02D, 0x00FFBF9D, 0x00FFC22D, 0x00FFC89D, 0x00FFCA2D, 0x00FFD09D,
+0x00FFD22D, 0x00FFD89D, 0x00FFDA2D, 0x00FFDD9D, 0x00FFE09C, 0x00FFE79D, 0x00FFE89C,
+0x00FFEF9D, 0x00FFF99C, 0x00FFFE9D, 0x01000048, 0x01000C9D, 0x01000D48, 0x0100279D,
+0x01002848, 0x01003B9D, 0x01003C48, 0x01003E9D, 0x01003F48, 0x01004E9D, 0x01005048,
+0x01005E9D, 0x01008048, 0x0100FB9D, 0x0101009C, 0x0101039D, 0x0101079C, 0x0101349D,
+0x0101379C, 0x0101402A, 0x01018F9D, 0x0101909C, 0x01019D9D, 0x0101A02A, 0x0101A19D,
+0x0101D09C, 0x0101FD9B, 0x0101FE9D, 0x0102804A, 0x01029D9D, 0x0102A014, 0x0102D19D,
+0x0102E09B, 0x0102E19C, 0x0102FC9D, 0x01030038, 0x0103249D, 0x01032D38, 0x01033028,
+0x01034B9D, 0x0103506A, 0x01037B9D, 0x01038092, 0x01039E9D, 0x01039F92, 0x0103A096,
+0x0103C49D, 0x0103C896, 0x0103D69D, 0x0104001E, 0x01045078, 0x01048067, 0x01049E9D,
+0x0104A067, 0x0104AA9D, 0x0104B066, 0x0104D49D, 0x0104D866, 0x0104FC9D, 0x01050021,
+0x0105289D, 0x01053001, 0x0105649D, 0x01056F01, 0x0105709D, 0x01060047, 0x0107379D,
+0x01074047, 0x0107569D, 0x01076047, 0x0107689D, 0x01080019, 0x0108069D, 0x01080819,
+0x0108099D, 0x01080A19, 0x0108369D, 0x01083719, 0x0108399D, 0x01083C19, 0x01083D9D,
+0x01083F19, 0x01084004, 0x0108569D, 0x01085704, 0x01086068, 0x0108805E, 0x01089F9D,
+0x0108A75E, 0x0108B09D, 0x0108E030, 0x0108F39D, 0x0108F430, 0x0108F69D, 0x0108FB30,
+0x0109006E, 0x01091C9D, 0x01091F6E, 0x0109204B, 0x01093A9D, 0x01093F4B, 0x0109409D,
+0x01098054, 0x0109A053, 0x0109B89D, 0x0109BC53, 0x0109D09D, 0x0109D253, 0x010A003C,
+0x010A049D, 0x010A053C, 0x010A079D, 0x010A0C3C, 0x010A149D, 0x010A153C, 0x010A189D,
+0x010A193C, 0x010A369D, 0x010A383C, 0x010A3B9D, 0x010A3F3C, 0x010A499D, 0x010A503C,
+0x010A599D, 0x010A6075, 0x010A805D, 0x010AA09D, 0x010AC04F, 0x010AE79D, 0x010AEB4F,
+0x010AF79D, 0x010B0006, 0x010B369D, 0x010B3906, 0x010B4070, 0x010B569D, 0x010B5870,
+0x010B606C, 0x010B739D, 0x010B786C, 0x010B806D, 0x010B929D, 0x010B996D, 0x010B9D9D,
+0x010BA96D, 0x010BB09D, 0x010C0064, 0x010C499D, 0x010C8037, 0x010CB39D, 0x010CC037,
+0x010CF39D, 0x010CFA37, 0x010D0072, 0x010D289D, 0x010D3072, 0x010D3A9D, 0x010E6003,
+0x010E7F9D, 0x010E8098, 0x010EAA9D, 0x010EAB98, 0x010EAE9D, 0x010EB098, 0x010EB29D,
+0x010F007E, 0x010F289D, 0x010F307D, 0x010F5A9D, 0x010FB017, 0x010FCC9D, 0x010FE022,
+0x010FF79D, 0x0110000E, 0x01104E9D, 0x0110520E, 0x0110709D, 0x01107F0E, 0x01108041,
+0x0110C29D, 0x0110CD41, 0x0110CE9D, 0x0110D07F, 0x0110E99D, 0x0110F07F, 0x0110FA9D,
+0x01110012, 0x0111359D, 0x01113612, 0x0111489D, 0x0111504C, 0x0111779D, 0x01118079,
+0x0111E09D, 0x0111E17C, 0x0111F59D, 0x0112003E, 0x0112129D, 0x0112133E, 0x01123F9D,
+0x0112805A, 0x0112879D, 0x0112885A, 0x0112899D, 0x01128A5A, 0x01128E9D, 0x01128F5A,
+0x01129E9D, 0x01129F5A, 0x0112AA9D, 0x0112B07B, 0x0112EB9D, 0x0112F07B, 0x0112FA9D,
+0x01130029, 0x0113049D, 0x01130529, 0x01130D9D, 0x01130F29, 0x0113119D, 0x01131329,
+0x0113299D, 0x01132A29, 0x0113319D, 0x01133229, 0x0113349D, 0x01133529, 0x01133A9D,
+0x01133B9B, 0x01133C29, 0x0113459D, 0x01134729, 0x0113499D, 0x01134B29, 0x01134E9D,
+0x01135029, 0x0113519D, 0x01135729, 0x0113589D, 0x01135D29, 0x0113649D, 0x01136629,
+0x01136D9D, 0x01137029, 0x0113759D, 0x0114005F, 0x01145C9D, 0x01145D5F, 0x0114629D,
+0x01148091, 0x0114C89D, 0x0114D091, 0x0114DA9D, 0x0115807A, 0x0115B69D, 0x0115B87A,
+0x0115DE9D, 0x01160056, 0x0116459D, 0x01165056, 0x01165A9D, 0x01166057, 0x01166D9D,
+0x01168085, 0x0116B99D, 0x0116C085, 0x0116CA9D, 0x01170002, 0x01171B9D, 0x01171D02,
+0x01172C9D, 0x01173002, 0x0117409D, 0x0118001D, 0x01183C9D, 0x0118A094, 0x0118F39D,
+0x0118FF94, 0x0119001C, 0x0119079D, 0x0119091C, 0x01190A9D, 0x01190C1C, 0x0119149D,
+0x0119151C, 0x0119179D, 0x0119181C, 0x0119369D, 0x0119371C, 0x0119399D, 0x01193B1C,
+0x0119479D, 0x0119501C, 0x01195A9D, 0x0119A05C, 0x0119A89D, 0x0119AA5C, 0x0119D89D,
+0x0119DA5C, 0x0119E59D, 0x011A009A, 0x011A489D, 0x011A5080, 0x011AA39D, 0x011AC069,
+0x011AF99D, 0x011C000C, 0x011C099D, 0x011C0A0C, 0x011C379D, 0x011C380C, 0x011C469D,
+0x011C500C, 0x011C6D9D, 0x011C7050, 0x011C909D, 0x011C9250, 0x011CA89D, 0x011CA950,
+0x011CB79D, 0x011D0027, 0x011D079D, 0x011D0827, 0x011D0A9D, 0x011D0B27, 0x011D379D,
+0x011D3A27, 0x011D3B9D, 0x011D3C27, 0x011D3E9D, 0x011D3F27, 0x011D489D, 0x011D5027,
+0x011D5A9D, 0x011D6026, 0x011D669D, 0x011D6726, 0x011D699D, 0x011D6A26, 0x011D8F9D,
+0x011D9026, 0x011D929D, 0x011D9326, 0x011D999D, 0x011DA026, 0x011DAA9D, 0x011EE04D,
+0x011EF99D, 0x011FB049, 0x011FB19D, 0x011FC088, 0x011FF29D, 0x011FFF88, 0x01200097,
+0x01239A9D, 0x01240097, 0x01246F9D, 0x01247097, 0x0124759D, 0x01248097, 0x0125449D,
+0x01300020, 0x01342F9D, 0x01343020, 0x0134399D, 0x01440033, 0x0146479D, 0x01680008,
+0x016A399D, 0x016A4058, 0x016A5F9D, 0x016A6058, 0x016A6A9D, 0x016A6E58, 0x016A709D,
+0x016AD009, 0x016AEE9D, 0x016AF009, 0x016AF69D, 0x016B0034, 0x016B469D, 0x016B5034,
+0x016B5A9D, 0x016B5B34, 0x016B629D, 0x016B6334, 0x016B789D, 0x016B7D34, 0x016B909D,
+0x016E4051, 0x016E9B9D, 0x016F006F, 0x016F4B9D, 0x016F4F6F, 0x016F889D, 0x016F8F6F,
+0x016FA09D, 0x016FE089, 0x016FE161, 0x016FE29C, 0x016FE43F, 0x016FE59D, 0x016FF02E,
+0x016FF29D, 0x01700089, 0x0187F89D, 0x01880089, 0x018B003F, 0x018CD69D, 0x018D0089,
+0x018D099D, 0x01B0003B, 0x01B00132, 0x01B11F9D, 0x01B15032, 0x01B1539D, 0x01B1643B,
+0x01B1689D, 0x01B17061, 0x01B2FC9D, 0x01BC001F, 0x01BC6B9D, 0x01BC701F, 0x01BC7D9D,
+0x01BC801F, 0x01BC899D, 0x01BC901F, 0x01BC9A9D, 0x01BC9C1F, 0x01BCA09C, 0x01BCA49D,
+0x01D0009C, 0x01D0F69D, 0x01D1009C, 0x01D1279D, 0x01D1299C, 0x01D1679B, 0x01D16A9C,
+0x01D17B9B, 0x01D1839C, 0x01D1859B, 0x01D18C9C, 0x01D1AA9B, 0x01D1AE9C, 0x01D1E99D,
+0x01D2002A, 0x01D2469D, 0x01D2E09C, 0x01D2F49D, 0x01D3009C, 0x01D3579D, 0x01D3609C,
+0x01D3799D, 0x01D4009C, 0x01D4559D, 0x01D4569C, 0x01D49D9D, 0x01D49E9C, 0x01D4A09D,
+0x01D4A29C, 0x01D4A39D, 0x01D4A59C, 0x01D4A79D, 0x01D4A99C, 0x01D4AD9D, 0x01D4AE9C,
+0x01D4BA9D, 0x01D4BB9C, 0x01D4BC9D, 0x01D4BD9C, 0x01D4C49D, 0x01D4C59C, 0x01D5069D,
+0x01D5079C, 0x01D50B9D, 0x01D50D9C, 0x01D5159D, 0x01D5169C, 0x01D51D9D, 0x01D51E9C,
+0x01D53A9D, 0x01D53B9C, 0x01D53F9D, 0x01D5409C, 0x01D5459D, 0x01D5469C, 0x01D5479D,
+0x01D54A9C, 0x01D5519D, 0x01D5529C, 0x01D6A69D, 0x01D6A89C, 0x01D7CC9D, 0x01D7CE9C,
+0x01D80077, 0x01DA8C9D, 0x01DA9B77, 0x01DAA09D, 0x01DAA177, 0x01DAB09D, 0x01E00025,
+0x01E0079D, 0x01E00825, 0x01E0199D, 0x01E01B25, 0x01E0229D, 0x01E02325, 0x01E0259D,
+0x01E02625, 0x01E02B9D, 0x01E10035, 0x01E12D9D, 0x01E13035, 0x01E13E9D, 0x01E14035,
+0x01E14A9D, 0x01E14E35, 0x01E1509D, 0x01E2C095, 0x01E2FA9D, 0x01E2FF95, 0x01E3009D,
+0x01E80052, 0x01E8C59D, 0x01E8C752, 0x01E8D79D, 0x01E90000, 0x01E94C9D, 0x01E95000,
+0x01E95A9D, 0x01E95E00, 0x01E9609D, 0x01EC719C, 0x01ECB59D, 0x01ED019C, 0x01ED3E9D,
+0x01EE0003, 0x01EE049D, 0x01EE0503, 0x01EE209D, 0x01EE2103, 0x01EE239D, 0x01EE2403,
+0x01EE259D, 0x01EE2703, 0x01EE289D, 0x01EE2903, 0x01EE339D, 0x01EE3403, 0x01EE389D,
+0x01EE3903, 0x01EE3A9D, 0x01EE3B03, 0x01EE3C9D, 0x01EE4203, 0x01EE439D, 0x01EE4703,
+0x01EE489D, 0x01EE4903, 0x01EE4A9D, 0x01EE4B03, 0x01EE4C9D, 0x01EE4D03, 0x01EE509D,
+0x01EE5103, 0x01EE539D, 0x01EE5403, 0x01EE559D, 0x01EE5703, 0x01EE589D, 0x01EE5903,
+0x01EE5A9D, 0x01EE5B03, 0x01EE5C9D, 0x01EE5D03, 0x01EE5E9D, 0x01EE5F03, 0x01EE609D,
+0x01EE6103, 0x01EE639D, 0x01EE6403, 0x01EE659D, 0x01EE6703, 0x01EE6B9D, 0x01EE6C03,
+0x01EE739D, 0x01EE7403, 0x01EE789D, 0x01EE7903, 0x01EE7D9D, 0x01EE7E03, 0x01EE7F9D,
+0x01EE8003, 0x01EE8A9D, 0x01EE8B03, 0x01EE9C9D, 0x01EEA103, 0x01EEA49D, 0x01EEA503,
+0x01EEAA9D, 0x01EEAB03, 0x01EEBC9D, 0x01EEF003, 0x01EEF29D, 0x01F0009C, 0x01F02C9D,
+0x01F0309C, 0x01F0949D, 0x01F0A09C, 0x01F0AF9D, 0x01F0B19C, 0x01F0C09D, 0x01F0C19C,
+0x01F0D09D, 0x01F0D19C, 0x01F0F69D, 0x01F1009C, 0x01F1AE9D, 0x01F1E69C, 0x01F20032,
+0x01F2019C, 0x01F2039D, 0x01F2109C, 0x01F23C9D, 0x01F2409C, 0x01F2499D, 0x01F2509C,
+0x01F2529D, 0x01F2609C, 0x01F2669D, 0x01F3009C, 0x01F6D89D, 0x01F6E09C, 0x01F6ED9D,
+0x01F6F09C, 0x01F6FD9D, 0x01F7009C, 0x01F7749D, 0x01F7809C, 0x01F7D99D, 0x01F7E09C,
+0x01F7EC9D, 0x01F8009C, 0x01F80C9D, 0x01F8109C, 0x01F8489D, 0x01F8509C, 0x01F85A9D,
+0x01F8609C, 0x01F8889D, 0x01F8909C, 0x01F8AE9D, 0x01F8B09C, 0x01F8B29D, 0x01F9009C,
+0x01F9799D, 0x01F97A9C, 0x01F9CC9D, 0x01F9CD9C, 0x01FA549D, 0x01FA609C, 0x01FA6E9D,
+0x01FA709C, 0x01FA759D, 0x01FA789C, 0x01FA7B9D, 0x01FA809C, 0x01FA879D, 0x01FA909C,
+0x01FAA99D, 0x01FAB09C, 0x01FAB79D, 0x01FAC09C, 0x01FAC39D, 0x01FAD09C, 0x01FAD79D,
+0x01FB009C, 0x01FB939D, 0x01FB949C, 0x01FBCB9D, 0x01FBF09C, 0x01FBFA9D, 0x0200002E,
+0x02A6DE9D, 0x02A7002E, 0x02B7359D, 0x02B7402E, 0x02B81E9D, 0x02B8202E, 0x02CEA29D,
+0x02CEB02E, 0x02EBE19D, 0x02F8002E, 0x02FA1E9D, 0x0300002E, 0x03134B9D, 0x0E00019C,
+0x0E00029D, 0x0E00209C, 0x0E00809D, 0x0E01009B, 0x0E01F09D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<1> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x0003422A, 0x0003439D, 0x0003452A, 0x0003469D, 0x00036344, 0x0003709D,
+0x0004831A, 0x0004889D, 0x00060C03, 0x00060D9D, 0x00061B03, 0x00061D9D, 0x00061F03,
+0x0006209D, 0x00064000, 0x0006419D, 0x00064B03, 0x0006569D, 0x00066003, 0x00066A9D,
+0x00067003, 0x0006719D, 0x0006D403, 0x0006D59D, 0x0009510B, 0x0009539D, 0x0009640B,
+0x0009661B, 0x0009709D, 0x0009E60B, 0x0009F09D, 0x000A662C, 0x000A709D, 0x000AE62B,
+0x000AF09D, 0x000BE629, 0x000BF49D, 0x000CE640, 0x000CF09D, 0x00104012, 0x00104A9D,
+0x0010FB24, 0x0010FC9D, 0x00173511, 0x0017379D, 0x00180257, 0x0018049D, 0x00180557,
+0x0018069D, 0x001CD00B, 0x001CD11B, 0x001CD20B, 0x001CD31B, 0x001CD50B, 0x001CD71B,
+0x001CD80B, 0x001CD91B, 0x001CE10B, 0x001CE21B, 0x001CEA0B, 0x001CEB1B, 0x001CED0B,
+0x001CEE1B, 0x001CF20B, 0x001CF31B, 0x001CF50B, 0x001CF81B, 0x001CFA5C, 0x001CFB9D,
+0x001DC02A, 0x001DC29D, 0x001DF81A, 0x001DF99D, 0x00202F44, 0x0020309D, 0x0020F01B,
+0x0020F19D, 0x002E431A, 0x002E449D, 0x0030010D, 0x0030049D, 0x0030062E, 0x0030079D,
+0x0030080D, 0x0030129D, 0x0030130D, 0x0030209D, 0x00302A0D, 0x00302E9D, 0x0030300D,
+0x00303132, 0x0030369D, 0x0030370D, 0x0030389D, 0x00303C2E, 0x0030409D, 0x00309932,
+0x00309D9D, 0x0030A032, 0x0030A19D, 0x0030FB0D, 0x0030FC32, 0x0030FD9D, 0x0031902E,
+0x0031A09D, 0x0031C02E, 0x0031E49D, 0x0032202E, 0x0032489D, 0x0032802E, 0x0032B19D,
+0x0032C02E, 0x0032CC9D, 0x0032FF2E, 0x0033009D, 0x0033582E, 0x0033719D, 0x00337B2E,
+0x0033809D, 0x0033E02E, 0x0033FF9D, 0x00A66F1A, 0x00A6709D, 0x00A7002E, 0x00A7089D,
+0x00A8301B, 0x00A83A9D, 0x00A8F10B, 0x00A8F29D, 0x00A8F31B, 0x00A8F49D, 0x00A92E3A,
+0x00A92F9D, 0x00A9CF10, 0x00A9D09D, 0x00FDF203, 0x00FDF39D, 0x00FDFD03, 0x00FDFE9D,
+0x00FE450D, 0x00FE479D, 0x00FF610D, 0x00FF669D, 0x00FF7032, 0x00FF719D, 0x00FF9E32,
+0x00FFA09D, 0x01010019, 0x0101039D, 0x01010719, 0x0101349D, 0x01013719, 0x0101409D,
+0x0102E003, 0x0102FC9D, 0x01130129, 0x0113029D, 0x01130329, 0x0113049D, 0x01133B29,
+0x01133D9D, 0x011FD029, 0x011FD29D, 0x011FD329, 0x011FD49D, 0x01BCA01F, 0x01BCA49D,
+0x01D3602E, 0x01D3729D, 0x01F2502E, 0x01F2529D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<2> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x0004836A, 0x00048425, 0x00048544, 0x00048725, 0x0004889D, 0x00060C72,
+0x00060D9D, 0x00061B72, 0x00061C83, 0x00061D9D, 0x00061F72, 0x0006209D, 0x00064003,
+0x0006419D, 0x00064B83, 0x0006569D, 0x0006608E, 0x00066A9D, 0x00067083, 0x0006719D,
+0x0006D472, 0x0006D59D, 0x0009511B, 0x0009539D, 0x0009641B, 0x0009661D, 0x0009709D,
+0x0009E612, 0x0009F09D, 0x000A665A, 0x000A709D, 0x000AE63E, 0x000AF09D, 0x000BE688,
+0x000BF49D, 0x000CE65C, 0x000CF09D, 0x0010405B, 0x00104A9D, 0x0010FB44, 0x0010FC9D,
+0x0017352F, 0x0017379D, 0x0018026B, 0x0018049D, 0x0018056B, 0x0018069D, 0x001CD01B,
+0x001CD19D, 0x001CD21B, 0x001CD329, 0x001CD49D, 0x001CD51B, 0x001CD779, 0x001CD81B,
+0x001CD979, 0x001CDA40, 0x001CDB9D, 0x001CDC79, 0x001CDE9D, 0x001CE079, 0x001CE11B,
+0x001CE29D, 0x001CE95C, 0x001CEA1B, 0x001CEB9D, 0x001CED1B, 0x001CEE9D, 0x001CF21B,
+0x001CF329, 0x001CF51B, 0x001CF79D, 0x001CF829, 0x001CFA9D, 0x001DF883, 0x001DF99D,
+0x00202F57, 0x0020309D, 0x0020F029, 0x0020F19D, 0x002E4325, 0x002E449D, 0x0030012D,
+0x0030049D, 0x0030082D, 0x0030129D, 0x0030132D, 0x0030209D, 0x00302A2E, 0x00302E9D,
+0x0030302D, 0x0030313B, 0x0030369D, 0x0030372D, 0x0030389D, 0x00303C32, 0x00303E9D,
+0x0030993B, 0x00309D9D, 0x0030A03B, 0x0030A19D, 0x0030FB2D, 0x0030FC3B, 0x0030FD9D,
+0x00A66F25, 0x00A6709D, 0x00A70044, 0x00A7089D, 0x00A8301D, 0x00A83A9D, 0x00A8F11B,
+0x00A8F29D, 0x00A8F388, 0x00A8F49D, 0x00A92E44, 0x00A92F9D, 0x00A9CF39, 0x00A9D09D,
+0x00FDF28E, 0x00FDF39D, 0x00FDFD8E, 0x00FDFE9D, 0x00FE452D, 0x00FE479D, 0x00FF612D,
+0x00FF669D, 0x00FF703B, 0x00FF719D, 0x00FF9E3B, 0x00FFA09D, 0x01010048, 0x0101039D,
+0x01010747, 0x0101349D, 0x01013748, 0x0101409D, 0x0102E018, 0x0102FC9D, 0x01130188,
+0x0113029D, 0x01130388, 0x0113049D, 0x01133B88, 0x01133D9D, 0x011FD088, 0x011FD29D,
+0x011FD388, 0x011FD49D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<3> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00060C83, 0x00060D9D, 0x00061B83, 0x00061C8E, 0x00061D9D, 0x00061F83,
+0x0006209D, 0x0006404E, 0x0006419D, 0x00066098, 0x00066A9D, 0x00095129, 0x0009539D,
+0x0009641D, 0x00096641, 0x0009709D, 0x0009E682, 0x0009F09D, 0x00104086, 0x00104A9D,
+0x00173584, 0x0017379D, 0x001CD029, 0x001CD19D, 0x001CD229, 0x001CD39D, 0x001CDA55,
+0x001CDB9D, 0x001CF229, 0x001CF39D, 0x001CF440, 0x001CF59D, 0x0020F044, 0x0020F19D,
+0x0030012E, 0x0030049D, 0x0030082E, 0x0030129D, 0x0030132E, 0x0030209D, 0x0030302E,
+0x0030319D, 0x0030372E, 0x0030389D, 0x00303C3B, 0x00303E9D, 0x0030FB2E, 0x0030FC9D,
+0x00A8302B, 0x00A83A9D, 0x00A92E5B, 0x00A92F9D, 0x00FE452E, 0x00FE479D, 0x00FF612E,
+0x00FF669D, 0x01010748, 0x0101349D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<4> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00060C8E, 0x00060D9D, 0x00061B8E, 0x00061C9D, 0x00061F8E, 0x0006209D,
+0x0006404F, 0x0006419D, 0x0009512B, 0x0009539D, 0x00096426, 0x0009664C, 0x0009709D,
+0x0017358D, 0x0017379D, 0x001CD040, 0x001CD19D, 0x001CD240, 0x001CD39D, 0x001CDA65,
+0x001CDB9D, 0x001CF240, 0x001CF39D, 0x00300132, 0x0030049D, 0x00300832, 0x0030129D,
+0x00301332, 0x0030209D, 0x00303032, 0x0030319D, 0x00303732, 0x0030389D, 0x0030FB32,
+0x0030FC9D, 0x00A8302C, 0x00A83A9D, 0x00FE4532, 0x00FE479D, 0x00FF6132, 0x00FF669D,
+0xFFFFFFFF};
+};
+template<>
+struct script_data<5> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00060C98, 0x00060D9D, 0x00061B98, 0x00061C9D, 0x00061F98,
+0x0006209D, 0x0006406D, 0x0006419D, 0x0009512C, 0x0009539D, 0x00096427,
+0x0009669D, 0x001CDA88, 0x001CDB9D, 0x001CF25C, 0x001CF39D, 0x0030013B,
+0x0030049D, 0x0030083B, 0x0030129D, 0x0030133B, 0x0030209D, 0x0030303B,
+0x0030319D, 0x0030373B, 0x0030389D, 0x0030FB3B, 0x0030FC9D, 0x00A8303E,
+0x00A83A9D, 0x00FE453B, 0x00FE479D, 0x00FF613B, 0x00FF669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<6> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00064072, 0x0006419D, 0x00095140, 0x0009539D, 0x00096429, 0x0009669D,
+0x001CDA8B, 0x001CDB9D, 0x001CF265, 0x001CF39D, 0x00300199, 0x0030039D, 0x00300899,
+0x0030129D, 0x00301499, 0x00301C9D, 0x0030FB99, 0x0030FC9D, 0x00A83040, 0x00A83641,
+0x00A83A9D, 0x00FF6199, 0x00FF669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<7> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x0006407D, 0x0006419D, 0x00095144, 0x0009539D, 0x0009642B, 0x0009669D,
+0x001CF28B, 0x001CF39D, 0x00A83041, 0x00A8364C, 0x00A83A9D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<8> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00064083, 0x0006419D, 0x00095155, 0x0009539D, 0x0009642C, 0x0009669D,
+0x001CF291, 0x001CF39D, 0x00A8304C, 0x00A83656, 0x00A83A9D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<9> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00095165, 0x0009539D, 0x00096440, 0x0009669D,
+0x00A83055, 0x00A83356, 0x00A8367B, 0x00A83A9D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<10> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00095179, 0x00095288, 0x0009539D, 0x0009644C, 0x00096546,
+0x0009669D, 0x00A83056, 0x00A8335C, 0x00A83685, 0x00A83A9D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<11> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00095188, 0x0009528B, 0x0009539D, 0x00096455, 0x0009654C,
+0x0009669D, 0x00A8305C, 0x00A8337B, 0x00A83691, 0x00A83A9D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<12> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x0009518B, 0x00095291, 0x0009539D, 0x0009645C, 0x00096555,
+0x0009669D, 0x00A8307B, 0x00A83385, 0x00A8369D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<13> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x00095191, 0x0009529D, 0x00096465, 0x0009655C,
+0x0009669D, 0x00A83085, 0x00A83391, 0x00A8369D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<14> {
+static constexpr const compact_range scripts_data = {
+0x0000009D, 0x0009647B, 0x00096565, 0x0009669D, 0x00A83091, 0x00A8339D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<15> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x0009647C, 0x0009657B,
+0x0009669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<16> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x00096482, 0x0009657C,
+0x0009669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<17> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x00096485, 0x00096582,
+0x0009669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<18> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x00096488, 0x00096585,
+0x0009669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<19> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x0009648B, 0x00096588,
+0x0009669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<20> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x00096491, 0x0009658B,
+0x0009669D, 0xFFFFFFFF};
+};
+template<>
+struct script_data<21> {
+static constexpr const compact_range scripts_data = {0x0000009D, 0x00096591, 0x0009669D,
+0xFFFFFFFF};
+};
+template<auto N>
+constexpr script cp_script(char32_t cp) {
+if(cp > 0x10FFFF)
+return script::unknown;
+
+uni::script sc = static_cast<uni::script>(
+script_data<N>::scripts_data.value(cp, uint8_t(script::unknown)));
+return sc;
+}
+constexpr script get_cp_script(char32_t cp, int idx) {
+switch(idx) {
+case 0: return cp_script<0>(cp);
+case 1: return cp_script<1>(cp);
+case 2: return cp_script<2>(cp);
+case 3: return cp_script<3>(cp);
+case 4: return cp_script<4>(cp);
+case 5: return cp_script<5>(cp);
+case 6: return cp_script<6>(cp);
+case 7: return cp_script<7>(cp);
+case 8: return cp_script<8>(cp);
+case 9: return cp_script<9>(cp);
+case 10: return cp_script<10>(cp);
+case 11: return cp_script<11>(cp);
+case 12: return cp_script<12>(cp);
+case 13: return cp_script<13>(cp);
+case 14: return cp_script<14>(cp);
+case 15: return cp_script<15>(cp);
+case 16: return cp_script<16>(cp);
+case 17: return cp_script<17>(cp);
+case 18: return cp_script<18>(cp);
+case 19: return cp_script<19>(cp);
+case 20: return cp_script<20>(cp);
+case 21: return cp_script<21>(cp);
+}
+return script::zzzz;
+}
+static constexpr compact_list numeric_data8 = {
+0x00003000, 0x00003101, 0x00003202, 0x00003303, 0x00003404, 0x00003505, 0x00003606,
+0x00003707, 0x00003808, 0x00003909, 0x0000B202, 0x0000B303, 0x0000B901, 0x0000BC01,
+0x0000BD01, 0x0000BE03, 0x00066000, 0x00066101, 0x00066202, 0x00066303, 0x00066404,
+0x00066505, 0x00066606, 0x00066707, 0x00066808, 0x00066909, 0x0006F000, 0x0006F101,
+0x0006F202, 0x0006F303, 0x0006F404, 0x0006F505, 0x0006F606, 0x0006F707, 0x0006F808,
+0x0006F909, 0x0007C000, 0x0007C101, 0x0007C202, 0x0007C303, 0x0007C404, 0x0007C505,
+0x0007C606, 0x0007C707, 0x0007C808, 0x0007C909, 0x00096600, 0x00096701, 0x00096802,
+0x00096903, 0x00096A04, 0x00096B05, 0x00096C06, 0x00096D07, 0x00096E08, 0x00096F09,
+0x0009E600, 0x0009E701, 0x0009E802, 0x0009E903, 0x0009EA04, 0x0009EB05, 0x0009EC06,
+0x0009ED07, 0x0009EE08, 0x0009EF09, 0x0009F401, 0x0009F501, 0x0009F603, 0x0009F701,
+0x0009F803, 0x0009F910, 0x000A6600, 0x000A6701, 0x000A6802, 0x000A6903, 0x000A6A04,
+0x000A6B05, 0x000A6C06, 0x000A6D07, 0x000A6E08, 0x000A6F09, 0x000AE600, 0x000AE701,
+0x000AE802, 0x000AE903, 0x000AEA04, 0x000AEB05, 0x000AEC06, 0x000AED07, 0x000AEE08,
+0x000AEF09, 0x000B6600, 0x000B6701, 0x000B6802, 0x000B6903, 0x000B6A04, 0x000B6B05,
+0x000B6C06, 0x000B6D07, 0x000B6E08, 0x000B6F09, 0x000B7201, 0x000B7301, 0x000B7403,
+0x000B7501, 0x000B7601, 0x000B7703, 0x000BE600, 0x000BE701, 0x000BE802, 0x000BE903,
+0x000BEA04, 0x000BEB05, 0x000BEC06, 0x000BED07, 0x000BEE08, 0x000BEF09, 0x000BF00A,
+0x000BF164, 0x000C6600, 0x000C6701, 0x000C6802, 0x000C6903, 0x000C6A04, 0x000C6B05,
+0x000C6C06, 0x000C6D07, 0x000C6E08, 0x000C6F09, 0x000C7800, 0x000C7901, 0x000C7A02,
+0x000C7B03, 0x000C7C01, 0x000C7D02, 0x000C7E03, 0x000CE600, 0x000CE701, 0x000CE802,
+0x000CE903, 0x000CEA04, 0x000CEB05, 0x000CEC06, 0x000CED07, 0x000CEE08, 0x000CEF09,
+0x000D5801, 0x000D5901, 0x000D5A03, 0x000D5B01, 0x000D5C01, 0x000D5D03, 0x000D5E01,
+0x000D6600, 0x000D6701, 0x000D6802, 0x000D6903, 0x000D6A04, 0x000D6B05, 0x000D6C06,
+0x000D6D07, 0x000D6E08, 0x000D6F09, 0x000D700A, 0x000D7164, 0x000D7301, 0x000D7401,
+0x000D7503, 0x000D7601, 0x000D7701, 0x000D7803, 0x000DE600, 0x000DE701, 0x000DE802,
+0x000DE903, 0x000DEA04, 0x000DEB05, 0x000DEC06, 0x000DED07, 0x000DEE08, 0x000DEF09,
+0x000E5000, 0x000E5101, 0x000E5202, 0x000E5303, 0x000E5404, 0x000E5505, 0x000E5606,
+0x000E5707, 0x000E5808, 0x000E5909, 0x000ED000, 0x000ED101, 0x000ED202, 0x000ED303,
+0x000ED404, 0x000ED505, 0x000ED606, 0x000ED707, 0x000ED808, 0x000ED909, 0x000F2000,
+0x000F2101, 0x000F2202, 0x000F2303, 0x000F2404, 0x000F2505, 0x000F2606, 0x000F2707,
+0x000F2808, 0x000F2909, 0x000F2A01, 0x000F2B03, 0x000F2C05, 0x000F2D07, 0x000F2E09,
+0x000F2F0B, 0x000F300D, 0x000F310F, 0x000F3211, 0x00104000, 0x00104101, 0x00104202,
+0x00104303, 0x00104404, 0x00104505, 0x00104606, 0x00104707, 0x00104808, 0x00104909,
+0x00109000, 0x00109101, 0x00109202, 0x00109303, 0x00109404, 0x00109505, 0x00109606,
+0x00109707, 0x00109808, 0x00109909, 0x00136901, 0x00136A02, 0x00136B03, 0x00136C04,
+0x00136D05, 0x00136E06, 0x00136F07, 0x00137008, 0x00137109, 0x0013720A, 0x00137314,
+0x0013741E, 0x00137528, 0x00137632, 0x0013773C, 0x00137846, 0x00137950, 0x00137A5A,
+0x00137B64, 0x0016EE11, 0x0016EF12, 0x0016F013, 0x0017E000, 0x0017E101, 0x0017E202,
+0x0017E303, 0x0017E404, 0x0017E505, 0x0017E606, 0x0017E707, 0x0017E808, 0x0017E909,
+0x0017F000, 0x0017F101, 0x0017F202, 0x0017F303, 0x0017F404, 0x0017F505, 0x0017F606,
+0x0017F707, 0x0017F808, 0x0017F909, 0x00181000, 0x00181101, 0x00181202, 0x00181303,
+0x00181404, 0x00181505, 0x00181606, 0x00181707, 0x00181808, 0x00181909, 0x00194600,
+0x00194701, 0x00194802, 0x00194903, 0x00194A04, 0x00194B05, 0x00194C06, 0x00194D07,
+0x00194E08, 0x00194F09, 0x0019D000, 0x0019D101, 0x0019D202, 0x0019D303, 0x0019D404,
+0x0019D505, 0x0019D606, 0x0019D707, 0x0019D808, 0x0019D909, 0x0019DA01, 0x001A8000,
+0x001A8101, 0x001A8202, 0x001A8303, 0x001A8404, 0x001A8505, 0x001A8606, 0x001A8707,
+0x001A8808, 0x001A8909, 0x001A9000, 0x001A9101, 0x001A9202, 0x001A9303, 0x001A9404,
+0x001A9505, 0x001A9606, 0x001A9707, 0x001A9808, 0x001A9909, 0x001B5000, 0x001B5101,
+0x001B5202, 0x001B5303, 0x001B5404, 0x001B5505, 0x001B5606, 0x001B5707, 0x001B5808,
+0x001B5909, 0x001BB000, 0x001BB101, 0x001BB202, 0x001BB303, 0x001BB404, 0x001BB505,
+0x001BB606, 0x001BB707, 0x001BB808, 0x001BB909, 0x001C4000, 0x001C4101, 0x001C4202,
+0x001C4303, 0x001C4404, 0x001C4505, 0x001C4606, 0x001C4707, 0x001C4808, 0x001C4909,
+0x001C5000, 0x001C5101, 0x001C5202, 0x001C5303, 0x001C5404, 0x001C5505, 0x001C5606,
+0x001C5707, 0x001C5808, 0x001C5909, 0x00207000, 0x00207404, 0x00207505, 0x00207606,
+0x00207707, 0x00207808, 0x00207909, 0x00208000, 0x00208101, 0x00208202, 0x00208303,
+0x00208404, 0x00208505, 0x00208606, 0x00208707, 0x00208808, 0x00208909, 0x00215001,
+0x00215101, 0x00215201, 0x00215301, 0x00215402, 0x00215501, 0x00215602, 0x00215703,
+0x00215804, 0x00215901, 0x00215A05, 0x00215B01, 0x00215C03, 0x00215D05, 0x00215E07,
+0x00215F01, 0x00216001, 0x00216102, 0x00216203, 0x00216304, 0x00216405, 0x00216506,
+0x00216607, 0x00216708, 0x00216809, 0x0021690A, 0x00216A0B, 0x00216B0C, 0x00216C32,
+0x00216D64, 0x00217001, 0x00217102, 0x00217203, 0x00217304, 0x00217405, 0x00217506,
+0x00217607, 0x00217708, 0x00217809, 0x0021790A, 0x00217A0B, 0x00217B0C, 0x00217C32,
+0x00217D64, 0x00218506, 0x00218632, 0x00218900, 0x00246001, 0x00246102, 0x00246203,
+0x00246304, 0x00246405, 0x00246506, 0x00246607, 0x00246708, 0x00246809, 0x0024690A,
+0x00246A0B, 0x00246B0C, 0x00246C0D, 0x00246D0E, 0x00246E0F, 0x00246F10, 0x00247011,
+0x00247112, 0x00247213, 0x00247314, 0x00247401, 0x00247502, 0x00247603, 0x00247704,
+0x00247805, 0x00247906, 0x00247A07, 0x00247B08, 0x00247C09, 0x00247D0A, 0x00247E0B,
+0x00247F0C, 0x0024800D, 0x0024810E, 0x0024820F, 0x00248310, 0x00248411, 0x00248512,
+0x00248613, 0x00248714, 0x00248801, 0x00248902, 0x00248A03, 0x00248B04, 0x00248C05,
+0x00248D06, 0x00248E07, 0x00248F08, 0x00249009, 0x0024910A, 0x0024920B, 0x0024930C,
+0x0024940D, 0x0024950E, 0x0024960F, 0x00249710, 0x00249811, 0x00249912, 0x00249A13,
+0x00249B14, 0x0024EA00, 0x0024EB0B, 0x0024EC0C, 0x0024ED0D, 0x0024EE0E, 0x0024EF0F,
+0x0024F010, 0x0024F111, 0x0024F212, 0x0024F313, 0x0024F414, 0x0024F501, 0x0024F602,
+0x0024F703, 0x0024F804, 0x0024F905, 0x0024FA06, 0x0024FB07, 0x0024FC08, 0x0024FD09,
+0x0024FE0A, 0x0024FF00, 0x00277601, 0x00277702, 0x00277803, 0x00277904, 0x00277A05,
+0x00277B06, 0x00277C07, 0x00277D08, 0x00277E09, 0x00277F0A, 0x00278001, 0x00278102,
+0x00278203, 0x00278304, 0x00278405, 0x00278506, 0x00278607, 0x00278708, 0x00278809,
+0x0027890A, 0x00278A01, 0x00278B02, 0x00278C03, 0x00278D04, 0x00278E05, 0x00278F06,
+0x00279007, 0x00279108, 0x00279209, 0x0027930A, 0x002CFD01, 0x00300700, 0x00302101,
+0x00302202, 0x00302303, 0x00302404, 0x00302505, 0x00302606, 0x00302707, 0x00302808,
+0x00302909, 0x0030380A, 0x00303914, 0x00303A1E, 0x00319201, 0x00319302, 0x00319403,
+0x00319504, 0x00322001, 0x00322102, 0x00322203, 0x00322304, 0x00322405, 0x00322506,
+0x00322607, 0x00322708, 0x00322809, 0x0032290A, 0x0032480A, 0x00324914, 0x00324A1E,
+0x00324B28, 0x00324C32, 0x00324D3C, 0x00324E46, 0x00324F50, 0x00325115, 0x00325216,
+0x00325317, 0x00325418, 0x00325519, 0x0032561A, 0x0032571B, 0x0032581C, 0x0032591D,
+0x00325A1E, 0x00325B1F, 0x00325C20, 0x00325D21, 0x00325E22, 0x00325F23, 0x00328001,
+0x00328102, 0x00328203, 0x00328304, 0x00328405, 0x00328506, 0x00328607, 0x00328708,
+0x00328809, 0x0032890A, 0x0032B124, 0x0032B225, 0x0032B326, 0x0032B427, 0x0032B528,
+0x0032B629, 0x0032B72A, 0x0032B82B, 0x0032B92C, 0x0032BA2D, 0x0032BB2E, 0x0032BC2F,
+0x0032BD30, 0x0032BE31, 0x0032BF32, 0x00340505, 0x00348302, 0x00382A05, 0x003B4D07,
+0x004E0001, 0x004E0307, 0x004E0903, 0x004E5D09, 0x004E8C02, 0x004E9405, 0x004E9604,
+0x004EC00A, 0x004EE803, 0x004F0D05, 0x004F7064, 0x00516902, 0x00516B08, 0x00516D06,
+0x0053410A, 0x00534414, 0x0053451E, 0x00534C28, 0x0053C103, 0x0053C203, 0x0053C303,
+0x0053C403, 0x0056DB04, 0x0058F101, 0x0058F901, 0x005E7A01, 0x005EFE09, 0x005EFF14,
+0x005F0C01, 0x005F0D02, 0x005F0E03, 0x005F1002, 0x0062FE0A, 0x00634C08, 0x0067D207,
+0x006F0607, 0x00739609, 0x00767E64, 0x00808604, 0x008CAE02, 0x008CB302, 0x008D3002,
+0x00964606, 0x00964C64, 0x00967806, 0x0096F600, 0x00A62000, 0x00A62101, 0x00A62202,
+0x00A62303, 0x00A62404, 0x00A62505, 0x00A62606, 0x00A62707, 0x00A62808, 0x00A62909,
+0x00A6E601, 0x00A6E702, 0x00A6E803, 0x00A6E904, 0x00A6EA05, 0x00A6EB06, 0x00A6EC07,
+0x00A6ED08, 0x00A6EE09, 0x00A6EF00, 0x00A83001, 0x00A83101, 0x00A83203, 0x00A83301,
+0x00A83401, 0x00A83503, 0x00A8D000, 0x00A8D101, 0x00A8D202, 0x00A8D303, 0x00A8D404,
+0x00A8D505, 0x00A8D606, 0x00A8D707, 0x00A8D808, 0x00A8D909, 0x00A90000, 0x00A90101,
+0x00A90202, 0x00A90303, 0x00A90404, 0x00A90505, 0x00A90606, 0x00A90707, 0x00A90808,
+0x00A90909, 0x00A9D000, 0x00A9D101, 0x00A9D202, 0x00A9D303, 0x00A9D404, 0x00A9D505,
+0x00A9D606, 0x00A9D707, 0x00A9D808, 0x00A9D909, 0x00A9F000, 0x00A9F101, 0x00A9F202,
+0x00A9F303, 0x00A9F404, 0x00A9F505, 0x00A9F606, 0x00A9F707, 0x00A9F808, 0x00A9F909,
+0x00AA5000, 0x00AA5101, 0x00AA5202, 0x00AA5303, 0x00AA5404, 0x00AA5505, 0x00AA5606,
+0x00AA5707, 0x00AA5808, 0x00AA5909, 0x00ABF000, 0x00ABF101, 0x00ABF202, 0x00ABF303,
+0x00ABF404, 0x00ABF505, 0x00ABF606, 0x00ABF707, 0x00ABF808, 0x00ABF909, 0x00F96B03,
+0x00F9730A, 0x00F97802, 0x00F9B200, 0x00F9D106, 0x00F9D306, 0x00F9FD0A, 0x00FF1000,
+0x00FF1101, 0x00FF1202, 0x00FF1303, 0x00FF1404, 0x00FF1505, 0x00FF1606, 0x00FF1707,
+0x00FF1808, 0x00FF1909, 0x01010701, 0x01010802, 0x01010903, 0x01010A04, 0x01010B05,
+0x01010C06, 0x01010D07, 0x01010E08, 0x01010F09, 0x0101100A, 0x01011114, 0x0101121E,
+0x01011328, 0x01011432, 0x0101153C, 0x01011646, 0x01011750, 0x0101185A, 0x01011964,
+0x01014001, 0x01014101, 0x01014201, 0x01014305, 0x01014432, 0x01014805, 0x0101490A,
+0x01014A32, 0x01014B64, 0x01014F05, 0x0101500A, 0x01015132, 0x01015264, 0x0101570A,
+0x01015801, 0x01015901, 0x01015A01, 0x01015B02, 0x01015C02, 0x01015D02, 0x01015E02,
+0x01015F05, 0x0101600A, 0x0101610A, 0x0101620A, 0x0101630A, 0x0101640A, 0x0101651E,
+0x01016632, 0x01016732, 0x01016832, 0x01016932, 0x01016A64, 0x01017305, 0x01017432,
+0x01017501, 0x01017601, 0x01017702, 0x01017803, 0x01018A00, 0x01018B01, 0x0102E101,
+0x0102E202, 0x0102E303, 0x0102E404, 0x0102E505, 0x0102E606, 0x0102E707, 0x0102E808,
+0x0102E909, 0x0102EA0A, 0x0102EB14, 0x0102EC1E, 0x0102ED28, 0x0102EE32, 0x0102EF3C,
+0x0102F046, 0x0102F150, 0x0102F25A, 0x0102F364, 0x01032001, 0x01032105, 0x0103220A,
+0x01032332, 0x0103415A, 0x0103D101, 0x0103D202, 0x0103D30A, 0x0103D414, 0x0103D564,
+0x0104A000, 0x0104A101, 0x0104A202, 0x0104A303, 0x0104A404, 0x0104A505, 0x0104A606,
+0x0104A707, 0x0104A808, 0x0104A909, 0x01085801, 0x01085902, 0x01085A03, 0x01085B0A,
+0x01085C14, 0x01085D64, 0x01087901, 0x01087A02, 0x01087B03, 0x01087C04, 0x01087D05,
+0x01087E0A, 0x01087F14, 0x0108A701, 0x0108A802, 0x0108A903, 0x0108AA04, 0x0108AB04,
+0x0108AC05, 0x0108AD0A, 0x0108AE14, 0x0108AF64, 0x0108FB01, 0x0108FC05, 0x0108FD0A,
+0x0108FE14, 0x0108FF64, 0x01091601, 0x0109170A, 0x01091814, 0x01091964, 0x01091A02,
+0x01091B03, 0x0109BC0B, 0x0109BD01, 0x0109C001, 0x0109C102, 0x0109C203, 0x0109C304,
+0x0109C405, 0x0109C506, 0x0109C607, 0x0109C708, 0x0109C809, 0x0109C90A, 0x0109CA14,
+0x0109CB1E, 0x0109CC28, 0x0109CD32, 0x0109CE3C, 0x0109CF46, 0x0109D264, 0x0109F601,
+0x0109F702, 0x0109F803, 0x0109F904, 0x0109FA05, 0x0109FB06, 0x0109FC07, 0x0109FD08,
+0x0109FE09, 0x0109FF0A, 0x010A4001, 0x010A4102, 0x010A4203, 0x010A4304, 0x010A440A,
+0x010A4514, 0x010A4664, 0x010A4801, 0x010A7D01, 0x010A7E32, 0x010A9D01, 0x010A9E0A,
+0x010A9F14, 0x010AEB01, 0x010AEC05, 0x010AED0A, 0x010AEE14, 0x010AEF64, 0x010B5801,
+0x010B5902, 0x010B5A03, 0x010B5B04, 0x010B5C0A, 0x010B5D14, 0x010B5E64, 0x010B7801,
+0x010B7902, 0x010B7A03, 0x010B7B04, 0x010B7C0A, 0x010B7D14, 0x010B7E64, 0x010BA901,
+0x010BAA02, 0x010BAB03, 0x010BAC04, 0x010BAD0A, 0x010BAE14, 0x010BAF64, 0x010CFA01,
+0x010CFB05, 0x010CFC0A, 0x010CFD32, 0x010CFE64, 0x010D3000, 0x010D3101, 0x010D3202,
+0x010D3303, 0x010D3404, 0x010D3505, 0x010D3606, 0x010D3707, 0x010D3808, 0x010D3909,
+0x010E6001, 0x010E6102, 0x010E6203, 0x010E6304, 0x010E6405, 0x010E6506, 0x010E6607,
+0x010E6708, 0x010E6809, 0x010E690A, 0x010E6A14, 0x010E6B1E, 0x010E6C28, 0x010E6D32,
+0x010E6E3C, 0x010E6F46, 0x010E7050, 0x010E715A, 0x010E7264, 0x010E7B01, 0x010E7C01,
+0x010E7D01, 0x010E7E02, 0x010F1D01, 0x010F1E02, 0x010F1F03, 0x010F2004, 0x010F2105,
+0x010F220A, 0x010F2314, 0x010F241E, 0x010F2564, 0x010F2601, 0x010F5101, 0x010F520A,
+0x010F5314, 0x010F5464, 0x010FC501, 0x010FC602, 0x010FC703, 0x010FC804, 0x010FC90A,
+0x010FCA14, 0x010FCB64, 0x01105201, 0x01105302, 0x01105403, 0x01105504, 0x01105605,
+0x01105706, 0x01105807, 0x01105908, 0x01105A09, 0x01105B0A, 0x01105C14, 0x01105D1E,
+0x01105E28, 0x01105F32, 0x0110603C, 0x01106146, 0x01106250, 0x0110635A, 0x01106464,
+0x01106600, 0x01106701, 0x01106802, 0x01106903, 0x01106A04, 0x01106B05, 0x01106C06,
+0x01106D07, 0x01106E08, 0x01106F09, 0x0110F000, 0x0110F101, 0x0110F202, 0x0110F303,
+0x0110F404, 0x0110F505, 0x0110F606, 0x0110F707, 0x0110F808, 0x0110F909, 0x01113600,
+0x01113701, 0x01113802, 0x01113903, 0x01113A04, 0x01113B05, 0x01113C06, 0x01113D07,
+0x01113E08, 0x01113F09, 0x0111D000, 0x0111D101, 0x0111D202, 0x0111D303, 0x0111D404,
+0x0111D505, 0x0111D606, 0x0111D707, 0x0111D808, 0x0111D909, 0x0111E101, 0x0111E202,
+0x0111E303, 0x0111E404, 0x0111E505, 0x0111E606, 0x0111E707, 0x0111E808, 0x0111E909,
+0x0111EA0A, 0x0111EB14, 0x0111EC1E, 0x0111ED28, 0x0111EE32, 0x0111EF3C, 0x0111F046,
+0x0111F150, 0x0111F25A, 0x0111F364, 0x0112F000, 0x0112F101, 0x0112F202, 0x0112F303,
+0x0112F404, 0x0112F505, 0x0112F606, 0x0112F707, 0x0112F808, 0x0112F909, 0x01145000,
+0x01145101, 0x01145202, 0x01145303, 0x01145404, 0x01145505, 0x01145606, 0x01145707,
+0x01145808, 0x01145909, 0x0114D000, 0x0114D101, 0x0114D202, 0x0114D303, 0x0114D404,
+0x0114D505, 0x0114D606, 0x0114D707, 0x0114D808, 0x0114D909, 0x01165000, 0x01165101,
+0x01165202, 0x01165303, 0x01165404, 0x01165505, 0x01165606, 0x01165707, 0x01165808,
+0x01165909, 0x0116C000, 0x0116C101, 0x0116C202, 0x0116C303, 0x0116C404, 0x0116C505,
+0x0116C606, 0x0116C707, 0x0116C808, 0x0116C909, 0x01173000, 0x01173101, 0x01173202,
+0x01173303, 0x01173404, 0x01173505, 0x01173606, 0x01173707, 0x01173808, 0x01173909,
+0x01173A0A, 0x01173B14, 0x0118E000, 0x0118E101, 0x0118E202, 0x0118E303, 0x0118E404,
+0x0118E505, 0x0118E606, 0x0118E707, 0x0118E808, 0x0118E909, 0x0118EA0A, 0x0118EB14,
+0x0118EC1E, 0x0118ED28, 0x0118EE32, 0x0118EF3C, 0x0118F046, 0x0118F150, 0x0118F25A,
+0x01195000, 0x01195101, 0x01195202, 0x01195303, 0x01195404, 0x01195505, 0x01195606,
+0x01195707, 0x01195808, 0x01195909, 0x011C5000, 0x011C5101, 0x011C5202, 0x011C5303,
+0x011C5404, 0x011C5505, 0x011C5606, 0x011C5707, 0x011C5808, 0x011C5909, 0x011C5A01,
+0x011C5B02, 0x011C5C03, 0x011C5D04, 0x011C5E05, 0x011C5F06, 0x011C6007, 0x011C6108,
+0x011C6209, 0x011C630A, 0x011C6414, 0x011C651E, 0x011C6628, 0x011C6732, 0x011C683C,
+0x011C6946, 0x011C6A50, 0x011C6B5A, 0x011C6C64, 0x011D5000, 0x011D5101, 0x011D5202,
+0x011D5303, 0x011D5404, 0x011D5505, 0x011D5606, 0x011D5707, 0x011D5808, 0x011D5909,
+0x011DA000, 0x011DA101, 0x011DA202, 0x011DA303, 0x011DA404, 0x011DA505, 0x011DA606,
+0x011DA707, 0x011DA808, 0x011DA909, 0x011FC001, 0x011FC101, 0x011FC201, 0x011FC301,
+0x011FC401, 0x011FC501, 0x011FC603, 0x011FC703, 0x011FC801, 0x011FC901, 0x011FCA01,
+0x011FCB01, 0x011FCC01, 0x011FCD03, 0x011FCE03, 0x011FCF01, 0x011FD001, 0x011FD101,
+0x011FD201, 0x011FD303, 0x011FD401, 0x01240002, 0x01240103, 0x01240204, 0x01240305,
+0x01240406, 0x01240507, 0x01240608, 0x01240709, 0x01240803, 0x01240904, 0x01240A05,
+0x01240B06, 0x01240C07, 0x01240D08, 0x01240E09, 0x01240F04, 0x01241005, 0x01241106,
+0x01241207, 0x01241308, 0x01241409, 0x01241501, 0x01241602, 0x01241703, 0x01241804,
+0x01241905, 0x01241A06, 0x01241B07, 0x01241C08, 0x01241D09, 0x01241E01, 0x01241F02,
+0x01242003, 0x01242104, 0x01242205, 0x01242302, 0x01242403, 0x01242503, 0x01242604,
+0x01242705, 0x01242806, 0x01242907, 0x01242A08, 0x01242B09, 0x01242C01, 0x01242D02,
+0x01242E03, 0x01242F03, 0x01243004, 0x01243105, 0x01243401, 0x01243502, 0x01243603,
+0x01243703, 0x01243804, 0x01243905, 0x01243A03, 0x01243B03, 0x01243C04, 0x01243D04,
+0x01243E04, 0x01243F04, 0x01244006, 0x01244107, 0x01244207, 0x01244307, 0x01244408,
+0x01244508, 0x01244609, 0x01244709, 0x01244809, 0x01244909, 0x01244A02, 0x01244B03,
+0x01244C04, 0x01244D05, 0x01244E06, 0x01244F01, 0x01245002, 0x01245103, 0x01245204,
+0x01245304, 0x01245405, 0x01245505, 0x01245602, 0x01245703, 0x01245801, 0x01245902,
+0x01245A01, 0x01245B02, 0x01245C05, 0x01245D01, 0x01245E02, 0x01245F01, 0x01246001,
+0x01246101, 0x01246201, 0x01246301, 0x01246401, 0x01246501, 0x01246602, 0x01246728,
+0x01246832, 0x01246904, 0x01246A05, 0x01246B06, 0x01246C07, 0x01246D08, 0x01246E09,
+0x016A6000, 0x016A6101, 0x016A6202, 0x016A6303, 0x016A6404, 0x016A6505, 0x016A6606,
+0x016A6707, 0x016A6808, 0x016A6909, 0x016B5000, 0x016B5101, 0x016B5202, 0x016B5303,
+0x016B5404, 0x016B5505, 0x016B5606, 0x016B5707, 0x016B5808, 0x016B5909, 0x016B5B0A,
+0x016B5C64, 0x016E8000, 0x016E8101, 0x016E8202, 0x016E8303, 0x016E8404, 0x016E8505,
+0x016E8606, 0x016E8707, 0x016E8808, 0x016E8909, 0x016E8A0A, 0x016E8B0B, 0x016E8C0C,
+0x016E8D0D, 0x016E8E0E, 0x016E8F0F, 0x016E9010, 0x016E9111, 0x016E9212, 0x016E9313,
+0x016E9401, 0x016E9502, 0x016E9603, 0x01D2E000, 0x01D2E101, 0x01D2E202, 0x01D2E303,
+0x01D2E404, 0x01D2E505, 0x01D2E606, 0x01D2E707, 0x01D2E808, 0x01D2E909, 0x01D2EA0A,
+0x01D2EB0B, 0x01D2EC0C, 0x01D2ED0D, 0x01D2EE0E, 0x01D2EF0F, 0x01D2F010, 0x01D2F111,
+0x01D2F212, 0x01D2F313, 0x01D36001, 0x01D36102, 0x01D36203, 0x01D36304, 0x01D36405,
+0x01D36506, 0x01D36607, 0x01D36708, 0x01D36809, 0x01D3690A, 0x01D36A14, 0x01D36B1E,
+0x01D36C28, 0x01D36D32, 0x01D36E3C, 0x01D36F46, 0x01D37050, 0x01D3715A, 0x01D37201,
+0x01D37302, 0x01D37403, 0x01D37504, 0x01D37605, 0x01D37701, 0x01D37805, 0x01D7CE00,
+0x01D7CF01, 0x01D7D002, 0x01D7D103, 0x01D7D204, 0x01D7D305, 0x01D7D406, 0x01D7D507,
+0x01D7D608, 0x01D7D709, 0x01D7D800, 0x01D7D901, 0x01D7DA02, 0x01D7DB03, 0x01D7DC04,
+0x01D7DD05, 0x01D7DE06, 0x01D7DF07, 0x01D7E008, 0x01D7E109, 0x01D7E200, 0x01D7E301,
+0x01D7E402, 0x01D7E503, 0x01D7E604, 0x01D7E705, 0x01D7E806, 0x01D7E907, 0x01D7EA08,
+0x01D7EB09, 0x01D7EC00, 0x01D7ED01, 0x01D7EE02, 0x01D7EF03, 0x01D7F004, 0x01D7F105,
+0x01D7F206, 0x01D7F307, 0x01D7F408, 0x01D7F509, 0x01D7F600, 0x01D7F701, 0x01D7F802,
+0x01D7F903, 0x01D7FA04, 0x01D7FB05, 0x01D7FC06, 0x01D7FD07, 0x01D7FE08, 0x01D7FF09,
+0x01E14000, 0x01E14101, 0x01E14202, 0x01E14303, 0x01E14404, 0x01E14505, 0x01E14606,
+0x01E14707, 0x01E14808, 0x01E14909, 0x01E2F000, 0x01E2F101, 0x01E2F202, 0x01E2F303,
+0x01E2F404, 0x01E2F505, 0x01E2F606, 0x01E2F707, 0x01E2F808, 0x01E2F909, 0x01E8C701,
+0x01E8C802, 0x01E8C903, 0x01E8CA04, 0x01E8CB05, 0x01E8CC06, 0x01E8CD07, 0x01E8CE08,
+0x01E8CF09, 0x01E95000, 0x01E95101, 0x01E95202, 0x01E95303, 0x01E95404, 0x01E95505,
+0x01E95606, 0x01E95707, 0x01E95808, 0x01E95909, 0x01EC7101, 0x01EC7202, 0x01EC7303,
+0x01EC7404, 0x01EC7505, 0x01EC7606, 0x01EC7707, 0x01EC7808, 0x01EC7909, 0x01EC7A0A,
+0x01EC7B14, 0x01EC7C1E, 0x01EC7D28, 0x01EC7E32, 0x01EC7F3C, 0x01EC8046, 0x01EC8150,
+0x01EC825A, 0x01EC8364, 0x01ECA301, 0x01ECA402, 0x01ECA503, 0x01ECA604, 0x01ECA705,
+0x01ECA806, 0x01ECA907, 0x01ECAA08, 0x01ECAB09, 0x01ECAD01, 0x01ECAE01, 0x01ECAF03,
+0x01ECB101, 0x01ECB202, 0x01ED0101, 0x01ED0202, 0x01ED0303, 0x01ED0404, 0x01ED0505,
+0x01ED0606, 0x01ED0707, 0x01ED0808, 0x01ED0909, 0x01ED0A0A, 0x01ED0B14, 0x01ED0C1E,
+0x01ED0D28, 0x01ED0E32, 0x01ED0F3C, 0x01ED1046, 0x01ED1150, 0x01ED125A, 0x01ED1364,
+0x01ED2F02, 0x01ED3003, 0x01ED3104, 0x01ED3205, 0x01ED3306, 0x01ED3407, 0x01ED3508,
+0x01ED3609, 0x01ED370A, 0x01ED3C01, 0x01ED3D01, 0x01F10000, 0x01F10100, 0x01F10201,
+0x01F10302, 0x01F10403, 0x01F10504, 0x01F10605, 0x01F10706, 0x01F10807, 0x01F10908,
+0x01F10A09, 0x01F10B00, 0x01F10C00, 0x01FBF000, 0x01FBF101, 0x01FBF202, 0x01FBF303,
+0x01FBF404, 0x01FBF505, 0x01FBF606, 0x01FBF707, 0x01FBF808, 0x01FBF909, 0x02000107,
+0x02006404, 0x0200E204, 0x02012105, 0x02092A01, 0x0209831E, 0x02098C28, 0x02099C28,
+0x020AEA06, 0x020AFD03, 0x020B1903, 0x02239002, 0x02299803, 0x023B1B03, 0x02626D04,
+0x02F89009};
+static constexpr uni::detail::pair<char32_t, int16_t> numeric_data16[] = {
+uni::detail::pair<char32_t, int16_t>{0x0BF2, 1000},
+uni::detail::pair<char32_t, int16_t>{0x0D72, 1000},
+uni::detail::pair<char32_t, int16_t>{0x0F33, -1},
+uni::detail::pair<char32_t, int16_t>{0x137C, 10000},
+uni::detail::pair<char32_t, int16_t>{0x216E, 500},
+uni::detail::pair<char32_t, int16_t>{0x216F, 1000},
+uni::detail::pair<char32_t, int16_t>{0x217E, 500},
+uni::detail::pair<char32_t, int16_t>{0x217F, 1000},
+uni::detail::pair<char32_t, int16_t>{0x2180, 1000},
+uni::detail::pair<char32_t, int16_t>{0x2181, 5000},
+uni::detail::pair<char32_t, int16_t>{0x2182, 10000},
+uni::detail::pair<char32_t, int16_t>{0x4E07, 10000},
+uni::detail::pair<char32_t, int16_t>{0x4EDF, 1000},
+uni::detail::pair<char32_t, int16_t>{0x5343, 1000},
+uni::detail::pair<char32_t, int16_t>{0x842C, 10000},
+uni::detail::pair<char32_t, int16_t>{0x9621, 1000},
+uni::detail::pair<char32_t, int16_t>{0x1011A, 200},
+uni::detail::pair<char32_t, int16_t>{0x1011B, 300},
+uni::detail::pair<char32_t, int16_t>{0x1011C, 400},
+uni::detail::pair<char32_t, int16_t>{0x1011D, 500},
+uni::detail::pair<char32_t, int16_t>{0x1011E, 600},
+uni::detail::pair<char32_t, int16_t>{0x1011F, 700},
+uni::detail::pair<char32_t, int16_t>{0x10120, 800},
+uni::detail::pair<char32_t, int16_t>{0x10121, 900},
+uni::detail::pair<char32_t, int16_t>{0x10122, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10123, 2000},
+uni::detail::pair<char32_t, int16_t>{0x10124, 3000},
+uni::detail::pair<char32_t, int16_t>{0x10125, 4000},
+uni::detail::pair<char32_t, int16_t>{0x10126, 5000},
+uni::detail::pair<char32_t, int16_t>{0x10127, 6000},
+uni::detail::pair<char32_t, int16_t>{0x10128, 7000},
+uni::detail::pair<char32_t, int16_t>{0x10129, 8000},
+uni::detail::pair<char32_t, int16_t>{0x1012A, 9000},
+uni::detail::pair<char32_t, int16_t>{0x1012B, 10000},
+uni::detail::pair<char32_t, int16_t>{0x1012C, 20000},
+uni::detail::pair<char32_t, int16_t>{0x1012D, 30000},
+uni::detail::pair<char32_t, int16_t>{0x10145, 500},
+uni::detail::pair<char32_t, int16_t>{0x10146, 5000},
+uni::detail::pair<char32_t, int16_t>{0x1014C, 500},
+uni::detail::pair<char32_t, int16_t>{0x1014D, 1000},
+uni::detail::pair<char32_t, int16_t>{0x1014E, 5000},
+uni::detail::pair<char32_t, int16_t>{0x10153, 500},
+uni::detail::pair<char32_t, int16_t>{0x10154, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10155, 10000},
+uni::detail::pair<char32_t, int16_t>{0x1016B, 300},
+uni::detail::pair<char32_t, int16_t>{0x1016C, 500},
+uni::detail::pair<char32_t, int16_t>{0x1016D, 500},
+uni::detail::pair<char32_t, int16_t>{0x1016E, 500},
+uni::detail::pair<char32_t, int16_t>{0x1016F, 500},
+uni::detail::pair<char32_t, int16_t>{0x10170, 500},
+uni::detail::pair<char32_t, int16_t>{0x10171, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10172, 5000},
+uni::detail::pair<char32_t, int16_t>{0x102F4, 200},
+uni::detail::pair<char32_t, int16_t>{0x102F5, 300},
+uni::detail::pair<char32_t, int16_t>{0x102F6, 400},
+uni::detail::pair<char32_t, int16_t>{0x102F7, 500},
+uni::detail::pair<char32_t, int16_t>{0x102F8, 600},
+uni::detail::pair<char32_t, int16_t>{0x102F9, 700},
+uni::detail::pair<char32_t, int16_t>{0x102FA, 800},
+uni::detail::pair<char32_t, int16_t>{0x102FB, 900},
+uni::detail::pair<char32_t, int16_t>{0x1034A, 900},
+uni::detail::pair<char32_t, int16_t>{0x1085E, 1000},
+uni::detail::pair<char32_t, int16_t>{0x1085F, 10000},
+uni::detail::pair<char32_t, int16_t>{0x109D3, 200},
+uni::detail::pair<char32_t, int16_t>{0x109D4, 300},
+uni::detail::pair<char32_t, int16_t>{0x109D5, 400},
+uni::detail::pair<char32_t, int16_t>{0x109D6, 500},
+uni::detail::pair<char32_t, int16_t>{0x109D7, 600},
+uni::detail::pair<char32_t, int16_t>{0x109D8, 700},
+uni::detail::pair<char32_t, int16_t>{0x109D9, 800},
+uni::detail::pair<char32_t, int16_t>{0x109DA, 900},
+uni::detail::pair<char32_t, int16_t>{0x109DB, 1000},
+uni::detail::pair<char32_t, int16_t>{0x109DC, 2000},
+uni::detail::pair<char32_t, int16_t>{0x109DD, 3000},
+uni::detail::pair<char32_t, int16_t>{0x109DE, 4000},
+uni::detail::pair<char32_t, int16_t>{0x109DF, 5000},
+uni::detail::pair<char32_t, int16_t>{0x109E0, 6000},
+uni::detail::pair<char32_t, int16_t>{0x109E1, 7000},
+uni::detail::pair<char32_t, int16_t>{0x109E2, 8000},
+uni::detail::pair<char32_t, int16_t>{0x109E3, 9000},
+uni::detail::pair<char32_t, int16_t>{0x109E4, 10000},
+uni::detail::pair<char32_t, int16_t>{0x109E5, 20000},
+uni::detail::pair<char32_t, int16_t>{0x109E6, 30000},
+uni::detail::pair<char32_t, int16_t>{0x10A47, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10B5F, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10B7F, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10CFF, 1000},
+uni::detail::pair<char32_t, int16_t>{0x10E73, 200},
+uni::detail::pair<char32_t, int16_t>{0x10E74, 300},
+uni::detail::pair<char32_t, int16_t>{0x10E75, 400},
+uni::detail::pair<char32_t, int16_t>{0x10E76, 500},
+uni::detail::pair<char32_t, int16_t>{0x10E77, 600},
+uni::detail::pair<char32_t, int16_t>{0x10E78, 700},
+uni::detail::pair<char32_t, int16_t>{0x10E79, 800},
+uni::detail::pair<char32_t, int16_t>{0x10E7A, 900},
+uni::detail::pair<char32_t, int16_t>{0x11065, 1000},
+uni::detail::pair<char32_t, int16_t>{0x111F4, 1000},
+uni::detail::pair<char32_t, int16_t>{0x16B5D, 10000},
+uni::detail::pair<char32_t, int16_t>{0x1EC84, 200},
+uni::detail::pair<char32_t, int16_t>{0x1EC85, 300},
+uni::detail::pair<char32_t, int16_t>{0x1EC86, 400},
+uni::detail::pair<char32_t, int16_t>{0x1EC87, 500},
+uni::detail::pair<char32_t, int16_t>{0x1EC88, 600},
+uni::detail::pair<char32_t, int16_t>{0x1EC89, 700},
+uni::detail::pair<char32_t, int16_t>{0x1EC8A, 800},
+uni::detail::pair<char32_t, int16_t>{0x1EC8B, 900},
+uni::detail::pair<char32_t, int16_t>{0x1EC8C, 1000},
+uni::detail::pair<char32_t, int16_t>{0x1EC8D, 2000},
+uni::detail::pair<char32_t, int16_t>{0x1EC8E, 3000},
+uni::detail::pair<char32_t, int16_t>{0x1EC8F, 4000},
+uni::detail::pair<char32_t, int16_t>{0x1EC90, 5000},
+uni::detail::pair<char32_t, int16_t>{0x1EC91, 6000},
+uni::detail::pair<char32_t, int16_t>{0x1EC92, 7000},
+uni::detail::pair<char32_t, int16_t>{0x1EC93, 8000},
+uni::detail::pair<char32_t, int16_t>{0x1EC94, 9000},
+uni::detail::pair<char32_t, int16_t>{0x1EC95, 10000},
+uni::detail::pair<char32_t, int16_t>{0x1EC96, 20000},
+uni::detail::pair<char32_t, int16_t>{0x1EC97, 30000},
+uni::detail::pair<char32_t, int16_t>{0x1ECB3, 10000},
+uni::detail::pair<char32_t, int16_t>{0x1ED14, 200},
+uni::detail::pair<char32_t, int16_t>{0x1ED15, 300},
+uni::detail::pair<char32_t, int16_t>{0x1ED16, 400},
+uni::detail::pair<char32_t, int16_t>{0x1ED17, 500},
+uni::detail::pair<char32_t, int16_t>{0x1ED18, 600},
+uni::detail::pair<char32_t, int16_t>{0x1ED19, 700},
+uni::detail::pair<char32_t, int16_t>{0x1ED1A, 800},
+uni::detail::pair<char32_t, int16_t>{0x1ED1B, 900},
+uni::detail::pair<char32_t, int16_t>{0x1ED1C, 1000},
+uni::detail::pair<char32_t, int16_t>{0x1ED1D, 2000},
+uni::detail::pair<char32_t, int16_t>{0x1ED1E, 3000},
+uni::detail::pair<char32_t, int16_t>{0x1ED1F, 4000},
+uni::detail::pair<char32_t, int16_t>{0x1ED20, 5000},
+uni::detail::pair<char32_t, int16_t>{0x1ED21, 6000},
+uni::detail::pair<char32_t, int16_t>{0x1ED22, 7000},
+uni::detail::pair<char32_t, int16_t>{0x1ED23, 8000},
+uni::detail::pair<char32_t, int16_t>{0x1ED24, 9000},
+uni::detail::pair<char32_t, int16_t>{0x1ED25, 10000},
+uni::detail::pair<char32_t, int16_t>{0x1ED26, 20000},
+uni::detail::pair<char32_t, int16_t>{0x1ED27, 30000},
+uni::detail::pair<char32_t, int16_t>{0x1ED38, 400},
+uni::detail::pair<char32_t, int16_t>{0x1ED39, 600},
+uni::detail::pair<char32_t, int16_t>{0x1ED3A, 2000},
+uni::detail::pair<char32_t, int16_t>{0x1ED3B, 10000},
+};
+static constexpr uni::detail::pair<char32_t, int32_t> numeric_data32[] = {
+uni::detail::pair<char32_t, int32_t>{0x2187, 50000},
+uni::detail::pair<char32_t, int32_t>{0x2188, 100000},
+uni::detail::pair<char32_t, int32_t>{0x4EBF, 100000000},
+uni::detail::pair<char32_t, int32_t>{0x5104, 100000000},
+uni::detail::pair<char32_t, int32_t>{0x1012E, 40000},
+uni::detail::pair<char32_t, int32_t>{0x1012F, 50000},
+uni::detail::pair<char32_t, int32_t>{0x10130, 60000},
+uni::detail::pair<char32_t, int32_t>{0x10131, 70000},
+uni::detail::pair<char32_t, int32_t>{0x10132, 80000},
+uni::detail::pair<char32_t, int32_t>{0x10133, 90000},
+uni::detail::pair<char32_t, int32_t>{0x10147, 50000},
+uni::detail::pair<char32_t, int32_t>{0x10156, 50000},
+uni::detail::pair<char32_t, int32_t>{0x109E7, 40000},
+uni::detail::pair<char32_t, int32_t>{0x109E8, 50000},
+uni::detail::pair<char32_t, int32_t>{0x109E9, 60000},
+uni::detail::pair<char32_t, int32_t>{0x109EA, 70000},
+uni::detail::pair<char32_t, int32_t>{0x109EB, 80000},
+uni::detail::pair<char32_t, int32_t>{0x109EC, 90000},
+uni::detail::pair<char32_t, int32_t>{0x109ED, 100000},
+uni::detail::pair<char32_t, int32_t>{0x109EE, 200000},
+uni::detail::pair<char32_t, int32_t>{0x109EF, 300000},
+uni::detail::pair<char32_t, int32_t>{0x109F0, 400000},
+uni::detail::pair<char32_t, int32_t>{0x109F1, 500000},
+uni::detail::pair<char32_t, int32_t>{0x109F2, 600000},
+uni::detail::pair<char32_t, int32_t>{0x109F3, 700000},
+uni::detail::pair<char32_t, int32_t>{0x109F4, 800000},
+uni::detail::pair<char32_t, int32_t>{0x109F5, 900000},
+uni::detail::pair<char32_t, int32_t>{0x12432, 216000},
+uni::detail::pair<char32_t, int32_t>{0x12433, 432000},
+uni::detail::pair<char32_t, int32_t>{0x16B5E, 1000000},
+uni::detail::pair<char32_t, int32_t>{0x16B5F, 100000000},
+uni::detail::pair<char32_t, int32_t>{0x1EC98, 40000},
+uni::detail::pair<char32_t, int32_t>{0x1EC99, 50000},
+uni::detail::pair<char32_t, int32_t>{0x1EC9A, 60000},
+uni::detail::pair<char32_t, int32_t>{0x1EC9B, 70000},
+uni::detail::pair<char32_t, int32_t>{0x1EC9C, 80000},
+uni::detail::pair<char32_t, int32_t>{0x1EC9D, 90000},
+uni::detail::pair<char32_t, int32_t>{0x1EC9E, 100000},
+uni::detail::pair<char32_t, int32_t>{0x1EC9F, 200000},
+uni::detail::pair<char32_t, int32_t>{0x1ECA0, 100000},
+uni::detail::pair<char32_t, int32_t>{0x1ECA1, 10000000},
+uni::detail::pair<char32_t, int32_t>{0x1ECA2, 20000000},
+uni::detail::pair<char32_t, int32_t>{0x1ECB4, 100000},
+uni::detail::pair<char32_t, int32_t>{0x1ED28, 40000},
+uni::detail::pair<char32_t, int32_t>{0x1ED29, 50000},
+uni::detail::pair<char32_t, int32_t>{0x1ED2A, 60000},
+uni::detail::pair<char32_t, int32_t>{0x1ED2B, 70000},
+uni::detail::pair<char32_t, int32_t>{0x1ED2C, 80000},
+uni::detail::pair<char32_t, int32_t>{0x1ED2D, 90000},
+};
+static constexpr uni::detail::pair<char32_t, int64_t> numeric_data64[] = {
+uni::detail::pair<char32_t, int64_t>{0x5146, 1000000000000},
+uni::detail::pair<char32_t, int64_t>{0x16B60, 10000000000},
+uni::detail::pair<char32_t, int64_t>{0x16B61, 1000000000000},
+};
+static constexpr uni::detail::pair<char32_t, int16_t> numeric_data_d[] = {
+uni::detail::pair<char32_t, int16_t>{0x00BC, 4},
+uni::detail::pair<char32_t, int16_t>{0x00BD, 2},
+uni::detail::pair<char32_t, int16_t>{0x00BE, 4},
+uni::detail::pair<char32_t, int16_t>{0x09F4, 16},
+uni::detail::pair<char32_t, int16_t>{0x09F5, 8},
+uni::detail::pair<char32_t, int16_t>{0x09F6, 16},
+uni::detail::pair<char32_t, int16_t>{0x09F7, 4},
+uni::detail::pair<char32_t, int16_t>{0x09F8, 4},
+uni::detail::pair<char32_t, int16_t>{0x0B72, 4},
+uni::detail::pair<char32_t, int16_t>{0x0B73, 2},
+uni::detail::pair<char32_t, int16_t>{0x0B74, 4},
+uni::detail::pair<char32_t, int16_t>{0x0B75, 16},
+uni::detail::pair<char32_t, int16_t>{0x0B76, 8},
+uni::detail::pair<char32_t, int16_t>{0x0B77, 16},
+uni::detail::pair<char32_t, int16_t>{0x0D58, 160},
+uni::detail::pair<char32_t, int16_t>{0x0D59, 40},
+uni::detail::pair<char32_t, int16_t>{0x0D5A, 80},
+uni::detail::pair<char32_t, int16_t>{0x0D5B, 20},
+uni::detail::pair<char32_t, int16_t>{0x0D5C, 10},
+uni::detail::pair<char32_t, int16_t>{0x0D5D, 20},
+uni::detail::pair<char32_t, int16_t>{0x0D5E, 5},
+uni::detail::pair<char32_t, int16_t>{0x0D73, 4},
+uni::detail::pair<char32_t, int16_t>{0x0D74, 2},
+uni::detail::pair<char32_t, int16_t>{0x0D75, 4},
+uni::detail::pair<char32_t, int16_t>{0x0D76, 16},
+uni::detail::pair<char32_t, int16_t>{0x0D77, 8},
+uni::detail::pair<char32_t, int16_t>{0x0D78, 16},
+uni::detail::pair<char32_t, int16_t>{0x0F2A, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F2B, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F2C, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F2D, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F2E, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F2F, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F30, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F31, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F32, 2},
+uni::detail::pair<char32_t, int16_t>{0x0F33, 2},
+uni::detail::pair<char32_t, int16_t>{0x2150, 7},
+uni::detail::pair<char32_t, int16_t>{0x2151, 9},
+uni::detail::pair<char32_t, int16_t>{0x2152, 10},
+uni::detail::pair<char32_t, int16_t>{0x2153, 3},
+uni::detail::pair<char32_t, int16_t>{0x2154, 3},
+uni::detail::pair<char32_t, int16_t>{0x2155, 5},
+uni::detail::pair<char32_t, int16_t>{0x2156, 5},
+uni::detail::pair<char32_t, int16_t>{0x2157, 5},
+uni::detail::pair<char32_t, int16_t>{0x2158, 5},
+uni::detail::pair<char32_t, int16_t>{0x2159, 6},
+uni::detail::pair<char32_t, int16_t>{0x215A, 6},
+uni::detail::pair<char32_t, int16_t>{0x215B, 8},
+uni::detail::pair<char32_t, int16_t>{0x215C, 8},
+uni::detail::pair<char32_t, int16_t>{0x215D, 8},
+uni::detail::pair<char32_t, int16_t>{0x215E, 8},
+uni::detail::pair<char32_t, int16_t>{0x2CFD, 2},
+uni::detail::pair<char32_t, int16_t>{0xA830, 4},
+uni::detail::pair<char32_t, int16_t>{0xA831, 2},
+uni::detail::pair<char32_t, int16_t>{0xA832, 4},
+uni::detail::pair<char32_t, int16_t>{0xA833, 16},
+uni::detail::pair<char32_t, int16_t>{0xA834, 8},
+uni::detail::pair<char32_t, int16_t>{0xA835, 16},
+uni::detail::pair<char32_t, int16_t>{0x10140, 4},
+uni::detail::pair<char32_t, int16_t>{0x10141, 2},
+uni::detail::pair<char32_t, int16_t>{0x10175, 2},
+uni::detail::pair<char32_t, int16_t>{0x10176, 2},
+uni::detail::pair<char32_t, int16_t>{0x10177, 3},
+uni::detail::pair<char32_t, int16_t>{0x10178, 4},
+uni::detail::pair<char32_t, int16_t>{0x1018B, 4},
+uni::detail::pair<char32_t, int16_t>{0x109BC, 12},
+uni::detail::pair<char32_t, int16_t>{0x109BD, 2},
+uni::detail::pair<char32_t, int16_t>{0x109F6, 12},
+uni::detail::pair<char32_t, int16_t>{0x109F7, 12},
+uni::detail::pair<char32_t, int16_t>{0x109F8, 12},
+uni::detail::pair<char32_t, int16_t>{0x109F9, 12},
+uni::detail::pair<char32_t, int16_t>{0x109FA, 12},
+uni::detail::pair<char32_t, int16_t>{0x109FB, 12},
+uni::detail::pair<char32_t, int16_t>{0x109FC, 12},
+uni::detail::pair<char32_t, int16_t>{0x109FD, 12},
+uni::detail::pair<char32_t, int16_t>{0x109FE, 12},
+uni::detail::pair<char32_t, int16_t>{0x109FF, 12},
+uni::detail::pair<char32_t, int16_t>{0x10A48, 2},
+uni::detail::pair<char32_t, int16_t>{0x10E7B, 2},
+uni::detail::pair<char32_t, int16_t>{0x10E7C, 4},
+uni::detail::pair<char32_t, int16_t>{0x10E7D, 3},
+uni::detail::pair<char32_t, int16_t>{0x10E7E, 3},
+uni::detail::pair<char32_t, int16_t>{0x10F26, 2},
+uni::detail::pair<char32_t, int16_t>{0x11FC0, 320},
+uni::detail::pair<char32_t, int16_t>{0x11FC1, 160},
+uni::detail::pair<char32_t, int16_t>{0x11FC2, 80},
+uni::detail::pair<char32_t, int16_t>{0x11FC3, 64},
+uni::detail::pair<char32_t, int16_t>{0x11FC4, 40},
+uni::detail::pair<char32_t, int16_t>{0x11FC5, 32},
+uni::detail::pair<char32_t, int16_t>{0x11FC6, 80},
+uni::detail::pair<char32_t, int16_t>{0x11FC7, 64},
+uni::detail::pair<char32_t, int16_t>{0x11FC8, 20},
+uni::detail::pair<char32_t, int16_t>{0x11FC9, 16},
+uni::detail::pair<char32_t, int16_t>{0x11FCA, 16},
+uni::detail::pair<char32_t, int16_t>{0x11FCB, 10},
+uni::detail::pair<char32_t, int16_t>{0x11FCC, 8},
+uni::detail::pair<char32_t, int16_t>{0x11FCD, 20},
+uni::detail::pair<char32_t, int16_t>{0x11FCE, 16},
+uni::detail::pair<char32_t, int16_t>{0x11FCF, 5},
+uni::detail::pair<char32_t, int16_t>{0x11FD0, 4},
+uni::detail::pair<char32_t, int16_t>{0x11FD1, 2},
+uni::detail::pair<char32_t, int16_t>{0x11FD2, 2},
+uni::detail::pair<char32_t, int16_t>{0x11FD3, 4},
+uni::detail::pair<char32_t, int16_t>{0x11FD4, 320},
+uni::detail::pair<char32_t, int16_t>{0x1245A, 3},
+uni::detail::pair<char32_t, int16_t>{0x1245B, 3},
+uni::detail::pair<char32_t, int16_t>{0x1245C, 6},
+uni::detail::pair<char32_t, int16_t>{0x1245D, 3},
+uni::detail::pair<char32_t, int16_t>{0x1245E, 3},
+uni::detail::pair<char32_t, int16_t>{0x1245F, 8},
+uni::detail::pair<char32_t, int16_t>{0x12460, 4},
+uni::detail::pair<char32_t, int16_t>{0x12461, 6},
+uni::detail::pair<char32_t, int16_t>{0x12462, 4},
+uni::detail::pair<char32_t, int16_t>{0x12463, 4},
+uni::detail::pair<char32_t, int16_t>{0x12464, 2},
+uni::detail::pair<char32_t, int16_t>{0x12465, 3},
+uni::detail::pair<char32_t, int16_t>{0x12466, 3},
+uni::detail::pair<char32_t, int16_t>{0x1ECAD, 4},
+uni::detail::pair<char32_t, int16_t>{0x1ECAE, 2},
+uni::detail::pair<char32_t, int16_t>{0x1ECAF, 4},
+uni::detail::pair<char32_t, int16_t>{0x1ED3C, 2},
+uni::detail::pair<char32_t, int16_t>{0x1ED3D, 6},
+uni::detail::pair<char32_t, int16_t>{0x110000, 0}};
+static constexpr bool_trie<32, 991, 1, 0, 118, 255, 1, 0, 1279, 1, 0, 150> prop_assigned{
+{0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xfcffffffffffffff, 0xfffffffbffffd7f0, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xfffeffffffffffff, 0xfffffffffe7fffff, 0xfffffffffffee7ff, 0x001f87ffffff00ff,
+0xffffffffdfffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffbfff, 0xffffffffffffe7ff, 0x0003ffffffffffff, 0xe7ffffffffffffff},
+{1,   2,   3,   4,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,
+18,  19,  20,  21,  22,  23,  24,  25,  26,  4,   27,  28,  29,  4,   4,   4,   30,  4,
+4,   4,   4,   4,   31,  32,  33,  34,  35,  36,  37,  4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   38,  39,  40,  41,  4,   42,  43,  39,  44,  45,  46,  47,  48,  49,  50,
+51,  52,  53,  4,   54,  4,   55,  56,  57,  58,  59,  4,   4,   4,   60,  4,   4,   4,
+4,   61,  62,  63,  64,  4,   65,  66,  67,  4,   4,   68,  4,   4,   4,   4,   4,   4,
+4,   4,   4,   69,  70,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   71,  72,  4,   73,
+74,  4,   75,  76,  77,  78,  79,  4,   80,  81,  82,  4,   4,   4,   83,  4,   84,  85,
+4,   86,  4,   87,  88,  74,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   89,  4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   90,  91,  4,   4,   4,
+4,   92,  4,   4,   93,  4,   4,   4,   94,  95,  93,  4,   96,  4,   97,  4,   98,  99,
+100, 4,   101, 102, 48,  4,   103, 4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   88,  104, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105, 105,
+105, 105, 105, 105, 105, 105, 105, 105, 105, 4,   4,   4,   4,   4,   106, 4,   107, 108,
+109, 4,   110, 4,   4,   4,   4,   4,   111, 112, 113, 36,  114, 4,   115, 84,  4,   116,
+117},
+{0x7fff3fffffffffff, 0x000007ff4fffffff, 0xffdfffff00000000, 0xfffffffffff800ff,
+0xffffffffffffffff, 0xf3c5fdfffff99fef, 0x7fffffcfb080799f, 0xd36dfdfffff987ee,
+0x007fffc05e023987, 0xf3edfdfffffbbfee, 0xfe03ffcf00013bbf, 0xf3edfdfffff99fee,
+0x00ffffcfb0e0399f, 0xc3ffc718d63dc7ec, 0x07ffffc000813dc7, 0xe3fffdfffffddfff,
+0xff80ffcf07603ddf, 0xf3effdfffffddfff, 0x0006ffcf40603ddf, 0xfffffffffffddfff,
+0xffffffcffff0fddf, 0x2ffbfffffc7fffee, 0x001cffc0ff5f847f, 0x87fffffffffffffe,
+0x000000000fffffff, 0x3fffffaffffff7d6, 0x00000000f3ff3f5f, 0xfffe1ffffffffeff,
+0xdffffffffeffffff, 0x0000000007ffdfff, 0xffffffffffff20bf, 0xffffffff3d7f3dff,
+0x7f3dffffffff3dff, 0xffffffffff7fff3d, 0xffffffffff3dffff, 0x1fffffffe7ffffff,
+0xffffffff03ffffff, 0x3f3fffffffffffff, 0xffffffff1fffffff, 0x01ffffffffffffff,
+0x007fffff001fdfff, 0x000ddfff000fffff, 0x03ff03ff3fffffff, 0xffffffff03ff7fff,
+0xffff07ffffffffff, 0x003fffffffffffff, 0x0fff0fff7fffffff, 0x001f3ffffffffff1,
+0xffff0fffffffffff, 0xffffffffc7ff03ff, 0xffffffffcfffffff, 0x9fffffff7fffffff,
+0xffff3fff03ff03ff, 0x0000000000000001, 0x1fffffffffff0fff, 0xf00fffffffffffff,
+0xf8ffffffffffffff, 0xffffffffffffe3ff, 0xe7ffffffffff01ff, 0x07ffffffffff00ff,
+0xfbffffffffffffff, 0xffffffff3f3fffff, 0x3fffffffaaff3f3f, 0xffdfffffffffffff,
+0x7fdcffffefcfffdf, 0xfff3ffdfffffffff, 0xffffffff1fff7fff, 0x0001ffffffff0000,
+0xffffffffffff0fff, 0x0000007fffffffff, 0xffffffff000007ff, 0xffcfffffffffffff,
+0xffffffffffbfffff, 0xffff7fffffffffff, 0xffffffff7fffffff, 0xfe0fffffffffffff,
+0xffff20bfffffffff, 0x800180ffffffffff, 0x7f7f7f7f007fffff, 0xffffffff7f7f7f7f,
+0x000000000007ffff, 0xfffffffffbffffff, 0x000fffffffffffff, 0x0fff0000003fffff,
+0xfffffffffffffffe, 0xfffffffffe7fffff, 0xfffeffffffffffe0, 0xffffffffffff7fff,
+0xffff000fffffffff, 0x1fffffffffffffff, 0xffffffffffff1fff, 0xffffffffffff007f,
+0x00000fffffffffff, 0x00ffffffffffffff, 0xffe00000000007fc, 0x03ff1fffffffffff,
+0xffffffff03ffc03f, 0x1fffffff800fffff, 0x7fffffffc3ffbfff, 0x007fffffffffffff,
+0xfffffffff3ff3fff, 0x007ffffff8000007, 0xffff7f7f007e7e7e, 0x03ff3fffffffffff,
+0x0ffffffffffff87f, 0x0000000000000000, 0xffff3fffffffffff, 0x0000000003ffffff,
+0x5f7fffffe0f8007f, 0xffffffffffffffdb, 0xfffffffffff80003, 0xffffffffffff0000,
+0xfffffffffffcffff, 0x3fff0000000000ff, 0xffdf0f7ffff7ffff, 0x9fffffffffffffff,
+0x7fffffffffffffff, 0x3e007f7f1cfcfcfc},
+{1,  2,  3, 4,  5,  6, 7,  8, 5, 5, 9, 5, 10, 11, 12, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 13,
+14, 15, 7, 16, 17, 7, 18, 5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 19,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5},
+{1,   2,   3,   4,   2,   5,   6,   7,   7,   8,   9,   10,  11,  12,  13,  2,   2,   14,
+15,  16,  17,  7,   7,   2,   2,   2,   2,   18,  19,  7,   7,   20,  21,  22,  23,  24,
+7,   25,  26,  27,  28,  29,  30,  31,  32,  33,  7,   2,   34,  35,  36,  37,  7,   7,
+7,   7,   38,  39,  7,   16,  40,  41,  42,  2,   43,  2,   44,  45,  46,  2,   47,  48,
+7,   49,  50,  51,  52,  7,   7,   2,   53,  2,   54,  7,   7,   55,  56,  2,   57,  58,
+59,  60,  7,   7,   7,   61,  7,   62,  63,  64,  65,  66,  67,  2,   68,  69,  58,  7,
+7,   7,   7,   70,  71,  72,  7,   73,  74,  75,  7,   7,   7,   7,   76,  7,   7,   77,
+78,  2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   40,  7,   2,
+79,  2,   2,   2,   80,  7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   81,  7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   2,   2,   2,   2,   2,   2,   2,   2,   2,   82,  7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   2,   2,   2,   2,   2,   2,   2,   2,   58,  83,  7,   84,  2,   85,  86,  7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   2,   87,  7,   2,   88,  89,  90,  2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   91,  2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   92,  34,  7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,
+2,   2,   2,   93,  94,  2,   2,   2,   2,   2,   61,  7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   95,  96,  7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   2,   2,   97,  98,  2,   2,   99,  2,
+100, 7,   101, 2,   102, 7,   7,   2,   103, 104, 105, 106, 107, 2,   2,   2,   2,   108,
+2,   2,   2,   2,   109, 2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   110, 7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   111, 7,   7,   7,   112, 113, 7,   7,   7,   7,   7,   114, 7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   2,   2,
+115, 2,   116, 7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   117, 118, 7,   119,
+7,   7,   7,   120, 121, 122, 123, 7,   7,   7,   7,   124, 2,   125, 126, 2,   2,   127,
+128, 129, 130, 7,   7,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   131, 2,   132, 2,   133, 134, 135, 136, 7,   2,   137, 2,   138, 2,   139, 140,
+141, 2,   2,   142, 143, 7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   56,  2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   118, 2,   2,   2,   144, 2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   145, 2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   146, 7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   2,   2,   2,   2,   2,   2,   2,   2,   56,  7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   147, 7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   148, 2,   7,   7,   2,   2,   2,   149, 7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7},
+{0xb7ffff7fffffefff, 0x000000003fff3fff, 0xffffffffffffffff, 0x07ffffffffffffff,
+0xff8fffffffffff87, 0x000000011fff7fff, 0x3fffffffffff0000, 0x0000000000000000,
+0xffffffff1fffffff, 0x0fffffff0001ffff, 0xffffe00fffffffff, 0x07ffffffffff07ff,
+0xffffffffbfffffff, 0x00000000003fff0f, 0xffff03ff3fffffff, 0x0fffffffff0fffff,
+0xffff00ffffffffff, 0x0000800fffffffff, 0x007fffffffffffff, 0x000000ff003fffff,
+0x91bffffffffffd3f, 0xffffffffffbfffff, 0x0000ff807fffffff, 0xf837ffff00000000,
+0x83ffffff8fffffff, 0xf0ffffffffffffff, 0xfffffffffffcffff, 0x873ffffffeeff06f,
+0xffffffff01ff01ff, 0x00000000ffffffff, 0x007ff87fffffffff, 0xfe3fffffffffffff,
+0xff07ffffff3fffff, 0x0000fe001e03ffff, 0x00000000000001ff, 0x0007ffffffffffff,
+0xfc07ffffffffffff, 0x03ff00ffffffffff, 0x7fffffff00000000, 0x00033bffffffffff,
+0x0000000003ffffff, 0xffff000000000000, 0x007fffff00000fff, 0x8000fffffffc3fff,
+0x03ff01ffffff2003, 0xffdfffffffffffff, 0x007fffffffff00ff, 0x001ffffeffffffff,
+0x7ffffffffffbffff, 0xffff03ffbfffbd7f, 0x03ff07ffffffffff, 0xfbedfdfffff99fef,
+0x001f1fcfe081399f, 0x00000003efffffff, 0x0000000003ff00ff, 0xff3fffffffffffff,
+0x000000003fffffff, 0x00001fff03ff001f, 0x01ffffffffffffff, 0x00000000000003ff,
+0xffff0fffe7ffffff, 0x0fffffffffffffff, 0xffffffff00000000, 0x8007ffffffffffff,
+0xf9bfffffff6ff27f, 0x0000000003ff007f, 0xfffffcff00000000, 0x0000001ffcffffff,
+0xffffffffffff00ff, 0x00000007ffffffff, 0xff7ffffffffffdff, 0xffff1fffffff003f,
+0x007ffefffffcffff, 0xb47ffffffffffb7f, 0xfffffdbf03ff00ff, 0x000003ff01fb7fff,
+0x01ffffff00000000, 0x0001000000000000, 0x8003ffffffffffff, 0x001f7fffffffffff,
+0x000000000000000f, 0x01ff7fffffffffff, 0x000000000000007f, 0x0000c3ff7fffffff,
+0x003f3fffffff0000, 0xe0fffffbfbff003f, 0x000000000000ffff, 0x0000000007ffffff,
+0xffffffffffff87ff, 0x00000000ffff80ff, 0x0003001f00000000, 0x00ffffffffffffff,
+0x00000000003fffff, 0x000000007fffffff, 0xffff00f000070000, 0x1fff07ffffffffff,
+0x0000000ff3ff01ff, 0x003fffffffffffff, 0xfffffe7fffffffff, 0x000001ffffffffff,
+0x000000000000003f, 0x000fffff00000000, 0x01ffffff007fffff, 0xffffffffffdfffff,
+0xebffde64dfffffff, 0xffffffffffffffef, 0x7bffffffdfdfe7bf, 0xfffffffffffdfc5f,
+0xffffff3fffffffff, 0xffffffffffffcfff, 0x0000fffef8000fff, 0x000007dbf9ffff7f,
+0x3fff1fffffffffff, 0x000000000000c3ff, 0x83ffffffffffffff, 0x00000000007fff9f,
+0x00000000c3ff0fff, 0xfffe000000000000, 0x001fffffffffffff, 0x3ffffffffffffffe,
+0x0af7fe96ffffffef, 0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff, 0x0003000000000000,
+0xffff0fffffffffff, 0xfffe7fff000fffff, 0x003ffffffffefffe, 0x00003fffffffffff,
+0xffffffc000000000, 0x0fffffffffff0007, 0x0000003f000301ff, 0x1fff1fff00ffffff,
+0x000fffffffffffff, 0x00000fff01ffffff, 0xffffffffffff0fff, 0xffffffff03ff00ff,
+0x00033fffffff00ff, 0xfdffffffffffffff, 0xffffffffffffefff, 0x071f3fff000fffff,
+0x007f01ffffff007f, 0x00000000007f0007, 0xfffffffffff7ffff, 0x03ff0000000007ff,
+0xffffffff3fffffff, 0xffff0003ffffffff, 0x00000001ffffffff, 0x00000000000007ff,
+0xffffffff00000002, 0x0000ffffffffffff}};
+}    // namespace detail::tables
+enum class property {
+ahex,
+ascii_hex_digit = ahex,
+alpha,
+alphabetic = alpha,
+bidi_c,
+bidi_control = bidi_c,
+bidi_m,
+bidi_mirrored = bidi_m,
+cased,
+ci,
+case_ignorable = ci,
+dash,
+dep,
+deprecated = dep,
+di,
+default_ignorable_code_point = di,
+dia,
+diacritic = dia,
+emoji,
+emoji_component,
+emoji_modifier,
+emoji_modifier_base,
+emoji_presentation,
+ext,
+extender = ext,
+extended_pictographic,
+gr_base,
+grapheme_base = gr_base,
+gr_ext,
+grapheme_extend = gr_ext,
+hex,
+hex_digit = hex,
+idc,
+id_continue = idc,
+ideo,
+ideographic = ideo,
+ids,
+id_start = ids,
+idsb,
+ids_binary_operator = idsb,
+idst,
+ids_trinary_operator = idst,
+join_c,
+join_control = join_c,
+loe,
+logical_order_exception = loe,
+lower,
+lowercase = lower,
+math,
+nchar,
+noncharacter_code_point = nchar,
+pat_syn,
+pattern_syntax = pat_syn,
+pat_ws,
+pattern_white_space = pat_ws,
+pcm,
+prepended_concatenation_mark = pcm,
+qmark,
+quotation_mark = qmark,
+radical,
+ri,
+regional_indicator = ri,
+sd,
+soft_dotted = sd,
+sterm,
+sentence_terminal = sterm,
+term,
+terminal_punctuation = term,
+uideo,
+unified_ideograph = uideo,
+upper,
+uppercase = upper,
+vs,
+variation_selector = vs,
+wspace,
+white_space = wspace,
+space = wspace,
+xidc,
+xid_continue = xidc,
+xids,
+xid_start = xids,
+max
+};
+namespace detail::tables {
+static constexpr range_array prop_ahex_data = {0x00000000, 0x00003001, 0x00003A00, 0x00004101,
+0x00004700, 0x00006101, 0x00006700};
+static constexpr bool_trie<32, 991, 1, 0, 134, 255, 1, 0, 1215, 1, 0, 117> prop_alpha_data{
+{0x0000000000000000, 0x07fffffe07fffffe, 0x0420040000000000, 0xff7fffffff7fffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x0000501f0003ffc3,
+0x0000000000000000, 0xbcdf000000000020, 0xfffffffbffffd740, 0xffbfffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xfffffffffffffc03, 0xffffffffffffffff,
+0xfffeffffffffffff, 0xffffffff027fffff, 0xbfff0000000001ff, 0x000787ffffff00b6,
+0xffffffff07ff0000, 0xffffc000feffffff, 0xffffffffffffffff, 0x9c00e1fe1fefffff,
+0xffffffffffff0000, 0xffffffffffffe000, 0x0003ffffffffffff, 0x043007fffffffc00},
+{1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12, 13,  14,  15,  16,  17,  18,
+19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30, 31,  32,  33,  34,  35,  36,
+36,  36,  36,  36,  37,  38,  39,  40,  41,  42,  43,  44, 36,  36,  36,  36,  36,  36,
+36,  36,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54, 55,  56,  57,  58,  59,  60,
+61,  62,  28,  63,  64,  65,  66,  67,  68,  69,  70,  36, 36,  36,  71,  36,  36,  36,
+36,  72,  73,  74,  75,  31,  76,  77,  31,  78,  79,  80, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  81,  82,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  83,
+84,  36,  85,  86,  87,  88,  89,  90,  31,  31,  31,  31, 31,  31,  31,  91,  44,  92,
+93,  94,  36,  95,  96,  31,  31,  31,  31,  31,  31,  31, 31,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  31,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 97,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  98,  99,  36,  36,  36,
+36,  100, 101, 36,  102, 103, 36,  104, 105, 106, 107, 36, 108, 109, 110, 111, 112, 67,
+113, 114, 115, 116, 117, 36,  118, 36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36,  36, 36,  36,  36,  36,  36,  36,
+36,  119, 120, 31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31,  31, 31,  31,  31,  31,  31,  31,
+31,  31,  31,  31,  31,  31,  31,  31,  31,  36,  36,  36, 36,  36,  121, 36,  122, 123,
+124, 125, 126, 36,  36,  36,  36,  127, 33,  128, 129, 31, 130, 36,  97,  131, 132, 114,
+133},
+{0x00001ffffcffffff, 0x000007ff01ffffff, 0xffdfffff00000000, 0xffff03f8fff000ff,
+0xefffffffffffffff, 0xfffe000fffe1dfff, 0xe3c5fdfffff99fef, 0x1003000fb080599f,
+0xc36dfdfffff987ee, 0x003f00005e021987, 0xe3edfdfffffbbfee, 0x1e00000f00011bbf,
+0xe3edfdfffff99fee, 0x0002000fb0c0199f, 0xc3ffc718d63dc7ec, 0x0000000000811dc7,
+0xe3fffdfffffddfef, 0x0000000f07601ddf, 0xe3effdfffffddfef, 0x0006000f40601ddf,
+0xe7fffffffffddfff, 0xfc00000f80f05ddf, 0x2ffbfffffc7fffee, 0x000c0000ff5f807f,
+0x07fffffffffffffe, 0x000000000000207f, 0x3bffffaffffff7d6, 0x00000000f000205f,
+0x0000000000000001, 0xfffe1ffffffffeff, 0x1ffffffffeffff03, 0x0000000000000000,
+0xf97fffffffffffff, 0xffffffffffff0000, 0xffffffff3c00ffff, 0xf7ffffffffff20bf,
+0xffffffffffffffff, 0xffffffff3d7f3dff, 0x7f3dffffffff3dff, 0xffffffffff7fff3d,
+0xffffffffff3dffff, 0x0000000007ffffff, 0xffffffff0000ffff, 0x3f3fffffffffffff,
+0xfffffffffffffffe, 0xffff9fffffffffff, 0xffffffff07fffffe, 0x01ffc7ffffffffff,
+0x000fffff000fdfff, 0x000ddfff000fffff, 0xffcfffffffffffff, 0x00000000108001ff,
+0xffffffff00000000, 0x01ffffffffffffff, 0xffff07ffffffffff, 0x003fffffffffffff,
+0x01ff0fff7fffffff, 0x001f3fffffff0000, 0xffff0fffffffffff, 0x00000000000003ff,
+0xffffffff0fffffff, 0x001ffffe7fffffff, 0x8000008000000000, 0xffefffffffffffff,
+0x0000000000000fef, 0xfc00f3ffffffffff, 0x0003ffbfffffffff, 0x007fffffffffffff,
+0x3ffffffffc00e000, 0xe7ffffffffff01ff, 0x046fde0000000000, 0x001fff8000000000,
+0xffffffff3f3fffff, 0x3fffffffaaff3f3f, 0x5fdfffffffffffff, 0x1fdc1fff0fcf1fdc,
+0x8002000000000000, 0x000000001fff0000, 0xf3ffbd503e2ffc84, 0xffffffff000043e0,
+0x00000000000001ff, 0xffc0000000000000, 0x000003ffffffffff, 0xffff7fffffffffff,
+0xffffffff7fffffff, 0x000c781fffffffff, 0xffff20bfffffffff, 0x000080ffffffffff,
+0x7f7f7f7f007fffff, 0xffffffff7f7f7f7f, 0x0000800000000000, 0x1f3e03fe000000e0,
+0xfffffffee07fffff, 0xf7ffffffffffffff, 0xfffeffffffffffe0, 0xffffffff00007fff,
+0xffff000000000000, 0x1fffffffffffffff, 0x0000000000001fff, 0x3fffffffffff0000,
+0x00000c00ffff1fff, 0x8ff07fffffffffff, 0x0000ffffffffffff, 0xfffffffcff800000,
+0xfffffffffffff9ff, 0xffe00000000007fc, 0x000000ffffffffbf, 0x000fffffffffffff,
+0xe8fc00000000002f, 0xffff07fffffffc00, 0x1fffffff0007ffff, 0xfff7ffffffffffff,
+0x7c00ffff00008000, 0xfc7fffff00003fff, 0x7fffffffffffffff, 0x003cffff38000005,
+0xffff7f7f007e7e7e, 0xffff03fff7ffffff, 0x000007ffffffffff, 0xffff000fffffffff,
+0x0ffffffffffff87f, 0xffff3fffffffffff, 0x0000000003ffffff, 0x5f7ffdffe0f8007f,
+0xffffffffffffffdb, 0x0003ffffffffffff, 0xfffffffffff80000, 0x3fffffffffffffff,
+0xfffffffffffcffff, 0x0fff0000000000ff, 0xffdf000000000000, 0x07fffffe00000000,
+0xffffffc007fffffe, 0x000000001cfcfcfc},
+{1,  2,  3, 4,  5,  6, 7,  8, 5, 5, 9, 5, 10, 11, 12, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 13,
+14, 15, 7, 16, 17, 7, 18, 5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5},
+{1,   2,   3,  4,   5,   4,   4,   4,  4,  6,  7,   8,   9,   10,  11, 2,  2,   12, 13,
+14,  15,  4,  4,   2,   2,   2,   2,  16, 17, 4,   4,   18,  19,  20, 21, 22,  4,  23,
+4,   24,  25, 26,  27,  28,  29,  30, 4,  2,  31,  32,  32,  33,  4,  4,  4,   4,  4,
+34,  4,   35, 36,  37,  38,  2,   36, 39, 40, 32,  41,  2,   42,  43, 4,  44,  45, 46,
+47,  4,   4,  2,   48,  2,   49,  4,  4,  50, 51,  52,  53,  54,  4,  55, 4,   4,  4,
+56,  4,   57, 58,  59,  60,  61,  62, 63, 64, 65,  56,  4,   4,   4,  4,  66,  67, 68,
+4,   69,  70, 71,  4,   4,   4,   4,  72, 4,  4,   73,  4,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  74, 4,  2,   75,  2,   2,   2,  76, 4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   75, 4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   2,   2,   2,  2,  2,  2,   2,   2,   2,   77, 4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  2,   2,  2,
+2,   2,   2,  2,   2,   56,  20,  4,  78, 79, 80,  81,  4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  2,   4,   4,   2,   82, 83, 84, 2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  85,  2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   86,  31,  4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   2,   2,   2,  2,  20, 87,  2,   2,   2,   2,  2,  88,  4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  2,  89,  90, 4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  2,  91,  92,  93,  94,  95, 2,  2,   2,  2,
+96,  97,  98, 99,  100, 101, 4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+102, 4,   4,  4,   103, 104, 4,   4,  4,  4,  4,   105, 4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   2,   2,  2,  106, 2,  107,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  108,
+109, 110, 4,  4,   4,   4,   4,   4,  4,  4,  4,   37,  111, 112, 4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  113, 2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   5,   2,   2,   2,  10, 2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  114, 2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   2,   2,  2,  2,  2,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   2,   115, 4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   2,  2,
+2,   2,   2,  2,   2,   2,   113, 4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   2,   2,   2,   2,  2,  2,   2,  2,
+2,   2,   2,  2,   2,   116, 4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4,  4,
+4,   4,   4,  4,   4,   4,   4,   4,  4,  4,  4,   4,   4,   4,   4,  4,  4,   4},
+{0xb7ffff7fffffefff, 0x000000003fff3fff, 0xffffffffffffffff, 0x07ffffffffffffff,
+0x0000000000000000, 0x001fffffffffffff, 0xffffffff1fffffff, 0x000000000001ffff,
+0xffffe000ffffffff, 0x07ffffffffff07ff, 0xffffffff3fffffff, 0x00000000003eff0f,
+0xffff00003fffffff, 0x0fffffffff0fffff, 0xffff00ffffffffff, 0x0000000fffffffff,
+0x007fffffffffffff, 0x000000ff003fffff, 0x91bffffffffffd3f, 0x007fffff003fffff,
+0x000000007fffffff, 0x0037ffff00000000, 0x03ffffff003fffff, 0xc0ffffffffffffff,
+0x003ffffffeeff06f, 0x1fffffff00000000, 0x000000001fffffff, 0x0000001ffffffeff,
+0x003fffffffffffff, 0x0007ffff003fffff, 0x000000000003ffff, 0x00000000000001ff,
+0x0007ffffffffffff, 0x000000ffffffffff, 0x00031bffffffffff, 0xffff00801fffffff,
+0x000000000000003f, 0xffff000000000000, 0x007fffff0000001f, 0x01fffffffffffffc,
+0x000001ffffff0000, 0x0047ffffffff00f0, 0x000000001400c01e, 0x409ffffffffbffff,
+0xffff01ffbfffbd7f, 0x000001ffffffffff, 0xe3edfdfffff99fef, 0x0000000fe081199f,
+0x00000003800007bb, 0x00000000000000b3, 0x7f3fffffffffffff, 0x000000003f000000,
+0x7fffffffffffffff, 0x0000000000000011, 0x013fffffffffffff, 0x000007ffe7ffffff,
+0x01ffffffffffffff, 0xffffffff00000000, 0x80000000ffffffff, 0x99bfffffff6ff27f,
+0x0000000000000007, 0xfffffcff00000000, 0x0000001afcffffff, 0x7fe7ffffffffffff,
+0xffffffffffff0000, 0x0000000020ffffff, 0x7f7ffffffffffdff, 0xfffc000000000001,
+0x007ffefffffcffff, 0xb47ffffffffffb7f, 0xfffffdbf000000cb, 0x00000000017b7fff,
+0x007fffff00000000, 0x0001000000000000, 0x0000000003ffffff, 0x00007fffffffffff,
+0x000000000000000f, 0x000000000000007f, 0x00003fffffff0000, 0x0000ffffffffffff,
+0xe0fffff80000000f, 0x000000000000ffff, 0xffffffffffff87ff, 0x00000000ffff80ff,
+0x0003000b00000000, 0x00ffffffffffffff, 0x00000000003fffff, 0xffff00f000070000,
+0x0fffffffffffffff, 0x1fff07ffffffffff, 0x0000000043ff01ff, 0xffffffffffdfffff,
+0xebffde64dfffffff, 0xffffffffffffffef, 0x7bffffffdfdfe7bf, 0xfffffffffffdfc5f,
+0xffffff3fffffffff, 0xf7fffffff7fffffd, 0xffdfffffffdfffff, 0xffff7fffffff7fff,
+0xfffffdfffffffdff, 0x0000000000000ff7, 0x000007dbf9ffff7f, 0x3f801fffffffffff,
+0x0000000000004000, 0x00000fffffffffff, 0x000000000000001f, 0x000000000000088f,
+0x0af7fe96ffffffef, 0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff, 0xffff03ffffff03ff,
+0x00000000000003ff, 0x000000003fffffff, 0xffff0003ffffffff, 0x00000001ffffffff,
+0x00000000000007ff}};
+static constexpr range_array prop_bidi_c_data = {0x00000000, 0x00061C01, 0x00061D00,
+0x00200E01, 0x00201000, 0x00202A01,
+0x00202F00, 0x00206601, 0x00206A00};
+static constexpr bool_trie<32, 962, 28, 2, 26, 1, 13, 242, 5, 91, 32, 6> prop_bidi_m_data{
+{0x5000030000000000, 0x2800000028000000, 0x0800080000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  2,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 3, 4, 5, 0,  0,  6,  0, 0, 7,  8,
+9, 10, 11, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 12, 0,  13, 0, 0, 0,  0,
+0, 0,  14, 15, 16, 17, 18, 19, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0,  21, 0,  0, 0, 0,  0,
+0, 0,  22, 0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0,  0,
+0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  23, 0, 0, 24, 25},
+{0x0000000000000000, 0x3c00000000000000, 0x0000000018000000, 0x0600000000000000,
+0x6000000000000060, 0x0000000000006000, 0x0000000000000001, 0xfa0ff857bc623f1e,
+0xffffcff5803c1fff, 0xc1ffffcc01079fff, 0xffff3fffffc33e00, 0x0000060300000f00,
+0x003fff0000000000, 0x0000fffc70783b79, 0x0100fffdf9fffff8, 0x33f0033a1f37c23f,
+0x70307a53dffffc00, 0xfe19bc3001800000, 0xffffbfcfffffffff, 0x2f88707c507fffff,
+0x4000000000000000, 0x000003ff3000363c, 0x000000000ff3ff00, 0x000000307e000000,
+0x2800000050000300, 0x0000000da8000000},
+{1},
+{1, 2, 3, 4, 5},
+{0x0000000000000000, 0x0000000008000000, 0x0000000000200000, 0x0000000000008000,
+0x0000000000000200, 0x0000000000000008}};
+static constexpr bool_trie<0, 969, 5, 18, 11, 1, 13, 242, 3, 69, 56, 4> prop_ce_data{
+{},
+{1, 0, 2, 3, 4, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 7, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 9, 10},
+{0x0000000000000000, 0x00000000ff000000, 0x00000000b0000000, 0x0048000000000000,
+0x000000004e000000, 0x0000000030000000, 0x0140020010842008, 0x0200108420080000,
+0x0000000010000000, 0x5f7ffc00a0000000, 0x0000000000007fdb},
+{1},
+{1, 2, 3},
+{0x0000000000000000, 0x0000001fc0000000, 0xf800000000000000, 0x0000000000000001}};
+static constexpr bool_trie<32, 969, 5, 18, 21, 19, 13, 224, 100, 69, 23, 6> prop_comp_ex_data{
+{0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x401000000000001b, 0x0000000000000080, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1,  0,  2,  3,  4,  0,  0, 0, 5, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  6,  7,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 8, 9, 10, 11, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0,  0,  13,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  14, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0,  0, 0, 0, 0, 0, 15, 15, 15,
+15, 16, 17, 15, 18, 19, 20},
+{0x0000000000000000, 0x00000000ff000000, 0x00000000b0000000, 0x0048000000000000,
+0x000000004e000000, 0x0000000030000000, 0x0168020010842008, 0x0200108420080002,
+0x2aaa000000000000, 0x4800000000000000, 0x2a00c80808080a00, 0x0000000000000003,
+0x00000c4000000000, 0x0000060000000000, 0x0000000010000000, 0xffffffffffffffff,
+0xfffffc657fe53fff, 0xffff3fffffffffff, 0x0000000003ffffff, 0x5f7ffc00a0000000,
+0x0000000000007fdb},
+{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2},
+{1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 5},
+{0x0000000000000000, 0x0000001fc0000000, 0xf800000000000000, 0x0000000000000001,
+0xffffffffffffffff, 0x000000003fffffff}};
+static constexpr flat_array<29> prop_dash_data{
+{0x002D, 0x058A, 0x05BE, 0x1400, 0x1806, 0x2010, 0x2011, 0x2012, 0x2013, 0x2014,
+0x2015, 0x2053, 0x207B, 0x208B, 0x2212, 0x2E17, 0x2E1A, 0x2E3A, 0x2E3B, 0x2E40,
+0x301C, 0x3030, 0x30A0, 0xFE31, 0xFE32, 0xFE58, 0xFE63, 0xFF0D, 0x10EAD}};
+static constexpr flat_array<15> prop_dep_data{{0x0149, 0x0673, 0x0F77, 0x0F79, 0x17A3, 0x17A4,
+0x206A, 0x206B, 0x206C, 0x206D, 0x206E, 0x206F,
+0x2329, 0x232A, 0xE0001}};
+static constexpr bool_trie<32, 991, 1, 0, 61, 255, 1, 0, 347, 11, 26, 35> prop_dia_data{
+{0x0000000000000000, 0x0000000140000000, 0x0190810000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0xffff000000000000, 0xffffffffffffffff,
+0xffffffffffffffff, 0x04300007e0ff7fff, 0x0000000000000030, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x00000000000000f8, 0x0000000000000000,
+0x0000000000000000, 0x0000000002000000, 0xbffffffbfffe0000, 0x0000000000000016,
+0x0000000000000000, 0x000000000187f800, 0x0000000000000000, 0x00001c6180000000,
+0xffff000000000000, 0x00000000000007ff, 0x0001ffc000000000, 0x003ff80000000000},
+{1,  1,  2,  3,  4,  3,  5,  3,  5,  3,  6,  3,  7,  1,  5,  1,  5,  3,  5, 8, 5, 1,  9,
+1,  10, 11, 12, 13, 1,  14, 15, 16, 17, 18, 1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 19, 1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  20, 1,  1, 1, 1, 21, 1,
+1,  1,  1,  22, 23, 1,  24, 25, 26, 1,  27, 28, 1,  29, 30, 31, 1,  32, 1, 1, 1, 1,  1,
+1,  33, 34, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  35, 1,  1,  1,  1,  36, 1,  1,  1,  1,  1, 1, 1, 37, 1,
+38, 3,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  39, 40, 41, 42, 1,  43, 44, 1, 1, 1, 45, 46,
+47, 48, 49, 1,  50, 51, 52, 1,  53, 1,  54, 1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1, 1, 1, 1,  1,
+1,  1,  1,  1,  1,  55, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  56, 1, 1, 1, 57, 58,
+59, 60},
+{0x0000000003000000, 0x0000000000000000, 0x7ffffff800000000, 0x1000000000000000,
+0x00020000001e2000, 0x0000000000002000, 0xe000000000002000, 0x0000000000202000,
+0x1800000000000000, 0x0000000000000400, 0x0000000000005f80, 0x0400000000000000,
+0x0000000000001f00, 0xc2a0000003000000, 0x00000000000000dc, 0x0000000000000040,
+0x0680000000000000, 0x00003e1800000000, 0x000000000c00bf80, 0x00000000e0000000,
+0x00000000200ffe00, 0x0e00000000000000, 0x9fe0000000000000, 0x3fff000000000000,
+0x0010000000000000, 0x000ff80000000010, 0x00000c0000000000, 0x00c0000000000000,
+0x3f00000000000000, 0x039021ffffff0000, 0xfffff00000000000, 0x000007ffffffffff,
+0xe3e000000000fff0, 0xa000000000000000, 0x6000e000e000e003, 0x0003800000000000,
+0x0000800000000000, 0x0000fc0000000000, 0x000000001e000000, 0xb000800000000000,
+0x0000000030000000, 0x0003000000000000, 0x00000003ffffffff, 0x0000000000000700,
+0x0300000000000000, 0x0003ffff00000010, 0x0000780000000000, 0x0000000000080000,
+0x0008000000000000, 0x0000002000000001, 0x3800000000000000, 0x8000000000000000,
+0x0040000000000007, 0x00000e00f8000000, 0x0000300000000000, 0x0000000040000000,
+0x0000ffff00000000, 0x4000000000000000, 0x0001000000000001, 0x00000000c0000000,
+0x0000000800000000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 2, 4, 5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  2,  0, 0, 0, 0, 0, 0,  0,  0,  3,  0, 0,  0,  0,  0, 0,  0, 0,
+4,  0,  0,  0, 0,  5, 0,  6,  7, 0, 8, 9, 0, 0,  10, 11, 12, 0, 0,  0,  13, 0, 14, 0, 0,
+15, 16, 15, 0, 17, 0, 18, 0,  0, 0, 5, 0, 0, 0,  19, 20, 0,  1, 21, 22, 23, 0, 0,  0, 0,
+0,  15, 0,  0, 0,  0, 24, 25, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 26,
+27, 0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 28, 29, 0,  0, 0,  0, 0,
+30, 31, 0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  0,  0,  0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 27, 0,  0,  0,  0, 0,  0,  32, 0, 0,  0, 0,
+0,  0,  0,  0, 0,  0, 0,  0,  0, 0, 0, 0, 0, 0,  0,  0,  0,  0, 0,  33, 0,  34},
+{0x0000000000000000, 0x0000000100000000, 0x0000006000000000, 0x000000fc00000000,
+0x000000000001ffc0, 0x0600000000000000, 0x0018000000000000, 0x0008000000000000,
+0x0000000000001c01, 0x0060000000000000, 0x0000060000000000, 0x1000000000000000,
+0x001f1fc000002000, 0x0000000000000044, 0x000000000000000c, 0x8000000000000000,
+0x0000000000000001, 0x00c0000000000000, 0x0000080000000000, 0x6000000000000000,
+0x0000000000000008, 0x0010000000000000, 0x0000000000000080, 0x0000000002000000,
+0x0000000000000034, 0x0000000000800000, 0x001f000000000000, 0x007f000000000000,
+0x00000000ffff8000, 0x0003000000000000, 0xf807e38000000000, 0x00003c0000000fe7,
+0x0000f00000000000, 0x00000000007f0000, 0x0000000000000770}};
+static constexpr bool_trie<32, 75, 96, 821, 22, 1, 15, 240, 44, 64, 20, 26> prop_emoji_data{
+{0x03ff040800000000, 0x0000000000000000, 0x0000420000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1,  2,  0,  0,  3,  0,  4, 0, 0, 0, 0, 0,  5, 0, 0,  6, 0, 0, 0, 7,  0,  0, 8, 9, 10,
+11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 17, 0, 0, 0,  0, 0, 0, 0, 18, 19, 0, 0, 0, 0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0, 20, 0, 0, 0, 0, 0,  0,  0, 0, 0, 21},
+{0x0000000000000000, 0x1000000000000000, 0x0000000000000200, 0x0200000400000000,
+0x0000060003f00000, 0x000001000c000000, 0x070ffe0000008000, 0x0000000000000004,
+0x00400c0000000000, 0x7800000000000001, 0x0700c44d2132401f, 0xc8000169800fff05,
+0x60030c831afc0000, 0x27bf0600001ac130, 0x001801022054bf24, 0x0000001800b85090,
+0x8001000200e00000, 0x0030000000000000, 0x00000000180000e0, 0x0000000000210000,
+0x2001000000000000, 0x0000000002800000},
+{1},
+{1,  0,  0, 2,  0, 3,  4, 5, 6, 7,  0, 0, 8, 9, 10, 11, 9, 9,  9, 12, 13, 14,
+15, 16, 9, 17, 9, 18, 0, 0, 0, 19, 0, 0, 0, 0, 20, 21, 9, 22, 0, 23, 24, 25},
+{0x0000000000000000, 0x0000000000000010, 0x0000000000008000, 0xc003000000000000,
+0x0000000007fe4000, 0xffffffc000000000, 0x07fc800004000006, 0x0000000000030000,
+0xfffffff3ffffffff, 0xffffffffffffffff, 0xffffffffcecfffff, 0xffb9ffffffffffff,
+0xbfffffffffffffff, 0x3fffffffffffffff, 0x07f980ffffff7e00, 0x1006013000613c80,
+0xfc08810a700e001c, 0x000000000000ffff, 0x1ff91a3f00e7f83f, 0x00000fff00000000,
+0xf7fffffffffff000, 0xfdffffffffffffbf, 0xffffffffffffefff, 0x071f000000000000,
+0x007f01ffffff007f, 0x00000000007f0007}};
+static constexpr range_array prop_emoji_component_data = {
+0x00000000, 0x00002301, 0x00002400, 0x00002A01, 0x00002B00, 0x00003001, 0x00003A00,
+0x00200D01, 0x00200E00, 0x0020E301, 0x0020E400, 0x00FE0F01, 0x00FE1000, 0x01F1E601,
+0x01F20000, 0x01F3FB01, 0x01F40000, 0x01F9B001, 0x01F9B400, 0x0E002001, 0x0E008000};
+static constexpr range_array prop_emoji_modifier_data = {0x00000000, 0x01F3FB01, 0x01F40000};
+static constexpr bool_trie<0, 5, 120, 867, 4, 1, 15, 240, 26, 78, 24, 14>
+prop_emoji_modifier_base_data{
+{},
+{1, 0, 0, 2, 3},
+{0x0000000000000000, 0x0000000020000000, 0x0200000000000000, 0x0000000000003c00},
+{1},
+{1, 2, 0, 3, 4, 0, 0, 5, 6, 0, 0, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13},
+{0x0000000000000000, 0x0000000000000020, 0x0000000000001c9c, 0x11ffffc00001ffcc,
+0x00000400000280ee, 0x0430000000000000, 0x0000000000610000, 0x000000000000f8e0,
+0x0070000800000000, 0x0000000000001001, 0x73ff0040ff009000, 0x0080000000000000,
+0x0b60000000000000, 0x000000003ffee000}};
+static constexpr bool_trie<0, 34, 108, 850, 13, 1, 15, 240, 44, 64, 20, 28>
+prop_emoji_presentation_data{
+{},
+{1, 0,  0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 4, 5, 6, 7,  8,
+9, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 11, 12},
+{0x0000000000000000, 0x000000000c000000, 0x00091e0000000000, 0x6000000000000000,
+0x0000000000300000, 0x80000000000fff00, 0x60000c0200080000, 0x242c040000104030,
+0x0000010000000c20, 0x0000000000b85000, 0x8001000000e00000, 0x0000000018000000,
+0x0000000000210000},
+{1},
+{1,  0,  0,  2,  0,  0,  3, 4, 5, 6,  0, 0, 7, 8, 9,  10, 11, 12, 13, 14, 15, 16,
+17, 18, 13, 19, 13, 20, 0, 0, 0, 21, 0, 0, 0, 0, 22, 23, 13, 24, 0,  25, 26, 27},
+{0x0000000000000000, 0x0000000000000010, 0x0000000000008000, 0x0000000007fe4000,
+0xffffffc000000000, 0x077c800004000002, 0x0000000000030000, 0xffbfe001ffffffff,
+0xdfffffffffffffff, 0xffffffff000fffff, 0xff11ffff000f87ff, 0x7fffffffffffffff,
+0xfffffffffffffffd, 0xffffffffffffffff, 0x9fffffffffffffff, 0x3fffffffffffffff,
+0x040000ffffff7800, 0x0000001000600000, 0xf800000000000000, 0x000000000000ffff,
+0x1ff0180000e7103f, 0x00000fff00000000, 0xf7fffffffffff000, 0xfdffffffffffffbf,
+0xffffffffffffefff, 0x071f000000000000, 0x007f01ffffff007f, 0x00000000007f0007}};
+static constexpr flat_array<48> prop_ext_data{
+{0x00B7,  0x02D0,  0x02D1,  0x0640,  0x07FA,  0x0B55,  0x0E46,  0x0EC6,  0x180A,  0x1843,
+0x1AA7,  0x1C36,  0x1C7B,  0x3005,  0x3031,  0x3032,  0x3033,  0x3034,  0x3035,  0x309D,
+0x309E,  0x30FC,  0x30FD,  0x30FE,  0xA015,  0xA60C,  0xA9CF,  0xA9E6,  0xAA70,  0xAADD,
+0xAAF3,  0xAAF4,  0xFF70,  0x1135D, 0x115C6, 0x115C7, 0x115C8, 0x11A98, 0x16B42, 0x16B43,
+0x16FE0, 0x16FE1, 0x16FE3, 0x1E13C, 0x1E13D, 0x1E944, 0x1E945, 0x1E946}};
+static constexpr bool_trie<32, 75, 96, 821, 22, 1, 15, 240, 44, 64, 20, 23>
+prop_extended_pictographic_data{
+{0x0000000000000000, 0x0000000000000000, 0x0000420000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1,  2,  0,  0,  3,  0,  4, 0, 0, 0, 0, 0,  5, 0, 6,  7, 0, 0, 0, 8,  0,  0, 9, 10, 11,
+12, 13, 12, 14, 15, 16, 0, 0, 0, 0, 0, 17, 0, 0, 0,  0, 0, 0, 0, 18, 19, 0, 0, 0,  0,
+0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0, 20, 0, 0, 0, 0, 0,  0,  0, 0, 0,  21},
+{0x0000000000000000, 0x1000000000000000, 0x0000000000000200, 0x0200000400000000,
+0x0000060003f00000, 0x000001000c000000, 0x0000000000000100, 0x070ffe0000008000,
+0x0000000000000004, 0x00400c0000000000, 0x7800000000000001, 0xfffffffffff7ffbf,
+0xffffffffffffffff, 0xffffffffffff003f, 0x001801022057ff3f, 0x000000f800b85090,
+0x8001000200e00000, 0x0030000000000000, 0x00000000180000e0, 0x0000000000210000,
+0x2001000000000000, 0x0000000002800000},
+{1},
+{1, 2, 3, 4,  5, 6,  7, 0, 8, 9,  0, 0, 2,  2, 2,  10, 2, 2,  2, 2,  11, 12,
+2, 2, 2, 13, 2, 14, 0, 0, 0, 15, 0, 0, 16, 0, 17, 18, 2, 19, 2, 20, 21, 22},
+{0x0000000000000000, 0xffff0fffffffffff, 0xffffffffffffffff, 0xfffe7fff000fffff,
+0x003ffffffffefffe, 0x000080000000e000, 0xc003f00000000000, 0x0000200007fe4000,
+0x07fc800004000006, 0x0000003f00030000, 0x07ffffffffffffff, 0x3fffffffffffffff,
+0xffffffffffffffc0, 0x000000000000ffff, 0x1fff1fff00ffffff, 0x00000fff01e00000,
+0x0003000000000000, 0xf7fffffffffff000, 0xfdffffffffffffbf, 0xffffffffffffefff,
+0x071f3fff000fffff, 0x007f01ffffff007f, 0x00000000007f0007}};
+static constexpr bool_trie<32, 991, 1, 0, 132, 255, 1, 0, 1215, 1, 0, 162> prop_gr_base_data{
+{0xffffffff00000000, 0x7fffffffffffffff, 0xffffdfff00000000, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0x0000000000000000, 0xfcff000000000000, 0xfffffffbffffd7f0, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xfffffffffffffc07, 0xffffffffffffffff,
+0xfffeffffffffffff, 0xfffffffffe7fffff, 0x400000000000e7ff, 0x001f87ffffff0049,
+0xffffffffc800ffc0, 0xfffeffff000007ff, 0xffffffffffffffff, 0xffffc260403fffff,
+0x0000fffffffd3fff, 0xffffffffffffe000, 0x0002003fffffffff, 0xc7f007ffffffffff},
+{1,   2,   3,   4,   5,   6,  7,   8,  9,   10,  11,  12,  13,  14,  15,  16,  17,  18,
+19,  20,  21,  22,  23,  24, 25,  26, 27,  28,  29,  30,  31,  32,  33,  34,  35,  36,
+36,  36,  36,  36,  37,  38, 39,  40, 41,  42,  43,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  44,  45,  46, 47,  48, 49,  50,  45,  51,  52,  53,  54,  55,  56,  57,
+58,  59,  60,  61,  62,  63, 64,  65, 66,  67,  68,  36,  36,  36,  60,  36,  36,  36,
+36,  69,  70,  71,  72,  73, 74,  75, 60,  36,  36,  76,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  77,  78,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  79,  80,  36,  81,
+82,  36,  83,  84,  85,  86, 87,  36, 88,  89,  90,  36,  36,  36,  91,  92,  93,  94,
+36,  95,  36,  96,  97,  82, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  98,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  99,  100, 36,  36,  36,
+36,  101, 102, 103, 104, 36, 36,  36, 105, 106, 107, 36,  108, 109, 110, 111, 112, 113,
+114, 115, 116, 117, 55,  36, 118, 36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  36,  36,  36,  36,  36, 36,  36, 36,  36,  36,  36,  36,  36,  36,  36,  36,  36,
+36,  97,  119, 60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  60,  60,  60,  60,  60,  60,  60,  60,  60,
+60,  60,  60,  60,  60,  60, 60,  60, 60,  36,  36,  36,  36,  36,  120, 36,  121, 122,
+123, 36,  124, 36,  36,  36, 36,  36, 125, 126, 127, 128, 129, 36,  98,  93,  36,  130,
+131},
+{0x7fff0110043fffff, 0x000007ff41ffffff, 0xffdfffff00000000, 0x00000000000000ff,
+0xebfffffffffffff8, 0xfffffff3ff01de01, 0xa3c5fdfffff99fed, 0x3fffffc3b0005981,
+0xc36dfdfffff987e8, 0x005cffc05e000001, 0xe3edfdfffffbbfe8, 0x0203ffc300011a01,
+0x23edfdfffff99fec, 0x00ffffc3b0001981, 0x83ffc718d63dc7e8, 0x07ffffc000011dc6,
+0x23fffdfffffddfee, 0xff80ffc30700001e, 0x63effdfffffddffd, 0x0006ffc340000d9b,
+0xa7fffffffffddffc, 0xffffffc3ff70ddc1, 0x2ffbfffffc7fffec, 0x001cffc07f03007f,
+0x800dfffffffffffe, 0x000000000fff807f, 0x200dffaffffff7d6, 0x00000000f3ff005f,
+0xfd5ffffffcffffff, 0x80001ffffffffeff, 0xc000000000001f20, 0x0000000007ffdfbf,
+0x99021fffffffffff, 0xffe1fffe3cffffff, 0xffffffffdfffdf9b, 0xffffffffffff20bf,
+0xffffffffffffffff, 0xffffffff3d7f3dff, 0x7f3dffffffff3dff, 0xffffffffff7fff3d,
+0xffffffffff3dffff, 0x1fffffff07ffffff, 0xffffffff03ffffff, 0x3f3fffffffffffff,
+0xffffffff1fffffff, 0x01ffffffffffffff, 0x0063ffff0003dfff, 0x0001dfff0003ffff,
+0xc04fffffffffffff, 0x03ff03ff1ff001bf, 0xffffffff03ff07ff, 0xffff05ffffffff9f,
+0x003fffffffffffff, 0x01fb0e787fffffff, 0x001f3ffffffffff1, 0xffff0fffffffffff,
+0xffffffffc7ff03ff, 0xffffffffc67fffff, 0x0007e01a00bfffff, 0x00003fff03ff03ff,
+0x0000000000000000, 0xe80ffffffffffff0, 0x1ff007ffffff0ffb, 0xffffc4c3fffffffc,
+0xf00c5cbfffffffff, 0xf8300fffffffffff, 0xffffffffffffe3ff, 0xe7ffffffffff01ff,
+0x04efde02000800ff, 0xffffffff3f3fffff, 0x3fffffffaaff3f3f, 0xffdfffffffffffff,
+0x7fdcffffefcfffdf, 0xffff80ffffff07ff, 0xfff30000ffffffff, 0xffffffff1fff7fff,
+0xffffffffffff0fff, 0x0000007fffffffff, 0xffffffff000007ff, 0xffcfffffffffffff,
+0xffffffffffbfffff, 0xffff7fffffffffff, 0xffffffff7fffffff, 0xfe0c7fffffffffff,
+0xffff20bfffffffff, 0x000180ffffffffff, 0x7f7f7f7f007fffff, 0x000000007f7f7f7f,
+0x000000000007ffff, 0xfffffffffbffffff, 0x000fffffffffffff, 0x0fff0000003fffff,
+0xffff03ffffffffff, 0xfffffffffffffffe, 0xfffffffff87fffff, 0xfffeffffffffffe0,
+0xffffffffffff7fff, 0xffff000fffffffff, 0x1fffffffffffffff, 0xffffffffffff1fff,
+0xffffffffffff007f, 0x00000fffffffffff, 0xc0087fffffffffff, 0xffffffff3fffffff,
+0x00fcffffffffffff, 0xffe00000000007fc, 0x03ff0f9ffffff7bb, 0x00ffffffffffffff,
+0x7ffc000003ffc00f, 0xffffc03fffffffff, 0x1fffffff800c007f, 0xcc37fffffffffff8,
+0x7fffffdfc3ffbfff, 0x001981ffffffffff, 0xeffffffff3ff2ff7, 0x3e62ffffffffffff,
+0x003fcffff8000005, 0xffff7f7f007e7e7e, 0x03ff1edfffffffff, 0x0ffffffffffff87f,
+0xffff3fffffffffff, 0x0000000003ffffff, 0x5f7fffffa0f8007f, 0xffffffffffffffdb,
+0xfffffffffff80003, 0xffffffffffff0000, 0xfffffffffffcffff, 0x3fff0000000000ff,
+0xffff000003ff0000, 0xffdf0f7ffff7ffff, 0x7fffffff3fffffff, 0x30007f7f1cfcfcfc},
+{1,  2,  3, 4,  5,  6, 7,  8, 5, 5, 9, 5, 10, 11, 12, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 13,
+14, 15, 7, 16, 17, 7, 18, 5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5},
+{1,   2,   3,   4,   2,   5,   6,   7,   7,   8,   9,   10,  11,  12,  13,  2,   2,   14,
+15,  16,  17,  7,   7,   2,   2,   2,   2,   18,  19,  7,   7,   20,  21,  22,  23,  24,
+7,   25,  26,  27,  28,  29,  30,  31,  32,  33,  7,   2,   34,  35,  36,  37,  7,   7,
+7,   7,   38,  39,  7,   16,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  50,  51,
+7,   52,  53,  54,  55,  7,   7,   56,  57,  58,  59,  7,   7,   60,  61,  62,  63,  64,
+65,  66,  7,   7,   7,   67,  7,   68,  69,  70,  71,  72,  73,  74,  75,  76,  77,  7,
+7,   7,   7,   78,  79,  80,  7,   81,  82,  83,  7,   7,   7,   7,   84,  7,   7,   85,
+86,  2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   87,  7,   2,
+88,  2,   2,   2,   89,  7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   90,  7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   2,   2,   2,   2,   2,   2,   2,   2,   2,   91,  7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   2,   2,   2,   2,   2,   2,   2,   2,   77,  92,  7,   93,  94,  95,  96,  7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   2,   97,  7,   2,   98,  99,  100, 2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   56,  2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   101, 34,  7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,
+2,   2,   2,   102, 103, 2,   2,   2,   2,   2,   104, 7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   105, 106, 7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   2,   2,   107, 108, 109, 110, 111, 2,
+112, 7,   113, 2,   114, 7,   7,   2,   115, 116, 117, 118, 119, 2,   2,   2,   2,   120,
+2,   2,   2,   2,   121, 2,   2,   2,   2,   2,   2,   2,   2,   122, 123, 124, 7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   125, 126, 7,   7,   7,   7,   7,   127, 7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,   2,   2,
+128, 2,   129, 7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   130, 131, 7,   132,
+7,   7,   7,   133, 134, 135, 136, 7,   7,   7,   7,   137, 2,   138, 139, 2,   2,   140,
+141, 142, 143, 7,   7,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   144, 2,   145, 2,   146, 147, 148, 149, 7,   2,   150, 2,   151, 2,   152, 153,
+154, 2,   2,   155, 156, 7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   157, 2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   131, 2,   2,   2,   158, 2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   159, 2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   160, 7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   2,   2,   2,   2,   2,   2,   2,   2,   157, 7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   2,
+2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   2,   161, 7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,   7,
+7,   7,   7,   7,   7,   7,   7,   7,   7},
+{0xb7ffff7fffffefff, 0x000000003fff3fff, 0xffffffffffffffff, 0x07ffffffffffffff,
+0xff8fffffffffff87, 0x000000011fff7fff, 0x1fffffffffff0000, 0x0000000000000000,
+0xffffffff1fffffff, 0x0ffffffe0001ffff, 0xffffe00fffffffff, 0x003fffffffff07ff,
+0xffffffffbfffffff, 0x00000000003fff0f, 0xffff03ff3fffffff, 0x0fffffffff0fffff,
+0xffff00ffffffffff, 0x0000800fffffffff, 0x007fffffffffffff, 0x000000ff003fffff,
+0x91bffffffffffd3f, 0xffffffffffbfffff, 0x0000ff807fffffff, 0xf837ffff00000000,
+0x83ffffff8fffffff, 0xf0ffffffffffffff, 0xfffffffffffcffff, 0x003ffffffeef0001,
+0xffffffff01ff01ff, 0x00000000ffffffff, 0x007ff81fffffffff, 0xfe3fffffffffffff,
+0xff07ffffff3fffff, 0x0000fe001e03ffff, 0x00000000000001ff, 0x0007ffffffffffff,
+0xfc07ffffffffffff, 0x03ff000fffffffff, 0x7fffffff00000000, 0x000323ffffffffff,
+0x0000000003fe003f, 0xffff000000000000, 0x007fffff00000fff, 0x00fffffffffffffd,
+0x0000fffffffc3f80, 0xd987fffffffffffc, 0x03ff01ffffff0003, 0xffc0107ffffffff8,
+0x0077ffffffff00ff, 0x803ffffffffffffc, 0x001ffffeffff61ff, 0x3f2c7ffffffbffff,
+0xffff03ffbfffbd7f, 0x03ff00077fffffff, 0xa3edfdfffff99fec, 0x0000000fe001399e,
+0x00ffffffffffffff, 0x00000003afffffa3, 0x5a06ffffffffffff, 0x0000000003ff00f2,
+0x4f037fffffffffff, 0x000000000ffffffe, 0x5807ffffffffffff, 0x00001fff03ff001e,
+0x0140d7ffffffffff, 0x00000000000003ff, 0xffff004307ffffff, 0x09007fffffffffff,
+0xffffffff00000000, 0x8007ffffffffffff, 0xa1beffffff6ff27f, 0x0000000003ff0077,
+0xfffffcff00000000, 0x0000001ef00fffff, 0x8607fffffffff801, 0xfffffffff181007f,
+0x00000007fc8003ff, 0x01ffffffffffffff, 0x4000fffffffffdff, 0xffff1fffffff003f,
+0x001202000000ffff, 0x0001fffffffffb7f, 0xfffffdbf03ff0040, 0x000003ff01587fff,
+0x01e7ffff00000000, 0x0001000000000000, 0x8003ffffffffffff, 0x0000000003ffffff,
+0x001f7fffffffffff, 0x000000000000000f, 0x00007fffffffffff, 0x000000000000007f,
+0x0000c3ff7fffffff, 0x00203fffffff0000, 0xff80ffffffffffff, 0xe0fffffbfbff003f,
+0x000000000000ffff, 0x0000000007ffffff, 0xffffffffffff07ff, 0x00000000fff800ff,
+0x0003000f00000000, 0x00000000003fffff, 0x000000007fffffff, 0xffff00f000070000,
+0x0fffffffffffffff, 0x1fff07ffffffffff, 0x0000000093ff01ff, 0x003fffffffffffff,
+0xfffffe7fffffffff, 0x00003c5fffffffff, 0xffffc3fffffff018, 0x000001ffffffffff,
+0x0000000000000023, 0x000fffff00000000, 0x01ffffff007fffff, 0xffffffffffdfffff,
+0xebffde64dfffffff, 0xffffffffffffffef, 0x7bffffffdfdfe7bf, 0xfffffffffffdfc5f,
+0xffffff3fffffffff, 0xffffffffffffcfff, 0x0780000000000000, 0xffdfe00000000000,
+0x0000000000000fef, 0x3f801fffffffffff, 0x000000000000c3ff, 0x83ff0fffffffffff,
+0x000000000000ff9f, 0x00000000c3ff080f, 0xfffe000000000000, 0x001fffffffffffff,
+0x3ffffffffffffffe, 0x0af7fe96ffffffef, 0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff,
+0x0003000000000000, 0xffff0fffffffffff, 0xfffe7fff000fffff, 0x003ffffffffefffe,
+0x00003fffffffffff, 0xffffffc000000000, 0x0fffffffffff0007, 0x0000003f000301ff,
+0x1fff1fff00ffffff, 0x000fffffffffffff, 0x00000fff01ffffff, 0xffffffffffff0fff,
+0xffffffff03ff00ff, 0x00033fffffff00ff, 0xfdffffffffffffff, 0xffffffffffffefff,
+0x071f3fff000fffff, 0x007f01ffffff007f, 0x00000000007f0007, 0xfffffffffff7ffff,
+0x03ff0000000007ff, 0x000000003fffffff, 0xffffffff3fffffff, 0xffff0003ffffffff,
+0x00000001ffffffff, 0x00000000000007ff}};
+static constexpr range_array prop_hex_data = {
+0x00000000, 0x00003001, 0x00003A00, 0x00004101, 0x00004700, 0x00006101, 0x00006700,
+0x00FF1001, 0x00FF1A00, 0x00FF2101, 0x00FF2700, 0x00FF4101, 0x00FF4700};
+static constexpr range_array prop_ideo_data = {
+0x00000000, 0x00300601, 0x00300800, 0x00302101, 0x00302A00, 0x00303801, 0x00303B00,
+0x00340001, 0x004DC000, 0x004E0001, 0x009FFD00, 0x00F90001, 0x00FA6E00, 0x00FA7001,
+0x00FADA00, 0x016FE401, 0x016FE500, 0x01700001, 0x0187F800, 0x01880001, 0x018CD600,
+0x018D0001, 0x018D0900, 0x01B17001, 0x01B2FC00, 0x02000001, 0x02A6DE00, 0x02A70001,
+0x02B73500, 0x02B74001, 0x02B81E00, 0x02B82001, 0x02CEA200, 0x02CEB001, 0x02EBE100,
+0x02F80001, 0x02FA1E00, 0x03000001, 0x03134B00};
+static constexpr range_array prop_idsb_data = {0x00000000, 0x002FF001, 0x002FF200, 0x002FF401,
+0x002FFC00};
+static constexpr flat_array<2> prop_idst_data{{0x2FF2, 0x2FF3}};
+static constexpr flat_array<2> prop_join_c_data{{0x200C, 0x200D}};
+static constexpr range_array prop_loe_data = {0x00000000, 0x000E4001, 0x000E4500, 0x000EC001,
+0x000EC500, 0x0019B501, 0x0019B800, 0x0019BA01,
+0x0019BB00, 0x00AAB501, 0x00AAB700, 0x00AAB901,
+0x00AABA00, 0x00AABB01, 0x00AABD00};
+static constexpr bool_trie<32, 991, 1, 0, 57, 255, 1, 0, 378, 13, 57, 47> prop_oalpha_data{
+{0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000020, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0xbfff000000000000, 0x00000000000000b6,
+0x0000000007ff0000, 0x00010000fefff800, 0x0000000000000000, 0x0000219e1fc00000,
+0xffff000000020000, 0x0000000000000000, 0x0001ffc000000000, 0x0000000000000000},
+{1,  1,  2,  3,  4,  5,  6,  5,  7,  5,  8,  5,  9,  10, 11, 12, 13, 5,  13, 12, 14, 15, 16,
+17, 18, 19, 18, 1,  20, 21, 1,  22, 23, 24, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  25, 25, 26, 27, 1,  1,  28, 1,  29, 1,
+1,  1,  30, 31, 32, 33, 34, 35, 36, 37, 38, 1,  1,  1,  1,  1,  1,  39, 1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  26, 40,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  41, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  42, 43, 1,  1,  1,  1,  1,  44, 1,  45, 46, 47,
+48, 49, 50, 51, 52, 53, 54, 1,  1,  1,  55, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1,  1,  1,  1,  56, 1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,  1,
+1,  1},
+{0x00001eeff8c00000, 0x0000000000000000, 0xffff03f8fff00000, 0xcc0000000000000f,
+0x0000000c00e0dfff, 0xc00000000000000e, 0x0000000c0080199f, 0x0023000000021987,
+0x1c00000c00001bbf, 0x0000000c00c0199f, 0xc000000000000004, 0x0000000000801dc7,
+0xc00000000000000f, 0x0000000c00601ddf, 0x0000000c00801ddf, 0x000000000000000e,
+0x000c0000ff5f8000, 0x07f2000000000000, 0x0000000000002000, 0x1bf2000000000000,
+0xfffe000000000000, 0x1ffffffffeffe003, 0x797ff80000000000, 0x001e3f9dc3c00000,
+0x000000003c00bffc, 0x000c0000000c0000, 0xffc0000000000000, 0x00000000000001ff,
+0x0000020000000060, 0x01ff0fff00000000, 0x000000000f800000, 0x001ffffe7fe00000,
+0x8000000000000000, 0x0000000000000001, 0xffe000000000001f, 0x000000000000000f,
+0x000033fe00000007, 0x0003ff8000000000, 0x007ffff000000000, 0x001fff8000000000,
+0x000003ffffffffff, 0xffffffff00000000, 0x0ff0000000000000, 0x00000000c0000000,
+0x000000f800000804, 0xfff0000000000003, 0x800000000000002f, 0x000007c000000000,
+0x000000000007ff80, 0xfff000000000000f, 0x0000002000000000, 0x007ffe0000000000,
+0x3800000000003008, 0x419d000000000000, 0x0020f80000000000, 0x000007f800000000,
+0x0000000040000000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 4, 2, 2, 5, 6, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  2,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  3,  0,  0, 0,  0,  0,  4,  0,  0,
+0,  0,  0,  5,  6,  7,  0, 8,  9,  10, 11, 12, 0, 0, 13, 14, 15, 0, 0,  16, 17, 18, 19, 0,
+0,  20, 21, 22, 23, 24, 0, 25, 0,  0,  0,  26, 0, 0, 0,  27, 28, 0, 29, 30, 31, 32, 0,  0,
+0,  0,  0,  33, 0,  34, 0, 35, 36, 37, 0,  0,  0, 0, 38, 0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+39, 40, 41, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  42, 0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  43, 0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  44, 0,  0,  0,  0, 0, 0,  0,  0,  0, 0,  0,  0,  0,  0,  0,
+0,  0,  0,  0,  0,  0,  0, 0,  0,  0,  0,  0,  0, 0, 0,  18, 45, 46},
+{0x0000000000000000, 0x07c0000000000000, 0x000000000000f06e, 0x000000f000000000,
+0x0000180000000000, 0xff00000000000007, 0x000000000000003f, 0x01ff000000000004,
+0x0007ff8000000007, 0x0000000000000060, 0xfff8000000000007, 0x000000000000c000,
+0x409ff00000000000, 0x000001ff80000000, 0xc00000000000000f, 0x0000000c0080199f,
+0xffe0000000000000, 0x000000000000003b, 0xffff000000000000, 0x0000000000000003,
+0x7f3f800000000000, 0x0000000030000000, 0x7fff000000000000, 0x0000000000000001,
+0x003ff80000000000, 0x000007ffe0000000, 0x01fff00000000000, 0x19bf000000000000,
+0x0000000000000005, 0x00000010fcfe0000, 0x7be00000000007fe, 0x000000000ffe0000,
+0x0000000000fffc00, 0x7f7f800000000000, 0x007ffefffffc0000, 0xb47e000000000000,
+0x000000000000008b, 0x00000000007b7c00, 0x0078000000000000, 0xfffffffffffe8000,
+0x00000000000780ff, 0x0003000000000000, 0x0000000040000000, 0x000007dbf9ffff7f,
+0x0000000000000080, 0xffff03ffffff03ff, 0x00000000000003ff}};
+static constexpr flat_array<7> prop_odi_data{
+{0x034F, 0x115F, 0x1160, 0x17B4, 0x17B5, 0x3164, 0xFFA0}};
+static constexpr bool_trie<0, 985, 6, 1, 9, 208, 1, 47, 118, 76, 62, 9> prop_ogr_ext_data{
+{},
+{1, 2, 0, 0, 0, 0, 1, 2, 1, 2, 0, 0, 0, 3, 1, 2, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8},
+{0x0000000000000000, 0x4000000000000000, 0x0000000000800000, 0x0000000000600004,
+0x0000000080008000, 0x0020000000000000, 0x0000000000001000, 0x0000c00000000000,
+0x00000000c0000000},
+{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3},
+{1, 2, 0, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 8},
+{0x0000000000000000, 0x4000000000000000, 0x0000000000800000, 0x2001000000000000,
+0x0000800000000000, 0x0001000000000000, 0x0007c02000000000, 0xffffffff00000000,
+0xffffffffffffffff}};
+static constexpr range_array prop_oidc_data = {0x00000000, 0x0000B701, 0x0000B800,
+0x00038701, 0x00038800, 0x00136901,
+0x00137200, 0x0019DA01, 0x0019DB00};
+static constexpr flat_array<6> prop_oids_data{{0x1885, 0x1886, 0x2118, 0x212E, 0x309B, 0x309C}};
+static constexpr range_array prop_olower_data = {
+0x00000000, 0x0000AA01, 0x0000AB00, 0x0000BA01, 0x0000BB00, 0x0002B001, 0x0002B900,
+0x0002C001, 0x0002C200, 0x0002E001, 0x0002E500, 0x00034501, 0x00034600, 0x00037A01,
+0x00037B00, 0x001D2C01, 0x001D6B00, 0x001D7801, 0x001D7900, 0x001D9B01, 0x001DC000,
+0x00207101, 0x00207200, 0x00207F01, 0x00208000, 0x00209001, 0x00209D00, 0x00217001,
+0x00218000, 0x0024D001, 0x0024EA00, 0x002C7C01, 0x002C7E00, 0x00A69C01, 0x00A69E00,
+0x00A77001, 0x00A77100, 0x00A7F801, 0x00A7FA00, 0x00AB5C01, 0x00AB6000};
+static constexpr bool_trie<32, 893, 96, 3, 21, 2, 13, 241, 107, 80, 5, 16> prop_omath_data{
+{0x0000000000000000, 0x0000000040000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0033000000270000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 2, 3, 4, 5,  6, 7, 8, 0, 0, 0, 0,  9,  0, 10, 11, 0, 0, 0, 0, 0, 0, 12, 13, 14, 15, 0,
+0, 0, 0, 0, 16, 0, 0, 0, 0, 0, 0, 17, 18, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,
+0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0,  0,  0, 0,  0,  0, 0, 0, 0, 0, 0, 0,  0,  0,  19, 0,
+0, 20},
+{0x0000000000000000, 0x001c000000400000, 0x6000001e00000001, 0x0000000000006000,
+0x0000f8621fff0000, 0xf1fbb3103e2ffc84, 0x00000000000003e0, 0xf0c33eb6f3e00000,
+0x000000302feb3fff, 0x0000000000000f00, 0x00b0000000000000, 0x0000000400010000,
+0xf07fc00300000000, 0x00001f94000f8cc1, 0x0000000000000060, 0x0000600f00000005,
+0x0000ffc000000060, 0x0000000001fffff8, 0x300000000f000000, 0x0000010a00000000,
+0x5000000000000000},
+{1, 2},
+{1, 2, 3, 4, 5, 6, 1, 1, 1, 1, 7, 8, 9, 10, 11, 12, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0,  0,  0, 0,
+0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 13, 14, 15},
+{0x0000000000000000, 0xffffffffffffffff, 0xffffffffffdfffff, 0xebffde64dfffffff,
+0xffffffffffffffef, 0x7bffffffdfdfe7bf, 0xfffffffffffdfc5f, 0xffffff3fffffffff,
+0xf7fffffff7fffffd, 0xffdfffffffdfffff, 0xffff7fffffff7fff, 0xfffffdfffffffdff,
+0xffffffffffffcff7, 0x0af7fe96ffffffef, 0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff}};
+static constexpr range_array prop_oupper_data = {0x00000000, 0x00216001, 0x00217000, 0x0024B601,
+0x0024D000, 0x01F13001, 0x01F14A00, 0x01F15001,
+0x01F16A00, 0x01F17001, 0x01F18A00};
+static constexpr bool_trie<32, 890, 96, 6, 15, 0, 0, 0, 0, 0, 0, 0> prop_pat_syn_data{
+{0xfc00fffe00000000, 0x7800000178000001, 0x88435afe00000000, 0x0080000000800000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000},
+{1, 2, 0, 0, 0, 0, 3,  4, 4, 4, 4, 4, 4, 4, 4,  4, 5, 6,  0, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+7, 8, 4, 4, 4, 4, 4,  4, 4, 4, 4, 4, 4, 4, 4,  4, 9, 10, 4, 0, 0, 0, 0, 0, 0, 0, 0, 4, 11,
+0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 13, 0, 0, 0,  0, 14},
+{0x0000000000000000, 0x7fff00ffffff0000, 0x000000007feffffe, 0xffffffffffff0000,
+0xffffffffffffffff, 0x0000007fffffffff, 0x00000000000007ff, 0x003fffffffffffff,
+0xfffffffffff00000, 0xffcfffffffffffff, 0xffffffffffbfffff, 0x000000000007ffff,
+0x00010001ffffff0e, 0xc000000000000000, 0x0000000000000060},
+{},
+{},
+{}};
+static constexpr flat_array<11> prop_pat_ws_data{
+{0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x0020, 0x0085, 0x200E, 0x200F, 0x2028, 0x2029}};
+static constexpr flat_array<11> prop_pcm_data{
+{0x0600, 0x0601, 0x0602, 0x0603, 0x0604, 0x0605, 0x06DD, 0x070F, 0x08E2, 0x110BD, 0x110CD}};
+static constexpr range_array prop_qmark_data = {
+0x00000000, 0x00002201, 0x00002300, 0x00002701, 0x00002800, 0x0000AB01, 0x0000AC00,
+0x0000BB01, 0x0000BC00, 0x00201801, 0x00202000, 0x00203901, 0x00203B00, 0x002E4201,
+0x002E4300, 0x00300C01, 0x00301000, 0x00301D01, 0x00302000, 0x00FE4101, 0x00FE4500,
+0x00FF0201, 0x00FF0300, 0x00FF0701, 0x00FF0800, 0x00FF6201, 0x00FF6400};
+static constexpr range_array prop_radical_data = {
+0x00000000, 0x002E8001, 0x002E9A00, 0x002E9B01, 0x002EF400, 0x002F0001, 0x002FD600};
+static constexpr range_array prop_ri_data = {0x00000000, 0x01F1E601, 0x01F20000};
+static constexpr flat_array<46> prop_sd_data{
+{0x0069,  0x006A,  0x012F,  0x0249,  0x0268,  0x029D,  0x02B2,  0x03F3,  0x0456,  0x0458,
+0x1D62,  0x1D96,  0x1DA4,  0x1DA8,  0x1E2D,  0x1ECB,  0x2071,  0x2148,  0x2149,  0x2C7C,
+0x1D422, 0x1D423, 0x1D456, 0x1D457, 0x1D48A, 0x1D48B, 0x1D4BE, 0x1D4BF, 0x1D4F2, 0x1D4F3,
+0x1D526, 0x1D527, 0x1D55A, 0x1D55B, 0x1D58E, 0x1D58F, 0x1D5C2, 0x1D5C3, 0x1D5F6, 0x1D5F7,
+0x1D62A, 0x1D62B, 0x1D65E, 0x1D65F, 0x1D692, 0x1D693}};
+static constexpr bool_trie<32, 991, 1, 0, 29, 255, 1, 0, 322, 41, 21, 24> prop_sterm_data{
+{0x8000400200000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000200, 0x0000000000000000,
+0x00000000c0000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000100000,
+0x0000000000000007, 0x0000000000000000, 0x0000000000000000, 0x0200000000000000},
+{1,  1,  1, 1, 2,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  3, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  4, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  5,  1, 1, 6,  1, 1, 1,  7,  1, 1,  1, 1,  8,  1, 1,  1,  1, 9,  1,
+1,  10, 1, 1, 11, 12, 1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 13, 14, 1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  15, 1, 1, 1,  1,  1,  1, 1, 16, 1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  17, 1, 1, 1,  1,  18, 1, 1, 19, 1, 1, 1,  1,  1, 20, 1, 18, 21, 1, 1,  22, 1, 23, 1,
+24, 1,  1, 1, 25, 1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 1,  1, 1, 1,  1,  1, 1,  1, 1,  1,  1, 1,  1,  1, 1,  1,
+1,  1,  1, 1, 1,  1,  1,  1, 1, 26, 1, 1, 27, 28, 1, 1},
+{0x6280000000000000, 0x0000000000000000, 0x0000003000000000, 0x0000000000000c00,
+0x0000018400000000, 0x0000400000000000, 0x0060000000000000, 0x0000000000000208,
+0x0000000000000030, 0x00000f0000000000, 0x00000000cc000000, 0x1800000000000000,
+0xc000000000000000, 0x3000000000000000, 0x0000000000000380, 0x1000400000000000,
+0x0000000000000004, 0x8000000000000000, 0x000000000000c000, 0x0088000000000000,
+0x00c0000000000000, 0x0000800000000000, 0x0000000000000300, 0x00000000e0000000,
+0x0003000000000000, 0x0000080000000000, 0x0000000000c40000, 0x0000000080004002,
+0x0000000200000000},
+{1, 2, 2, 2, 2, 3, 2, 2, 2, 2, 4, 2, 5, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+{1, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  2,  0,  0,  0,  3,
+4, 5,  0, 6, 0, 7, 8, 0,  9, 0,  0,  0, 0, 0, 0,  10, 0, 0,  0, 0,  0,  11, 0,  12, 0,
+0, 13, 0, 0, 0, 0, 0, 0,  0, 0,  14, 0, 0, 0, 15, 16, 0, 0,  0, 0,  0,  0,  12, 0,  0,
+0, 0,  0, 0, 0, 0, 0, 17, 0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 18, 0, 19, 17, 20, 0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 21, 0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  22, 0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  0,  0,  0,  0,
+0, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0, 0,  0, 0,  0,  23},
+{0x0000000000000000, 0x0000000000c00000, 0x0000000003e00000, 0x0000000000000180,
+0xc000000000000000, 0x0000000000000003, 0x000000000000000e, 0x00000000c0002060,
+0x1b00000000000000, 0x0000020000000000, 0x0000000000001800, 0x0000000000fffe0c,
+0x0000000000000006, 0x7000000000000000, 0x0000000000000050, 0x000000000000000c,
+0x0000000018000000, 0x0180000000000000, 0x0000c00000000000, 0x0020000000000000,
+0x0000000000000010, 0x0000000001000000, 0x0000000080000000, 0x0000000000000100}};
+static constexpr bool_trie<32, 991, 1, 0, 34, 255, 1, 0, 413, 14, 21, 32> prop_term_data{
+{0x8c00500200000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x4000000000000000, 0x0000000000000080, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000000, 0x0000000000000000,
+0x0000000000000000, 0x0000000000000000, 0x0000000000000200, 0x0000000000000008,
+0x00000000c8001000, 0x0000000000000000, 0x0000000000000000, 0x0000000000100000,
+0x00000000000017ff, 0x0000000000000000, 0x0000000000000000, 0x0300000000000000},
+{1,  2,  2,  2, 3,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  4,
+2,  2,  5,  2, 2,  2,  2,  6, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  7, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  8,  2, 9, 10, 2, 2, 11, 12, 2, 2,  2, 2,  13, 2, 2,  2,  2, 14, 2,
+2,  15, 2,  2, 16, 17, 2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 18, 19, 2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  20, 21, 2, 2,  2,  2,  2, 2, 22, 2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  17, 2,  2, 2,  2,  23, 2, 2, 24, 2, 2, 2,  2,  2, 25, 2, 26, 27, 2, 2,  19, 2, 28, 2,
+29, 2,  2,  2, 30, 2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 2,  2, 2, 2,  2,  2, 2,  2, 2,  2,  2, 2,  2,  2, 2,  2,
+2,  2,  2,  2, 2,  2,  2,  2, 2, 31, 2, 2, 32, 33, 2, 2},
+{0x7fff000000000000, 0x0000000040000000, 0x0000000000000000, 0x0000003000000000,
+0x000000000c000000, 0x000000000007e100, 0x0000000000000c00, 0x000001fe00000000,
+0x0000400000000000, 0x0000380000000000, 0x0060000000000000, 0x0000000004700000,
+0x000000000000033c, 0x0000000000000030, 0x00000f0000000000, 0x00000000ec000000,
+0xf800000000000000, 0xc000000000000000, 0x3000000000000000, 0x0000000000000380,
+0x1000400000000000, 0x000000000000d002, 0x0000000000000006, 0x000000000000e000,
+0x00f8000000000000, 0x00c0000000000000, 0x000000000000c000, 0x0000800000000000,
+0x00000000e0000000, 0x0003000080000000, 0x0000080000000000, 0x0000000000f70000,
+0x000000008c005002, 0x0000001200000000},
+{1, 2, 3, 3, 3, 4, 3, 3, 3, 3, 5, 3, 6, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
+{1,  2,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 3, 0, 0,  1, 0,  0, 0,
+0,  4,  0, 5,  6, 0,  7,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 8,  0, 0,  0, 9,
+10, 11, 0, 12, 0, 13, 14, 0, 15, 0,  0, 0, 0, 0,  0,  16, 0, 0, 0, 0, 0, 17, 0, 18, 0, 0,
+19, 0,  0, 0,  0, 0,  0,  0, 0,  20, 0, 0, 0, 21, 22, 0,  0, 0, 0, 0, 0, 23, 0, 0,  0, 0,
+0,  0,  0, 0,  0, 24, 0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  25, 0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 26, 0, 27,
+28, 29, 0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  30, 0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 1, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  0, 0,  0, 0,
+0,  0,  0, 0,  0, 0,  0,  0, 0,  0,  0, 0, 0, 0,  0,  0,  0, 0, 0, 0, 0, 0,  31},
+{0x0000000000000000, 0x0000000080000000, 0x0000000000010000, 0x0000000000800000,
+0x0000000000c00000, 0x003f000000000000, 0xfc00000000000000, 0x000000001e000000,
+0x0000000003e00000, 0x0000000000003f80, 0xc000000000000000, 0x0000000000000003,
+0x000000000000000e, 0x00000000c0002060, 0x1f00000000000000, 0x0000020000000000,
+0x000000000c003800, 0x0000000000fffe3c, 0x0000000000000006, 0x7000000000000000,
+0x0000000000000050, 0x000000000000000c, 0x0000000618000000, 0x000200000000000e,
+0x0180000000000000, 0x001f000000000000, 0x0000c00000000000, 0x0020000000000000,
+0x0380000000000000, 0x0000000000000010, 0x0000000001800000, 0x0000000000000780}};
+static constexpr range_array prop_uideo_data = {
+0x00000000, 0x00340001, 0x004DC000, 0x004E0001, 0x009FFD00, 0x00FA0E01, 0x00FA1000,
+0x00FA1101, 0x00FA1200, 0x00FA1301, 0x00FA1500, 0x00FA1F01, 0x00FA2000, 0x00FA2101,
+0x00FA2200, 0x00FA2301, 0x00FA2500, 0x00FA2701, 0x00FA2A00, 0x02000001, 0x02A6DE00,
+0x02A70001, 0x02B73500, 0x02B74001, 0x02B81E00, 0x02B82001, 0x02CEA200, 0x02CEB001,
+0x02EBE100, 0x03000001, 0x03134B00};
+static constexpr range_array prop_vs_data = {0x00000000, 0x00180B01, 0x00180E00, 0x00FE0001,
+0x00FE1000, 0x0E010001, 0x0E01F000};
+static constexpr range_array prop_wspace_data = {
+0x00000000, 0x00000901, 0x00000E00, 0x00002001, 0x00002100, 0x00008501, 0x00008600,
+0x0000A001, 0x0000A100, 0x00168001, 0x00168100, 0x00200001, 0x00200B00, 0x00202801,
+0x00202A00, 0x00202F01, 0x00203000, 0x00205F01, 0x00206000, 0x00300001, 0x00300100};
+static constexpr bool_trie<32, 991, 1, 0, 130, 255, 1, 0, 1279, 1, 0, 124> prop_xidc_data{
+{0x03ff000000000000, 0x07fffffe87fffffe, 0x04a0040000000000, 0xff7fffffff7fffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x0000501f0003ffc3,
+0xffffffffffffffff, 0xb8dfffffffffffff, 0xfffffffbffffd7c0, 0xffbfffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xfffffffffffffcfb, 0xffffffffffffffff,
+0xfffeffffffffffff, 0xffffffff027fffff, 0xbffffffffffe01ff, 0x000787ffffff00b6,
+0xffffffff07ff0000, 0xffffc3ffffffffff, 0xffffffffffffffff, 0x9ffffdff9fefffff,
+0xffffffffffff0000, 0xffffffffffffe7ff, 0x0003ffffffffffff, 0x243fffffffffffff},
+{1,   2,   3,   4,   5,   6,  7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,
+19,  20,  21,  22,  23,  24, 25,  26,  27,  28,  29,  30,  31,  4,   32,  33,  34,  4,
+4,   4,   4,   4,   35,  36, 37,  38,  39,  40,  41,  42,  4,   4,   4,   4,   4,   4,
+4,   4,   43,  44,  45,  46, 47,  4,   48,  49,  50,  51,  52,  53,  54,  55,  56,  57,
+58,  59,  60,  4,   61,  4,  62,  63,  64,  65,  66,  4,   4,   4,   67,  4,   4,   4,
+4,   68,  69,  70,  71,  72, 73,  74,  75,  76,  77,  78,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  80,
+81,  4,   82,  83,  84,  85, 86,  79,  79,  79,  79,  79,  79,  79,  79,  87,  42,  88,
+89,  90,  4,   91,  92,  79, 79,  79,  79,  79,  79,  79,  79,  4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   79,  4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   93,  4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   94,  95,  4,   4,   4,
+4,   96,  97,  4,   98,  99, 4,   100, 101, 102, 62,  4,   103, 104, 105, 4,   106, 107,
+108, 4,   109, 110, 111, 4,  112, 4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   4,   4,   4,   4,   4,  4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,   4,
+4,   113, 114, 79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,  79,
+79,  79,  79,  79,  79,  79, 79,  79,  79,  4,   4,   4,   4,   4,   104, 4,   115, 116,
+117, 98,  118, 4,   119, 4,  4,   120, 121, 122, 123, 124, 125, 4,   93,  126, 127, 128,
+129},
+{0x00003fffffffffff, 0x000007ff0fffffff, 0xffdfffff00000000, 0xfffffffbfff800ff,
+0xffffffffffffffff, 0xfffeffcfffffffff, 0xf3c5fdfffff99fef, 0x5003ffcfb080799f,
+0xd36dfdfffff987ee, 0x003fffc05e023987, 0xf3edfdfffffbbfee, 0xfe00ffcf00013bbf,
+0xf3edfdfffff99fee, 0x0002ffcfb0e0399f, 0xc3ffc718d63dc7ec, 0x0000ffc000813dc7,
+0xe3fffdfffffddfff, 0x0000ffcf07603ddf, 0xf3effdfffffddfef, 0x0006ffcf40603ddf,
+0xfffffffffffddfff, 0xfc00ffcf80f07ddf, 0x2ffbfffffc7fffee, 0x000cffc0ff5f847f,
+0x07fffffffffffffe, 0x0000000003ff7fff, 0x3fffffaffffff7d6, 0x00000000f3ff3f5f,
+0xc2a003ff03000001, 0xfffe1ffffffffeff, 0x1ffffffffeffffdf, 0x0000000000000040,
+0xffffffffffff03ff, 0xffffffff3fffffff, 0xf7ffffffffff20bf, 0xffffffff3d7f3dff,
+0x7f3dffffffff3dff, 0xffffffffff7fff3d, 0xffffffffff3dffff, 0x0003fe00e7ffffff,
+0xffffffff0000ffff, 0x3f3fffffffffffff, 0xfffffffffffffffe, 0xffff9fffffffffff,
+0xffffffff07fffffe, 0x01ffc7ffffffffff, 0x001fffff001fdfff, 0x000ddfff000fffff,
+0x000003ff308fffff, 0xffffffff03ff3800, 0x01ffffffffffffff, 0xffff07ffffffffff,
+0x003fffffffffffff, 0x0fff0fff7fffffff, 0x001f3fffffffffc0, 0xffff0fffffffffff,
+0x0000000007ff03ff, 0xffffffff0fffffff, 0x9fffffff7fffffff, 0xbfff008003ff03ff,
+0x0000000000000001, 0x000ff80003ff0fff, 0x000fffffffffffff, 0x00ffffffffffffff,
+0x3fffffffffffe3ff, 0xe7ffffffffff01ff, 0x07fffffffff70000, 0xfbffffffffffffff,
+0xffffffff3f3fffff, 0x3fffffffaaff3f3f, 0x5fdfffffffffffff, 0x1fdc1fff0fcf1fdc,
+0x8000000000000000, 0x8002000000100001, 0x000000001fff0000, 0x0001ffe21fff0000,
+0xf3fffd503f2ffc84, 0xffffffff000043e0, 0x00000000000001ff, 0x0000000000000000,
+0xffff7fffffffffff, 0xffffffff7fffffff, 0x000ff81fffffffff, 0xffff20bfffffffff,
+0x800080ffffffffff, 0x7f7f7f7f007fffff, 0xffffffff7f7f7f7f, 0x1f3efffe000000e0,
+0xfffffffee67fffff, 0xf7ffffffffffffff, 0xfffeffffffffffe0, 0xffffffff00007fff,
+0xffff000000000000, 0x1fffffffffffffff, 0x0000000000001fff, 0x3fffffffffff0000,
+0x00000fffffff1fff, 0xbff0ffffffffffff, 0x0003ffffffffffff, 0xfffffffcff800000,
+0xfffffffffffff9ff, 0xffe00000000007fc, 0x000010ffffffffff, 0xe8ffffff03ff003f,
+0xffff3fffffffffff, 0x1fffffff000fffff, 0x7fffffff03ff8001, 0x007fffffffffffff,
+0xfc7fffff03ff3fff, 0x007cffff38000007, 0xffff7f7f007e7e7e, 0xffff03fff7ffffff,
+0x03ff37ffffffffff, 0xffff000fffffffff, 0x0ffffffffffff87f, 0x0000000003ffffff,
+0x5f7ffdffe0f8007f, 0xffffffffffffffdb, 0xfffffffffff80000, 0xfffffff03fffffff,
+0x3fffffffffffffff, 0xffffffffffff0000, 0xfffffffffffcffff, 0x03ff0000000000ff,
+0x0018ffff0000ffff, 0xaa8a00000000e000, 0x87fffffe03ff0000, 0xffffffc007fffffe,
+0x7fffffffffffffff, 0x000000001cfcfcfc},
+{1,  2,  3, 4,  5,  6, 7,  8, 5, 5, 9, 5, 10, 11, 12, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 13,
+14, 15, 7, 16, 17, 7, 18, 5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 19,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5,  5, 5, 5, 5, 5, 5},
+{1,   2,   3,   4,   5,   4,   6,   4,  4,  7,  8,   9,   10, 11, 12,  2,   2,   13, 14,
+15,  16,  4,   4,   2,   2,   2,   2,  17, 18, 4,   4,   19, 20, 21,  22,  23,  4,  24,
+4,   25,  26,  27,  28,  29,  30,  31, 4,  2,  32,  33,  33, 34, 4,   4,   4,   4,  4,
+35,  4,   36,  37,  38,  39,  2,   40, 3,  41, 42,  43,  2,  44, 45,  4,   46,  47, 48,
+49,  4,   4,   2,   50,  2,   51,  4,  4,  52, 53,  2,   54, 55, 56,  57,  4,   4,  4,
+3,   4,   58,  59,  60,  61,  62,  63, 64, 65, 66,  55,  4,  4,  4,   4,   67,  68, 69,
+4,   70,  71,  72,  4,   4,   4,   4,  73, 4,  4,   74,  4,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  75, 4,  2,   76,  2,  2,  2,   77,  4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   76, 4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   2,   2,   2,  2,  2,  2,   2,   2,  2,  78,  4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   2,   2,  2,
+2,   2,   2,   2,   2,   55,  79,  4,  80, 17, 81,  82,  4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   2,   4,   4,   2,   83, 84, 85, 2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  86,  2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   87,  32, 4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   2,   2,   2,  2,  21, 88,  2,   2,  2,  2,   2,   89,  4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   2,   90,  91, 4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   92, 93,
+4,   4,   94,  4,   4,   4,   4,   4,  4,  2,  95,  96,  97, 98, 99,  2,   2,   2,  2,
+100, 101, 102, 103, 104, 105, 4,   4,  4,  4,  4,   4,   4,  4,  106, 107, 108, 4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+109, 4,   4,   4,   110, 111, 4,   4,  4,  4,  4,   112, 4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  2,  2,   2,   113, 2,  114,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  115,
+116, 117, 4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   118, 4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   119, 2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   5,   2,  2,  2,   11,  2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  120, 2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   2,   2,  2,  2,  2,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   2,   121, 4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   2,  2,
+2,   2,   2,   2,   2,   2,   119, 4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   2,   2,  2,  2,   2,   2,   2,  2,
+2,   2,   2,   2,   2,   122, 4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   2,   2,   2,   123, 4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4,   4,   4,  4,  4,  4,   4,   4,  4,  4,   4,   4,   4,  4,
+4,   4,   4,   4,   4,   4},
+{0xb7ffff7fffffefff, 0x000000003fff3fff, 0xffffffffffffffff, 0x07ffffffffffffff,
+0x0000000000000000, 0x001fffffffffffff, 0x2000000000000000, 0xffffffff1fffffff,
+0x000000010001ffff, 0xffffe000ffffffff, 0x07ffffffffff07ff, 0xffffffff3fffffff,
+0x00000000003eff0f, 0xffff03ff3fffffff, 0x0fffffffff0fffff, 0xffff00ffffffffff,
+0x0000000fffffffff, 0x007fffffffffffff, 0x000000ff003fffff, 0x91bffffffffffd3f,
+0x007fffff003fffff, 0x000000007fffffff, 0x0037ffff00000000, 0x03ffffff003fffff,
+0xc0ffffffffffffff, 0x873ffffffeeff06f, 0x1fffffff00000000, 0x000000001fffffff,
+0x0000007ffffffeff, 0x003fffffffffffff, 0x0007ffff003fffff, 0x000000000003ffff,
+0x00000000000001ff, 0x0007ffffffffffff, 0x03ff00ffffffffff, 0x00031bffffffffff,
+0xffff00801fffffff, 0x000000000001ffff, 0xffff000000000000, 0x007fffff0000001f,
+0x8000ffc00000007f, 0x03ff01ffffff0000, 0xffdfffffffffffff, 0x004fffffffff00f0,
+0x0000000017ffde1f, 0x40fffffffffbffff, 0xffff01ffbfffbd7f, 0x03ff07ffffffffff,
+0xfbedfdfffff99fef, 0x001f1fcfe081399f, 0x00000003c3ff07ff, 0x0000000003ff00bf,
+0xff3fffffffffffff, 0x000000003f000001, 0x0000000003ff0011, 0x01ffffffffffffff,
+0x00000000000003ff, 0x03ff0fffe7ffffff, 0xffffffff00000000, 0x800003ffffffffff,
+0xf9bfffffff6ff27f, 0x0000000003ff000f, 0xfffffcff00000000, 0x0000001bfcffffff,
+0x7fffffffffffffff, 0xffffffffffff0080, 0x0000000023ffffff, 0xff7ffffffffffdff,
+0xfffc000003ff0001, 0x007ffefffffcffff, 0xb47ffffffffffb7f, 0xfffffdbf03ff00ff,
+0x000003ff01fb7fff, 0x007fffff00000000, 0x0001000000000000, 0x0000000003ffffff,
+0x00007fffffffffff, 0x000000000000000f, 0x000000000000007f, 0x000003ff7fffffff,
+0x001f3fffffff0000, 0xe0fffff803ff000f, 0x000000000000ffff, 0xffffffffffff87ff,
+0x00000000ffff80ff, 0x0003001b00000000, 0x00ffffffffffffff, 0x00000000003fffff,
+0xffff00f000070000, 0x0fffffffffffffff, 0x1fff07ffffffffff, 0x0000000063ff01ff,
+0xf807e3e000000000, 0x00003c0000000fe7, 0x000000000000001c, 0xffffffffffdfffff,
+0xebffde64dfffffff, 0xffffffffffffffef, 0x7bffffffdfdfe7bf, 0xfffffffffffdfc5f,
+0xffffff3fffffffff, 0xf7fffffff7fffffd, 0xffdfffffffdfffff, 0xffff7fffffff7fff,
+0xfffffdfffffffdff, 0xffffffffffffcff7, 0xf87fffffffffffff, 0x00201fffffffffff,
+0x0000fffef8000010, 0x000007dbf9ffff7f, 0x3fff1fffffffffff, 0x00000000000043ff,
+0x03ffffffffffffff, 0x00000000007f001f, 0x0000000003ff0fff, 0x0af7fe96ffffffef,
+0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff, 0x03ff000000000000, 0x000000003fffffff,
+0xffff0003ffffffff, 0x00000001ffffffff, 0x00000000000007ff, 0x0000ffffffffffff}};
+static constexpr bool_trie<32, 991, 1, 0, 134, 255, 1, 0, 1151, 1, 0, 112> prop_xids_data{
+{0x0000000000000000, 0x07fffffe07fffffe, 0x0420040000000000, 0xff7fffffff7fffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0x0000501f0003ffc3,
+0x0000000000000000, 0xb8df000000000000, 0xfffffffbffffd740, 0xffbfffffffffffff,
+0xffffffffffffffff, 0xffffffffffffffff, 0xfffffffffffffc03, 0xffffffffffffffff,
+0xfffeffffffffffff, 0xffffffff027fffff, 0x00000000000001ff, 0x000787ffffff0000,
+0xffffffff00000000, 0xfffec000000007ff, 0xffffffffffffffff, 0x9c00c060002fffff,
+0x0000fffffffd0000, 0xffffffffffffe000, 0x0002003fffffffff, 0x043007fffffffc00},
+{1,   2,   3,   4,   5,   6,  7,   8,   9,   10,  11,  12,  13,  14,  15,  16,  17,  18,
+19,  20,  21,  22,  23,  24, 23,  25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,
+35,  35,  35,  35,  36,  37, 38,  39,  40,  41,  42,  43,  35,  35,  35,  35,  35,  35,
+35,  35,  44,  45,  46,  47, 48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+60,  61,  30,  62,  63,  64, 65,  66,  67,  68,  69,  35,  35,  35,  30,  35,  35,  35,
+35,  70,  71,  72,  73,  30, 74,  75,  30,  76,  77,  78,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  79,
+80,  35,  81,  82,  83,  84, 85,  30,  30,  30,  30,  30,  30,  30,  30,  86,  43,  87,
+88,  89,  35,  90,  91,  30, 30,  30,  30,  30,  30,  30,  30,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  30,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  92,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  93,  94,  35,  35,  35,
+35,  95,  96,  97,  98,  99, 35,  100, 101, 102, 49,  103, 104, 105, 106, 107, 108, 109,
+110, 111, 112, 113, 114, 35, 115, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  35,  35,  35,  35,  35, 35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,  35,
+35,  116, 117, 30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,  30,
+30,  30,  30,  30,  30,  30, 30,  30,  30,  35,  35,  35,  35,  35,  118, 35,  119, 120,
+121, 122, 123, 35,  124, 35, 35,  125, 126, 127, 128, 30,  129, 35,  92,  130, 131, 132,
+133},
+{0x00000110043fffff, 0x000007ff01ffffff, 0xffdfffff00000000, 0x00000000000000ff,
+0x23fffffffffffff0, 0xfffe0003ff010000, 0x23c5fdfffff99fe1, 0x10030003b0004000,
+0x036dfdfffff987e0, 0x001c00005e000000, 0x23edfdfffffbbfe0, 0x0200000300010000,
+0x23edfdfffff99fe0, 0x00020003b0000000, 0x03ffc718d63dc7e8, 0x0000000000010000,
+0x23fffdfffffddfe0, 0x0000000307000000, 0x23effdfffffddfe1, 0x0006000340000000,
+0x27fffffffffddff0, 0xfc00000380704000, 0x2ffbfffffc7fffe0, 0x000000000000007f,
+0x0005fffffffffffe, 0x2005ffaffffff7d6, 0x00000000f000005f, 0x0000000000000001,
+0x00001ffffffffeff, 0x0000000000001f00, 0x0000000000000000, 0x800007ffffffffff,
+0xffe1c0623c3f0000, 0xffffffff00004003, 0xf7ffffffffff20bf, 0xffffffffffffffff,
+0xffffffff3d7f3dff, 0x7f3dffffffff3dff, 0xffffffffff7fff3d, 0xffffffffff3dffff,
+0x0000000007ffffff, 0xffffffff0000ffff, 0x3f3fffffffffffff, 0xfffffffffffffffe,
+0xffff9fffffffffff, 0xffffffff07fffffe, 0x01ffc7ffffffffff, 0x0003ffff0003dfff,
+0x0001dfff0003ffff, 0x000fffffffffffff, 0x0000000010800000, 0xffffffff00000000,
+0x01ffffffffffffff, 0xffff05ffffffffff, 0x003fffffffffffff, 0x000000007fffffff,
+0x001f3fffffff0000, 0xffff0fffffffffff, 0x00000000000003ff, 0xffffffff007fffff,
+0x00000000001fffff, 0x0000008000000000, 0x000fffffffffffe0, 0x0000000000000fe0,
+0xfc00c001fffffff8, 0x0000003fffffffff, 0x0000000fffffffff, 0x3ffffffffc00e000,
+0xe7ffffffffff01ff, 0x046fde0000000000, 0xffffffff3f3fffff, 0x3fffffffaaff3f3f,
+0x5fdfffffffffffff, 0x1fdc1fff0fcf1fdc, 0x8002000000000000, 0x000000001fff0000,
+0xf3fffd503f2ffc84, 0xffffffff000043e0, 0x00000000000001ff, 0xffff7fffffffffff,
+0xffffffff7fffffff, 0x000c781fffffffff, 0xffff20bfffffffff, 0x000080ffffffffff,
+0x7f7f7f7f007fffff, 0x000000007f7f7f7f, 0x1f3e03fe000000e0, 0xfffffffee07fffff,
+0xf7ffffffffffffff, 0xfffeffffffffffe0, 0xffffffff00007fff, 0xffff000000000000,
+0x1fffffffffffffff, 0x0000000000001fff, 0x3fffffffffff0000, 0x00000c00ffff1fff,
+0x80007fffffffffff, 0xffffffff3fffffff, 0x0000ffffffffffff, 0xfffffffcff800000,
+0xfffffffffffff9ff, 0xffe00000000007fc, 0x00000007fffff7bb, 0x000ffffffffffffc,
+0x68fc000000000000, 0xffff003ffffffc00, 0x1fffffff0000007f, 0x0007fffffffffff0,
+0x7c00ffdf00008000, 0x000001ffffffffff, 0xc47fffff00000ff7, 0x3e62ffffffffffff,
+0x001c07ff38000005, 0xffff7f7f007e7e7e, 0xffff03fff7ffffff, 0x00000007ffffffff,
+0xffff000fffffffff, 0x0ffffffffffff87f, 0xffff3fffffffffff, 0x0000000003ffffff,
+0x5f7ffdffa0f8007f, 0xffffffffffffffdb, 0x0003ffffffffffff, 0xfffffffffff80000,
+0xfffffff03fffffff, 0x3fffffffffffffff, 0xffffffffffff0000, 0xfffffffffffcffff,
+0x03ff0000000000ff, 0xaa8a000000000000, 0x07fffffe00000000, 0xffffffc007fffffe,
+0x7fffffff3fffffff, 0x000000001cfcfcfc},
+{1,  2,  3, 4,  5,  6, 7,  8, 5, 5, 9, 5, 10, 11, 5, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 12,
+13, 14, 7, 15, 16, 7, 17, 5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+5,  5,  5, 5,  5,  5, 5,  5, 5, 5, 5, 5, 5,  5,  5, 5, 5, 5, 5, 5, 5},
+{1,   2,   3,  4,   5,  4,  4,   4,   4,   6,  7,   8,  9,  10,  11,  2,  2,  12, 13,  14,
+15,  4,   4,  2,   2,  2,  2,   16,  17,  4,  4,   18, 19, 20,  21,  22, 4,  23, 4,   24,
+25,  26,  27, 28,  29, 30, 4,   2,   31,  32, 32,  15, 4,  4,   4,   4,  4,  33, 4,   34,
+35,  36,  37, 38,  4,  39, 40,  41,  42,  43, 44,  45, 4,  46,  20,  47, 48, 4,  4,   5,
+49,  50,  51, 4,   4,  52, 53,  50,  54,  55, 4,   56, 4,  4,   4,   57, 4,  58, 59,  60,
+61,  62,  63, 64,  65, 66, 67,  4,   4,   4,  4,   68, 69, 70,  4,   71, 72, 73, 4,   4,
+4,   4,   74, 4,   4,  75, 4,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   76,  4,  2,   52, 2,  2,   2,   77,  4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   52,  4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+78,  4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   2,  2,  2,  2,   2,
+2,   2,   2,  67,  20, 4,  79,  50,  80,  70, 4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+2,   4,   4,  2,   81, 82, 83,  2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   84, 2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   85, 31,  4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   2,  2,  2,  2,   20,
+86,  2,   2,  2,   2,  2,  87,  4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  2,   88, 89, 4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   2,  90, 91, 92,  93,
+94,  2,   2,  2,   2,  95, 96,  97,  98,  99, 100, 4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   101, 102, 4,  4,   4,  4,  4,   57,  4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   2,  2,  2,  103, 2,
+104, 4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   105,
+106, 107, 4,  4,   4,  4,  4,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   108, 2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   5,
+2,   2,   2,  10,  2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  109, 2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  2,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+2,   2,   2,  2,   2,  2,  110, 4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   2,  2,  2,  2,   2,
+2,   2,   2,  108, 4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   2,   2,   2,  2,   2,  2,  2,   2,   2,  2,  2,  2,   2,
+111, 4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4,   4,  4,  4,   4,   4,  4,  4,  4,   4,
+4,   4,   4,  4,   4,  4,  4,   4,   4,   4,  4},
+{0xb7ffff7fffffefff, 0x000000003fff3fff, 0xffffffffffffffff, 0x07ffffffffffffff,
+0x0000000000000000, 0x001fffffffffffff, 0xffffffff1fffffff, 0x000000000001ffff,
+0xffffe000ffffffff, 0x003fffffffff07ff, 0xffffffff3fffffff, 0x00000000003eff0f,
+0xffff00003fffffff, 0x0fffffffff0fffff, 0xffff00ffffffffff, 0x0000000fffffffff,
+0x007fffffffffffff, 0x000000ff003fffff, 0x91bffffffffffd3f, 0x007fffff003fffff,
+0x000000007fffffff, 0x0037ffff00000000, 0x03ffffff003fffff, 0xc0ffffffffffffff,
+0x003ffffffeef0001, 0x1fffffff00000000, 0x000000001fffffff, 0x0000001ffffffeff,
+0x003fffffffffffff, 0x0007ffff003fffff, 0x000000000003ffff, 0x00000000000001ff,
+0x0007ffffffffffff, 0x000303ffffffffff, 0xffff00801fffffff, 0x000000000000003f,
+0xffff000000000000, 0x007fffff0000001f, 0x00fffffffffffff8, 0x0000fffffffffff8,
+0x000001ffffff0000, 0x0000007ffffffff8, 0x0047ffffffff0090, 0x0007fffffffffff8,
+0x000000001400001e, 0x00000ffffffbffff, 0xffff01ffbfffbd7f, 0x23edfdfffff99fe0,
+0x00000003e0010000, 0x0000000380000780, 0x0000ffffffffffff, 0x00000000000000b0,
+0x00007fffffffffff, 0x000000000f000000, 0x0000000000000010, 0x010007ffffffffff,
+0x0000000007ffffff, 0x00000fffffffffff, 0xffffffff00000000, 0x80000000ffffffff,
+0x8000ffffff6ff27f, 0x0000000000000002, 0xfffffcff00000000, 0x0000000a0001ffff,
+0x0407fffffffff801, 0xfffffffff0010000, 0x00000000200003ff, 0x01ffffffffffffff,
+0x00007ffffffffdff, 0xfffc000000000001, 0x000000000000ffff, 0x0001fffffffffb7f,
+0xfffffdbf00000040, 0x00000000010003ff, 0x0007ffff00000000, 0x0001000000000000,
+0x0000000003ffffff, 0x000000000000000f, 0x000000000000007f, 0x00003fffffff0000,
+0xe0fffff80000000f, 0x00000000000107ff, 0x00000000fff80000, 0x0000000b00000000,
+0x00ffffffffffffff, 0x00000000003fffff, 0xffff00f000070000, 0x0fffffffffffffff,
+0x1fff07ffffffffff, 0x0000000003ff01ff, 0xffffffffffdfffff, 0xebffde64dfffffff,
+0xffffffffffffffef, 0x7bffffffdfdfe7bf, 0xfffffffffffdfc5f, 0xffffff3fffffffff,
+0xf7fffffff7fffffd, 0xffdfffffffdfffff, 0xffff7fffffff7fff, 0xfffffdfffffffdff,
+0x0000000000000ff7, 0x3f801fffffffffff, 0x0000000000004000, 0x000000000000001f,
+0x000000000000080f, 0x0af7fe96ffffffef, 0x5ef7f796aa96ea84, 0x0ffffbee0ffffbff,
+0x000000003fffffff, 0xffff0003ffffffff, 0x00000001ffffffff, 0x00000000000007ff}};
+}    // namespace detail::tables
+template<>
+constexpr bool cp_is<property::ahex>(char32_t c) {
+return detail::tables::prop_ahex_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::alpha>(char32_t c) {
+return detail::tables::prop_alpha_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::bidi_c>(char32_t c) {
+return detail::tables::prop_bidi_c_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::bidi_m>(char32_t c) {
+return detail::tables::prop_bidi_m_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::dash>(char32_t c) {
+return detail::tables::prop_dash_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::dep>(char32_t c) {
+return detail::tables::prop_dep_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::dia>(char32_t c) {
+return detail::tables::prop_dia_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::emoji>(char32_t c) {
+return detail::tables::prop_emoji_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::emoji_component>(char32_t c) {
+return detail::tables::prop_emoji_component_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::emoji_modifier>(char32_t c) {
+return detail::tables::prop_emoji_modifier_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::emoji_modifier_base>(char32_t c) {
+return detail::tables::prop_emoji_modifier_base_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::emoji_presentation>(char32_t c) {
+return detail::tables::prop_emoji_presentation_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::ext>(char32_t c) {
+return detail::tables::prop_ext_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::extended_pictographic>(char32_t c) {
+return detail::tables::prop_extended_pictographic_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::gr_base>(char32_t c) {
+return detail::tables::prop_gr_base_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::hex>(char32_t c) {
+return detail::tables::prop_hex_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::ideo>(char32_t c) {
+return detail::tables::prop_ideo_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::idsb>(char32_t c) {
+return detail::tables::prop_idsb_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::idst>(char32_t c) {
+return detail::tables::prop_idst_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::join_c>(char32_t c) {
+return detail::tables::prop_join_c_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::loe>(char32_t c) {
+return detail::tables::prop_loe_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::pat_syn>(char32_t c) {
+return detail::tables::prop_pat_syn_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::pat_ws>(char32_t c) {
+return detail::tables::prop_pat_ws_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::pcm>(char32_t c) {
+return detail::tables::prop_pcm_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::qmark>(char32_t c) {
+return detail::tables::prop_qmark_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::radical>(char32_t c) {
+return detail::tables::prop_radical_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::ri>(char32_t c) {
+return detail::tables::prop_ri_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::sd>(char32_t c) {
+return detail::tables::prop_sd_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::sterm>(char32_t c) {
+return detail::tables::prop_sterm_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::term>(char32_t c) {
+return detail::tables::prop_term_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::uideo>(char32_t c) {
+return detail::tables::prop_uideo_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::vs>(char32_t c) {
+return detail::tables::prop_vs_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::wspace>(char32_t c) {
+return detail::tables::prop_wspace_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::xidc>(char32_t c) {
+return detail::tables::prop_xidc_data.lookup(c);
+}
+template<>
+constexpr bool cp_is<property::xids>(char32_t c) {
+return detail::tables::prop_xids_data.lookup(c);
+}
+}    // namespace uni
+#include <iterator>
+
+namespace uni {
+
+constexpr category cp_category(char32_t cp) {
+if(cp > 0x10FFFF)
+return category::unassigned;
+return detail::tables::get_category(cp);
+}
+
+constexpr uni::version detail::age_from_string(std::string_view a) {
+for(std::size_t i = 0; i < std::size(detail::tables::age_strings); ++i) {
+const auto res = detail::propnamecomp(a, detail::tables::age_strings[i]);
+if(res == 0)
+return uni::version(i);
+}
+return uni::version::unassigned;
+}
+
+constexpr category detail::category_from_string(std::string_view s) {
+for(const auto& c : detail::tables::categories_names) {
+const auto res = detail::propnamecomp(s, c.name);
+if(res == 0)
+return category(c.value);
+}
+return category::unassigned;
+}
+
+constexpr block detail::block_from_string(std::string_view s) {
+for(const auto& c : detail::tables::blocks_names) {
+const auto res = detail::propnamecomp(s, c.name);
+if(res == 0)
+return block(c.value);
+}
+return block::no_block;
+}
+
+constexpr script detail::script_from_string(std::string_view s) {
+for(const auto& c : detail::tables::scripts_names) {
+const auto res = detail::propnamecomp(s, c.name);
+if(res == 0)
+return script(c.value);
+}
+return script::unknown;
+}
+
+constexpr bool detail::is_unassigned(category cat)
+{
+return cat == category::unassigned;
+}
+
+constexpr bool detail::is_unknown(script s)
+{
+return s == script::unknown;
+}
+
+constexpr bool detail::is_unknown(block b) {
+return b == block::no_block;
+}
+
+constexpr bool detail::is_unassigned(version v)
+{
+return v == version::unassigned;
+}
+
+constexpr script cp_script(char32_t cp) {
+return detail::tables::cp_script<0>(cp);
+}
+
+constexpr script_extensions_view::script_extensions_view(char32_t c) : c(c){}
+
+constexpr script_extensions_view::iterator::iterator(char32_t c) : m_c(c), m_script(detail::tables::get_cp_script(m_c, 1)) {
+if(m_script == script::unknown)
+m_script = detail::tables::cp_script<0>(m_c);
+}
+
+constexpr script script_extensions_view::iterator::operator*() const {
+return m_script;
+}
+
+constexpr auto script_extensions_view::iterator::operator++(int) ->iterator & {
+idx++;
+m_script = detail::tables::get_cp_script(m_c, idx);
+return *this;
+}
+
+constexpr auto script_extensions_view::iterator::operator++()  -> iterator {
+auto c = *this;
+idx++;
+m_script = detail::tables::get_cp_script(m_c, idx);
+return c;
+}
+
+constexpr bool script_extensions_view::iterator::operator==(sentinel) const {
+return m_script == script::unknown;
+}
+
+constexpr bool script_extensions_view::iterator::operator!=(sentinel) const {
+return m_script != script::unknown;
+}
+
+/*constexpr bool script_extensions_view::iterator::operator==(iterator it) const {
+    return m_script == it.m_script && m_c == it.m_c;
+};
+constexpr bool script_extensions_view::iterator::operator!=(iterator it) const {
+    return !(*this == it);
+};*/
+
+constexpr script_extensions_view::iterator script_extensions_view::begin() const {
+return iterator{c};
+}
+constexpr script_extensions_view::sentinel script_extensions_view::end() const {
+return {};
+}
+
+constexpr script_extensions_view cp_script_extensions(char32_t cp) {
+return script_extensions_view(cp);
+}
+
+constexpr version cp_age(char32_t cp) {
+return static_cast<version>(detail::tables::age_data.value(cp, uint8_t(version::unassigned)));
+}
+
+constexpr block cp_block(char32_t cp) {
+const auto end = std::end(detail::tables::block_data._data);
+auto it = detail::upper_bound(std::begin(detail::tables::block_data._data), end, cp, [](char32_t cp, uint32_t v) {
+char32_t c = (v >> 8);
+return cp < c;
+});
+if(it == end)
+return block::no_block;
+it--;
+auto offset = (*it) & 0xFF;
+if(offset == 0)
+return block::no_block;
+offset--;
+
+const auto d = std::distance(std::begin(detail::tables::block_data._data), it);
+return uni::block((d - offset) + 1);
+}
+
+template<>
+constexpr bool cp_is<property::noncharacter_code_point>(char32_t cp) {
+return (char32_t(cp) & 0xfffe) == 0xfffe || (char32_t(cp) >= 0xfdd0 && char32_t(cp) <= 0xfdef);
+}
+
+// http://unicode.org/reports/tr44/#Lowercase
+template<>
+constexpr bool cp_is<property::lowercase>(char32_t cp) {
+return detail::tables::cat_ll.lookup(char32_t(cp)) || detail::tables::prop_olower_data.lookup(char32_t(cp));
+}
+
+// http://unicode.org/reports/tr44/#Uppercase
+template<>
+constexpr bool cp_is<property::uppercase>(char32_t cp) {
+return detail::tables::cat_lu.lookup(char32_t(cp)) || detail::tables::prop_oupper_data.lookup(char32_t(cp));
+}
+
+// http://unicode.org/reports/tr44/#Cased
+template<>
+constexpr bool cp_is<property::cased>(char32_t cp) {
+return cp_is<property::lower>(cp) || cp_is<property::upper>(cp) ||
+detail::tables::cat_lt.lookup(char32_t(cp));
+}
+
+// http://unicode.org/reports/tr44/#Math
+template<>
+constexpr bool cp_is<property::math>(char32_t cp) {
+return detail::tables::cat_sm.lookup(char32_t(cp)) || detail::tables::prop_omath_data.lookup(cp);
+}
+
+// http://unicode.org/reports/tr44/#Case_Ignorable
+template<>
+constexpr bool cp_is<property::case_ignorable>(char32_t) {
+return false;
+}
+
+// http://unicode.org/reports/tr44/#Grapheme_Extend
+template<>
+constexpr bool cp_is<property::grapheme_extend>(char32_t cp) {
+return detail::tables::cat_me.lookup(char32_t(cp)) || detail::tables::cat_mn.lookup(char32_t(cp)) ||
+detail::tables::prop_ogr_ext_data.lookup(cp);
+}
+
+constexpr bool cp_is_valid(char32_t cp) {
+return char32_t(cp) <= 0x10FFFF;
+}
+constexpr bool cp_is_assigned(char32_t cp) {
+return detail::tables::prop_assigned.lookup(char32_t(cp));
+}
+
+constexpr bool cp_is_ascii(char32_t cp) {
+return char32_t(cp) <= 0x7F;
+}
+
+template<>
+constexpr bool cp_is<property::default_ignorable_code_point>(char32_t cp) {
+const auto c = char32_t(cp);
+const bool maybe = detail::tables::prop_odi_data.lookup(cp) || detail::tables::cat_cf.lookup(cp) ||
+detail::tables::prop_vs_data.lookup(cp);
+if(!maybe)
+return false;
+// ignore (Interlinear annotation format characters
+if(c >= 0xFFF9 && c <= 0xFFFB) {
+return false;
+}
+// Ignore Egyptian hieroglyph format characters
+else if(c >= 0x13430 && c <= 0x13438) {
+return false;
+} else if(detail::tables::prop_wspace_data.lookup(cp))
+return false;
+else if(detail::tables::prop_pcm_data.lookup(cp))
+return false;
+return true;
+}
+
+// http://www.unicode.org/reports/tr31/#D1
+template<>
+constexpr bool cp_is<property::id_start>(char32_t cp) {
+const bool maybe =
+cp_is<category::letter>(cp) || detail::tables::cat_nl.lookup(cp) || detail::tables::prop_oids_data.lookup(cp);
+if(!maybe)
+return false;
+return !detail::tables::prop_pat_syn_data.lookup(cp) && !detail::tables::prop_pat_ws_data.lookup(cp);
+}
+
+template<>
+constexpr bool cp_is<property::id_continue>(char32_t cp) {
+const bool maybe = cp_is<category::letter>(cp) || detail::tables::cat_nl.lookup(cp) ||
+detail::tables::prop_oids_data.lookup(cp) || detail::tables::cat_mn.lookup(cp) || detail::tables::cat_mc.lookup(cp) ||
+detail::tables::cat_nd.lookup(cp) || detail::tables::cat_pc.lookup(cp) || detail::tables::prop_oidc_data.lookup(cp);
+if(!maybe)
+return false;
+return !detail::tables::prop_pat_syn_data.lookup(cp) && !detail::tables::prop_pat_ws_data.lookup(cp);
+}
+
+namespace detail {
+
+template<typename Array, typename Res = long long>
+constexpr bool get_numeric_value(char32_t cp, const Array& array, Res& res) {
+auto it = detail::lower_bound(std::begin(array), std::end(array), cp,
+[](const auto& d, char32_t cp) { return d.first < cp; });
+if(it == std::end(array) || it->first != cp)
+return false;
+res = it->second;
+return true;
+}
+
+}
+
+constexpr numeric_value cp_numeric_value(char32_t cp) {
+long long res = 0;
+if(!(detail::get_numeric_value(cp, detail::tables::numeric_data64, res) ||
+detail::get_numeric_value(cp, detail::tables::numeric_data32, res) ||
+detail::get_numeric_value(cp, detail::tables::numeric_data16, res) || [&res, cp]() -> bool {
+res = detail::tables::numeric_data8.value(cp, 255);
+return res != 255;
+}())) {
+return {};
+}
+uint16_t d = 1;
+detail::get_numeric_value(cp, detail::tables::numeric_data_d, d);
+return numeric_value(res, d);
+}
+
+}    // namespace uni
+
+namespace std
+{
+template<>
+struct iterator_traits<uni::script_extensions_view::iterator>
+{
+using difference_type = std::ptrdiff_t;
+using value_type = uni::script;
+using pointer =  uni::script *;
+using reference	=  uni::script;
+using iterator_category = std::forward_iterator_tag;
+};
+}
+
+namespace uni::detail {
+enum class binary_prop {
+ahex,
+alpha,
+bidi_c,
+bidi_m,
+cased,
+ci,
+dash,
+dep,
+di,
+dia,
+emoji,
+emoji_component,
+emoji_modifier,
+emoji_modifier_base,
+emoji_presentation,
+ext,
+extended_pictographic,
+gr_base,
+gr_ext,
+hex,
+idc,
+ideo,
+ids,
+idsb,
+idst,
+join_c,
+loe,
+lower,
+math,
+nchar,
+pat_syn,
+pat_ws,
+pcm,
+qmark,
+radical,
+ri,
+sd,
+sterm,
+term,
+uideo,
+upper,
+vs,
+wspace,
+xidc,
+xids,
+any,
+ascii,
+assigned,
+c,
+cc,
+cf,
+cn,
+co,
+cs,
+l,
+lc,
+ll,
+lm,
+lo,
+lt,
+lu,
+m,
+mc,
+me,
+mn,
+n,
+nd,
+nl,
+no,
+p,
+pc,
+pd,
+pe,
+pf,
+pi,
+po,
+ps,
+s,
+sc,
+sk,
+sm,
+so,
+z,
+zl,
+zp,
+zs,
+adlm,
+aghb,
+ahom,
+arab,
+armi,
+armn,
+avst,
+bali,
+bamu,
+bass,
+batk,
+beng,
+bhks,
+bopo,
+brah,
+brai,
+bugi,
+buhd,
+cakm,
+cans,
+cari,
+cham,
+cher,
+chrs,
+copt,
+cprt,
+cyrl,
+deva,
+diak,
+dogr,
+dsrt,
+dupl,
+egyp,
+elba,
+elym,
+ethi,
+geor,
+glag,
+gong,
+gonm,
+goth,
+gran,
+grek,
+gujr,
+guru,
+hang,
+hani,
+hano,
+hatr,
+hebr,
+hira,
+hluw,
+hmng,
+hmnp,
+hrkt,
+hung,
+ital,
+java,
+kali,
+kana,
+khar,
+khmr,
+khoj,
+kits,
+knda,
+kthi,
+lana,
+laoo,
+latn,
+lepc,
+limb,
+lina,
+linb,
+lisu,
+lyci,
+lydi,
+mahj,
+maka,
+mand,
+mani,
+marc,
+medf,
+mend,
+merc,
+mero,
+mlym,
+modi,
+mong,
+mroo,
+mtei,
+mult,
+mymr,
+nand,
+narb,
+nbat,
+newa,
+nkoo,
+nshu,
+ogam,
+olck,
+orkh,
+orya,
+osge,
+osma,
+palm,
+pauc,
+perm,
+phag,
+phli,
+phlp,
+phnx,
+plrd,
+prti,
+rjng,
+rohg,
+runr,
+samr,
+sarb,
+saur,
+sgnw,
+shaw,
+shrd,
+sidd,
+sind,
+sinh,
+sogd,
+sogo,
+sora,
+soyo,
+sund,
+sylo,
+syrc,
+tagb,
+takr,
+tale,
+talu,
+taml,
+tang,
+tavt,
+telu,
+tfng,
+tglg,
+thaa,
+thai,
+tibt,
+tirh,
+ugar,
+vaii,
+wara,
+wcho,
+xpeo,
+xsux,
+yezi,
+yiii,
+zanb,
+zinh,
+zyyy,
+zzzz,
+unknown
+};
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ahex>(char32_t c) {
+return cp_is<property::ahex>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::alpha>(char32_t c) {
+return cp_is<property::alpha>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bidi_c>(char32_t c) {
+return cp_is<property::bidi_c>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bidi_m>(char32_t c) {
+return cp_is<property::bidi_m>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cased>(char32_t c) {
+return cp_is<property::cased>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ci>(char32_t c) {
+return cp_is<property::ci>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::dash>(char32_t c) {
+return cp_is<property::dash>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::dep>(char32_t c) {
+return cp_is<property::dep>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::di>(char32_t c) {
+return cp_is<property::di>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::dia>(char32_t c) {
+return cp_is<property::dia>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::emoji>(char32_t c) {
+return cp_is<property::emoji>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::emoji_component>(char32_t c) {
+return cp_is<property::emoji_component>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::emoji_modifier>(char32_t c) {
+return cp_is<property::emoji_modifier>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::emoji_modifier_base>(char32_t c) {
+return cp_is<property::emoji_modifier_base>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::emoji_presentation>(char32_t c) {
+return cp_is<property::emoji_presentation>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ext>(char32_t c) {
+return cp_is<property::ext>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::extended_pictographic>(char32_t c) {
+return cp_is<property::extended_pictographic>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::gr_base>(char32_t c) {
+return cp_is<property::gr_base>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::gr_ext>(char32_t c) {
+return cp_is<property::gr_ext>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hex>(char32_t c) {
+return cp_is<property::hex>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::idc>(char32_t c) {
+return cp_is<property::idc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ideo>(char32_t c) {
+return cp_is<property::ideo>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ids>(char32_t c) {
+return cp_is<property::ids>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::idsb>(char32_t c) {
+return cp_is<property::idsb>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::idst>(char32_t c) {
+return cp_is<property::idst>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::join_c>(char32_t c) {
+return cp_is<property::join_c>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::loe>(char32_t c) {
+return cp_is<property::loe>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lower>(char32_t c) {
+return cp_is<property::lower>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::math>(char32_t c) {
+return cp_is<property::math>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nchar>(char32_t c) {
+return cp_is<property::nchar>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pat_syn>(char32_t c) {
+return cp_is<property::pat_syn>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pat_ws>(char32_t c) {
+return cp_is<property::pat_ws>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pcm>(char32_t c) {
+return cp_is<property::pcm>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::qmark>(char32_t c) {
+return cp_is<property::qmark>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::radical>(char32_t c) {
+return cp_is<property::radical>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ri>(char32_t c) {
+return cp_is<property::ri>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sd>(char32_t c) {
+return cp_is<property::sd>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sterm>(char32_t c) {
+return cp_is<property::sterm>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::term>(char32_t c) {
+return cp_is<property::term>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::uideo>(char32_t c) {
+return cp_is<property::uideo>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::upper>(char32_t c) {
+return cp_is<property::upper>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::vs>(char32_t c) {
+return cp_is<property::vs>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::wspace>(char32_t c) {
+return cp_is<property::wspace>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::xidc>(char32_t c) {
+return cp_is<property::xidc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::xids>(char32_t c) {
+return cp_is<property::xids>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::c>(char32_t c) {
+return cp_is<category::c>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cc>(char32_t c) {
+return cp_is<category::cc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cf>(char32_t c) {
+return cp_is<category::cf>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cn>(char32_t c) {
+return cp_is<category::cn>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::co>(char32_t c) {
+return cp_is<category::co>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cs>(char32_t c) {
+return cp_is<category::cs>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::l>(char32_t c) {
+return cp_is<category::l>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lc>(char32_t c) {
+return cp_is<category::lc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ll>(char32_t c) {
+return cp_is<category::ll>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lm>(char32_t c) {
+return cp_is<category::lm>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lo>(char32_t c) {
+return cp_is<category::lo>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lt>(char32_t c) {
+return cp_is<category::lt>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lu>(char32_t c) {
+return cp_is<category::lu>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::m>(char32_t c) {
+return cp_is<category::m>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mc>(char32_t c) {
+return cp_is<category::mc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::me>(char32_t c) {
+return cp_is<category::me>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mn>(char32_t c) {
+return cp_is<category::mn>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::n>(char32_t c) {
+return cp_is<category::n>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nd>(char32_t c) {
+return cp_is<category::nd>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nl>(char32_t c) {
+return cp_is<category::nl>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::no>(char32_t c) {
+return cp_is<category::no>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::p>(char32_t c) {
+return cp_is<category::p>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pc>(char32_t c) {
+return cp_is<category::pc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pd>(char32_t c) {
+return cp_is<category::pd>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pe>(char32_t c) {
+return cp_is<category::pe>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pf>(char32_t c) {
+return cp_is<category::pf>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pi>(char32_t c) {
+return cp_is<category::pi>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::po>(char32_t c) {
+return cp_is<category::po>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ps>(char32_t c) {
+return cp_is<category::ps>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::s>(char32_t c) {
+return cp_is<category::s>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sc>(char32_t c) {
+return cp_is<category::sc>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sk>(char32_t c) {
+return cp_is<category::sk>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sm>(char32_t c) {
+return cp_is<category::sm>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::so>(char32_t c) {
+return cp_is<category::so>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::z>(char32_t c) {
+return cp_is<category::z>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zl>(char32_t c) {
+return cp_is<category::zl>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zp>(char32_t c) {
+return cp_is<category::zp>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zs>(char32_t c) {
+return cp_is<category::zs>(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::adlm>(char32_t c) {
+return cp_script(c) == script::adlm;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::aghb>(char32_t c) {
+return cp_script(c) == script::aghb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ahom>(char32_t c) {
+return cp_script(c) == script::ahom;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::arab>(char32_t c) {
+return cp_script(c) == script::arab;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::armi>(char32_t c) {
+return cp_script(c) == script::armi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::armn>(char32_t c) {
+return cp_script(c) == script::armn;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::avst>(char32_t c) {
+return cp_script(c) == script::avst;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bali>(char32_t c) {
+return cp_script(c) == script::bali;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bamu>(char32_t c) {
+return cp_script(c) == script::bamu;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bass>(char32_t c) {
+return cp_script(c) == script::bass;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::batk>(char32_t c) {
+return cp_script(c) == script::batk;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::beng>(char32_t c) {
+return cp_script(c) == script::beng;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bhks>(char32_t c) {
+return cp_script(c) == script::bhks;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bopo>(char32_t c) {
+return cp_script(c) == script::bopo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::brah>(char32_t c) {
+return cp_script(c) == script::brah;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::brai>(char32_t c) {
+return cp_script(c) == script::brai;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::bugi>(char32_t c) {
+return cp_script(c) == script::bugi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::buhd>(char32_t c) {
+return cp_script(c) == script::buhd;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cakm>(char32_t c) {
+return cp_script(c) == script::cakm;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cans>(char32_t c) {
+return cp_script(c) == script::cans;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cari>(char32_t c) {
+return cp_script(c) == script::cari;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cham>(char32_t c) {
+return cp_script(c) == script::cham;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cher>(char32_t c) {
+return cp_script(c) == script::cher;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::chrs>(char32_t c) {
+return cp_script(c) == script::chrs;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::copt>(char32_t c) {
+return cp_script(c) == script::copt;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cprt>(char32_t c) {
+return cp_script(c) == script::cprt;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::cyrl>(char32_t c) {
+return cp_script(c) == script::cyrl;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::deva>(char32_t c) {
+return cp_script(c) == script::deva;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::diak>(char32_t c) {
+return cp_script(c) == script::diak;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::dogr>(char32_t c) {
+return cp_script(c) == script::dogr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::dsrt>(char32_t c) {
+return cp_script(c) == script::dsrt;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::dupl>(char32_t c) {
+return cp_script(c) == script::dupl;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::egyp>(char32_t c) {
+return cp_script(c) == script::egyp;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::elba>(char32_t c) {
+return cp_script(c) == script::elba;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::elym>(char32_t c) {
+return cp_script(c) == script::elym;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ethi>(char32_t c) {
+return cp_script(c) == script::ethi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::geor>(char32_t c) {
+return cp_script(c) == script::geor;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::glag>(char32_t c) {
+return cp_script(c) == script::glag;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::gong>(char32_t c) {
+return cp_script(c) == script::gong;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::gonm>(char32_t c) {
+return cp_script(c) == script::gonm;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::goth>(char32_t c) {
+return cp_script(c) == script::goth;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::gran>(char32_t c) {
+return cp_script(c) == script::gran;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::grek>(char32_t c) {
+return cp_script(c) == script::grek;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::gujr>(char32_t c) {
+return cp_script(c) == script::gujr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::guru>(char32_t c) {
+return cp_script(c) == script::guru;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hang>(char32_t c) {
+return cp_script(c) == script::hang;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hani>(char32_t c) {
+return cp_script(c) == script::hani;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hano>(char32_t c) {
+return cp_script(c) == script::hano;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hatr>(char32_t c) {
+return cp_script(c) == script::hatr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hebr>(char32_t c) {
+return cp_script(c) == script::hebr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hira>(char32_t c) {
+return cp_script(c) == script::hira;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hluw>(char32_t c) {
+return cp_script(c) == script::hluw;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hmng>(char32_t c) {
+return cp_script(c) == script::hmng;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hmnp>(char32_t c) {
+return cp_script(c) == script::hmnp;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hrkt>(char32_t c) {
+return cp_script(c) == script::hrkt;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::hung>(char32_t c) {
+return cp_script(c) == script::hung;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ital>(char32_t c) {
+return cp_script(c) == script::ital;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::java>(char32_t c) {
+return cp_script(c) == script::java;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::kali>(char32_t c) {
+return cp_script(c) == script::kali;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::kana>(char32_t c) {
+return cp_script(c) == script::kana;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::khar>(char32_t c) {
+return cp_script(c) == script::khar;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::khmr>(char32_t c) {
+return cp_script(c) == script::khmr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::khoj>(char32_t c) {
+return cp_script(c) == script::khoj;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::kits>(char32_t c) {
+return cp_script(c) == script::kits;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::knda>(char32_t c) {
+return cp_script(c) == script::knda;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::kthi>(char32_t c) {
+return cp_script(c) == script::kthi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lana>(char32_t c) {
+return cp_script(c) == script::lana;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::laoo>(char32_t c) {
+return cp_script(c) == script::laoo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::latn>(char32_t c) {
+return cp_script(c) == script::latn;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lepc>(char32_t c) {
+return cp_script(c) == script::lepc;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::limb>(char32_t c) {
+return cp_script(c) == script::limb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lina>(char32_t c) {
+return cp_script(c) == script::lina;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::linb>(char32_t c) {
+return cp_script(c) == script::linb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lisu>(char32_t c) {
+return cp_script(c) == script::lisu;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lyci>(char32_t c) {
+return cp_script(c) == script::lyci;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::lydi>(char32_t c) {
+return cp_script(c) == script::lydi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mahj>(char32_t c) {
+return cp_script(c) == script::mahj;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::maka>(char32_t c) {
+return cp_script(c) == script::maka;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mand>(char32_t c) {
+return cp_script(c) == script::mand;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mani>(char32_t c) {
+return cp_script(c) == script::mani;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::marc>(char32_t c) {
+return cp_script(c) == script::marc;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::medf>(char32_t c) {
+return cp_script(c) == script::medf;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mend>(char32_t c) {
+return cp_script(c) == script::mend;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::merc>(char32_t c) {
+return cp_script(c) == script::merc;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mero>(char32_t c) {
+return cp_script(c) == script::mero;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mlym>(char32_t c) {
+return cp_script(c) == script::mlym;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::modi>(char32_t c) {
+return cp_script(c) == script::modi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mong>(char32_t c) {
+return cp_script(c) == script::mong;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mroo>(char32_t c) {
+return cp_script(c) == script::mroo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mtei>(char32_t c) {
+return cp_script(c) == script::mtei;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mult>(char32_t c) {
+return cp_script(c) == script::mult;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::mymr>(char32_t c) {
+return cp_script(c) == script::mymr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nand>(char32_t c) {
+return cp_script(c) == script::nand;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::narb>(char32_t c) {
+return cp_script(c) == script::narb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nbat>(char32_t c) {
+return cp_script(c) == script::nbat;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::newa>(char32_t c) {
+return cp_script(c) == script::newa;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nkoo>(char32_t c) {
+return cp_script(c) == script::nkoo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::nshu>(char32_t c) {
+return cp_script(c) == script::nshu;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ogam>(char32_t c) {
+return cp_script(c) == script::ogam;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::olck>(char32_t c) {
+return cp_script(c) == script::olck;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::orkh>(char32_t c) {
+return cp_script(c) == script::orkh;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::orya>(char32_t c) {
+return cp_script(c) == script::orya;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::osge>(char32_t c) {
+return cp_script(c) == script::osge;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::osma>(char32_t c) {
+return cp_script(c) == script::osma;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::palm>(char32_t c) {
+return cp_script(c) == script::palm;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::pauc>(char32_t c) {
+return cp_script(c) == script::pauc;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::perm>(char32_t c) {
+return cp_script(c) == script::perm;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::phag>(char32_t c) {
+return cp_script(c) == script::phag;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::phli>(char32_t c) {
+return cp_script(c) == script::phli;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::phlp>(char32_t c) {
+return cp_script(c) == script::phlp;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::phnx>(char32_t c) {
+return cp_script(c) == script::phnx;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::plrd>(char32_t c) {
+return cp_script(c) == script::plrd;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::prti>(char32_t c) {
+return cp_script(c) == script::prti;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::rjng>(char32_t c) {
+return cp_script(c) == script::rjng;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::rohg>(char32_t c) {
+return cp_script(c) == script::rohg;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::runr>(char32_t c) {
+return cp_script(c) == script::runr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::samr>(char32_t c) {
+return cp_script(c) == script::samr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sarb>(char32_t c) {
+return cp_script(c) == script::sarb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::saur>(char32_t c) {
+return cp_script(c) == script::saur;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sgnw>(char32_t c) {
+return cp_script(c) == script::sgnw;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::shaw>(char32_t c) {
+return cp_script(c) == script::shaw;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::shrd>(char32_t c) {
+return cp_script(c) == script::shrd;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sidd>(char32_t c) {
+return cp_script(c) == script::sidd;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sind>(char32_t c) {
+return cp_script(c) == script::sind;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sinh>(char32_t c) {
+return cp_script(c) == script::sinh;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sogd>(char32_t c) {
+return cp_script(c) == script::sogd;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sogo>(char32_t c) {
+return cp_script(c) == script::sogo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sora>(char32_t c) {
+return cp_script(c) == script::sora;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::soyo>(char32_t c) {
+return cp_script(c) == script::soyo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sund>(char32_t c) {
+return cp_script(c) == script::sund;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::sylo>(char32_t c) {
+return cp_script(c) == script::sylo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::syrc>(char32_t c) {
+return cp_script(c) == script::syrc;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tagb>(char32_t c) {
+return cp_script(c) == script::tagb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::takr>(char32_t c) {
+return cp_script(c) == script::takr;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tale>(char32_t c) {
+return cp_script(c) == script::tale;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::talu>(char32_t c) {
+return cp_script(c) == script::talu;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::taml>(char32_t c) {
+return cp_script(c) == script::taml;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tang>(char32_t c) {
+return cp_script(c) == script::tang;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tavt>(char32_t c) {
+return cp_script(c) == script::tavt;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::telu>(char32_t c) {
+return cp_script(c) == script::telu;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tfng>(char32_t c) {
+return cp_script(c) == script::tfng;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tglg>(char32_t c) {
+return cp_script(c) == script::tglg;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::thaa>(char32_t c) {
+return cp_script(c) == script::thaa;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::thai>(char32_t c) {
+return cp_script(c) == script::thai;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tibt>(char32_t c) {
+return cp_script(c) == script::tibt;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::tirh>(char32_t c) {
+return cp_script(c) == script::tirh;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ugar>(char32_t c) {
+return cp_script(c) == script::ugar;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::vaii>(char32_t c) {
+return cp_script(c) == script::vaii;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::wara>(char32_t c) {
+return cp_script(c) == script::wara;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::wcho>(char32_t c) {
+return cp_script(c) == script::wcho;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::xpeo>(char32_t c) {
+return cp_script(c) == script::xpeo;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::xsux>(char32_t c) {
+return cp_script(c) == script::xsux;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::yezi>(char32_t c) {
+return cp_script(c) == script::yezi;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::yiii>(char32_t c) {
+return cp_script(c) == script::yiii;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zanb>(char32_t c) {
+return cp_script(c) == script::zanb;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zinh>(char32_t c) {
+return cp_script(c) == script::zinh;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zyyy>(char32_t c) {
+return cp_script(c) == script::zyyy;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::zzzz>(char32_t c) {
+return cp_script(c) == script::zzzz;
+}
+namespace tables {
+static constexpr string_with_idx binary_prop_names[] = {
+string_with_idx{"adlam", 86},
+string_with_idx{"adlm", 86},
+string_with_idx{"aghb", 87},
+string_with_idx{"ahex", 0},
+string_with_idx{"ahom", 88},
+string_with_idx{"alpha", 1},
+string_with_idx{"alphabetic", 1},
+string_with_idx{"anatolian_hieroglyphs", 137},
+string_with_idx{"any", 45},
+string_with_idx{"arab", 89},
+string_with_idx{"arabic", 89},
+string_with_idx{"armenian", 91},
+string_with_idx{"armi", 90},
+string_with_idx{"armn", 91},
+string_with_idx{"ascii", 46},
+string_with_idx{"ascii_hex_digit", 0},
+string_with_idx{"assigned", 47},
+string_with_idx{"avestan", 92},
+string_with_idx{"avst", 92},
+string_with_idx{"bali", 93},
+string_with_idx{"balinese", 93},
+string_with_idx{"bamu", 94},
+string_with_idx{"bamum", 94},
+string_with_idx{"bass", 95},
+string_with_idx{"bassa_vah", 95},
+string_with_idx{"batak", 96},
+string_with_idx{"batk", 96},
+string_with_idx{"beng", 97},
+string_with_idx{"bengali", 97},
+string_with_idx{"bhaiksuki", 98},
+string_with_idx{"bhks", 98},
+string_with_idx{"bidi_c", 2},
+string_with_idx{"bidi_control", 2},
+string_with_idx{"bidi_m", 3},
+string_with_idx{"bidi_mirrored", 3},
+string_with_idx{"bopo", 99},
+string_with_idx{"bopomofo", 99},
+string_with_idx{"brah", 100},
+string_with_idx{"brahmi", 100},
+string_with_idx{"brai", 101},
+string_with_idx{"braille", 101},
+string_with_idx{"bugi", 102},
+string_with_idx{"buginese", 102},
+string_with_idx{"buhd", 103},
+string_with_idx{"buhid", 103},
+string_with_idx{"c", 48},
+string_with_idx{"cakm", 104},
+string_with_idx{"canadian_aboriginal", 105},
+string_with_idx{"cans", 105},
+string_with_idx{"cari", 106},
+string_with_idx{"carian", 106},
+string_with_idx{"case_ignorable", 5},
+string_with_idx{"cased", 4},
+string_with_idx{"cased_letter", 55},
+string_with_idx{"caucasian_albanian", 87},
+string_with_idx{"cc", 49},
+string_with_idx{"cf", 50},
+string_with_idx{"chakma", 104},
+string_with_idx{"cham", 107},
+string_with_idx{"cher", 108},
+string_with_idx{"cherokee", 108},
+string_with_idx{"chorasmian", 109},
+string_with_idx{"chrs", 109},
+string_with_idx{"ci", 5},
+string_with_idx{"close_punctuation", 72},
+string_with_idx{"cn", 51},
+string_with_idx{"co", 52},
+string_with_idx{"common", 242},
+string_with_idx{"connector_punctuation", 70},
+string_with_idx{"control", 49},
+string_with_idx{"copt", 110},
+string_with_idx{"coptic", 110},
+string_with_idx{"cprt", 111},
+string_with_idx{"cs", 53},
+string_with_idx{"cuneiform", 237},
+string_with_idx{"currency_symbol", 78},
+string_with_idx{"cypriot", 111},
+string_with_idx{"cyrillic", 112},
+string_with_idx{"cyrl", 112},
+string_with_idx{"dash", 6},
+string_with_idx{"dash_punctuation", 71},
+string_with_idx{"decimal_number", 66},
+string_with_idx{"default_ignorable_code_point", 8},
+string_with_idx{"dep", 7},
+string_with_idx{"deprecated", 7},
+string_with_idx{"deseret", 116},
+string_with_idx{"deva", 113},
+string_with_idx{"devanagari", 113},
+string_with_idx{"di", 8},
+string_with_idx{"dia", 9},
+string_with_idx{"diacritic", 9},
+string_with_idx{"diak", 114},
+string_with_idx{"dives_akuru", 114},
+string_with_idx{"dogr", 115},
+string_with_idx{"dogra", 115},
+string_with_idx{"dsrt", 116},
+string_with_idx{"dupl", 117},
+string_with_idx{"duployan", 117},
+string_with_idx{"egyp", 118},
+string_with_idx{"egyptian_hieroglyphs", 118},
+string_with_idx{"elba", 119},
+string_with_idx{"elbasan", 119},
+string_with_idx{"elym", 120},
+string_with_idx{"elymaic", 120},
+string_with_idx{"emoji", 10},
+string_with_idx{"emoji_component", 11},
+string_with_idx{"emoji_modifier", 12},
+string_with_idx{"emoji_modifier_base", 13},
+string_with_idx{"emoji_presentation", 14},
+string_with_idx{"enclosing_mark", 63},
+string_with_idx{"ethi", 121},
+string_with_idx{"ethiopic", 121},
+string_with_idx{"ext", 15},
+string_with_idx{"extended_pictographic", 16},
+string_with_idx{"extender", 15},
+string_with_idx{"final_punctuation", 73},
+string_with_idx{"format", 50},
+string_with_idx{"geor", 122},
+string_with_idx{"georgian", 122},
+string_with_idx{"glag", 123},
+string_with_idx{"glagolitic", 123},
+string_with_idx{"gong", 124},
+string_with_idx{"gonm", 125},
+string_with_idx{"goth", 126},
+string_with_idx{"gothic", 126},
+string_with_idx{"gr_base", 17},
+string_with_idx{"gr_ext", 18},
+string_with_idx{"gran", 127},
+string_with_idx{"grantha", 127},
+string_with_idx{"grapheme_base", 17},
+string_with_idx{"grapheme_extend", 18},
+string_with_idx{"greek", 128},
+string_with_idx{"grek", 128},
+string_with_idx{"gujarati", 129},
+string_with_idx{"gujr", 129},
+string_with_idx{"gunjala_gondi", 124},
+string_with_idx{"gurmukhi", 130},
+string_with_idx{"guru", 130},
+string_with_idx{"han", 132},
+string_with_idx{"hang", 131},
+string_with_idx{"hangul", 131},
+string_with_idx{"hani", 132},
+string_with_idx{"hanifi_rohingya", 200},
+string_with_idx{"hano", 133},
+string_with_idx{"hanunoo", 133},
+string_with_idx{"hatr", 134},
+string_with_idx{"hatran", 134},
+string_with_idx{"hebr", 135},
+string_with_idx{"hebrew", 135},
+string_with_idx{"hex", 19},
+string_with_idx{"hex_digit", 19},
+string_with_idx{"hira", 136},
+string_with_idx{"hiragana", 136},
+string_with_idx{"hluw", 137},
+string_with_idx{"hmng", 138},
+string_with_idx{"hmnp", 139},
+string_with_idx{"hrkt", 140},
+string_with_idx{"hung", 141},
+string_with_idx{"id_continue", 20},
+string_with_idx{"id_start", 22},
+string_with_idx{"idc", 20},
+string_with_idx{"ideo", 21},
+string_with_idx{"ideographic", 21},
+string_with_idx{"ids", 22},
+string_with_idx{"ids_binary_operator", 23},
+string_with_idx{"ids_trinary_operator", 24},
+string_with_idx{"idsb", 23},
+string_with_idx{"idst", 24},
+string_with_idx{"imperial_aramaic", 90},
+string_with_idx{"inherited", 241},
+string_with_idx{"initial_punctuation", 74},
+string_with_idx{"inscriptional_pahlavi", 194},
+string_with_idx{"inscriptional_parthian", 198},
+string_with_idx{"ital", 142},
+string_with_idx{"java", 143},
+string_with_idx{"javanese", 143},
+string_with_idx{"join_c", 25},
+string_with_idx{"join_control", 25},
+string_with_idx{"kaithi", 151},
+string_with_idx{"kali", 144},
+string_with_idx{"kana", 145},
+string_with_idx{"kannada", 150},
+string_with_idx{"katakana", 145},
+string_with_idx{"katakana_or_hiragana", 140},
+string_with_idx{"kayah_li", 144},
+string_with_idx{"khar", 146},
+string_with_idx{"kharoshthi", 146},
+string_with_idx{"khitan_small_script", 149},
+string_with_idx{"khmer", 147},
+string_with_idx{"khmr", 147},
+string_with_idx{"khoj", 148},
+string_with_idx{"khojki", 148},
+string_with_idx{"khudawadi", 209},
+string_with_idx{"kits", 149},
+string_with_idx{"knda", 150},
+string_with_idx{"kthi", 151},
+string_with_idx{"l", 54},
+string_with_idx{"lana", 152},
+string_with_idx{"lao", 153},
+string_with_idx{"laoo", 153},
+string_with_idx{"latin", 154},
+string_with_idx{"latn", 154},
+string_with_idx{"lc", 55},
+string_with_idx{"lepc", 155},
+string_with_idx{"lepcha", 155},
+string_with_idx{"letter", 54},
+string_with_idx{"letter_number", 67},
+string_with_idx{"limb", 156},
+string_with_idx{"limbu", 156},
+string_with_idx{"lina", 157},
+string_with_idx{"linb", 158},
+string_with_idx{"line_separator", 83},
+string_with_idx{"linear_a", 157},
+string_with_idx{"linear_b", 158},
+string_with_idx{"lisu", 159},
+string_with_idx{"ll", 56},
+string_with_idx{"lm", 57},
+string_with_idx{"lo", 58},
+string_with_idx{"loe", 26},
+string_with_idx{"logical_order_exception", 26},
+string_with_idx{"lower", 27},
+string_with_idx{"lowercase", 27},
+string_with_idx{"lowercase_letter", 56},
+string_with_idx{"lt", 59},
+string_with_idx{"lu", 60},
+string_with_idx{"lyci", 160},
+string_with_idx{"lycian", 160},
+string_with_idx{"lydi", 161},
+string_with_idx{"lydian", 161},
+string_with_idx{"m", 61},
+string_with_idx{"mahajani", 162},
+string_with_idx{"mahj", 162},
+string_with_idx{"maka", 163},
+string_with_idx{"makasar", 163},
+string_with_idx{"malayalam", 171},
+string_with_idx{"mand", 164},
+string_with_idx{"mandaic", 164},
+string_with_idx{"mani", 165},
+string_with_idx{"manichaean", 165},
+string_with_idx{"marc", 166},
+string_with_idx{"marchen", 166},
+string_with_idx{"mark", 61},
+string_with_idx{"masaram_gondi", 125},
+string_with_idx{"math", 28},
+string_with_idx{"math_symbol", 80},
+string_with_idx{"mc", 62},
+string_with_idx{"me", 63},
+string_with_idx{"medefaidrin", 167},
+string_with_idx{"medf", 167},
+string_with_idx{"meetei_mayek", 175},
+string_with_idx{"mend", 168},
+string_with_idx{"mende_kikakui", 168},
+string_with_idx{"merc", 169},
+string_with_idx{"mero", 170},
+string_with_idx{"meroitic_cursive", 169},
+string_with_idx{"meroitic_hieroglyphs", 170},
+string_with_idx{"miao", 197},
+string_with_idx{"mlym", 171},
+string_with_idx{"mn", 64},
+string_with_idx{"modi", 172},
+string_with_idx{"modifier_letter", 57},
+string_with_idx{"modifier_symbol", 79},
+string_with_idx{"mong", 173},
+string_with_idx{"mongolian", 173},
+string_with_idx{"mro", 174},
+string_with_idx{"mroo", 174},
+string_with_idx{"mtei", 175},
+string_with_idx{"mult", 176},
+string_with_idx{"multani", 176},
+string_with_idx{"myanmar", 177},
+string_with_idx{"mymr", 177},
+string_with_idx{"n", 65},
+string_with_idx{"nabataean", 180},
+string_with_idx{"nand", 178},
+string_with_idx{"nandinagari", 178},
+string_with_idx{"narb", 179},
+string_with_idx{"nbat", 180},
+string_with_idx{"nchar", 29},
+string_with_idx{"nd", 66},
+string_with_idx{"new_tai_lue", 221},
+string_with_idx{"newa", 181},
+string_with_idx{"nko", 182},
+string_with_idx{"nkoo", 182},
+string_with_idx{"nl", 67},
+string_with_idx{"no", 68},
+string_with_idx{"noncharacter_code_point", 29},
+string_with_idx{"nonspacing_mark", 64},
+string_with_idx{"nshu", 183},
+string_with_idx{"number", 65},
+string_with_idx{"nushu", 183},
+string_with_idx{"nyiakeng_puachue_hmong", 139},
+string_with_idx{"ogam", 184},
+string_with_idx{"ogham", 184},
+string_with_idx{"ol_chiki", 185},
+string_with_idx{"olck", 185},
+string_with_idx{"old_hungarian", 141},
+string_with_idx{"old_italic", 142},
+string_with_idx{"old_north_arabian", 179},
+string_with_idx{"old_permic", 192},
+string_with_idx{"old_persian", 236},
+string_with_idx{"old_sogdian", 212},
+string_with_idx{"old_south_arabian", 203},
+string_with_idx{"old_turkic", 186},
+string_with_idx{"open_punctuation", 76},
+string_with_idx{"oriya", 187},
+string_with_idx{"orkh", 186},
+string_with_idx{"orya", 187},
+string_with_idx{"osage", 188},
+string_with_idx{"osge", 188},
+string_with_idx{"osma", 189},
+string_with_idx{"osmanya", 189},
+string_with_idx{"other", 48},
+string_with_idx{"other_letter", 58},
+string_with_idx{"other_number", 68},
+string_with_idx{"other_punctuation", 75},
+string_with_idx{"other_symbol", 81},
+string_with_idx{"p", 69},
+string_with_idx{"pahawh_hmong", 138},
+string_with_idx{"palm", 190},
+string_with_idx{"palmyrene", 190},
+string_with_idx{"paragraph_separator", 84},
+string_with_idx{"pat_syn", 30},
+string_with_idx{"pat_ws", 31},
+string_with_idx{"pattern_syntax", 30},
+string_with_idx{"pattern_white_space", 31},
+string_with_idx{"pau_cin_hau", 191},
+string_with_idx{"pauc", 191},
+string_with_idx{"pc", 70},
+string_with_idx{"pcm", 32},
+string_with_idx{"pd", 71},
+string_with_idx{"pe", 72},
+string_with_idx{"perm", 192},
+string_with_idx{"pf", 73},
+string_with_idx{"phag", 193},
+string_with_idx{"phags_pa", 193},
+string_with_idx{"phli", 194},
+string_with_idx{"phlp", 195},
+string_with_idx{"phnx", 196},
+string_with_idx{"phoenician", 196},
+string_with_idx{"pi", 74},
+string_with_idx{"plrd", 197},
+string_with_idx{"po", 75},
+string_with_idx{"prepended_concatenation_mark", 32},
+string_with_idx{"private_use", 52},
+string_with_idx{"prti", 198},
+string_with_idx{"ps", 76},
+string_with_idx{"psalter_pahlavi", 195},
+string_with_idx{"punctuation", 69},
+string_with_idx{"qmark", 33},
+string_with_idx{"quotation_mark", 33},
+string_with_idx{"radical", 34},
+string_with_idx{"regional_indicator", 35},
+string_with_idx{"rejang", 199},
+string_with_idx{"ri", 35},
+string_with_idx{"rjng", 199},
+string_with_idx{"rohg", 200},
+string_with_idx{"runic", 201},
+string_with_idx{"runr", 201},
+string_with_idx{"s", 77},
+string_with_idx{"samaritan", 202},
+string_with_idx{"samr", 202},
+string_with_idx{"sarb", 203},
+string_with_idx{"saur", 204},
+string_with_idx{"saurashtra", 204},
+string_with_idx{"sc", 78},
+string_with_idx{"sd", 36},
+string_with_idx{"sentence_terminal", 37},
+string_with_idx{"separator", 82},
+string_with_idx{"sgnw", 205},
+string_with_idx{"sharada", 207},
+string_with_idx{"shavian", 206},
+string_with_idx{"shaw", 206},
+string_with_idx{"shrd", 207},
+string_with_idx{"sidd", 208},
+string_with_idx{"siddham", 208},
+string_with_idx{"signwriting", 205},
+string_with_idx{"sind", 209},
+string_with_idx{"sinh", 210},
+string_with_idx{"sinhala", 210},
+string_with_idx{"sk", 79},
+string_with_idx{"sm", 80},
+string_with_idx{"so", 81},
+string_with_idx{"soft_dotted", 36},
+string_with_idx{"sogd", 211},
+string_with_idx{"sogdian", 211},
+string_with_idx{"sogo", 212},
+string_with_idx{"sora", 213},
+string_with_idx{"sora_sompeng", 213},
+string_with_idx{"soyo", 214},
+string_with_idx{"soyombo", 214},
+string_with_idx{"space", 42},
+string_with_idx{"space_separator", 85},
+string_with_idx{"spacing_mark", 62},
+string_with_idx{"sterm", 37},
+string_with_idx{"sund", 215},
+string_with_idx{"sundanese", 215},
+string_with_idx{"surrogate", 53},
+string_with_idx{"sylo", 216},
+string_with_idx{"syloti_nagri", 216},
+string_with_idx{"symbol", 77},
+string_with_idx{"syrc", 217},
+string_with_idx{"syriac", 217},
+string_with_idx{"tagalog", 227},
+string_with_idx{"tagb", 218},
+string_with_idx{"tagbanwa", 218},
+string_with_idx{"tai_le", 220},
+string_with_idx{"tai_tham", 152},
+string_with_idx{"tai_viet", 224},
+string_with_idx{"takr", 219},
+string_with_idx{"takri", 219},
+string_with_idx{"tale", 220},
+string_with_idx{"talu", 221},
+string_with_idx{"tamil", 222},
+string_with_idx{"taml", 222},
+string_with_idx{"tang", 223},
+string_with_idx{"tangut", 223},
+string_with_idx{"tavt", 224},
+string_with_idx{"telu", 225},
+string_with_idx{"telugu", 225},
+string_with_idx{"term", 38},
+string_with_idx{"terminal_punctuation", 38},
+string_with_idx{"tfng", 226},
+string_with_idx{"tglg", 227},
+string_with_idx{"thaa", 228},
+string_with_idx{"thaana", 228},
+string_with_idx{"thai", 229},
+string_with_idx{"tibetan", 230},
+string_with_idx{"tibt", 230},
+string_with_idx{"tifinagh", 226},
+string_with_idx{"tirh", 231},
+string_with_idx{"tirhuta", 231},
+string_with_idx{"titlecase_letter", 59},
+string_with_idx{"ugar", 232},
+string_with_idx{"ugaritic", 232},
+string_with_idx{"uideo", 39},
+string_with_idx{"unassigned", 51},
+string_with_idx{"unified_ideograph", 39},
+string_with_idx{"unknown", 243},
+string_with_idx{"upper", 40},
+string_with_idx{"uppercase", 40},
+string_with_idx{"uppercase_letter", 60},
+string_with_idx{"vai", 233},
+string_with_idx{"vaii", 233},
+string_with_idx{"variation_selector", 41},
+string_with_idx{"vs", 41},
+string_with_idx{"wancho", 235},
+string_with_idx{"wara", 234},
+string_with_idx{"warang_citi", 234},
+string_with_idx{"wcho", 235},
+string_with_idx{"white_space", 42},
+string_with_idx{"wspace", 42},
+string_with_idx{"xid_continue", 43},
+string_with_idx{"xid_start", 44},
+string_with_idx{"xidc", 43},
+string_with_idx{"xids", 44},
+string_with_idx{"xpeo", 236},
+string_with_idx{"xsux", 237},
+string_with_idx{"yezi", 238},
+string_with_idx{"yezidi", 238},
+string_with_idx{"yi", 239},
+string_with_idx{"yiii", 239},
+string_with_idx{"z", 82},
+string_with_idx{"zanabazar_square", 240},
+string_with_idx{"zanb", 240},
+string_with_idx{"zinh", 241},
+string_with_idx{"zl", 83},
+string_with_idx{"zp", 84},
+string_with_idx{"zs", 85},
+string_with_idx{"zyyy", 242},
+string_with_idx{"zzzz", 243}};
+}
+}    // namespace uni::detail
+
+// More regex support for ctre
+
+namespace uni::detail {
+
+constexpr binary_prop binary_prop_from_string(std::string_view s) {
+for(const auto& c : tables::binary_prop_names) {
+const auto res = propnamecomp(s, c.name);
+if(res == 0)
+return binary_prop(c.value);
+}
+return binary_prop::unknown;
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::ascii>(char32_t c) {
+return cp_is_ascii(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::assigned>(char32_t c) {
+return cp_is_assigned(c);
+}
+
+template<>
+constexpr bool get_binary_prop<binary_prop::any>(char32_t c) {
+return cp_is_valid(c);
+}
+
+constexpr bool is_unknown(binary_prop s)
+{
+return s == binary_prop::unknown;
+}
+
+}    // namespace uni::detail
 
 #endif
 


### PR DESCRIPTION
Updated the CTRE library to the current release. The most visible effect of this is getting rid of compiler warnings.

It also includes small adaptations of the CTRE-based Turtle Parser, because the internal semantics of the `ctll::fixed_string` have slightly changed.