### PR TITLE
Use likely attribute for escape functions

### DIFF
--- a/src/parser/RdfEscaping.cpp
+++ b/src/parser/RdfEscaping.cpp
@@ -263,14 +263,14 @@ std::string replaceAll(std::string str, const std::string_view from,
 }
 
 std::string escapeForCsv(std::string input) {
-  if (!ctre::search<"[\r\n\",]">(input)) {
+  if (!ctre::search<"[\r\n\",]">(input)) [[likely]] {
     return input;
   }
   return '"' + replaceAll(std::move(input), "\"", "\"\"") + '"';
 }
 
 std::string escapeForTsv(std::string input) {
-  if (!ctre::search<"[\n\t]">(input)) {
+  if (!ctre::search<"[\n\t]">(input)) [[likely]] {
     return input;
   }
   auto stage1 = replaceAll(std::move(input), "\t", " ");


### PR DESCRIPTION
At least for CONSTRUCT queries (which is currently the only usage for this function) the no-op case should be more likely. For literals (which are enclosed with double quotes + lang tags this might not be the case, so I'm not sure if this is a change without drawbacks.