### PR TITLE
Fix "almost empty" prefix filters

### DIFF
--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -609,14 +609,12 @@ class TripleComponentComparator {
              std::numeric_limits<unsigned char>::max())
     if (transformed.transformedVal.get().empty()) {
       transformed.firstOriginalChar += 1;
-      // transformed.transformedVal.get().push_back('\1');
     } else {
       unsigned char last = transformed.transformedVal.get().back();
       if (last < std::numeric_limits<unsigned char>::max()) {
         transformed.transformedVal.get().back() += 1;
       } else {
-        // transformed.transformedVal.get().push_back('\1');
-        transformed.firstOriginalChar += 1;
+        transformed.transformedVal.get().push_back('\1');
       }
     }
     return transformed;

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -605,6 +605,7 @@ class TripleComponentComparator {
       std::string_view s, const Level level) const {
     AD_CHECK(level == Level::PRIMARY)
     auto transformed = extractAndTransformComparable(s, Level::PRIMARY);
+    // The `firstOriginalChar` is either " or < or @ 
     AD_CHECK(static_cast<unsigned char>(transformed.firstOriginalChar) <
              std::numeric_limits<unsigned char>::max())
     if (transformed.transformedVal.get().empty()) {

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -605,11 +605,19 @@ class TripleComponentComparator {
       std::string_view s, const Level level) const {
     AD_CHECK(level == Level::PRIMARY)
     auto transformed = extractAndTransformComparable(s, Level::PRIMARY);
-    unsigned char last = transformed.transformedVal.get().back();
-    if (last < std::numeric_limits<unsigned char>::max()) {
-      transformed.transformedVal.get().back() += 1;
+    AD_CHECK(static_cast<unsigned char>(transformed.firstOriginalChar) <
+             std::numeric_limits<unsigned char>::max())
+    if (transformed.transformedVal.get().empty()) {
+      transformed.firstOriginalChar += 1;
+      // transformed.transformedVal.get().push_back('\1');
     } else {
-      transformed.transformedVal.get().push_back('\0');
+      unsigned char last = transformed.transformedVal.get().back();
+      if (last < std::numeric_limits<unsigned char>::max()) {
+        transformed.transformedVal.get().back() += 1;
+      } else {
+        // transformed.transformedVal.get().push_back('\1');
+        transformed.firstOriginalChar += 1;
+      }
     }
     return transformed;
   }


### PR DESCRIPTION
Prefix filters with a single < or " (all iris or all literals) are currently broken in QLever, this is now fixed.

