### PR TITLE
Remove unused non-compiling function

### DIFF
--- a/src/engine/IdTable.h
+++ b/src/engine/IdTable.h
@@ -879,19 +879,6 @@ class IdTableTemplated : private IdTableImpl<COLS, DATA, Allocator> {
   /**
    * @brief Read cols() elements from init and stores them in a new row
    **/
-  template <bool ManagesStorage = DATA::ManagesStorage,
-            typename = std::enable_if_t<ManagesStorage>>
-  void push_back(const Id* init) {
-    if (_size + 1 >= _capacity) {
-      grow();
-    }
-    std::memcpy(_data + _size * _cols, init, sizeof(Id) * _cols);
-    _size++;
-  }
-
-  /**
-   * @brief Read cols() elements from init and stores them in a new row
-   **/
   template <
       typename T,
       typename = std::enable_if_t<


### PR DESCRIPTION
This is something discovered during the development of #540 
Basically this function wasn't refactored properly as part of #320 because `_data` wasn't updated to `data()`.
Because this function was unused and continues to be unused to this day the template was never instantiated and the compilation did never fail.

I talked with @joka921 about this and we came to the conclusion that passing raw pointers to read data of potentially arbitrary length is dangerous and error-prone.
If this function is ever required in the future it should get re-implemented using [`std::span`](https://en.cppreference.com/w/cpp/container/span) to provide that extra bit of safety, but for now it can just be removed to keep maintenance costs at a minimum