### PR TITLE
Smaller default batch size in index building

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -75,7 +75,7 @@ static const std::string ERROR_IGNORE_CASE_UNSUPPORTED =
     "your settings.json and rebuild your index. You can optionally specify the "
     "\"locale\" key, otherwise \"en.US\" will be used as default";
 static const std::string WARNING_ASCII_ONLY_PREFIXES =
-    "You specified \"ascii-prefixes-only = true\", which enables faster "
+    "Setting \"ascii-prefixes-only = true\", which enables faster "
     "parsing for well-behaved TTL files";
 // " but only works correctly if there are no escape sequences in "
 // "prefixed names (e.g., rdfs:label\\,el is not allowed), no multiline "

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -19,7 +19,7 @@ static const size_t MAX_INTERNAL_LITERAL_BYTES = 1024;
 
 // How many lines are parsed at once during index creation.
 // Reduce to save RAM
-static const int NUM_TRIPLES_PER_PARTIAL_VOCAB = 100000000;
+static const int NUM_TRIPLES_PER_PARTIAL_VOCAB = 10'000'000;
 
 // How many Triples is the Buffer supposed to parse ahead.
 // If too big, the memory consumption is high, if too low we possibly lose speed

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -1001,7 +1001,7 @@ void Index::initializeVocabularySettingsBuild() {
                    "en_US"
                 << std::endl;
     }
-    LOG(INFO) << "You specified \"locale = " << lang << "_" << country << "\" "
+    LOG(INFO) << "Setting \"locale = " << lang << "_" << country << "\" "
               << "and \"ignore-punctuation = " << ignorePunctuation << "\""
               << std::endl;
 
@@ -1046,11 +1046,10 @@ void Index::initializeVocabularySettingsBuild() {
 
   if (j.count("num-triples-per-batch")) {
     _numTriplesPerBatch = size_t{j["num-triples-per-batch"]};
-    LOG(INFO)
-        << "You specified \"num-triples-per-batch = " << _numTriplesPerBatch
-        << "\", choose a lower value if the index builder runs out of memory"
-        << std::endl;
   }
+  LOG(INFO) << "Setting \"num-triples-per-batch = " << _numTriplesPerBatch
+            << "\", choose a lower value if the index builder runs out of memory"
+            << std::endl;
 
   if (j.count("parser-batch-size")) {
     _parserBatchSize = size_t{j["parser-batch-size"]};

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -1031,7 +1031,6 @@ void Index::initializeVocabularySettingsBuild() {
     if constexpr (std::is_same_v<std::decay_t<Parser>, TurtleParserAuto>) {
       bool v{j["ascii-prefixes-only"]};
       if (v) {
-        LOG(INFO) << WARNING_ASCII_ONLY_PREFIXES << std::endl;
         _onlyAsciiTurtlePrefixes = true;
       } else {
         _onlyAsciiTurtlePrefixes = false;
@@ -1041,7 +1040,11 @@ void Index::initializeVocabularySettingsBuild() {
                    "not the Turtle stream parser. This means that this setting "
                    "is ignored."
                 << std::endl;
+      _onlyAsciiTurtlePrefixes = false;
     }
+  }
+  if (_onlyAsciiTurtlePrefixes) {
+    LOG(INFO) << WARNING_ASCII_ONLY_PREFIXES << std::endl;
   }
 
   if (j.count("num-triples-per-batch")) {

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -280,7 +280,7 @@ int main(int argc, char** argv) {
       }
 
       if (!filetype.empty()) {
-        LOG(INFO) << "You specified the input format: "
+        LOG(INFO) << "Input format: "
                   << ad_utility::getUppercase(filetype) << std::endl;
       } else {
         bool filetypeDeduced = false;


### PR DESCRIPTION
Was 100M, which is too much for most machines and datasets. The typical effect is that the index building crashes after a minute or so, but without any error message (because no std::bad_alloc is thrown). That is especially confusing for new users.

Reduced it to 10M now, which worked fine for all our datasets so far and using < 64 GB of RAM.