### PR TITLE
Make test is a separate line in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /app/
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=DEBUG -DUSE_PARALLEL=true .. && make -j $(nproc) && make test
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=DEBUG -DUSE_PARALLEL=true .. && make -j $(nproc)
+RUN make test
 
 FROM base as runtime
 WORKDIR /app

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -164,7 +164,7 @@ target_link_libraries(MinusTest gtest_main engine ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(SortPerformanceEstimatorTest SortPerformanceEstimatorTest.cpp)
 target_link_libraries(SortPerformanceEstimatorTest gtest_main SortPerformanceEstimator ${CMAKE_THREAD_LIBS_INIT})
-# this test runs for quite some time! If this is undesired, comment it out
-add_test(SortPerformanceEstimatorTest SortPerformanceEstimatorTest)
+# this test runs for quite some time and might have spurious failures! If this is undesired, comment it out
+#add_test(SortPerformanceEstimatorTest SortPerformanceEstimatorTest)
 
 


### PR DESCRIPTION
This allows using/building a docker container without recompilation in case of a test failure.
Also comment out the SortPerformanceEstimatorTest because it has spurious failures which are nasty.