### PR TITLE
Changes to make the fast CTRE index builder work for OSM (do not merge)

### DIFF
--- a/src/index/ConstantsIndexCreation.h
+++ b/src/index/ConstantsIndexCreation.h
@@ -15,7 +15,11 @@ const std::string EXTERNAL_LITS_TEXT_FILE_NAME = ".externalized-text";
 // Determines the maximum number of bytes of an internal literal (before
 // compression). Every literal larger as this size is externalized regardless
 // of its language tag
-static const size_t MAX_INTERNAL_LITERAL_BYTES = 1024;
+//
+// HACK OSM (Hannah 14.05.2021): Lower this, so that all non-trivial geometries
+// are externalized (points and typical names should remain internal).
+static const size_t MAX_INTERNAL_LITERAL_BYTES = 128;
+// static const size_t MAX_INTERNAL_LITERAL_BYTES = 1024;
 
 // How many lines are parsed at once during index creation.
 // Reduce to save RAM

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -1406,6 +1406,12 @@ LangtagAndTriple Index::tripleToInternalRepresentation(Triple&& tripleIn) {
   }
 
   for (size_t k = 0; k < upperBound; ++k) {
+    // OSM HACK: Check how the triples look like at this point.
+    //
+    // LOG(INFO) << "OSM DEBUG: " << k << ", " << spo[k] << ", "
+    //           << _onDiskLiterals << ", "
+    //           << _vocab.shouldBeExternalized(spo[k])
+    //           << std::endl;
     if (_onDiskLiterals && _vocab.shouldBeExternalized(spo[k])) {
       if (isLiteral(spo[k])) {
         spo[k][0] = EXTERNALIZED_LITERALS_PREFIX_CHAR;

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -393,7 +393,11 @@ bool TurtleParser<T>::pnameLnRelaxed() {
   // these can also be part of a collection etc.
   // find any character that can end a pnameLn when assuming that no
   // escape sequences were used
-  auto posEnd = view.find_first_of(" \n,;", pos);
+  //
+  // OSM HACK (Hannah 14.05.2021): assume that all triples end with \n, so that
+  // we can have , and ; in prefixed names.
+  auto posEnd = view.find_first_of(" \n", pos);
+  // auto posEnd = view.find_first_of(" \n,;", pos);
   if (posEnd == string::npos) {
     // make tests work
     posEnd = view.size();

--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -616,10 +616,8 @@ bool isXsdValue(const string& val) {
   size_t posLastQuote = val.rfind("\"");
   return !val.empty() && val[0] == '\"' && posLastQuote > 0 &&
          val.find("^^", posLastQuote) != string::npos &&
-         val.size() > posLastQuote + 37 &&
-         val[posLastQuote + 27] == 'X' &&
-         val[posLastQuote + 29] == 'L' &&
-         val[posLastQuote + 36] == '#';
+         val.size() > posLastQuote + 37 && val[posLastQuote + 27] == 'X' &&
+         val[posLastQuote + 29] == 'L' && val[posLastQuote + 36] == '#';
 }
 
 // _____________________________________________________________________________

--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -607,9 +607,19 @@ bool isXsdValue(const string& val) {
   // Search for the last quote and check if it is followed by ^^.
   // NOTE: searching for "^^ starting at position 1 (as done previously) fails
   // for literal "\"^^"@en (which is contained in the RDF dump of DBpedia).
+  //
+  // HACK OSM (Hannah 14.05.21): Make sure that only literals of type
+  // ^^<http://www.w3.org/2001/XMLSchema#...> are recognized as XSD values.
+  // For example, <http://www.opengis.net/ont/geosparql#wktLiteral> is not an
+  // XSD value and should not be recognized as one because it cannot be
+  // externalized otherwise.
   size_t posLastQuote = val.rfind("\"");
   return !val.empty() && val[0] == '\"' && posLastQuote > 0 &&
-         val.find("^^", posLastQuote) != string::npos;
+         val.find("^^", posLastQuote) != string::npos &&
+         val.size() > posLastQuote + 37 &&
+         val[posLastQuote + 27] == 'X' &&
+         val[posLastQuote + 29] == 'L' &&
+         val[posLastQuote + 36] == '#';
 }
 
 // _____________________________________________________________________________

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,9 +103,11 @@ add_executable(TokenTest TokenTest.cpp)
 add_test(TokenTest TokenTest)
 target_link_libraries(TokenTest parser re2 gtest_main -pthread ${ICU_LIBRARIES})
 
-add_executable(TurtleParserTest TurtleParserTest.cpp)
-add_test(TurtleParserTest TurtleParserTest)
-target_link_libraries(TurtleParserTest parser absl::flat_hash_map re2 gtest_main -pthread)
+# Disable due to OSM HACK (all triples end with \n because of , and ; in IRIs)
+#
+# add_executable(TurtleParserTest TurtleParserTest.cpp)
+# add_test(TurtleParserTest TurtleParserTest)
+# target_link_libraries(TurtleParserTest parser absl::flat_hash_map re2 gtest_main -pthread)
 
 add_executable(MultiColumnJoinTest MultiColumnJoinTest.cpp)
 add_test(MultiColumnJoinTest MultiColumnJoinTest)


### PR DESCRIPTION
This PR should not be merged into the master as is because some of it is ad-hoc (items 1 and 4) and some of it is just congifuration (item 3). Here is what it does:

1. Assume that all triples are subject-predicate-object (no , or ; syntax to avoid repeating the subject and/or predicate) and that all triples are on a single line and end with a newline.

2. In the current master, all literals with ^^ after the last quote are considered as xsd values, which cannot be externalized. In particular, this prevents the externalization of literals of type ^^geo:wktLiteral . This could be considered a BUG in the current master, which is fixed by a change in this PR.

3. Externalize all literals of length > 128 (so far the threshold was 1024). This will externalize all larger geometries, but not POINTs and simple geometries like buildings. This should actually be configurable in the `settings.json`.

4. Don't run the TurtleParserTest because it has several tests concerning the escaping of , and ; which now fail due to 1.