### PR TITLE
Fix empty Mantissa converting error

### DIFF
--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -428,7 +428,11 @@ float convertIndexWordToFloat(const string& indexWord) {
     ;
   double absMantissa = 0;
   try {
-    absMantissa = stod(mantissa.substr(mStart, mStop - mStart + 1));
+    auto mantissaSubstr = mantissa.substr(mStart, mStop - mStart + 1);
+    // empty mantissa means "0.0"
+    if (!mantissaSubstr.empty()) {
+      absMantissa = stod(mantissa.substr(mStart, mStop - mStart + 1));
+    }
   } catch (const std::exception& e) {
     string substr = mantissa.substr(mStart, mStop - mStart + 1);
     throw std::runtime_error(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(QueryPlannerTest gtest_main engine ${CMAKE_THREAD_LIBS_INI
 
 add_executable(ConversionsTest ConversionsTest.cpp)
 add_test(ConversionsTest ConversionsTest)
-target_link_libraries(ConversionsTest gtest_main engine ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(ConversionsTest gtest_main  ${CMAKE_THREAD_LIBS_INIT})
 
 add_executable(HashMapTest HashMapTest.cpp)
 add_test(HashMapTest HashMapTest)

--- a/test/ConversionsTest.cpp
+++ b/test/ConversionsTest.cpp
@@ -368,6 +368,13 @@ TEST(ConversionsTest, convertNumericToIndexWordEndToEnd) {
   //                "\"123\"^^<http://www.w3.org/2001/XMLSchema#int>");
 }
 
+TEST(ConversionsTest, BugDiscoveredByHannah) {
+  ASSERT_FLOAT_EQ(
+      convertIndexWordToFloat(
+          ":v:float:PM99999999999999999998E000000000000000000000000000000F"),
+      0.0);
+}
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
In certain cases, the handling of the float value "0.0" in QLever's representation failed previously.
This is now fixed with this PR.