### PR TITLE
Better cost estimate for non-prefix FILTER REGEX

### DIFF
--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -80,7 +80,11 @@ class Filter : public Operation {
 
   virtual size_t getCostEstimate() override {
     if (_type == SparqlFilter::FilterType::REGEX) {
-      return std::numeric_limits<size_t>::max();
+      // We assume that checking a REGEX for an element is 10 times more
+      // expensive than an "ordinary" filter check.
+      return getSizeEstimate() + 10 * _subtree->getSizeEstimate() +
+             _subtree->getCostEstimate();
+      // return std::numeric_limits<size_t>::max();
     }
     if (isLhsSorted()) {
       // we can apply the very cheap binary sort filter


### PR DESCRIPTION
Here is an example of a query that is slower than it should be, for obvious reasons: https://qlever.cs.uni-freiburg.de/wikidata/uIa4EY