### PR TITLE
Add support for prefixes

### DIFF
--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -42,7 +42,12 @@ ParsedQuery SparqlParser::parse() {
 void SparqlParser::parseQuery(ParsedQuery* query, QueryType queryType) {
   if (queryType == CONSTRUCT_QUERY) {
     auto str = _lexer.getUnconsumedInput();
-    auto parseResult = sparqlParserHelpers::parseConstructTemplate(str);
+    SparqlQleverVisitor::PrefixMap prefixes;
+    for (const auto& prefix : query->_prefixes) {
+      prefixes[prefix._prefix] = prefix._uri;
+    }
+    auto parseResult =
+        sparqlParserHelpers::parseConstructTemplate(str, std::move(prefixes));
     query->_clause = std::move(parseResult._resultOfParse);
     _lexer.reset(std::move(parseResult._remainingText));
     _lexer.expect("where");

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -20,7 +20,9 @@ struct ParserAndVisitor {
  public:
   SparqlAutomaticParser _parser{&_tokens};
   SparqlQleverVisitor _visitor;
-  explicit ParserAndVisitor(string input, SparqlQleverVisitor::PrefixMap prefixes) : _input{std::move(input)}, _visitor{std::move(prefixes)} {
+  explicit ParserAndVisitor(string input,
+                            SparqlQleverVisitor::PrefixMap prefixes)
+      : _input{std::move(input)}, _visitor{std::move(prefixes)} {
     _parser.setErrorHandler(std::make_shared<ThrowingErrorStrategy>());
   }
 
@@ -66,7 +68,8 @@ ResultOfParseAndRemainingText<ParsedQuery::Alias> parseAlias(
 // _____________________________________________________________________________
 
 ResultOfParseAndRemainingText<std::vector<std::array<VarOrTerm, 3>>>
-parseConstructTemplate(const std::string& input, SparqlQleverVisitor::PrefixMap prefixes) {
+parseConstructTemplate(const std::string& input,
+                       SparqlQleverVisitor::PrefixMap prefixes) {
   ParserAndVisitor p{input, std::move(prefixes)};
   return p.parse<std::vector<std::array<VarOrTerm, 3>>>(
       input, "construct template", &SparqlAutomaticParser::constructTemplate);

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -5,7 +5,6 @@
 #include "SparqlParserHelpers.h"
 
 #include "../util/antlr/ThrowingErrorStrategy.h"
-#include "sparqlParser/SparqlQleverVisitor.h"
 #include "sparqlParser/generated/SparqlAutomaticLexer.h"
 
 namespace sparqlParserHelpers {
@@ -21,7 +20,7 @@ struct ParserAndVisitor {
  public:
   SparqlAutomaticParser _parser{&_tokens};
   SparqlQleverVisitor _visitor;
-  explicit ParserAndVisitor(string input) : _input{std::move(input)} {
+  explicit ParserAndVisitor(string input, SparqlQleverVisitor::PrefixMap prefixes) : _input{std::move(input)}, _visitor{std::move(prefixes)} {
     _parser.setErrorHandler(std::make_shared<ThrowingErrorStrategy>());
   }
 
@@ -46,7 +45,7 @@ struct ParserAndVisitor {
 // ____________________________________________________________________________
 ResultOfParseAndRemainingText<sparqlExpression::SparqlExpressionPimpl>
 parseExpression(const std::string& input) {
-  ParserAndVisitor p{input};
+  ParserAndVisitor p{input, {}};
   auto resultOfParseAndRemainingText =
       p.parse<sparqlExpression::SparqlExpression::Ptr>(
           input, "expression", &SparqlAutomaticParser::expression);
@@ -60,15 +59,15 @@ parseExpression(const std::string& input) {
 // ____________________________________________________________________________
 ResultOfParseAndRemainingText<ParsedQuery::Alias> parseAlias(
     const std::string& input) {
-  ParserAndVisitor p{input};
+  ParserAndVisitor p{input, {}};
   return p.parse<ParsedQuery::Alias>(
       input, "alias", &SparqlAutomaticParser::aliasWithouBrackes);
 }
 // _____________________________________________________________________________
 
 ResultOfParseAndRemainingText<std::vector<std::array<VarOrTerm, 3>>>
-parseConstructTemplate(const std::string& input) {
-  ParserAndVisitor p{input};
+parseConstructTemplate(const std::string& input, SparqlQleverVisitor::PrefixMap prefixes) {
+  ParserAndVisitor p{input, std::move(prefixes)};
   return p.parse<std::vector<std::array<VarOrTerm, 3>>>(
       input, "construct template", &SparqlAutomaticParser::constructTemplate);
 }

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -10,6 +10,7 @@
 
 #include "../engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "./ParsedQuery.h"
+#include "sparqlParser/SparqlQleverVisitor.h"
 
 namespace sparqlParserHelpers {
 
@@ -32,7 +33,8 @@ ResultOfParseAndRemainingText<ParsedQuery::Alias> parseAlias(
     const std::string& input);
 
 ResultOfParseAndRemainingText<std::vector<std::array<VarOrTerm, 3>>>
-parseConstructTemplate(const std::string& input);
+parseConstructTemplate(const std::string& input,
+                       SparqlQleverVisitor::PrefixMap prefixes);
 }  // namespace sparqlParserHelpers
 
 #endif  // QLEVER_SPARQLPARSERHELPERS_H

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -82,7 +82,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   PrefixMap& prefixMap() { return _prefixMap; }
   FRIEND_TEST(SparqlParser, Prefix);
 
-  PrefixMap _prefixMap{{":", "<>"}};
+  PrefixMap _prefixMap{{"", "<>"}};
 
   template <typename T>
   void appendVector(std::vector<T>& destination, std::vector<T>&& source) {
@@ -125,14 +125,15 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   // ___________________________________________________________________________
   antlrcpp::Any visitBaseDecl(
       SparqlAutomaticParser::BaseDeclContext* ctx) override {
-    _prefixMap[":"] = visitIriref(ctx->iriref()).as<string>();
+    _prefixMap[""] = visitIriref(ctx->iriref()).as<string>();
     return nullptr;
   }
 
   // ___________________________________________________________________________
   antlrcpp::Any visitPrefixDecl(
       SparqlAutomaticParser::PrefixDeclContext* ctx) override {
-    _prefixMap[ctx->PNAME_NS()->getText()] =
+    auto text = ctx->PNAME_NS()->getText();
+    _prefixMap[text.substr(0, text.length() - 1)] =
         visitIriref(ctx->iriref()).as<string>();
     return nullptr;
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -1172,7 +1172,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
       SparqlAutomaticParser::PnameLnContext* ctx) override {
     string text = ctx->getText();
     auto pos = text.find(':');
-    auto pnameNS = text.substr(0, pos + 1);
+    auto pnameNS = text.substr(0, pos);
     auto pnLocal = text.substr(pos + 1);
     if (!_prefixMap.contains(pnameNS)) {
       // TODO<joka921> : proper name
@@ -1189,7 +1189,8 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   antlrcpp::Any visitPnameNs(
       SparqlAutomaticParser::PnameNsContext* ctx) override {
-    auto prefix = ctx->getText();
+    auto text = ctx->getText();
+    auto prefix = text.substr(0, text.length() - 1);
     if (!_prefixMap.contains(prefix)) {
       // TODO<joka921> : proper name
       throw SparqlParseException{

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -133,6 +133,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   antlrcpp::Any visitPrefixDecl(
       SparqlAutomaticParser::PrefixDeclContext* ctx) override {
     auto text = ctx->PNAME_NS()->getText();
+    // Strip trailing ':'.
     _prefixMap[text.substr(0, text.length() - 1)] =
         visitIriref(ctx->iriref()).as<string>();
     return nullptr;

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -58,14 +58,14 @@ TEST(SparqlParser, Prefix) {
     p.visitor.visitPrefixDecl(context);
     const auto& m = p.visitor.prefixMap();
     ASSERT_EQ(2ul, m.size());
-    ASSERT_TRUE(m.at("wd:") == "<www.wikidata.org/>");
-    ASSERT_EQ(m.at(":"), "<>");
+    ASSERT_TRUE(m.at("wd") == "<www.wikidata.org/>");
+    ASSERT_EQ(m.at(""), "<>");
   }
   {
     string s = "wd:bimbam";
     ParserAndVisitor p{s};
     auto& m = p.visitor.prefixMap();
-    m["wd:"] = "<www.wikidata.org/>";
+    m["wd"] = "<www.wikidata.org/>";
 
     auto context = p.parser.pnameLn();
     auto result = p.visitor.visitPnameLn(context).as<string>();
@@ -75,7 +75,7 @@ TEST(SparqlParser, Prefix) {
     string s = "wd:";
     ParserAndVisitor p{s};
     auto& m = p.visitor.prefixMap();
-    m["wd:"] = "<www.wikidata.org/>";
+    m["wd"] = "<www.wikidata.org/>";
 
     auto context = p.parser.pnameNs();
     auto result = p.visitor.visitPnameNs(context).as<string>();
@@ -85,7 +85,7 @@ TEST(SparqlParser, Prefix) {
     string s = "wd:bimbam";
     ParserAndVisitor p{s};
     auto& m = p.visitor.prefixMap();
-    m["wd:"] = "<www.wikidata.org/>";
+    m["wd"] = "<www.wikidata.org/>";
 
     auto context = p.parser.prefixedName();
     auto result = p.visitor.visitPrefixedName(context).as<string>();
@@ -95,7 +95,7 @@ TEST(SparqlParser, Prefix) {
     string s = "<somethingsomething> <rest>";
     ParserAndVisitor p{s};
     auto& m = p.visitor.prefixMap();
-    m["wd:"] = "<www.wikidata.org/>";
+    m["wd"] = "<www.wikidata.org/>";
 
     auto context = p.parser.iriref();
     auto result = p.visitor.visitIriref(context).as<string>();


### PR DESCRIPTION
Fixes a bug that was mentioned in https://github.com/ad-freiburg/qlever/pull/528#issuecomment-1003658581
Prefix IRIs were not parsed correctly