### PR TITLE
Let `SparqlExpressionPimpl` know if it holds a single variable

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -43,6 +43,11 @@ SparqlExpressionPimpl::getVariableForNonDistinctCountOrNullopt() const {
 }
 
 // ___________________________________________________________________________
+std::optional<std::string> SparqlExpressionPimpl::getVariableOrNullopt() const {
+  return _pimpl->getVariableOrNullopt();
+}
+
+// ___________________________________________________________________________
 std::string SparqlExpressionPimpl::getCacheKey(
     const VariableColumnMap& variableColumnMap) const {
   return _pimpl->getCacheKey(variableColumnMap);

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -50,8 +50,9 @@ class SparqlExpressionPimpl {
   getVariableForNonDistinctCountOrNullopt() const;
 
   // If this expression is a single variable, return that variable, else return
-  // std::nullopt. This enables some optimizations as we can directly handle
-  // these trivial "expressions" without using the `SparqlExpressions` module.
+  // std::nullopt. Knowing this enables some optimizations because we can
+  // directly handle these trivial "expressions" without using the
+  // `SparqlExpression` module.
   [[nodiscard]] std::optional<std::string> getVariableOrNullopt() const;
 
   // The implementation of these methods is small and straightforward, but

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -49,6 +49,11 @@ class SparqlExpressionPimpl {
   [[nodiscard]] std::optional<std::string>
   getVariableForNonDistinctCountOrNullopt() const;
 
+  // If this expression is a single variable, return that variable, else return
+  // std::nullopt. This enables some optimizations as we can directly handle
+  // these trivial "expressions" without using the `SparqlExpressions` module.
+  [[nodiscard]] std::optional<std::string> getVariableOrNullopt() const;
+
   // The implementation of these methods is small and straightforward, but
   // has to be in the .cpp file because `SparqlExpression` is only forward
   // declared.


### PR DESCRIPTION


This enables certain optimizations (such trivial "expressions" don't need to use the Expression module).