### PR TITLE
Add CORS header

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -122,7 +122,7 @@ boost::asio::awaitable<void> Server::process(
     }
 
     co_return co_await processQuery(params, requestTimer, std::move(request),
-                                    send);
+                                    sendWithCors);
   } else if (responseFromCommand.has_value()) {
     co_return co_await sendWithCors(std::move(responseFromCommand.value()));
   }
@@ -248,7 +248,6 @@ boost::asio::awaitable<void> Server::processQuery(
   auto sendJson = [&request, &send](
                       const json& jsonString) -> boost::asio::awaitable<void> {
     auto response = createJsonResponse(jsonString, request);
-    response.set(http::field::access_control_allow_origin, "*");
     co_return co_await send(std::move(response));
   };
 

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -75,6 +75,11 @@ boost::asio::awaitable<void> Server::process(
   auto filenameAndParams = ad_utility::UrlParser::parseTarget(request.target());
   const auto& params = filenameAndParams._parameters;
 
+  auto sendWithCors = [&send](auto response) -> boost::asio::awaitable<void> {
+    response.set(http::field::access_control_allow_origin, "*");
+    co_return co_await send(std::move(response));
+  };
+
   // If there is a command like "clear_cache" which might be combined with a
   // query, track if there is such a command but no query and still send
   // a useful response.
@@ -84,12 +89,11 @@ boost::asio::awaitable<void> Server::process(
     if (cmd == "stats") {
       LOG(INFO) << "Supplying index stats..." << std::endl;
       auto response = createJsonResponse(composeStatsJson(), request);
-      co_return co_await send(std::move(response));
+      co_return co_await sendWithCors(std::move(response));
     } else if (cmd == "cachestats") {
       LOG(INFO) << "Supplying cache stats..." << std::endl;
-      auto response =
-          createJsonResponse(composeCacheStatsJson().dump(), request);
-      co_return co_await send(std::move(response));
+      auto response = createJsonResponse(composeCacheStatsJson(), request);
+      co_return co_await sendWithCors(std::move(response));
     } else if (cmd == "clearcache") {
       LOG(INFO) << "Clearing the cache, unpinned elements only" << std::endl;
       _cache.clearUnpinnedOnly();
@@ -104,7 +108,7 @@ boost::asio::awaitable<void> Server::process(
           "Successfully cleared the cache (including the pinned elements)",
           request, ad_utility::MediaType::textPlain);
     } else {
-      co_await send(createBadRequestResponse(
+      co_await sendWithCors(createBadRequestResponse(
           R"(unknown value for query paramter "cmd" : ")" + cmd + '\"',
           request));
       co_return;
@@ -113,14 +117,14 @@ boost::asio::awaitable<void> Server::process(
 
   if (params.contains("query")) {
     if (params.at("query").empty()) {
-      co_return co_await send(createBadRequestResponse(
+      co_return co_await sendWithCors(createBadRequestResponse(
           "Parameter \"query\" must not have an empty value", request));
     }
 
     co_return co_await processQuery(params, requestTimer, std::move(request),
                                     send);
   } else if (responseFromCommand.has_value()) {
-    co_return co_await send(std::move(responseFromCommand.value()));
+    co_return co_await sendWithCors(std::move(responseFromCommand.value()));
   }
 
   // Neither a query nor a command were specified, simply serve a file.
@@ -244,6 +248,7 @@ boost::asio::awaitable<void> Server::processQuery(
   auto sendJson = [&request, &send](
                       const json& jsonString) -> boost::asio::awaitable<void> {
     auto response = createJsonResponse(jsonString, request);
+    response.set(http::field::access_control_allow_origin, "*");
     co_return co_await send(std::move(response));
   };
 

--- a/src/util/HttpServer/HttpUtils.h
+++ b/src/util/HttpServer/HttpUtils.h
@@ -56,7 +56,6 @@ auto createHttpResponseFromString(std::string body, http::status status,
                                   MediaType mediaType = MediaType::html) {
   http::response<http::string_body> response{status, request.version()};
   response.set(http::field::content_type, toString(mediaType));
-  response.set(http::field::access_control_allow_origin, "*");
   response.keep_alive(request.keep_alive());
   response.body() = std::move(body);
   // Set Content-Length and Transfer-Encoding.

--- a/src/util/HttpServer/HttpUtils.h
+++ b/src/util/HttpServer/HttpUtils.h
@@ -56,6 +56,7 @@ auto createHttpResponseFromString(std::string body, http::status status,
                                   MediaType mediaType = MediaType::html) {
   http::response<http::string_body> response{status, request.version()};
   response.set(http::field::content_type, toString(mediaType));
+  response.set(http::field::access_control_allow_origin, "*");
   response.keep_alive(request.keep_alive());
   response.body() = std::move(body);
   // Set Content-Length and Transfer-Encoding.


### PR DESCRIPTION
The QLever backend currently does not send an Access-Control-Allow-Origin header. This works fine when the QLever UI and the QLever backend operate under the same domain, like https://qlever.cs.uni-freiburg.de .

However, this is not always the case. In particular, when someone installs QLever for the first time, they typically run QLever and the QLever UI on different ports of the same machine, for example localhost:7000 (Backend) and localhost:8000 (UI).
Then the UI will block the results from localhost:7000 because of the same-origin policy (different ports on the same machine count as different origins).

A simple fix is to let QLever always send the header `Access-Control-Allow-Origin: *`. Then the results from the QLever backend can be used on any website. Right now, I don't see a problem with that. I have checked the Wikidata Query Service and they also do this: https://query.wikidata.org .
