### PR TITLE
Movable CompactStringVector

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -195,7 +195,7 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
       patternCounts[hasPattern[i]]++;
     } else if (i < hasPredicate.size()) {
       size_t numPredicates;
-      Id* predicateData;
+      const Id* predicateData;
       std::tie(predicateData, numPredicates) = hasPredicate[i];
       if (numPredicates > 0) {
         for (size_t i = 0; i < numPredicates; i++) {
@@ -213,7 +213,7 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
   LOG(DEBUG) << "Using " << patternCounts.size()
              << " patterns for computing the result." << std::endl;
   for (const auto& it : patternCounts) {
-    std::pair<Id*, size_t> pattern = patterns[it.first];
+    const auto& pattern = patterns[it.first];
     for (size_t i = 0; i < pattern.second; i++) {
       predicateCounts[pattern.first[i]] += it.second;
     }
@@ -262,7 +262,7 @@ void CountAvailablePredicates::computePatternTrick(
     } else if (subject < hasPredicate.size()) {
       // The subject does not match a pattern
       size_t numPredicates;
-      Id* predicateData;
+      const Id* predicateData;
       std::tie(predicateData, numPredicates) = hasPredicate[subject];
       numListPredicates += numPredicates;
       if (numPredicates > 0) {
@@ -287,7 +287,7 @@ void CountAvailablePredicates::computePatternTrick(
   size_t numPredicatesSubsumedInPatterns = 0;
   // resolve the patterns to predicate counts
   for (const auto& it : patternCounts) {
-    std::pair<Id*, size_t> pattern = patterns[it.first];
+    const auto& pattern = patterns[it.first];
     numPatternPredicates += pattern.second;
     for (size_t i = 0; i < pattern.second; i++) {
       predicateCounts[pattern.first[i]] += it.second;

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -273,7 +273,7 @@ void HasPredicateScan::computeFreeS(
     if (id < hasPattern.size() && hasPattern[id] != NO_PATTERN) {
       // add the pattern
       size_t numPredicates;
-      Id* patternData;
+      const Id* patternData;
       std::tie(patternData, numPredicates) = patterns[hasPattern[id]];
       for (size_t i = 0; i < numPredicates; i++) {
         if (patternData[i] == objectId) {
@@ -283,7 +283,7 @@ void HasPredicateScan::computeFreeS(
     } else if (id < hasPredicate.size()) {
       // add the relations
       size_t numPredicates;
-      Id* predicateData;
+      const Id* predicateData;
       std::tie(predicateData, numPredicates) = hasPredicate[id];
       for (size_t i = 0; i < numPredicates; i++) {
         if (predicateData[i] == objectId) {
@@ -307,7 +307,7 @@ void HasPredicateScan::computeFreeO(
   if (subjectId < hasPattern.size() && hasPattern[subjectId] != NO_PATTERN) {
     // add the pattern
     size_t numPredicates;
-    Id* patternData;
+    const Id* patternData;
     std::tie(patternData, numPredicates) = patterns[hasPattern[subjectId]];
     for (size_t i = 0; i < numPredicates; i++) {
       result.push_back({patternData[i]});
@@ -315,7 +315,7 @@ void HasPredicateScan::computeFreeO(
   } else if (subjectId < hasPredicate.size()) {
     // add the relations
     size_t numPredicates;
-    Id* predicateData;
+    const Id* predicateData;
     std::tie(predicateData, numPredicates) = hasPredicate[subjectId];
     for (size_t i = 0; i < numPredicates; i++) {
       result.push_back({predicateData[i]});
@@ -338,7 +338,7 @@ void HasPredicateScan::computeFullScan(
     if (id < hasPattern.size() && hasPattern[id] != NO_PATTERN) {
       // add the pattern
       size_t numPredicates;
-      Id* patternData;
+      const Id* patternData;
       std::tie(patternData, numPredicates) = patterns[hasPattern[id]];
       for (size_t i = 0; i < numPredicates; i++) {
         result.push_back({id, patternData[i]});
@@ -346,7 +346,7 @@ void HasPredicateScan::computeFullScan(
     } else if (id < hasPredicate.size()) {
       // add the relations
       size_t numPredicates;
-      Id* predicateData;
+      const Id* predicateData;
       std::tie(predicateData, numPredicates) = hasPredicate[id];
       for (size_t i = 0; i < numPredicates; i++) {
         result.push_back({id, predicateData[i]});
@@ -373,7 +373,7 @@ void HasPredicateScan::computeSubqueryS(
     if (id < hasPattern.size() && hasPattern[id] != NO_PATTERN) {
       // Expand the pattern and add it to the result
       size_t numPredicates;
-      Id* patternData;
+      const Id* patternData;
       std::tie(patternData, numPredicates) = patterns[hasPattern[id]];
       for (size_t j = 0; j < numPredicates; j++) {
         result.push_back();
@@ -386,7 +386,7 @@ void HasPredicateScan::computeSubqueryS(
     } else if (id < hasPredicate.size()) {
       // add the relations
       size_t numPredicates;
-      Id* predicateData;
+      const Id* predicateData;
       std::tie(predicateData, numPredicates) = hasPredicate[id];
       for (size_t j = 0; j < numPredicates; j++) {
         result.push_back();

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -184,12 +184,13 @@ class CompactStringVector {
    * @return A std::pair containing a pointer to the data, and the number of
    *         elements stored at the pointers target.
    */
-  const std::pair<DataT*, size_t> operator[](size_t i) const {
+  const std::pair<const DataT*, size_t> operator[](size_t i) const {
     IndexT ind, nextInd;
     std::memcpy(&ind, data() + (i * sizeof(IndexT)), sizeof(IndexT));
     std::memcpy(&nextInd, data() + ((i + 1) * sizeof(IndexT)), sizeof(IndexT));
-    return std::pair<DataT*, size_t>(
-        reinterpret_cast<DataT*>(data() + (_indexEnd + sizeof(DataT) * ind)),
+    return std::pair<const DataT*, size_t>(
+        reinterpret_cast<const DataT*>(data() +
+                                       (_indexEnd + sizeof(DataT) * ind)),
         nextInd - ind);
   }
 

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -135,16 +135,16 @@ class CompactStringVector {
     size_t indPos = 0;
     for (IndexT i = 0; i < _size; i++) {
       // add an entry to the index
-      std::memcpy(data() + (indPos * sizeof(IndexT)), &currentLength,
+      std::memcpy(this->data() + (indPos * sizeof(IndexT)), &currentLength,
                   sizeof(IndexT));
       // copy the vectors actual data
-      std::memcpy(data() + (_indexEnd + currentLength * sizeof(DataT)),
+      std::memcpy(this->data() + (_indexEnd + currentLength * sizeof(DataT)),
                   data[i].data(), data[i].size() * sizeof(DataT));
       indPos++;
       currentLength += data[i].size();
     }
     // add a final entry that stores the end of the data field
-    std::memcpy(data() + (indPos * sizeof(IndexT)), &currentLength,
+    std::memcpy(this->data() + (indPos * sizeof(IndexT)), &currentLength,
                 sizeof(IndexT));
   }
 

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -111,7 +111,7 @@ class CompactStringVector {
     load(file, offset);
   }
 
-  virtual ~CompactStringVector() { delete[] _data; }
+  virtual ~CompactStringVector() = default;
 
   /**
    * @brief Fills this CompactStringVector with data.
@@ -130,21 +130,21 @@ class CompactStringVector {
           std::to_string(std::numeric_limits<IndexT>::max()));
     }
     _dataSize = _indexEnd + sizeof(DataT) * dataCount;
-    _data = new uint8_t[_dataSize];
+    _data.reset(new uint8_t[_dataSize]);
     IndexT currentLength = 0;
     size_t indPos = 0;
     for (IndexT i = 0; i < _size; i++) {
       // add an entry to the index
-      std::memcpy(_data + (indPos * sizeof(IndexT)), &currentLength,
+      std::memcpy(data() + (indPos * sizeof(IndexT)), &currentLength,
                   sizeof(IndexT));
       // copy the vectors actual data
-      std::memcpy(_data + (_indexEnd + currentLength * sizeof(DataT)),
+      std::memcpy(data() + (_indexEnd + currentLength * sizeof(DataT)),
                   data[i].data(), data[i].size() * sizeof(DataT));
       indPos++;
       currentLength += data[i].size();
     }
     // add a final entry that stores the end of the data field
-    std::memcpy(_data + (indPos * sizeof(IndexT)), &currentLength,
+    std::memcpy(data() + (indPos * sizeof(IndexT)), &currentLength,
                 sizeof(IndexT));
   }
 
@@ -152,11 +152,15 @@ class CompactStringVector {
     file.read(&_size, sizeof(size_t), offset);
     file.read(&_dataSize, sizeof(size_t), offset + sizeof(size_t));
     _indexEnd = (_size + 1) * sizeof(IndexT);
-    _data = new uint8_t[_dataSize];
-    file.read(_data, _dataSize, offset + 2 * sizeof(size_t));
+    _data.reset(new uint8_t[_dataSize]);
+    file.read(data(), _dataSize, offset + 2 * sizeof(size_t));
   }
 
+  // This is a move-only type
   CompactStringVector& operator=(const CompactStringVector&) = delete;
+  CompactStringVector& operator=(CompactStringVector&&) = default;
+  CompactStringVector(const CompactStringVector&) = delete;
+  CompactStringVector(CompactStringVector&&) = default;
 
   size_t size() const { return _size; }
 
@@ -168,7 +172,7 @@ class CompactStringVector {
   size_t write(ad_utility::File& file) {
     file.write(&_size, sizeof(size_t));
     file.write(&_dataSize, sizeof(size_t));
-    file.write(_data, _dataSize);
+    file.write(data(), _dataSize);
     return _dataSize + 2 * sizeof(size_t);
   }
 
@@ -182,15 +186,17 @@ class CompactStringVector {
    */
   const std::pair<DataT*, size_t> operator[](size_t i) const {
     IndexT ind, nextInd;
-    std::memcpy(&ind, _data + (i * sizeof(IndexT)), sizeof(IndexT));
-    std::memcpy(&nextInd, _data + ((i + 1) * sizeof(IndexT)), sizeof(IndexT));
+    std::memcpy(&ind, data() + (i * sizeof(IndexT)), sizeof(IndexT));
+    std::memcpy(&nextInd, data() + ((i + 1) * sizeof(IndexT)), sizeof(IndexT));
     return std::pair<DataT*, size_t>(
-        reinterpret_cast<DataT*>(_data + (_indexEnd + sizeof(DataT) * ind)),
+        reinterpret_cast<DataT*>(data() + (_indexEnd + sizeof(DataT) * ind)),
         nextInd - ind);
   }
 
  private:
-  uint8_t* _data;
+  uint8_t* data() { return _data.get(); };
+  const uint8_t* data() const { return _data.get(); };
+  std::unique_ptr<uint8_t[]> _data;
   size_t _size;
   size_t _indexEnd;
   size_t _dataSize;

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -401,7 +401,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     Pattern p;
     p.push_back(3);
     p.push_back(6);
-    std::pair<Id*, size_t> ip = index._patterns[0];
+    auto ip = index._patterns[0];
     for (size_t i = 0; i < ip.second; i++) {
       ASSERT_EQ(p[i], ip.first[i]);
     }
@@ -424,7 +424,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     Pattern p;
     p.push_back(3);
     p.push_back(6);
-    std::pair<Id*, size_t> ip = index._patterns[0];
+    auto ip = index._patterns[0];
     for (size_t i = 0; i < ip.second; i++) {
       ASSERT_EQ(p[i], ip.first[i]);
     }

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -401,7 +401,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     Pattern p;
     p.push_back(3);
     p.push_back(6);
-    auto ip = index._patterns[0];
+    const auto& ip = index._patterns[0];
     for (size_t i = 0; i < ip.second; i++) {
       ASSERT_EQ(p[i], ip.first[i]);
     }
@@ -424,7 +424,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     Pattern p;
     p.push_back(3);
     p.push_back(6);
-    auto ip = index._patterns[0];
+    const auto& ip = index._patterns[0];
     for (size_t i = 0; i < ip.second; i++) {
       ASSERT_EQ(p[i], ip.first[i]);
     }


### PR DESCRIPTION
Improve this type's interface and safety by using a std::unique_ptr for the data storage, which allows as safe and correctly defaulted move constructors.