### PR TITLE
Start cleaning up the QueryPlanner

### DIFF
--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -5,9 +5,9 @@
 
 #include <string>
 
+#include "../parser/ParsedQuery.h"
 #include "../util/Conversions.h"
 #include "./Operation.h"
-#include "../parser/ParsedQuery.h"
 
 using std::string;
 
@@ -37,7 +37,8 @@ class IndexScan : public Operation {
  public:
   virtual string getDescriptor() const override;
 
-  IndexScan(QueryExecutionContext* qec, ScanType type, const SparqlTriple& triple)
+  IndexScan(QueryExecutionContext* qec, ScanType type,
+            const SparqlTriple& triple)
       : Operation(qec),
         _type(type),
         _sizeEstimate(std::numeric_limits<size_t>::max()) {
@@ -45,6 +46,7 @@ class IndexScan : public Operation {
     AD_CHECK(triple._p._operation == PropertyPath::Operation::IRI);
     setPredicate(triple._p._iri);
     setObject(triple._o);
+    precomputeSizeEstimate();
   }
 
   virtual ~IndexScan() {}

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -7,6 +7,7 @@
 
 #include "../util/Conversions.h"
 #include "./Operation.h"
+#include "../parser/ParsedQuery.h"
 
 using std::string;
 
@@ -36,10 +37,15 @@ class IndexScan : public Operation {
  public:
   virtual string getDescriptor() const override;
 
-  IndexScan(QueryExecutionContext* qec, ScanType type)
+  IndexScan(QueryExecutionContext* qec, ScanType type, const SparqlTriple& triple)
       : Operation(qec),
         _type(type),
-        _sizeEstimate(std::numeric_limits<size_t>::max()) {}
+        _sizeEstimate(std::numeric_limits<size_t>::max()) {
+    setSubject(triple._s);
+    AD_CHECK(triple._p._operation == PropertyPath::Operation::IRI);
+    setPredicate(triple._p._iri);
+    setObject(triple._o);
+  }
 
   virtual ~IndexScan() {}
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -151,37 +151,33 @@ ad_utility::HashMap<string, size_t> Join::getVariableColumns() const {
   if (!isFullScanDummy(_left) && !isFullScanDummy(_right)) {
     retVal = _left->getVariableColumns();
     size_t leftSize = _left->getResultWidth();
-    for (auto it = _right->getVariableColumns().begin();
-         it != _right->getVariableColumns().end(); ++it) {
-      if (it->second < _rightJoinCol) {
-        retVal[it->first] = leftSize + it->second;
+    for (const auto& [variable, column] :_right->getVariableColumns()){
+      if (column < _rightJoinCol) {
+        retVal[variable] = leftSize + column;
       }
-      if (it->second > _rightJoinCol) {
-        retVal[it->first] = leftSize + it->second - 1;
+      if (column > _rightJoinCol) {
+        retVal[variable] = leftSize + column - 1;
       }
     }
   } else {
     if (isFullScanDummy(_right)) {
       retVal = _left->getVariableColumns();
       size_t leftSize = _left->getResultWidth();
-      for (auto it = _right->getVariableColumns().begin();
-           it != _right->getVariableColumns().end(); ++it) {
+      for (const auto& [variable, column] : _right->getVariableColumns()){
         // Skip the first col for the dummy
-        if (it->second != 0) {
-          retVal[it->first] = leftSize + it->second - 1;
+        if (column != 0) {
+          retVal[variable] = leftSize + column - 1;
         }
       }
     } else {
-      for (auto it = _left->getVariableColumns().begin();
-           it != _left->getVariableColumns().end(); ++it) {
+      for (const auto& [variable, column] : _left->getVariableColumns()) {
         // Skip+drop the first col for the dummy and subtract one from others.
-        if (it->second != 0) {
-          retVal[it->first] = it->second - 1;
+        if (column != 0) {
+          retVal[variable] = column - 1;
         }
       }
-      for (auto it = _right->getVariableColumns().begin();
-           it != _right->getVariableColumns().end(); ++it) {
-        retVal[it->first] = 2 + it->second;
+      for (const auto& [variable, column]: _right->getVariableColumns()) {
+        retVal[variable] = 2 + column;
       }
     }
   }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -151,7 +151,7 @@ ad_utility::HashMap<string, size_t> Join::getVariableColumns() const {
   if (!isFullScanDummy(_left) && !isFullScanDummy(_right)) {
     retVal = _left->getVariableColumns();
     size_t leftSize = _left->getResultWidth();
-    for (const auto& [variable, column] :_right->getVariableColumns()){
+    for (const auto& [variable, column] : _right->getVariableColumns()) {
       if (column < _rightJoinCol) {
         retVal[variable] = leftSize + column;
       }
@@ -163,7 +163,7 @@ ad_utility::HashMap<string, size_t> Join::getVariableColumns() const {
     if (isFullScanDummy(_right)) {
       retVal = _left->getVariableColumns();
       size_t leftSize = _left->getResultWidth();
-      for (const auto& [variable, column] : _right->getVariableColumns()){
+      for (const auto& [variable, column] : _right->getVariableColumns()) {
         // Skip the first col for the dummy
         if (column != 0) {
           retVal[variable] = leftSize + column - 1;
@@ -176,7 +176,7 @@ ad_utility::HashMap<string, size_t> Join::getVariableColumns() const {
           retVal[variable] = column - 1;
         }
       }
-      for (const auto& [variable, column]: _right->getVariableColumns()) {
+      for (const auto& [variable, column] : _right->getVariableColumns()) {
         retVal[variable] = 2 + column;
       }
     }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -202,14 +202,6 @@ vector<size_t> Join::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-std::unordered_set<string> Join::getContextVars() const {
-  auto cvars = _left->getContextVars();
-  cvars.insert(_right->getContextVars().begin(),
-               _right->getContextVars().end());
-  return cvars;
-}
-
-// _____________________________________________________________________________
 float Join::getMultiplicity(size_t col) {
   if (_multiplicities.size() == 0) {
     computeSizeEstimateAndMultiplicities();

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -38,8 +38,6 @@ class Join : public Operation {
 
   ad_utility::HashMap<string, size_t> getVariableColumns() const override;
 
-  std::unordered_set<string> getContextVars() const;
-
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);
     _right->setTextLimit(limit);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -20,6 +20,7 @@
 #include "./TransitivePath.h"
 #include "./Union.h"
 #include "./Values.h"
+#include "./GroupBy.h"
 
 using std::string;
 
@@ -601,6 +602,8 @@ void QueryExecutionTree::setOperation(std::shared_ptr<Op> operation) {
     _type = TRANSITIVE_PATH;
   } else if constexpr (std::is_same_v<Op, OrderBy>) {
     _type = ORDER_BY;
+  } else if constexpr (std::is_same_v<Op, GroupBy>) {
+    _type = GROUP_BY;
 
   } else {
     static_assert(ad_utility::alwaysFalse<Op>,
@@ -617,3 +620,4 @@ template void QueryExecutionTree::setOperation(std::shared_ptr<Distinct>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<Values>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<TransitivePath>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<OrderBy>);
+template void QueryExecutionTree::setOperation(std::shared_ptr<GroupBy>);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -14,13 +14,13 @@
 #include "../parser/RdfEscaping.h"
 #include "./Bind.h"
 #include "./Distinct.h"
+#include "./GroupBy.h"
 #include "./IndexScan.h"
 #include "./OrderBy.h"
 #include "./Sort.h"
 #include "./TransitivePath.h"
 #include "./Union.h"
 #include "./Values.h"
-#include "./GroupBy.h"
 
 using std::string;
 
@@ -29,7 +29,6 @@ QueryExecutionTree::QueryExecutionTree(QueryExecutionContext* const qec)
     : _qec(qec),
       _rootOperation(nullptr),
       _type(OperationType::UNDEFINED),
-      _contextVars(),
       _asString(),
       _sizeEstimate(std::numeric_limits<size_t>::max()) {}
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -579,9 +579,7 @@ nlohmann::json QueryExecutionTree::writeRdfGraphJson(
   return jsonArray;
 }
 
-bool QueryExecutionTree::isIndexScan() const {
-  return dynamic_cast<IndexScan*>(_rootOperation.get()) != nullptr;
-}
+bool QueryExecutionTree::isIndexScan() const { return _type == SCAN; }
 
 template <typename Op>
 void QueryExecutionTree::setOperation(std::shared_ptr<Op> operation) {

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -13,14 +13,13 @@
 
 #include "../parser/RdfEscaping.h"
 #include "./Bind.h"
+#include "./Distinct.h"
 #include "./IndexScan.h"
 #include "./OrderBy.h"
 #include "./Sort.h"
-#include "./Distinct.h"
-#include "./OrderBy.h"
-#include "./Values.h"
-#include "./Union.h"
 #include "./TransitivePath.h"
+#include "./Union.h"
+#include "./Values.h"
 
 using std::string;
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -61,8 +61,10 @@ class QueryExecutionTree {
 
   const QueryExecutionContext* getQec() const { return _qec; }
 
-  const ad_utility::HashMap<string, size_t>& getVariableColumns() const {
-    return _variableColumnMap;
+  // TODO<joka921> make this a const&
+  ad_utility::HashMap<string, size_t> getVariableColumns() const {
+    AD_CHECK(_rootOperation);
+    return _rootOperation->getVariableColumns();
   }
 
   std::shared_ptr<Operation> getRootOperation() const { return _rootOperation; }
@@ -73,12 +75,7 @@ class QueryExecutionTree {
     return _type == OperationType::UNDEFINED || !_rootOperation;
   }
 
-  void setVariableColumn(std::string variable, size_t columnIndex);
-  void setVariableColumn(TripleComponent variable, size_t columnIndex);
-
   size_t getVariableColumn(const string& var) const;
-
-  void setVariableColumns(const ad_utility::HashMap<string, size_t>& map);
 
   void setContextVars(const std::unordered_set<string>& set) {
     _contextVars = set;
@@ -220,7 +217,6 @@ class QueryExecutionTree {
 
  private:
   QueryExecutionContext* _qec;  // No ownership
-  ad_utility::HashMap<string, size_t> _variableColumnMap;
   std::shared_ptr<Operation>
       _rootOperation;  // Owned child. Will be deleted at deconstruction.
   OperationType _type;

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -28,6 +28,12 @@ using std::string;
 class QueryExecutionTree {
  public:
   explicit QueryExecutionTree(QueryExecutionContext* const qec);
+  template <typename Op>
+  QueryExecutionTree(QueryExecutionContext* const qec,
+                     std::shared_ptr<Op> operation)
+      : QueryExecutionTree(qec) {
+    setOperation(std::move(operation));
+  }
 
   enum OperationType {
     UNDEFINED = 0,
@@ -57,6 +63,9 @@ class QueryExecutionTree {
 
   void setOperation(OperationType type, std::shared_ptr<Operation> op);
 
+  template <typename Op>
+  void setOperation(std::shared_ptr<Op>);
+
   string asString(size_t indent = 0);
 
   const QueryExecutionContext* getQec() const { return _qec; }
@@ -70,6 +79,10 @@ class QueryExecutionTree {
   std::shared_ptr<Operation> getRootOperation() const { return _rootOperation; }
 
   const OperationType& getType() const { return _type; }
+
+  // Is the root operation of this tree a `IndexScan` operation.
+  // This is the only query for a concrete type that is actually used.
+  bool isIndexScan() const;
 
   bool isEmpty() const {
     return _type == OperationType::UNDEFINED || !_rootOperation;

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -80,8 +80,8 @@ class QueryExecutionTree {
 
   const OperationType& getType() const { return _type; }
 
-  // Is the root operation of this tree a `IndexScan` operation.
-  // This is the only query for a concrete type that is actually used.
+  // Is the root operation of this tree an `IndexScan` operation.
+  // This is the only query for a concrete type that is frequently used.
   bool isIndexScan() const;
 
   bool isEmpty() const {

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -154,10 +154,6 @@ class QueryExecutionTree {
     return _rootOperation->getResultSortedOn();
   }
 
-  bool isContextvar(const string& var) const {
-    return _contextVars.count(var) > 0;
-  }
-
   void addContextVar(const string& var) { _contextVars.insert(var); }
 
   void setTextLimit(size_t limit) {

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -90,14 +90,6 @@ class QueryExecutionTree {
 
   size_t getVariableColumn(const string& var) const;
 
-  void setContextVars(const std::unordered_set<string>& set) {
-    _contextVars = set;
-  }
-
-  const std::unordered_set<string>& getContextVars() const {
-    return _contextVars;
-  }
-
   size_t getResultWidth() const { return _rootOperation->getResultWidth(); }
 
   shared_ptr<const ResultTable> getResult() const {
@@ -153,8 +145,6 @@ class QueryExecutionTree {
   const std::vector<size_t>& resultSortedOn() const {
     return _rootOperation->getResultSortedOn();
   }
-
-  void addContextVar(const string& var) { _contextVars.insert(var); }
 
   void setTextLimit(size_t limit) {
     _rootOperation->setTextLimit(limit);
@@ -229,7 +219,6 @@ class QueryExecutionTree {
   std::shared_ptr<Operation>
       _rootOperation;  // Owned child. Will be deleted at deconstruction.
   OperationType _type;
-  std::unordered_set<string> _contextVars;
   string _asString;
   size_t _indent = 0;  // the indent with which the _asString repr was formatted
   size_t _sizeEstimate;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1235,12 +1235,10 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             std::string filterVar = generateUniqueVarName();
 
             auto scanTree = std::make_shared<QueryExecutionTree>(_qec);
+            auto scanTriple = node._triple;
+            scanTriple._o = filterVar;
             auto scan = std::make_shared<IndexScan>(
-                _qec, IndexScan::ScanType::PSO_FREE_S);
-            scan->setSubject(node._triple._s);
-
-            scan->setPredicate(node._triple._p._iri);
-            scan->setObject(filterVar);
+                _qec, IndexScan::ScanType::PSO_FREE_S, scanTriple);
             scan->precomputeSizeEstimate();
             scanTree->setOperation(QueryExecutionTree::OperationType::SCAN,
                                    scan);
@@ -1252,25 +1250,16 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                               filter);
           } else if (isVariable(node._triple._s)) {
             auto scan = std::make_shared<IndexScan>(
-                _qec, IndexScan::ScanType::POS_BOUND_O);
-            scan->setSubject(node._triple._s);
-            scan->setPredicate(node._triple._p._iri);
-            scan->setObject(node._triple._o);
+                _qec, IndexScan::ScanType::POS_BOUND_O, node._triple);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
           } else if (isVariable(node._triple._o)) {
             auto scan = std::make_shared<IndexScan>(
-                _qec, IndexScan::ScanType::PSO_BOUND_S);
-            scan->setSubject(node._triple._s);
-            scan->setPredicate(node._triple._p._iri);
-            scan->setObject(node._triple._o);
+                _qec, IndexScan::ScanType::PSO_BOUND_S, node._triple);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
           } else {
             assert(isVariable(node._triple._p));
             auto scan = std::make_shared<IndexScan>(
-                _qec, IndexScan::ScanType::SOP_BOUND_O);
-            scan->setSubject(node._triple._s);
-            scan->setPredicate(node._triple._p._iri);
-            scan->setObject(node._triple._o);
+                _qec, IndexScan::ScanType::SOP_BOUND_O,node._triple);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
           }
           seeds.push_back(plan);
@@ -1294,10 +1283,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::PSO_FREE_S);
-              scan->setSubject(node._triple._s);
-              scan->setPredicate(node._triple._p._iri);
-              scan->setObject(node._triple._o);
+                  _qec, IndexScan::ScanType::PSO_FREE_S, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1307,10 +1293,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::POS_FREE_O);
-              scan->setSubject(node._triple._s);
-              scan->setPredicate(node._triple._p._iri);
-              scan->setObject(node._triple._o);
+                  _qec, IndexScan::ScanType::POS_FREE_O, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1321,10 +1304,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::SPO_FREE_P);
-              scan->setSubject(node._triple._s);
-              scan->setPredicate(node._triple._p._iri);
-              scan->setObject(node._triple._o);
+                  _qec, IndexScan::ScanType::SPO_FREE_P, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1334,10 +1314,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::SOP_FREE_O);
-              scan->setSubject(node._triple._s);
-              scan->setPredicate(node._triple._p._iri);
-              scan->setObject(node._triple._o);
+                  _qec, IndexScan::ScanType::SOP_FREE_O, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1348,10 +1325,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::OSP_FREE_S);
-              scan->setSubject(node._triple._s);
-              scan->setPredicate(node._triple._p._iri);
-              scan->setObject(node._triple._o);
+                  _qec, IndexScan::ScanType::OSP_FREE_S, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1361,10 +1335,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::OPS_FREE_P);
-              scan->setSubject(node._triple._s);
-              scan->setPredicate(node._triple._p._iri);
-              scan->setObject(node._triple._o);
+                  _qec, IndexScan::ScanType::OPS_FREE_P, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1379,7 +1350,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SPO);
+                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SPO, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1390,7 +1361,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SOP);
+                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SOP, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1401,7 +1372,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_PSO);
+                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_PSO, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1412,7 +1383,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_POS);
+                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_POS, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1423,7 +1394,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OSP);
+                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OSP, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
@@ -1434,7 +1405,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               plan._idsOfIncludedNodes |= (uint64_t(1) << i);
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
-                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OPS);
+                  _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OPS, node._triple);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1239,7 +1239,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scanTriple._o = filterVar;
             auto scan = std::make_shared<IndexScan>(
                 _qec, IndexScan::ScanType::PSO_FREE_S, scanTriple);
-            scan->precomputeSizeEstimate();
             scanTree->setOperation(QueryExecutionTree::OperationType::SCAN,
                                    scan);
             auto filter = std::make_shared<Filter>(
@@ -1259,7 +1258,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
           } else {
             assert(isVariable(node._triple._p));
             auto scan = std::make_shared<IndexScan>(
-                _qec, IndexScan::ScanType::SOP_BOUND_O,node._triple);
+                _qec, IndexScan::ScanType::SOP_BOUND_O, node._triple);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
           }
           seeds.push_back(plan);
@@ -1284,7 +1283,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::PSO_FREE_S, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1294,7 +1292,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::POS_FREE_O, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1305,7 +1302,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::SPO_FREE_P, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1315,7 +1311,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::SOP_FREE_O, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1326,7 +1321,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::OSP_FREE_S, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1336,7 +1330,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::OPS_FREE_P, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1351,7 +1344,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SPO, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1362,7 +1354,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SOP, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1373,7 +1364,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_PSO, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1384,7 +1374,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_POS, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1395,7 +1384,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OSP, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }
@@ -1406,7 +1394,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               auto& tree = *plan._qet;
               auto scan = std::make_shared<IndexScan>(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OPS, node._triple);
-              scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
               seeds.push_back(plan);
             }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -206,7 +206,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         plan._idsOfIncludedFilters = a._idsOfIncludedFilters;
         // TODO<joka921> : should we make this setVariableColumns call a part
         // of setOperation in the queryExecutionTree, since it is invariant?
-        plan._qet->setVariableColumns(op->getVariableColumns());
         plan._qet->setOperation(QueryExecutionTree::OperationType::BIND, op);
         candidatePlans.back().push_back(std::move(plan));
       }
@@ -317,7 +316,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         SubtreePlan candidate(_qec);
         auto unionOp = std::make_shared<Union>(_qec, left._qet, right._qet);
         QueryExecutionTree& tree = *candidate._qet;
-        tree.setVariableColumns(unionOp->getVariableColumns());
         tree.setOperation(QueryExecutionTree::UNION, unionOp);
         joinCandidates(std::vector{std::move(candidate)});
       } else if constexpr (std::is_same_v<T, GraphPatternOperation::Subquery>) {
@@ -382,8 +380,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
               rightValue, leftColName, rightColName, min, max);
           candidatesOut.emplace_back(_qec);
           QueryExecutionTree& tree = *candidatesOut.back()._qet;
-          tree.setVariableColumns(static_cast<TransitivePath*>(transOp.get())
-                                      ->getVariableColumns());
           tree.setOperation(QueryExecutionTree::TRANSITIVE_PATH, transOp);
         }
         joinCandidates(std::move(candidatesOut));
@@ -394,7 +390,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
             std::make_shared<Values>(_qec, arg._inlineValues);
         valuesPlan._qet->setOperation(QueryExecutionTree::OperationType::VALUES,
                                       op);
-        valuesPlan._qet->setVariableColumns(op->getVariableColumns());
         joinCandidates(std::vector{std::move(valuesPlan)});
 
       } else if constexpr (std::is_same_v<T, GraphPatternOperation::Bind>) {
@@ -871,18 +866,15 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
       auto distinct =
           std::make_shared<Distinct>(_qec, parent._qet, keepIndices);
       distinctPlan._qet->setOperation(QueryExecutionTree::DISTINCT, distinct);
-      distinctPlan._qet->setVariableColumns(distinct->getVariableColumns());
       distinctPlan._qet->setContextVars(parent._qet->getContextVars());
     } else {
       if (keepIndices.size() == 1) {
         auto tree = std::make_shared<QueryExecutionTree>(_qec);
         auto sort = std::make_shared<Sort>(_qec, parent._qet, keepIndices[0]);
-        tree->setVariableColumns(parent._qet->getVariableColumns());
         tree->setOperation(QueryExecutionTree::SORT, sort);
         tree->setContextVars(parent._qet->getContextVars());
         auto distinct = std::make_shared<Distinct>(_qec, tree, keepIndices);
         distinctPlan._qet->setOperation(QueryExecutionTree::DISTINCT, distinct);
-        distinctPlan._qet->setVariableColumns(distinct->getVariableColumns());
         distinctPlan._qet->setContextVars(parent._qet->getContextVars());
       } else {
         auto tree = std::make_shared<QueryExecutionTree>(_qec);
@@ -891,12 +883,10 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
           obCols.emplace_back(std::make_pair(i, false));
         }
         auto ob = std::make_shared<OrderBy>(_qec, parent._qet, obCols);
-        tree->setVariableColumns(parent._qet->getVariableColumns());
         tree->setOperation(QueryExecutionTree::ORDER_BY, ob);
         tree->setContextVars(parent._qet->getContextVars());
         auto distinct = std::make_shared<Distinct>(_qec, tree, keepIndices);
         distinctPlan._qet->setOperation(QueryExecutionTree::DISTINCT, distinct);
-        distinctPlan._qet->setVariableColumns(distinct->getVariableColumns());
         distinctPlan._qet->setContextVars(parent._qet->getContextVars());
       }
     }
@@ -946,7 +936,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
       if (!isSorted) {
         auto orderByOp =
             std::make_shared<OrderBy>(_qec, parent._qet, sortIndices);
-        orderByPlan._qet->setVariableColumns(parent._qet->getVariableColumns());
         orderByPlan._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByOp);
       }
       SubtreePlan patternTrickPlan(_qec);
@@ -956,7 +945,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
       countPred->setVarNames(patternTrickTriple._o.getString(),
                              aliases[0]._outVarName);
       QueryExecutionTree& tree = *patternTrickPlan._qet;
-      tree.setVariableColumns(countPred->getVariableColumns());
       tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
                         countPred);
       added.push_back(patternTrickPlan);
@@ -970,7 +958,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
     countPred->setVarNames(patternTrickTriple._o.getString(),
                            aliases[0]._outVarName);
     QueryExecutionTree& tree = *patternTrickPlan._qet;
-    tree.setVariableColumns(countPred->getVariableColumns());
     tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
                       countPred);
     added.push_back(patternTrickPlan);
@@ -987,7 +974,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
                              generateUniqueVarName());
     }
     QueryExecutionTree& tree = *patternTrickPlan._qet;
-    tree.setVariableColumns(countPred->getVariableColumns());
     tree.setOperation(QueryExecutionTree::COUNT_AVAILABLE_PREDICATES,
                       countPred);
     added.push_back(patternTrickPlan);
@@ -1006,7 +992,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getHavingRow(
     for (const SparqlFilter& filter : pq._havingClauses) {
       SubtreePlan plan(_qec);
       auto& tree = *plan._qet;
-      tree.setVariableColumns(parent._qet->getVariableColumns());
       tree.setOperation(QueryExecutionTree::FILTER,
                         createFilterOperation(filter, parent));
       tree.setContextVars(parent._qet->getContextVars());
@@ -1054,13 +1039,11 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
       // Create an order by operation as required by the group by
       auto orderBy = std::make_shared<OrderBy>(_qec, parent._qet, sortColumns);
       QueryExecutionTree& orderByTree = *orderByPlan._qet;
-      orderByTree.setVariableColumns(parent._qet->getVariableColumns());
       orderByTree.setOperation(QueryExecutionTree::ORDER_BY, orderBy);
       groupBy->setSubtree(orderByPlan._qet);
     } else
       groupBy->setSubtree(parent._qet);
 
-    groupByTree.setVariableColumns(groupBy->getVariableColumns());
     groupByTree.setOperation(QueryExecutionTree::GROUP_BY, groupBy);
     added.push_back(groupByPlan);
   }
@@ -1087,7 +1070,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
         added.push_back(parent);
       } else {
         auto sort = std::make_shared<Sort>(_qec, parent._qet, col);
-        tree.setVariableColumns(parent._qet->getVariableColumns());
         tree.setOperation(QueryExecutionTree::SORT, sort);
         tree.setContextVars(parent._qet->getContextVars());
         added.push_back(plan);
@@ -1110,7 +1092,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
         added.push_back(parent);
       } else {
         auto ob = std::make_shared<OrderBy>(_qec, parent._qet, sortIndices);
-        tree.setVariableColumns(parent._qet->getVariableColumns());
         tree.setOperation(QueryExecutionTree::ORDER_BY, ob);
         tree.setContextVars(parent._qet->getContextVars());
 
@@ -1240,7 +1221,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scan->setObject(node._triple._o);
             tree.setOperation(
                 QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
-            tree.setVariableColumns(scan->getVariableColumns());
           } else if (isVariable(node._triple._s) &&
                      isVariable(node._triple._o) &&
                      node._triple._s == node._triple._o) {
@@ -1264,15 +1244,12 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scan->precomputeSizeEstimate();
             scanTree->setOperation(QueryExecutionTree::OperationType::SCAN,
                                    scan);
-            scanTree->setVariableColumn(node._triple._s.getString(), 0);
-            scanTree->setVariableColumn(filterVar, 1);
             auto filter = std::make_shared<Filter>(
                 _qec, scanTree, SparqlFilter::FilterType::EQ,
                 node._triple._s.getString(), filterVar, vector<string>{},
                 vector<string>{});
             tree.setOperation(QueryExecutionTree::OperationType::FILTER,
                               filter);
-            tree.setVariableColumns(filter->getVariableColumns());
           } else if (isVariable(node._triple._s)) {
             auto scan = std::make_shared<IndexScan>(
                 _qec, IndexScan::ScanType::POS_BOUND_O);
@@ -1280,7 +1257,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scan->setPredicate(node._triple._p._iri);
             scan->setObject(node._triple._o);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-            tree.setVariableColumn(node._triple._s.getString(), 0);
           } else if (isVariable(node._triple._o)) {
             auto scan = std::make_shared<IndexScan>(
                 _qec, IndexScan::ScanType::PSO_BOUND_S);
@@ -1288,7 +1264,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scan->setPredicate(node._triple._p._iri);
             scan->setObject(node._triple._o);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-            tree.setVariableColumn(node._triple._o.getString(), 0);
           } else {
             assert(isVariable(node._triple._p));
             auto scan = std::make_shared<IndexScan>(
@@ -1297,7 +1272,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scan->setPredicate(node._triple._p._iri);
             scan->setObject(node._triple._o);
             tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-            tree.setVariableColumn(node._triple._p._iri, 0);
           }
           seeds.push_back(plan);
         } else if (node._variables.size() == 2) {
@@ -1313,7 +1287,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
             scan->setObject(node._triple._o);
             tree.setOperation(
                 QueryExecutionTree::OperationType::HAS_RELATION_SCAN, scan);
-            tree.setVariableColumns(scan->getVariableColumns());
             seeds.push_back(plan);
           } else if (!isVariable(node._triple._p._iri)) {
             {
@@ -1327,8 +1300,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               scan->setObject(node._triple._o);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._s.getString(), 0);
-              tree.setVariableColumn(node._triple._o.getString(), 1);
               seeds.push_back(plan);
             }
             {
@@ -1342,8 +1313,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               scan->setObject(node._triple._o);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._o.getString(), 0);
-              tree.setVariableColumn(node._triple._s.getString(), 1);
               seeds.push_back(plan);
             }
           } else if (!isVariable(node._triple._s)) {
@@ -1358,8 +1327,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               scan->setObject(node._triple._o);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._p._iri, 0);
-              tree.setVariableColumn(node._triple._o.getString(), 1);
               seeds.push_back(plan);
             }
             {
@@ -1373,8 +1340,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               scan->setObject(node._triple._o);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._o.getString(), 0);
-              tree.setVariableColumn(node._triple._p._iri, 1);
               seeds.push_back(plan);
             }
           } else if (!isVariable(node._triple._o)) {
@@ -1389,8 +1354,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               scan->setObject(node._triple._o);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._s.getString(), 0);
-              tree.setVariableColumn(node._triple._p._iri, 1);
               seeds.push_back(plan);
             }
             {
@@ -1404,8 +1367,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
               scan->setObject(node._triple._o);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._p._iri, 0);
-              tree.setVariableColumn(node._triple._s, 1);
               seeds.push_back(plan);
             }
           }
@@ -1421,9 +1382,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SPO);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._s, 0);
-              tree.setVariableColumn(node._triple._p._iri, 1);
-              tree.setVariableColumn(node._triple._o.getString(), 2);
               seeds.push_back(plan);
             }
             // SOP
@@ -1435,9 +1393,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_SOP);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._s, 0);
-              tree.setVariableColumn(node._triple._o.getString(), 1);
-              tree.setVariableColumn(node._triple._p._iri, 2);
               seeds.push_back(plan);
             }
             // PSO
@@ -1449,9 +1404,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_PSO);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._p._iri, 0);
-              tree.setVariableColumn(node._triple._s, 1);
-              tree.setVariableColumn(node._triple._o.getString(), 2);
               seeds.push_back(plan);
             }
             // POS
@@ -1463,9 +1415,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_POS);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._p._iri, 0);
-              tree.setVariableColumn(node._triple._o.getString(), 1);
-              tree.setVariableColumn(node._triple._s, 2);
               seeds.push_back(plan);
             }
             // OSP
@@ -1477,9 +1426,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OSP);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._o.getString(), 0);
-              tree.setVariableColumn(node._triple._s, 1);
-              tree.setVariableColumn(node._triple._p._iri, 2);
               seeds.push_back(plan);
             }
             // OPS
@@ -1491,9 +1437,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
                   _qec, IndexScan::ScanType::FULL_INDEX_SCAN_OPS);
               scan->precomputeSizeEstimate();
               tree.setOperation(QueryExecutionTree::OperationType::SCAN, scan);
-              tree.setVariableColumn(node._triple._o.getString(), 0);
-              tree.setVariableColumn(node._triple._p._iri, 1);
-              tree.setVariableColumn(node._triple._s, 2);
               seeds.push_back(plan);
             }
           } else {
@@ -1879,7 +1822,6 @@ QueryPlanner::SubtreePlan QueryPlanner::getTextLeafPlan(
       _qec, node._wordPart, node._variables, node._cvar);
   tree.setOperation(QueryExecutionTree::OperationType::TEXT_WITHOUT_FILTER,
                     textOp);
-  tree.setVariableColumns(textOp->getVariableColumns());
   tree.addContextVar(node._cvar);
   return plan;
 }
@@ -1980,11 +1922,9 @@ QueryPlanner::SubtreePlan QueryPlanner::optionalJoin(
   auto orderByB = std::make_shared<OrderBy>(_qec, b._qet, sortIndicesB);
 
   if (!aSorted) {
-    orderByPlanA._qet->setVariableColumns(a._qet->getVariableColumns());
     orderByPlanA._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByA);
   }
   if (!bSorted) {
-    orderByPlanB._qet->setVariableColumns(b._qet->getVariableColumns());
     orderByPlanB._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByB);
   }
 
@@ -1993,7 +1933,6 @@ QueryPlanner::SubtreePlan QueryPlanner::optionalJoin(
       a.type == SubtreePlan::OPTIONAL, bSorted ? b._qet : orderByPlanB._qet,
       b.type == SubtreePlan::OPTIONAL, jcs);
   QueryExecutionTree& tree = *plan._qet;
-  tree.setVariableColumns(join->getVariableColumns());
   tree.setOperation(QueryExecutionTree::OPTIONAL_JOIN, join);
 
   plan.type = SubtreePlan::BASIC;
@@ -2034,11 +1973,9 @@ QueryPlanner::SubtreePlan QueryPlanner::minus(const SubtreePlan& a,
   auto orderByB = std::make_shared<OrderBy>(_qec, b._qet, sortIndicesB);
 
   if (!aSorted) {
-    orderByPlanA._qet->setVariableColumns(a._qet->getVariableColumns());
     orderByPlanA._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByA);
   }
   if (!bSorted) {
-    orderByPlanB._qet->setVariableColumns(b._qet->getVariableColumns());
     orderByPlanB._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByB);
   }
 
@@ -2048,7 +1985,6 @@ QueryPlanner::SubtreePlan QueryPlanner::minus(const SubtreePlan& a,
       std::make_shared<Minus>(_qec, aSorted ? a._qet : orderByPlanA._qet,
                               bSorted ? b._qet : orderByPlanB._qet, jcs);
   QueryExecutionTree& tree = *plan._qet;
-  tree.setVariableColumns(join->getVariableColumns());
   tree.setOperation(QueryExecutionTree::MINUS, join);
 
   plan.type = SubtreePlan::BASIC;
@@ -2090,11 +2026,9 @@ QueryPlanner::SubtreePlan QueryPlanner::multiColumnJoin(
   auto orderByB = std::make_shared<OrderBy>(_qec, b._qet, sortIndicesB);
 
   if (!aSorted) {
-    orderByPlanA._qet->setVariableColumns(a._qet->getVariableColumns());
     orderByPlanA._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByA);
   }
   if (!bSorted) {
-    orderByPlanB._qet->setVariableColumns(b._qet->getVariableColumns());
     orderByPlanB._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByB);
   }
 
@@ -2108,7 +2042,6 @@ QueryPlanner::SubtreePlan QueryPlanner::multiColumnJoin(
 
   auto join = std::make_shared<MultiColumnJoin>(_qec, actualA, actualB, jcs);
   QueryExecutionTree& tree = *plan._qet;
-  tree.setVariableColumns(join->getVariableColumns());
   tree.setOperation(QueryExecutionTree::MULTICOLUMN_JOIN, join);
 
   return plan;
@@ -2275,7 +2208,6 @@ void QueryPlanner::applyFiltersIfPossible(
         auto& tree = *newPlan._qet;
         tree.setOperation(QueryExecutionTree::FILTER,
                           createFilterOperation(filters[i], row[n]));
-        tree.setVariableColumns(row[n]._qet->getVariableColumns());
         tree.setContextVars(row[n]._qet->getContextVars());
         if (replace) {
           row[n] = newPlan;
@@ -2914,7 +2846,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
           sortIndices.emplace_back(
               std::make_pair(jcs[(c + 1) % 2][(0 + swap) % 2], false));
           auto orderBy = std::make_shared<OrderBy>(_qec, a._qet, sortIndices);
-          left->setVariableColumns(a._qet->getVariableColumns());
           left->setOperation(QueryExecutionTree::ORDER_BY, orderBy);
         }
         const vector<size_t>& bSortedOn = b._qet->resultSortedOn();
@@ -2930,7 +2861,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
           sortIndices.emplace_back(
               std::make_pair(jcs[(c + 1) % 2][(1 + swap) % 2], false));
           auto orderBy = std::make_shared<OrderBy>(_qec, b._qet, sortIndices);
-          right->setVariableColumns(b._qet->getVariableColumns());
           right->setOperation(QueryExecutionTree::ORDER_BY, orderBy);
         }
         // TODO(florian): consider replacing this with a multicolumn join.
@@ -2938,7 +2868,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         SubtreePlan plan(_qec);
         auto& tree = *plan._qet;
         auto join = std::make_shared<TwoColumnJoin>(_qec, left, right, jcs);
-        tree.setVariableColumns(join->getVariableColumns());
         tree.setOperation(QueryExecutionTree::TWO_COL_JOIN, join);
         // TODO<joka921>: shouldn't we |= the filters here to avoid duplicate
         // filtering when it might hurt (although filters are always cheap).
@@ -2996,7 +2925,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
           filterPlan._qet, otherPlanJc);
       tree.setOperation(QueryExecutionTree::OperationType::TEXT_WITH_FILTER,
                         textOp);
-      tree.setVariableColumns(textOp->getVariableColumns());
       tree.setContextVars(filterPlan._qet->getContextVars());
       tree.addContextVar(noFilter.getCVar());
       candidates.push_back(std::move(plan));
@@ -3056,7 +2984,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         scan->setObject(static_cast<HasPredicateScan*>(
                             hasPredicateScan->getRootOperation().get())
                             ->getObject());
-        tree.setVariableColumns(scan->getVariableColumns());
         tree.setOperation(QueryExecutionTree::HAS_RELATION_SCAN, scan);
         plan._idsOfIncludedNodes = a._idsOfIncludedNodes;
         plan.addAllNodes(b._idsOfIncludedNodes);
@@ -3104,7 +3031,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
           }
           auto sort = std::make_shared<Sort>(_qec, other, jcs[0][0]);
           auto sortedOther = std::make_shared<QueryExecutionTree>(_qec);
-          sortedOther->setVariableColumns(other->getVariableColumns());
           sortedOther->setContextVars(other->getContextVars());
           sortedOther->setOperation(QueryExecutionTree::SORT, sort);
           other = sortedOther;
@@ -3113,7 +3039,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         SubtreePlan plan{_qec};
         QueryExecutionTree& tree = *plan._qet;
         auto newpath = srcpath->bindLeftSide(other, otherCol);
-        tree.setVariableColumns(newpath->getVariableColumns());
         tree.setOperation(QueryExecutionTree::TRANSITIVE_PATH, newpath);
         plan._idsOfIncludedNodes = a._idsOfIncludedNodes;
         plan.addAllNodes(b._idsOfIncludedNodes);
@@ -3160,7 +3085,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
           }
           auto sort = std::make_shared<Sort>(_qec, other, jcs[0][0]);
           auto sortedOther = std::make_shared<QueryExecutionTree>(_qec);
-          sortedOther->setVariableColumns(other->getVariableColumns());
           sortedOther->setContextVars(other->getContextVars());
           sortedOther->setOperation(QueryExecutionTree::SORT, sort);
           other = sortedOther;
@@ -3169,7 +3093,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         SubtreePlan plan{_qec};
         auto& tree = *plan._qet;
         auto newpath = srcpath->bindRightSide(other, otherCol);
-        tree.setVariableColumns(newpath->getVariableColumns());
         tree.setOperation(QueryExecutionTree::TRANSITIVE_PATH, newpath);
         plan._idsOfIncludedNodes = a._idsOfIncludedNodes;
         plan.addAllNodes(b._idsOfIncludedNodes);
@@ -3197,7 +3120,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         return candidates;
       }
       auto sort = std::make_shared<Sort>(_qec, a._qet, jcs[0][0]);
-      left->setVariableColumns(a._qet->getVariableColumns());
       left->setContextVars(a._qet->getContextVars());
       left->setOperation(QueryExecutionTree::SORT, sort);
     }
@@ -3212,7 +3134,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         return candidates;
       }
       auto sort = std::make_shared<Sort>(_qec, b._qet, jcs[0][1]);
-      right->setVariableColumns(b._qet->getVariableColumns());
       right->setContextVars(b._qet->getContextVars());
       right->setOperation(QueryExecutionTree::SORT, sort);
     }
@@ -3222,7 +3143,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
     SubtreePlan plan{_qec};
     auto& tree = *plan._qet;
     auto join = std::make_shared<Join>(_qec, left, right, jcs[0][0], jcs[0][1]);
-    tree.setVariableColumns(join->getVariableColumns());
     tree.setContextVars(join->getContextVars());
     tree.setOperation(QueryExecutionTree::JOIN, join);
     plan._idsOfIncludedNodes = a._idsOfIncludedNodes;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -132,6 +132,12 @@ class QueryPlanner {
     explicit SubtreePlan(QueryExecutionContext* qec)
         : _qet(std::make_shared<QueryExecutionTree>(qec)) {}
 
+    template <typename Operation>
+    SubtreePlan(QueryExecutionContext* qec,
+                std::shared_ptr<Operation> operation)
+        : _qet{std::make_shared<QueryExecutionTree>(qec,
+                                                    std::move(operation))} {}
+
     std::shared_ptr<QueryExecutionTree> _qet;
     std::shared_ptr<ResultTable> _cachedResult;
     bool _isCached = false;


### PR DESCRIPTION
It has a lot of redundant code.

- The variable to column mapping was stored redundantly in the ExecutionTree as well as in the Operations. Now it is only stored in the Operations. TODO: Figure out the correct place to precompute this mapping, mostly by removing two-phase initializations in the Operations classes.

- The IndexScan constructor now directly takes a Triple instead of manually called `setSubject()`,... etc. methods.