### PR TITLE
Update clang format to version 11

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y clang-format-8
+        run: sudo apt-get install -y clang-format-11
 
       - name: Run the format checker
         run: ${{github.workspace}}/misc/format-check.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ FROM base as builder
 RUN apt-get update && apt-get install -y build-essential cmake libsparsehash-dev libicu-dev tzdata
 COPY . /app/
 
-# Check formatting with the .clang-format project style
 WORKDIR /app/
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -17,8 +17,8 @@ for source in "${SOURCE_FILES[@]}" ;do
 		printf "The source file \x1b[m$source\x1b[31m does not match the code style\n"
 		printf "Use clang-format with the .clang-format provided in the QLever\n"
 		printf "repository's root to ensure all code files are formatted "
-		printf "properly. We currently use the clang-format 11.0.1\n"
-		printf "(can be installed as \"clang-format-11\" in Ubuntu 21.04.\n"
+		printf "properly. We currently use the clang-format-11\n"
+		printf "(can be installed as \"clang-format-11\" in Ubuntu 20.04.\n"
 		printf "\x1b[m"
 		ERROR=1
 	fi

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -9,7 +9,7 @@ done <sourcelist
 
 ERROR=0
 for source in "${SOURCE_FILES[@]}" ;do
-	clang-format-8 -output-replacements-xml $source | grep "<replacement " &> /dev/null
+	clang-format-11 -output-replacements-xml $source | grep "<replacement " &> /dev/null
 	HAS_WRONG_FILES=$?
 	if [ $HAS_WRONG_FILES -ne 1 ] ; then
 		# Print an error and exit
@@ -17,8 +17,8 @@ for source in "${SOURCE_FILES[@]}" ;do
 		printf "The source file \x1b[m$source\x1b[31m does not match the code style\n"
 		printf "Use clang-format with the .clang-format provided in the QLever\n"
 		printf "repository's root to ensure all code files are formatted "
-		printf "properly. We currently use the clang-format 8.0.0-3\n"
-		printf "(can be installed as \"clang-format-8\" in Ubuntu 18.04.x\n"
+		printf "properly. We currently use the clang-format 11.0.1\n"
+		printf "(can be installed as \"clang-format-11\" in Ubuntu 21.04.\n"
 		printf "\x1b[m"
 		ERROR=1
 	fi

--- a/src/MetaDataConverterMain.cpp
+++ b/src/MetaDataConverterMain.cpp
@@ -4,6 +4,7 @@
 //
 #include <array>
 #include <iostream>
+
 #include "./global/Constants.h"
 #include "./index/MetaDataConverter.h"
 #include "./util/File.h"

--- a/src/PrefixHeuristicEvaluatorMain.cpp
+++ b/src/PrefixHeuristicEvaluatorMain.cpp
@@ -3,6 +3,7 @@
 // Author: Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
 
 #include <iostream>
+
 #include "./global/Constants.h"
 #include "./index/PrefixHeuristic.h"
 

--- a/src/TurtleParserMain.cpp
+++ b/src/TurtleParserMain.cpp
@@ -3,10 +3,12 @@
 // Author: Johannes Kalmbach(joka921) <johannes.kalmbach@gmail.com>
 
 #include <getopt.h>
+
 #include <array>
 #include <fstream>
 #include <iostream>
 #include <string>
+
 #include "./parser/NTriplesParser.h"
 #include "./parser/TsvParser.h"
 #include "./parser/TurtleParser.h"

--- a/src/engine/Comparators.h
+++ b/src/engine/Comparators.h
@@ -5,7 +5,8 @@
 
 #include <utility>
 #include <vector>
-#include "IdTable.h"
+
+#include "./IdTable.h"
 
 using std::pair;
 using std::vector;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -2,8 +2,9 @@
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 
-#include "CountAvailablePredicates.h"
-#include "CallFixedSize.h"
+#include "./CountAvailablePredicates.h"
+
+#include "./CallFixedSize.h"
 
 // _____________________________________________________________________________
 CountAvailablePredicates::CountAvailablePredicates(QueryExecutionContext* qec)

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -6,8 +6,8 @@
 
 #include <sstream>
 
-#include "./QueryExecutionTree.h"
 #include "./CallFixedSize.h"
+#include "./QueryExecutionTree.h"
 
 using std::string;
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -3,9 +3,11 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./Distinct.h"
+
 #include <sstream>
+
 #include "./QueryExecutionTree.h"
-#include "CallFixedSize.h"
+#include "./CallFixedSize.h"
 
 using std::string;
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -3,10 +3,12 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "Filter.h"
+
 #include <algorithm>
 #include <optional>
 #include <regex>
 #include <sstream>
+
 #include "CallFixedSize.h"
 #include "QueryExecutionTree.h"
 

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <utility>
 #include <vector>
+
 #include "../parser/ParsedQuery.h"
 #include "./Operation.h"
 #include "./QueryExecutionTree.h"

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -3,6 +3,7 @@
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 
 #include "HasPredicateScan.h"
+
 #include "CallFixedSize.h"
 
 template <typename A, typename R>

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./IndexScan.h"
+
 #include <sstream>
 #include <string>
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+
 #include "../util/Conversions.h"
 #include "./Operation.h"
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -3,10 +3,12 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./Join.h"
+
 #include <functional>
 #include <sstream>
 #include <type_traits>
 #include <unordered_set>
+
 #include "./QueryExecutionTree.h"
 #include "CallFixedSize.h"
 

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <list>
+
 #include "../util/HashMap.h"
 #include "../util/HashSet.h"
 #include "./IndexScan.h"

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -3,6 +3,7 @@
 // Author: Florian Kramer (florian.kramer@netpun.uni-freiburg.de)
 
 #include "MultiColumnJoin.h"
+
 #include "CallFixedSize.h"
 
 using std::string;

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -3,6 +3,7 @@
 // Author: Johannes Kalmbach  (johannes.kalmbach@gmail.com)
 
 #include "Operation.h"
+
 #include "QueryExecutionTree.h"
 
 template <typename F>

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -4,6 +4,7 @@
 //         Florian Kramer (florian.kramer@netpun.uni-freiburg.de)
 
 #include "OptionalJoin.h"
+
 #include "CallFixedSize.h"
 
 using std::string;

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -2,11 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
+#include "OrderBy.h"
+
 #include <sstream>
 
 #include "CallFixedSize.h"
 #include "Comparators.h"
-#include "OrderBy.h"
 #include "QueryExecutionTree.h"
 
 using std::string;

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -3,9 +3,11 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./QueryExecutionTree.h"
+
 #include <algorithm>
 #include <sstream>
 #include <string>
+
 #include "./Distinct.h"
 #include "./Filter.h"
 #include "./IndexScan.h"

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+
 #include "../util/Conversions.h"
 #include "../util/HashSet.h"
 #include "./Operation.h"

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -5,6 +5,7 @@
 
 #include <set>
 #include <vector>
+
 #include "../parser/ParsedQuery.h"
 #include "QueryExecutionTree.h"
 

--- a/src/engine/QueryPlanningCostFactors.cpp
+++ b/src/engine/QueryPlanningCostFactors.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./QueryPlanningCostFactors.h"
+
 #include <fstream>
+
 #include "../util/Exception.h"
 #include "../util/Log.h"
 #include "../util/StringUtils.h"

--- a/src/engine/QueryPlanningCostFactors.h
+++ b/src/engine/QueryPlanningCostFactors.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+
 #include "../util/HashMap.h"
 
 using std::string;

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./ResultTable.h"
+
 #include <cassert>
 
 // _____________________________________________________________________________

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <optional>
 #include <vector>
+
 #include "../global/Id.h"
 #include "../util/Exception.h"
 #include "IdTable.h"

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold <buchholb>
 
+#include "./Server.h"
+
 #include <algorithm>
 #include <cstring>
 #include <nlohmann/json.hpp>
@@ -13,7 +15,6 @@
 #include "../parser/ParseException.h"
 #include "../util/Log.h"
 #include "../util/StringUtils.h"
-#include "./Server.h"
 #include "QueryPlanner.h"
 
 // _____________________________________________________________________________

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./Sort.h"
+
 #include <sstream>
+
 #include "CallFixedSize.h"
 #include "QueryExecutionTree.h"
 

--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -27,8 +27,8 @@ class SortPerformanceEstimator {
 
   // Compute and return an Estimate for how long sorting an IdTable with the
   // specified number of rows and columns takes.
-  double estimatedSortTimeInSeconds(size_t numRows, size_t numCols) const
-      noexcept;
+  double estimatedSortTimeInSeconds(size_t numRows,
+                                    size_t numCols) const noexcept;
 
   // Create an uninitialized SortPerformanceEstimator, which is cheap. Before
   // using it, computeEstimatesExpensively has to be called

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -2,10 +2,11 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
+#include "TextOperationWithFilter.h"
+
 #include <sstream>
 
 #include "./QueryExecutionTree.h"
-#include "TextOperationWithFilter.h"
 
 using std::string;
 

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "TextOperationWithoutFilter.h"
+
 #include <sstream>
+
 #include "./QueryExecutionTree.h"
 
 using std::string;

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "TwoColumnJoin.h"
+
 #include "CallFixedSize.h"
 
 using std::string;

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 #include "Union.h"
+
 #include "CallFixedSize.h"
 
 const size_t Union::NO_COLUMN = std::numeric_limits<size_t>::max();

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -5,9 +5,10 @@
 #include "Values.h"
 
 #include <sstream>
+
 #include "../util/Exception.h"
 #include "../util/HashSet.h"
-#include "CallFixedSize.h"
+#include "./CallFixedSize.h"
 
 Values::Values(QueryExecutionContext* qec, SparqlValues values)
     : Operation(qec) {

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+
 #include "../util/File.h"
 #include "Id.h"
 

--- a/src/index/CreatePatternsMain.cpp
+++ b/src/index/CreatePatternsMain.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 #include <getopt.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <iomanip>

--- a/src/index/DocsDB.cpp
+++ b/src/index/DocsDB.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "DocsDB.h"
+
 #include <algorithm>
+
 #include "../global/Constants.h"
 
 // _____________________________________________________________________________

--- a/src/index/DocsDB.h
+++ b/src/index/DocsDB.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "../global/Id.h"
 #include "../util/File.h"
 

--- a/src/index/ExternalVocabulary.h
+++ b/src/index/ExternalVocabulary.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <vector>
+
 #include "../global/Id.h"
 #include "../util/File.h"
 #include "StringSortComparator.h"

--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -3,10 +3,12 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./FTSAlgorithms.h"
+
 #include <cmath>
 #include <map>
 #include <set>
 #include <utility>
+
 #include "../util/HashMap.h"
 #include "../util/HashSet.h"
 

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -5,6 +5,7 @@
 #include <stxxl/algorithm>
 #include <tuple>
 #include <utility>
+
 #include "../engine/CallFixedSize.h"
 #include "../parser/ContextFileParser.h"
 #include "../util/Simple8bCode.h"

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
+#include "./Index.h"
+
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -18,7 +20,6 @@
 #include "../util/Conversions.h"
 #include "../util/HashMap.h"
 #include "../util/TupleHelpers.h"
-#include "./Index.h"
 #include "./PrefixHeuristic.h"
 #include "./VocabularyGenerator.h"
 #include "MetaDataIterator.h"
@@ -1540,7 +1541,7 @@ std::future<void> Index::writeNextPartialVocabulary(
                  vocab = &_vocab, partialFilename, partialCompressionFilename,
                  vocabPrefixCompressed = _vocabPrefixCompressed]() {
     auto vec = vocabMapsToVector(items);
-    const auto identicalPred = [& c = vocab->getCaseComparator()](
+    const auto identicalPred = [&c = vocab->getCaseComparator()](
                                    const auto& a, const auto& b) {
       return c(a.second.m_splitVal, b.second.m_splitVal,
                decltype(_vocab)::SortLevel::TOTAL);

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <getopt.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
@@ -10,8 +11,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-
 #include <unordered_set>
+
 #include "../global/Constants.h"
 #include "../util/File.h"
 #include "../util/ReadableNumberFact.h"

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -3,16 +3,17 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 #pragma once
 
+#include <stdio.h>
+
+#include <algorithm>
 #include <array>
+#include <cmath>
+#include <exception>
+#include <google/sparse_hash_map>
 #include <limits>
 #include <utility>
 #include <vector>
 
-#include <stdio.h>
-#include <algorithm>
-#include <cmath>
-#include <exception>
-#include <google/sparse_hash_map>
 #include "../global/Id.h"
 #include "../util/File.h"
 #include "../util/HashMap.h"

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -21,7 +21,8 @@ void IndexMetaData<MapType>::add(const FullRelationMetaData& rmd,
 
   off_t afterExpected =
       rmd.hasBlocks() ? bRmd._offsetAfter
-                      : static_cast<off_t>(rmd._startFullIndex + rmd.getNofBytesForFulltextIndex());
+                      : static_cast<off_t>(rmd._startFullIndex +
+                                           rmd.getNofBytesForFulltextIndex());
   if (rmd.hasBlocks()) {
     _blockData[rmd._relId] = bRmd;
   }
@@ -131,12 +132,15 @@ bool IndexMetaData<MapType>::relationExists(Id relId) const {
 
 // _____________________________________________________________________________
 template <class MapType>
-ad_utility::File& operator<<(ad_utility::File& f, const IndexMetaData<MapType>& imd) {
+ad_utility::File& operator<<(ad_utility::File& f,
+                             const IndexMetaData<MapType>& imd) {
   // first write magic number
   if constexpr (IndexMetaData<MapType>::_isMmapBased) {
-    f.write(&MAGIC_NUMBER_MMAP_META_DATA_VERSION, sizeof(MAGIC_NUMBER_MMAP_META_DATA_VERSION));
+    f.write(&MAGIC_NUMBER_MMAP_META_DATA_VERSION,
+            sizeof(MAGIC_NUMBER_MMAP_META_DATA_VERSION));
   } else {
-    f.write(&MAGIC_NUMBER_SPARSE_META_DATA_VERSION, sizeof(MAGIC_NUMBER_SPARSE_META_DATA_VERSION));
+    f.write(&MAGIC_NUMBER_SPARSE_META_DATA_VERSION,
+            sizeof(MAGIC_NUMBER_SPARSE_META_DATA_VERSION));
   }
   // write version
   f.write(&V_CURRENT, sizeof(V_CURRENT));
@@ -231,8 +235,10 @@ string IndexMetaData<MapType>::statistics() const {
 
   os << "# Elements:  " << _totalElements << '\n';
   os << "# Blocks:    " << _totalBlocks << "\n\n";
-  os << "Theoretical size of Id triples: " << _totalElements * 3 * sizeof(Id) << " bytes \n";
-  os << "Size of pair index:             " << totalPairIndexBytes << " bytes \n";
+  os << "Theoretical size of Id triples: " << _totalElements * 3 * sizeof(Id)
+     << " bytes \n";
+  os << "Size of pair index:             " << totalPairIndexBytes
+     << " bytes \n";
   os << "Total Size:                     " << _totalBytes << " bytes \n";
   os << "-------------------------------------------------------------------\n";
   return os.str();
@@ -251,7 +257,8 @@ size_t IndexMetaData<MapType>::getNofBlocksForRelation(const Id id) const {
 
 // _____________________________________________________________________________
 template <class MapType>
-size_t IndexMetaData<MapType>::getTotalBytesForRelation(const FullRelationMetaData& frmd) const {
+size_t IndexMetaData<MapType>::getTotalBytesForRelation(
+    const FullRelationMetaData& frmd) const {
   auto it = _blockData.find(frmd._relId);
   if (it != _blockData.end()) {
     return static_cast<size_t>(it->second._offsetAfter - frmd._startFullIndex);
@@ -282,7 +289,8 @@ void IndexMetaData<MapType>::calculateExpensiveStatistics() {
 
 // ___________________________________________________________________
 template <class MapType>
-VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char* buf) {
+VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(
+    unsigned char* buf) {
   uint64_t magicNumber = *reinterpret_cast<uint64_t*>(buf);
   size_t nOfBytes = 0;
   bool hasVersion = false;
@@ -315,11 +323,12 @@ VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char*
       hasVersion = true;
       nOfBytes = sizeof(uint64_t);
     } else {
-      throw WrongFormatException("ERROR: No or wrong magic number found in persistent "
-                                 "mmap-based meta data. "
-                                 "Please use ./MetaDataConverterMain "
-                                 "to convert old indices without rebuilding them (See "
-                                 "README.md).Terminating...\n");
+      throw WrongFormatException(
+          "ERROR: No or wrong magic number found in persistent "
+          "mmap-based meta data. "
+          "Please use ./MetaDataConverterMain "
+          "to convert old indices without rebuilding them (See "
+          "README.md).Terminating...\n");
     }
   }
 
@@ -332,9 +341,10 @@ VersionInfo IndexMetaData<MapType>::parseMagicNumberAndVersioning(unsigned char*
     res._nOfBytes += sizeof(uint64_t);
   }
   if (res._version < V_CURRENT) {
-    LOG(INFO) << "WARNING: your IndexMetaData seems to have an old format (version "
-                 "tag < V_CURRENT). Please consider using ./MetaDataConverterMain to "
-                 "benefit from improvements in the index structure.\n";
+    LOG(INFO)
+        << "WARNING: your IndexMetaData seems to have an old format (version "
+           "tag < V_CURRENT). Please consider using ./MetaDataConverterMain to "
+           "benefit from improvements in the index structure.\n";
 
   } else if (res._version > V_CURRENT) {
     LOG(INFO) << "ERROR: version tag does not match any actual version (> "

--- a/src/index/MetaDataConverter.cpp
+++ b/src/index/MetaDataConverter.cpp
@@ -4,8 +4,10 @@
 //
 
 #include "./MetaDataConverter.h"
+
 #include <nlohmann/json.hpp>
 #include <string>
+
 #include "../global/Constants.h"
 #include "./CompressedString.h"
 #include "./IndexMetaData.h"

--- a/src/index/MetaDataConverter.h
+++ b/src/index/MetaDataConverter.h
@@ -4,6 +4,7 @@
 //
 
 #include <string>
+
 #include "./IndexMetaData.h"
 
 using ad_utility::MmapVector;

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <stxxl/vector>
+
 #include "../global/Id.h"
 #include "../util/Exception.h"
 #include "../util/HashMap.h"

--- a/src/index/MetaDataTypes.cpp
+++ b/src/index/MetaDataTypes.cpp
@@ -3,9 +3,12 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./MetaDataTypes.h"
+
 #include <stdio.h>
+
 #include <algorithm>
 #include <cmath>
+
 #include "../util/ReadableNumberFact.h"
 #include "./MetaDataHandler.h"
 

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <string>
+
 #include "../global/Constants.h"
 #include "../util/File.h"
 #include "../util/Log.h"

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -12,8 +12,10 @@
 #include <unicode/unistr.h>
 #include <unicode/unorm2.h>
 #include <unicode/utypes.h>
+
 #include <cstring>
 #include <memory>
+
 #include "../global/Constants.h"
 #include "../util/Exception.h"
 #include "../util/StringUtils.h"

--- a/src/index/StxxlSortFunctors.h
+++ b/src/index/StxxlSortFunctors.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <tuple>
+
 #include "../global/Id.h"
 
 using std::array;

--- a/src/index/TextMetaData.cpp
+++ b/src/index/TextMetaData.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./TextMetaData.h"
+
 #include "../global/Constants.h"
 #include "../util/ReadableNumberFact.h"
 

--- a/src/index/TextMetaData.h
+++ b/src/index/TextMetaData.h
@@ -5,6 +5,7 @@
 
 #include <cstdio>
 #include <vector>
+
 #include "../global/Id.h"
 #include "../util/Exception.h"
 #include "../util/File.h"

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -411,8 +411,8 @@ void Vocabulary<S, C>::push_back(const string& word) {
 // _____________________________________________________________________________
 template <typename S, typename C>
 template <typename, typename>
-const std::optional<std::reference_wrapper<const string>> Vocabulary<S, C>::
-operator[](Id id) const {
+const std::optional<std::reference_wrapper<const string>>
+Vocabulary<S, C>::operator[](Id id) const {
   if (id < _words.size()) {
     return _words[static_cast<size_t>(id)];
   } else {
@@ -420,7 +420,7 @@ operator[](Id id) const {
   }
 }
 template const std::optional<std::reference_wrapper<const string>>
-    TextVocabulary::operator[]<std::string, void>(Id id) const;
+TextVocabulary::operator[]<std::string, void>(Id id) const;
 
 template <typename S, typename C>
 template <typename, typename>

--- a/src/parser/ContextFileParser.cpp
+++ b/src/parser/ContextFileParser.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./ContextFileParser.h"
+
 #include <cassert>
+
 #include "../util/Exception.h"
 #include "../util/StringUtils.h"
 

--- a/src/parser/ContextFileParser.h
+++ b/src/parser/ContextFileParser.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <unicode/locid.h>
+
 #include <fstream>
 #include <string>
 

--- a/src/parser/NTriplesParser.cpp
+++ b/src/parser/NTriplesParser.cpp
@@ -3,8 +3,10 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./NTriplesParser.h"
+
 #include <cassert>
 #include <iostream>
+
 #include "../util/Exception.h"
 #include "../util/Log.h"
 

--- a/src/parser/ParallelBuffer.h
+++ b/src/parser/ParallelBuffer.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+
 #include "../util/File.h"
 
 /**
@@ -63,7 +64,7 @@ class ParallelFileBuffer : public ParallelBuffer {
     _file.open(filename, "r");
     _eof = false;
     _buf.resize(_blocksize);
-    auto task = [& file = this->_file, bs = this->_blocksize,
+    auto task = [&file = this->_file, bs = this->_blocksize,
                  &buf = this->_buf]() { return file.read(buf.data(), bs); };
     _fut = std::async(task);
   }
@@ -80,7 +81,7 @@ class ParallelFileBuffer : public ParallelBuffer {
     std::optional<std::vector<char>> ret = std::move(_buf);
 
     _buf.resize(_blocksize);
-    auto task = [& file = this->_file, bs = this->_blocksize,
+    auto task = [&file = this->_file, bs = this->_blocksize,
                  &buf = this->_buf]() { return file.read(buf.data(), bs); };
     _fut = std::async(task);
 

--- a/src/parser/ParallelParseBuffer.h
+++ b/src/parser/ParallelParseBuffer.h
@@ -8,6 +8,7 @@
 #include <future>
 #include <string>
 #include <vector>
+
 #include "../util/Log.h"
 
 using std::array;

--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -3,6 +3,7 @@
 // Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 
 #include "SparqlLexer.h"
+
 #include "../util/StringUtils.h"
 #include "ParseException.h"
 #include "Tokenizer.h"

--- a/src/parser/SparqlLexer.h
+++ b/src/parser/SparqlLexer.h
@@ -3,6 +3,7 @@
 // Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 
 #include <re2/re2.h>
+
 #include <iostream>
 #include <string>
 

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+
 #include "ParsedQuery.h"
 #include "SparqlLexer.h"
 

--- a/src/parser/TsvParser.cpp
+++ b/src/parser/TsvParser.cpp
@@ -3,8 +3,10 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include "./TsvParser.h"
+
 #include <cassert>
 #include <iostream>
+
 #include "../util/Log.h"
 
 // _____________________________________________________________________________

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -7,11 +7,13 @@
 
 #include <gtest/gtest.h>
 #include <sys/mman.h>
+
 #include <codecvt>
 #include <exception>
 #include <future>
 #include <locale>
 #include <string_view>
+
 #include "../global/Constants.h"
 #include "../index/ConstantsIndexCreation.h"
 #include "../util/Exception.h"

--- a/src/util/BatchedPipeline.h
+++ b/src/util/BatchedPipeline.h
@@ -7,6 +7,7 @@
 
 #include <future>
 #include <utility>
+
 #include "./Timer.h"
 #include "./TupleHelpers.h"
 

--- a/src/util/BufferedVector.h
+++ b/src/util/BufferedVector.h
@@ -3,10 +3,11 @@
 // Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
 
 #pragma once
-#include <vector>
-#include "MmapVector.h"
-
 #include <gtest/gtest.h>
+
+#include <vector>
+
+#include "MmapVector.h"
 
 namespace ad_utility {
 

--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
 #include <cmath>
 #include <iostream>
 #include <string>

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/container/flat_hash_set.h>
+
 #include <string>
 
 using std::string;

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -6,13 +6,14 @@
 
 #include <sys/timeb.h>
 #include <time.h>
+
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <locale>
 #include <sstream>
 #include <string>
 
-#include <chrono>
 #include "./StringUtils.h"
 
 #ifndef LOGLEVEL

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include <string>
-
 #include <exception>
 #include <fstream>
 #include <sstream>
+#include <string>
+
 #include "../util/Exception.h"
 #include "File.h"
 

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -8,7 +8,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <utility>
+
 #include "../util/Log.h"
 
 namespace ad_utility {

--- a/src/util/PriorityQueue.h
+++ b/src/util/PriorityQueue.h
@@ -21,6 +21,7 @@
 #include <queue>
 #include <set>
 #include <variant>
+
 #include "./Exception.h"
 #include "./HashMap.h"
 #include "./Log.h"

--- a/src/util/Simple8bCode.h
+++ b/src/util/Simple8bCode.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <assert.h>
 #include <stdint.h>
+
 #include <algorithm>
 
 namespace ad_utility {

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -9,6 +9,7 @@
 #include <grp.h>
 #include <stdint.h>
 #include <stdlib.h>
+
 #include <array>
 #include <clocale>
 #include <cstring>
@@ -21,6 +22,7 @@
 #include <string>
 #include <string_view>
 #include <vector>
+
 #include "../parser/ParseException.h"
 
 using std::array;

--- a/test/BatchedPipelineTest.cpp
+++ b/test/BatchedPipelineTest.cpp
@@ -3,7 +3,9 @@
 // Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
 
 #include <gtest/gtest.h>
+
 #include <optional>
+
 #include "../src/parser/TurtleParser.h"
 #include "../src/util/BatchedPipeline.h"
 

--- a/test/BufferedVectorTest.cpp
+++ b/test/BufferedVectorTest.cpp
@@ -3,7 +3,9 @@
 // Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
 
 #include <gtest/gtest.h>
+
 #include <vector>
+
 #include "../src/util/BufferedVector.h"
 
 using ad_utility::BufferedVector;

--- a/test/CacheTest.cpp
+++ b/test/CacheTest.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <string>
+
 #include "../src/util/Cache.h"
 
 using std::string;

--- a/test/ContextFileParserTest.cpp
+++ b/test/ContextFileParserTest.cpp
@@ -3,8 +3,10 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <cstdio>
 #include <fstream>
+
 #include "../src/parser/ContextFileParser.h"
 
 TEST(ContextFileParserTest, getLineTest) {

--- a/test/ConversionsTest.cpp
+++ b/test/ConversionsTest.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold <buchholb>
 
 #include <gtest/gtest.h>
+
 #include "../src/util/Conversions.h"
 
 using std::string;

--- a/test/ExternalVocabularyTest.cpp
+++ b/test/ExternalVocabularyTest.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold <buchholb>
 
 #include <gtest/gtest.h>
+
 #include "../src/index/ExternalVocabulary.h"
 
 TEST(ExternalVocabularyTest, getWordbyIdTest) {

--- a/test/HashMapTest.cpp
+++ b/test/HashMapTest.cpp
@@ -3,6 +3,7 @@
 // Author: Niklas Schnelle (schnelle@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <string>
 #include <utility>
 #include <vector>

--- a/test/HashSetTest.cpp
+++ b/test/HashSetTest.cpp
@@ -3,6 +3,7 @@
 // Author: Niklas Schnelle (schnelle@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <utility>
 #include <vector>
 

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -3,7 +3,9 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <fstream>
+
 #include "../src/index/IndexMetaData.h"
 #include "../src/util/File.h"
 

--- a/test/MmapVectorTest.cpp
+++ b/test/MmapVectorTest.cpp
@@ -4,8 +4,10 @@
 //
 #include <gtest/gtest.h>
 #include <unistd.h>
+
 #include <stdexcept>
 #include <vector>
+
 #include "../src/util/MmapVector.h"
 
 using ad_utility::MmapVector;

--- a/test/NTriplesParserTest.cpp
+++ b/test/NTriplesParserTest.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <cstdio>
 #include <fstream>
 #include <iostream>

--- a/test/PriorityQueueTest.cpp
+++ b/test/PriorityQueueTest.cpp
@@ -3,7 +3,9 @@
 // Author: Johannes Kalmbach (johannes.kalmbach@gmail.com)
 
 #include <gtest/gtest.h>
+
 #include <string>
+
 #include "../src/util/Cache.h"
 
 using ad_utility::HeapBasedPQ;

--- a/test/Simple8bTest.cpp
+++ b/test/Simple8bTest.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold <buchholb>
 
 #include <gtest/gtest.h>
+
 #include "../src/util/Simple8bCode.h"
 
 using std::string;

--- a/test/SparqlLexerTest.cpp
+++ b/test/SparqlLexerTest.cpp
@@ -3,9 +3,9 @@
 // Author: Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 
 #include <gtest/gtest.h>
-#include "../src/parser/SparqlLexer.h"
-
 #include <re2/re2.h>
+
+#include "../src/parser/SparqlLexer.h"
 
 TEST(SparqlLexerTest, basicTest) {
   //  ASSERT_TRUE(

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include "../src/global/Constants.h"
 #include "../src/parser/PropertyPathParser.h"
 #include "../src/parser/SparqlParser.h"

--- a/test/StringSortComparatorTest.cpp
+++ b/test/StringSortComparatorTest.cpp
@@ -3,6 +3,7 @@
 // Author: Johannes Kalmbach (johannes.kalmbach@gmail.com)
 
 #include <gtest/gtest.h>
+
 #include "../src/index/StringSortComparator.h"
 using namespace std::literals;
 

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -3,9 +3,11 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <algorithm>
 #include <string>
 #include <vector>
+
 #include "../src/util/StringUtils.h"
 
 using std::string;

--- a/test/SynchronizedTest.cpp
+++ b/test/SynchronizedTest.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <gtest/gtest.h>
+
 #include "../src/util/Synchronized.h"
 
 using ad_utility::Synchronized;

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -2,10 +2,10 @@
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 
+#include <gtest/gtest.h>
+
 #include <array>
 #include <vector>
-
-#include <gtest/gtest.h>
 
 #include "../src/engine/TransitivePath.h"
 #include "../src/global/Id.h"

--- a/test/TsvParserTest.cpp
+++ b/test/TsvParserTest.cpp
@@ -3,8 +3,10 @@
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
 #include <gtest/gtest.h>
+
 #include <cstdio>
 #include <fstream>
+
 #include "../src/parser/TsvParser.h"
 
 TEST(TsvParserTest,

--- a/test/TupleHelpersTest.cpp
+++ b/test/TupleHelpersTest.cpp
@@ -3,7 +3,9 @@
 // Author: Johannes Kalmbach (johannes.kalmbach@gmail.com)
 
 #include <gtest/gtest.h>
+
 #include <string>
+
 #include "../src/util/TupleHelpers.h"
 
 using namespace ad_tuple_helpers;

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -3,8 +3,10 @@
 // Author: Johannes Kalmbach(joka921) <johannes.kalmbach@gmail.com>
 //
 #include <gtest/gtest.h>
+
 #include <iostream>
 #include <string>
+
 #include "../src/parser/TurtleParser.h"
 
 using std::string;

--- a/test/Utf8RegexTest.cpp
+++ b/test/Utf8RegexTest.cpp
@@ -10,9 +10,11 @@
 
 #include <ctre/ctre.h>
 #include <gtest/gtest.h>
+
 #include <codecvt>
 #include <locale>
 #include <string>
+
 #include "../src/parser/Tokenizer.h"
 
 using namespace std::literals::string_literals;

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include <cstdlib>
 #include <ctime>
 #include <fstream>
@@ -263,7 +264,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
     auto ptr = std::make_shared<const ItemMapArray>(std::move(arr));
     writePartialIdMapToBinaryFileForMerging(
         ptr, basename + PARTIAL_VOCAB_FILE_NAME + "0",
-        [& c = v.getCaseComparator()](const auto& a, const auto& b) {
+        [&c = v.getCaseComparator()](const auto& a, const auto& b) {
           return c(a.second.m_splitVal, b.second.m_splitVal,
                    TripleComponentComparator::Level::IDENTICAL);
         },

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -3,9 +3,11 @@
 // Author: Björn Buchhold <buchholb>
 
 #include <gtest/gtest.h>
+
 #include <cstdio>
 #include <nlohmann/json.hpp>
 #include <vector>
+
 #include "../src/index/Vocabulary.h"
 
 using json = nlohmann::json;


### PR DESCRIPTION
We previously used clang-format-8 which was the default in Ubuntu 18.04

This version is not provided by newer Ubuntu versions (starting from 20.04 clang-format-11 is the standard) and chooses some strange formattings for modern C++ constructs which it does not understand.

This PR updates the format-checking script to use clang-format-11 and reformats the complete code

The changes are only minor (mostly only headers are reordered)