### PR TITLE
Use better macro for coroutine support

### DIFF
--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -5,21 +5,21 @@
 #ifndef CPPCORO_GENERATOR_HPP_INCLUDED
 #define CPPCORO_GENERATOR_HPP_INCLUDED
 
-// coroutines are still experimental in clang, adapt the appropriate
-// namespaces.
-#ifdef __clang__
+#include <exception>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+// coroutines are still experimental in clang libcpp,
+// adapt the appropriate namespaces.
+#ifdef _LIBCPP_VERSION
 #include <experimental/coroutine>
 namespace qlever_stdOrExp = std::experimental;
 #else
 #include <coroutine>
 namespace qlever_stdOrExp = std;
 #endif
-
-#include <exception>
-#include <functional>
-#include <iterator>
-#include <type_traits>
-#include <utility>
 
 namespace cppcoro {
 template <typename T>

--- a/src/util/streamable_generator.h
+++ b/src/util/streamable_generator.h
@@ -7,16 +7,17 @@
 #include <exception>
 #include <sstream>
 
-#include "./ostringstream.h"
-
-// coroutines are still experimental in clang, adapt the appropriate namespaces.
-#ifdef __clang__
+// coroutines are still experimental in clang libcpp,
+// adapt the appropriate namespaces.
+#ifdef _LIBCPP_VERSION
 #include <experimental/coroutine>
 namespace qlever_stdOrExp = std::experimental;
 #else
 #include <coroutine>
 namespace qlever_stdOrExp = std;
 #endif
+
+#include "./ostringstream.h"
 
 namespace ad_utility::stream_generator {
 


### PR DESCRIPTION
I just noticed that CLion syntaxt highlighting works properly when using the `_LIBCPP_VERSION` instead of `__clang__`