### PR TITLE
Interleaved External vocabulary

### DIFF
--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -24,6 +24,11 @@ int main(int argc, char** argv) {
   auto internalVocabularyAction = [&file](const auto& word) {
     file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
   };
-  m.mergeVocabulary(basename, numFiles, TripleComponentComparator(),
-                    internalVocabularyAction);
+  auto sortPred = [cmp = TripleComponentComparator()](
+                      std::string_view a, std::string_view b,
+                      bool aExternalized, bool bExternalized) {
+    return cmp(a, b, TripleComponentComparator::Level::TOTAL, aExternalized,
+               bExternalized);
+  };
+  m.mergeVocabulary(basename, numFiles, sortPred, internalVocabularyAction);
 }

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -112,6 +112,10 @@ static constexpr size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
 // times this factor.
 static constexpr double MAKE_ROOM_SLACK_FACTOR = 2;
 
+// TODO<joka921> Comment, Currently this means 3 bytes for the "External part",
+// leaving 5 bytes for Internal IDs.
+static constexpr uint64_t InternalExternalIdMilestoneDistance = 256 * 256 * 256;
+
 inline auto& RuntimeParameters() {
   using ad_utility::detail::parameterShortNames::Double;
   using ad_utility::detail::parameterShortNames::SizeT;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -416,12 +416,8 @@ Index::createPermutationPairImpl(const string& fileName1,
   using MetaData = typename MetaDataDispatcher::WriteType;
   MetaData metaData1, metaData2;
   if constexpr (metaData1._isMmapBased) {
-    metaData1.setup(_totalVocabularySize,
-                    CompressedRelationMetaData::emptyMetaData(),
-                    fileName1 + MMAP_FILE_SUFFIX);
-    metaData2.setup(_totalVocabularySize,
-                    CompressedRelationMetaData::emptyMetaData(),
-                    fileName2 + MMAP_FILE_SUFFIX);
+    metaData1.setup(fileName1 + MMAP_FILE_SUFFIX, ad_utility::CreateTag{});
+    metaData2.setup(fileName2 + MMAP_FILE_SUFFIX, ad_utility::CreateTag{});
   }
 
   if (triples.empty()) {
@@ -603,10 +599,16 @@ void Index::exchangeMultiplicities(MetaData* m1, MetaData* m2) {
     // permutation is inefficient. So it is fine to use const_cast here as an
     // exception: we delibarately write to a read-only data structure and are
     // knowing what we are doing
-    m2->data()[it->first].setCol2Multiplicity(
-        m1->data()[it->first].getCol1Multiplicity());
-    m1->data()[it->first].setCol2Multiplicity(
-        m2->data()[it->first].getCol1Multiplicity());
+    Id id;
+    if constexpr (ad_utility::isSimilar<CompressedRelationMetaData,
+                                        decltype(*it)>) {
+      id = it->_col0Id;
+    } else {
+      id = it->first;
+    }
+
+    m2->data()[id].setCol2Multiplicity(m1->data()[id].getCol1Multiplicity());
+    m1->data()[id].setCol2Multiplicity(m2->data()[id].getCol1Multiplicity());
   }
 }
 

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -13,90 +13,14 @@
 #include "../util/Log.h"
 #include "./CompressedRelation.h"
 
-// _____________________________________________________________
-// hidden in implementation namespace
-namespace VecWrapperImpl {
-template <class Vec>
-// iterator class for a unordered_map interface based on an array with the size
-// of the key space. access is done by the index, and when iterating, we have
-// to skip the empty entries. Needs an empty key to work properly
-class Iterator {
- public:
-  using iterator_category = std::forward_iterator_tag;
-  using value_type = CompressedRelationMetaData;
-
-  // _________________________________________________
-  std::pair<Id, const value_type&> operator*() const {
-    // make sure that we do not conflict with the empty key
-    AD_CHECK(_id != size_t(-1));
-    return std::make_pair(_id, std::cref(*_it));
-  }
-
-  // _________________________________________________
-  std::pair<Id, std::reference_wrapper<const value_type>>* operator->() const {
-    // make sure that we do not conflict with the empty key
-    AD_CHECK(_id != size_t(-1));
-    _accessPair = **this;
-    return &_accessPair;
-  }
-
-  // _____________________________________________________________
-  Iterator(Id id, const typename Vec::const_iterator& it, const Vec* const vec)
-      : _id(id), _it(it), _accessPair(**this), _vec(vec) {}
-
-  // ________________________________________________
-  Iterator& operator++() {
-    ++_id;
-    ++_it;
-    goToNexValidEntry();
-
-    return *this;
-  }
-
-  // ___________________________________________________
-  void goToNexValidEntry() {
-    while (_it != _vec->cend() && (*_it) == emptyMetaData) {
-      ++_id;
-      ++_it;
-    }
-  }
-
-  // ________________________________________________
-  Iterator operator++(int) {
-    Iterator old(*this);
-    ++_id;
-    ++_it;
-    goToNexValidEntry();
-    return old;
-  }
-
-  // _______________________________________________
-  bool operator==(const Iterator& other) const { return _it == other._it; }
-
-  // _______________________________________________
-  bool operator!=(const Iterator& other) const { return _it != other._it; }
-
- private:
-  Id _id;
-  typename Vec::const_iterator _it;
-  // here we store the pair needed for operator->()
-  // will be updated before each access
-  mutable std::pair<Id, std::reference_wrapper<const value_type>> _accessPair;
-  const Vec* const _vec;
-
-  const value_type emptyMetaData = value_type::emptyMetaData();
-};
-}  // namespace VecWrapperImpl
-
 // _____________________________________________________________________
 template <class M>
 class MetaDataWrapperDense {
  public:
-  using Iterator = VecWrapperImpl::Iterator<M>;
-  // The VecWrapperImpl::Iterator is actually const
-  using ConstIterator = VecWrapperImpl::Iterator<M>;
-  // The VecWrapperImpl::Iterator iterates in order;
-  using ConstOrderedIterator = VecWrapperImpl::Iterator<M>;
+  using Iterator = typename M::iterator;
+  using ConstIterator = typename M::const_iterator;
+  // The underlying array is sorted, so all iterators are ordered iterators
+  using ConstOrderedIterator = ConstIterator;
 
   using value_type = typename M::value_type;
 
@@ -104,108 +28,93 @@ class MetaDataWrapperDense {
   MetaDataWrapperDense() = default;
 
   // ________________________________________________________
-  MetaDataWrapperDense(MetaDataWrapperDense<M>&& other)
-      : _size(other._size), _vec(std::move(other._vec)) {}
+  MetaDataWrapperDense(MetaDataWrapperDense<M>&& other) = default;
 
   // ______________________________________________________________
-  MetaDataWrapperDense& operator=(MetaDataWrapperDense<M>&& other) {
-    _size = other._size;
-    _vec = std::move(other._vec);
-    return *this;
-  }
+  MetaDataWrapperDense& operator=(MetaDataWrapperDense<M>&& other) = default;
 
   // Templated setup version
   // Arguments are passsed through to template argument M.
   // TODO<joka921>: enable_if  for better error messages
   template <typename... Args>
   void setup(Args... args) {
-    // size has to be set correctly by a call to setSize(), this is done
-    // via the serialization
-    _size = 0;
     _vec = M(args...);
   }
 
-  // The serialization only affects the (important!) `_size` member. The
+  // The serialization is a noop. The
   // external vector has to be restored via the `setup()` call.
   template <typename Serializer>
-  friend void serialize(Serializer& serializer, MetaDataWrapperDense& wrapper) {
-    serializer | wrapper._size;
-  }
+  friend void serialize([[maybe_unused]] Serializer& serializer,
+                        [[maybe_unused]] MetaDataWrapperDense& wrapper) {}
 
   // ___________________________________________________________
-  size_t size() const { return _size; }
-
-  // ___________________________________________________________
-  void setSize(size_t newSize) { _size = newSize; }
+  size_t size() const { return _vec.size(); }
 
   // __________________________________________________________________
-  Iterator cbegin() const {
-    Iterator it(0, _vec.cbegin(), &_vec);
-    it.goToNexValidEntry();
-    return it;
-  }
+  ConstIterator cbegin() const { return _vec.begin(); }
 
   // __________________________________________________________________
-  Iterator begin() const {
-    Iterator it(0, _vec.begin(), &_vec);
-    it.goToNexValidEntry();
-    return it;
-  }
+  Iterator begin() { return _vec.begin(); }
+
+  // __________________________________________________________________
+  ConstIterator begin() const { return _vec.begin(); }
 
   // __________________________________________________________________________
   ConstOrderedIterator ordered_begin() const { return begin(); }
 
   // __________________________________________________________________________
-  Iterator cend() const { return Iterator(_vec.size(), _vec.cend(), &_vec); }
+  ConstIterator cend() const { return _vec.end(); }
 
   // __________________________________________________________________________
-  Iterator end() const { return Iterator(_vec.size(), _vec.end(), &_vec); }
+  ConstIterator end() const { return _vec.end(); }
+  Iterator end() { return _vec.end(); }
 
   // __________________________________________________________________________
   ConstOrderedIterator ordered_end() const { return end(); }
 
   // ____________________________________________________________
   void set(Id id, const value_type& value) {
-    if (id >= _vec.size()) {
-      AD_CHECK(id < _vec.size());
-    }
-    bool previouslyEmpty = _vec[id] == emptyMetaData;
-
-    // check that we never insert the empty key
-    assert(value != emptyMetaData);
-    _vec[id] = value;
-    if (previouslyEmpty) {
-      _size++;
-    }
+    // Assert that the ids are ascending.
+    AD_CHECK(_vec.size() == 0 || _vec.back()._col0Id < id);
+    _vec.push_back(value);
   }
 
   // __________________________________________________________
   const value_type& getAsserted(Id id) const {
-    const auto& res = _vec[id];
-    AD_CHECK(res != emptyMetaData);
-    return res;
+    auto it = lower_bound(id);
+    AD_CHECK(it != _vec.end() && it->_col0Id == id);
+    return *it;
   }
 
   // _________________________________________________________
   value_type& operator[](Id id) {
-    auto& res = _vec[id];
-    AD_CHECK(res != emptyMetaData);
-    return res;
+    auto it = lower_bound(id);
+    AD_CHECK(it != _vec.end() && it->_col0Id == id);
+    return *it;
   }
 
   // ________________________________________________________
   size_t count(Id id) const {
-    // can either be 1 or 0 for map-like types
-    return _vec[id] != emptyMetaData;
+    auto it = lower_bound(id);
+    return it != _vec.end() && it->_col0Id == id;
   }
 
   // ___________________________________________________________
   std::string getFilename() const { return _vec.getFilename(); }
 
  private:
-  // the empty key, must be the first member to be initialized
-  const value_type emptyMetaData = value_type::emptyMetaData();
-  size_t _size = 0;
+  auto lower_bound(Id id) const {
+    auto cmp = [](const auto& metaData, Id id) {
+      return metaData._col0Id < id;
+    };
+    return std::lower_bound(_vec.begin(), _vec.end(), id, cmp);
+  }
+  auto lower_bound(Id id) {
+    auto cmp = [](const auto& metaData, Id id) {
+      return metaData._col0Id < id;
+    };
+    return std::lower_bound(_vec.begin(), _vec.end(), id, cmp);
+  }
   M _vec;
 };
 

--- a/src/index/MetaDataIterator.h
+++ b/src/index/MetaDataIterator.h
@@ -38,15 +38,28 @@ class MetaDataIterator {
   }
 
   std::array<Id, 3> operator*() {
-    return {_iterator->first, _buffer[_buffer_offset][0],
-            _buffer[_buffer_offset][1]};
+    if constexpr (ad_utility::isSimilar<CompressedRelationMetaData,
+                                        decltype(*_iterator)>) {
+      return {_iterator->_col0Id, _buffer[_buffer_offset][0],
+              _buffer[_buffer_offset][1]};
+
+    } else {
+      return {_iterator->first, _buffer[_buffer_offset][0],
+              _buffer[_buffer_offset][1]};
+    }
   }
 
   bool empty() const { return _iterator == _endIterator; }
 
  private:
   void scanCurrentPos() {
-    auto id = _iterator->first;
+    uint64_t id;
+    if constexpr (ad_utility::isSimilar<CompressedRelationMetaData,
+                                        decltype(*_iterator)>) {
+      id = _iterator->_col0Id;
+    } else {
+      id = _iterator->first;
+    }
     CompressedRelationMetaData::scan(id, &_buffer, permutation_);
   }
 

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -26,15 +26,10 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
                                     const string& extLitsFileName) {
   LOG(INFO) << "Reading internal vocabulary from file " << fileName << " ..."
             << std::endl;
-  auto comparator = _vocabulary.getComparator();
-  _vocabulary.close();
-  ad_utility::serialization::FileReadSerializer file(fileName);
-  InternalVocabulary internalVocabulary;
-  internalVocabulary.open(fileName);
-  LOG(INFO) << "Done, number of words: " << internalVocabulary.size()
+  internalVocabulary().open(fileName);
+  LOG(INFO) << "Done, number of words: " << internalVocabulary().size()
             << std::endl;
 
-  VocabularyOnDisk externalVocabulary;
   if (!extLitsFileName.empty()) {
     if (!_isCompressed) {
       LOG(INFO) << "ERROR: trying to load externalized literals to an "
@@ -43,19 +38,12 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
       AD_CHECK(false);
     }
 
-    LOG(DEBUG) << "Registering external vocabulary" << std::endl;
-    externalVocabulary.open(extLitsFileName);
-    LOG(INFO) << "Number of words in external vocabulary: "
-              << externalVocabulary.size() << std::endl;
-  }
-
-  if constexpr (_isCompressed) {
-    _vocabulary = VocabularyImpl{
-        comparator,
-        VocabularyWithoutUnicode{std::move(internalVocabulary),
-                                 std::move(externalVocabulary), IdConverter{}}};
-  } else {
-    _vocabulary = VocabularyImpl{comparator, std::move(internalVocabulary)};
+    if constexpr (_isCompressed) {
+      LOG(DEBUG) << "Registering external vocabulary" << std::endl;
+      externalVocabulary().open(extLitsFileName);
+      LOG(INFO) << "Number of words in external vocabulary: "
+                << externalVocabulary().size() << std::endl;
+    }
   }
 }
 

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -26,12 +26,16 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
                                     const string& extLitsFileName) {
   LOG(INFO) << "Reading internal vocabulary from file " << fileName << " ..."
             << std::endl;
-  _internalVocabulary.close();
+  auto comparator = _vocabulary.getComparator();
+  _vocabulary.close();
   ad_utility::serialization::FileReadSerializer file(fileName);
-  _internalVocabulary.open(fileName);
-  LOG(INFO) << "Done, number of words: " << _internalVocabulary.size()
+  InternalVocabulary internalVocabulary;
+  internalVocabulary.open(fileName);
+  LOG(INFO) << "Done, number of words: " << internalVocabulary.size()
             << std::endl;
-  if (extLitsFileName.size() > 0) {
+
+  VocabularyOnDisk externalVocabulary;
+  if (!extLitsFileName.empty()) {
     if (!_isCompressed) {
       LOG(INFO) << "ERROR: trying to load externalized literals to an "
                    "uncompressed vocabulary. This is not valid and a "
@@ -40,9 +44,18 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
     }
 
     LOG(DEBUG) << "Registering external vocabulary" << std::endl;
-    _externalVocabulary.open(extLitsFileName);
+    externalVocabulary.open(extLitsFileName);
     LOG(INFO) << "Number of words in external vocabulary: "
-              << _externalVocabulary.size() << std::endl;
+              << externalVocabulary.size() << std::endl;
+  }
+
+  if constexpr (_isCompressed) {
+    _vocabulary = VocabularyImpl{
+        comparator,
+        VocabularyWithoutUnicode{std::move(internalVocabulary),
+                                 std::move(externalVocabulary), IdConverter{}}};
+  } else {
+    _vocabulary = VocabularyImpl{comparator, std::move(internalVocabulary)};
   }
 }
 
@@ -52,7 +65,7 @@ template <typename, typename>
 void Vocabulary<S, C>::writeToFile(const string& fileName) const {
   LOG(INFO) << "Writing vocabulary to file " << fileName << "\n";
   ad_utility::serialization::FileWriteSerializer file{fileName};
-  _internalVocabulary.getUnderlyingVocabulary().writeToFile(fileName);
+  internalVocabulary().writeToFile(fileName);
 
   LOG(INFO) << "Done writing vocabulary to file.\n";
 }
@@ -62,14 +75,14 @@ template <class S, class C>
 void Vocabulary<S, C>::createFromSet(
     const ad_utility::HashSet<std::string>& set) {
   LOG(INFO) << "Creating vocabulary from set ...\n";
-  _internalVocabulary.close();
+  internalVocabulary().close();
   std::vector<std::string> words(set.begin(), set.end());
   LOG(INFO) << "... sorting ...\n";
   auto totalComparison = [this](const auto& a, const auto& b) {
     return getCaseComparator()(a, b, SortLevel::TOTAL);
   };
   std::sort(begin(words), end(words), totalComparison);
-  _internalVocabulary.build(words);
+  internalVocabulary().build(words);
   LOG(INFO) << "Done creating vocabulary.\n";
 }
 
@@ -146,8 +159,7 @@ template <class S, class C>
 template <class StringRange, typename, typename>
 void Vocabulary<S, C>::buildCodebookForPrefixCompression(
     const StringRange& prefixes) {
-  _internalVocabulary.getUnderlyingVocabulary().getCompressor().buildCodebook(
-      prefixes);
+  internalVocabulary().getCompressor().buildCodebook(prefixes);
 }
 
 // ______________________________________________________________________________
@@ -183,8 +195,9 @@ bool Vocabulary<S, C>::getIdRangeForFullTextPrefix(const string& word,
   range->_last = prefixRange.second - 1;
 
   if (success) {
-    AD_CHECK_LT(range->_first, _internalVocabulary.size());
-    AD_CHECK_LT(range->_last, _internalVocabulary.size());
+    // TODO<joka921> These should now fail and become milestone checks
+    AD_CHECK_LT(range->_first, internalVocabulary().size());
+    AD_CHECK_LT(range->_last, internalVocabulary().size());
   }
   return success;
 }
@@ -193,14 +206,14 @@ bool Vocabulary<S, C>::getIdRangeForFullTextPrefix(const string& word,
 template <typename S, typename C>
 Id Vocabulary<S, C>::upper_bound(const string& word,
                                  const SortLevel level) const {
-  return _internalVocabulary.upper_bound(word, level)._index;
+  return _vocabulary.upper_bound(word, level)._index;
 }
 
 // _____________________________________________________________________________
 template <typename S, typename C>
 Id Vocabulary<S, C>::lower_bound(const string& word,
                                  const SortLevel level) const {
-  return _internalVocabulary.lower_bound(word, level)._index;
+  return _vocabulary.lower_bound(word, level)._index;
 }
 
 // _____________________________________________________________________________
@@ -208,39 +221,23 @@ template <typename S, typename ComparatorType>
 void Vocabulary<S, ComparatorType>::setLocale(const std::string& language,
                                               const std::string& country,
                                               bool ignorePunctuation) {
-  _internalVocabulary.getComparator() =
+  _vocabulary.getComparator() =
       ComparatorType(language, country, ignorePunctuation);
-  _externalVocabulary.getComparator() =
-      ComparatorType(language, country, ignorePunctuation);
-}
-
-template <typename StringType, typename C>
-//! Get the word with the given id.
-//! lvalue for compressedString and const& for string-based vocabulary
-AccessReturnType_t<StringType> Vocabulary<StringType, C>::at(Id id) const {
-  return _internalVocabulary[static_cast<size_t>(id)];
 }
 
 // _____________________________________________________________________________
 template <typename S, typename C>
 bool Vocabulary<S, C>::getId(const string& word, Id* id) const {
-  if (!shouldBeExternalized(word)) {
-    // need the TOTAL level because we want the unique word.
-    *id = lower_bound(word, SortLevel::TOTAL);
-    // works for the case insensitive version because
-    // of the strict ordering.
-    return *id < _internalVocabulary.size() && at(*id) == word;
-  }
-  auto wordAndIndex = _externalVocabulary.lower_bound(word, SortLevel::TOTAL);
+  // need the TOTAL level because we want the unique word.
+  auto wordAndIndex = _vocabulary.lower_bound(word, SortLevel::TOTAL);
   *id = wordAndIndex._index;
-  *id += _internalVocabulary.size();
   return wordAndIndex._word == word;
 }
 
 // ___________________________________________________________________________
 template <typename S, typename C>
 std::pair<Id, Id> Vocabulary<S, C>::prefix_range(const string& prefix) const {
-  return _internalVocabulary.prefix_range(prefix);
+  return _vocabulary.prefix_range(prefix);
 }
 
 // _____________________________________________________________________________
@@ -248,11 +245,8 @@ template <typename S, typename C>
 template <typename, typename>
 const std::optional<std::string_view> Vocabulary<S, C>::operator[](
     Id id) const {
-  if (id < _internalVocabulary.size()) {
-    return _internalVocabulary[static_cast<size_t>(id)];
-  } else {
-    return std::nullopt;
-  }
+  // TODO<joka921> should we perform a check whether this ID is legal?
+  return _vocabulary[id];
 }
 template const std::optional<std::string_view>
 TextVocabulary::operator[]<std::string, void>(Id id) const;
@@ -260,16 +254,12 @@ TextVocabulary::operator[]<std::string, void>(Id id) const;
 template <typename S, typename C>
 template <typename, typename>
 const std::optional<string> Vocabulary<S, C>::idToOptionalString(Id id) const {
-  if (id < _internalVocabulary.size()) {
-    return _internalVocabulary[static_cast<size_t>(id)];
-  } else if (id == ID_NO_VALUE) {
+  if (id == ID_NO_VALUE) {
     return std::nullopt;
-  } else {
-    // this word must be externalized
-    id -= _internalVocabulary.size();
-    AD_CHECK(id < _externalVocabulary.size());
-    return _externalVocabulary[id];
   }
+  // TODO<joka921> The vocabularies need an api that CHECKS whether
+  // the vocabulary in fact contains this id.
+  return _vocabulary[id];
 }
 
 // ___________________________________________________________________________
@@ -288,6 +278,9 @@ Vocabulary<S, C>::getRangesForDatatypes() const {
 template <typename S, typename C>
 template <typename, typename>
 void Vocabulary<S, C>::printRangesForDatatypes() {
+  // TODO<joka921>:
+  // This will become obsolete soon, is it actually used?
+  /*
   auto ranges = getRangesForDatatypes();
   auto logRange = [&](const auto& range) {
     LOG(INFO) << range.first << " " << range.second << '\n';
@@ -307,6 +300,7 @@ void Vocabulary<S, C>::printRangesForDatatypes() {
   for (const auto& pair : ranges) {
     logRange(pair.second);
   }
+   */
 }
 
 template const std::optional<string>

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -95,6 +95,7 @@ class VocabularyMerger {
 
   // close all associated files and MmapVectors and reset all internal variables
   void clear() {
+    _idManager = IdManager{};
     _totalWritten = 0;
     _lastTripleComponent = std::nullopt;
     _outfileExternal = std::ofstream();
@@ -106,8 +107,13 @@ class VocabularyMerger {
 
   // private data members
 
-  // the number of words we have written. This also is the global Id of the next
-  // word we see, unless it is is equal to the previous word
+  // Obtain the IDs for internal and external words. Internal words will get
+  // Milestone IDs, and external words will get ordinary IDs. If an external
+  // word "accidentally" gets a Milestone ID, it will be internalized.
+  using IdManager =
+      ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance>;
+  IdManager _idManager;
+  // The number of words we have written. Only used for statistical purposes
   size_t _totalWritten = 0;
   // keep track of the last seen word to correctly handle duplicates
 

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -153,7 +153,7 @@ void VocabularyMerger::writeQueueWordsToIdVec(
       auto id = top.isExternal() ? _idManager.getNextId()
                                  : _idManager.getNextMilestoneId();
       _lastTripleComponent = TripleComponentWithId{
-          top.iriOrLiteral(), _idManager.isMilestoneId(id), id};
+          top.iriOrLiteral(), !_idManager.isMilestoneId(id), id};
 
       // TODO<optimization> If we aim to further speed this up, we could
       // order all the write requests to _outfile _externalOutfile and all the

--- a/src/index/vocabulary/CombinedMilestoneVocabulary.h
+++ b/src/index/vocabulary/CombinedMilestoneVocabulary.h
@@ -1,0 +1,39 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#ifndef QLEVER_COMBINEDMILESTONEVOCABULARY_H
+#define QLEVER_COMBINEDMILESTONEVOCABULARY_H
+
+#include "../../global/Id.h"
+#include "../VocabularyOnDisk.h"
+#include "./CombinedVocabulary.h"
+#include "./VocabularyInMemory.h"
+
+template <uint64_t distanceBetweenMilestones>
+class MilestoneIndexConverter {
+ private:
+  ad_utility::MilestoneIdManager<distanceBetweenMilestones> _idManager;
+
+ public:
+  bool isInFirst(uint64_t id, const auto&) const {
+    return _idManager.isMilestoneId(id);
+  }
+
+  uint64_t localFirstToGlobal(uint64_t id, const auto&) const {
+    return _idManager.milestoneIdFromLocal(id);
+    ;
+  }
+
+  uint64_t localSecondToGlobal(uint64_t id, const auto&) const { return id; }
+
+  uint64_t globalToLocalFirst(uint64_t id, const auto&) const {
+    return _idManager.milestoneIdToLocal(id);
+  }
+
+  uint64_t globalToLocalSecond(uint64_t id, const auto&) const {
+    return _idManager.milestoneIdToLocal(id);
+  }
+};
+
+#endif  // QLEVER_COMBINEDMILESTONEVOCABULARY_H

--- a/src/index/vocabulary/CombinedVocabulary.h
+++ b/src/index/vocabulary/CombinedVocabulary.h
@@ -64,10 +64,11 @@ class CombinedVocabulary {
  public:
   // Construct from pre-initialized vocabularies and `IndexConverter`.
   CombinedVocabulary(
-      FirstVocabulary firstVocab, SecondVocabulary secondVocab,
-      IndexConverter
-          converter) requires IndexConverterConcept<CombinedVocabulary,
-                                                    IndexConverter>
+      FirstVocabulary firstVocab = FirstVocabulary{},
+      SecondVocabulary secondVocab = SecondVocabulary{},
+      IndexConverter converter =
+          IndexConverter{}) requires IndexConverterConcept<CombinedVocabulary,
+                                                           IndexConverter>
       : _firstVocab{std::move(firstVocab)},
         _secondVocab{std::move(secondVocab)},
         _indexConverter{converter} {}
@@ -86,6 +87,18 @@ class CombinedVocabulary {
   [[nodiscard]] uint64_t sizeSecondVocab() const { return _secondVocab.size(); }
   [[nodiscard]] uint64_t size() const {
     return sizeFirstVocab() + sizeSecondVocab();
+  }
+
+  /// Direct access to the underlying vocabularies
+  const auto& firstVocab() const { return _firstVocab; }
+  auto& firstVocab() { return _firstVocab; }
+  const auto& secondVocab() const { return _secondVocab; }
+  auto& secondVocab() { return _secondVocab; }
+
+  /// Close both underlying vocabularies
+  void close() {
+    _firstVocab.close();
+    _secondVocab.close();
   }
 
   /// The highest ID (=index) that occurs in this vocabulary. May only be called

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -23,8 +23,12 @@ class CompressedVocabulary {
   CompressedVocabulary(Compressor compressor = Compressor())
       : _compressor{std::move(compressor)} {}
 
-  auto operator[](uint64_t id) const {
-    return _compressor.decompress(_underlyingVocabulary[id]);
+  std::optional<std::string> operator[](uint64_t id) const {
+    auto optionalCompressed = _underlyingVocabulary[id];
+    if (!optionalCompressed.has_value()) {
+      return std::nullopt;
+    }
+    return _compressor.decompress(optionalCompressed.value());
   }
 
   [[nodiscard]] uint64_t size() const { return _underlyingVocabulary.size(); }

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -55,8 +55,11 @@ class VocabularyInMemory {
     return size() - 1;
   }
 
-  /// Return the `i-th` word. The behavior is undefined if `i >= size()`
-  auto operator[](uint64_t i) const { return _words[i]; }
+  /// Return the `i-th` word. Return `nullopt` if `i >= size()`
+  std::optional<std::string> operator[](uint64_t i) const {
+    auto view = _words[i];
+    return std::string(view.begin(), view.end());
+  }
 
   /// Return a `WordAndIndex` that points to the first entry that is equal or
   /// greater than `word` wrt. to the `comparator`. Only works correctly if the

--- a/test/CombinedMilestoneVocabularyTest.cpp
+++ b/test/CombinedMilestoneVocabularyTest.cpp
@@ -1,0 +1,8 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+#include "../src/index/vocabulary/CombinedMilestoneVocabulary.h
+
+TEST(CombinedMilestoneVocabulary, FirstTest) {}

--- a/test/CompressedVocabularyTest.cpp
+++ b/test/CompressedVocabularyTest.cpp
@@ -80,7 +80,7 @@ TEST(CompressedVocabulary, CompressionIsActuallyApplied) {
   ASSERT_EQ(simple.size(), words.size());
   for (size_t i = 0; i < simple.size(); ++i) {
     ASSERT_NE(simple[i], words[i]);
-    ASSERT_EQ(DummyCompressor::decompress(simple[i]), words[i]);
+    ASSERT_EQ(DummyCompressor::decompress(simple[i].value()), words[i]);
   }
 }
 

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -86,9 +86,7 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
     // force destruction to close and reopen the mmap-File
     {
       IndexMetaDataMmap imd;
-      // size of 3 would suffice, but we also want to simulate the sparseness
-      imd.setup(5, CompressedRelationMetaData::emptyMetaData(),
-                "_testtmp.imd.mmap");
+      imd.setup("_testtmp.imd.mmap", ad_utility::CreateTag{});
       imd.add(rmdF);
       imd.add(rmdF2);
       imd.blockData() = bs;

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -76,37 +76,40 @@ TEST(IndexTest, createFromTsvTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
-    ASSERT_TRUE(index._PSO.metaData().col0IdExists(2));
-    ASSERT_TRUE(index._PSO.metaData().col0IdExists(3));
-    ASSERT_FALSE(index._PSO.metaData().col0IdExists(1));
-    ASSERT_FALSE(index._PSO.metaData().col0IdExists(0));
-    ASSERT_FALSE(index._PSO.metaData().getMetaData(2).isFunctional());
-    ASSERT_TRUE(index._PSO.metaData().getMetaData(3).isFunctional());
+    ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance> m;
+    auto c = [&](auto id) { return m.milestoneIdFromLocal(id); };
 
-    ASSERT_TRUE(index.POS().metaData().col0IdExists(2));
-    ASSERT_TRUE(index.POS().metaData().col0IdExists(3));
-    ASSERT_FALSE(index.POS().metaData().col0IdExists(1));
-    ASSERT_FALSE(index.POS().metaData().col0IdExists(4));
-    ASSERT_TRUE(index.POS().metaData().getMetaData(2).isFunctional());
-    ASSERT_TRUE(index.POS().metaData().getMetaData(3).isFunctional());
+    ASSERT_TRUE(index._PSO.metaData().col0IdExists(c(2)));
+    ASSERT_TRUE(index._PSO.metaData().col0IdExists(c(3)));
+    ASSERT_FALSE(index._PSO.metaData().col0IdExists(c(1)));
+    ASSERT_FALSE(index._PSO.metaData().col0IdExists(c(0)));
+    ASSERT_FALSE(index._PSO.metaData().getMetaData(c(2)).isFunctional());
+    ASSERT_TRUE(index._PSO.metaData().getMetaData(c(3)).isFunctional());
+
+    ASSERT_TRUE(index.POS().metaData().col0IdExists(c(2)));
+    ASSERT_TRUE(index.POS().metaData().col0IdExists(c(3)));
+    ASSERT_FALSE(index.POS().metaData().col0IdExists(c(1)));
+    ASSERT_FALSE(index.POS().metaData().col0IdExists(c(4)));
+    ASSERT_TRUE(index.POS().metaData().getMetaData(c(2)).isFunctional());
+    ASSERT_TRUE(index.POS().metaData().getMetaData(c(3)).isFunctional());
 
     // Relation b
     // Pair index
     std::vector<std::array<Id, 2>> buffer;
-    CompressedRelationMetaData::scan(2, &buffer, index.PSO());
+    CompressedRelationMetaData::scan(c(2), &buffer, index.PSO());
     ASSERT_EQ(2ul, buffer.size());
-    ASSERT_EQ(Id(0), buffer[0][0]);
-    ASSERT_EQ(4u, buffer[0][1]);
-    ASSERT_EQ(0u, buffer[1][0]);
-    ASSERT_EQ(5u, buffer[1][1]);
+    ASSERT_EQ(c(0), buffer[0][0]);
+    ASSERT_EQ(c(4), buffer[0][1]);
+    ASSERT_EQ(c(0), buffer[1][0]);
+    ASSERT_EQ(c(5), buffer[1][1]);
 
     // Relation b2
-    CompressedRelationMetaData::scan(3, &buffer, index.PSO());
+    CompressedRelationMetaData::scan(c(3), &buffer, index.PSO());
     ASSERT_EQ(2ul, buffer.size());
-    ASSERT_EQ(Id(0), buffer[0][0]);
-    ASSERT_EQ(4u, buffer[0][1]);
-    ASSERT_EQ(1u, buffer[1][0]);
-    ASSERT_EQ(5u, buffer[1][1]);
+    ASSERT_EQ(c(0), buffer[0][0]);
+    ASSERT_EQ(c(4), buffer[0][1]);
+    ASSERT_EQ(c(1), buffer[1][0]);
+    ASSERT_EQ(c(5), buffer[1][1]);
 
     remove("_testtmp2.tsv");
     std::remove(stxxlFileName.c_str());
@@ -150,52 +153,55 @@ TEST(IndexTest, createFromTsvTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
-    ASSERT_TRUE(index._PSO.metaData().col0IdExists(7));
-    ASSERT_FALSE(index._PSO.metaData().col0IdExists(1));
+    ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance> m;
+    auto c = [&](auto id) { return m.milestoneIdFromLocal(id); };
 
-    ASSERT_FALSE(index._PSO.metaData().getMetaData(7).isFunctional());
+    ASSERT_TRUE(index._PSO.metaData().col0IdExists(c(7)));
+    ASSERT_FALSE(index._PSO.metaData().col0IdExists(c(1)));
 
-    ASSERT_TRUE(index.POS().metaData().col0IdExists(7));
-    ASSERT_FALSE(index.POS().metaData().getMetaData(7).isFunctional());
+    ASSERT_FALSE(index._PSO.metaData().getMetaData(c(7)).isFunctional());
+
+    ASSERT_TRUE(index.POS().metaData().col0IdExists(c(7)));
+    ASSERT_FALSE(index.POS().metaData().getMetaData(c(7)).isFunctional());
 
     std::vector<std::array<Id, 2>> buffer;
     // is-a
-    CompressedRelationMetaData::scan(7, &buffer, index.PSO());
+    CompressedRelationMetaData::scan(c(7), &buffer, index.PSO());
     ASSERT_EQ(7ul, buffer.size());
     // Pair index
-    ASSERT_EQ(4u, buffer[0][0]);
-    ASSERT_EQ(0u, buffer[0][1]);
-    ASSERT_EQ(4u, buffer[1][0]);
-    ASSERT_EQ(1u, buffer[1][1]);
-    ASSERT_EQ(4u, buffer[2][0]);
-    ASSERT_EQ(2u, buffer[2][1]);
-    ASSERT_EQ(5u, buffer[3][0]);
-    ASSERT_EQ(0u, buffer[3][1]);
-    ASSERT_EQ(5u, buffer[4][0]);
-    ASSERT_EQ(3u, buffer[4][1]);
-    ASSERT_EQ(6u, buffer[5][0]);
-    ASSERT_EQ(1u, buffer[5][1]);
-    ASSERT_EQ(6u, buffer[6][0]);
-    ASSERT_EQ(2u, buffer[6][1]);
+    ASSERT_EQ(c(4), buffer[0][0]);
+    ASSERT_EQ(c(0), buffer[0][1]);
+    ASSERT_EQ(c(4), buffer[1][0]);
+    ASSERT_EQ(c(1), buffer[1][1]);
+    ASSERT_EQ(c(4), buffer[2][0]);
+    ASSERT_EQ(c(2), buffer[2][1]);
+    ASSERT_EQ(c(5), buffer[3][0]);
+    ASSERT_EQ(c(0), buffer[3][1]);
+    ASSERT_EQ(c(5), buffer[4][0]);
+    ASSERT_EQ(c(3), buffer[4][1]);
+    ASSERT_EQ(c(6), buffer[5][0]);
+    ASSERT_EQ(c(1), buffer[5][1]);
+    ASSERT_EQ(c(6), buffer[6][0]);
+    ASSERT_EQ(c(2), buffer[6][1]);
 
     // is-a for POS
-    CompressedRelationMetaData::scan(7, &buffer, index.POS());
+    CompressedRelationMetaData::scan(c(7), &buffer, index.POS());
     ASSERT_EQ(7ul, buffer.size());
     // Pair index
-    ASSERT_EQ(0u, buffer[0][0]);
-    ASSERT_EQ(4u, buffer[0][1]);
-    ASSERT_EQ(0u, buffer[1][0]);
-    ASSERT_EQ(5u, buffer[1][1]);
-    ASSERT_EQ(1u, buffer[2][0]);
-    ASSERT_EQ(4u, buffer[2][1]);
-    ASSERT_EQ(1u, buffer[3][0]);
-    ASSERT_EQ(6u, buffer[3][1]);
-    ASSERT_EQ(2u, buffer[4][0]);
-    ASSERT_EQ(4u, buffer[4][1]);
-    ASSERT_EQ(2u, buffer[5][0]);
-    ASSERT_EQ(6u, buffer[5][1]);
-    ASSERT_EQ(3u, buffer[6][0]);
-    ASSERT_EQ(5u, buffer[6][1]);
+    ASSERT_EQ(c(0), buffer[0][0]);
+    ASSERT_EQ(c(4), buffer[0][1]);
+    ASSERT_EQ(c(0), buffer[1][0]);
+    ASSERT_EQ(c(5), buffer[1][1]);
+    ASSERT_EQ(c(1), buffer[2][0]);
+    ASSERT_EQ(c(4), buffer[2][1]);
+    ASSERT_EQ(c(1), buffer[3][0]);
+    ASSERT_EQ(c(6), buffer[3][1]);
+    ASSERT_EQ(c(2), buffer[4][0]);
+    ASSERT_EQ(c(4), buffer[4][1]);
+    ASSERT_EQ(c(2), buffer[5][0]);
+    ASSERT_EQ(c(6), buffer[5][1]);
+    ASSERT_EQ(c(3), buffer[6][0]);
+    ASSERT_EQ(c(5), buffer[6][1]);
 
     remove("_testtmp2.tsv");
     std::remove(stxxlFileName.c_str());
@@ -321,19 +327,21 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
   Index index;
   index.createFromOnDiskIndex("_testindex2");
 
-  ASSERT_TRUE(index.PSO().metaData().col0IdExists(2));
-  ASSERT_TRUE(index.PSO().metaData().col0IdExists(3));
-  ASSERT_FALSE(index.PSO().metaData().col0IdExists(1));
-  ASSERT_FALSE(index.PSO().metaData().col0IdExists(4));
-  ASSERT_FALSE(index.PSO().metaData().getMetaData(2).isFunctional());
-  ASSERT_TRUE(index.PSO().metaData().getMetaData(3).isFunctional());
+  ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance> m;
+  auto c = [&](auto id) { return m.milestoneIdFromLocal(id); };
+  ASSERT_TRUE(index.PSO().metaData().col0IdExists(c(2)));
+  ASSERT_TRUE(index.PSO().metaData().col0IdExists(c(3)));
+  ASSERT_FALSE(index.PSO().metaData().col0IdExists(c(1)));
+  ASSERT_FALSE(index.PSO().metaData().col0IdExists(c(4)));
+  ASSERT_FALSE(index.PSO().metaData().getMetaData(c(2)).isFunctional());
+  ASSERT_TRUE(index.PSO().metaData().getMetaData(c(3)).isFunctional());
 
-  ASSERT_TRUE(index.POS().metaData().col0IdExists(2));
-  ASSERT_TRUE(index.POS().metaData().col0IdExists(3));
-  ASSERT_FALSE(index.POS().metaData().col0IdExists(1));
-  ASSERT_FALSE(index.POS().metaData().col0IdExists(4));
-  ASSERT_TRUE(index.POS().metaData().getMetaData(2).isFunctional());
-  ASSERT_TRUE(index.POS().metaData().getMetaData(3).isFunctional());
+  ASSERT_TRUE(index.POS().metaData().col0IdExists(c(2)));
+  ASSERT_TRUE(index.POS().metaData().col0IdExists(c(3)));
+  ASSERT_FALSE(index.POS().metaData().col0IdExists(c(1)));
+  ASSERT_FALSE(index.POS().metaData().col0IdExists(c(4)));
+  ASSERT_TRUE(index.POS().metaData().getMetaData(c(2)).isFunctional());
+  ASSERT_TRUE(index.POS().metaData().getMetaData(c(3)).isFunctional());
 
   remove("_testtmp3.tsv");
   remove("_testindex2.index.pso");
@@ -371,15 +379,18 @@ TEST(IndexTest, scanTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
+    ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance> m;
+    auto c = [&](auto id) { return m.milestoneIdFromLocal(id); };
+
     IdTable wol(1, allocator());
     IdTable wtl(2, allocator());
 
     index.scan("<b>", &wtl, index._PSO);
     ASSERT_EQ(2u, wtl.size());
-    ASSERT_EQ(0u, wtl[0][0]);
-    ASSERT_EQ(4u, wtl[0][1]);
-    ASSERT_EQ(0u, wtl[1][0]);
-    ASSERT_EQ(5u, wtl[1][1]);
+    ASSERT_EQ(c(0), wtl[0][0]);
+    ASSERT_EQ(c(4), wtl[0][1]);
+    ASSERT_EQ(c(0), wtl[1][0]);
+    ASSERT_EQ(c(5), wtl[1][1]);
     wtl.clear();
     index.scan("<x>", &wtl, index._PSO);
     ASSERT_EQ(0u, wtl.size());
@@ -389,10 +400,10 @@ TEST(IndexTest, scanTest) {
 
     index.scan("<b>", &wtl, index._POS);
     ASSERT_EQ(2u, wtl.size());
-    ASSERT_EQ(4u, wtl[0][0]);
-    ASSERT_EQ(0u, wtl[0][1]);
-    ASSERT_EQ(5u, wtl[1][0]);
-    ASSERT_EQ(0u, wtl[1][1]);
+    ASSERT_EQ(c(4), wtl[0][0]);
+    ASSERT_EQ(c(0), wtl[0][1]);
+    ASSERT_EQ(c(5), wtl[1][0]);
+    ASSERT_EQ(c(0), wtl[1][1]);
     wtl.clear();
     index.scan("<x>", &wtl, index._POS);
     ASSERT_EQ(0u, wtl.size());
@@ -402,15 +413,15 @@ TEST(IndexTest, scanTest) {
 
     index.scan("<b>", "<a>", &wol, index._PSO);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(5u, wol[1][0]);
+    ASSERT_EQ(c(4), wol[0][0]);
+    ASSERT_EQ(c(5), wol[1][0]);
     wol.clear();
     index.scan("<b>", "<c>", &wol, index._PSO);
     ASSERT_EQ(0u, wol.size());
 
     index.scan("<b2>", "<c2>", &wol, index._POS);
     ASSERT_EQ(1u, wol.size());
-    ASSERT_EQ(1u, wol[0][0]);
+    ASSERT_EQ(c(1), wol[0][0]);
   }
 
   remove("_testtmp2.tsv");
@@ -455,83 +466,86 @@ TEST(IndexTest, scanTest) {
     Index index;
     index.createFromOnDiskIndex("_testindex");
 
+    ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance> m;
+    auto c = [&](auto id) { return m.milestoneIdFromLocal(id); };
+
     IdTable wol(1, allocator());
     IdTable wtl(2, allocator());
 
     index.scan("<is-a>", &wtl, index._PSO);
     ASSERT_EQ(7u, wtl.size());
-    ASSERT_EQ(4u, wtl[0][0]);
-    ASSERT_EQ(0u, wtl[0][1]);
-    ASSERT_EQ(4u, wtl[1][0]);
-    ASSERT_EQ(1u, wtl[1][1]);
-    ASSERT_EQ(4u, wtl[2][0]);
-    ASSERT_EQ(2u, wtl[2][1]);
-    ASSERT_EQ(5u, wtl[3][0]);
-    ASSERT_EQ(0u, wtl[3][1]);
-    ASSERT_EQ(5u, wtl[4][0]);
-    ASSERT_EQ(3u, wtl[4][1]);
-    ASSERT_EQ(6u, wtl[5][0]);
-    ASSERT_EQ(1u, wtl[5][1]);
-    ASSERT_EQ(6u, wtl[6][0]);
-    ASSERT_EQ(2u, wtl[6][1]);
+    ASSERT_EQ(c(4), wtl[0][0]);
+    ASSERT_EQ(c(0), wtl[0][1]);
+    ASSERT_EQ(c(4), wtl[1][0]);
+    ASSERT_EQ(c(1), wtl[1][1]);
+    ASSERT_EQ(c(4), wtl[2][0]);
+    ASSERT_EQ(c(2), wtl[2][1]);
+    ASSERT_EQ(c(5), wtl[3][0]);
+    ASSERT_EQ(c(0), wtl[3][1]);
+    ASSERT_EQ(c(5), wtl[4][0]);
+    ASSERT_EQ(c(3), wtl[4][1]);
+    ASSERT_EQ(c(6), wtl[5][0]);
+    ASSERT_EQ(c(1), wtl[5][1]);
+    ASSERT_EQ(c(6), wtl[6][0]);
+    ASSERT_EQ(c(2), wtl[6][1]);
 
     index.scan("<is-a>", &wtl, index._POS);
     ASSERT_EQ(7u, wtl.size());
-    ASSERT_EQ(0u, wtl[0][0]);
-    ASSERT_EQ(4u, wtl[0][1]);
-    ASSERT_EQ(0u, wtl[1][0]);
-    ASSERT_EQ(5u, wtl[1][1]);
-    ASSERT_EQ(1u, wtl[2][0]);
-    ASSERT_EQ(4u, wtl[2][1]);
-    ASSERT_EQ(1u, wtl[3][0]);
-    ASSERT_EQ(6u, wtl[3][1]);
-    ASSERT_EQ(2u, wtl[4][0]);
-    ASSERT_EQ(4u, wtl[4][1]);
-    ASSERT_EQ(2u, wtl[5][0]);
-    ASSERT_EQ(6u, wtl[5][1]);
-    ASSERT_EQ(3u, wtl[6][0]);
-    ASSERT_EQ(5u, wtl[6][1]);
+    ASSERT_EQ(c(0), wtl[0][0]);
+    ASSERT_EQ(c(4), wtl[0][1]);
+    ASSERT_EQ(c(0), wtl[1][0]);
+    ASSERT_EQ(c(5), wtl[1][1]);
+    ASSERT_EQ(c(1), wtl[2][0]);
+    ASSERT_EQ(c(4), wtl[2][1]);
+    ASSERT_EQ(c(1), wtl[3][0]);
+    ASSERT_EQ(c(6), wtl[3][1]);
+    ASSERT_EQ(c(2), wtl[4][0]);
+    ASSERT_EQ(c(4), wtl[4][1]);
+    ASSERT_EQ(c(2), wtl[5][0]);
+    ASSERT_EQ(c(6), wtl[5][1]);
+    ASSERT_EQ(c(3), wtl[6][0]);
+    ASSERT_EQ(c(5), wtl[6][1]);
 
     index.scan("<is-a>", "<0>", &wol, index._POS);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(5u, wol[1][0]);
+    ASSERT_EQ(c(4), wol[0][0]);
+    ASSERT_EQ(c(5), wol[1][0]);
 
     wol.clear();
     index.scan("<is-a>", "<1>", &wol, index._POS);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(6u, wol[1][0]);
+    ASSERT_EQ(c(4), wol[0][0]);
+    ASSERT_EQ(c(6), wol[1][0]);
 
     wol.clear();
     index.scan("<is-a>", "<2>", &wol, index._POS);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(4u, wol[0][0]);
-    ASSERT_EQ(6u, wol[1][0]);
+    ASSERT_EQ(c(4), wol[0][0]);
+    ASSERT_EQ(c(6), wol[1][0]);
 
     wol.clear();
     index.scan("<is-a>", "<3>", &wol, index._POS);
     ASSERT_EQ(1u, wol.size());
-    ASSERT_EQ(5u, wol[0][0]);
+    ASSERT_EQ(c(5), wol[0][0]);
 
     wol.clear();
     index.scan("<is-a>", "<a>", &wol, index._PSO);
     ASSERT_EQ(3u, wol.size());
-    ASSERT_EQ(0u, wol[0][0]);
-    ASSERT_EQ(1u, wol[1][0]);
-    ASSERT_EQ(2u, wol[2][0]);
+    ASSERT_EQ(c(0), wol[0][0]);
+    ASSERT_EQ(c(1), wol[1][0]);
+    ASSERT_EQ(c(2), wol[2][0]);
 
     wol.clear();
     index.scan("<is-a>", "<b>", &wol, index._PSO);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(0u, wol[0][0]);
-    ASSERT_EQ(3u, wol[1][0]);
+    ASSERT_EQ(c(0), wol[0][0]);
+    ASSERT_EQ(c(3), wol[1][0]);
 
     wol.clear();
     index.scan("<is-a>", "<c>", &wol, index._PSO);
     ASSERT_EQ(2u, wol.size());
-    ASSERT_EQ(1u, wol[0][0]);
-    ASSERT_EQ(2u, wol[1][0]);
+    ASSERT_EQ(c(1), wol[0][0]);
+    ASSERT_EQ(c(2), wol[1][0]);
   }
   remove("_testtmp2.tsv");
   std::remove(stxxlFileName.c_str());

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -123,6 +123,8 @@ TEST(Vocabulary, PrefixFilter) {
   voc.createFromSet(s);
 
   auto x = voc.prefix_range("\"exp");
-  ASSERT_EQ(x.first, 1u);
-  ASSERT_EQ(x.second, 2u);
+  auto idManager =
+      ad_utility::MilestoneIdManager<InternalExternalIdMilestoneDistance>{};
+  ASSERT_EQ(x.first, idManager.milestoneIdFromLocal(1u));
+  ASSERT_EQ(x.second, idManager.milestoneIdFromLocal(2u));
 }


### PR DESCRIPTION
This allows more correct queries that involve external literals, and more flexible
externalization.

TODO: Currently a non-contiguous ID space does not really work efficiently with
the pattern trick.