### PR TITLE
Reduce the usage of Macros in the logging and json module.

### DIFF
--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -29,12 +29,12 @@
   '[' << ad_utility::getLastPartOfString(__FILE__, '/') << ':' << __LINE__ \
       << "] "  // NOLINT
 
-#define TRACE 5
-#define DEBUG 4
-#define INFO 3
-#define WARN 2
-#define ERROR 1
-#define FATAL 0
+static constexpr size_t TRACE = 5;
+static constexpr size_t DEBUG = 4;
+static constexpr size_t INFO = 3;
+static constexpr size_t WARN = 2;
+static constexpr size_t ERROR = 1;
+static constexpr size_t FATAL = 0;
 
 namespace ad_utility {
 /* A singleton (According to Scott Meyer's pattern that holds

--- a/third_party/json/nlohmann/json.hpp
+++ b/third_party/json/nlohmann/json.hpp
@@ -4824,7 +4824,7 @@ std::char_traits<char>::int_type get_character()
 {
 auto res = sb->sbumpc();
 // set eof manually, as we don't use the istream interface.
-if (JSON_HEDLEY_UNLIKELY(res == EOF))
+if (JSON_HEDLEY_UNLIKELY(res == std::char_traits<char>::eof()))
 {
 is->clear(is->rdstate() | std::ios::eofbit);
 }


### PR DESCRIPTION
This reduces collisions with the SPARQL parser and makes the code safer in general.