### PR TITLE
Move the `ResultType` enum to a separate file

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -34,6 +34,6 @@ add_library(engine
         IdTable.h
         ../util/Random.h
         Minus.h Minus.cpp
-        )
+        ResultType.h)
 
 target_link_libraries(engine index parser SortPerformanceEstimator absl::flat_hash_set)

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -26,8 +26,6 @@ class ResultTable {
   enum Status { IN_PROGRESS = 0, FINISHED = 1, ABORTED = 2 };
   using ResultType = qlever::ResultType;
 
-
-
   /**
    * @brief This vector contains a list of column indices by which the result
    *        is sorted. This vector may be empty if the result is not sorted

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -12,6 +12,7 @@
 #include "../global/Id.h"
 #include "../util/Exception.h"
 #include "IdTable.h"
+#include "ResultType.h"
 
 using std::array;
 using std::condition_variable;
@@ -23,23 +24,9 @@ using std::vector;
 class ResultTable {
  public:
   enum Status { IN_PROGRESS = 0, FINISHED = 1, ABORTED = 2 };
+  using ResultType = qlever::ResultType;
 
-  /**
-   * @brief Describes the type of a columns data
-   */
-  enum class ResultType {
-    // An entry in the knowledgebase
-    KB,
-    // An unsigned integer (size_t)
-    VERBATIM,
-    // A byte offset in the text index
-    TEXT,
-    // A 32 bit float, stored in the first 4 bytes of the entry. The last four
-    // bytes have to be zero.
-    FLOAT,
-    // An entry in the ResultTable's _localVocab
-    LOCAL_VOCAB
-  };
+
 
   /**
    * @brief This vector contains a list of column indices by which the result

--- a/src/engine/ResultType.h
+++ b/src/engine/ResultType.h
@@ -1,0 +1,28 @@
+//
+// Created by johannes on 09.05.21.
+//
+
+#ifndef QLEVER_RESULTTYPE_H
+#define QLEVER_RESULTTYPE_H
+
+namespace qlever {
+/**
+ * @brief Describes the type of a columns data
+ */
+enum class ResultType {
+  // An entry in the knowledgebase
+  KB,
+  // An unsigned integer (size_t)
+  VERBATIM,
+  // A byte offset in the text index
+  TEXT,
+  // A 32 bit float, stored in the first 4 bytes of the entry. The last four
+  // bytes have to be zero.
+  FLOAT,
+  // An entry in the ResultTable's _localVocab
+  LOCAL_VOCAB
+};
+}
+
+#endif  // QLEVER_RESULTTYPE_H
+

--- a/src/engine/ResultType.h
+++ b/src/engine/ResultType.h
@@ -22,7 +22,6 @@ enum class ResultType {
   // An entry in the ResultTable's _localVocab
   LOCAL_VOCAB
 };
-}
+}  // namespace qlever
 
 #endif  // QLEVER_RESULTTYPE_H
-

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -397,8 +397,7 @@ struct GraphPatternOperation {
     struct Constant {
       int64_t _intValue = 0;  // the Value of an integer constant (VERBATIM)
       string _kbValue;  // the value of a knowledge base entity or literal (KB)
-      qlever::ResultType
-          _type;  // the type, currently always KB or VERBATIM
+      qlever::ResultType _type;  // the type, currently always KB or VERBATIM
 
       Constant() = default;
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -9,7 +9,7 @@
 #include <variant>
 #include <vector>
 
-#include "../engine/ResultTable.h"
+#include "../engine/ResultType.h"
 #include "../util/Exception.h"
 #include "../util/HashMap.h"
 #include "../util/StringUtils.h"
@@ -397,7 +397,7 @@ struct GraphPatternOperation {
     struct Constant {
       int64_t _intValue = 0;  // the Value of an integer constant (VERBATIM)
       string _kbValue;  // the value of a knowledge base entity or literal (KB)
-      ResultTable::ResultType
+      qlever::ResultType
           _type;  // the type, currently always KB or VERBATIM
 
       Constant() = default;
@@ -407,12 +407,12 @@ struct GraphPatternOperation {
       explicit Constant(int64_t val)
           : _intValue(val),
             _kbValue(std::to_string(val)),
-            _type(ResultTable::ResultType::VERBATIM) {}
+            _type(qlever::ResultType::VERBATIM) {}
       // Initialize a KB constant. If the argument string is not part of the KB
       // this will lead to an error later on (currently no possibility to
       // already check this during parsing
       explicit Constant(std::string entry)
-          : _kbValue(std::move(entry)), _type(ResultTable::ResultType::KB) {}
+          : _kbValue(std::move(entry)), _type(qlever::ResultType::KB) {}
       // TODO<joka921> in c++ 20 we have constexpr strings.
       static constexpr const char* Name = "Constant";
       // Some other functions need this interface, for example,


### PR DESCRIPTION
This allows using it without including the large ResultTable.h header.