### PR TITLE
Correct Request Timing for the Server

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -432,30 +432,6 @@ string Server::composeResponseSepValues(const ParsedQuery& query,
 }
 
 // _____________________________________________________________________________
-string Server::composeResponseJson(
-    const string& query, const ad_semsearch::Exception& exception) const {
-  std::ostringstream os;
-  _requestProcessingTimer.stop();
-
-  os << "{\n"
-     << "\"query\": " << ad_utility::toJson(query) << ",\n"
-     << "\"status\": \"ERROR\",\n"
-     << "\"resultsize\": \"0\",\n"
-     << "\"time\": {\n"
-     << "\"total\": \"" << _requestProcessingTimer.msecs() / 1000.0 << "ms\",\n"
-     << "\"computeResult\": \"" << _requestProcessingTimer.msecs() / 1000.0
-     << "ms\"\n"
-     << "},\n";
-
-  string msg = ad_utility::toJson(exception.getFullErrorMessage());
-
-  os << "\"exception\": " << msg << "\n"
-     << "}\n";
-
-  return os.str();
-}
-
-// _____________________________________________________________________________
 string Server::composeResponseJson(const string& query,
                                    const std::exception* exception) const {
   std::ostringstream os;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -91,6 +91,8 @@ void Server::runAcceptLoop() {
 
 // _____________________________________________________________________________
 void Server::process(Socket* client) {
+  ad_utility::Timer totalTimer;
+  totalTimer.start();
   string contentType;
   LOG(DEBUG) << "Waiting for receive call to complete." << endl;
   string request;
@@ -227,7 +229,7 @@ void Server::process(Socket* client) {
             "Content-Disposition: attachment;filename=export.tsv";
       } else {
         // Normal case: JSON response
-        response = composeResponseJson(pq, qet, maxSend);
+        response = composeResponseJson(pq, qet, maxSend, &totalTimer);
         contentType = "application/json";
       }
       // Print the runtime info. This needs to be done after the query
@@ -365,7 +367,10 @@ string Server::create400HttpResponse() const {
 // _____________________________________________________________________________
 string Server::composeResponseJson(const ParsedQuery& query,
                                    const QueryExecutionTree& qet,
-                                   size_t maxSend) const {
+                                   size_t maxSend, ad_utility::Timer* totalTimer) const {
+  if (!totalTimer) {
+    totalTimer = &_requestProcessingTimer;
+  }
   // TODO(schnelle) we really should use a json library
   // such as https://github.com/nlohmann/json
   shared_ptr<const ResultTable> rt = qet.getResult();
@@ -399,8 +404,10 @@ string Server::composeResponseJson(const ParsedQuery& query,
     _requestProcessingTimer.stop();
   }
 
+
+  totalTimer->stop();
   j["time"]["total"] =
-      std::to_string(_requestProcessingTimer.usecs() / 1000.0) + "ms";
+      std::to_string(totalTimer->usecs() / 1000.0) + "ms";
   j["time"]["computeResult"] = std::to_string(compResultUsecs / 1000.0) + "ms";
 
   return j.dump(4);

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -366,8 +366,6 @@ string Server::composeResponseJson(const ParsedQuery& query,
                                    const QueryExecutionTree& qet,
                                    ad_utility::Timer& requestTimer,
                                    size_t maxSend) const {
-  // TODO(schnelle) we really should use a json library
-  // such as https://github.com/nlohmann/json
   shared_ptr<const ResultTable> rt = qet.getResult();
   requestTimer.stop();
   off_t compResultUsecs = requestTimer.usecs();

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -229,16 +229,14 @@ void Server::process(Socket* client) {
             "Content-Disposition: attachment;filename=export.tsv";
       } else {
         // Normal case: JSON response
-        response = composeResponseJson(pq, qet, maxSend, &totalTimer);
+        response = composeResponseJson(pq, qet, totalTimer, maxSend);
         contentType = "application/json";
       }
       // Print the runtime info. This needs to be done after the query
       // was computed.
       LOG(INFO) << '\n' << qet.getRootOperation()->getRuntimeInfo().toString();
-    } catch (const ad_semsearch::Exception& e) {
-      response = composeResponseJson(query, e);
     } catch (const std::exception& e) {
-      response = composeResponseJson(query, &e);
+      response = composeResponseJson(query, e, totalTimer);
     }
     string httpResponse = createHttpResponse(response, contentType);
     auto bytesSent = client->send(httpResponse);
@@ -256,7 +254,6 @@ Server::ParamValueMap Server::parseHttpRequest(
     const string& httpRequest) const {
   LOG(DEBUG) << "Parsing HTTP Request." << endl;
   ParamValueMap params;
-  _requestProcessingTimer.start();
   // Parse the HTTP Request.
 
   size_t indexOfGET = httpRequest.find("GET");
@@ -367,15 +364,13 @@ string Server::create400HttpResponse() const {
 // _____________________________________________________________________________
 string Server::composeResponseJson(const ParsedQuery& query,
                                    const QueryExecutionTree& qet,
-                                   size_t maxSend, ad_utility::Timer* totalTimer) const {
-  if (!totalTimer) {
-    totalTimer = &_requestProcessingTimer;
-  }
+                                   ad_utility::Timer& totalTimer,
+                                   size_t maxSend) const {
   // TODO(schnelle) we really should use a json library
   // such as https://github.com/nlohmann/json
   shared_ptr<const ResultTable> rt = qet.getResult();
-  _requestProcessingTimer.stop();
-  off_t compResultUsecs = _requestProcessingTimer.usecs();
+  totalTimer.stop();
+  off_t compResultUsecs = totalTimer.usecs();
   size_t resultSize = rt->size();
 
   nlohmann::json j;
@@ -398,16 +393,14 @@ string Server::composeResponseJson(const ParsedQuery& query,
     if (query._offset.size() > 0) {
       offset = static_cast<size_t>(atol(query._offset.c_str()));
     }
-    _requestProcessingTimer.cont();
+    totalTimer.cont();
     j["res"] = qet.writeResultAsJson(query._selectedVariables,
                                      std::min(limit, maxSend), offset);
-    _requestProcessingTimer.stop();
+    totalTimer.stop();
   }
 
-
-  totalTimer->stop();
-  j["time"]["total"] =
-      std::to_string(totalTimer->usecs() / 1000.0) + "ms";
+  totalTimer.stop();
+  j["time"]["total"] = std::to_string(totalTimer.usecs() / 1000.0) + "ms";
   j["time"]["computeResult"] = std::to_string(compResultUsecs / 1000.0) + "ms";
 
   return j.dump(4);
@@ -433,25 +426,19 @@ string Server::composeResponseSepValues(const ParsedQuery& query,
 
 // _____________________________________________________________________________
 string Server::composeResponseJson(const string& query,
-                                   const std::exception* exception) const {
+                                   const std::exception& exception,
+                                   ad_utility::Timer& totalTimer) const {
   std::ostringstream os;
-  _requestProcessingTimer.stop();
+  totalTimer.stop();
 
-  os << "{\n"
-     << "\"query\": " << ad_utility::toJson(query) << ",\n"
-     << "\"status\": \"ERROR\",\n"
-     << "\"resultsize\": \"0\",\n"
-     << "\"time\": {\n"
-     << "\"total\": \"" << _requestProcessingTimer.msecs() << "ms\",\n"
-     << "\"computeResult\": \"" << _requestProcessingTimer.msecs() << "ms\"\n"
-     << "},\n";
-
-  string msg = ad_utility::toJson(exception->what());
-
-  os << "\"exception\": " << msg << "\n"
-     << "}\n";
-
-  return os.str();
+  json j;
+  j["query"] = query;
+  j["status"] = "ERROR";
+  j["resultsize"] = 0;
+  j["time"]["total"] = totalTimer.msecs();
+  j["time"]["computeResult"] = totalTimer.msecs();
+  j["exception"] = exception.what();
+  return j.dump(4);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -86,7 +86,8 @@ class Server {
 
   string composeResponseJson(const ParsedQuery& query,
                              const QueryExecutionTree& qet,
-                             size_t sendMax = MAX_NOF_ROWS_IN_RESULT) const;
+                             size_t sendMax = MAX_NOF_ROWS_IN_RESULT,
+                             ad_utility::Timer* totalTimer = nullptr) const;
 
   string composeResponseSepValues(const ParsedQuery& query,
                                   const QueryExecutionTree& qet,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -86,19 +86,17 @@ class Server {
 
   string composeResponseJson(const ParsedQuery& query,
                              const QueryExecutionTree& qet,
-                             size_t sendMax = MAX_NOF_ROWS_IN_RESULT,
-                             ad_utility::Timer* totalTimer = nullptr) const;
+                             ad_utility::Timer& totalTimer,
+                             size_t sendMax = MAX_NOF_ROWS_IN_RESULT) const;
 
   string composeResponseSepValues(const ParsedQuery& query,
                                   const QueryExecutionTree& qet,
                                   char sep) const;
 
-  string composeResponseJson(const string& query,
-                             const std::exception* e) const;
+  string composeResponseJson(const string& query, const std::exception& e,
+                             ad_utility::Timer& totalTimer) const;
 
   string composeStatsJson() const;
-
-  mutable ad_utility::Timer _requestProcessingTimer;
 
   json composeCacheStatsJson() const;
 };

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -94,9 +94,6 @@ class Server {
                                   char sep) const;
 
   string composeResponseJson(const string& query,
-                             const ad_semsearch::Exception& e) const;
-
-  string composeResponseJson(const string& query,
                              const std::exception* e) const;
 
   string composeStatsJson() const;

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -86,7 +86,7 @@ class Server {
 
   string composeResponseJson(const ParsedQuery& query,
                              const QueryExecutionTree& qet,
-                             ad_utility::Timer& totalTimer,
+                             ad_utility::Timer& requestTimer,
                              size_t sendMax = MAX_NOF_ROWS_IN_RESULT) const;
 
   string composeResponseSepValues(const ParsedQuery& query,
@@ -94,7 +94,7 @@ class Server {
                                   char sep) const;
 
   string composeResponseJson(const string& query, const std::exception& e,
-                             ad_utility::Timer& totalTimer) const;
+                             ad_utility::Timer& requestTimer) const;
 
   string composeStatsJson() const;
 


### PR DESCRIPTION
Previously the `Server` class had only one timer instance. This lead to wrong request times in the result json when
multiple requests were processed concurrently (this often happens in the autocompletion evaluation).

This PR introduces one timer per request.