### PR TITLE
Disable several github workflows to save the environment.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         compiler: [ gcc11, clang13 ]
         os: [ ubuntu-latest ]
-        warnings: [ "", -Werror ]
-        exclude:
-          - compiler: gcc11
-            warnings: -Werror
+        warnings: [  "-Wall -Wextra -Werror" ]
+        #exclude:
+        #  - compiler: gcc11
+        #    warnings: -Werror
 
 
     steps:
@@ -65,5 +65,5 @@ jobs:
 
     - name: E2E
       run: ${{github.workspace}}/e2e/e2e.sh
-      if: ${{matrix.warnings != '-Werror'}}
+      #if: ${{matrix.warnings != '-Werror'}}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dockerfile: [ Dockerfile, Dockerfiles/Dockerfile.Ubuntu18.04, Dockerfiles/Dockerfile.Ubuntu20.04]
+        #dockerfile: [ Dockerfile, Dockerfiles/Dockerfile.Ubuntu18.04, Dockerfiles/Dockerfile.Ubuntu20.04]
+        dockerfile: [ Dockerfile]
         os: [ ubuntu-latest ]
 
     steps:


### PR DESCRIPTION
They are just commented out and can be reinstated
temporarily when needed.

This can be useful e.g. to check if the Ubuntu 18.04 and 20.04 Dockerfiles still work after a change.
of external dependencies.