### PR TITLE
Introduce CSV/TSV header row

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -5,6 +5,7 @@
 #include "./QueryExecutionTree.h"
 
 #include <algorithm>
+#include <boost/algorithm/string/join.hpp>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -407,7 +408,11 @@ ad_utility::stream_generator::stream_generator QueryExecutionTree::writeTable(
     co_return;
   }
 
-  constexpr char sep = format == ExportSubFormat::TSV ? '\t' : ',';
+  static constexpr char sep = format == ExportSubFormat::TSV ? '\t' : ',';
+  constexpr std::string_view sepView{&sep, 1};
+  // Print header line
+  co_yield boost::algorithm::join(selectVars, sepView);
+  co_yield '\n';
 
   for (size_t i = offset; i < upperBound; ++i) {
     for (size_t j = 0; j < validIndices.size(); ++j) {

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -265,4 +265,8 @@ class QueryExecutionTree {
   cppcoro::generator<StringTriple> generateRdfGraph(
       const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
       size_t offset, std::shared_ptr<const ResultTable> res) const;
+
+  vector<std::optional<pair<size_t, ResultTable::ResultType>>>
+  buildValidIndices(const vector<string>& selectVars,
+                    const ResultTable& resultTable) const;
 };

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -109,11 +109,6 @@ class QueryExecutionTree {
       const std::vector<string>& selectVariables,
       const ResultTable& resultTable) const;
 
-  template <ExportSubFormat format>
-  ad_utility::stream_generator::stream_generator generateResults(
-      const vector<string>& selectVars, size_t limit = MAX_NOF_ROWS_IN_RESULT,
-      size_t offset = 0) const;
-
   // Generate an RDF graph in turtle format for a CONSTRUCT query.
   ad_utility::stream_generator::stream_generator writeRdfGraphTurtle(
       const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
@@ -137,6 +132,10 @@ class QueryExecutionTree {
   nlohmann::json writeResultAsSparqlJson(
       const vector<string>& selectVars, size_t limit, size_t offset,
       shared_ptr<const ResultTable> preComputedResult = nullptr) const;
+
+  template <ExportSubFormat format>
+  ad_utility::stream_generator::stream_generator writeTable(
+      const vector<string>& selectVars, size_t limit, size_t offset) const;
 
   const std::vector<size_t>& resultSortedOn() const {
     return _rootOperation->getResultSortedOn();
@@ -261,12 +260,6 @@ class QueryExecutionTree {
   [[nodiscard]] std::optional<std::pair<std::string, const char*>>
   toStringAndXsdType(Id id, ResultTable::ResultType type,
                      const ResultTable& resultTable) const;
-
-  template <ExportSubFormat format>
-  ad_utility::stream_generator::stream_generator writeTable(
-      size_t from, size_t upperBound,
-      vector<std::optional<pair<size_t, ResultTable::ResultType>>> validIndices,
-      shared_ptr<const ResultTable> resultTable = nullptr) const;
 
   // Generate an RDF graph for a CONSTRUCT query.
   cppcoro::generator<StringTriple> generateRdfGraph(

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -237,7 +237,7 @@ Server::composeResponseSepValues(const ParsedQuery& query,
     size_t limit = query._limit.value_or(MAX_NOF_ROWS_IN_RESULT);
     size_t offset = query._offset.value_or(0);
     return query.hasSelectClause()
-               ? qet.generateResults<format>(
+               ? qet.writeTable<format>(
                      query.selectClause()._selectedVariables, limit, offset)
                : qet.writeRdfGraphSeparatedValues<format>(
                      query.constructClause(), limit, offset, qet.getResult());


### PR DESCRIPTION
As discussed with @joka921 the current CSV/TSV export doesn't properly print the headers as specified in the standard.
This PR fixes this issue and does some small-scale refactoring to reduce duplicated code