### PR TITLE
docs, ctest break, serverMain, e2e, clang version format-check update

### DIFF
--- a/docs/native_setup.md
+++ b/docs/native_setup.md
@@ -7,6 +7,7 @@ For Ubuntu 18.04 the following packages are required
 
 * build-essential cmake libicu-dev
 * wget python3-yaml unzip curl (for End-to-End Tests)
+* libjemalloc-dev ninja-build libzstd-dev google-perftools libunwind-dev libgoogle-perftools-dev 
 
 This roughly translates to
 
@@ -15,41 +16,128 @@ This roughly translates to
 * python >= 3.6 (for End-to-End Tests with type hints)
 * python-yaml >= 3.10
 
+
+ 
 ## Build and run unit tests
 
-Go to a folder where you want to build the binaries. Usually this is done
+- Go to a folder where you want to build the binaries. Usually this is done
 with a separate `build` subfolder. This is also assumed by the `e2e/e2e.sh`
 script.
 
-    mkdir build && cd build
+      mkdir build && cd build
 
-Build the project (Optional: add `-DPERFTOOLS_PROFILER=True/False` and `-DALLOW_SHUTDOWN=True/False`)
+- Build the project with TYPE='Release' or TYPE='Debug' (Optional: add `-DPERFTOOLS_PROFILER=True/False` and `-DALLOW_SHUTDOWN=True/False`)
 
-    cmake -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc)
+      cmake -DCMAKE_BUILD_TYPE=Release .. && make -j $(nproc)
+  or
 
-Run ctest. All tests should pass:
+      cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=DEBUG -DUSE_PARALLEL=true -DPERFTOOLS_PROFILER=true -DALLOW_SHUTDOWN=true -GNinja .. && ninja
 
-    ctest
+
+
+- Run ctest. All tests should pass:
+
+      ctest
+  or
+
+      env CTEST_OUTPUT_ON_FAILURE=1 ctest -C Release
+
+- Run e2e.sh tests. All tests should also pass:
+ 
+      ./path/to/qlever-code/e2e/e2e.sh
 
 ## Create or reuse an index
+
+<!---
 See the main [README](../README.md#creating-an-index) but make sure to
 either add `./build/` to your path or prefix all commands with `./` and that
 `/index` and `/input` need to be the path to the index and input on your host.
+-->
+
+Index file-path example:
+
+    /path/to/myindex/indexName.nt
+
+Notice the lack of the file-extension '.nt' on the following commands.
+
+    cd /path/to/qlever-code/build && chmod o+w .
+    mkdir -p qlever-indices/olympics && cd qlever-indices/olympics 
+    cp ../../../examples/olympics.* .
+    xzcat olympics.nt.xz | ./../../IndexBuilderMain -F ttl -f - -l -i olympics -s olympics.settings.json | tee olympics.index-log.txt
+
+All options:
+
+    «Argument»            Required  Flag   Input
+
+    docs-by-contexts          Y      'd'  path/to/file
+    help                      N      'h'
+    index-basename            Y      'i'  string of index-basename
+    file-format               Y      'F'  [tsv|nt|ttl|mmap]
+    knowledge-base-input-file Y      'f'  stdin ('-') or path/to/file
+    kb-index-name             Y      'K'  string for UI (default: name of [file-format]-file)
+    on-disk-literals          N      'l'  
+    no-patterns               N      'P'  
+    text-index-name           Y      'T'  string for UI (default: name of words-file)
+    words-by-contexts         Y      'w'  /path/to/file
+    add-text-index            N      'A'  
+    keep-temporary-files      N      'k'  
+    settings-file             Y      's'  path/to/file (normally: filename.settings.json)
+    no-compressed-vocabulary  N      'N'  
 
 ## Start a Sever
 
+Reminder of the Index file-path example:
+
+    /path/to/qlever-code/build/qlever-indices/indexName/indexName.nt
+
 * Without text collection:
 
-    ./ServerMain -i /path/to/myindex -p <PORT>
+      cd /path/to/qlever-code/build/
+      ./ServerMain -i /path/to/indexName/indexName -p $PORT
+
+  or
+
+      cd /path/to/qlever-code/build/qlever-indices/indexName/
+      ./../../ServerMain -i indexName -p $PORT
 
 * With text collection:
 
-    ./ServerMain -i /path/to/myindex -p <PORT> -t
+      cd /path/to/qlever-code/build/
+      ./ServerMain -i /path/to/indexName/indexName -p $PORT -t
 
+  or
+
+      cd /path/to/qlever-code/build/qlever-indices/indexName/
+      ./../../ServerMain -i indexName -p $PORT -t
+
+<!---
+
+    ./ServerMain -i /path/to/indexName/indexName -j ${worker-threads} -m ${MEMORY_FOR_QUERIES} -c ${CACHE_MAX_SIZE_GB} -e ${CACHE_MAX_SIZE_GB_SINGLE_ENTRY} -k ${CACHE_MAX_NUM_ENTRIES} -p ${PORT}
+-->
+
+All options:
+
+    «Argument»                 Required  Flag   Input
+
+    help                           N     'h'
+    index                          Y     'i'   /path/to/indexName/indexName
+    worker-threads                 Y     'j'   recommended between [1, threads_hardware_concurrency] (enter '-1' for threads_hardware_concurrency)
+    memory-for-queries             Y     'm'   [int]
+    cache-max-size-gb              Y     'c'   [int]
+    cache-max-size-gb-single-entry Y     'e'   [int]
+    cache-max-num-entries          Y     'k'   [int]
+    on-disk-literals               N     'l' 
+    port                           Y     'p'   [0, 65535]
+    no-patterns                    N     'P'
+    no-pattern-trick               N     'T'
+    text                           N     't'
+
+
+<!---
 Depending on if you built the index with the -a version, two or six index permutations will be registered.
 For some data this can be a significant difference in memory consumption.
 
 If you built an index using the -a option, make sure to include it at startup
 (otherwise only 2 of the 6 permutations will be registered).
+-->
 
-    ./ServerMain -i /path/to/myindex -p <PORT> -t -a

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -60,9 +60,9 @@ PROJECT_DIR=$(readlink -f -- "$(dirname ${BASH_SOURCE[0]})/..")
 
 # Change to the project directory so we can use simple relative paths
 echo "Changing to project directory: $PROJECT_DIR"
-pushd $PROJECT_DIR
+pushd "$PROJECT_DIR"
 BINARY_DIR=$(readlink -f -- ./build)
-if [ ! -e $BINARY_DIR ]; then
+if [ ! -e "$BINARY_DIR" ]; then
 	BINARY_DIR=$(readlink -f -- .)
 fi
 echo "Binary dir is $BINARY_DIR"
@@ -88,7 +88,7 @@ mkdir -p "$INDEX_DIR"
 # Travis' caching creates it
 if [ ! -e "$INPUT.nt" ]; then
 	# Why the hell is this a ZIP that can't easily be decompressed from stdin?!?
-	unzip -j $ZIPPED_INPUT -d "$INPUT_DIR/"
+	unzip -j "$ZIPPED_INPUT" -d "$INPUT_DIR/"
 fi;
 
 
@@ -123,5 +123,5 @@ echo "Waiting for ServerMain to launch and open port"
 while ! curl --max-time 1 --output /dev/null --silent http://localhost:9099/; do
 	sleep 1
 done
-$PYTHON_BINARY "$PROJECT_DIR/e2e/queryit.py" "$PROJECT_DIR/e2e/scientists_queries.yaml" "http://localhost:9099" &> $BINARY_DIR/query_log.txt || bail "Querying Server failed"
+$PYTHON_BINARY "$PROJECT_DIR/e2e/queryit.py" "$PROJECT_DIR/e2e/scientists_queries.yaml" "http://localhost:9099" &> "$BINARY_DIR/query_log.txt" || bail "Querying Server failed"
 popd

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -9,7 +9,7 @@ done <sourcelist
 
 ERROR=0
 for source in "${SOURCE_FILES[@]}" ;do
-	clang-format-11 -output-replacements-xml $source | grep "<replacement " &> /dev/null
+	clang-format-13 -output-replacements-xml $source | grep "<replacement " &> /dev/null
 	HAS_WRONG_FILES=$?
 	if [ $HAS_WRONG_FILES -ne 1 ] ; then
 		# Print an error and exit

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -181,35 +181,37 @@ int main(int argc, char** argv) {
     exit(1);
   }
 
-  if(numThreads == -1) {
-    numThreads = (int) std::thread::hardware_concurrency();
+  if (numThreads == -1) {
+    numThreads = (int)std::thread::hardware_concurrency();
   }
 
-  if(cacheMaxSizeGB <= 0) {
+  if (cacheMaxSizeGB <= 0) {
     cerr << "ERROR: cacheMaxSizeGB cannot be equal or less then zero." << endl;
     printUsage(argv[0]);
     exit(1);
   }
 
-  if(cacheMaxSizeGBSingleEntry <= 0) {
-    cerr << "ERROR: cacheMaxSizeGBSingleEntry cannot be equal or less then zero." << endl;
-    printUsage(argv[0]);
-    exit(1);
-  }
-  
-  if(cacheMaxNumEntries <= 0) {
-    cerr << "ERROR: cacheMaxNumEntries cannot be equal or less then zero." << endl;
+  if (cacheMaxSizeGBSingleEntry <= 0) {
+    cerr << "ERROR: cacheMaxSizeGBSingleEntry cannot "
+         << "be equal or less then zero." << endl;
     printUsage(argv[0]);
     exit(1);
   }
 
-  if(memLimit <= 0) {
+  if (cacheMaxNumEntries <= 0) {
+    cerr << "ERROR: cacheMaxNumEntries cannot be equal "
+         << "or less then zero." << endl;
+    printUsage(argv[0]);
+    exit(1);
+  }
+
+  if (memLimit <= 0) {
     cerr << "ERROR: memLimit cannot be equal or less then zero." << endl;
     printUsage(argv[0]);
     exit(1);
   }
 
-  if(numThreads <= 0) {
+  if (numThreads <= 0) {
     cerr << "ERROR: numThreads cannot be equal or less then zero." << endl;
     printUsage(argv[0]);
     exit(1);

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
   optind = 1;
   // Process command line arguments.
   while (true) {
-    int c = getopt_long(argc, argv, "i:p:j:tauhm:lc:e:k:T", options, NULL);
+    int c = getopt_long(argc, argv, "i:p:j:tauhm:lc:e:k:T", options, nullptr);
     if (c == -1) break;
     switch (c) {
       case 'i':
@@ -170,13 +170,47 @@ int main(int argc, char** argv) {
     }
   }
 
-  if (index.size() == 0 || port == -1) {
-    if (index.size() == 0) {
+  if (index.empty() || port == -1) {
+    if (index.empty()) {
       cerr << "ERROR: No index specified, but an index is required." << endl;
     }
     if (port == -1) {
       cerr << "ERROR: No port specified, but the port is required." << endl;
     }
+    printUsage(argv[0]);
+    exit(1);
+  }
+
+  if(numThreads == -1) {
+    numThreads = (int) std::thread::hardware_concurrency();
+  }
+
+  if(cacheMaxSizeGB <= 0) {
+    cerr << "ERROR: cacheMaxSizeGB cannot be equal or less then zero." << endl;
+    printUsage(argv[0]);
+    exit(1);
+  }
+
+  if(cacheMaxSizeGBSingleEntry <= 0) {
+    cerr << "ERROR: cacheMaxSizeGBSingleEntry cannot be equal or less then zero." << endl;
+    printUsage(argv[0]);
+    exit(1);
+  }
+  
+  if(cacheMaxNumEntries <= 0) {
+    cerr << "ERROR: cacheMaxNumEntries cannot be equal or less then zero." << endl;
+    printUsage(argv[0]);
+    exit(1);
+  }
+
+  if(memLimit <= 0) {
+    cerr << "ERROR: memLimit cannot be equal or less then zero." << endl;
+    printUsage(argv[0]);
+    exit(1);
+  }
+
+  if(numThreads <= 0) {
+    cerr << "ERROR: numThreads cannot be equal or less then zero." << endl;
     printUsage(argv[0]);
     exit(1);
   }

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -31,9 +31,11 @@ constexpr uint32_t MmapVector<T>::Version;
 template <class T>
 void MmapVector<T>::writeMetaDataToEnd() {
   // does  this not matter
+  /*
   if (truncate(_filename.c_str(), _bytesize)) {
     throw TruncateException(_filename, _bytesize, errno);
   }
+  */
 
   // open file and seek to end of array space
   // additionally specifying ios::in avoids truncation of file


### PR DESCRIPTION
native docs --> update and improvement of the doc &&  Flag '-a' in shortopts (ServerMain.cpp.120)  but not addressed, causing it to break. Presented all flags options.

ctest --> comment truncate exception (MmapVectorImpl.h.34) [previously questioned if it did matter]. Previously 6 tests failed.

serverMain --> server arguments valid verification (options_value > 0) && new value for threads: max_threads_concurrency ("-j -1")

e2e --> upgrade for paths contaning spaces

format-check --> update for clang-13

Local Native Run/Tested on Ubuntu 20.04.3 LTS via WSL2