### PR TITLE
Have `std::endl` after each `LOG(INFO)` message

### DIFF
--- a/src/TurtleParserMain.cpp
+++ b/src/TurtleParserMain.cpp
@@ -94,7 +94,8 @@ void writeNTDispatch(std::ostream& out, const string& fileFormat,
     LOG(ERROR)
         << "Please specify a valid regex engine via the -r flag. "
            "Options are \"re2\" or \"ctre\" (The latter only works correct if "
-           "prefix names only use ascii characters but is faster.\n";
+           "prefix names only use ASCII characters but is faster"
+        << std::endl;
     exit(1);
   }
 }
@@ -185,23 +186,24 @@ int main(int argc, char** argv) {
       LOG(WARN)
           << " Could not deduce the type of the input knowledge-base-file by "
              "its extension. Assuming the input to be turtle. Please specify "
-             "--file-format (-F)\n";
-      LOG(WARN) << "In case this is not correct \n";
+             "--file-format (-F) if this is not correct"
+          << std::endl;
     }
     if (filetypeDeduced) {
       LOG(INFO) << "Assuming input file format to be " << fileFormat
-                << " due to the input file's extension.\n";
+                << " due to the input file's extension." << std::endl;
       LOG(INFO)
           << "If this is wrong, please manually specify the --file-format "
-             "(-F) flag.\n";
+             "(-F) flag"
+          << std::endl;
     }
   }
 
   if (inputFile.empty()) {
-    LOG(INFO) << "No input file was specified, parsing from stdin\n";
+    LOG(INFO) << "No input file was specified, parsing from stdin" << std::endl;
     inputFile = "/dev/stdin";
   } else if (inputFile == "-") {
-    LOG(INFO) << "Parsing from stdin\n";
+    LOG(INFO) << "Parsing from stdin" << std::endl;
     inputFile = "/dev/stdin";
   }
 

--- a/src/engine/QueryPlanningCostFactors.cpp
+++ b/src/engine/QueryPlanningCostFactors.cpp
@@ -45,7 +45,7 @@ void QueryPlanningCostFactors::readFromFile(const string& fileName) {
     AD_CHECK_EQ(v.size(), 2);
     float factor = toFloat(v[1]);
     LOG(INFO) << "Setting cost factor: " << v[0] << " from " << _factors[v[0]]
-              << " to " << factor << '\n';
+              << " to " << factor << std::endl;
     _factors[v[0]] = factor;
   }
 }

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -313,7 +313,7 @@ int main(int argc, char** argv) {
         }
         if (filetypeDeduced) {
           LOG(INFO) << "Format of input file deduced from extension: "
-                    << ad_utility::getUppercase(filetype) << "\n";
+                    << ad_utility::getUppercase(filetype) << std::endl;
         }
         LOG(INFO) << "If this is not correct, start again using the option "
                      "--file-format (-F)"

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -35,7 +35,8 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
     if (!_isCompressed) {
       LOG(INFO) << "ERROR: trying to load externalized literals to an "
                    "uncompressed vocabulary. This is not valid and a "
-                   "programming error. Terminating\n";
+                   "programming error. Terminating"
+                << std::endl;
       AD_CHECK(false);
     }
 
@@ -50,27 +51,27 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
 template <class S, class C>
 template <typename, typename>
 void Vocabulary<S, C>::writeToFile(const string& fileName) const {
-  LOG(INFO) << "Writing vocabulary to file " << fileName << "\n";
+  LOG(INFO) << "Writing vocabulary to file " << fileName << std::endl;
   ad_utility::serialization::FileWriteSerializer file{fileName};
   _internalVocabulary.getUnderlyingVocabulary().writeToFile(fileName);
 
-  LOG(INFO) << "Done writing vocabulary to file.\n";
+  LOG(INFO) << "Done writing vocabulary to file" << std::endl;
 }
 
 // _____________________________________________________________________________
 template <class S, class C>
 void Vocabulary<S, C>::createFromSet(
     const ad_utility::HashSet<std::string>& set) {
-  LOG(INFO) << "Creating vocabulary from set ...\n";
+  LOG(INFO) << "Creating vocabulary from set ..." << std::endl;
   _internalVocabulary.close();
   std::vector<std::string> words(set.begin(), set.end());
-  LOG(INFO) << "... sorting ...\n";
+  LOG(TRACE) << "Sorting ..." << std::endl;
   auto totalComparison = [this](const auto& a, const auto& b) {
     return getCaseComparator()(a, b, SortLevel::TOTAL);
   };
   std::sort(begin(words), end(words), totalComparison);
   _internalVocabulary.build(words);
-  LOG(INFO) << "Done creating vocabulary.\n";
+  LOG(INFO) << "Done creating vocabulary" << std::endl;
 }
 
 // _____________________________________________________________________________
@@ -299,19 +300,19 @@ template <typename, typename>
 void Vocabulary<S, C>::printRangesForDatatypes() {
   auto ranges = getRangesForDatatypes();
   auto logRange = [&](const auto& range) {
-    LOG(INFO) << range.first << " " << range.second << '\n';
+    LOG(INFO) << range.first << " " << range.second << std::endl;
     if (range.second > range.first) {
-      LOG(INFO) << indexToOptionalString(range.first).value() << '\n';
+      LOG(INFO) << indexToOptionalString(range.first).value() << std::endl;
       LOG(INFO) << indexToOptionalString(range.second.decremented()).value()
-                << '\n';
+                << std::endl;
     }
     if (range.second.get() < _internalVocabulary.size()) {
-      LOG(INFO) << indexToOptionalString(range.second).value() << '\n';
+      LOG(INFO) << indexToOptionalString(range.second).value() << std::endl;
     }
 
     if (range.first.get() > 0) {
       LOG(INFO) << indexToOptionalString(range.first.decremented()).value()
-                << '\n';
+                << std::endl;
     }
   };
 

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -267,8 +267,8 @@ void writeMappedIdsToExtVec(const auto& input,
       }
       auto iterator = map.find(curTriple[k].getVocabIndex().get());
       if (iterator == map.end()) {
-        LOG(INFO) << "not found in partial local Vocab: " << curTriple[k]
-                  << '\n';
+        LOG(ERROR) << "not found in partial local vocabulary: " << curTriple[k]
+                   << std::endl;
         AD_CHECK(false);
       }
       mappedTriple[k] =
@@ -301,7 +301,7 @@ template <class Pred>
 void writePartialIdMapToBinaryFileForMerging(
     std::shared_ptr<const ItemMapArray> map, const string& fileName, Pred comp,
     const bool doParallelSort) {
-  LOG(INFO) << "Creating partial vocabulary from set ...\n";
+  LOG(INFO) << "Creating partial vocabulary from set ..." << std::endl;
   ItemVec els;
   size_t totalEls = std::accumulate(
       map->begin(), map->end(), 0,
@@ -310,11 +310,11 @@ void writePartialIdMapToBinaryFileForMerging(
   for (const auto& singleMap : *map) {
     els.insert(end(els), begin(singleMap), end(singleMap));
   }
-  LOG(INFO) << "... sorting ...\n";
+  LOG(TRACE) << "Sorting ..." << std::endl;
 
   sortVocabVector(&els, comp, doParallelSort);
 
-  LOG(INFO) << "Done creating vocabulary.\n";
+  LOG(INFO) << "Done creating vocabulary" << std::endl;
 
   writePartialVocabularyToFile(els, fileName);
 }

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -322,7 +322,8 @@ class Tokenizer {
       auto pos = v.find('\n');
       if (pos == string::npos) {
         // TODO: this actually should yield a n error
-        LOG(INFO) << "Warning, unfinished comment found while parsing";
+        LOG(INFO) << "Warning, unfinished comment found while parsing"
+                  << std::endl;
       } else {
         _data.remove_prefix(pos + 1);
       }

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -288,7 +288,8 @@ class TokenizerCtre {
       auto pos = v.find('\n');
       if (pos == string::npos) {
         // TODO<joka921>: This should rather yield an error.
-        LOG(INFO) << "Warning, unfinished comment found while parsing";
+        LOG(INFO) << "Warning, unfinished comment found while parsing"
+                  << std::endl;
       } else {
         _data.remove_prefix(pos + 1);
       }

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -723,7 +723,7 @@ bool TurtleStreamParser<T>::getLine(TurtleTriple* triple) {
                           "use --file-format mmap\n";
             auto s = std::min(size_t(1000), size_t(d.size()));
             LOG(INFO) << "Logging first 1000 unparsed characters\n";
-            LOG(INFO) << std::string_view(d.data(), s);
+            LOG(INFO) << std::string_view(d.data(), s) << std::endl;
             if (exceptionThrown) {
               throw ex;
 
@@ -753,7 +753,7 @@ bool TurtleStreamParser<T>::getLine(TurtleTriple* triple) {
                         << d.size() << '\n';
               auto s = std::min(size_t(1000), size_t(d.size()));
               LOG(INFO) << "Logging first 1000 unparsed characters\n";
-              LOG(INFO) << std::string_view(d.data(), s);
+              LOG(INFO) << std::string_view(d.data(), s) << std::endl;
             }
             _isParserExhausted = true;
             break;

--- a/src/util/HttpServer/HttpServer.h
+++ b/src/util/HttpServer/HttpServer.h
@@ -202,7 +202,13 @@ class HttpServer {
           beast::error_code ec;
           stream.socket().shutdown(tcp::socket::shutdown_send, ec);
         } else {
-          logBeastError(error.code(), error.what());
+          // This is the error "The socket was closed due to a timeout".
+          if (error.code() == beast::error::timeout) {
+            LOG(TRACE) << error.what() << " (code " << error.code() << ")"
+                       << std::endl;
+          } else {
+            logBeastError(error.code(), error.what());
+          }
         }
         // In case of an error, close the session by returning.
         co_return;


### PR DESCRIPTION
This makes the log messages appear immediately without buffering. Since LOG(INFO) happens very infrequently, the additional cost of the flush operation is not an issue. Also made some minor improvements to the server log along the way.