### PR TITLE
BIND with more general binary operations

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -196,10 +196,10 @@ void Bind::computeBinaryOperationBind(
   const float NO_VALUE = std::numeric_limits<float>::quiet_NaN();
   char op = binaryOperator[0];
   std::function<float(float, float)> binaryOperations[4] = {
-    [](float v1, float v2) { return v1 + v2; },
-    [](float v1, float v2) { return v1 - v2; },
-    [](float v1, float v2) { return v1 * v2; },
-    [](float v1, float v2) { return v1 / v2; } };
+      [](float v1, float v2) { return v1 + v2; },
+      [](float v1, float v2) { return v1 - v2; },
+      [](float v1, float v2) { return v1 * v2; },
+      [](float v1, float v2) { return v1 / v2; }};
   size_t i = "+|*/"s.find(op);
   AD_CHECK(i != std::string::npos);
   auto binaryOperation = binaryOperations[i];

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -37,10 +37,9 @@ float Bind::getMultiplicity(size_t col) {
       return _subtree->getSizeEstimate();
     }
 
-    // If sum (or arithmetic expression), we make the simplifying assumption
-    // that all results values are different (which will indeed often be the
-    // case).
-    if (std::get_if<GraphPatternOperation::Bind::Sum>(
+    // If binary operation, we make the simplifying assumption that all results
+    // values are different (which will indeed often be the case).
+    if (std::get_if<GraphPatternOperation::Bind::BinaryOperation>(
             &(_bind._expressionVariant))) {
       return 1;
     }
@@ -130,18 +129,18 @@ void Bind::computeResult(ResultTable* result) {
   int inwidth = subRes->_data.cols();
   int outwidth = getResultWidth();
 
-  if (auto ptr = std::get_if<GraphPatternOperation::Bind::Sum>(
+  if (auto ptr = std::get_if<GraphPatternOperation::Bind::BinaryOperation>(
           &_bind._expressionVariant)) {
     std::array<size_t, 2> columns{_subtree->getVariableColumn(ptr->_var1),
                                   _subtree->getVariableColumn(ptr->_var2)};
     array<ResultTable::ResultType, 2> inTypes{subRes->_resultTypes[columns[0]],
                                               subRes->_resultTypes[columns[1]]};
-    // currently the result type for a SUM is always float, this will be changed
-    // with proper datatype support.
+    // Currently the result type for a Binary Operation is always float, this
+    // will be changed with proper datatype support.
     result->_resultTypes.push_back(ResultTable::ResultType::FLOAT);
-    CALL_FIXED_SIZE_2(inwidth, outwidth, Bind::computeSumBind, &result->_data,
-                      subRes->_data, columns, inTypes,
-                      _subtree->getQec()->getIndex());
+    CALL_FIXED_SIZE_2(inwidth, outwidth, Bind::computeBinaryOperationBind,
+                      &result->_data, subRes->_data, columns, inTypes,
+                      ptr->_binaryOperator, _subtree->getQec()->getIndex());
   } else if (auto ptr = std::get_if<GraphPatternOperation::Bind::Rename>(
                  &_bind._expressionVariant)) {
     size_t inColumn{_subtree->getVariableColumn(ptr->_var)};
@@ -182,47 +181,66 @@ void Bind::computeResult(ResultTable* result) {
 }
 
 template <int IN_WIDTH, int OUT_WIDTH>
-void Bind::computeSumBind(IdTable* dynRes, const IdTable& inputDyn,
-                          std::array<size_t, 2> columns,
-                          array<ResultTable::ResultType, 2> inputTypes,
-                          const Index& index) {
+void Bind::computeBinaryOperationBind(
+    IdTable* dynRes, const IdTable& inputDyn, std::array<size_t, 2> columns,
+    array<ResultTable::ResultType, 2> inputTypes,
+    const std::string& binaryOperator, const Index& index) {
   const auto input = inputDyn.asStaticView<IN_WIDTH>();
   auto result = dynRes->moveToStatic<OUT_WIDTH>();
 
   const auto inSize = input.size();
   result.reserve(inSize);
   const auto inCols = input.cols();
-  // copy the input to the first cols;
+
+  // Lambda for the binary operation.
+  const float NO_VALUE = std::numeric_limits<float>::quiet_NaN();
+  char op = binaryOperator[0];
+  std::function<float(float, float)> binaryOperations[4] = {
+    [](float v1, float v2) { return v1 + v2; },
+    [](float v1, float v2) { return v1 - v2; },
+    [](float v1, float v2) { return v1 * v2; },
+    [](float v1, float v2) { return v1 / v2; } };
+  size_t i = "+|*/"s.find(op);
+  AD_CHECK(i != std::string::npos);
+  auto binaryOperation = binaryOperations[i];
+
+  // Iterate of all rows.
   for (size_t i = 0; i < inSize; ++i) {
     result.emplace_back();
     for (size_t j = 0; j < inCols; ++j) {
       result(i, j) = input(i, j);
     }
-    float singleRes = .0f;
+    // Iterate over the two values of the binary operation.
+    float value1 = NO_VALUE;
+    float value2 = NO_VALUE;
     for (size_t colIdx = 0; colIdx < columns.size(); ++colIdx) {
+      float& value = colIdx == 0 ? value1 : value2;
+      // CASE 1: Verbatim value (like value from a COUNT).
       if (inputTypes[colIdx] == ResultTable::ResultType::VERBATIM) {
-        singleRes += input(i, columns[colIdx]);
+        value = input(i, columns[colIdx]);
+        // CASE 2: Value stored as float.
       } else if (inputTypes[colIdx] == ResultTable::ResultType::FLOAT) {
-        // used to store the id value of the entry interpreted as a float
-        float tmpF;
-        std::memcpy(&tmpF, &input(i, colIdx), sizeof(float));
-        singleRes += tmpF;
+        std::memcpy(&value, &input(i, colIdx), sizeof(float));
+        // CASE 3: Not a value.
       } else if (inputTypes[colIdx] == ResultTable::ResultType::TEXT ||
                  inputTypes[colIdx] == ResultTable::ResultType::LOCAL_VOCAB) {
-        singleRes = std::numeric_limits<float>::quiet_NaN();
+        // CASE 4: RDF value which needs to be parsed first.
       } else {
-        // load the string, parse it as an xsd::int or float
         std::string entity =
             index.idToOptionalString(input(i, columns[colIdx])).value_or("");
         if (!ad_utility::startsWith(entity, VALUE_FLOAT_PREFIX)) {
-          singleRes = std::numeric_limits<float>::quiet_NaN();
           break;
         } else {
-          singleRes += ad_utility::convertIndexWordToFloat(entity);
+          value = ad_utility::convertIndexWordToFloat(entity);
         }
       }
     }
-    std::memcpy(&result(i, inCols), &singleRes, sizeof(float));
+    // Perform the operation. Result is NO_VALUE if one of the operands is
+    // NO_VALUE or if division by zero.
+    bool invalid = value1 == NO_VALUE || value2 == NO_VALUE ||
+                   (binaryOperator[0] == '/' && value2 == .0f);
+    float opResult = invalid ? NO_VALUE : binaryOperation(value1, value2);
+    std::memcpy(&result(i, inCols), &opResult, sizeof(float));
   }
   *dynRes = result.moveToDynamic();
 }

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -44,8 +44,8 @@ class Bind : public Operation {
   template <int IN_WIDTH, int OUT_WIDTH>
   static void computeBinaryOperationBind(
       IdTable* dynRes, const IdTable& inputDyn, std::array<size_t, 2> columns,
-      array<ResultTable::ResultType, 2> inputTypes,
-      const std::string& binaryOperator, const Index& index);
+      array<ResultTable::ResultType, 2> inputTypes, char binaryOperator,
+      const Index& index);
 
   // Implementation for renaming a columns: BIND (?x As ?y)
   template <int IN_WIDTH, int OUT_WIDTH>

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -42,10 +42,10 @@ class Bind : public Operation {
 
   // Implementation for binding the sum of two columns: BIND (?x + ?y As ?z)
   template <int IN_WIDTH, int OUT_WIDTH>
-  static void computeSumBind(IdTable* dynRes, const IdTable& inputDyn,
-                             std::array<size_t, 2> columns,
-                             array<ResultTable::ResultType, 2> inputTypes,
-                             const Index& index);
+  static void computeBinaryOperationBind(
+      IdTable* dynRes, const IdTable& inputDyn, std::array<size_t, 2> columns,
+      array<ResultTable::ResultType, 2> inputTypes,
+      const std::string& binaryOperator, const Index& index);
 
   // Implementation for renaming a columns: BIND (?x As ?y)
   template <int IN_WIDTH, int OUT_WIDTH>

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -420,12 +420,13 @@ struct GraphPatternOperation {
       vector<string*> strings() { return {&_kbValue}; }
       [[nodiscard]] string getDescriptor() const { return _kbValue; }
     };
-    struct Sum {
-      static constexpr const char* Name = "Sum";
+    struct BinaryOperation {
+      static constexpr const char* Name = "Binary operation";
       string _var1, _var2;
-      vector<string*> strings() { return {&_var1, &_var2}; }
+      string _binaryOperator;
+      vector<string*> strings() { return {&_var1, &_var2, &_binaryOperator}; }
       [[nodiscard]] string getDescriptor() const {
-        return _var1 + " + " + _var2;
+        return _var1 + " " + _binaryOperator + " " + _var2;
       }
     };
 
@@ -435,7 +436,7 @@ struct GraphPatternOperation {
       vector<string*> strings() { return {&_var}; }
       [[nodiscard]] string getDescriptor() const { return _var; }
     };
-    std::variant<Rename, Constant, Sum> _expressionVariant;
+    std::variant<Rename, Constant, BinaryOperation> _expressionVariant;
     std::string _target;  // the variable to which the expression will be bound
 
     // Return all the strings contained in the BIND expression (variables,

--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -58,7 +58,7 @@ const std::string SparqlLexer::AGGREGATE =
     "(?i)(SAMPLE|COUNT|MIN|MAX|AVG|SUM|GROUP_CONCAT)";
 const std::string SparqlLexer::VARIABLE = "(\\?" + VARNAME + ")";
 const std::string SparqlLexer::SYMBOL =
-    "([\\.\\{\\}\\(\\)\\=\\*,;:<>!\\|/\\^\\?\\*\\+])";
+    "([\\.\\{\\}\\(\\)\\=\\*,;:<>!\\|/\\^\\?\\*\\+-])";
 
 const std::string SparqlLexer::STRING_LITERAL =
     "(('([^\\x27\\x5C\\x0A\\x0D]|(" + ECHAR +


### PR DESCRIPTION
Now allows the four basic arithmetic binary operations:  + - * /

TODO 1: Since the - is not recognized by a SYMBOL, the minus is currently
realized via | (like a minus but vertical). I hope that Johannes finds a
better way.

I tried it out on a few example queries and it worked.

TODO 2: If one of the two operands is a constant -- from a previous BIND,
like in BIND(100 AS ?hundred) BIND(100 * ?x AS ?y) -- the operations don't
work as expected and I am not sure why. Maybe Johannes can help.