### PR TITLE
Improve code for parsing FILTER expressions

### DIFF
--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -446,8 +446,8 @@ void ParsedQuery::GraphPattern::addLanguageFilter(const std::string& lhs,
                                                   const std::string& rhs) {
   auto langTag = rhs.substr(1, rhs.size() - 2);
   // First find a suitable triple for the given variable. It
-  // must use a predicate that is not a variable or complex
-  // predicate path
+  // must use a predicate that is neither a variable nor a complex
+  // predicate path.
   if (_children.empty() ||
       !_children.back().is<GraphPatternOperation::BasicGraphPattern>()) {
     _children.emplace_back(GraphPatternOperation::BasicGraphPattern{});
@@ -457,7 +457,7 @@ void ParsedQuery::GraphPattern::addLanguageFilter(const std::string& lhs,
                 ._whereClauseTriples;
   auto it = std::find_if(t.begin(), t.end(), [&lhs](const auto& tr) {
     // TODO<joka921> Also apply the efficient language filter for
-    // property paths like "rdfs:label|skos:altLabel"
+    // property paths like "rdfs:label|skos:altLabel".
     return tr._o == lhs && (tr._p._operation == PropertyPath::Operation::IRI &&
                             !isVariable(tr._p));
   });
@@ -470,9 +470,9 @@ void ParsedQuery::GraphPattern::addLanguageFilter(const std::string& lhs,
     PropertyPath taggedPredicate(PropertyPath::Operation::IRI);
     taggedPredicate._iri = LANGUAGE_PREDICATE;
     SparqlTriple triple(lhs, taggedPredicate, langEntity);
-    // Quadratic in number of triples in query.
-    // Shouldn't be a problem here, though.
-    // Could use a (hash)-set instead of vector.
+    // This `find` is linear in the number of triples (per language filter).
+    // This shouldn't be a problem here, though. If needed, we could use a
+    // (hash)-set instead of a vector.
     if (std::find(t.begin(), t.end(), triple) != t.end()) {
       LOG(DEBUG) << "Ignoring duplicate triple: lang(" << lhs << ") = " << rhs
                  << std::endl;

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -441,3 +441,51 @@ void GraphPatternOperation::toString(std::ostringstream& os,
 
 // __________________________________________________________________________
 ParsedQuery::GraphPattern::GraphPattern() : _optional(false) {}
+
+void ParsedQuery::GraphPattern::addLanguageFilter(const std::string& lhs,
+                                                  const std::string& rhs) {
+  auto langTag = rhs.substr(1, rhs.size() - 2);
+  // First find a suitable triple for the given variable. It
+  // must use a predicate that is not a variable or complex
+  // predicate path
+  if (_children.empty() ||
+      !_children.back().is<GraphPatternOperation::BasicGraphPattern>()) {
+    _children.emplace_back(GraphPatternOperation::BasicGraphPattern{});
+  }
+  auto& t = _children.back()
+                .get<GraphPatternOperation::BasicGraphPattern>()
+                ._whereClauseTriples;
+  auto it = std::find_if(t.begin(), t.end(), [&lhs](const auto& tr) {
+    // TODO<joka921> Also apply the efficient language filter for
+    // property paths like "rdfs:label|skos:altLabel"
+    return tr._o == lhs && (tr._p._operation == PropertyPath::Operation::IRI &&
+                            !isVariable(tr._p));
+  });
+  if (it == t.end()) {
+    LOG(DEBUG) << "language filter variable " + lhs +
+                      " did not appear as object in any suitable "
+                      "triple. "
+                      "Using literal-to-language predicate instead.\n";
+    auto langEntity = ad_utility::convertLangtagToEntityUri(langTag);
+    PropertyPath taggedPredicate(PropertyPath::Operation::IRI);
+    taggedPredicate._iri = LANGUAGE_PREDICATE;
+    SparqlTriple triple(lhs, taggedPredicate, langEntity);
+    // Quadratic in number of triples in query.
+    // Shouldn't be a problem here, though.
+    // Could use a (hash)-set instead of vector.
+    if (std::find(t.begin(), t.end(), triple) != t.end()) {
+      LOG(DEBUG) << "Ignoring duplicate triple: lang(" << lhs << ") = " << rhs
+                 << std::endl;
+    } else {
+      t.push_back(triple);
+    }
+  } else {
+    // replace the triple
+    PropertyPath taggedPredicate(PropertyPath::Operation::IRI);
+    taggedPredicate._iri = '@' + langTag + '@' + it->_p._iri;
+    SparqlTriple taggedTriple(it->_s, taggedPredicate, it->_o);
+    LOG(DEBUG) << "replacing predicate " << it->_p.asString() << " with "
+               << taggedTriple._p.asString() << std::endl;
+    *it = taggedTriple;
+  }
+}

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -166,6 +166,8 @@ class ParsedQuery {
     // pattern
     void recomputeIds(size_t* id_count = nullptr);
 
+    // Modify query to take care of language filter. `lhs` is the variable,
+    // `rhs` is the language.
     void addLanguageFilter(const std::string& lhs, const std::string& rhs);
 
     bool _optional;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -119,6 +119,8 @@ class SparqlFilter {
   bool _regexIgnoreCase = false;
   // True if the str function was applied to the left side.
   bool _lhsAsString = false;
+
+  bool operator==(const SparqlFilter&) const = default;
 };
 
 // Represents a VALUES statement in the query.

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -162,6 +162,8 @@ class ParsedQuery {
     // pattern
     void recomputeIds(size_t* id_count = nullptr);
 
+    void addLanguageFilter(const std::string& lhs, const std::string& rhs);
+
     bool _optional;
     /**
      * @brief A id that is unique for the ParsedQuery. Ids are guaranteed to

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -114,8 +114,8 @@ class SparqlFilter {
   FilterType _type;
   string _lhs;
   string _rhs;
-  vector<string> _additionalLhs;
-  vector<string> _additionalPrefixes;
+  vector<string> _additionalLhs = {};
+  vector<string> _additionalPrefixes = {};
   bool _regexIgnoreCase = false;
   // True if the str function was applied to the left side.
   bool _lhsAsString = false;

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -894,3 +894,9 @@ Variable SparqlParser::addInternalBind(
   //  query.
   return Variable{std::move(targetVariable)};
 }
+
+// _____________________________________________________________________________
+SparqlFilter SparqlParser::parseFilterExpression(const string& filterContent) {
+  SparqlParser parser(filterContent);
+  return parser.parseFilter(true).value();
+}

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -510,7 +510,7 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
           auto& filter = filterOpt.value();
           if (filter._type == SparqlFilter::LANG_MATCHES) {
             throw ParseException(
-                "Language filters in having clauses are currently not "
+                "Language filter in HAVING clause currently not "
                 "supported by QLever");
           }
           query->_havingClauses.push_back(std::move(filter));
@@ -521,6 +521,7 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
         }
       };
       addHavingFilter(true);
+      // Add remaining filters.
       while (addHavingFilter(false)) {
       }
     } else {
@@ -661,11 +662,6 @@ std::optional<SparqlFilter> SparqlParser::parseFilter(bool failOnNoFilter) {
   }
   expectClose();
   return std::nullopt;
-}
-
-void SparqlParser::addLangFilter(const std::string& lhs, const std::string& rhs,
-                                 ParsedQuery::GraphPattern* pattern) {
-  pattern->addLanguageFilter(lhs, rhs);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -274,7 +274,12 @@ void SparqlParser::parseWhere(ParsedQuery* query,
       }
     } else if (lexer_.accept("filter")) {
       // append to the global filters of the pattern.
-      parseFilter(&currentPattern->_filters, true, currentPattern);
+      SparqlFilter filter = parseFilter(true).value();
+      if (filter._type == SparqlFilter::LANG_MATCHES) {
+        currentPattern->addLanguageFilter(filter._lhs, filter._rhs);
+      } else {
+        currentPattern->_filters.push_back(std::move(filter));
+      }
       // A filter may have an optional dot after it
       lexer_.accept(".");
     } else if (lexer_.peek("values")) {
@@ -501,9 +506,24 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
             std::move(orderKey));
       }
     } else if (lexer_.accept("having")) {
-      parseFilter(&query->_havingClauses, true, &query->_rootGraphPattern);
-      while (parseFilter(&query->_havingClauses, false,
-                         &query->_rootGraphPattern)) {
+      auto addHavingFilter = [&](bool failOnNoFilter) {
+        auto filterOpt = parseFilter(failOnNoFilter);
+        if (filterOpt.has_value()) {
+          auto& filter = filterOpt.value();
+          if (filter._type == SparqlFilter::LANG_MATCHES) {
+            throw ParseException(
+                "Language filters in having clauses are currently not "
+                "supported by QLever");
+          }
+          query->_havingClauses.push_back(std::move(filter));
+          return true;
+        } else {
+          AD_CHECK(!failOnNoFilter);
+          return false;
+        }
+      };
+      addHavingFilter(true);
+      while (addHavingFilter(false)) {
       }
     } else {
       lexer_.accept();
@@ -514,9 +534,7 @@ void SparqlParser::parseSolutionModifiers(ParsedQuery* query) {
 }
 
 // _____________________________________________________________________________
-bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
-                               bool failOnNoFilter,
-                               ParsedQuery::GraphPattern* pattern) {
+std::optional<SparqlFilter> SparqlParser::parseFilter(bool failOnNoFilter) {
   size_t numParentheses = 0;
   while (lexer_.accept("(")) {
     numParentheses++;
@@ -536,8 +554,7 @@ bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
     lexer_.expect(SparqlToken::Type::RDFLITERAL);
     std::string rhs = lexer_.current().raw;
     expectClose();
-    addLangFilter(lhs, rhs, pattern);
-    return true;
+    return SparqlFilter{SparqlFilter::LANG_MATCHES, lhs, rhs};
   } else if (lexer_.accept("langmatches")) {
     lexer_.expect("(");
     lexer_.expect("lang");
@@ -549,8 +566,7 @@ bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
     lexer_.expect(SparqlToken::Type::RDFLITERAL);
     std::string rhs = lexer_.current().raw;
     expectClose();
-    addLangFilter(lhs, rhs, pattern);
-    return true;
+    return SparqlFilter{SparqlFilter::LANG_MATCHES, lhs, rhs};
   } else if (lexer_.accept("regex")) {
     std::vector<SparqlFilter> v;
     v.push_back(parseRegexFilter(false));
@@ -571,32 +587,8 @@ bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
       v[0]._additionalLhs.push_back(std::move(it->_lhs));
       v[0]._additionalPrefixes.push_back(std::move(it->_rhs));
     }
-    _filters->push_back(v[0]);
     expectClose();
-    return true;
-  } else if (lexer_.accept("prefix")) {
-    lexer_.expect("(");
-    SparqlFilter f1;
-    SparqlFilter f2;
-    f1._type = SparqlFilter::GE;
-    f2._type = SparqlFilter::LT;
-    // Do prefix filtering by using two filters (one testing >=, the other =)
-    lexer_.expect(SparqlToken::Type::VARIABLE);
-    f1._lhs = lexer_.current().raw;
-    f2._lhs = f1._lhs;
-    lexer_.expect(",");
-    lexer_.expect(SparqlToken::Type::RDFLITERAL);
-    f1._rhs = lexer_.current().raw;
-    f2._rhs = f1._lhs;
-    f1._rhs = f1._rhs.substr(0, f1._rhs.size() - 1) + " ";
-    f2._rhs = f2._rhs.substr(0, f2._rhs.size() - 2);
-    f2._rhs += f1._rhs[f1._rhs.size() - 2] + 1;
-    f2._rhs += f1._rhs[f1._rhs.size() - 1];
-    _filters->emplace_back(f1);
-    _filters->emplace_back(f2);
-    lexer_.expect(")");
-    expectClose();
-    return true;
+    return v[0];
   } else if (numParentheses) {
     SparqlFilter f;
     if (lexer_.accept("str")) {
@@ -663,55 +655,19 @@ bool SparqlParser::parseFilter(vector<SparqlFilter>* _filters,
                            " is not a valid right hand side for a filter.");
     }
     expectClose();
-    _filters->emplace_back(f);
-    return true;
+    return f;
 
   } else if (failOnNoFilter) {
     lexer_.accept();
     throw ParseException("Expected a filter but got " + lexer_.current().raw);
   }
   expectClose();
-  return false;
+  return std::nullopt;
 }
 
 void SparqlParser::addLangFilter(const std::string& lhs, const std::string& rhs,
                                  ParsedQuery::GraphPattern* pattern) {
-  auto langTag = rhs.substr(1, rhs.size() - 2);
-  // First find a suitable triple for the given variable. It
-  // must use a predicate that is not a variable or complex
-  // predicate path
-  auto& t = lastBasicPattern(pattern)._whereClauseTriples;
-  auto it = std::find_if(t.begin(), t.end(), [&lhs](const auto& tr) {
-    return tr._o == lhs && (tr._p._operation == PropertyPath::Operation::IRI &&
-                            !isVariable(tr._p));
-  });
-  if (it == t.end()) {
-    LOG(DEBUG) << "language filter variable " + lhs +
-                      " did not appear as object in any suitable "
-                      "triple. "
-                      "Using literal-to-language predicate instead.\n";
-    auto langEntity = ad_utility::convertLangtagToEntityUri(langTag);
-    PropertyPath taggedPredicate(PropertyPath::Operation::IRI);
-    taggedPredicate._iri = LANGUAGE_PREDICATE;
-    SparqlTriple triple(lhs, taggedPredicate, langEntity);
-    // Quadratic in number of triples in query.
-    // Shouldn't be a problem here, though.
-    // Could use a (hash)-set instead of vector.
-    if (std::find(t.begin(), t.end(), triple) != t.end()) {
-      LOG(DEBUG) << "Ignoring duplicate triple: lang(" << lhs << ") = " << rhs
-                 << std::endl;
-    } else {
-      t.push_back(triple);
-    }
-  } else {
-    // replace the triple
-    PropertyPath taggedPredicate(PropertyPath::Operation::IRI);
-    taggedPredicate._iri = '@' + langTag + '@' + it->_p._iri;
-    SparqlTriple taggedTriple(it->_s, taggedPredicate, it->_o);
-    LOG(DEBUG) << "replacing predicate " << it->_p.asString() << " with "
-               << taggedTriple._p.asString() << std::endl;
-    *it = taggedTriple;
-  }
+  pattern->addLanguageFilter(lhs, rhs);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -23,9 +23,9 @@ class SparqlParser {
   explicit SparqlParser(const string& query);
   ParsedQuery parse();
 
-  /// Parse the Expression of a filter statement (without the `FILTER` keyword.
-  /// This helper method is needed, as long the set of expressions supported
-  /// by  FILTERs and BIND/GROUP BY is not the same.
+  /// Parse the expression of a filter statement (without the `FILTER` keyword).
+  /// This helper method is needed as long as the set of expressions supported
+  /// by FILTER and BIND/GROUP BY is not the same.
   static SparqlFilter parseFilterExpression(const string& filterContent);
 
   /**

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -23,6 +23,11 @@ class SparqlParser {
   explicit SparqlParser(const string& query);
   ParsedQuery parse();
 
+  /// Parse the Expression of a filter statement (without the `FILTER` keyword.
+  /// This helper method is needed, as long the set of expressions supported
+  /// by  FILTERs and BIND/GROUP BY is not the same.
+  static SparqlFilter parseFilterExpression(const string& filterContent);
+
   /**
    * @brief This method looks for the first string literal it can find and
    * parses it. During the parsing any escaped characters are resolved (e.g. \")

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -42,8 +42,7 @@ class SparqlParser {
   void parseSolutionModifiers(ParsedQuery* query);
   void addPrefix(const string& key, const string& value, ParsedQuery* query);
   // Returns true if it found a filter
-  bool parseFilter(vector<SparqlFilter>* _filters, bool failOnNoFilter = true,
-                   ParsedQuery::GraphPattern* pattern = nullptr);
+  std::optional<SparqlFilter> parseFilter(bool failOnNoFilter = true);
   // Parses an expressiong of the form (?a) = "en"
   void addLangFilter(const std::string& lhs, const std::string& rhs,
                      ParsedQuery::GraphPattern* pattern);

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -46,9 +46,6 @@ class SparqlParser {
   void parseSolutionModifiers(ParsedQuery* query);
   // Returns true if it found a filter
   std::optional<SparqlFilter> parseFilter(bool failOnNoFilter = true);
-  // Parses an expressiong of the form (?a) = "en"
-  void addLangFilter(const std::string& lhs, const std::string& rhs,
-                     ParsedQuery::GraphPattern* pattern);
 
   // Reads the next element of a triple (an iri, a variable, a property path,
   // etc.) out of s beginning at the current value of pos. Sets pos to the

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -1338,3 +1338,43 @@ TEST(ParserTest, Group) {
         ParseException);
   }
 }
+
+TEST(ParserTest, ParseFilterExpression) {
+  auto f = SparqlParser::parseFilterExpression("(LANG(?x) = \"en\")");
+  ASSERT_EQ(f, (SparqlFilter{SparqlFilter::LANG_MATCHES, "?x", "\"en\""}));
+
+  f = SparqlParser::parseFilterExpression("(?x <= 42.3)");
+  ASSERT_EQ(f, (SparqlFilter{SparqlFilter::LE, "?x", "42.3"}));
+}
+
+TEST(ParserTest, LanguageFilterPostProcessing) {
+  {
+    ParsedQuery q =
+        SparqlParser(
+            "SELECT * WHERE {?x <label> ?y . FILTER (LANG(?y) = \"en\")}")
+            .parse();
+    ASSERT_TRUE(q._rootGraphPattern._filters.empty());
+    const auto& triples =
+        q._rootGraphPattern._children[0].getBasic()._whereClauseTriples;
+    ASSERT_EQ(1u, triples.size());
+    ASSERT_EQ((SparqlTriple{"?x", PropertyPath::fromIri("@en@<label>"), "?y"}),
+              triples[0]);
+  }
+  {
+    ParsedQuery q =
+        SparqlParser(
+            "SELECT * WHERE {<somebody> ?p ?y . FILTER (LANG(?y) = \"en\")}")
+            .parse();
+    ASSERT_TRUE(q._rootGraphPattern._filters.empty());
+    const auto& triples =
+        q._rootGraphPattern._children[0].getBasic()._whereClauseTriples;
+    ASSERT_EQ(2u, triples.size());
+    ASSERT_EQ((SparqlTriple{"<somebody>", PropertyPath::fromIri("?p"), "?y"}),
+              triples[0]);
+    ASSERT_EQ(
+        (SparqlTriple{
+            "?y", PropertyPath::fromIri("<QLever-internal-function/langtag>"),
+            "<QLever-internal-function/@en>"}),
+        triples[1]);
+  }
+}


### PR DESCRIPTION
Then Julian can integrate it into the ANTLR parser as long as we don't have the "proper" FILTER expressions.

TODO: Do we actually have unit or e2e tests for the Language Filters?
TODO: Support the efficient handling of language filters in combination with property paths like `rdfs:label|skos:altLabel`