### PR TITLE
Make `File` and all serializers move-only.

### DIFF
--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -115,11 +115,10 @@ void VocabularyOnDisk::buildFromTextFile(const string& textFileName,
     std::string word;
     uint64_t index = 0;
     while (std::getline(infile, word)) {
-      /* The temporary file for the to-be-externalized vocabulary strings is
-         line-based, just like the normal vocabulary file. Therefore, \n and \
-         are escaped there. When we read from this file, we have to unescape
-         these.
-      */
+      // The temporary file for the to-be-externalized vocabulary strings is
+      // line-based, just like the normal vocabulary file. Therefore, newlines
+      // and backslashes are escaped there. When we read from this file, we have
+      // to unescape these.
       word = RdfEscaping::unescapeNewlinesAndBackslashes(word);
       co_yield std::pair{std::string_view{word}, index};
       index++;

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -115,10 +115,11 @@ void VocabularyOnDisk::buildFromTextFile(const string& textFileName,
     std::string word;
     uint64_t index = 0;
     while (std::getline(infile, word)) {
-      // The temporary file for the to-be-externalized vocabulary strings is
-      // line-based, just like the normal vocabulary file. Therefore, \n and \
-      // are escaped there. When we read from this file, we have to unescape
-      // these.
+      /* The temporary file for the to-be-externalized vocabulary strings is
+         line-based, just like the normal vocabulary file. Therefore, \n and \
+         are escaped there. When we read from this file, we have to unescape
+         these.
+      */
       word = RdfEscaping::unescapeNewlinesAndBackslashes(word);
       co_yield std::pair{std::string_view{word}, index};
       index++;

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -55,11 +55,11 @@ class File {
     open(filename, mode);
   }
 
-  // TODO<joka921> This copies non-owning pointer semantics which is really
-  // dangerous. This operator should be deleted.
-  File& operator=(const File&) = default;
-
   File& operator=(File&& rhs) noexcept {
+    if (isOpen()) {
+      close();
+    }
+
     _file = rhs._file;
     rhs._file = nullptr;
     _name = std::move(rhs._name);
@@ -68,15 +68,6 @@ class File {
 
   File(File&& rhs) : _name{std::move(rhs._name)}, _file{rhs._file} {
     rhs._file = nullptr;
-  }
-
-  // TODO<joka921> should also be deleted!
-  //! Copy constructor.
-  //! Does not copy the file in the file system!
-  File(const File& orig) {
-    _name = orig._name;
-    open(_name.c_str(), "r");
-    assert(_file);
   }
 
   //! Destructor closes file if still open

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -28,6 +28,10 @@ class ByteBufferWriteSerializer {
   using Storage = std::vector<char>;
   ByteBufferWriteSerializer() = default;
   ByteBufferWriteSerializer(const ByteBufferWriteSerializer&) = delete;
+  ByteBufferWriteSerializer& operator=(const ByteBufferWriteSerializer&) =
+      delete;
+  ByteBufferWriteSerializer(ByteBufferWriteSerializer&&) = default;
+  ByteBufferWriteSerializer& operator=(ByteBufferWriteSerializer&&) = default;
 
   void serializeBytes(const char* bytePointer, size_t numBytes) {
     _data.insert(_data.end(), bytePointer, bytePointer + numBytes);
@@ -50,17 +54,23 @@ class ByteBufferReadSerializer {
   constexpr static bool IsWriteSerializer = false;
   using Storage = std::vector<char>;
 
-  ByteBufferReadSerializer(Storage data) : _data{std::move(data)} {};
+  explicit ByteBufferReadSerializer(Storage data) : _data{std::move(data)} {};
   void serializeBytes(char* bytePointer, size_t numBytes) {
     AD_CHECK(_iterator + numBytes <= _data.end());
     std::copy(_iterator, _iterator + numBytes, bytePointer);
     _iterator += numBytes;
   }
 
+  ByteBufferReadSerializer(const ByteBufferReadSerializer&) noexcept = delete;
+  ByteBufferReadSerializer& operator=(const ByteBufferReadSerializer&) = delete;
+  ByteBufferReadSerializer(ByteBufferReadSerializer&&) noexcept = default;
+  ByteBufferReadSerializer& operator=(ByteBufferReadSerializer&&) noexcept =
+      default;
+
   const Storage& data() const noexcept { return _data; }
 
  private:
-  const Storage _data;
+  Storage _data;
   Storage::const_iterator _iterator{_data.begin()};
 };
 

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -151,7 +151,7 @@ TEST_F(FileTest, testReadIntoVector) {
 }
 
 TEST(File, move) {
-  std::string filename = "_tmp_testFileMove";
+  std::string filename = "testFileMove.tmp";
   File file1(filename, "w");
   ASSERT_TRUE(file1.isOpen());
   file1.write("aaa", 3);
@@ -173,12 +173,25 @@ TEST(File, move) {
   File fileRead(filename, "r");
   ASSERT_TRUE(fileRead.isOpen());
   std::string s;
-  s.resize(9);
-  auto numBytes = fileRead.read(s.data(), 9);
-  ASSERT_EQ(numBytes, 9u);
-  ASSERT_EQ(s, "aaabbbccc");
+  s.resize(2);
+  auto numBytes = fileRead.read(s.data(), 2);
+  ASSERT_EQ(numBytes, 2u);
+  ASSERT_EQ(s, "aa");
 
-  ASSERT_EQ(0u, fileRead.read(s.data(), 9));
+  File fileRead2;
+  fileRead2 = std::move(fileRead);
+  s.resize(5);
+  numBytes = fileRead2.read(s.data(), 5);
+  ASSERT_EQ(numBytes, 5u);
+  ASSERT_EQ(s, "abbbc");
+
+  File fileRead3{std::move(fileRead2)};
+  s.resize(2);
+  numBytes = fileRead3.read(s.data(), 2);
+  ASSERT_EQ(numBytes, 2u);
+  ASSERT_EQ(s, "cc");
+
+  ASSERT_EQ(0u, fileRead3.read(s.data(), 9));
+  ad_utility::deleteFile(filename);
 }
-
 }  // namespace ad_utility

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -150,4 +150,35 @@ TEST_F(FileTest, testReadIntoVector) {
   ASSERT_EQ("line2", lines2[1]);
 }
 
+TEST(File, move) {
+  std::string filename = "_tmp_testFileMove";
+  File file1(filename, "w");
+  ASSERT_TRUE(file1.isOpen());
+  file1.write("aaa", 3);
+
+  File file2;
+  ASSERT_TRUE(file1.isOpen());
+  ASSERT_FALSE(file2.isOpen());
+  file2 = std::move(file1);
+  ASSERT_FALSE(file1.isOpen());
+  ASSERT_TRUE(file2.isOpen());
+
+  file2.write("bbb", 3);
+  File file3(std::move(file2));
+  ASSERT_FALSE(file2.isOpen());
+  ASSERT_TRUE(file3.isOpen());
+  file3.write("ccc", 3);
+  file3.close();
+
+  File fileRead(filename, "r");
+  ASSERT_TRUE(fileRead.isOpen());
+  std::string s;
+  s.resize(9);
+  auto numBytes = fileRead.read(s.data(), 9);
+  ASSERT_EQ(numBytes, 9u);
+  ASSERT_EQ(s, "aaabbbccc");
+
+  ASSERT_EQ(0u, fileRead.read(s.data(), 9));
+}
+
 }  // namespace ad_utility

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -164,7 +164,7 @@ TEST(Serializer, CopyAndMove) {
 
     // Assert that moving writers consistently writes to the same resource.
     writer | 1;
-    std::decay_t<decltype(writer)> writer2(std::move(writer));
+    Writer writer2(std::move(writer));
     writer2 | 2;
     writer = std::move(writer2);
     writer | 3;

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -153,3 +153,37 @@ TEST(Serializer, Vector) {
   testWithAllSerializers(testTriviallyCopyableDatatype);
   testWithAllSerializers(testNonTriviallyCopyableDatatype);
 }
+
+TEST(Serializer, CopyAndMove) {
+  auto testWithMove = [](auto&& writer, auto makeReaderFromWriter) {
+    using Writer = std::decay_t<decltype(writer)>;
+
+    // Assert that write serializers cannot be copied.
+    static_assert(!requires(Writer w1, Writer w2) { {w1 = w2}; });
+    static_assert(!std::constructible_from<Writer, const Writer&>);
+
+    // Assert that moving writers consistently writes to the same resource.
+    writer | 1;
+    std::decay_t<decltype(writer)> writer2(std::move(writer));
+    writer2 | 2;
+    writer = std::move(writer2);
+    writer | 3;
+
+    auto reader = makeReaderFromWriter();
+    // Assert that read serializers cannot be copied.
+    using Reader = decltype(reader);
+    static_assert(!requires(Reader r1, Reader r2) { {r1 = r2}; });
+    static_assert(!std::constructible_from<Reader, const Reader&>);
+    // Assert that moving writers consistently reads from the same resource.
+    int i;
+    reader | i;
+    ASSERT_EQ(i, 1);
+    decltype(reader) reader2{std::move(reader)};
+    reader2 | i;
+    ASSERT_EQ(i, 2);
+    reader = std::move(reader2);
+    reader | i;
+    ASSERT_EQ(i, 3);
+  };
+  testWithAllSerializers(testWithMove);
+}


### PR DESCRIPTION
Also add unit tests for the moving of these types.