### PR TITLE
Reduce memory required for unit tests

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -8,7 +8,7 @@
 
 #include "../util/Parameters.h"
 
-static const size_t STXXL_MEMORY_TO_USE = 1024UL * 1024UL * 1024UL * 2UL;
+static const size_t DEFAULT_STXXL_MEMORY_IN_GB = 1024UL * 1024UL * 1024UL * 2UL;
 static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000 * 1000;
 static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -8,7 +8,8 @@
 
 #include "../util/Parameters.h"
 
-static const size_t DEFAULT_STXXL_MEMORY_IN_GB = 1024UL * 1024UL * 1024UL * 2UL;
+static const size_t DEFAULT_STXXL_MEMORY_IN_BYTES =
+    1024UL * 1024UL * 1024UL * 2UL;
 static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000 * 1000;
 static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -9,7 +9,7 @@
 #include "../util/Parameters.h"
 
 static const size_t DEFAULT_STXXL_MEMORY_IN_BYTES =
-    1024UL * 1024UL * 1024UL * 2UL;
+    1024UL * 1024UL * 1024UL * 5UL;
 static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000 * 1000;
 static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -25,7 +25,7 @@ void Index::addTextFromContextFile(const string& contextFile) {
   passContextFileIntoVector(contextFile, v);
   LOG(INFO) << "Sorting text index with " << v.size() << " items ..."
             << std::endl;
-  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryBytes());
+  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryInBytes() / 3);
   LOG(INFO) << "Sort done." << std::endl;
   createTextIndex(indexFilename, v);
   openTextFileHandle();

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -25,7 +25,7 @@ void Index::addTextFromContextFile(const string& contextFile) {
   passContextFileIntoVector(contextFile, v);
   LOG(INFO) << "Sorting text index with " << v.size() << " items ..."
             << std::endl;
-  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryToUse());
+  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryGb());
   LOG(INFO) << "Sort done." << std::endl;
   createTextIndex(indexFilename, v);
   openTextFileHandle();

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -25,7 +25,7 @@ void Index::addTextFromContextFile(const string& contextFile) {
   passContextFileIntoVector(contextFile, v);
   LOG(INFO) << "Sorting text index with " << v.size() << " items ..."
             << std::endl;
-  stxxl::sort(begin(v), end(v), SortText(), STXXL_MEMORY_TO_USE);
+  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryToUse());
   LOG(INFO) << "Sort done." << std::endl;
   createTextIndex(indexFilename, v);
   openTextFileHandle();

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -25,7 +25,7 @@ void Index::addTextFromContextFile(const string& contextFile) {
   passContextFileIntoVector(contextFile, v);
   LOG(INFO) << "Sorting text index with " << v.size() << " items ..."
             << std::endl;
-  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryGb());
+  stxxl::sort(begin(v), end(v), SortText(), stxxlMemoryBytes());
   LOG(INFO) << "Sort done." << std::endl;
   createTextIndex(indexFilename, v);
   openTextFileHandle();

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -160,7 +160,7 @@ void Index::createFromFile(const string& filename) {
   // case any of the permutations fail.
   writeConfiguration();
 
-  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryToUse()};
+  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryGb()};
   auto& psoSorter = *indexBuilderData.psoSorter;
   // For the first permutation, perform a unique.
   auto uniqueSorter = ad_utility::uniqueView(psoSorter.sortedView());
@@ -174,7 +174,7 @@ void Index::createFromFile(const string& filename) {
 
   if (_loadAllPermutations) {
     // After the SPO permutation, create patterns if so desired.
-    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryToUse()};
+    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryGb()};
     if (_usePatterns) {
       PatternCreator patternCreator{_onDiskBase + ".index.patterns"};
       auto pushTripleToPatterns = [&patternCreator,
@@ -417,7 +417,7 @@ std::unique_ptr<PsoSorter> Index::convertPartialToGlobalIds(
 
   // Iterate over all partial vocabularies.
   TripleVec::bufreader_type reader(data);
-  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryToUse());
+  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryGb());
   auto& result = *resultPtr;
   size_t i = 0;
   for (size_t partialNum = 0; partialNum < actualLinesPerPartial.size();

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -160,7 +160,7 @@ void Index::createFromFile(const string& filename) {
   // case any of the permutations fail.
   writeConfiguration();
 
-  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryGb()};
+  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryBytes() / 5};
   auto& psoSorter = *indexBuilderData.psoSorter;
   // For the first permutation, perform a unique.
   auto uniqueSorter = ad_utility::uniqueView(psoSorter.sortedView());
@@ -174,7 +174,7 @@ void Index::createFromFile(const string& filename) {
 
   if (_loadAllPermutations) {
     // After the SPO permutation, create patterns if so desired.
-    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryGb()};
+    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryBytes() / 5};
     if (_usePatterns) {
       PatternCreator patternCreator{_onDiskBase + ".index.patterns"};
       auto pushTripleToPatterns = [&patternCreator,
@@ -417,7 +417,7 @@ std::unique_ptr<PsoSorter> Index::convertPartialToGlobalIds(
 
   // Iterate over all partial vocabularies.
   TripleVec::bufreader_type reader(data);
-  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryGb());
+  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryBytes() / 5);
   auto& result = *resultPtr;
   size_t i = 0;
   for (size_t partialNum = 0; partialNum < actualLinesPerPartial.size();

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -160,7 +160,7 @@ void Index::createFromFile(const string& filename) {
   // case any of the permutations fail.
   writeConfiguration();
 
-  StxxlSorter<SortBySPO> spoSorter{STXXL_MEMORY_TO_USE};
+  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryToUse()};
   auto& psoSorter = *indexBuilderData.psoSorter;
   // For the first permutation, perform a unique.
   auto uniqueSorter = ad_utility::uniqueView(psoSorter.sortedView());
@@ -174,7 +174,7 @@ void Index::createFromFile(const string& filename) {
 
   if (_loadAllPermutations) {
     // After the SPO permutation, create patterns if so desired.
-    StxxlSorter<SortByOSP> ospSorter{STXXL_MEMORY_TO_USE};
+    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryToUse()};
     if (_usePatterns) {
       PatternCreator patternCreator{_onDiskBase + ".index.patterns"};
       auto pushTripleToPatterns = [&patternCreator,
@@ -417,7 +417,7 @@ std::unique_ptr<PsoSorter> Index::convertPartialToGlobalIds(
 
   // Iterate over all partial vocabularies.
   TripleVec::bufreader_type reader(data);
-  auto resultPtr = std::make_unique<PsoSorter>(STXXL_MEMORY_TO_USE);
+  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryToUse());
   auto& result = *resultPtr;
   size_t i = 0;
   for (size_t partialNum = 0; partialNum < actualLinesPerPartial.size();

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -160,7 +160,7 @@ void Index::createFromFile(const string& filename) {
   // case any of the permutations fail.
   writeConfiguration();
 
-  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryBytes() / 5};
+  StxxlSorter<SortBySPO> spoSorter{stxxlMemoryInBytes() / 5};
   auto& psoSorter = *indexBuilderData.psoSorter;
   // For the first permutation, perform a unique.
   auto uniqueSorter = ad_utility::uniqueView(psoSorter.sortedView());
@@ -174,7 +174,7 @@ void Index::createFromFile(const string& filename) {
 
   if (_loadAllPermutations) {
     // After the SPO permutation, create patterns if so desired.
-    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryBytes() / 5};
+    StxxlSorter<SortByOSP> ospSorter{stxxlMemoryInBytes() / 5};
     if (_usePatterns) {
       PatternCreator patternCreator{_onDiskBase + ".index.patterns"};
       auto pushTripleToPatterns = [&patternCreator,
@@ -417,7 +417,7 @@ std::unique_ptr<PsoSorter> Index::convertPartialToGlobalIds(
 
   // Iterate over all partial vocabularies.
   TripleVec::bufreader_type reader(data);
-  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryBytes() / 5);
+  auto resultPtr = std::make_unique<PsoSorter>(stxxlMemoryInBytes() / 5);
   auto& result = *resultPtr;
   size_t i = 0;
   for (size_t partialNum = 0; partialNum < actualLinesPerPartial.size();

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -323,8 +323,8 @@ class Index {
 
   void setKeepTempFiles(bool keepTempFiles);
 
-  uint64_t& stxxlMemoryBytes() { return _stxxlMemoryGb; }
-  const uint64_t& stxxlMemoryBytes() const { return _stxxlMemoryGb; }
+  uint64_t& stxxlMemoryInBytes() { return _stxxlMemoryInBytes; }
+  const uint64_t& stxxlMemoryInBytes() const { return _stxxlMemoryInBytes; }
 
   void setOnDiskBase(const std::string& onDiskBase);
 
@@ -484,7 +484,7 @@ class Index {
   bool _turtleParserSkipIllegalLiterals = false;
   bool _onDiskLiterals = false;
   bool _keepTempFiles = false;
-  uint64_t _stxxlMemoryBytes = DEFAULT_STXXL_MEMORY_IN_BYTES;
+  uint64_t _stxxlMemoryInBytes = DEFAULT_STXXL_MEMORY_IN_BYTES;
   json _configurationJson;
   Vocabulary<CompressedString, TripleComponentComparator> _vocab;
   size_t _totalVocabularySize = 0;

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -323,8 +323,8 @@ class Index {
 
   void setKeepTempFiles(bool keepTempFiles);
 
-  uint64_t& stxxlMemoryToUse() { return this->_stxxlMemoryToUse; }
-  const uint64_t& stxxlMemoryToUse() const { return this->_stxxlMemoryToUse; }
+  uint64_t& stxxlMemoryGb() { return _stxxlMemoryGb; }
+  const uint64_t& stxxlMemoryGb() const { return _stxxlMemoryGb; }
 
   void setOnDiskBase(const std::string& onDiskBase);
 
@@ -484,7 +484,7 @@ class Index {
   bool _turtleParserSkipIllegalLiterals = false;
   bool _onDiskLiterals = false;
   bool _keepTempFiles = false;
-  uint64_t _stxxlMemoryToUse = STXXL_MEMORY_TO_USE;
+  uint64_t _stxxlMemoryGb = DEFAULT_STXXL_MEMORY_IN_GB;
   json _configurationJson;
   Vocabulary<CompressedString, TripleComponentComparator> _vocab;
   size_t _totalVocabularySize = 0;

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -323,8 +323,8 @@ class Index {
 
   void setKeepTempFiles(bool keepTempFiles);
 
-  uint64_t& stxxlMemoryGb() { return _stxxlMemoryGb; }
-  const uint64_t& stxxlMemoryGb() const { return _stxxlMemoryGb; }
+  uint64_t& stxxlMemoryBytes() { return _stxxlMemoryGb; }
+  const uint64_t& stxxlMemoryBytes() const { return _stxxlMemoryGb; }
 
   void setOnDiskBase(const std::string& onDiskBase);
 
@@ -484,7 +484,7 @@ class Index {
   bool _turtleParserSkipIllegalLiterals = false;
   bool _onDiskLiterals = false;
   bool _keepTempFiles = false;
-  uint64_t _stxxlMemoryGb = DEFAULT_STXXL_MEMORY_IN_GB;
+  uint64_t _stxxlMemoryBytes = DEFAULT_STXXL_MEMORY_IN_BYTES;
   json _configurationJson;
   Vocabulary<CompressedString, TripleComponentComparator> _vocab;
   size_t _totalVocabularySize = 0;

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -99,10 +99,12 @@ class Index {
       tuple<TextBlockIndex, TextRecordIndex, WordOrEntityIndex, Score, bool>>;
   using Posting = std::tuple<TextRecordIndex, WordIndex, Score>;
 
-  // Forbid copy and assignment
+  /// Forbid copy and assignment.
   Index& operator=(const Index&) = delete;
-
   Index(const Index&) = delete;
+
+  /// Allow move construction, which is mostly used in unit tests.
+  Index(Index&&) noexcept = default;
 
   Index();
 
@@ -321,6 +323,9 @@ class Index {
 
   void setKeepTempFiles(bool keepTempFiles);
 
+  uint64_t& stxxlMemoryToUse() { return this->_stxxlMemoryToUse; }
+  const uint64_t& stxxlMemoryToUse() const { return this->_stxxlMemoryToUse; }
+
   void setOnDiskBase(const std::string& onDiskBase);
 
   void setSettingsFile(const std::string& filename);
@@ -479,6 +484,7 @@ class Index {
   bool _turtleParserSkipIllegalLiterals = false;
   bool _onDiskLiterals = false;
   bool _keepTempFiles = false;
+  uint64_t _stxxlMemoryToUse = STXXL_MEMORY_TO_USE;
   json _configurationJson;
   Vocabulary<CompressedString, TripleComponentComparator> _vocab;
   size_t _totalVocabularySize = 0;

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -235,6 +235,7 @@ int main(int argc, char** argv) {
       case 'm':
         index.stxxlMemoryInBytes() =
             1024ul * 1024ul * 1024ul * std::strtoul(optarg, nullptr, 10);
+        break;
       default:
         cerr << endl
              << "! ERROR in processing options (getopt returned '" << c

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -46,7 +46,7 @@ struct option options[] = {
     {"settings-file", required_argument, NULL, 's'},
     {"no-compressed-vocabulary", no_argument, NULL, 'N'},
     {"only-pso-and-pos-permutations", no_argument, NULL, 'o'},
-    {"stxxl-memory-gb", no_argument, NULL, 'm'},
+    {"stxxl-memory-gb", required_argument, NULL, 'm'},
     {NULL, 0, NULL, 0}};
 
 string getStxxlConfigFileName(const string& location) {
@@ -233,7 +233,8 @@ int main(int argc, char** argv) {
         loadAllPermutations = false;
         break;
       case 'm':
-        index.stxxlMemoryGb() = std::strtoul(optarg, nullptr, 10);
+        index.stxxlMemoryBytes() =
+            1024ul * 1024ul * 1024ul * std::strtoul(optarg, nullptr, 10);
       default:
         cerr << endl
              << "! ERROR in processing options (getopt returned '" << c

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -46,6 +46,7 @@ struct option options[] = {
     {"settings-file", required_argument, NULL, 's'},
     {"no-compressed-vocabulary", no_argument, NULL, 'N'},
     {"only-pso-and-pos-permutations", no_argument, NULL, 'o'},
+    {"stxxl-memory-gb", no_argument, NULL, 'm'},
     {NULL, 0, NULL, 0}};
 
 string getStxxlConfigFileName(const string& location) {
@@ -142,6 +143,11 @@ void printUsage(char* execName) {
   cerr << "  " << std::setw(20) << "o, only-pos-and-pso-permutations"
        << std::setw(1) << "    "
        << "Only load PSO and POS permutations" << endl;
+  cerr << "  " << std::setw(20) << "m, stxxl-memory-gb" << std::setw(1)
+       << "    "
+       << "The amount of memory to use for sorting during the index build. "
+          "Decrease if the index builder runs out of memory."
+       << endl;
   cerr.copyfmt(cerrState);
 }
 
@@ -169,9 +175,13 @@ int main(int argc, char** argv) {
   bool keepTemporaryFiles = false;
   bool loadAllPermutations = true;
   optind = 1;
+
+  Index index;
+
   // Process command line arguments.
   while (true) {
-    int c = getopt_long(argc, argv, "F:f:i:w:d:lT:K:hAks:No", options, nullptr);
+    int c =
+        getopt_long(argc, argv, "F:f:i:w:d:lT:K:hAks:Nom:", options, nullptr);
     if (c == -1) {
       break;
     }
@@ -222,6 +232,8 @@ int main(int argc, char** argv) {
       case 'o':
         loadAllPermutations = false;
         break;
+      case 'm':
+        index.stxxlMemoryGb() = std::strtoul(optarg, nullptr, 10);
       default:
         cerr << endl
              << "! ERROR in processing options (getopt returned '" << c
@@ -261,7 +273,6 @@ int main(int argc, char** argv) {
     string stxxlFileName = getStxxlDiskFileName(location, tail);
     LOG(TRACE) << "done." << std::endl;
 
-    Index index;
     index.setKbName(kbIndexName);
     index.setTextName(textIndexName);
     index.setUsePatterns(usePatterns);

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -233,7 +233,7 @@ int main(int argc, char** argv) {
         loadAllPermutations = false;
         break;
       case 'm':
-        index.stxxlMemoryBytes() =
+        index.stxxlMemoryInBytes() =
             1024ul * 1024ul * 1024ul * std::strtoul(optarg, nullptr, 10);
       default:
         cerr << endl

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -99,6 +99,7 @@ class Vocabulary {
                                   std::is_same_v<StringType, CompressedString>>>
   Vocabulary(){};
   Vocabulary& operator=(Vocabulary&&) noexcept = default;
+  Vocabulary(Vocabulary&&) noexcept = default;
 
   // variable for dispatching
   static constexpr bool _isCompressed =

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -391,7 +391,7 @@ class TurtleStringParser : public TurtleParser<Tokenizer_T> {
 
  private:
   // The complete input to this parser.
-  std::vector<char> _tmpToParse;
+  ParallelBuffer::BufferType _tmpToParse;
   // Used to add a certain offset to the parsing position when using this
   // in a parallel setting.
   size_t _positionOffset = 0;
@@ -412,7 +412,7 @@ class TurtleStringParser : public TurtleParser<Tokenizer_T> {
   const auto& getPrefixMap() const { return _prefixMap; }
 
   // __________________________________________________________
-  void setInputStream(std::vector<char> toParse) {
+  void setInputStream(ParallelBuffer::BufferType&& toParse) {
     _tmpToParse = std::move(toParse);
     this->_tok.reset(_tmpToParse.data(), _tmpToParse.size());
   }
@@ -491,7 +491,7 @@ class TurtleStreamParser : public TurtleParser<Tokenizer_T> {
   // stores the current batch of bytes we have to parse.
   // Might end in the middle of a statement or even a multibyte utf8 character,
   // that's why we need the backupState() and resetStateAndRead() methods
-  std::vector<char> _byteVec;
+  ParallelBuffer::BufferType _byteVec;
 
   std::unique_ptr<ParallelBuffer> _fileBuffer;
   // this many characters will be buffered at once,
@@ -614,5 +614,5 @@ class TurtleParallelParser : public TurtleParser<Tokenizer_T> {
                                              "parallel parser"};
   std::future<void> _parseFuture;
 
-  std::vector<char> _remainingBatchFromInitialization;
+  ParallelBuffer::BufferType _remainingBatchFromInitialization;
 };

--- a/src/util/UninitializedAllocator.h
+++ b/src/util/UninitializedAllocator.h
@@ -4,6 +4,8 @@
 #ifndef QLEVER_UNINITIALIZEDALLOCATOR_H
 #define QLEVER_UNINITIALIZEDALLOCATOR_H
 
+#include <vector>
+
 namespace ad_utility {
 // Allocator adaptor that interposes construct() calls to
 // convert value initialization into default initialization.
@@ -55,6 +57,10 @@ class default_init_allocator : public A {
     a_t::construct(static_cast<A&>(*this), ptr, std::forward<Args>(args)...);
   }
 };
+
+/// Alias for a `std::vector<T>` that uses the `default_init_allocator`
+template <typename T>
+using UninitializedVector = std::vector<T, default_init_allocator<T>>;
 }  // namespace ad_utility
 
 #endif  // QLEVER_UNINITIALIZEDALLOCATOR_H

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 
 #include "../src/engine/GroupBy.h"
+#include "./IndexTestHelpers.h"
 
 ad_utility::AllocatorWithLimit<Id>& allocator() {
   static ad_utility::AllocatorWithLimit<Id> a{
@@ -46,7 +47,6 @@ class GroupByTest : public ::testing::Test {
       _index.setKbName("group_by_test");
       _index.setTextName("group_by_test");
       _index.setOnDiskBase("group_ty_test");
-      _index.setNumTriplesPerBatch(2);
       _index.createFromFile<TurtleParserAuto>("group_by_test.nt");
       _index.addTextFromContextFile("group_by_test.words");
       _index.buildDocsDB("group_by_test.documents");
@@ -73,7 +73,7 @@ class GroupByTest : public ::testing::Test {
     std::remove("group_by_test.nt");
   }
 
-  Index _index;
+  Index _index = makeIndexWithTestSettings();
 };
 
 TEST_F(GroupByTest, doGroupBy) {

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -9,6 +9,7 @@
 
 #include "../src/global/Pattern.h"
 #include "../src/index/Index.h"
+#include "./IndexTestHelpers.h"
 
 ad_utility::AllocatorWithLimit<Id>& allocator() {
   static ad_utility::AllocatorWithLimit<Id> a{
@@ -73,9 +74,8 @@ TEST(IndexTest, createFromTurtleTest) {
     f.close();
 
     {
-      Index index;
+      Index index = makeIndexWithTestSettings();
       index.setOnDiskBase("_testindex");
-      index.setNumTriplesPerBatch(2);
       index.createFromFile<TurtleParserAuto>(filename);
     }
     Index index;
@@ -148,9 +148,8 @@ TEST(IndexTest, createFromTurtleTest) {
     f.close();
 
     {
-      Index index;
+      Index index = makeIndexWithTestSettings();
       index.setOnDiskBase("_testindex");
-      index.setNumTriplesPerBatch(2);
       index.createFromFile<TurtleParserAuto>(filename);
     }
     Index index;
@@ -247,10 +246,9 @@ TEST_F(CreatePatternsFixture, createPatterns) {
     f.close();
 
     {
-      Index index;
+      Index index = makeIndexWithTestSettings();
       index.setUsePatterns(true);
       index.setOnDiskBase("_testindex");
-      index.setNumTriplesPerBatch(2);
       index.createFromFile<TurtleParserAuto>(inputFilename);
     }
     Index index;
@@ -314,9 +312,8 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
   f.close();
 
   {
-    Index indexPrim;
+    Index indexPrim = makeIndexWithTestSettings();
     indexPrim.setOnDiskBase("_testindex2");
-    indexPrim.setNumTriplesPerBatch(2);
     indexPrim.createFromFile<TurtleParserAuto>(filename);
   }
 
@@ -365,9 +362,8 @@ TEST(IndexTest, scanTest) {
   f.close();
   {
     {
-      Index index;
+      Index index = makeIndexWithTestSettings();
       index.setOnDiskBase("_testindex");
-      index.setNumTriplesPerBatch(2);
       index.createFromFile<TurtleParserAuto>(filename);
     }
 
@@ -451,9 +447,8 @@ TEST(IndexTest, scanTest) {
 
   {
     {
-      Index index;
+      Index index = makeIndexWithTestSettings();
       index.setOnDiskBase("_testindex");
-      index.setNumTriplesPerBatch(2);
       index.createFromFile<TurtleParserAuto>(filename);
     }
     Index index;

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -1,0 +1,17 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#ifndef QLEVER_INDEXTESTHELPERS_H
+#define QLEVER_INDEXTESTHELPERS_H
+
+#include "../src/index/Index.h"
+
+inline Index makeIndexWithTestSettings() {
+  Index index;
+  index.setNumTriplesPerBatch(2);
+  index.stxxlMemoryToUse() = 1024ul * 1024ul * 10;
+  return index;
+}
+
+#endif  // QLEVER_INDEXTESTHELPERS_H

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -10,7 +10,7 @@
 inline Index makeIndexWithTestSettings() {
   Index index;
   index.setNumTriplesPerBatch(2);
-  index.stxxlMemoryGb() = 1024ul * 1024ul * 10;
+  index.stxxlMemoryBytes() = 1024ul * 1024ul * 10;
   return index;
 }
 

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -10,7 +10,7 @@
 inline Index makeIndexWithTestSettings() {
   Index index;
   index.setNumTriplesPerBatch(2);
-  index.stxxlMemoryInBytes() = 1024ul * 1024ul * 10;
+  index.stxxlMemoryInBytes() = 1024ul * 1024ul * 50;
   return index;
 }
 

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -10,7 +10,7 @@
 inline Index makeIndexWithTestSettings() {
   Index index;
   index.setNumTriplesPerBatch(2);
-  index.stxxlMemoryToUse() = 1024ul * 1024ul * 10;
+  index.stxxlMemoryGb() = 1024ul * 1024ul * 10;
   return index;
 }
 

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -10,7 +10,7 @@
 inline Index makeIndexWithTestSettings() {
   Index index;
   index.setNumTriplesPerBatch(2);
-  index.stxxlMemoryBytes() = 1024ul * 1024ul * 10;
+  index.stxxlMemoryInBytes() = 1024ul * 1024ul * 10;
   return index;
 }
 


### PR DESCRIPTION
We can now configure the amount of memory that STXXL is allowed to use at runtime.
This PR also eliminates some unnecessary copies in the TurtleParser and unnecessary initialization of Buffers.