### PR TITLE
Settings for UniProt (which cannot be specified in settings.json)

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -15,7 +15,10 @@ const std::string EXTERNAL_LITS_TEXT_FILE_NAME = ".externalized-text";
 // Determines the maximum number of bytes of an internal literal (before
 // compression). Every literal larger as this size is externalized regardless
 // of its language tag
-static const size_t MAX_INTERNAL_LITERAL_BYTES = 1'000'000;
+//
+// UNIPROT HACK: Keep only short literals in RAM.
+// TODO: This length should be configurable in the `settings.json`.
+static const size_t MAX_INTERNAL_LITERAL_BYTES = 128;  // 1'000'000
 
 // How many lines are parsed at once during index creation.
 // Reduce to save RAM


### PR DESCRIPTION
1. Externalize literals longer than 128 bytes (default is 1024 bytes).

2. Externalize all objects of the predicates
<http://www.w3.org/1999/02/22-rdf-syntax-ns#value> and
<http://purl.uniprot.org/core/md5Checksum> .