### PR TITLE
Update quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -116,7 +116,7 @@ endpoint by logging into QLever UI (user and password `demo`) and clicking on
         cd qlever-ui
         docker build -t qlever-ui .
         chmod o+w db && cp $QLEVER_HOME/qlever-code/examples/qleverui.sqlite3 db && chmod o+w db/qleverui.sqlite3
-        PORT=8000; docker run -it --rm -p $PORT:8000 -v $(pwd)/db:/app/db qlever-ui
+        PORT=8000; docker run -it --rm -p $PORT:7000 -v $(pwd)/db:/app/db qlever-ui
 
 If you just want to see the QLever UI in action and not install it yourself,
 here is [a demo instance of the QLever UI](https://qlever.cs.uni-freiburg.de)


### PR DESCRIPTION
I was executing all the steps listed in this Quickstart guide, but the Qlever UI was not working. I looked into the Qlever UI Dockerfile and saw that there is a bind of Port 7000 (I guess), so I changed the inner port 8000 to 7000 and it worked. I was then able to adress localhost:8000.