### PR TITLE
Implement a peek operation for the qlever lexer

### DIFF
--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -184,6 +184,23 @@ bool SparqlLexer::accept(const std::string& raw, bool match_case) {
 
 void SparqlLexer::accept() { readNext(); }
 
+bool SparqlLexer::peek(SparqlToken::Type type) {
+  if (_next.type == type) {
+    return true;
+  }
+  return false;
+}
+
+bool SparqlLexer::peek(const std::string& raw, bool match_case) {
+  if (match_case && _next.raw == raw) {
+    return true;
+  } else if (!match_case && ad_utility::getLowercaseUtf8(_next.raw) ==
+                                ad_utility::getLowercaseUtf8(raw)) {
+    return true;
+  }
+  return false;
+}
+
 void SparqlLexer::expect(SparqlToken::Type type) {
   if (_next.type != type) {
     std::ostringstream s;

--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -163,7 +163,7 @@ void SparqlLexer::expandNextUntilWhitespace() {
 }
 
 bool SparqlLexer::accept(SparqlToken::Type type) {
-  if (_next.type == type) {
+  if (peek(type)) {
     readNext();
     return true;
   }
@@ -171,34 +171,27 @@ bool SparqlLexer::accept(SparqlToken::Type type) {
 }
 
 bool SparqlLexer::accept(const std::string& raw, bool match_case) {
-  if (match_case && _next.raw == raw) {
+  if (peek(raw, match_case)) {
     readNext();
     return true;
-  } else if (!match_case && ad_utility::getLowercaseUtf8(_next.raw) ==
-                                ad_utility::getLowercaseUtf8(raw)) {
-    readNext();
-    return true;
+  } else {
+    return false;
   }
-  return false;
 }
 
 void SparqlLexer::accept() { readNext(); }
 
-bool SparqlLexer::peek(SparqlToken::Type type) {
-  if (_next.type == type) {
-    return true;
-  }
-  return false;
+bool SparqlLexer::peek(SparqlToken::Type type) const {
+  return _next.type == type;
 }
 
-bool SparqlLexer::peek(const std::string& raw, bool match_case) {
-  if (match_case && _next.raw == raw) {
-    return true;
-  } else if (!match_case && ad_utility::getLowercaseUtf8(_next.raw) ==
-                                ad_utility::getLowercaseUtf8(raw)) {
-    return true;
+bool SparqlLexer::peek(const std::string& raw, bool match_case) const {
+  if (match_case) {
+    return _next.raw == raw;
+  } else {
+    return ad_utility::getLowercaseUtf8(_next.raw) ==
+           ad_utility::getLowercaseUtf8(raw);
   }
-  return false;
 }
 
 void SparqlLexer::expect(SparqlToken::Type type) {

--- a/src/parser/SparqlLexer.cpp
+++ b/src/parser/SparqlLexer.cpp
@@ -170,7 +170,7 @@ bool SparqlLexer::accept(SparqlToken::Type type) {
   return false;
 }
 
-bool SparqlLexer::accept(const std::string& raw, bool match_case) {
+bool SparqlLexer::accept(std::string_view raw, bool match_case) {
   if (peek(raw, match_case)) {
     readNext();
     return true;
@@ -185,7 +185,7 @@ bool SparqlLexer::peek(SparqlToken::Type type) const {
   return _next.type == type;
 }
 
-bool SparqlLexer::peek(const std::string& raw, bool match_case) const {
+bool SparqlLexer::peek(std::string_view raw, bool match_case) const {
   if (match_case) {
     return _next.raw == raw;
   } else {

--- a/src/parser/SparqlLexer.h
+++ b/src/parser/SparqlLexer.h
@@ -63,13 +63,13 @@ class SparqlLexer {
   [[nodiscard]] bool empty() const;
 
   bool accept(SparqlToken::Type type);
-  bool accept(const std::string& raw, bool match_case = true);
+  bool accept(std::string_view raw, bool match_case = true);
   // Accepts any token
   void accept();
 
   // Checks whether the next token matches but does not consume it
-  bool peek(SparqlToken::Type type) const;
-  bool peek(const std::string& raw, bool match_case = true) const;
+  [[nodiscard]] bool peek(SparqlToken::Type type) const;
+  [[nodiscard]] bool peek(std::string_view raw, bool match_case = true) const;
 
   // Adds all symbols up to the next whitespace to the next token
   void expandNextUntilWhitespace();

--- a/src/parser/SparqlLexer.h
+++ b/src/parser/SparqlLexer.h
@@ -67,6 +67,10 @@ class SparqlLexer {
   // Accepts any token
   void accept();
 
+  // Checks whether the next token matches but does not consume it
+  bool peek(SparqlToken::Type type);
+  bool peek(const std::string& raw, bool match_case = true);
+
   // Adds all symbols up to the next whitespace to the next token
   void expandNextUntilWhitespace();
 

--- a/src/parser/SparqlLexer.h
+++ b/src/parser/SparqlLexer.h
@@ -68,8 +68,8 @@ class SparqlLexer {
   void accept();
 
   // Checks whether the next token matches but does not consume it
-  bool peek(SparqlToken::Type type);
-  bool peek(const std::string& raw, bool match_case = true);
+  bool peek(SparqlToken::Type type) const;
+  bool peek(const std::string& raw, bool match_case = true) const;
 
   // Adds all symbols up to the next whitespace to the next token
   void expandNextUntilWhitespace();

--- a/test/SparqlLexerTest.cpp
+++ b/test/SparqlLexerTest.cpp
@@ -188,8 +188,20 @@ TEST(SparqlLexer, peek) {
 
   SparqlLexer lexer(query);
   ASSERT_TRUE(lexer.peek("prefix"));
+  ASSERT_FALSE(lexer.peek("select"));
   ASSERT_EQ(std::string("prefix"), lexer.getUnconsumedInput());
 
   ASSERT_TRUE(lexer.peek(SparqlToken::Type::KEYWORD));
+  ASSERT_FALSE(lexer.peek(SparqlToken::Type::GROUP_BY));
   ASSERT_EQ(std::string("prefix"), lexer.getUnconsumedInput());
+
+  // Test with RDF_LITERAL because these are not lowercased by the lexer
+  std::string query2 = R"("RDF_LITERAL")";
+  SparqlLexer lexer2(query2);
+  ASSERT_TRUE(lexer2.peek(SparqlToken::Type::RDFLITERAL));
+  ASSERT_TRUE(lexer2.peek("\"RDF_LITERAL\""));
+  ASSERT_TRUE(lexer2.peek("\"RDF_LITERAL\"", true));
+  ASSERT_FALSE(lexer2.peek("\"rdf_literal\"", true));
+  ASSERT_TRUE(lexer2.peek("\"rdf_literal\"", false));
+  ASSERT_EQ(std::string("\"RDF_LITERAL\""), lexer2.getUnconsumedInput());
 }

--- a/test/SparqlLexerTest.cpp
+++ b/test/SparqlLexerTest.cpp
@@ -182,3 +182,16 @@ TEST(SparqlLexer, reset) {
   lexer.expect("<cs.uni-freiburg.de/>");
   ASSERT_TRUE(lexer.getUnconsumedInput().empty());
 }
+
+TEST(SparqlLexer, peek) {
+  std::string query = "PREFIX";
+
+  SparqlLexer lexer(query);
+  ASSERT_TRUE(lexer.peek("prefix"));
+  ASSERT_EQ(std::string("prefix"),
+            lexer.getUnconsumedInput());
+
+  ASSERT_TRUE(lexer.peek(SparqlToken::Type::KEYWORD));
+  ASSERT_EQ(std::string("prefix"),
+            lexer.getUnconsumedInput());
+}

--- a/test/SparqlLexerTest.cpp
+++ b/test/SparqlLexerTest.cpp
@@ -183,10 +183,10 @@ TEST(SparqlLexer, reset) {
   ASSERT_TRUE(lexer.getUnconsumedInput().empty());
 }
 
-TEST(SparqlLexer, peek) {
+TEST(SparqlLexer, PeekKeyword) {
   std::string query = "PREFIX";
-
   SparqlLexer lexer(query);
+
   ASSERT_TRUE(lexer.peek("prefix"));
   ASSERT_FALSE(lexer.peek("select"));
   ASSERT_EQ(std::string("prefix"), lexer.getUnconsumedInput());
@@ -194,14 +194,17 @@ TEST(SparqlLexer, peek) {
   ASSERT_TRUE(lexer.peek(SparqlToken::Type::KEYWORD));
   ASSERT_FALSE(lexer.peek(SparqlToken::Type::GROUP_BY));
   ASSERT_EQ(std::string("prefix"), lexer.getUnconsumedInput());
+}
 
+TEST(SparqlLexer, PeekLiteral) {
   // Test with RDF_LITERAL because these are not lowercased by the lexer
-  std::string query2 = R"("RDF_LITERAL")";
-  SparqlLexer lexer2(query2);
-  ASSERT_TRUE(lexer2.peek(SparqlToken::Type::RDFLITERAL));
-  ASSERT_TRUE(lexer2.peek("\"RDF_LITERAL\""));
-  ASSERT_TRUE(lexer2.peek("\"RDF_LITERAL\"", true));
-  ASSERT_FALSE(lexer2.peek("\"rdf_literal\"", true));
-  ASSERT_TRUE(lexer2.peek("\"rdf_literal\"", false));
-  ASSERT_EQ(std::string("\"RDF_LITERAL\""), lexer2.getUnconsumedInput());
+  std::string query = R"("RDF_LITERAL")";
+  SparqlLexer lexer(query);
+
+  ASSERT_TRUE(lexer.peek(SparqlToken::Type::RDFLITERAL));
+  ASSERT_TRUE(lexer.peek("\"RDF_LITERAL\""));
+  ASSERT_TRUE(lexer.peek("\"RDF_LITERAL\"", true));
+  ASSERT_FALSE(lexer.peek("\"rdf_literal\"", true));
+  ASSERT_TRUE(lexer.peek("\"rdf_literal\"", false));
+  ASSERT_EQ(query, lexer.getUnconsumedInput());
 }

--- a/test/SparqlLexerTest.cpp
+++ b/test/SparqlLexerTest.cpp
@@ -188,10 +188,8 @@ TEST(SparqlLexer, peek) {
 
   SparqlLexer lexer(query);
   ASSERT_TRUE(lexer.peek("prefix"));
-  ASSERT_EQ(std::string("prefix"),
-            lexer.getUnconsumedInput());
+  ASSERT_EQ(std::string("prefix"), lexer.getUnconsumedInput());
 
   ASSERT_TRUE(lexer.peek(SparqlToken::Type::KEYWORD));
-  ASSERT_EQ(std::string("prefix"),
-            lexer.getUnconsumedInput());
+  ASSERT_EQ(std::string("prefix"), lexer.getUnconsumedInput());
 }


### PR DESCRIPTION
`SparlqlLexer.peek` behaves similar to `SparlqlLexer.accept` but does not consume the token if matched.

`SparlqlLexer.peek` might be needed in places where the custom parsers passes to the ANTLR parser. The matching rule is still determined by the custom parser but the tokens must not be consumed. After determining the matching rule the ANTLR parser parses that specific rule.