### PR TITLE
Lower initial size of STXXL disk from 1 TB to 1 GB

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -8,25 +8,24 @@
 
 #include "../util/Parameters.h"
 
-static const size_t DEFAULT_STXXL_MEMORY_IN_BYTES =
-    1024UL * 1024UL * 1024UL * 5UL;
-static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000 * 1000;
+static const size_t DEFAULT_STXXL_MEMORY_IN_BYTES = 5'000'000'000UL;
+static const size_t STXXL_DISK_SIZE_INDEX_BUILDER = 1000;  // In MB.
 static const size_t STXXL_DISK_SIZE_INDEX_TEST = 10;
 
 static constexpr size_t DEFAULT_MEM_FOR_QUERIES_IN_GB = 4;
 
-static const size_t MAX_NOF_ROWS_IN_RESULT = 100000;
+static const size_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
 static const size_t MIN_WORD_PREFIX_SIZE = 4;
 static const char PREFIX_CHAR = '*';
 static const size_t MAX_NOF_NODES = 64;
 static const size_t MAX_NOF_FILTERS = 64;
 
-static const size_t BUFFER_SIZE_RELATION_SIZE = 1000 * 1000 * 1000;
-static const size_t BUFFER_SIZE_DOCSFILE_LINE = 1024 * 1024 * 100;
-static const size_t DISTINCT_LHS_PER_BLOCK = 10 * 1000;
-static const size_t USE_BLOCKS_INDEX_SIZE_TRESHOLD = 20 * 1000;
+static const size_t BUFFER_SIZE_RELATION_SIZE = 1'000'000'000;
+static const size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
+static const size_t DISTINCT_LHS_PER_BLOCK = 10'000;
+static const size_t USE_BLOCKS_INDEX_SIZE_TRESHOLD = 20'000;
 
-static const size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1000 * 1000 * 1000;
+static const size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
 
 static const size_t GALLOP_THRESHOLD = 1000;
 


### PR DESCRIPTION
It is weird that the initial size is so huge, even when only a very
small portion of it is actually needed to build most indexes. It is not
an actual problem on systems that support sparse files, where only the
space that is actually used is taken from the the filesystem. But some
older systems do not support sparse files. Note that STXXL will
automatically increase the size of the disk when it needs more space, so
an initial size that is too small is not a problem.

Along the way, formatted some of the other constants as, for example,
1'000'000 instead of 1000 * 1000. Some of the constant used to be (small
multiples) of powers of 2 and are now (small multiples of) powers of 10.
Does that matter anywhere?