### PR TITLE
Fix the prefix filter

### DIFF
--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -672,6 +672,8 @@ inline size_t findClosingBracket(const string& haystack, size_t start,
 
 inline size_t findLiteralEnd(const std::string_view input,
                              const std::string_view literalEnd) {
+
+  auto lastFoundQuotePos = size_t(-1);
   auto endPos = input.find(literalEnd, 0);
   while (endPos != string::npos) {
     if (endPos > 0 && input[endPos - 1] == '\\') {
@@ -689,9 +691,13 @@ inline size_t findLiteralEnd(const std::string_view input,
       }
       endPos = input.find(literalEnd, endPos + 1);
     } else {
+      lastFoundQuotePos = endPos;
       // no backslash before " , the string has definitely ended
-      break;
+      endPos = input.find(literalEnd, endPos + 1);
     }
+  }
+  if (lastFoundQuotePos != size_t(-1)) {
+    return lastFoundQuotePos;
   }
   return endPos;
 }

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -149,7 +149,7 @@ inline size_t findClosingBracket(const string& haystack, size_t start = 0,
 inline string decodeUrl(const string& orig);
 
 /**
- * @brief Return the first position where <literalEnd> was found in the <input>
+ * @brief Return the last position where <literalEnd> was found in the <input>
  * without being escaped by backslashes. If it is not found at all, string::npos
  * is returned.
  */
@@ -670,10 +670,11 @@ inline size_t findClosingBracket(const string& haystack, size_t start,
   return -1;
 }
 
+// _________________________________________________________________________
 inline size_t findLiteralEnd(const std::string_view input,
                              const std::string_view literalEnd) {
-
-  auto lastFoundQuotePos = size_t(-1);
+  // keep track of the last position where the literalEnd was found unescaped
+  auto lastFoundPos = size_t(-1);
   auto endPos = input.find(literalEnd, 0);
   while (endPos != string::npos) {
     if (endPos > 0 && input[endPos - 1] == '\\') {
@@ -691,13 +692,16 @@ inline size_t findLiteralEnd(const std::string_view input,
       }
       endPos = input.find(literalEnd, endPos + 1);
     } else {
-      lastFoundQuotePos = endPos;
-      // no backslash before " , the string has definitely ended
+      // no backslash before the literalEnd, mark this as a candidate position
+      lastFoundPos = endPos;
       endPos = input.find(literalEnd, endPos + 1);
     }
   }
-  if (lastFoundQuotePos != size_t(-1)) {
-    return lastFoundQuotePos;
+
+  // if we have found any unescaped occurence of literalEnd, return the last
+  // of these positions
+  if (lastFoundPos != size_t(-1)) {
+    return lastFoundPos;
   }
   return endPos;
 }

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -120,32 +120,11 @@ TEST(Vocabulary, PrefixFilter) {
   voc.push_back("\"exa\"");
   voc.push_back("\"exp\"");
   voc.push_back("\"ext\"");
+  voc.push_back("\"[\"Ex-vivo\" renal artery revascularization]\"@en");
 
   auto x = voc.prefix_range("\"exp");
-  ASSERT_EQ(x.first, 1);
-  ASSERT_EQ(x.second, 2);
-
-  auto to_number_string = [](const auto& trans) {
-    std:string s = trans.transformedVal.get();
-    string result;
-    for (auto c : s) {
-      result.push_back(' ');
-      result += std::to_string(c);
-    }
-    return result;
-  };
-
-  TripleComponentComparator comp;
-  auto res = comp.extractAndTransformComparable("\"exp", LocaleManager::Level::PRIMARY);
-  auto rest = comp.transformToFirstPossibleBiggerValue("\"exp", LocaleManager::Level::PRIMARY);
-  auto resq = comp.extractAndTransformComparable("\"exq", LocaleManager::Level::PRIMARY);
-  auto resa = comp.extractAndTransformComparable("\"expl", LocaleManager::Level::PRIMARY);
-  auto resc = comp.extractAndTransformComparable( "\"[\"Ex-vivo\" renal artery revascularization]\"@en", LocaleManager::Level::PRIMARY);
-  LOG(INFO) << to_number_string(res) << '\n';
-  LOG(INFO) << resq.transformedVal.get()<< '\n';
-  LOG(INFO) << rest.transformedVal.get()<< '\n';
-  LOG(INFO) << resa.transformedVal.get()<< '\n';
-  LOG(INFO) << to_number_string(resc)<< '\n';
+  ASSERT_EQ(x.first, 1u);
+  ASSERT_EQ(x.second, 2u);
 }
 
 int main(int argc, char** argv) {

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -125,15 +125,27 @@ TEST(Vocabulary, PrefixFilter) {
   ASSERT_EQ(x.first, 1);
   ASSERT_EQ(x.second, 2);
 
+  auto to_number_string = [](const auto& trans) {
+    std:string s = trans.transformedVal.get();
+    string result;
+    for (auto c : s) {
+      result.push_back(' ');
+      result += std::to_string(c);
+    }
+    return result;
+  };
+
   TripleComponentComparator comp;
   auto res = comp.extractAndTransformComparable("\"exp", LocaleManager::Level::PRIMARY);
   auto rest = comp.transformToFirstPossibleBiggerValue("\"exp", LocaleManager::Level::PRIMARY);
   auto resq = comp.extractAndTransformComparable("\"exq", LocaleManager::Level::PRIMARY);
   auto resa = comp.extractAndTransformComparable("\"expl", LocaleManager::Level::PRIMARY);
-  LOG(INFO) << res.transformedVal.get()<< '\n';
+  auto resc = comp.extractAndTransformComparable( "\"[\"Ex-vivo\" renal artery revascularization]\"@en", LocaleManager::Level::PRIMARY);
+  LOG(INFO) << to_number_string(res) << '\n';
   LOG(INFO) << resq.transformedVal.get()<< '\n';
   LOG(INFO) << rest.transformedVal.get()<< '\n';
   LOG(INFO) << resa.transformedVal.get()<< '\n';
+  LOG(INFO) << to_number_string(resc)<< '\n';
 }
 
 int main(int argc, char** argv) {

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -115,6 +115,27 @@ TEST(VocabularyTest, IncompleteLiterals) {
   ASSERT_TRUE(comp("\"fieldofwork", "\"GOLD\"@en"));
 }
 
+TEST(Vocabulary, PrefixFilter) {
+  RdfsVocabulary voc;
+  voc.push_back("\"exa\"");
+  voc.push_back("\"exp\"");
+  voc.push_back("\"ext\"");
+
+  auto x = voc.prefix_range("\"exp");
+  ASSERT_EQ(x.first, 1);
+  ASSERT_EQ(x.second, 2);
+
+  TripleComponentComparator comp;
+  auto res = comp.extractAndTransformComparable("\"exp", LocaleManager::Level::PRIMARY);
+  auto rest = comp.transformToFirstPossibleBiggerValue("\"exp", LocaleManager::Level::PRIMARY);
+  auto resq = comp.extractAndTransformComparable("\"exq", LocaleManager::Level::PRIMARY);
+  auto resa = comp.extractAndTransformComparable("\"expl", LocaleManager::Level::PRIMARY);
+  LOG(INFO) << res.transformedVal.get()<< '\n';
+  LOG(INFO) << resq.transformedVal.get()<< '\n';
+  LOG(INFO) << rest.transformedVal.get()<< '\n';
+  LOG(INFO) << resa.transformedVal.get()<< '\n';
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
The Prefix filter used to yield wrong results for certain cases, when the underlying binary search had to touch vocabulary
entries that contained quotation marks. This is now fixed.
Fixes #414 