### PR TITLE
Introduce a Strong Type for Sparql Variables

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -13,7 +13,7 @@ queries:
     checks:
       - num_cols: 3
       - num_rows: 1653
-      - selected: ["?x", "SCORE(?t)", "?t"]
+      - selected: ["?x", "?:qlever-text-score-?t", "?t"]
       - contains_row:
         - "<Albert_Einstein>"
         - 169
@@ -22,7 +22,7 @@ queries:
           he published a paper on general relativity."
       - contains_row: ["<Albert_Einstein>", null, null] # null cells are ignored
       - contains_row: ["<Luís_Lindley_Cintra>", null, null] # Test Unicode
-      - order_numeric: {"dir" : "DESC", "var": "SCORE(?t)"}
+      - order_numeric: {"dir" : "DESC", "var": "?:qlever-text-score-?t"}
   - query: relativ-star-scientists-from-ulm  # should use TextOperationWithFilter
     type: text
     sparql: |
@@ -36,7 +36,7 @@ queries:
     checks:
       - num_cols: 3
       - num_rows: 1
-      - selected: ["?x", "SCORE(?t)", "?t"]
+      - selected: ["?x", "?:qlever-text-score-?t", "?t"]
       - contains_row:
         - "<Albert_Einstein>"
         - 169
@@ -56,9 +56,9 @@ queries:
     checks:
       - num_cols: 2
       - num_rows: 11
-      - selected: ["?x", "SCORE(?t)"]
+      - selected: ["?x", "?:qlever-text-score-?t"]
       - contains_row: ["<Grete_Hermann>"]
-      - order_numeric: {"dir": "DESC", "var" : "SCORE(?t)"}
+      - order_numeric: {"dir": "DESC", "var" : "?:qlever-text-score-?t"}
   - query: algor-start-female-born-before-1940
     type: text
     sparql: |

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -13,7 +13,7 @@ queries:
     checks:
       - num_cols: 3
       - num_rows: 1653
-      - selected: ["?x", "SCORE(?t)", "TEXT(?t)"]
+      - selected: ["?x", "SCORE(?t)", "?t"]
       - contains_row:
         - "<Albert_Einstein>"
         - 169
@@ -36,7 +36,7 @@ queries:
     checks:
       - num_cols: 3
       - num_rows: 1
-      - selected: ["?x", "SCORE(?t)", "TEXT(?t)"]
+      - selected: ["?x", "SCORE(?t)", "?t"]
       - contains_row:
         - "<Albert_Einstein>"
         - 169

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -78,7 +78,7 @@ string Bind::asString(size_t indent) const {
   os << "BIND (" << _bind.operationName() << ") on";
 
   // non-variable entries are added directly
-  for (const auto& ptr: strings) {
+  for (const auto& ptr : strings) {
     os << *ptr << ' ';
   }
 
@@ -88,9 +88,9 @@ string Bind::asString(size_t indent) const {
     // variables are converted to the corresponding column index, to create the
     // same cache key for same query with changed variable names.
     if (!m.contains(s)) {
-      AD_THROW(
-          ad_semsearch::Exception::BAD_INPUT,
-          "Variable"s + s.asString() + " could not be mapped to column of BIND input");
+      AD_THROW(ad_semsearch::Exception::BAD_INPUT,
+               "Variable"s + s.asString() +
+                   " could not be mapped to column of BIND input");
     }
     os << "(col " << m[s] << ") ";
   }

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -25,11 +25,12 @@ class Bind : public Operation {
   size_t getSizeEstimate() override;
   float getMultiplicity(size_t col) override;
   bool knownEmptyResult() override;
-  [[nodiscard]] VariableColumnMap getVariableColumns()
-      const override;
+  [[nodiscard]] VariableColumnMap getVariableColumns() const override;
 
   // Returns the variable to which the expression will be bound
-  [[nodiscard]] const SparqlVariable& targetVariable() const { return _bind._target; }
+  [[nodiscard]] const SparqlVariable& targetVariable() const {
+    return _bind._target;
+  }
 
  protected:
   [[nodiscard]] vector<size_t> resultSortedOn() const override;

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -25,11 +25,11 @@ class Bind : public Operation {
   size_t getSizeEstimate() override;
   float getMultiplicity(size_t col) override;
   bool knownEmptyResult() override;
-  [[nodiscard]] ad_utility::HashMap<string, size_t> getVariableColumns()
+  [[nodiscard]] VariableColumnMap getVariableColumns()
       const override;
 
   // Returns the variable to which the expression will be bound
-  [[nodiscard]] const string& targetVariable() const { return _bind._target; }
+  [[nodiscard]] const SparqlVariable& targetVariable() const { return _bind._target; }
 
  protected:
   [[nodiscard]] vector<size_t> resultSortedOn() const override;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -11,8 +11,8 @@ CountAvailablePredicates::CountAvailablePredicates(QueryExecutionContext* qec)
       _subtree(nullptr),
       _subjectColumnIndex(0),
       _subjectEntityName(),
-      _predicateVarName("predicate"),
-      _countVarName("count") {}
+      _predicateVarName("?:qlever-patterntrick-default-predicate"),
+      _countVarName("?:qlever-patterntrick-default-count") {}
 
 // _____________________________________________________________________________
 CountAvailablePredicates::CountAvailablePredicates(
@@ -22,8 +22,8 @@ CountAvailablePredicates::CountAvailablePredicates(
       _subtree(subtree),
       _subjectColumnIndex(subjectColumnIndex),
       _subjectEntityName(),
-      _predicateVarName("predicate"),
-      _countVarName("count") {}
+      _predicateVarName("?:qlever-patterntrick-default-predicate"),
+      _countVarName("?:qlever-patterntrick-default-count") {}
 
 CountAvailablePredicates::CountAvailablePredicates(QueryExecutionContext* qec,
                                                    std::string entityName)
@@ -31,8 +31,8 @@ CountAvailablePredicates::CountAvailablePredicates(QueryExecutionContext* qec,
       _subtree(nullptr),
       _subjectColumnIndex(0),
       _subjectEntityName(entityName),
-      _predicateVarName("predicate"),
-      _countVarName("count") {}
+      _predicateVarName("?:qlever-patterntrick-default-predicate"),
+      _countVarName("?:qlever-patterntrick-default-count") {}
 
 // _____________________________________________________________________________
 string CountAvailablePredicates::asString(size_t indent) const {

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -71,16 +71,16 @@ vector<size_t> CountAvailablePredicates::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-void CountAvailablePredicates::setVarNames(const std::string& predicateVarName,
-                                           const std::string& countVarName) {
+void CountAvailablePredicates::setVarNames(const SparqlVariable& predicateVarName,
+                                           const SparqlVariable& countVarName) {
   _predicateVarName = predicateVarName;
   _countVarName = countVarName;
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t>
+Operation::VariableColumnMap
 CountAvailablePredicates::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> varCols;
+  VariableColumnMap varCols;
   varCols[_predicateVarName] = 0;
   varCols[_countVarName] = 1;
   return varCols;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -71,15 +71,16 @@ vector<size_t> CountAvailablePredicates::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-void CountAvailablePredicates::setVarNames(const SparqlVariable& predicateVarName,
-                                           const SparqlVariable& countVarName) {
+void CountAvailablePredicates::setVarNames(
+    const SparqlVariable& predicateVarName,
+    const SparqlVariable& countVarName) {
   _predicateVarName = predicateVarName;
   _countVarName = countVarName;
 }
 
 // _____________________________________________________________________________
-Operation::VariableColumnMap
-CountAvailablePredicates::getVariableColumns() const {
+Operation::VariableColumnMap CountAvailablePredicates::getVariableColumns()
+    const {
   VariableColumnMap varCols;
   varCols[_predicateVarName] = 0;
   varCols[_countVarName] = 1;

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -60,7 +60,7 @@ class CountAvailablePredicates : public Operation {
     return _subtree != nullptr ? R{_subtree.get()} : R{};
   }
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override {
     if (_subtree != nullptr) {
@@ -81,8 +81,8 @@ class CountAvailablePredicates : public Operation {
 
   virtual size_t getCostEstimate() override;
 
-  void setVarNames(const std::string& predicateVarName,
-                   const std::string& countVarName);
+  void setVarNames(const SparqlVariable& predicateVarName,
+                   const SparqlVariable& countVarName);
 
   // This method is declared here solely for unit testing purposes
   /**
@@ -115,8 +115,8 @@ class CountAvailablePredicates : public Operation {
   size_t _subjectColumnIndex;
   // This can be used to aquire the predicates for a single entity
   std::optional<std::string> _subjectEntityName;
-  std::string _predicateVarName;
-  std::string _countVarName;
+  SparqlVariable _predicateVarName;
+  SparqlVariable _countVarName;
 
   virtual void computeResult(ResultTable* result) override;
 };

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -32,7 +32,7 @@ string Distinct::asString(size_t indent) const {
 string Distinct::getDescriptor() const { return "Distinct"; }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> Distinct::getVariableColumns() const {
+Operation::VariableColumnMap Distinct::getVariableColumns() const {
   return _subtree->getVariableColumns();
 }
 

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -51,7 +51,7 @@ class Distinct : public Operation {
 
   bool knownEmptyResult() override { return _subtree->knownEmptyResult(); }
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   vector<QueryExecutionTree*> getChildren() override {
     return {_subtree.get()};

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -19,7 +19,8 @@ size_t Filter::getResultWidth() const { return _subtree->getResultWidth(); }
 Filter::Filter(QueryExecutionContext* qec,
                std::shared_ptr<QueryExecutionTree> subtree,
                SparqlFilter::FilterType type, SparqlVariable lhs, string rhs,
-               vector<SparqlVariable> additionalLhs, vector<string> additionalPrefixes)
+               vector<SparqlVariable> additionalLhs,
+               vector<string> additionalPrefixes)
     : Operation(qec),
       _subtree(std::move(subtree)),
       _type(type),
@@ -81,7 +82,8 @@ string Filter::asString(size_t indent) const {
   }
   os << _rhs;
   for (size_t i = 0; i < _additionalLhs.size(); ++i) {
-    os << " || " << _additionalLhs[i].asString() << " " << _additionalPrefixRegexes[i];
+    os << " || " << _additionalLhs[i].asString() << " "
+       << _additionalPrefixRegexes[i];
   }
   os << '\n';
   return os.str();
@@ -125,7 +127,8 @@ string Filter::getDescriptor() const {
   }
   os << _rhs;
   for (size_t i = 0; i < _additionalLhs.size(); ++i) {
-    os << " || " << _additionalLhs[i].asString() << " " << _additionalPrefixRegexes[i];
+    os << " || " << _additionalLhs[i].asString() << " "
+       << _additionalPrefixRegexes[i];
   }
   return os.str();
 }

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -21,8 +21,8 @@ class Filter : public Operation {
  public:
   Filter(QueryExecutionContext* qec,
          std::shared_ptr<QueryExecutionTree> subtree,
-         SparqlFilter::FilterType type, string lhs, string rhs,
-         vector<string> additionalLhs, vector<string> additionalPrefixes);
+         SparqlFilter::FilterType type, SparqlVariable lhs, string rhs,
+         vector<SparqlVariable> additionalLhs, vector<string> additionalPrefixes);
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -104,7 +104,7 @@ class Filter : public Operation {
     return _subtree->getMultiplicity(col);
   }
 
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns()
+  virtual VariableColumnMap getVariableColumns()
       const override {
     return _subtree->getVariableColumns();
   }
@@ -112,17 +112,17 @@ class Filter : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   SparqlFilter::FilterType _type;
-  string _lhs;
+  SparqlVariable _lhs;
   string _rhs;
 
-  std::vector<string> _additionalLhs;
+  std::vector<SparqlVariable> _additionalLhs;
   std::vector<string> _additionalPrefixRegexes;
   bool _regexIgnoreCase;
   bool _lhsAsString;
 
   [[nodiscard]] bool isLhsSorted() const {
     const auto& subresSortedOn = _subtree->resultSortedOn();
-    size_t lhsInd = _subtree->getVariableColumn(_lhs);
+    size_t lhsInd = _subtree->getVariableColumn(SparqlVariable{_lhs});
     return !subresSortedOn.empty() && subresSortedOn[0] == lhsInd;
   }
   /**

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -22,7 +22,8 @@ class Filter : public Operation {
   Filter(QueryExecutionContext* qec,
          std::shared_ptr<QueryExecutionTree> subtree,
          SparqlFilter::FilterType type, SparqlVariable lhs, string rhs,
-         vector<SparqlVariable> additionalLhs, vector<string> additionalPrefixes);
+         vector<SparqlVariable> additionalLhs,
+         vector<string> additionalPrefixes);
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -104,8 +105,7 @@ class Filter : public Operation {
     return _subtree->getMultiplicity(col);
   }
 
-  virtual VariableColumnMap getVariableColumns()
-      const override {
+  virtual VariableColumnMap getVariableColumns() const override {
     return _subtree->getVariableColumns();
   }
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -23,14 +23,15 @@ GroupBy::GroupBy(QueryExecutionContext* qec,
   }
   std::sort(_aliases.begin(), _aliases.end(),
             [](const ParsedQuery::Alias& a1, const ParsedQuery::Alias& a2) {
-              return a1._outVarName.variableName() < a2._outVarName.variableName();
+              return a1._outVarName.variableName() <
+                     a2._outVarName.variableName();
             });
 
   // sort the groupByVariables to ensure the cache key is order invariant
   std::sort(_groupByVariables.begin(), _groupByVariables.end(),
             [](const auto& a1, const auto& a2) {
-              return a1.variableName() < a2.variableName();}
-            );
+              return a1.variableName() < a2.variableName();
+            });
 
   // The returned columns are all groupByVariables followed by aggregrates
   size_t colIndex = 0;
@@ -75,7 +76,7 @@ string GroupBy::asString(size_t indent) const {
 
 string GroupBy::getDescriptor() const {
   std::vector<string> groupVariableNames;
-  for (const auto& var: _groupByVariables) {
+  for (const auto& var : _groupByVariables) {
     groupVariableNames.push_back(var.variableName());
   }
   return "GroupBy on " + ad_utility::join(groupVariableNames, ' ');
@@ -101,8 +102,7 @@ vector<pair<size_t, bool>> GroupBy::computeSortColumns(
     return cols;
   }
 
-  auto inVarColMap =
-      inputTree->getVariableColumns();
+  auto inVarColMap = inputTree->getVariableColumns();
 
   std::unordered_set<size_t> sortColSet;
 
@@ -701,13 +701,12 @@ void GroupBy::computeResult(ResultTable* result) {
   aggregates.reserve(_aliases.size() + _groupByVariables.size());
 
   // parse the group by columns
-  auto subtreeVarCols =
-      _subtree->getVariableColumns();
+  auto subtreeVarCols = _subtree->getVariableColumns();
   for (const auto& var : _groupByVariables) {
     auto it = subtreeVarCols.find(var);
     if (it == subtreeVarCols.end()) {
-      LOG(WARN) << "Group by variable " << var.variableName() << " is not groupable."
-                << std::endl;
+      LOG(WARN) << "Group by variable " << var.variableName()
+                << " is not groupable." << std::endl;
       AD_THROW(ad_semsearch::Exception::BAD_QUERY,
                "Groupby variable " + var.variableName() + " is not groupable");
     }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -42,7 +42,7 @@ class GroupBy : public Operation {
    * @param groupByVariables
    * @param aliases
    */
-  GroupBy(QueryExecutionContext* qec, const vector<string>& groupByVariables,
+  GroupBy(QueryExecutionContext* qec, const vector<SparqlVariable>& groupByVariables,
           const std::vector<ParsedQuery::Alias>& aliases);
 
   virtual string asString(size_t indent = 0) const override;
@@ -93,7 +93,7 @@ class GroupBy : public Operation {
 
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
-  vector<string> _groupByVariables;
+  vector<SparqlVariable> _groupByVariables;
   std::vector<ParsedQuery::Alias> _aliases;
   ad_utility::HashMap<string, size_t> _varColMap;
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -42,7 +42,8 @@ class GroupBy : public Operation {
    * @param groupByVariables
    * @param aliases
    */
-  GroupBy(QueryExecutionContext* qec, const vector<SparqlVariable>& groupByVariables,
+  GroupBy(QueryExecutionContext* qec,
+          const vector<SparqlVariable>& groupByVariables,
           const std::vector<ParsedQuery::Alias>& aliases);
 
   virtual string asString(size_t indent = 0) const override;

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -53,7 +53,7 @@ class GroupBy : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _subtree->setTextLimit(limit);
@@ -95,7 +95,7 @@ class GroupBy : public Operation {
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<SparqlVariable> _groupByVariables;
   std::vector<ParsedQuery::Alias> _aliases;
-  ad_utility::HashMap<string, size_t> _varColMap;
+  VariableColumnMap _varColMap;
 
   virtual void computeResult(ResultTable* result) override;
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -86,23 +86,23 @@ vector<size_t> HasPredicateScan::resultSortedOn() const {
   return {};
 }
 
-ad_utility::HashMap<string, size_t> HasPredicateScan::getVariableColumns()
+Operation::VariableColumnMap HasPredicateScan::getVariableColumns()
     const {
-  ad_utility::HashMap<string, size_t> varCols;
+  VariableColumnMap varCols;
   switch (_type) {
     case ScanType::FREE_S:
-      varCols.insert(std::make_pair(_subject, 0));
+      varCols.insert(std::make_pair(SparqlVariable{_subject}, 0));
       break;
     case ScanType::FREE_O:
-      varCols.insert(std::make_pair(_object, 0));
+      varCols.insert(std::make_pair(SparqlVariable{_object}, 0));
       break;
     case ScanType::FULL_SCAN:
-      varCols.insert(std::make_pair(_subject, 0));
-      varCols.insert(std::make_pair(_object, 1));
+      varCols.insert(std::make_pair(SparqlVariable{_subject}, 0));
+      varCols.insert(std::make_pair(SparqlVariable{_object}, 1));
       break;
     case ScanType::SUBQUERY_S:
       varCols = _subtree->getVariableColumns();
-      varCols.insert(std::make_pair(_object, getResultWidth() - 1));
+      varCols.insert(std::make_pair(SparqlVariable{_object}, getResultWidth() - 1));
       break;
   }
   return varCols;

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -86,8 +86,7 @@ vector<size_t> HasPredicateScan::resultSortedOn() const {
   return {};
 }
 
-Operation::VariableColumnMap HasPredicateScan::getVariableColumns()
-    const {
+Operation::VariableColumnMap HasPredicateScan::getVariableColumns() const {
   VariableColumnMap varCols;
   switch (_type) {
     case ScanType::FREE_S:
@@ -102,7 +101,8 @@ Operation::VariableColumnMap HasPredicateScan::getVariableColumns()
       break;
     case ScanType::SUBQUERY_S:
       varCols = _subtree->getVariableColumns();
-      varCols.insert(std::make_pair(SparqlVariable{_object}, getResultWidth() - 1));
+      varCols.insert(
+          std::make_pair(SparqlVariable{_object}, getResultWidth() - 1));
       break;
   }
   return varCols;

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -36,7 +36,7 @@ class HasPredicateScan : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  [[nodiscard]] VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override;
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -125,94 +125,94 @@ vector<size_t> IndexScan::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> IndexScan::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> res;
+IndexScan::VariableColumnMap IndexScan::getVariableColumns() const {
+  VariableColumnMap res;
   size_t col = 0;
 
   switch (_type) {
     case SPO_FREE_P:
     case FULL_INDEX_SCAN_SPO:
       if (_subject[0] == '?') {
-        res[_subject] = col++;
+        res[SparqlVariable{_subject}] = col++;
       }
       if (_predicate[0] == '?') {
-        res[_predicate] = col++;
+        res[SparqlVariable{_predicate}] = col++;
       }
 
       if (_object[0] == '?') {
-        res[_object] = col++;
+        res[SparqlVariable{_object}] = col++;
       }
       return res;
     case SOP_FREE_O:
     case SOP_BOUND_O:
     case FULL_INDEX_SCAN_SOP:
       if (_subject[0] == '?') {
-        res[_subject] = col++;
+        res[SparqlVariable{_subject}] = col++;
       }
 
       if (_object[0] == '?') {
-        res[_object] = col++;
+        res[SparqlVariable{_object}] = col++;
       }
 
       if (_predicate[0] == '?') {
-        res[_predicate] = col++;
+        res[SparqlVariable{_predicate}] = col++;
       }
       return res;
     case PSO_BOUND_S:
     case PSO_FREE_S:
     case FULL_INDEX_SCAN_PSO:
       if (_predicate[0] == '?') {
-        res[_predicate] = col++;
+        res[SparqlVariable{_predicate}] = col++;
       }
       if (_subject[0] == '?') {
-        res[_subject] = col++;
+        res[SparqlVariable{_subject}] = col++;
       }
 
       if (_object[0] == '?') {
-        res[_object] = col++;
+        res[SparqlVariable{_object}] = col++;
       }
       return res;
     case POS_BOUND_O:
     case POS_FREE_O:
     case FULL_INDEX_SCAN_POS:
       if (_predicate[0] == '?') {
-        res[_predicate] = col++;
+        res[SparqlVariable{_predicate}] = col++;
       }
 
       if (_object[0] == '?') {
-        res[_object] = col++;
+        res[SparqlVariable{_object}] = col++;
       }
 
       if (_subject[0] == '?') {
-        res[_subject] = col++;
+        res[SparqlVariable{_subject}] = col++;
       }
       return res;
     case OPS_FREE_P:
     case FULL_INDEX_SCAN_OPS:
       if (_object[0] == '?') {
-        res[_object] = col++;
+        res[SparqlVariable{_object}] = col++;
       }
 
       if (_predicate[0] == '?') {
-        res[_predicate] = col++;
+        res[SparqlVariable{_predicate}] = col++;
       }
 
       if (_subject[0] == '?') {
-        res[_subject] = col++;
+        res[SparqlVariable{_subject}] = col++;
       }
       return res;
     case OSP_FREE_S:
     case FULL_INDEX_SCAN_OSP:
       if (_object[0] == '?') {
-        res[_object] = col++;
+        res[SparqlVariable{_object}] = col++;
       }
 
       if (_subject[0] == '?') {
-        res[_subject] = col++;
+        res[SparqlVariable{_subject}] = col++;
       }
 
       if (_predicate[0] == '?') {
-        res[_predicate] = col++;
+        res[SparqlVariable{_predicate}] = col++;
       }
       return res;
     default:

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -84,8 +84,7 @@ class IndexScan : public Operation {
 
   virtual bool knownEmptyResult() override { return getSizeEstimate() == 0; }
 
-  virtual VariableColumnMap getVariableColumns()
-      const override;
+  virtual VariableColumnMap getVariableColumns() const override;
 
   ScanType getType() const { return _type; }
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -84,7 +84,7 @@ class IndexScan : public Operation {
 
   virtual bool knownEmptyResult() override { return getSizeEstimate() == 0; }
 
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns()
+  virtual VariableColumnMap getVariableColumns()
       const override;
 
   ScanType getType() const { return _type; }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -54,7 +54,7 @@ string Join::getDescriptor() const {
   std::string joinVar = "";
   for (auto p : _left->getVariableColumns()) {
     if (p.second == _leftJoinCol) {
-      joinVar = p.first;
+      joinVar = p.first.asString();
       break;
     }
   }
@@ -134,8 +134,8 @@ void Join::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> Join::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> retVal;
+Join::VariableColumnMap Join::getVariableColumns() const {
+  VariableColumnMap retVal;
   if (!isFullScanDummy(_left) && !isFullScanDummy(_right)) {
     retVal = _left->getVariableColumns();
     size_t leftSize = _left->getResultWidth();

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -194,7 +194,7 @@ vector<size_t> Join::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-std::unordered_set<string> Join::getContextVars() const {
+std::unordered_set<SparqlVariable> Join::getContextVars() const {
   auto cvars = _left->getContextVars();
   cvars.insert(_right->getContextVars().begin(),
                _right->getContextVars().end());

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -33,7 +33,7 @@ class Join : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   std::unordered_set<string> getContextVars() const;
 

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -35,7 +35,7 @@ class Join : public Operation {
 
   VariableColumnMap getVariableColumns() const override;
 
-  std::unordered_set<string> getContextVars() const;
+  std::unordered_set<SparqlVariable> getContextVars() const;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -75,7 +75,7 @@ void Minus::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> Minus::getVariableColumns() const {
+Operation::VariableColumnMap Minus::getVariableColumns() const {
   return _left->getVariableColumns();
 }
 

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -29,7 +29,7 @@ class Minus : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -62,7 +62,7 @@ string MultiColumnJoin::getDescriptor() const {
       // If the left join column matches the index of a variable in the left
       // subresult.
       if (jc[0] == p.second) {
-        joinVars += p.first + " ";
+        joinVars += p.first.asString() + " ";
       }
     }
   }
@@ -119,9 +119,9 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> MultiColumnJoin::getVariableColumns()
+Operation::VariableColumnMap MultiColumnJoin::getVariableColumns()
     const {
-  ad_utility::HashMap<string, size_t> retVal(_left->getVariableColumns());
+  VariableColumnMap retVal(_left->getVariableColumns());
   size_t columnIndex = retVal.size();
   for (const auto& it : _right->getVariableColumns()) {
     bool isJoinColumn = false;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -119,8 +119,7 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-Operation::VariableColumnMap MultiColumnJoin::getVariableColumns()
-    const {
+Operation::VariableColumnMap MultiColumnJoin::getVariableColumns() const {
   VariableColumnMap retVal(_left->getVariableColumns());
   size_t columnIndex = retVal.size();
   for (const auto& it : _right->getVariableColumns()) {

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -24,7 +24,7 @@ class MultiColumnJoin : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -8,13 +8,13 @@
 #include <memory>
 #include <utility>
 
+#include "../parser/ParsedQuery.h"
 #include "../util/Exception.h"
 #include "../util/Log.h"
 #include "../util/Timer.h"
 #include "QueryExecutionContext.h"
 #include "ResultTable.h"
 #include "RuntimeInformation.h"
-#include "../parser/ParsedQuery.h"
 
 using std::endl;
 using std::pair;

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -14,6 +14,7 @@
 #include "QueryExecutionContext.h"
 #include "ResultTable.h"
 #include "RuntimeInformation.h"
+#include "../parser/ParsedQuery.h"
 
 using std::endl;
 using std::pair;
@@ -80,7 +81,9 @@ class Operation {
   virtual size_t getSizeEstimate() = 0;
   virtual float getMultiplicity(size_t col) = 0;
   virtual bool knownEmptyResult() = 0;
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns() const = 0;
+
+  using VariableColumnMap = ad_utility::HashMap<SparqlVariable, size_t>;
+  virtual VariableColumnMap getVariableColumns() const = 0;
 
   RuntimeInformation& getRuntimeInfo() { return _runtimeInfo; }
 

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -65,7 +65,7 @@ string OptionalJoin::getDescriptor() const {
       // If the left join column matches the index of a variable in the left
       // subresult.
       if (jc[0] == p.second) {
-        joinVars += p.first + " ";
+        joinVars += p.first.asString() + " ";
       }
     }
   }
@@ -124,8 +124,8 @@ void OptionalJoin::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> OptionalJoin::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> retVal(_left->getVariableColumns());
+Operation::VariableColumnMap OptionalJoin::getVariableColumns() const {
+  VariableColumnMap retVal(_left->getVariableColumns());
   size_t leftSize = _left->getResultWidth();
   for (auto it = _right->getVariableColumns().begin();
        it != _right->getVariableColumns().end(); ++it) {

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -26,7 +26,7 @@ class OptionalJoin : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -48,9 +48,9 @@ string OrderBy::getDescriptor() const {
     for (auto oc : _sortIndices) {
       if (oc.first == p.second) {
         if (oc.second) {
-          orderByVars += "DESC(" + p.first + ") ";
+          orderByVars += "DESC(" + p.first.asString() + ") ";
         } else {
-          orderByVars += "ASC(" + p.first + ") ";
+          orderByVars += "ASC(" + p.first.asString() + ") ";
         }
       }
     }

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -56,7 +56,7 @@ class OrderBy : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns()
+  virtual VariableColumnMap getVariableColumns()
       const override {
     return _subtree->getVariableColumns();
   }

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -56,8 +56,7 @@ class OrderBy : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual VariableColumnMap getVariableColumns()
-      const override {
+  virtual VariableColumnMap getVariableColumns() const override {
     return _subtree->getVariableColumns();
   }
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -85,19 +85,15 @@ void QueryExecutionTree::setVariableColumns(
 }
 
 // _____________________________________________________________________________
-void QueryExecutionTree::writeResultToStream(std::ostream& out,
-                                             const vector<string>& selectVars,
+void QueryExecutionTree::writeResultToStream(std::ostream& out, const vector<SparqlVariable>& selectVars,
                                              size_t limit, size_t offset,
                                              char sep) const {
   // They may trigger computation (but does not have to).
   shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
   vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices;
-  for (auto var : selectVars) {
-    if (ad_utility::startsWith(var, "TEXT(")) {
-      var = var.substr(5, var.rfind(')') - 5);
-    }
-    auto it = getVariableColumns().find(var);
+  for (const auto& var : selectVars) {
+    auto it = getVariableColumns().find(var.variableName());
     if (it != getVariableColumns().end()) {
       validIndices.push_back(pair<size_t, ResultTable::ResultType>(
           it->second, res->getResultType(it->second)));
@@ -118,16 +114,13 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out,
 
 // _____________________________________________________________________________
 nlohmann::json QueryExecutionTree::writeResultAsJson(
-    const vector<string>& selectVars, size_t limit, size_t offset) const {
+    const vector<SparqlVariable>& selectVars, size_t limit, size_t offset) const {
   // They may trigger computation (but does not have to).
   shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
   vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices;
-  for (auto var : selectVars) {
-    if (ad_utility::startsWith(var, "TEXT(")) {
-      var = var.substr(5, var.rfind(')') - 5);
-    }
-    auto vc = getVariableColumns().find(var);
+  for (const auto& var : selectVars) {
+    auto vc = getVariableColumns().find(var.variableName());
     if (vc != getVariableColumns().end()) {
       validIndices.push_back(pair<size_t, ResultTable::ResultType>(
           vc->second, res->getResultType(vc->second)));

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -64,23 +64,23 @@ void QueryExecutionTree::setOperation(QueryExecutionTree::OperationType type,
 }
 
 // _____________________________________________________________________________
-void QueryExecutionTree::setVariableColumn(const string& variable,
+void QueryExecutionTree::setVariableColumn(const SparqlVariable& variable,
                                            size_t column) {
   _variableColumnMap[variable] = column;
 }
 
 // _____________________________________________________________________________
-size_t QueryExecutionTree::getVariableColumn(const string& variable) const {
+size_t QueryExecutionTree::getVariableColumn(const SparqlVariable& variable) const {
   if (_variableColumnMap.count(variable) == 0) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-             "Variable could not be mapped to result column. Var: " + variable);
+             "Variable could not be mapped to result column. Var: " + variable.asString());
   }
   return _variableColumnMap.find(variable)->second;
 }
 
 // _____________________________________________________________________________
 void QueryExecutionTree::setVariableColumns(
-    ad_utility::HashMap<string, size_t> const& map) {
+    const VariableColumnMap & map) {
   _variableColumnMap = map;
 }
 
@@ -93,7 +93,7 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out, const vector<Spa
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
   vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices;
   for (const auto& var : selectVars) {
-    auto it = getVariableColumns().find(var.variableName());
+    auto it = getVariableColumns().find(var);
     if (it != getVariableColumns().end()) {
       validIndices.push_back(pair<size_t, ResultTable::ResultType>(
           it->second, res->getResultType(it->second)));
@@ -120,7 +120,7 @@ nlohmann::json QueryExecutionTree::writeResultAsJson(
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
   vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices;
   for (const auto& var : selectVars) {
-    auto vc = getVariableColumns().find(var.variableName());
+    auto vc = getVariableColumns().find(var);
     if (vc != getVariableColumns().end()) {
       validIndices.push_back(pair<size_t, ResultTable::ResultType>(
           vc->second, res->getResultType(vc->second)));
@@ -173,8 +173,8 @@ bool QueryExecutionTree::knownEmptyResult() {
 }
 
 // _____________________________________________________________________________
-bool QueryExecutionTree::varCovered(string var) const {
-  return _variableColumnMap.count(var) > 0;
+bool QueryExecutionTree::varCovered(const SparqlVariable& var) const {
+  return _variableColumnMap.contains(var);
 }
 
 // _______________________________________________________________________

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -70,24 +70,25 @@ void QueryExecutionTree::setVariableColumn(const SparqlVariable& variable,
 }
 
 // _____________________________________________________________________________
-size_t QueryExecutionTree::getVariableColumn(const SparqlVariable& variable) const {
+size_t QueryExecutionTree::getVariableColumn(
+    const SparqlVariable& variable) const {
   if (_variableColumnMap.count(variable) == 0) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-             "Variable could not be mapped to result column. Var: " + variable.asString());
+             "Variable could not be mapped to result column. Var: " +
+                 variable.asString());
   }
   return _variableColumnMap.find(variable)->second;
 }
 
 // _____________________________________________________________________________
-void QueryExecutionTree::setVariableColumns(
-    const VariableColumnMap & map) {
+void QueryExecutionTree::setVariableColumns(const VariableColumnMap& map) {
   _variableColumnMap = map;
 }
 
 // _____________________________________________________________________________
-void QueryExecutionTree::writeResultToStream(std::ostream& out, const vector<SparqlVariable>& selectVars,
-                                             size_t limit, size_t offset,
-                                             char sep) const {
+void QueryExecutionTree::writeResultToStream(
+    std::ostream& out, const vector<SparqlVariable>& selectVars, size_t limit,
+    size_t offset, char sep) const {
   // They may trigger computation (but does not have to).
   shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
@@ -114,7 +115,8 @@ void QueryExecutionTree::writeResultToStream(std::ostream& out, const vector<Spa
 
 // _____________________________________________________________________________
 nlohmann::json QueryExecutionTree::writeResultAsJson(
-    const vector<SparqlVariable>& selectVars, size_t limit, size_t offset) const {
+    const vector<SparqlVariable>& selectVars, size_t limit,
+    size_t offset) const {
   // They may trigger computation (but does not have to).
   shared_ptr<const ResultTable> res = getResult();
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -8,11 +8,11 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include "../parser/ParsedQuery.h"
 #include "../util/Conversions.h"
 #include "../util/HashSet.h"
 #include "./Operation.h"
 #include "./QueryExecutionContext.h"
-#include "../parser/ParsedQuery.h"
 
 using std::shared_ptr;
 using std::string;
@@ -72,13 +72,13 @@ class QueryExecutionTree {
 
   size_t getVariableColumn(const SparqlVariable& var) const;
 
-  void setVariableColumns(const VariableColumnMap & map);
+  void setVariableColumns(const VariableColumnMap& map);
 
-  void setContextVars(const std::unordered_set<string>& set) {
+  void setContextVars(const std::unordered_set<SparqlVariable>& set) {
     _contextVars = set;
   }
 
-  const std::unordered_set<string>& getContextVars() const {
+  const std::unordered_set<SparqlVariable>& getContextVars() const {
     return _contextVars;
   }
 
@@ -100,11 +100,11 @@ class QueryExecutionTree {
     return _rootOperation->getResultSortedOn();
   }
 
-  bool isContextvar(const string& var) const {
+  bool isContextvar(const SparqlVariable& var) const {
     return _contextVars.count(var) > 0;
   }
 
-  void addContextVar(const string& var) { _contextVars.insert(var); }
+  void addContextVar(const SparqlVariable& var) { _contextVars.insert(var); }
 
   void setTextLimit(size_t limit) {
     _rootOperation->setTextLimit(limit);
@@ -174,14 +174,13 @@ class QueryExecutionTree {
   bool& isRoot() noexcept { return _isRoot; }
   [[nodiscard]] const bool& isRoot() const noexcept { return _isRoot; }
 
-
  private:
   QueryExecutionContext* _qec;  // No ownership
   VariableColumnMap _variableColumnMap;
   std::shared_ptr<Operation>
       _rootOperation;  // Owned child. Will be deleted at deconstruction.
   OperationType _type;
-  std::unordered_set<string> _contextVars;
+  std::unordered_set<SparqlVariable> _contextVars;
   string _asString;
   size_t _indent = 0;  // the indent with which the _asString repr was formatted
   size_t _sizeEstimate;

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -12,6 +12,7 @@
 #include "../util/HashSet.h"
 #include "./Operation.h"
 #include "./QueryExecutionContext.h"
+#include "../parser/ParsedQuery.h"
 
 using std::shared_ptr;
 using std::string;
@@ -85,11 +86,12 @@ class QueryExecutionTree {
     return _rootOperation->getResult(isRoot());
   }
 
-  void writeResultToStream(std::ostream& out, const vector<string>& selectVars,
+  void writeResultToStream(std::ostream& out,
+                           const vector<SparqlVariable>& selectVars,
                            size_t limit = MAX_NOF_ROWS_IN_RESULT,
                            size_t offset = 0, char sep = '\t') const;
 
-  nlohmann::json writeResultAsJson(const vector<string>& selectVars,
+  nlohmann::json writeResultAsJson(const vector<SparqlVariable>& selectVars,
                                    size_t limit, size_t offset) const;
 
   const std::vector<size_t>& resultSortedOn() const {

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -24,6 +24,8 @@ class QueryExecutionTree {
  public:
   explicit QueryExecutionTree(QueryExecutionContext* const qec);
 
+  using VariableColumnMap = ad_utility::HashMap<SparqlVariable, size_t>;
+
   enum OperationType {
     UNDEFINED = 0,
     SCAN = 1,
@@ -54,7 +56,7 @@ class QueryExecutionTree {
 
   const QueryExecutionContext* getQec() const { return _qec; }
 
-  const ad_utility::HashMap<string, size_t>& getVariableColumns() const {
+  const VariableColumnMap& getVariableColumns() const {
     return _variableColumnMap;
   }
 
@@ -66,11 +68,11 @@ class QueryExecutionTree {
     return _type == OperationType::UNDEFINED || !_rootOperation;
   }
 
-  void setVariableColumn(const string& var, size_t i);
+  void setVariableColumn(const SparqlVariable& var, size_t i);
 
-  size_t getVariableColumn(const string& var) const;
+  size_t getVariableColumn(const SparqlVariable& var) const;
 
-  void setVariableColumns(const ad_utility::HashMap<string, size_t>& map);
+  void setVariableColumns(const VariableColumnMap & map);
 
   void setContextVars(const std::unordered_set<string>& set) {
     _contextVars = set;
@@ -124,7 +126,7 @@ class QueryExecutionTree {
                                _rootOperation->getMultiplicity(col));
   }
 
-  bool varCovered(string var) const;
+  bool varCovered(const SparqlVariable& var) const;
 
   bool knownEmptyResult();
 
@@ -172,9 +174,10 @@ class QueryExecutionTree {
   bool& isRoot() noexcept { return _isRoot; }
   [[nodiscard]] const bool& isRoot() const noexcept { return _isRoot; }
 
+
  private:
   QueryExecutionContext* _qec;  // No ownership
-  ad_utility::HashMap<string, size_t> _variableColumnMap;
+  VariableColumnMap _variableColumnMap;
   std::shared_ptr<Operation>
       _rootOperation;  // Owned child. Will be deleted at deconstruction.
   OperationType _type;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -336,12 +336,14 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           bool leftVar, rightVar;
           if (isVariable(arg._left)) {
             leftVar = true;
-            leftCol = sub._qet->getVariableColumn(SparqlVariable{arg._innerLeft});
+            leftCol =
+                sub._qet->getVariableColumn(SparqlVariable{arg._innerLeft});
             leftColName = SparqlVariable{arg._left};
           } else {
             leftVar = false;
             leftColName = generateUniqueVarName();
-            leftCol = sub._qet->getVariableColumn(SparqlVariable{arg._innerLeft});
+            leftCol =
+                sub._qet->getVariableColumn(SparqlVariable{arg._innerLeft});
             if (!_qec->getIndex().getVocab().getId(arg._left, &leftValue)) {
               AD_THROW(ad_semsearch::Exception::BAD_QUERY,
                        "No vocabulary entry for " + arg._left);
@@ -349,11 +351,13 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           }
           if (isVariable(arg._right)) {
             rightVar = true;
-            rightCol = sub._qet->getVariableColumn(SparqlVariable{arg._innerRight});
+            rightCol =
+                sub._qet->getVariableColumn(SparqlVariable{arg._innerRight});
             rightColName = SparqlVariable{arg._right};
           } else {
             rightVar = false;
-            rightCol = sub._qet->getVariableColumn(SparqlVariable{arg._innerRight});
+            rightCol =
+                sub._qet->getVariableColumn(SparqlVariable{arg._innerRight});
             rightColName = generateUniqueVarName();
             if (!_qec->getIndex().getVocab().getId(arg._right, &rightValue)) {
               AD_THROW(ad_semsearch::Exception::BAD_QUERY,
@@ -487,8 +491,8 @@ bool QueryPlanner::checkUsePatternTrick(
       // Also check that the triples object or subject matches the aliases input
       // variable and the group by variable.
       if (t._p._iri != HAS_PREDICATE_PREDICATE ||
-          (returns_counts &&
-           !(counted_var_name.variableName() == t._o || counted_var_name.variableName() == t._s)) ||
+          (returns_counts && !(counted_var_name.variableName() == t._o ||
+                               counted_var_name.variableName() == t._s)) ||
           pq->_groupByVariables[0].variableName() != t._o) {
         usePatternTrick = false;
         continue;
@@ -669,7 +673,7 @@ bool QueryPlanner::checkUsePatternTrick(
       auto& filters = pq->_rootGraphPattern._filters;
       for (size_t i = 0; i < filters.size(); i++) {
         const SparqlFilter& filter = filters[i];
-        if (filter._lhs == t._o && filter._rhs[0] != '?') {
+        if (filter._lhs.asString() == t._o && filter._rhs[0] != '?') {
           pq->_havingClauses.push_back(filter);
           filters.erase(filters.begin() + i);
           i--;
@@ -885,7 +889,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
       const SubtreePlan& parent = (*previous)[i];
       // Determine the column containing the subjects for which we are
       // interested in their predicates.
-      auto it = parent._qet->getVariableColumns().find(SparqlVariable{patternTrickTriple._s});
+      auto it = parent._qet->getVariableColumns().find(
+          SparqlVariable{patternTrickTriple._s});
       if (it == parent._qet->getVariableColumns().end()) {
         AD_THROW(ad_semsearch::Exception::BAD_QUERY,
                  "The root operation of the "
@@ -916,7 +921,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
       auto countPred = std::make_shared<CountAvailablePredicates>(
           _qec, isSorted ? parent._qet : orderByPlan._qet, subjectColumn);
 
-      countPred->setVarNames(SparqlVariable{patternTrickTriple._o}, pq._aliases[0]._outVarName);
+      countPred->setVarNames(SparqlVariable{patternTrickTriple._o},
+                             pq._aliases[0]._outVarName);
       QueryExecutionTree& tree = *patternTrickPlan._qet;
       tree.setVariableColumns(countPred->getVariableColumns());
       tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
@@ -929,7 +935,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
     auto countPred =
         std::make_shared<CountAvailablePredicates>(_qec, patternTrickTriple._s);
 
-    countPred->setVarNames(SparqlVariable{patternTrickTriple._o}, pq._aliases[0]._outVarName);
+    countPred->setVarNames(SparqlVariable{patternTrickTriple._o},
+                           pq._aliases[0]._outVarName);
     QueryExecutionTree& tree = *patternTrickPlan._qet;
     tree.setVariableColumns(countPred->getVariableColumns());
     tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
@@ -941,9 +948,11 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
     auto countPred = std::make_shared<CountAvailablePredicates>(_qec);
 
     if (pq._aliases.size() > 0) {
-      countPred->setVarNames(SparqlVariable{patternTrickTriple._o}, pq._aliases[0]._outVarName);
+      countPred->setVarNames(SparqlVariable{patternTrickTriple._o},
+                             pq._aliases[0]._outVarName);
     } else {
-      countPred->setVarNames(SparqlVariable{patternTrickTriple._o}, generateUniqueVarName());
+      countPred->setVarNames(SparqlVariable{patternTrickTriple._o},
+                             generateUniqueVarName());
     }
     QueryExecutionTree& tree = *patternTrickPlan._qet;
     tree.setVariableColumns(countPred->getVariableColumns());
@@ -1036,7 +1045,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     plan._idsOfIncludedNodes = previous[i]._idsOfIncludedNodes;
     plan._idsOfIncludedFilters = previous[i]._idsOfIncludedFilters;
     if (pq._orderBy.size() == 1 && !pq._orderBy[0]._desc) {
-      size_t col = previous[i]._qet->getVariableColumn(SparqlVariable{pq._orderBy[0]._key});
+      size_t col = previous[i]._qet->getVariableColumn(
+          SparqlVariable{pq._orderBy[0]._key});
       const std::vector<size_t>& previousSortedOn =
           previous[i]._qet->resultSortedOn();
       if (previousSortedOn.size() > 0 && col == previousSortedOn[0]) {
@@ -1053,7 +1063,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
       vector<pair<size_t, bool>> sortIndices;
       for (auto& ord : pq._orderBy) {
         sortIndices.emplace_back(pair<size_t, bool>{
-            previous[i]._qet->getVariableColumn(SparqlVariable{ord._key}), ord._desc});
+            previous[i]._qet->getVariableColumn(SparqlVariable{ord._key}),
+            ord._desc});
       }
       const std::vector<size_t>& previousSortedOn =
           previous[i]._qet->resultSortedOn();
@@ -1213,8 +1224,9 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scanTree->setVariableColumn(SparqlVariable{node._triple._s}, 0);
             scanTree->setVariableColumn(filterVar, 1);
             auto filter = std::make_shared<Filter>(
-                _qec, scanTree, SparqlFilter::FilterType::EQ, SparqlVariable{node._triple._s},
-                filterVar, vector<string>{}, vector<string>{});
+                _qec, scanTree, SparqlFilter::FilterType::EQ,
+                SparqlVariable{node._triple._s}, filterVar.asString(),
+                vector<SparqlVariable>{}, vector<string>{});
             tree.setOperation(QueryExecutionTree::OperationType::FILTER,
                               filter);
             tree.setVariableColumns(filter->getVariableColumns());
@@ -1566,7 +1578,7 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromSequence(
   connectionVarNames[0] = left;
   connectionVarNames.back() = right;
   for (size_t i = 1; i + 1 < connectionVarNames.size(); i++) {
-    connectionVarNames[i] = generateUniqueVarName();
+    connectionVarNames[i] = generateUniqueVarName().asString();
   }
 
   // Stores the pattern for every non null chunk
@@ -1620,9 +1632,9 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromSequence(
         continue;
       }
       std::string l = left;
-      SparqlVariable r;
+      std::string r;
       if (included_ids.size() > 1) {
-        r = generateUniqueVarName();
+        r = generateUniqueVarName().asString();
       } else {
         r = right;
       }
@@ -1638,7 +1650,7 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromSequence(
         // Update the variables used on the left and right of the child path
         l = r;
         if (i + 2 < included_ids.size()) {
-          r = generateUniqueVarName();
+          r = generateUniqueVarName().asString();
         } else {
           r = right;
         }
@@ -1706,8 +1718,8 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromAlternative(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitive(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-  std::string innerLeft = generateUniqueVarName();
-  std::string innerRight = generateUniqueVarName();
+  std::string innerLeft = generateUniqueVarName().asString();
+  std::string innerRight = generateUniqueVarName().asString();
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =
       seedFromPropertyPath(innerLeft, path._children[0], innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> p =
@@ -1728,8 +1740,8 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitive(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitiveMin(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-  std::string innerLeft = generateUniqueVarName();
-  std::string innerRight = generateUniqueVarName();
+  std::string innerLeft = generateUniqueVarName().asString();
+  std::string innerRight = generateUniqueVarName().asString();
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =
       seedFromPropertyPath(innerLeft, path._children[0], innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> p =
@@ -1750,8 +1762,8 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitiveMin(
 std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromTransitiveMax(
     const std::string& left, const PropertyPath& path,
     const std::string& right) {
-  std::string innerLeft = generateUniqueVarName();
-  std::string innerRight = generateUniqueVarName();
+  std::string innerLeft = generateUniqueVarName().asString();
+  std::string innerRight = generateUniqueVarName().asString();
   std::shared_ptr<ParsedQuery::GraphPattern> childPlan =
       seedFromPropertyPath(innerLeft, path._children[0], innerRight);
   std::shared_ptr<ParsedQuery::GraphPattern> p =
@@ -1818,7 +1830,9 @@ QueryPlanner::SubtreePlan QueryPlanner::getTextLeafPlan(
   auto& tree = *plan._qet;
   AD_CHECK(node._wordPart.size() > 0);
   auto textOp = std::make_shared<TextOperationWithoutFilter>(
-      _qec, node._wordPart, node._variables, node._cvar);
+      _qec, node._wordPart,
+      std::set<SparqlVariable>{node._variables.begin(), node._variables.end()},
+      node._cvar);
   tree.setOperation(QueryExecutionTree::OperationType::TEXT_WITHOUT_FILTER,
                     textOp);
   tree.setVariableColumns(textOp->getVariableColumns());
@@ -2037,10 +2051,10 @@ QueryPlanner::SubtreePlan QueryPlanner::multiColumnJoin(
 string QueryPlanner::TripleGraph::asString() const {
   std::ostringstream os;
   for (size_t i = 0; i < _adjLists.size(); ++i) {
-    if (_nodeMap.find(i)->second->_cvar.size() == 0) {
+    if (_nodeMap.find(i)->second->_cvar.asString().size() == 0) {
       os << i << " " << _nodeMap.find(i)->second->_triple.asString() << " : (";
     } else {
-      os << i << " {TextOP for " << _nodeMap.find(i)->second->_cvar
+      os << i << " {TextOP for " << _nodeMap.find(i)->second->_cvar.asString()
          << ", wordPart: \"" << _nodeMap.find(i)->second->_wordPart
          << "\"} : (";
     }
@@ -2130,7 +2144,7 @@ string QueryPlanner::getPruningKey(
   for (size_t orderedOnCol : orderedOnColumns) {
     for (const auto& varCol : varCols) {
       if (varCol.second == orderedOnCol) {
-        os << varCol.first << ", ";
+        os << varCol.first.asString() << ", ";
         break;
       }
     }
@@ -2184,7 +2198,7 @@ void QueryPlanner::applyFiltersIfPossible(
                         return row[n]._qet->varCovered(lhs);
                       }) &&
           (!isVariable(filters[i]._rhs) ||
-           row[n]._qet->varCovered(filters[i]._rhs))) {
+           row[n]._qet->varCovered(SparqlVariable{filters[i]._rhs}))) {
         // Apply this filter.
         SubtreePlan newPlan(_qec);
         newPlan._idsOfIncludedFilters = row[n]._idsOfIncludedFilters;
@@ -2279,15 +2293,15 @@ bool QueryPlanner::TripleGraph::isTextNode(size_t i) const {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, vector<size_t>>
+ad_utility::HashMap<SparqlVariable, vector<size_t>>
 QueryPlanner::TripleGraph::identifyTextCliques() const {
-  ad_utility::HashMap<string, vector<size_t>> contextVarToTextNodesIds;
+  ad_utility::HashMap<SparqlVariable, vector<size_t>> contextVarToTextNodesIds;
   // Fill contextVar -> triples map
   for (size_t i = 0; i < _adjLists.size(); ++i) {
     if (isTextNode(i)) {
       auto& triple = _nodeMap.find(i)->second->_triple;
       auto& cvar = triple._s;
-      contextVarToTextNodesIds[cvar].push_back(i);
+      contextVarToTextNodesIds[SparqlVariable{cvar}].push_back(i);
     }
   }
   return contextVarToTextNodesIds;
@@ -2399,16 +2413,16 @@ vector<SparqlFilter> QueryPlanner::TripleGraph::pickFilters(
     const vector<SparqlFilter>& origFilters,
     const vector<size_t>& nodes) const {
   vector<SparqlFilter> ret;
-  ad_utility::HashSet<string> coveredVariables;
+  ad_utility::HashSet<SparqlVariable> coveredVariables;
   for (auto n : nodes) {
     auto& node = *_nodeMap.find(n)->second;
     for (const auto& variable : node._variables) {
-      coveredVariables.insert(variable.asString());
+      coveredVariables.insert(variable);
     }
   }
   for (auto& f : origFilters) {
     if (coveredVariables.count(f._lhs) > 0 ||
-        coveredVariables.count(f._rhs) > 0) {
+        coveredVariables.count(SparqlVariable{f._rhs}) > 0) {
       ret.push_back(f);
     }
   }
@@ -2489,7 +2503,7 @@ void QueryPlanner::TripleGraph::collapseTextCliques() {
   // complex than need be.
 
   // Create a map from context var to triples it occurs in (the cliques).
-  ad_utility::HashMap<string, vector<size_t>> cvarsToTextNodes(
+  ad_utility::HashMap<SparqlVariable, vector<size_t>> cvarsToTextNodes(
       identifyTextCliques());
   if (cvarsToTextNodes.size() == 0) {
     return;
@@ -2670,29 +2684,30 @@ bool QueryPlanner::TripleGraph::isSimilar(
 
 // _____________________________________________________________________________
 bool QueryPlanner::TripleGraph::isPureTextQuery() {
-  return _nodeStorage.size() == 1 && _nodeStorage.begin()->_cvar.asString().size() > 0;
+  return _nodeStorage.size() == 1 &&
+         _nodeStorage.begin()->_cvar.asString().size() > 0;
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t>
+Operation::VariableColumnMap
 QueryPlanner::createVariableColumnsMapForTextOperation(
     const string& contextVar, const string& entityVar,
     const ad_utility::HashSet<string>& freeVars,
     const vector<pair<QueryExecutionTree, size_t>>& subtrees) {
   AD_CHECK(contextVar.size() > 0);
-  ad_utility::HashMap<string, size_t> map;
+  Operation::VariableColumnMap map;
   size_t n = 0;
   if (entityVar.size() > 0) {
-    map[entityVar] = n++;
-    map[string("SCORE(") + contextVar + ")"] = n++;
-    map[contextVar] = n++;
+    map[SparqlVariable{entityVar}] = n++;
+    map[SparqlVariable{contextVar, SparqlVariable::Type::SCORE}] = n++;
+    map[SparqlVariable{contextVar}] = n++;
   } else {
-    map[contextVar] = n++;
-    map[string("SCORE(") + contextVar + ")"] = n++;
+    map[SparqlVariable{contextVar}] = n++;
+    map[SparqlVariable{contextVar, SparqlVariable::Type::SCORE}] = n++;
   }
 
   for (const auto& v : freeVars) {
-    map[v] = n++;
+    map[SparqlVariable{v}] = n++;
   }
 
   for (size_t i = 0; i < subtrees.size(); ++i) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -452,9 +452,9 @@ bool QueryPlanner::checkUsePatternTrick(
 
   // These will only be set if the query returns the count of predicates
   // The varialbe the COUNT alias counts
-  SparqlVariable counted_var_name;
+  std::optional<SparqlVariable> counted_var_name;
   // The variable holding the counts
-  SparqlVariable count_var_name;
+  std::optional<SparqlVariable> count_var_name;
 
   if (returns_counts) {
     // There has to be a single count alias
@@ -491,8 +491,8 @@ bool QueryPlanner::checkUsePatternTrick(
       // Also check that the triples object or subject matches the aliases input
       // variable and the group by variable.
       if (t._p._iri != HAS_PREDICATE_PREDICATE ||
-          (returns_counts && !(counted_var_name.asString() == t._o ||
-                               counted_var_name.asString() == t._s)) ||
+          (returns_counts && !(counted_var_name == t._o ||
+                               counted_var_name == t._s)) ||
           pq->_groupByVariables[0].asString() != t._o) {
         usePatternTrick = false;
         continue;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -491,9 +491,9 @@ bool QueryPlanner::checkUsePatternTrick(
       // Also check that the triples object or subject matches the aliases input
       // variable and the group by variable.
       if (t._p._iri != HAS_PREDICATE_PREDICATE ||
-          (returns_counts && !(counted_var_name.variableName() == t._o ||
-                               counted_var_name.variableName() == t._s)) ||
-          pq->_groupByVariables[0].variableName() != t._o) {
+          (returns_counts && !(counted_var_name.asString() == t._o ||
+                               counted_var_name.asString() == t._s)) ||
+          pq->_groupByVariables[0].asString() != t._o) {
         usePatternTrick = false;
         continue;
       }
@@ -501,7 +501,7 @@ bool QueryPlanner::checkUsePatternTrick(
       // check that all selected variables are outputs of
       // CountAvailablePredicates
       for (const auto& s : pq->_selectedVariables) {
-        if (s.variableName() != t._o && s != count_var_name) {
+        if (s.asString() != t._o && s != count_var_name) {
           usePatternTrick = false;
           break;
         }
@@ -565,7 +565,7 @@ bool QueryPlanner::checkUsePatternTrick(
           } else if constexpr (std::is_same_v<
                                    T, GraphPatternOperation::Subquery>) {
             for (const auto& v : arg._subquery._selectedVariables) {
-              if (v.variableName() == t._o) {
+              if (v.asString() == t._o) {
                 usePatternTrick = false;
                 break;
               }
@@ -612,7 +612,7 @@ bool QueryPlanner::checkUsePatternTrick(
             } else if constexpr (std::is_same_v<
                                      T, GraphPatternOperation::Subquery>) {
               for (const auto& v : arg._subquery._selectedVariables) {
-                if (v.variableName() == t._o) {
+                if (v == t._o) {
                   usePatternTrick = false;
                   break;
                 }
@@ -629,7 +629,7 @@ bool QueryPlanner::checkUsePatternTrick(
             } else if constexpr (std::is_same_v<
                                      T, GraphPatternOperation::Values>) {
               for (const auto& var : arg._inlineValues._variables) {
-                if (var.variableName() == t._o) {
+                if (var == t._o) {
                   usePatternTrick = false;
                   break;
                 }
@@ -2699,11 +2699,11 @@ QueryPlanner::createVariableColumnsMapForTextOperation(
   size_t n = 0;
   if (entityVar.size() > 0) {
     map[SparqlVariable{entityVar}] = n++;
-    map[SparqlVariable{contextVar, SparqlVariable::Type::SCORE}] = n++;
+    map[SparqlVariable{getTextScoreVariableName(contextVar)}] = n++;
     map[SparqlVariable{contextVar}] = n++;
   } else {
     map[SparqlVariable{contextVar}] = n++;
-    map[SparqlVariable{contextVar, SparqlVariable::Type::SCORE}] = n++;
+    map[SparqlVariable{getTextScoreVariableName(contextVar)}] = n++;
   }
 
   for (const auto& v : freeVars) {

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -82,14 +82,16 @@ class QueryPlanner {
         for (const auto& s : n._variables) {
           out << s.asString() << ", ";
         }
-        out << " cvar " << n._cvar.asString() << " wordPart " << n._wordPart;
+        if (n._cvar) {
+          out << " cvar " << n._cvar->asString() << " wordPart " << n._wordPart;
+        }
         return out;
       }
 
       size_t _id;
       SparqlTriple _triple;
       ad_utility::HashSet<SparqlVariable> _variables;
-      SparqlVariable _cvar;
+      std::optional<SparqlVariable> _cvar;
       string _wordPart;
     };
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include "../parser/ParsedQuery.h"
 #include "QueryExecutionTree.h"
+#include "../util/HashSet.h"
 
 using std::vector;
 
@@ -30,20 +31,20 @@ class QueryPlanner {
       Node(size_t id, const SparqlTriple& t)
           : _id(id), _triple(t), _variables(), _cvar(), _wordPart() {
         if (isVariable(t._s)) {
-          _variables.insert(t._s);
+          _variables.insert(SparqlVariable{t._s});
         }
         if (isVariable(t._p)) {
-          _variables.insert(t._p._iri);
+          _variables.insert(SparqlVariable{t._p._iri});
         }
         if (isVariable(t._o)) {
-          _variables.insert(t._o);
+          _variables.insert(SparqlVariable{t._o});
         }
       }
 
-      Node(size_t id, const string& cvar, const string& wordPart,
+      Node(size_t id, const SparqlVariable& cvar, const string& wordPart,
            const vector<SparqlTriple>& trips)
           : _id(id),
-            _triple(cvar,
+            _triple(cvar.asString(),
                     PropertyPath(PropertyPath::Operation::IRI, 0,
                                  INTERNAL_TEXT_MATCH_PREDICATE, {}),
                     wordPart),
@@ -53,13 +54,13 @@ class QueryPlanner {
         _variables.insert(cvar);
         for (const auto& t : trips) {
           if (isVariable(t._s)) {
-            _variables.insert(t._s);
+            _variables.insert(SparqlVariable{t._s});
           }
           if (isVariable(t._p)) {
-            _variables.insert(t._p._iri);
+            _variables.insert(SparqlVariable{t._p._iri});
           }
           if (isVariable(t._o)) {
-            _variables.insert(t._o);
+            _variables.insert(SparqlVariable{t._o});
           }
         }
       }
@@ -78,17 +79,17 @@ class QueryPlanner {
       friend std::ostream& operator<<(std::ostream& out, const Node& n) {
         out << "id: " << n._id << " triple: " << n._triple.asString()
             << " _vars ";
-        for (const std::string& s : n._variables) {
-          out << s << ", ";
+        for (const auto& s : n._variables) {
+          out << s.asString() << ", ";
         }
-        out << " cvar " << n._cvar << " wordPart " << n._wordPart;
+        out << " cvar " << n._cvar.asString() << " wordPart " << n._wordPart;
         return out;
       }
 
       size_t _id;
       SparqlTriple _triple;
-      std::set<std::string> _variables;
-      string _cvar;
+      ad_utility::HashSet<SparqlVariable> _variables;
+      SparqlVariable _cvar;
       string _wordPart;
     };
 
@@ -247,7 +248,7 @@ class QueryPlanner {
       const std::string& left, const PropertyPath& path,
       const std::string& right);
 
-  std::string generateUniqueVarName();
+  SparqlVariable generateUniqueVarName();
 
   // Creates a tree of unions with the given patterns as the trees leaves
   ParsedQuery::GraphPattern uniteGraphPatterns(

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -6,8 +6,8 @@
 #include <set>
 #include <vector>
 #include "../parser/ParsedQuery.h"
-#include "QueryExecutionTree.h"
 #include "../util/HashSet.h"
+#include "QueryExecutionTree.h"
 
 using std::vector;
 
@@ -106,7 +106,8 @@ class QueryPlanner {
     ad_utility::HashMap<size_t, Node*> _nodeMap;
     std::list<TripleGraph::Node> _nodeStorage;
 
-    ad_utility::HashMap<string, vector<size_t>> identifyTextCliques() const;
+    ad_utility::HashMap<SparqlVariable, vector<size_t>> identifyTextCliques()
+        const;
 
     vector<size_t> bfsLeaveOut(size_t startNode,
                                ad_utility::HashSet<size_t> leaveOut) const;
@@ -149,29 +150,25 @@ class QueryPlanner {
   TripleGraph createTripleGraph(
       const GraphPatternOperation::BasicGraphPattern* pattern) const;
 
-  static ad_utility::HashMap<string, size_t>
-  createVariableColumnsMapForTextOperation(
+  static Operation::VariableColumnMap createVariableColumnsMapForTextOperation(
       const string& contextVar, const string& entityVar,
       const ad_utility::HashSet<string>& freeVars,
       const vector<pair<QueryExecutionTree, size_t>>& subtrees);
 
-  static ad_utility::HashMap<string, size_t>
-  createVariableColumnsMapForTextOperation(
+  static Operation::VariableColumnMap createVariableColumnsMapForTextOperation(
       const string& contextVar, const string& entityVar,
       const vector<pair<QueryExecutionTree, size_t>>& subtrees) {
     return createVariableColumnsMapForTextOperation(
         contextVar, entityVar, ad_utility::HashSet<string>(), subtrees);
   };
 
-  static ad_utility::HashMap<string, size_t>
-  createVariableColumnsMapForTextOperation(const string& contextVar,
-                                           const string& entityVar) {
+  static Operation::VariableColumnMap createVariableColumnsMapForTextOperation(
+      const string& contextVar, const string& entityVar) {
     return createVariableColumnsMapForTextOperation(
         contextVar, entityVar, vector<pair<QueryExecutionTree, size_t>>());
   }
 
-  static ad_utility::HashMap<string, size_t>
-  createVariableColumnsMapForTextOperation(
+  static Operation::VariableColumnMap createVariableColumnsMapForTextOperation(
       const string& contextVar, const string& entityVar,
       const ad_utility::HashSet<string>& freeVars) {
     return createVariableColumnsMapForTextOperation(

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -9,10 +9,10 @@
 #include <string>
 #include <vector>
 
+#include "../parser/ParsedQuery.h"
 #include "../util/HashMap.h"
 #include "../util/StringUtils.h"
 #include "../util/Timer.h"
-#include "../parser/ParsedQuery.h"
 
 class RuntimeInformation {
  public:

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -12,6 +12,7 @@
 #include "../util/HashMap.h"
 #include "../util/StringUtils.h"
 #include "../util/Timer.h"
+#include "../parser/ParsedQuery.h"
 
 class RuntimeInformation {
  public:
@@ -90,10 +91,10 @@ class RuntimeInformation {
   }
 
   void setColumnNames(
-      const ad_utility::HashMap<std::string, size_t>& columnMap) {
+      const ad_utility::HashMap<SparqlVariable, size_t>& columnMap) {
     _columnNames.resize(columnMap.size());
     for (const auto& column : columnMap) {
-      _columnNames[column.second] = column.first;
+      _columnNames[column.second] = column.first.asString();
     }
   }
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -379,7 +379,11 @@ string Server::composeResponseJson(const ParsedQuery& query,
   j["status"] = "OK";
   j["resultsize"] = resultSize;
   j["warnings"] = qet.collectWarnings();
-  j["selected"] = query._selectedVariables;
+  std::vector<string> selectedAsString;
+  for (const auto& s : query._selectedVariables) {
+    selectedAsString.push_back(s.asString());
+  }
+  j["selected"] = selectedAsString;
 
   j["runtimeInformation"] = RuntimeInformation::ordered_json(
       qet.getRootOperation()->getRuntimeInfo());

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -39,7 +39,7 @@ string Sort::getDescriptor() const {
   std::string orderByVars;
   for (const auto& p : _subtree->getVariableColumns()) {
     if (p.second == _sortCol) {
-      orderByVars = "ASC(" + p.first + ") ";
+      orderByVars = "ASC(" + p.first.asString() + ") ";
       break;
     }
   }

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -50,7 +50,7 @@ class Sort : public Operation {
 
   [[nodiscard]] size_t getResultWidth() const override;
 
-  [[nodiscard]] ad_utility::HashMap<string, size_t> getVariableColumns()
+  [[nodiscard]] VariableColumnMap getVariableColumns()
       const override {
     return _subtree->getVariableColumns();
   }

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -50,8 +50,7 @@ class Sort : public Operation {
 
   [[nodiscard]] size_t getResultWidth() const override;
 
-  [[nodiscard]] VariableColumnMap getVariableColumns()
-      const override {
+  [[nodiscard]] VariableColumnMap getVariableColumns() const override {
     return _subtree->getVariableColumns();
   }
 

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -36,7 +36,7 @@ Operation::VariableColumnMap TextOperationWithFilter::getVariableColumns()
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.
   vcmap[_cvar] = 0;
-  vcmap[SparqlVariable{_cvar.variableName(), SparqlVariable::Type::SCORE}] = 1;
+  vcmap[SparqlVariable{getTextScoreVariableName(_cvar.asString())}] = 1;
   size_t colN = 2;
   const auto& filterColumns = _filterResult.get()->getVariableColumns();
   for (const auto& var : _variables) {

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -17,7 +17,7 @@ size_t TextOperationWithFilter::getResultWidth() const {
 // _____________________________________________________________________________
 TextOperationWithFilter::TextOperationWithFilter(
     QueryExecutionContext* qec, const string& words,
-    const std::set<string>& variables, const string& cvar,
+    const std::set<SparqlVariable>& variables, const SparqlVariable& cvar,
     std::shared_ptr<QueryExecutionTree> filterResult, size_t filterColumn,
     size_t textLimit)
     : Operation(qec),
@@ -30,16 +30,16 @@ TextOperationWithFilter::TextOperationWithFilter(
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t>
+Operation::VariableColumnMap
 TextOperationWithFilter::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> vcmap;
+  VariableColumnMap vcmap;
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.
   vcmap[_cvar] = 0;
-  vcmap["SCORE(" + _cvar + ")"] = 1;
+  vcmap[SparqlVariable{_cvar.variableName(), SparqlVariable::Type::SCORE}] = 1;
   size_t colN = 2;
   const auto& filterColumns = _filterResult.get()->getVariableColumns();
-  for (const string& var : _variables) {
+  for (const auto& var : _variables) {
     if (var == _cvar) {
       continue;
     }

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -30,8 +30,8 @@ TextOperationWithFilter::TextOperationWithFilter(
 }
 
 // _____________________________________________________________________________
-Operation::VariableColumnMap
-TextOperationWithFilter::getVariableColumns() const {
+Operation::VariableColumnMap TextOperationWithFilter::getVariableColumns()
+    const {
   VariableColumnMap vcmap;
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.

--- a/src/engine/TextOperationWithFilter.h
+++ b/src/engine/TextOperationWithFilter.h
@@ -18,7 +18,8 @@ using std::vector;
 class TextOperationWithFilter : public Operation {
  public:
   TextOperationWithFilter(QueryExecutionContext* qec, const string& words,
-                          const std::set<SparqlVariable>& variables, const SparqlVariable& cvar,
+                          const std::set<SparqlVariable>& variables,
+                          const SparqlVariable& cvar,
                           std::shared_ptr<QueryExecutionTree> filterResult,
                           size_t filterColumn, size_t textLimit = 1);
 
@@ -66,8 +67,7 @@ class TextOperationWithFilter : public Operation {
 
   virtual float getMultiplicity(size_t col) override;
 
-  virtual VariableColumnMap getVariableColumns()
-      const override;
+  virtual VariableColumnMap getVariableColumns() const override;
 
  private:
   const string _words;

--- a/src/engine/TextOperationWithFilter.h
+++ b/src/engine/TextOperationWithFilter.h
@@ -18,7 +18,7 @@ using std::vector;
 class TextOperationWithFilter : public Operation {
  public:
   TextOperationWithFilter(QueryExecutionContext* qec, const string& words,
-                          const std::set<string>& variables, const string& cvar,
+                          const std::set<SparqlVariable>& variables, const SparqlVariable& cvar,
                           std::shared_ptr<QueryExecutionTree> filterResult,
                           size_t filterColumn, size_t textLimit = 1);
 
@@ -50,9 +50,9 @@ class TextOperationWithFilter : public Operation {
     return _variables.size() - 1;
   }
 
-  const std::set<string>& getVars() const { return _variables; }
+  const std::set<SparqlVariable>& getVars() const { return _variables; }
 
-  const string getCVar() const { return _cvar; }
+  const SparqlVariable getCVar() const { return _cvar; }
 
   virtual bool knownEmptyResult() override {
     return _filterResult->knownEmptyResult() ||
@@ -66,13 +66,13 @@ class TextOperationWithFilter : public Operation {
 
   virtual float getMultiplicity(size_t col) override;
 
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns()
+  virtual VariableColumnMap getVariableColumns()
       const override;
 
  private:
   const string _words;
-  const std::set<string> _variables;
-  const string _cvar;
+  const std::set<SparqlVariable> _variables;
+  const SparqlVariable _cvar;
   size_t _textLimit;
 
   std::shared_ptr<QueryExecutionTree> _filterResult;

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -17,7 +17,8 @@ size_t TextOperationWithoutFilter::getResultWidth() const {
 // _____________________________________________________________________________
 TextOperationWithoutFilter::TextOperationWithoutFilter(
     QueryExecutionContext* qec, const string& words,
-    const std::set<SparqlVariable>& variables, const SparqlVariable& cvar, size_t textLimit)
+    const std::set<SparqlVariable>& variables, const SparqlVariable& cvar,
+    size_t textLimit)
     : Operation(qec),
       _words(words),
       _variables(variables),
@@ -26,12 +27,13 @@ TextOperationWithoutFilter::TextOperationWithoutFilter(
       _sizeEstimate(std::numeric_limits<size_t>::max()) {}
 
 // _____________________________________________________________________________
-Operation::VariableColumnMap
-TextOperationWithoutFilter::getVariableColumns() const {
+Operation::VariableColumnMap TextOperationWithoutFilter::getVariableColumns()
+    const {
   VariableColumnMap vcmap;
   size_t index = 0;
   vcmap[_cvar] = index++;
-  vcmap[SparqlVariable{_cvar.variableName(), SparqlVariable::Type::SCORE}] = index++;
+  vcmap[SparqlVariable{_cvar.variableName(), SparqlVariable::Type::SCORE}] =
+      index++;
   for (const auto& var : _variables) {
     if (var != _cvar) {
       vcmap[var] = index++;

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -17,7 +17,7 @@ size_t TextOperationWithoutFilter::getResultWidth() const {
 // _____________________________________________________________________________
 TextOperationWithoutFilter::TextOperationWithoutFilter(
     QueryExecutionContext* qec, const string& words,
-    const std::set<string>& variables, const string& cvar, size_t textLimit)
+    const std::set<SparqlVariable>& variables, const SparqlVariable& cvar, size_t textLimit)
     : Operation(qec),
       _words(words),
       _variables(variables),
@@ -26,12 +26,12 @@ TextOperationWithoutFilter::TextOperationWithoutFilter(
       _sizeEstimate(std::numeric_limits<size_t>::max()) {}
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t>
+Operation::VariableColumnMap
 TextOperationWithoutFilter::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> vcmap;
+  VariableColumnMap vcmap;
   size_t index = 0;
   vcmap[_cvar] = index++;
-  vcmap["SCORE(" + _cvar + ")"] = index++;
+  vcmap[SparqlVariable{_cvar.variableName(), SparqlVariable::Type::SCORE}] = index++;
   for (const auto& var : _variables) {
     if (var != _cvar) {
       vcmap[var] = index++;

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -32,8 +32,7 @@ Operation::VariableColumnMap TextOperationWithoutFilter::getVariableColumns()
   VariableColumnMap vcmap;
   size_t index = 0;
   vcmap[_cvar] = index++;
-  vcmap[SparqlVariable{_cvar.variableName(), SparqlVariable::Type::SCORE}] =
-      index++;
+  vcmap[SparqlVariable{getTextScoreVariableName(_cvar.asString())}] = index++;
   for (const auto& var : _variables) {
     if (var != _cvar) {
       vcmap[var] = index++;

--- a/src/engine/TextOperationWithoutFilter.h
+++ b/src/engine/TextOperationWithoutFilter.h
@@ -16,8 +16,8 @@ using std::vector;
 class TextOperationWithoutFilter : public Operation {
  public:
   TextOperationWithoutFilter(QueryExecutionContext* qec, const string& words,
-                             const std::set<string>& variables,
-                             const string& cvar, size_t textLimit = 1);
+                             const std::set<SparqlVariable>& variables,
+                             const SparqlVariable& cvar, size_t textLimit = 1);
 
   virtual string asString(size_t indent = 0) const override;
 
@@ -49,24 +49,24 @@ class TextOperationWithoutFilter : public Operation {
     return _variables.size() - 1;
   }
 
-  const std::set<string>& getVars() const { return _variables; }
+  const std::set<SparqlVariable>& getVars() const { return _variables; }
 
-  const string getCVar() const { return _cvar; }
+  const SparqlVariable& getCVar() const { return _cvar; }
 
   virtual bool knownEmptyResult() override {
     return _executionContext &&
            _executionContext->getIndex().getSizeEstimate(_words) == 0;
   }
 
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns()
+  virtual VariableColumnMap getVariableColumns()
       const override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 
  private:
   const string _words;
-  const std::set<string> _variables;
-  const string _cvar;
+  const std::set<SparqlVariable> _variables;
+  const SparqlVariable _cvar;
 
   size_t _textLimit;
 

--- a/src/engine/TextOperationWithoutFilter.h
+++ b/src/engine/TextOperationWithoutFilter.h
@@ -58,8 +58,7 @@ class TextOperationWithoutFilter : public Operation {
            _executionContext->getIndex().getSizeEstimate(_words) == 0;
   }
 
-  virtual VariableColumnMap getVariableColumns()
-      const override;
+  virtual VariableColumnMap getVariableColumns() const override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -14,8 +14,8 @@
 TransitivePath::TransitivePath(
     QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
     bool leftIsVar, bool rightIsVar, size_t leftSubCol, size_t rightSubCol,
-    size_t leftValue, size_t rightValue, const std::string& leftColName,
-    const std::string& rightColName, size_t minDist, size_t maxDist)
+    size_t leftValue, size_t rightValue, const SparqlVariable& leftColName,
+    const SparqlVariable& rightColName, size_t minDist, size_t maxDist)
     : Operation(qec),
       _leftSideTree(nullptr),
       _leftSideCol(-1),
@@ -132,7 +132,7 @@ vector<size_t> TransitivePath::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<std::string, size_t> TransitivePath::getVariableColumns()
+Operation::VariableColumnMap TransitivePath::getVariableColumns()
     const {
   return _variableColumns;
 }

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -76,7 +76,7 @@ std::string TransitivePath::getDescriptor() const {
   }
   // Left variable or entity name.
   if (_leftIsVar) {
-    os << _leftColName;
+    os << _leftColName.asString();
   } else {
     os << getIndex()
               .idToOptionalString(_leftValue)
@@ -93,7 +93,7 @@ std::string TransitivePath::getDescriptor() const {
   }
   // Right variable or entity name.
   if (_rightIsVar) {
-    os << _rightColName;
+    os << _rightColName.asString();
   } else {
     os << getIndex()
               .idToOptionalString(_rightValue)
@@ -132,8 +132,7 @@ vector<size_t> TransitivePath::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-Operation::VariableColumnMap TransitivePath::getVariableColumns()
-    const {
+Operation::VariableColumnMap TransitivePath::getVariableColumns() const {
   return _variableColumns;
 }
 
@@ -711,8 +710,8 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftSide(
   std::shared_ptr<TransitivePath> p = std::make_shared<TransitivePath>(*this);
   p->_leftSideTree = leftop;
   p->_leftSideCol = inputCol;
-  const ad_utility::HashMap<string, size_t>& var = leftop->getVariableColumns();
-  for (auto col : var) {
+  const VariableColumnMap& var = leftop->getVariableColumns();
+  for (const auto& col : var) {
     if (col.second != inputCol) {
       if (col.second > inputCol) {
         p->_variableColumns[col.first] = col.second + 1;
@@ -732,9 +731,8 @@ std::shared_ptr<TransitivePath> TransitivePath::bindRightSide(
   std::shared_ptr<TransitivePath> p = std::make_shared<TransitivePath>(*this);
   p->_rightSideTree = rightop;
   p->_rightSideCol = inputCol;
-  const ad_utility::HashMap<string, size_t>& var =
-      rightop->getVariableColumns();
-  for (auto col : var) {
+  const VariableColumnMap& var = rightop->getVariableColumns();
+  for (const auto& col : var) {
     if (col.second != inputCol) {
       if (col.second > inputCol) {
         p->_variableColumns[col.first] = col.second + 1;

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -16,8 +16,8 @@ class TransitivePath : public Operation {
                  std::shared_ptr<QueryExecutionTree> child, bool leftIsVar,
                  bool rightIsVar, size_t leftSubCol, size_t rightSubCol,
                  size_t leftValue, size_t rightValue,
-                 const std::string& leftColName,
-                 const std::string& rightColName, size_t minDist,
+                 const SparqlVariable& leftColName,
+                 const SparqlVariable& rightColName, size_t minDist,
                  size_t maxDist);
 
   /**
@@ -54,7 +54,7 @@ class TransitivePath : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<std::string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override;
 
@@ -122,7 +122,7 @@ class TransitivePath : public Operation {
   size_t _rightSideCol;
 
   size_t _resultWidth;
-  ad_utility::HashMap<std::string, size_t> _variableColumns;
+  VariableColumnMap _variableColumns;
 
   std::shared_ptr<QueryExecutionTree> _subtree;
   bool _leftIsVar;
@@ -131,8 +131,8 @@ class TransitivePath : public Operation {
   size_t _rightSubCol;
   size_t _leftValue;
   size_t _rightValue;
-  std::string _leftColName;
-  std::string _rightColName;
+  SparqlVariable _leftColName;
+  SparqlVariable _rightColName;
   size_t _minDist;
   size_t _maxDist;
 };

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -82,7 +82,7 @@ string TwoColumnJoin::getDescriptor() const {
   std::string joinVars = "";
   for (auto p : _left->getVariableColumns()) {
     if (p.second == _jc1Left || p.second == _jc2Left) {
-      joinVars += p.first + " ";
+      joinVars += p.first.asString() + " ";
     }
   }
   return "TwoColumnJoin on " + joinVars;
@@ -131,7 +131,7 @@ void TwoColumnJoin::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<string, size_t> TwoColumnJoin::getVariableColumns() const {
+Operation::VariableColumnMap TwoColumnJoin::getVariableColumns() const {
   if ((_left->getResultWidth() == 2 && _jc1Left == 0 && _jc2Left == 1) ||
       (_right->getResultWidth() == 2 && _jc1Right == 0 && _jc2Right == 1)) {
     // This is for the implemented filter case from computeResult()
@@ -146,7 +146,7 @@ ad_utility::HashMap<string, size_t> TwoColumnJoin::getVariableColumns() const {
     // that variables are missing from the query if it tries to use
     // TwoColumnJoin in the unsupported (super expensive variant)
     // it then gives up and we don't find a working alternative.
-    ad_utility::HashMap<string, size_t> retVal(_left->getVariableColumns());
+    VariableColumnMap retVal(_left->getVariableColumns());
     size_t leftSize = _left->getResultWidth();
     const auto& rightVarCols = _right->getVariableColumns();
     for (const auto& rightVarCol : rightVarCols) {

--- a/src/engine/TwoColumnJoin.h
+++ b/src/engine/TwoColumnJoin.h
@@ -25,7 +25,7 @@ class TwoColumnJoin : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -61,8 +61,7 @@ size_t Union::getResultWidth() const {
 vector<size_t> Union::resultSortedOn() const { return {}; }
 
 Operation::VariableColumnMap Union::getVariableColumns() const {
-  VariableColumnMap variableColumns(
-      _subtrees[0]->getVariableColumns());
+  VariableColumnMap variableColumns(_subtrees[0]->getVariableColumns());
 
   size_t column = variableColumns.size();
   for (auto it : _subtrees[1]->getVariableColumns()) {

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -15,7 +15,7 @@ Union::Union(QueryExecutionContext* qec,
   _subtrees[1] = t2;
 
   // compute the column origins
-  ad_utility::HashMap<string, size_t> variableColumns = getVariableColumns();
+  VariableColumnMap variableColumns = getVariableColumns();
   _columnOrigins.resize(variableColumns.size(), {NO_COLUMN, NO_COLUMN});
   const auto& t1VarCols = t1->getVariableColumns();
   const auto& t2VarCols = t2->getVariableColumns();
@@ -60,8 +60,8 @@ size_t Union::getResultWidth() const {
 
 vector<size_t> Union::resultSortedOn() const { return {}; }
 
-ad_utility::HashMap<string, size_t> Union::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> variableColumns(
+Operation::VariableColumnMap Union::getVariableColumns() const {
+  VariableColumnMap variableColumns(
       _subtrees[0]->getVariableColumns());
 
   size_t column = variableColumns.size();

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -33,7 +33,7 @@ class Union : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override;
 

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -21,7 +21,7 @@ string Values::asString(size_t indent) const {
   }
   os << "VALUES (";
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    os << _values._variables[i];
+    os << _values._variables[i].variableName();
     if (i + 1 < _values._variables.size()) {
       os << " ";
     }
@@ -49,7 +49,7 @@ string Values::getDescriptor() const {
   std::ostringstream os;
   os << "Values with variables ";
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    os << _values._variables[i];
+    os << _values._variables[i].variableName();
     if (i + 1 < _values._variables.size()) {
       os << " ";
     }
@@ -79,7 +79,7 @@ vector<size_t> Values::resultSortedOn() const { return {}; }
 ad_utility::HashMap<string, size_t> Values::getVariableColumns() const {
   ad_utility::HashMap<string, size_t> map;
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    map[_values._variables[i]] = i;
+    map[_values._variables[i].variableName()] = i;
   }
   return map;
 }

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -76,10 +76,11 @@ size_t Values::getResultWidth() const { return _values._variables.size(); }
 
 vector<size_t> Values::resultSortedOn() const { return {}; }
 
-ad_utility::HashMap<string, size_t> Values::getVariableColumns() const {
-  ad_utility::HashMap<string, size_t> map;
+// _________________________________________________________________________
+Operation::VariableColumnMap Values::getVariableColumns() const {
+  VariableColumnMap map;
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    map[_values._variables[i].variableName()] = i;
+    map[_values._variables[i]] = i;
   }
   return map;
 }

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -21,7 +21,7 @@ string Values::asString(size_t indent) const {
   }
   os << "VALUES (";
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    os << _values._variables[i].variableName();
+    os << _values._variables[i].asString();
     if (i + 1 < _values._variables.size()) {
       os << " ";
     }
@@ -49,7 +49,7 @@ string Values::getDescriptor() const {
   std::ostringstream os;
   os << "Values with variables ";
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    os << _values._variables[i].variableName();
+    os << _values._variables[i].asString();
     if (i + 1 < _values._variables.size()) {
       os << " ";
     }

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -21,7 +21,7 @@ class Values : public Operation {
 
   virtual vector<size_t> resultSortedOn() const override;
 
-  ad_utility::HashMap<string, size_t> getVariableColumns() const override;
+  VariableColumnMap getVariableColumns() const override;
 
   virtual void setTextLimit(size_t limit) override { (void)limit; }
 

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -255,7 +255,7 @@ void ParsedQuery::expandPrefixes() {
 
   for (auto& f : _rootGraphPattern._filters) {
     // lhs of a filter is always
-    //expandPrefix(f._lhs, prefixMap);
+    // expandPrefix(f._lhs, prefixMap);
     // TODO<joka921>: proper type system for variable/regex/iri/etc
     if (f._type != SparqlFilter::REGEX) {
       expandPrefix(f._rhs, prefixMap);

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -208,7 +208,7 @@ string SparqlTriple::asString() const {
 // _____________________________________________________________________________
 string SparqlFilter::asString() const {
   std::ostringstream os;
-  os << "FILTER(" << _lhs;
+  os << "FILTER(" << _lhs.asString();
   switch (_type) {
     case EQ:
       os << " < ";
@@ -254,7 +254,8 @@ void ParsedQuery::expandPrefixes() {
   }
 
   for (auto& f : _rootGraphPattern._filters) {
-    expandPrefix(f._lhs, prefixMap);
+    // lhs of a filter is always
+    //expandPrefix(f._lhs, prefixMap);
     // TODO<joka921>: proper type system for variable/regex/iri/etc
     if (f._type != SparqlFilter::REGEX) {
       expandPrefix(f._rhs, prefixMap);

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -35,7 +35,7 @@ string ParsedQuery::asString() const {
   // SELECT
   os << "\nSELECT: {\n\t";
   for (size_t i = 0; i < _selectedVariables.size(); ++i) {
-    os << _selectedVariables[i];
+    os << _selectedVariables[i].asString();
     if (i + 1 < _selectedVariables.size()) {
       os << ", ";
     }
@@ -390,13 +390,13 @@ void ParsedQuery::expandPrefix(
 
 void ParsedQuery::parseAliases() {
   for (size_t i = 0; i < _selectedVariables.size(); i++) {
-    const std::string& var = _selectedVariables[i];
+    const std::string& var = _selectedVariables[i].asString();
     if (var[0] == '(') {
       // remove the leading and trailing bracket
       std::string inner = var.substr(1, var.size() - 2);
       // Replace the variable in the selected variables array with the aliased
       // name.
-      _selectedVariables[i] = parseAlias(inner);
+      _selectedVariables[i] = SparqlVariable(parseAlias(inner));
     }
   }
   for (size_t i = 0; i < _orderBy.size(); i++) {
@@ -435,7 +435,7 @@ std::string ParsedQuery::parseAlias(const std::string& alias) {
     pos++;
     newVarName = alias.substr(pos + 2);
     newVarName = ad_utility::strip(newVarName, " \t\n");
-    a._outVarName = newVarName;
+    a._outVarName = SparqlVariable{newVarName};
     a._function = alias;
 
     // find the second opening bracket
@@ -464,7 +464,7 @@ std::string ParsedQuery::parseAlias(const std::string& alias) {
           ") is malformed: no input variable given (e.g. COUNT(?a))");
     }
 
-    a._inVarName = alias.substr(start, pos - start - 1);
+    a._inVarName = SparqlVariable{alias.substr(start, pos - start - 1)};
     bool isUnique = true;
     // check if another alias for the output variable already exists:
     for (const Alias& other : _aliases) {
@@ -477,7 +477,7 @@ std::string ParsedQuery::parseAlias(const std::string& alias) {
           // at this point the comparison of two aliases is also string based.
           throw ParseException(
               "Two aliases try to bind values to the variable " +
-              a._outVarName);
+              a._outVarName.asString());
         } else {
           isUnique = false;
           break;
@@ -595,7 +595,7 @@ void GraphPatternOperation::toString(std::ostringstream& os,
     } else if constexpr (std::is_same_v<T, Values>) {
       os << "VALUES (";
       for (const auto& v : arg._inlineValues._variables) {
-        os << v << ' ';
+        os << v.asString() << ' ';
       }
       os << ") ";
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -32,8 +32,6 @@ class SparqlVariable {
   explicit SparqlVariable(string variable) : _variable{std::move(variable)} {
     AD_CHECK(_variable.starts_with('?'));
   }
-  // TODO<joka921> We should get rid of this with the new Parser for type safety
-  SparqlVariable() = default;
 
   bool operator==(const SparqlVariable&) const = default;
 
@@ -239,7 +237,7 @@ class SparqlFilter {
   string asString() const;
 
   FilterType _type;
-  SparqlVariable _lhs;
+  SparqlVariable _lhs{"?:qlever-default-sparql-filter-lhs"};
   string _rhs;
   vector<SparqlVariable> _additionalLhs;
   vector<string> _additionalPrefixes;
@@ -339,8 +337,9 @@ class ParsedQuery {
 
   struct Alias {
     AggregateType _type;
-    SparqlVariable _inVarName;
-    SparqlVariable _outVarName;
+    SparqlVariable _inVarName{"?:qlever-default-alias-uninitialized-inVarName"};
+    SparqlVariable _outVarName{
+        "?:qlever-default-alias-uninitialized-outVarName"};
     bool _isAggregate = true;
     bool _isDistinct = false;
     std::string _function;
@@ -479,7 +478,9 @@ struct GraphPatternOperation {
       vector<const SparqlVariable*> variables() { return {&_var}; }
       [[nodiscard]] string getDescriptor() const { return _var.asString(); }
     };
-    std::variant<Rename, Constant, Sum> _expressionVariant;
+
+    using ExpressionVariant = std::variant<Rename, Constant, Sum>;
+    ExpressionVariant _expressionVariant;
     SparqlVariable
         _target;  // the variable to which the expression will be bound
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -30,9 +30,7 @@ class SparqlVariable {
   [[nodiscard]] const string asString() const { return _variable; }
   //[[nodiscard]] const string& variableName() const { return _variable; }
   explicit SparqlVariable(string variable) : _variable{std::move(variable)} {
-    // Currently there are still many empty variables in the setup process.
-    // TODO<joka921> get rid of them via optional<>
-    AD_CHECK(_variable.empty() || _variable.starts_with('?'));
+    AD_CHECK(_variable.starts_with('?'));
   }
   // TODO<joka921> We should get rid of this with the new Parser for type safety
   SparqlVariable() = default;

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -123,13 +123,16 @@ void SparqlParser::parseSelect(ParsedQuery* query) {
       _lexer.expect(SparqlToken::Type::VARIABLE);
       auto variableName = _lexer.current().raw;
       _lexer.expect(")");
-      query->_selectedVariables.emplace_back(variableName, SparqlVariable::Type::TEXT);
+      // TODO<joka921> The TEXT(?t) is redundant and equivalend to ?t
+      // we should warn here or remove it.
+      query->_selectedVariables.emplace_back(variableName);
     } else if (_lexer.accept("score")) {
       _lexer.expect("(");
       _lexer.expect(SparqlToken::Type::VARIABLE);
       auto variableName = _lexer.current().raw;
       _lexer.expect(")");
-      query->_selectedVariables.emplace_back(variableName, SparqlVariable::Type::SCORE);
+      query->_selectedVariables.emplace_back(variableName,
+                                             SparqlVariable::Type::SCORE);
     } else if (_lexer.accept("(")) {
       // expect an alias
       ParsedQuery::Alias a = parseAlias();
@@ -310,9 +313,11 @@ void SparqlParser::parseWhere(ParsedQuery* query,
       _lexer.expect(SparqlToken::Type::VARIABLE);
       GraphPatternOperation::Bind b;
       if (isSum) {
-        b._expressionVariant = GraphPatternOperation::Bind::Sum{SparqlVariable{inVar}, SparqlVariable{inVar2}};
+        b._expressionVariant = GraphPatternOperation::Bind::Sum{
+            SparqlVariable{inVar}, SparqlVariable{inVar2}};
       } else if (rename) {
-        b._expressionVariant = GraphPatternOperation::Bind::Rename{SparqlVariable{inVar}};
+        b._expressionVariant =
+            GraphPatternOperation::Bind::Rename{SparqlVariable{inVar}};
       } else {
         if (isString) {
           // Note that this only works if the literal or iri stored in inVar is
@@ -772,8 +777,10 @@ bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
       f._lhs = SparqlVariable{_lexer.current().raw};
     } else {
       _lexer.accept();
-      throw ParseException(_lexer.current().raw +
-                           " is not a valid left hand side for a filter. QLever currently only accepts variables in this position");
+      throw ParseException(
+          _lexer.current().raw +
+          " is not a valid left hand side for a filter. QLever currently only "
+          "accepts variables in this position");
     }
     if (f._lhsAsString) {
       _lexer.expect(")");

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -623,7 +623,6 @@ bool TurtleStreamParser<T>::getLine(std::array<string, 3>* triple) {
           if (exceptionThrown) {
             throw ex;
           } else {
-
             // we are at the end of an input stream without an exception
             // the input is exhausted, but we still may retrieve
             // triples parsed so far, check if we have indeed parsed through

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -623,6 +623,7 @@ bool TurtleStreamParser<T>::getLine(std::array<string, 3>* triple) {
           if (exceptionThrown) {
             throw ex;
           } else {
+
             // we are at the end of an input stream without an exception
             // the input is exhausted, but we still may retrieve
             // triples parsed so far, check if we have indeed parsed through

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -56,11 +56,10 @@ class DummyOperation : public Operation {
 
   virtual bool knownEmptyResult() override { return false; }
 
-  virtual ad_utility::HashMap<string, size_t> getVariableColumns()
-      const override {
-    ad_utility::HashMap<string, size_t> m;
-    m["?a"] = 0;
-    m["?b"] = 1;
+  virtual VariableColumnMap getVariableColumns() const override {
+    VariableColumnMap m;
+    m[SparqlVariable{"?a"}] = 0;
+    m[SparqlVariable{"?b"}] = 1;
     return m;
   }
 };

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1012,7 +1012,7 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
         qet.asString());
     ASSERT_EQ(0u, qet.getVariableColumn(SparqlVariable{"?c"}));
     ASSERT_EQ(1u, qet.getVariableColumn(
-                      SparqlVariable{"?c", SparqlVariable::Type::SCORE}));
+                      SparqlVariable{getTextScoreVariableName("?c")}));
     ASSERT_EQ(2u, qet.getVariableColumn(SparqlVariable{"?y"}));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -249,7 +249,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
             TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
                 {std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         0, "?c", "abc",
+                         0, SparqlVariable{"?c"}, "abc",
                          {
                              SparqlTriple(
                                  "?c",
@@ -292,7 +292,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
             TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
                 {std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         0, "?c", "abc",
+                         0, SparqlVariable{"?c"}, "abc",
                          {SparqlTriple(
                               "?c",
                               "<QLever-internal-function/contains-entity>",
@@ -336,7 +336,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
             TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
                 {std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         0, "?c", "abc",
+                         0, SparqlVariable{"?c"}, "abc",
                          {SparqlTriple(
                               "?c",
                               "<QLever-internal-function/contains-entity>",
@@ -412,7 +412,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
             TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
                 {std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         0, "?c", "abc",
+                         0, SparqlVariable{"?c"}, "abc",
                          {SparqlTriple(
                               "?c",
                               "<QLever-internal-function/contains-entity>",
@@ -427,7 +427,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                      {1, 2}),
                  std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         1, "?c2", "xx",
+                         1, SparqlVariable{"?c2"}, "xx",
                          {SparqlTriple(
                               "?c2",
                               "<QLever-internal-function/contains-entity>",
@@ -472,7 +472,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
             TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
                 {std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         0, "?c", "abc",
+                         0, SparqlVariable{"?c"}, "abc",
                          {SparqlTriple(
                               "?c",
                               "<QLever-internal-function/contains-entity>",
@@ -487,7 +487,7 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                      {1, 2, 3}),
                  std::make_pair<Node, vector<size_t>>(
                      QueryPlanner::TripleGraph::Node(
-                         1, "?c2", "xx",
+                         1, SparqlVariable{"?c2"}, "xx",
                          {SparqlTriple(
                               "?c2",
                               "<QLever-internal-function/contains-entity>",
@@ -1010,9 +1010,10 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
         "      qet-width: 2 \n    } join-column: [0]\n    qet-width: 2 \n"
         "  }\n   filtered on column 1\n  qet-width: 4 \n}",
         qet.asString());
-    ASSERT_EQ(0u, qet.getVariableColumn("?c"));
-    ASSERT_EQ(1u, qet.getVariableColumn("SCORE(?c)"));
-    ASSERT_EQ(2u, qet.getVariableColumn("?y"));
+    ASSERT_EQ(0u, qet.getVariableColumn(SparqlVariable{"?c"}));
+    ASSERT_EQ(1u, qet.getVariableColumn(
+                      SparqlVariable{"?c", SparqlVariable::Type::SCORE}));
+    ASSERT_EQ(2u, qet.getVariableColumn(SparqlVariable{"?y"}));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1142,8 +1143,8 @@ TEST(QueryExecutionTreeTest, testFormerSegfaultTriFilter) {
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_TRUE(qet.varCovered("?1"));
-    ASSERT_TRUE(qet.varCovered("?0"));
+    ASSERT_TRUE(qet.varCovered(SparqlVariable{"?1"}));
+    ASSERT_TRUE(qet.varCovered(SparqlVariable{"?0"}));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -272,12 +272,12 @@ TEST(ParserTest, testParse) {
       const auto& values2 =
           pq.children()[1].get<GraphPatternOperation::Values>()._inlineValues;
 
-      vector<string> vvars = {"?a"};
+      vector<SparqlVariable> vvars = {SparqlVariable{"?a"}};
       ASSERT_EQ(vvars, values1._variables);
       vector<vector<string>> vvals = {{"<1>"}, {"\"2\""}};
       ASSERT_EQ(vvals, values1._values);
 
-      vvars = {"?b", "?c"};
+      vvars = {SparqlVariable{"?b"}, SparqlVariable{"?c"}};
       ASSERT_EQ(vvars, values2._variables);
       vvals = {{"<1>", "<2>"}, {"\"1\"", "\"2\""}};
       ASSERT_EQ(vvals, values2._values);
@@ -299,12 +299,12 @@ SELECT ?a ?b ?c WHERE {
       const auto& values2 =
           pq.children()[1].get<GraphPatternOperation::Values>()._inlineValues;
 
-      vector<string> vvars = {"?a"};
+      vector<SparqlVariable> vvars = {SparqlVariable{"?a"}};
       ASSERT_EQ(vvars, values1._variables);
       vector<vector<string>> vvals = {{"<Albert_Einstein>"}};
       ASSERT_EQ(vvals, values1._values);
 
-      vvars = {"?b", "?c"};
+      vvars = {SparqlVariable{"?b"}, SparqlVariable{"?c"}};
       ASSERT_EQ(vvars, values2._variables);
       vvals = {{"<Marie_Curie>", "<Joseph_Jacobson>"},
                {"<Freiherr>", "<Lord_of_the_Isles>"}};
@@ -333,7 +333,7 @@ SELECT ?a ?b ?c WHERE {
       ASSERT_EQ(c._whereClauseTriples[0]._p._iri, "wdt:P31");
       ASSERT_EQ(c._whereClauseTriples[0]._s, "?city");
 
-      vector<string> vvars = {"?citytype"};
+      vector<SparqlVariable> vvars = {SparqlVariable{"?citytype"}};
       ASSERT_EQ(vvars, values1._variables);
       vector<vector<string>> vvals = {{"wd:Q515"}, {"wd:Q262166"}};
       ASSERT_EQ(vvals, values1._values);

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -495,14 +495,14 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& c = pq.children()[0].getBasic();
     ASSERT_EQ(0u, pq._prefixes.size());
     ASSERT_EQ(3u, pq._selectedVariables.size());
-    ASSERT_EQ("SCORE(?x)", pq._selectedVariables[1]);
+    ASSERT_EQ("?:qlever-text-score-?x", pq._selectedVariables[1]);
     ASSERT_EQ(1u, c._whereClauseTriples.size());
     ASSERT_EQ("10", pq._limit);
     ASSERT_EQ("15", pq._offset);
     ASSERT_EQ(size_t(2), pq._orderBy.size());
     ASSERT_EQ("?y", pq._orderBy[0]._key);
     ASSERT_FALSE(pq._orderBy[0]._desc);
-    ASSERT_EQ("SCORE(?x)", pq._orderBy[1]._key);
+    ASSERT_EQ("?:qlever-text-score-?x", pq._orderBy[1]._key);
     ASSERT_TRUE(pq._orderBy[1]._desc);
     ASSERT_TRUE(pq._distinct);
     ASSERT_FALSE(pq._reduced);

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -71,8 +71,8 @@ TEST(TransitivePathTest, computeTransitivePath) {
   expected.push_back({7, 7});
   expected.push_back({10, 11});
 
-  TransitivePath T(nullptr, nullptr, false, false, 0, 0, 0, 0, "bim"s, "bam"s,
-                   0, 0);
+  TransitivePath T(nullptr, nullptr, false, false, 0, 0, 0, 0,
+                   SparqlVariable{"?bim"s}, SparqlVariable{"bam"s}, 0, 0);
 
   T.computeTransitivePath<2>(&result, sub, true, true, 0, 1, 0, 0, 1,
                              std::numeric_limits<size_t>::max());

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -72,7 +72,7 @@ TEST(TransitivePathTest, computeTransitivePath) {
   expected.push_back({10, 11});
 
   TransitivePath T(nullptr, nullptr, false, false, 0, 0, 0, 0,
-                   SparqlVariable{"?bim"s}, SparqlVariable{"bam"s}, 0, 0);
+                   SparqlVariable{"?bim"s}, SparqlVariable{"?bam"s}, 0, 0);
 
   T.computeTransitivePath<2>(&result, sub, true, true, 0, 1, 0, 0, 1,
                              std::numeric_limits<size_t>::max());


### PR DESCRIPTION
Previously, all variables were plain `std::strings` which made them hard to reason about ("does this store a variable, a variable or iri/literal, or does this store an arbitrary string)
and easy to make mistakes.

This PR goes one big step in the direction of fixing this, by introducing a `SparqlVariable` type which cannot be implicitly
converted to and from String.

The next step would be to introduce more of those types, e.g.a `TripleElement` (variable, literal/iri or property path).