### PR TITLE
Parse InlineData with ANTLR

### DIFF
--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -281,8 +281,7 @@ void SparqlParser::parseWhere(ParsedQuery* query,
       lexer_.accept(".");
     } else if (lexer_.peek("values")) {
       auto values =
-          parseWithAntlr(sparqlParserHelpers::parseValuesClause, *query)
-              .value();
+          parseWithAntlr(sparqlParserHelpers::parseInlineDataClause, *query);
       for (const auto& variable : values._inlineValues._variables) {
         query->registerVariableVisibleInQueryBody(variable);
       }

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -93,12 +93,12 @@ ResultOfParseAndRemainingText<vector<GroupKey>> parseGroupClause(
 }
 // _____________________________________________________________________________
 
-ResultOfParseAndRemainingText<std::optional<GraphPatternOperation::Values>>
-parseValuesClause(const std::string& input,
-                  SparqlQleverVisitor::PrefixMap prefixes) {
+ResultOfParseAndRemainingText<GraphPatternOperation::Values>
+parseInlineDataClause(const std::string& input,
+                      SparqlQleverVisitor::PrefixMap prefixes) {
   ParserAndVisitor p{input, std::move(prefixes)};
-  return p.parseTypesafe(input, "values clause",
-                         &SparqlAutomaticParser::valuesClause);
+  return p.parseTypesafe(input, "inline data",
+                         &SparqlAutomaticParser::inlineData);
 }
 // _____________________________________________________________________________
 

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -98,9 +98,9 @@ ResultOfParseAndRemainingText<vector<OrderKey>> parseOrderClause(
 ResultOfParseAndRemainingText<vector<GroupKey>> parseGroupClause(
     const std::string& input, SparqlQleverVisitor::PrefixMap prefixes);
 
-ResultOfParseAndRemainingText<std::optional<GraphPatternOperation::Values>>
-parseValuesClause(const std::string& input,
-                  SparqlQleverVisitor::PrefixMap prefixes);
+ResultOfParseAndRemainingText<GraphPatternOperation::Values>
+parseInlineDataClause(const std::string& input,
+                      SparqlQleverVisitor::PrefixMap prefixes);
 
 ResultOfParseAndRemainingText<PropertyPath> parseVerbPathOrSimple(
     const std::string& input, SparqlQleverVisitor::PrefixMap prefixes);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -115,3 +115,32 @@ Variable SparqlQleverVisitor::visitTypesafe(
     SparqlAutomaticParser::VarContext* ctx) {
   return Variable{ctx->getText()};
 }
+
+// ____________________________________________________________________________________
+GraphPatternOperation::Values SparqlQleverVisitor::visitTypesafe(
+    SparqlAutomaticParser::InlineDataContext* ctx) {
+  return visitTypesafe(ctx->dataBlock());
+}
+
+// ____________________________________________________________________________________
+GraphPatternOperation::Values SparqlQleverVisitor::visitTypesafe(
+    SparqlAutomaticParser::DataBlockContext* ctx) {
+  if (ctx->inlineDataOneVar()) {
+    return GraphPatternOperation::Values{
+        std::move(visit(ctx->inlineDataOneVar()).as<SparqlValues>())};
+  } else if (ctx->inlineDataFull()) {
+    return GraphPatternOperation::Values{
+        std::move(visit(ctx->inlineDataFull()).as<SparqlValues>())};
+  }
+  AD_FAIL()  // Should be unreachable.
+}
+
+// ____________________________________________________________________________________
+std::optional<GraphPatternOperation::Values> SparqlQleverVisitor::visitTypesafe(
+    SparqlAutomaticParser::ValuesClauseContext* ctx) {
+  if (ctx->dataBlock()) {
+    return visitTypesafe(ctx->dataBlock());
+  } else {
+    return std::nullopt;
+  }
+}

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -343,13 +343,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   }
 
   std::optional<GraphPatternOperation::Values> visitTypesafe(
-      SparqlAutomaticParser::ValuesClauseContext* ctx) {
-    if (ctx->dataBlock()) {
-      return visitTypesafe(ctx->dataBlock());
-    } else {
-      return std::nullopt;
-    }
-  }
+      SparqlAutomaticParser::ValuesClauseContext* ctx);
 
   antlrcpp::Any visitTriplesTemplate(
       SparqlAutomaticParser::TriplesTemplateContext* ctx) override {
@@ -399,8 +393,11 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   antlrcpp::Any visitInlineData(
       SparqlAutomaticParser::InlineDataContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
+
+  GraphPatternOperation::Values visitTypesafe(
+      SparqlAutomaticParser::InlineDataContext* ctx);
 
   antlrcpp::Any visitDataBlock(
       SparqlAutomaticParser::DataBlockContext* ctx) override {
@@ -408,16 +405,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   }
 
   GraphPatternOperation::Values visitTypesafe(
-      SparqlAutomaticParser::DataBlockContext* ctx) {
-    if (ctx->inlineDataOneVar()) {
-      return GraphPatternOperation::Values{
-          std::move(visit(ctx->inlineDataOneVar()).as<SparqlValues>())};
-    } else if (ctx->inlineDataFull()) {
-      return GraphPatternOperation::Values{
-          std::move(visit(ctx->inlineDataFull()).as<SparqlValues>())};
-    }
-    AD_FAIL()  // Should be unreachable.
-  }
+      SparqlAutomaticParser::DataBlockContext* ctx);
 
   antlrcpp::Any visitInlineDataOneVar(
       SparqlAutomaticParser::InlineDataOneVarContext* ctx) override {

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -251,9 +251,9 @@ MATCHER_P(GroupByVariablesMatch, vars, "") {
                     [](auto& var, auto& var1) { return var.name() == var1; });
 }
 
-MATCHER_P2(IsValues, vars, values, "") {
-  return (arg.value()._inlineValues._variables == vars) &&
-         (arg.value()._inlineValues._values == values);
+MATCHER_P2(IsInlineData, vars, values, "") {
+  return (arg._inlineValues._variables == vars) &&
+         (arg._inlineValues._values == values);
 }
 
 // A trivial matcher for PropertyPaths because e.g. expectCompleteParse needs


### PR DESCRIPTION
- Some small adjusts to also parse `inlineData` with ANTLR.
- Adjusted the tests and added a test to test that `inlineData` may not be empty.
- Further changed the parser to call the correct parsing function in ANTLR. Though this won't cause any trouble. The code currently called is only different in that it also accepts an empty input.

TODO:
- [ ] Split Tests in `dataBlock` and `inlineData`/`valuesClause` part.