### PR TITLE
Enable parallel execution of tests

### DIFF
--- a/src/util/File.h
+++ b/src/util/File.h
@@ -267,10 +267,13 @@ class File {
  * @brief Delete the file at a given path
  * @param path
  */
-inline void deleteFile(const std::filesystem::path& path) {
+inline void deleteFile(const std::filesystem::path& path,
+                       bool warnOnFailure = true) {
   if (!std::filesystem::remove(path)) {
-    LOG(WARN) << "Deletion of file '" << path << "' was not successful"
-              << std::endl;
+    if (warnOnFailure) {
+      LOG(WARN) << "Deletion of file '" << path << "' was not successful"
+                << std::endl;
+    }
   }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,9 @@ addLinkAndDiscoverTest(ContextFileParserTest parser ${ICU_LIBRARIES})
 
 addLinkAndDiscoverTest(IndexMetaDataTest index)
 
+# Stxxl currently always uses a file ./-stxxl.disk for all indices, which
+# makes it impossible to run the test cases for the Index class in parallel.
+# TODO<qup42, joka921> fix this
 addLinkAndDiscoverTestSerial(IndexTest index)
 
 addLinkAndDiscoverTest(FTSAlgorithmsTest index)
@@ -136,7 +139,11 @@ addAndLinkTest(SortPerformanceEstimatorTest SortPerformanceEstimator)
 
 addLinkAndDiscoverTest(SparqlAntlrParserTest parser sparqlExpressions)
 
-addLinkAndDiscoverTest(SerializerTest absl::flat_hash_map)
+# The SerializerTest uses temporary files. The tests fail when multiple test
+# cases are run in parallel. This should be fixed by using distinct filenames
+# for each test case.
+# TODO<qup42, joka921> fix this
+addLinkAndDiscoverTestSerial(SerializerTest absl::flat_hash_map)
 
 addLinkAndDiscoverTest(ParametersTest absl::flat_hash_map)
 
@@ -176,6 +183,9 @@ addLinkAndDiscoverTest(PrefixCompressorTest)
 
 addLinkAndDiscoverTest(MilestoneIdTest absl::strings)
 
+# The VocabularyOnDisk uses mmap which fails when the tests are run in
+# parallel. This should be fixed by using distinct filenames for each test case.
+# TODO<qup42, joka921> fix this
 addLinkAndDiscoverTestSerial(VocabularyOnDiskTest index)
 
 addLinkAndDiscoverTest(VocabularyTest index)
@@ -184,7 +194,10 @@ addLinkAndDiscoverTest(IteratorTest)
 
 addLinkAndDiscoverTest(PatternCreatorTest index)
 
-addLinkAndDiscoverTest(BackgroundStxxlSorterTest ${STXXL_LIBRARIES})
+# Stxxl currently always uses a file ./-stxxl.disk for all indices, which
+# makes it impossible to run the test cases for the Index class in parallel.
+# TODO<qup42, joka921> fix this
+addLinkAndDiscoverTestSerial(BackgroundStxxlSorterTest ${STXXL_LIBRARIES})
 
 addLinkAndDiscoverTest(ViewsTest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,7 +67,7 @@ addLinkAndDiscoverTest(ContextFileParserTest parser ${ICU_LIBRARIES})
 
 addLinkAndDiscoverTest(IndexMetaDataTest index)
 
-addLinkAndDiscoverTest(IndexTest index)
+addLinkAndDiscoverTestSerial(IndexTest index)
 
 addLinkAndDiscoverTest(FTSAlgorithmsTest index)
 
@@ -87,7 +87,7 @@ addLinkAndDiscoverTest(VocabularyGeneratorTest index)
 
 addLinkAndDiscoverTest(HasPredicateScanTest engine)
 
-addLinkAndDiscoverTest(MmapVectorTest)
+addLinkAndDiscoverTestSerial(MmapVectorTest)
 
 addLinkAndDiscoverTest(BufferedVectorTest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,6 +59,8 @@ function(addAndLinkTest basename)
     linkTest(${basename} ${ARGN})
 endfunction()
 
+addLinkAndDiscoverTest(ValueIdComparatorsTest)
+
 addLinkAndDiscoverTest(SparqlParserTest parser sparqlExpressions ${ICU_LIBRARIES})
 
 addLinkAndDiscoverTest(StringUtilsTest ${ICU_LIBRARIES})
@@ -67,7 +69,8 @@ addLinkAndDiscoverTest(CacheTest absl::flat_hash_map)
 
 addLinkAndDiscoverTest(ConcurrentCacheTest absl::flat_hash_map)
 
-addLinkAndDiscoverTest(FileTest)
+# This test also seems to use the same filenames and should be fixed.
+addLinkAndDiscoverTestSerial(FileTest)
 
 addLinkAndDiscoverTest(Simple8bTest)
 
@@ -100,7 +103,8 @@ addLinkAndDiscoverTest(HasPredicateScanTest engine)
 
 addLinkAndDiscoverTest(MmapVectorTest)
 
-addLinkAndDiscoverTest(BufferedVectorTest)
+# BufferedVectorTest also uses conflicting filenames.
+addLinkAndDiscoverTestSerial(BufferedVectorTest)
 
 addLinkAndDiscoverTest(UnionTest engine)
 
@@ -186,13 +190,14 @@ addLinkAndDiscoverTest(MilestoneIdTest absl::strings)
 # The VocabularyOnDisk uses mmap which fails when the tests are run in
 # parallel. This should be fixed by using distinct filenames for each test case.
 # TODO<qup42, joka921> fix this
-addLinkAndDiscoverTestSerial(VocabularyOnDiskTest index)
+addLinkAndDiscoverTest(VocabularyOnDiskTest index)
 
 addLinkAndDiscoverTest(VocabularyTest index)
 
 addLinkAndDiscoverTest(IteratorTest)
 
-addLinkAndDiscoverTest(PatternCreatorTest index)
+# Here we also seem to have race conditions on the tests
+addLinkAndDiscoverTestSerial(PatternCreatorTest index)
 
 # Stxxl currently always uses a file ./-stxxl.disk for all indices, which
 # makes it impossible to run the test cases for the Index class in parallel.
@@ -221,6 +226,6 @@ addLinkAndDiscoverTest(TripleObjectTest absl::strings)
 
 addLinkAndDiscoverTest(ValueIdTest absl::flat_hash_set)
 
-addLinkAndDiscoverTest(ValueIdComparatorsTest)
+#addLinkAndDiscoverTest(ValueIdComparatorsTest)
 
 addLinkAndDiscoverTest(LambdaHelpersTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -176,7 +176,7 @@ addLinkAndDiscoverTest(PrefixCompressorTest)
 
 addLinkAndDiscoverTest(MilestoneIdTest absl::strings)
 
-addLinkAndDiscoverTest(VocabularyOnDiskTest index)
+addLinkAndDiscoverTestSerial(VocabularyOnDiskTest index)
 
 addLinkAndDiscoverTest(VocabularyTest index)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,10 @@ function(linkAndDiscoverTest basename)
     gtest_discover_tests(${basename} ${basename})
 endfunction()
 
+# Usage: `linkAndDiscoverTestSerial(basename, [additionalLibraries...]`
+# Similar to `linkAndDiscoverTestSerial` but also requires that the test is run serially
+# (without any of the other test cases running in parallel). This can be
+# required e.g. if several tests cases write to the same file.
 function(linkAndDiscoverTestSerial basename)
     linkTest(${basename} ${ARGN})
     gtest_discover_tests(${basename} ${basename} PROPERTIES RUN_SERIAL
@@ -39,6 +43,10 @@ function(addLinkAndDiscoverTest basename)
     linkAndDiscoverTest(${basename} ${ARGN})
 endfunction()
 
+# Usage: `addAndLinkTestSerial(basename, [additionalLibraries...]`
+# Similar to `addAndLinkTest` but also requires that the test is run serially
+# (without any of the other test cases running in parallel). This can be
+# required e.g. if several tests cases write to the same file.
 function(addLinkAndDiscoverTestSerial basename)
     addTest(${basename})
     linkAndDiscoverTestSerial(${basename} ${ARGN})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,7 +87,7 @@ addLinkAndDiscoverTest(VocabularyGeneratorTest index)
 
 addLinkAndDiscoverTest(HasPredicateScanTest engine)
 
-addLinkAndDiscoverTestSerial(MmapVectorTest)
+addLinkAndDiscoverTest(MmapVectorTest)
 
 addLinkAndDiscoverTest(BufferedVectorTest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,12 @@ function(linkAndDiscoverTest basename)
     gtest_discover_tests(${basename} ${basename})
 endfunction()
 
+function(linkAndDiscoverTestSerial basename)
+    linkTest(${basename} ${ARGN})
+    gtest_discover_tests(${basename} ${basename} PROPERTIES RUN_SERIAL
+            TRUE)
+endfunction()
+
 # Usage: `addAndLinkTest(basename, [additionalLibraries...]`
 # Add a GTest/GMock test case that is called `basename` and compiled from a file called
 # `basename.cpp`. All tests are linked against `gmock_main` and the threading library.
@@ -31,6 +37,11 @@ endfunction()
 function(addLinkAndDiscoverTest basename)
     addTest(${basename})
     linkAndDiscoverTest(${basename} ${ARGN})
+endfunction()
+
+function(addLinkAndDiscoverTestSerial basename)
+    addTest(${basename})
+    linkAndDiscoverTestSerial(${basename} ${ARGN})
 endfunction()
 
 # Only compile and link the test, but do not run it.

--- a/test/MmapVectorTest.cpp
+++ b/test/MmapVectorTest.cpp
@@ -29,7 +29,7 @@ TEST(MmapVectorTest, DefaultConstructor) {
 
 // ___________________________________________________________________
 TEST(MmapVectorTest, NewEmptyFileConstructor) {
-  MmapVector<int> v("_test.mmap", ad_utility::CreateTag());
+  MmapVector<int> v("_test0.mmap", ad_utility::CreateTag());
   ASSERT_EQ(size_t(0), v.size());
   ASSERT_NE(nullptr, v.data());
   ASSERT_EQ(v.begin(), v.end());
@@ -39,7 +39,7 @@ TEST(MmapVectorTest, NewEmptyFileConstructor) {
 TEST(MmapVectorTest, NewFileSizeConstructor) {
   // make sure that we get a unsignned 5000 to prevent compiler warnings
   size_t s = 5000;
-  MmapVector<int> v(s, "_test.mmap");
+  MmapVector<int> v(s, "_test1.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_LE(s, v.capacity());
   ASSERT_NE(nullptr, v.data());
@@ -49,7 +49,7 @@ TEST(MmapVectorTest, NewFileSizeConstructor) {
 // ___________________________________________________________________
 TEST(MmapVectorTest, AccessOperator) {
   {
-    MmapVector<int> v(5000, "_test.mmap");
+    MmapVector<int> v(5000, "_test2.mmap");
     for (size_t i = 0; i < 5000; i++) {
       v[i] = 5000 - i;
     }
@@ -60,7 +60,7 @@ TEST(MmapVectorTest, AccessOperator) {
     }
   }
   size_t s = 5000;
-  MmapVectorView<int> v("_test.mmap");
+  MmapVectorView<int> v("_test2.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_NE(nullptr, v.data());
   ASSERT_EQ(v.begin() + s, v.end());
@@ -73,7 +73,7 @@ TEST(MmapVectorTest, AccessOperator) {
 // ___________________________________________________________________
 TEST(MmapVectorTest, At) {
   {
-    MmapVector<int> v(5000, "_test.mmap");
+    MmapVector<int> v(5000, "_test3.mmap");
     for (int i = 0; i < 5000; i++) {
       v.at(i) = 5000 - i;
     }
@@ -86,7 +86,7 @@ TEST(MmapVectorTest, At) {
     ASSERT_THROW(v.at(5000), std::out_of_range);
   }
 
-  MmapVectorView<int> v("_test.mmap");
+  MmapVectorView<int> v("_test3.mmap");
   size_t s = 5000;
   ASSERT_EQ(s, v.size());
   ASSERT_NE(nullptr, v.data());
@@ -101,7 +101,7 @@ TEST(MmapVectorTest, At) {
 TEST(MmapVectorTest, DefaultValueConstructor) {
   // make sure that we get a unsignned 5000 to prevent compiler warnings
   size_t s = 5000;
-  MmapVector<int> v(s, 42, "_test.mmap");
+  MmapVector<int> v(s, 42, "_test4.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_LE(s, v.capacity());
   ASSERT_NE(nullptr, v.data());
@@ -120,7 +120,7 @@ TEST(MmapVectorTest, IteratorConstructor) {
   for (int i = 0; i < 5000; ++i) {
     tmpVec[i] = 5000 - i;
   }
-  MmapVector<int> v(tmpVec.begin(), tmpVec.end(), "_test.mmap");
+  MmapVector<int> v(tmpVec.begin(), tmpVec.end(), "_test5.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_LE(s, v.capacity());
   ASSERT_NE(nullptr, v.data());
@@ -134,7 +134,7 @@ TEST(MmapVectorTest, IteratorConstructor) {
 // ___________________________________________________________________
 TEST(MmapVectorTest, PushBackRvalue) {
   {
-    MmapVector<int> v(0, "_test.mmap");
+    MmapVector<int> v(0, "_test6.mmap");
     ASSERT_EQ(size_t(0), v.size());
     for (int i = 0; i < 5000; i++) {
       v.push_back(5000 - i);
@@ -151,7 +151,7 @@ TEST(MmapVectorTest, PushBackRvalue) {
 // ___________________________________________________________________
 TEST(MmapVectorTest, PushBackLvalue) {
   {
-    MmapVector<int> v(0, "_test.mmap");
+    MmapVector<int> v(0, "_test7.mmap");
     ASSERT_EQ(size_t(0), v.size());
     for (int i = 0; i < 5000; i++) {
       int tmp = 5000 - i;
@@ -175,7 +175,7 @@ TEST(MmapVectorTest, constIterators) {
     tmpVec[i] = 5000 - i;
   }
   {
-    MmapVector<int> v(tmpVec.begin(), tmpVec.end(), "_test.mmap");
+    MmapVector<int> v(tmpVec.begin(), tmpVec.end(), "_test8.mmap");
     ASSERT_EQ(s, v.size());
     ASSERT_LE(s, v.capacity());
     ASSERT_NE(nullptr, v.data());
@@ -197,7 +197,7 @@ TEST(MmapVectorTest, constIterators) {
       }
     }
   }
-  MmapVectorView<int> v("_test.mmap");
+  MmapVectorView<int> v("_test8.mmap");
   int idx = 0;
   auto it = v.cbegin();
   while (it != v.cend()) {
@@ -218,7 +218,7 @@ TEST(MmapVectorTest, nonConstIterators) {
   // make sure that we get a unsignned 5000 to prevent compiler warnings
   size_t s = 5000;
   // initialize all elements to 42
-  MmapVector<int> v(s, 42, "_test.mmap");
+  MmapVector<int> v(s, 42, "_test9.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_LE(s, v.capacity());
   ASSERT_NE(nullptr, v.data());
@@ -238,7 +238,7 @@ TEST(MmapVectorTest, Close) {
   // make sure that we get a unsignned 5000 to prevent compiler warnings
   size_t s = 5000;
   // initialize all elements to 42
-  MmapVector<int> v(s, 42, "_test.mmap");
+  MmapVector<int> v(s, 42, "_test10.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_LE(s, v.capacity());
   ASSERT_NE(nullptr, v.data());
@@ -248,7 +248,7 @@ TEST(MmapVectorTest, Close) {
   ASSERT_EQ(size_t(0), v.size());
   ASSERT_EQ(nullptr, v.data());
 
-  MmapVectorView<int> v2("_test.mmap");
+  MmapVectorView<int> v2("_test10.mmap");
   ASSERT_EQ(s, v2.size());
   ASSERT_NE(nullptr, v2.data());
   ASSERT_EQ(v2.begin() + s, v2.end());
@@ -264,7 +264,7 @@ TEST(MmapVectorTest, Reuse) {
   size_t s = 5000;
   // initialize all elements to 42
   {
-    MmapVector<int> v(s, "_test.mmap");
+    MmapVector<int> v(s, "_test11.mmap");
     ASSERT_EQ(s, v.size());
     ASSERT_LE(s, v.capacity());
     ASSERT_NE(nullptr, v.data());
@@ -274,7 +274,7 @@ TEST(MmapVectorTest, Reuse) {
     }
   }
   // v is now destroyed
-  MmapVector<int> v2("_test.mmap", ad_utility::ReuseTag());
+  MmapVector<int> v2("_test11.mmap", ad_utility::ReuseTag());
   ASSERT_EQ(s, v2.size());
   ASSERT_LE(s, v2.capacity());
   ASSERT_NE(nullptr, v2.data());
@@ -284,7 +284,7 @@ TEST(MmapVectorTest, Reuse) {
   }
 
   // v is now destroyed
-  MmapVectorView<int> v3("_test.mmap");
+  MmapVectorView<int> v3("_test11.mmap");
   ASSERT_EQ(s, v3.size());
   ASSERT_NE(nullptr, v3.data());
   ASSERT_EQ(v3.begin() + s, v3.end());
@@ -300,7 +300,7 @@ TEST(MmapVectorTest, MoveConstructor) {
   size_t s = 5000;
   {
     // initialize all elements to 42
-    MmapVector<int> v(s, "_test.mmap");
+    MmapVector<int> v(s, "_test12.mmap");
     ASSERT_EQ(s, v.size());
     ASSERT_LE(s, v.capacity());
     ASSERT_NE(nullptr, v.data());
@@ -320,7 +320,7 @@ TEST(MmapVectorTest, MoveConstructor) {
       ASSERT_EQ(v2[i], i);
     }
   }
-  MmapVectorView<int> v("_test.mmap");
+  MmapVectorView<int> v("_test12.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_NE(nullptr, v.data());
   ASSERT_EQ(v.begin() + s, v.end());
@@ -345,7 +345,7 @@ TEST(MmapVectorTest, MoveAssignment) {
   size_t s = 5000;
   {
     // initialize all elements to 42
-    MmapVector<int> v(s, "_test.mmap");
+    MmapVector<int> v(s, "_test13.mmap");
     ASSERT_EQ(s, v.size());
     ASSERT_LE(s, v.capacity());
     ASSERT_NE(nullptr, v.data());
@@ -365,7 +365,7 @@ TEST(MmapVectorTest, MoveAssignment) {
       ASSERT_EQ(v2[i], i);
     }
   }
-  MmapVectorView<int> v("_test.mmap");
+  MmapVectorView<int> v("_test13.mmap");
   ASSERT_EQ(s, v.size());
   ASSERT_NE(nullptr, v.data());
   ASSERT_EQ(v.begin() + s, v.end());

--- a/test/VocabularyOnDiskTest.cpp
+++ b/test/VocabularyOnDiskTest.cpp
@@ -5,121 +5,157 @@
 #include <gtest/gtest.h>
 
 #include "../src/index/VocabularyOnDisk.h"
+#include "../src/util/Forward.h"
 #include "./VocabularyTestHelpers.h"
 
 using namespace vocabulary_test;
 
-const std::string vocabFilename = "vocabulary.tmp.test.dat";
+// A common suffix for all files to reduce the probability of colliding file
+// names, when other tests are run in parallel.
+std::string suffix = ".vocabularyOnDiskTest.dat";
 
-// Create and return a `VocabularyOnDisk` from words and ids. `words` and `ids`
-// must have the same size.
-auto createVocabularyImpl(
-    const std::vector<std::string>& words,
-    std::optional<std::vector<uint64_t>> ids = std::nullopt) {
-  VocabularyOnDisk vocabulary;
-  if (!ids.has_value()) {
-    vocabulary.buildFromVector(words, vocabFilename);
-  } else {
-    AD_CHECK(words.size() == ids.value().size());
-    std::vector<std::pair<std::string, uint64_t>> wordsAndIds;
-    for (size_t i = 0; i < words.size(); ++i) {
-      wordsAndIds.emplace_back(words[i], ids.value()[i]);
-    }
-    vocabulary.buildFromStringsAndIds(wordsAndIds, vocabFilename);
+// Store a VocabularyOnDisk and read it back from file. For each instance of
+// `VocabularyCreator` that exists at the same time, a different filename has to
+// be chosen.
+class VocabularyCreator {
+ private:
+  std::string vocabFilename_;
+
+ public:
+  explicit VocabularyCreator(std::string filename)
+      : vocabFilename_{std::move(filename)} {
+    ad_utility::deleteFile(vocabFilename_, false);
   }
-  return vocabulary;
+  ~VocabularyCreator() { ad_utility::deleteFile(vocabFilename_); }
+
+  // Create and return a `VocabularyOnDisk` from words and ids. `words` and
+  // `ids` must have the same size.
+  auto createVocabularyImpl(
+      const std::vector<std::string>& words,
+      std::optional<std::vector<uint64_t>> ids = std::nullopt) {
+    VocabularyOnDisk vocabulary;
+    if (!ids.has_value()) {
+      vocabulary.buildFromVector(words, vocabFilename_);
+    } else {
+      AD_CHECK(words.size() == ids.value().size());
+      std::vector<std::pair<std::string, uint64_t>> wordsAndIds;
+      for (size_t i = 0; i < words.size(); ++i) {
+        wordsAndIds.emplace_back(words[i], ids.value()[i]);
+      }
+      vocabulary.buildFromStringsAndIds(wordsAndIds, vocabFilename_);
+    }
+    return vocabulary;
+  }
+
+  // Create and return a `VocabularyOnDisk` from words and ids. `words` and
+  // `ids` must have the same size. Note: The resulting vocabulary will be
+  // destroyed and re-initialized from disk before it is returned.
+  auto createVocabularyFromDiskImpl(
+      const std::vector<std::string>& words,
+      std::optional<std::vector<uint64_t>> ids = std::nullopt) {
+    { createVocabularyImpl(words, std::move(ids)); }
+    VocabularyOnDisk vocabulary;
+    vocabulary.open(vocabFilename_);
+    return vocabulary;
+  }
+
+  // Create and return a `VocabularyOnDisk` from words. The ids will be [0, ..
+  // words.size()).
+  auto createVocabulary(const std::vector<std::string>& words) {
+    return createVocabularyImpl(words);
+  }
+
+  // Create and return a `VocabularyOnDisk` from words. The ids will be [0, ..
+  // words.size()). Note: The resulting vocabulary will be destroyed and
+  // re-initialized from disk before it is returned.
+  auto createVocabularyFromDisk(const std::vector<std::string>& words) {
+    return createVocabularyFromDiskImpl(words);
+  }
+};
+
+auto createVocabulary(std::string filename) {
+  return [c = VocabularyCreator{std::move(filename)}](auto&&... args) mutable {
+    return c.createVocabulary(AD_FWD(args)...);
+  };
 }
 
-// Create and return a `VocabularyOnDisk` from words and ids. `words` and `ids`
-// must have the same size. Note: The resulting vocabulary will be destroyed and
-// re-initialized from disk before it is returned.
-auto createVocabularyFromDiskImpl(
-    const std::vector<std::string>& words,
-    std::optional<std::vector<uint64_t>> ids = std::nullopt) {
-  { createVocabularyImpl(words, std::move(ids)); }
-  VocabularyOnDisk vocabulary;
-  vocabulary.open(vocabFilename);
-  return vocabulary;
+auto createVocabularyFromDisk(std::string filename) {
+  return [c = VocabularyCreator{std::move(filename)}](auto&&... args) mutable {
+    return c.createVocabularyFromDisk(AD_FWD(args)...);
+  };
 }
 
-// Create and return a `VocabularyOnDisk` from words. The ids will be [0, ..
-// words.size()).
-auto createVocabulary(const std::vector<std::string>& words) {
-  return createVocabularyImpl(words);
-}
-
-// Create and return a `VocabularyOnDisk` from words. The ids will be [0, ..
-// words.size()). Note: The resulting vocabulary will be destroyed and
-// re-initialized from disk before it is returned.
-auto createVocabularyFromDisk(const std::vector<std::string>& words) {
-  return createVocabularyFromDiskImpl(words);
+auto createVocabularyFromDiskImpl(std::string filename) {
+  return [c = VocabularyCreator{std::move(filename)}](auto&&... args) mutable {
+    return c.createVocabularyFromDiskImpl(AD_FWD(args)...);
+  };
 }
 
 TEST(VocabularyOnDisk, LowerUpperBoundStdLess) {
-  ad_utility::deleteFile(vocabFilename);
-  testUpperAndLowerBoundWithStdLess(createVocabulary);
-  ad_utility::deleteFile(vocabFilename);
-  testUpperAndLowerBoundWithStdLess(createVocabularyFromDisk);
-  ad_utility::deleteFile(vocabFilename);
+  testUpperAndLowerBoundWithStdLess(
+      createVocabulary("lowerUpperBoundStdLess1"));
+  testUpperAndLowerBoundWithStdLess(
+      createVocabularyFromDisk("lowerUpperBoundStdLess2"));
 }
 
 TEST(VocabularyOnDisk, LowerUpperBoundStdLessNonContiguousIds) {
   std::vector<std::string> words{"alpha", "betta", "chimes", "someVery123Word"};
   std::vector<uint64_t> ids{2, 4, 8, 42};
-  ad_utility::deleteFile(vocabFilename);
+  VocabularyCreator creator1{"lowerUppperBoundStdLessNonContiguousIds1"};
   testUpperAndLowerBoundWithStdLessFromWordsAndIds(
-      createVocabularyImpl(words, ids), words, ids);
-  ad_utility::deleteFile(vocabFilename);
+      creator1.createVocabularyImpl(words, ids), words, ids);
+
+  VocabularyCreator creator2{"lowerUppperBoundStdLessNonContiguousIds2"};
   testUpperAndLowerBoundWithStdLessFromWordsAndIds(
-      createVocabularyFromDiskImpl(words, ids), words, ids);
-  ad_utility::deleteFile(vocabFilename);
+      creator2.createVocabularyFromDiskImpl(words, ids), words, ids);
 }
 
 TEST(VocabularyOnDisk, LowerUpperBoundNumeric) {
-  ad_utility::deleteFile(vocabFilename);
-  testUpperAndLowerBoundWithNumericComparator(createVocabulary);
-  ad_utility::deleteFile(vocabFilename);
-  testUpperAndLowerBoundWithNumericComparator(createVocabularyFromDisk);
-  ad_utility::deleteFile(vocabFilename);
+  testUpperAndLowerBoundWithNumericComparator(
+      createVocabulary("lowerUpperBoundNumeric1"));
+  testUpperAndLowerBoundWithNumericComparator(
+      createVocabularyFromDisk("lowerUpperBoundNumeric2"));
 }
 
 TEST(VocabularyOnDisk, LowerUpperBoundNumericNonContiguousIds) {
   std::vector<std::string> words{"4", "33", "222", "1111"};
   std::vector<uint64_t> ids{2, 4, 8, 42};
-  ad_utility::deleteFile(vocabFilename);
+
+  VocabularyCreator creator1{"lowerUpperBoundNumericNonContiguousIds1"};
   testUpperAndLowerBoundWithNumericComparatorFromWordsAndIds(
-      createVocabularyImpl(words, ids), words, ids);
-  ad_utility::deleteFile(vocabFilename);
+      creator1.createVocabularyImpl(words, ids), words, ids);
+  VocabularyCreator creator2{"lowerUpperBoundNumericNonContiguousIds2"};
   testUpperAndLowerBoundWithNumericComparatorFromWordsAndIds(
-      createVocabularyFromDiskImpl(words, ids), words, ids);
-  ad_utility::deleteFile(vocabFilename);
+      creator2.createVocabularyFromDiskImpl(words, ids), words, ids);
 }
 
 TEST(VocabularyOnDisk, AccessOperator) {
-  ad_utility::deleteFile(vocabFilename);
-  testAccessOperatorForUnorderedVocabulary(createVocabulary);
-  ad_utility::deleteFile(vocabFilename);
-  testAccessOperatorForUnorderedVocabulary(createVocabularyFromDisk);
+  testAccessOperatorForUnorderedVocabulary(createVocabulary("AccessOperator1"));
+  testAccessOperatorForUnorderedVocabulary(
+      createVocabularyFromDisk("AccessOperator2"));
 }
 
 TEST(VocabularyOnDisk, AccessOperatorWithNonContiguousIds) {
   std::vector<std::string> words{"game",  "4",      "nobody", "33",
                                  "alpha", "\n\1\t", "222",    "1111"};
   std::vector<uint64_t> ids{2, 4, 8, 16, 17, 19, 42, 42 * 42 + 7};
-  ad_utility::deleteFile(vocabFilename);
-  testAccessOperatorForUnorderedVocabulary(createVocabulary);
-  ad_utility::deleteFile(vocabFilename);
-  testAccessOperatorForUnorderedVocabulary(createVocabularyFromDisk);
+  testAccessOperatorForUnorderedVocabulary(
+      createVocabulary("AccessOperatorWithNonContiguousIds1"));
+  testAccessOperatorForUnorderedVocabulary(
+      createVocabularyFromDisk("AccessOperatorWithNonContiguousIds2"));
 }
 
 TEST(VocabularyOnDisk, ErrorOnNonAscendingIds) {
   std::vector<std::string> words{"game", "4", "nobody"};
   std::vector<uint64_t> ids{2, 4, 3};
-  ASSERT_THROW(createVocabularyImpl(words, ids), ad_semsearch::Exception);
-  ASSERT_THROW(createVocabularyFromDiskImpl(words, ids),
+  VocabularyCreator creator1{"ErrorOnNonAscendingIds1"};
+  ASSERT_THROW(creator1.createVocabularyImpl(words, ids),
+               ad_semsearch::Exception);
+  VocabularyCreator creator2{"ErrorOnNonAscendingIds2"};
+  ASSERT_THROW(creator2.createVocabularyFromDiskImpl(words, ids),
                ad_semsearch::Exception);
 }
 
 TEST(VocabularyOnDisk, EmptyVocabulary) {
-  testEmptyVocabulary(createVocabulary);
+  testEmptyVocabulary(createVocabulary("EmptyVocabulary"));
 }


### PR DESCRIPTION
This PR adds functions in the test `CMakeLists.txt` to register tests that should always be run in serial. Tests that require this also use this new function.

These safeguards make it possible to also run `ctest` with multiple jobs (`-jn`). Using more than one job currently **halves the time required to run the tests**. The time required is dominated by two long running tests (`ValueIdComparators.NumericTypes` and `ValueIdComparators.IndexTypes`). But the gain could get larger with more tests in the future.