### PR TITLE
Allow Id-space exports of query results

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -272,6 +272,20 @@ void QueryExecutionTree::writeTable(
         validIndices,
     std::ostream& out) const {
   shared_ptr<const ResultTable> res = getResult();
+
+  // special case : binary export of IdTable
+  if (sep == 'b') {
+    for (size_t i = from; i < upperBound; ++i) {
+      for (size_t j = 0; j < validIndices.size(); ++j) {
+        if (validIndices[j]) {
+          const auto& val = *validIndices[j];
+          out.write(reinterpret_cast<const char*>(&data(i, val.first)),
+                    sizeof(Id));
+        }
+      }
+    }
+    return;
+  }
   for (size_t i = from; i < upperBound; ++i) {
     for (size_t j = 0; j < validIndices.size(); ++j) {
       if (validIndices[j]) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -232,6 +232,13 @@ void Server::process(Socket* client) {
         contentType =
             "text/tab-separated-values\r\n"
             "Content-Disposition: attachment;filename=export.tsv";
+      } else if (ad_utility::getLowercase(params["action"]) ==
+                 "binary_export") {
+        // binary export
+        response = composeResponseSepValues(pq, qet, 'b');
+        contentType =
+            "application/octet-stream\r\n"
+            "Content-Disposition: attachment;filename=export.dat";
       } else {
         // Normal case: JSON response
         response = composeResponseJson(pq, qet, requestTimer, maxSend);


### PR DESCRIPTION
This PR allows the export of query results directly in the ID space in a dense binary format.
This is very useful for debugging.