### PR TITLE
Disable TwoColumnJoin

### DIFF
--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -97,11 +97,13 @@ class Join : public Operation {
 
   virtual void computeResult(ResultTable* result) override;
 
+ public:
   static bool isFullScanDummy(std::shared_ptr<QueryExecutionTree> tree) {
     return tree->getType() == QueryExecutionTree::SCAN &&
            tree->getResultWidth() == 3;
   }
 
+ private:
   void computeResultForJoinWithFullScanDummy(ResultTable* result) const;
 
   using ScanMethodType = std::function<void(Id, IdTable*)>;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -211,7 +211,8 @@ void MultiColumnJoin::computeSizeEstimateAndMultiplicities() {
   float multRight = std::numeric_limits<float>::max();
   for (size_t i = 0; i < _joinColumns.size(); i++) {
     multLeft = std::min(multLeft, _left->getMultiplicity(_joinColumns[i][0]));
-    multRight = std::min(multLeft, _left->getMultiplicity(_joinColumns[i][1]));
+    multRight =
+        std::min(multRight, _right->getMultiplicity(_joinColumns[i][1]));
   }
   float multResult = multLeft * multRight;
 

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -605,7 +605,7 @@ class TripleComponentComparator {
       std::string_view s, const Level level) const {
     AD_CHECK(level == Level::PRIMARY)
     auto transformed = extractAndTransformComparable(s, Level::PRIMARY);
-    // The `firstOriginalChar` is either " or < or @ 
+    // The `firstOriginalChar` is either " or < or @
     AD_CHECK(static_cast<unsigned char>(transformed.firstOriginalChar) <
              std::numeric_limits<unsigned char>::max())
     if (transformed.transformedVal.get().empty()) {

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -827,13 +827,7 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
                          "<s> ?p ?x . ?x ?p ?o }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_EQ(
-        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN FOR FULL INDEX POS (DUMMY "
-        "OPERATION)\n    qet-width: 3 \n  }\n  join-columns: [0 & 2]\n  |X|\n  "
-        "  {\n    SCAN SPO with S = \"<s>\"\n    qet-width: 2 \n  }\n  "
-        "join-columns: [0 & 1]\n  qet-width: 3 \n}",
-        qet.asString());
+    ASSERT_THROW(qp.createExecutionTree(pq), ad_semsearch::Exception);
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -848,13 +842,8 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
                          "?s ?p ?o . ?s ?p <x> }")
                          .parse();
     QueryPlanner qp(nullptr);
-    QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_EQ(
-        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN FOR FULL INDEX POS (DUMMY "
-        "OPERATION)\n    qet-width: 3 \n  }\n  join-columns: [0 & 2]\n  |X|\n  "
-        "  {\n    SCAN OPS with O = \"<x>\"\n    qet-width: 2 \n  }\n  "
-        "join-columns: [0 & 1]\n  qet-width: 3 \n}",
-        qet.asString());
+    ASSERT_THROW(QueryExecutionTree qet = qp.createExecutionTree(pq),
+                 ad_semsearch::Exception);
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -872,7 +861,7 @@ TEST(QueryPlannerTest, threeVarXthreeVarException) {
                          .parse();
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
-    FAIL() << "Was expecting exception" << std::endl;
+    FAIL() << "Was expecting exception, but got" << qet.asString() << std::endl;
   } catch (const ad_semsearch::Exception& e) {
     ASSERT_EQ(
         "Could not find a suitable execution tree. "
@@ -1102,7 +1091,21 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
     pq.expandPrefixes();
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_EQ(
+
+    // There are three possible outcomes of this test with the same size
+    // estimate. It is currently very hard to make the query planning
+    // deterministic in a test scenario, so we allow all three candidates
+    std::string possible1 =
+        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN PSO with P = "
+        "\"<Film_performance>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & "
+        "1]\n  |X|\n    {\n    SORT / ORDER BY on columns:asc(2) asc(1) \n    "
+        "{\n      JOIN\n      {\n        SCAN PSO with P = "
+        "\"<Film_performance>\"\n        qet-width: 2 \n      } join-column: "
+        "[0]\n      |X|\n      {\n        SCAN PSO with P = "
+        "\"<Spouse_(or_domestic_partner)>\"\n        qet-width: 2 \n      } "
+        "join-column: [0]\n      qet-width: 3 \n    }\n    qet-width: 3 \n  "
+        "}\n  join-columns: [2 & 1]\n  qet-width: 3 \n}";
+    std::string possible2 =
         "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN POS with P = "
         "\"<Film_performance>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & "
         "1]\n  |X|\n    {\n    SORT / ORDER BY on columns:asc(1) asc(2) \n    "
@@ -1111,8 +1114,25 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
         "[0]\n      |X|\n      {\n        SCAN PSO with P = "
         "\"<Spouse_(or_domestic_partner)>\"\n        qet-width: 2 \n      } "
         "join-column: [0]\n      qet-width: 3 \n    }\n    qet-width: 3 \n  "
-        "}\n  join-columns: [1 & 2]\n  qet-width: 3 \n}",
-        qet.asString());
+        "}\n  join-columns: [1 & 2]\n  qet-width: 3 \n}";
+    std::string possible3 =
+        "{\n  TWO_COLUMN_JOIN\n    {\n    SCAN POS with P = "
+        "\"<Spouse_(or_domestic_partner)>\"\n    qet-width: 2 \n  }\n  "
+        "join-columns: [0 & 1]\n  |X|\n    {\n    SORT / ORDER BY on "
+        "columns:asc(1) asc(2) \n    {\n      JOIN\n      {\n        SCAN POS "
+        "with P = \"<Film_performance>\"\n        qet-width: 2 \n      } "
+        "join-column: [0]\n      |X|\n      {\n        SCAN POS with P = "
+        "\"<Film_performance>\"\n        qet-width: 2 \n      } join-column: "
+        "[0]\n      qet-width: 3 \n    }\n    qet-width: 3 \n  }\n  "
+        "join-columns: [1 & 2]\n  qet-width: 3 \n}";
+    auto actual = qet.asString();
+
+    if (actual != possible1 && actual != possible2 && actual != possible3) {
+      FAIL() << "query execution tree is none of the possible trees, it is "
+                "actually "
+             << actual << '\n';
+    }
+
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();


### PR DESCRIPTION
The TwoColumnJoin does not work when both tables have more than two
columns. For now, always use the MultiColumnJoin.

TODO: However, the TwoColumnJoin can be used in some cases. See the TODO
in the code. Do you know how to do this, Johannes? 