### PR TITLE
Make QLever compile with clang++12

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-10, clang++-11 ]
+        compiler: [ g++-10, clang++-12 ]
         os: [ ubuntu-latest ]
         warnings: [ "", -Werror ]
         exclude:
@@ -32,7 +32,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      run:  sudo apt-get install -y libsparsehash-dev libicu-dev tzdata clang gcc-10 clang-11
+      run:  sudo apt-get install -y libsparsehash-dev libicu-dev tzdata gcc-10
+    - name: Install clang 12
+      run: wget https://apt.llvm.org/llvm.sh && sudo chmod +x llvm.sh && sudo ./llvm.sh 12
+
     - name: Python dependencies
       run: sudo apt-get install python3-yaml unzip pkg-config python3-icu
 
@@ -57,4 +60,4 @@ jobs:
     - name: E2E
       run: ${{github.workspace}}/e2e/e2e.sh
       if: ${{matrix.warnings != '-Werror'}}
-      
+

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -135,6 +135,10 @@ class AllocatorWithLimit {
       : memoryLeft_(std::move(ml)) {}
   AllocatorWithLimit() = delete;
 
+  template <typename U>
+  AllocatorWithLimit(const AllocatorWithLimit<U>& other)
+      : memoryLeft_(other.getMemoryLeft()){};
+
   // An allocator must have a function "allocate" with exactly this signature.
   // TODO<C++20> : the exact signature of allocate changes
   T* allocate(std::size_t n) {
@@ -164,18 +168,18 @@ class AllocatorWithLimit {
         ->numFreeBytes();
   }
 
+  const auto& getMemoryLeft() const { return memoryLeft_; }
+
   // The STL needs two allocators to be equal if and only they refer to the same
   // memory pool. For us, they are hence equal if they use the same
   // AllocationMemoryLeft object.00
-  template <typename U, typename V>
-  friend bool operator==(const AllocatorWithLimit<U>& u,
-                         const AllocatorWithLimit<V>& v) {
-    return u.memoryLeft_ == v.memoryLeft_;
+  template <typename V>
+  bool operator==(const AllocatorWithLimit<V>& v) {
+    return memoryLeft_ == v.memoryLeft_;
   }
-  template <typename U, typename V>
-  friend bool operator!=(const AllocatorWithLimit<U>& u,
-                         const AllocatorWithLimit<V>& v) {
-    return !(u == v);
+  template <typename V>
+  bool operator!=(const AllocatorWithLimit<V>& v) {
+    return !(*this == v);
   }
 };
 


### PR DESCRIPTION
Changed to clang++12 in the CI pipeline and applied small fixes to ensure compilation without warnings.