### PR TITLE
Clean up the Sparql ANTLR parser by consistently using `visitAlternative`

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -7,16 +7,17 @@
 #include <absl/strings/str_join.h>
 
 #include "../index/Index.h"
+#include "../parser/Alias.h"
 #include "../util/Conversions.h"
 #include "../util/HashSet.h"
 #include "./sparqlExpressions/SparqlExpression.h"
 #include "CallFixedSize.h"
 
 GroupBy::GroupBy(QueryExecutionContext* qec, vector<Variable> groupByVariables,
-                 std::vector<ParsedQuery::Alias> aliases)
+                 std::vector<Alias> aliases)
     : Operation(qec), _subtree(nullptr), _aliases{std::move(aliases)} {
   std::sort(_aliases.begin(), _aliases.end(),
-            [](const ParsedQuery::Alias& a1, const ParsedQuery::Alias& a2) {
+            [](const Alias& a1, const Alias& a2) {
               return a1._outVarName < a2._outVarName;
             });
 
@@ -32,7 +33,7 @@ GroupBy::GroupBy(QueryExecutionContext* qec, vector<Variable> groupByVariables,
     _varColMap[var] = colIndex;
     colIndex++;
   }
-  for (const ParsedQuery::Alias& a : _aliases) {
+  for (const Alias& a : _aliases) {
     _varColMap[a._outVarName] = colIndex;
     colIndex++;
   }
@@ -290,7 +291,7 @@ void GroupBy::computeResult(ResultTable* result) {
   }
 
   // parse the aggregate aliases
-  for (const ParsedQuery::Alias& alias : _aliases) {
+  for (const Alias& alias : _aliases) {
     aggregates.push_back(Aggregate{alias._expression,
                                    _varColMap.find(alias._outVarName)->second});
   }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "../parser/Alias.h"
 #include "../parser/ParsedQuery.h"
 #include "./Operation.h"
 #include "./QueryExecutionTree.h"
@@ -39,7 +40,7 @@ class GroupBy : public Operation {
    * @param aliases
    */
   GroupBy(QueryExecutionContext* qec, vector<Variable> groupByVariables,
-          std::vector<ParsedQuery::Alias> aliases);
+          std::vector<Alias> aliases);
 
  protected:
   virtual string asStringImpl(size_t indent = 0) const override;
@@ -92,7 +93,7 @@ class GroupBy : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<string> _groupByVariables;
-  std::vector<ParsedQuery::Alias> _aliases;
+  std::vector<Alias> _aliases;
   ad_utility::HashMap<string, size_t> _varColMap;
 
   virtual void computeResult(ResultTable* result) override;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <ctime>
 
+#include "../parser/Alias.h"
 #include "Bind.h"
 #include "CountAvailablePredicates.h"
 #include "Distinct.h"
@@ -60,7 +61,7 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) {
   if (!doGrouping && pq.hasSelectClause()) {
     // if there is no group by statement, but an aggregate alias is used
     // somewhere do grouping anyways.
-    for (const ParsedQuery::Alias& alias : pq.selectClause().getAliases()) {
+    for (const Alias& alias : pq.selectClause().getAliases()) {
       if (alias._expression.isAggregate({})) {
         doGrouping = true;
         break;
@@ -473,7 +474,7 @@ bool QueryPlanner::checkUsePatternTrick(
 
   if (returns_counts) {
     // We have already verified above that there is exactly one alias.
-    const ParsedQuery::Alias& alias = aliases.front();
+    const Alias& alias = aliases.front();
     auto countVariable =
         alias._expression.getVariableForNonDistinctCountOrNullopt();
     if (!countVariable.has_value()) {
@@ -1003,7 +1004,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
     SubtreePlan groupByPlan(_qec);
     groupByPlan._idsOfIncludedNodes = parent._idsOfIncludedNodes;
     groupByPlan._idsOfIncludedFilters = parent._idsOfIncludedFilters;
-    std::vector<ParsedQuery::Alias> aliases;
+    std::vector<Alias> aliases;
     if (pq.hasSelectClause()) {
       aliases = pq.selectClause().getAliases();
     }

--- a/src/parser/Alias.h
+++ b/src/parser/Alias.h
@@ -1,0 +1,27 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
+
+#pragma once
+
+#include <string>
+
+#include "../engine/sparqlExpressions/SparqlExpressionPimpl.h"
+
+using std::string;
+
+struct Alias {
+  sparqlExpression::SparqlExpressionPimpl _expression;
+  string _outVarName;
+  [[nodiscard]] std::string getDescriptor() const {
+    return "(" + _expression.getDescriptor() + " as " + _outVarName + ")";
+  }
+  bool operator==(const Alias& other) const {
+    return _expression.getDescriptor() == other._expression.getDescriptor() &&
+           _outVarName == other._outVarName;
+  }
+
+  [[nodiscard]] const std::string& targetVariable() const {
+    return _outVarName;
+  }
+};

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -16,5 +16,5 @@ add_library(parser
         ParallelBuffer.cpp
         SparqlParserHelpers.h SparqlParserHelpers.cpp
         TripleComponent.h
-        PropertyPath.h PropertyPath.cpp)
+        PropertyPath.h PropertyPath.cpp Alias.h)
 target_link_libraries(parser sparqlParser sparqlExpressions rdfEscaping re2 absl::flat_hash_map util)

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -17,6 +17,7 @@
 #include "../util/OverloadCallOperator.h"
 #include "../util/StringUtils.h"
 #include "./TripleComponent.h"
+#include "Alias.h"
 #include "ParseException.h"
 #include "PropertyPath.h"
 #include "data/Types.h"
@@ -226,22 +227,6 @@ class ParsedQuery {
     }
   }
 
-  struct Alias {
-    sparqlExpression::SparqlExpressionPimpl _expression;
-    string _outVarName;
-    [[nodiscard]] std::string getDescriptor() const {
-      return "(" + _expression.getDescriptor() + " as " + _outVarName + ")";
-    }
-    bool operator==(const Alias& other) const {
-      return _expression.getDescriptor() == other._expression.getDescriptor() &&
-             _outVarName == other._outVarName;
-    }
-
-    [[nodiscard]] const std::string& targetVariable() const {
-      return _outVarName;
-    }
-  };
-
   using VarOrAlias = std::variant<Variable, Alias>;
 
   // Represents either "all Variables" (Select *) or a list of explicitly
@@ -405,8 +390,8 @@ class ParsedQuery {
       string& item, const ad_utility::HashMap<string, string>& prefixMap);
 };
 
-using GroupKey = std::variant<sparqlExpression::SparqlExpressionPimpl,
-                              ParsedQuery::Alias, Variable>;
+using GroupKey =
+    std::variant<sparqlExpression::SparqlExpressionPimpl, Alias, Variable>;
 
 struct GraphPatternOperation {
   struct BasicGraphPattern {

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -11,6 +11,7 @@
 #include "../util/OverloadCallOperator.h"
 #include "./SparqlParserHelpers.h"
 #include "Alias.h"
+#include "data/Types.h"
 #include "sparqlParser/SparqlQleverVisitor.h"
 
 using namespace std::literals::string_literals;
@@ -63,7 +64,8 @@ void SparqlParser::parseQuery(ParsedQuery* query, QueryType queryType) {
     }
     auto parseResult =
         sparqlParserHelpers::parseConstructTemplate(str, std::move(prefixes));
-    query->_clause = std::move(parseResult.resultOfParse_);
+    query->_clause = std::move(parseResult.resultOfParse_)
+                         .value_or(ad_utility::sparql_types::Triples{});
     lexer_.reset(std::move(parseResult.remainingText_));
     lexer_.expect("where");
   } else if (queryType == SELECT_QUERY) {

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -57,16 +57,13 @@ ParsedQuery SparqlParser::parse() {
 // _____________________________________________________________________________
 void SparqlParser::parseQuery(ParsedQuery* query, QueryType queryType) {
   if (queryType == CONSTRUCT_QUERY) {
-    auto str = lexer_.getUnconsumedInput();
     SparqlQleverVisitor::PrefixMap prefixes;
     for (const auto& prefix : query->_prefixes) {
       prefixes[prefix._prefix] = prefix._uri;
     }
-    auto parseResult =
-        sparqlParserHelpers::parseConstructTemplate(str, std::move(prefixes));
-    query->_clause = std::move(parseResult.resultOfParse_)
-                         .value_or(ad_utility::sparql_types::Triples{});
-    lexer_.reset(std::move(parseResult.remainingText_));
+    query->_clause =
+        parseWithAntlr(sparqlParserHelpers::parseConstructTemplate, prefixes)
+            .value_or(ad_utility::sparql_types::Triples{});
     lexer_.expect("where");
   } else if (queryType == SELECT_QUERY) {
     parseSelect(query);

--- a/src/parser/data/Types.h
+++ b/src/parser/data/Types.h
@@ -28,4 +28,5 @@ struct TripleWithPropertyPath {
 using Node = std::pair<VarOrTerm, Triples>;
 using ObjectList = std::pair<Objects, Triples>;
 using PropertyList = std::pair<Tuples, Triples>;
+using VarOrAlias = std::variant<Variable, Alias>;
 }  // namespace ad_utility::sparql_types

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -164,7 +164,7 @@ Triples Visitor::visitTypesafe(Parser::ConstructQueryContext* ctx) {
   // TODO: once where clause is supported also process whereClause and
   // solutionModifiers
   if (ctx->constructTemplate()) {
-    return visitTypesafe(ctx->constructTemplate());
+    return visitTypesafe(ctx->constructTemplate()).value_or(Triples{});
   } else {
     return {};
   }
@@ -229,9 +229,9 @@ vector<GroupKey> Visitor::visitTypesafe(Parser::GroupClauseContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Visitor::Triples Visitor::visitTypesafe(Parser::ConstructTemplateContext* ctx) {
-  return ctx->constructTriples() ? visitTypesafe(ctx->constructTriples())
-                                 : Triples{};
+std::optional<Triples> Visitor::visitTypesafe(
+    Parser::ConstructTemplateContext* ctx) {
+  return visitOptional(ctx->constructTriples());
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -11,10 +11,8 @@ using namespace ad_utility::sparql_types;
 using ExpressionPtr = sparqlExpression::SparqlExpression::Ptr;
 using SparqlExpressionPimpl = sparqlExpression::SparqlExpressionPimpl;
 using SelectClause = ParsedQuery::SelectClause;
-using Alias = ParsedQuery::Alias;
 using Bind = GraphPatternOperation::Bind;
 using Values = GraphPatternOperation::Values;
-using VarOrAlias = std::variant<Variable, Alias>;
 
 using Visitor = SparqlQleverVisitor;
 using Parser = SparqlAutomaticParser;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -206,15 +206,9 @@ sparqlExpression::SparqlExpression::Ptr Visitor::visitTypesafe(
 LimitOffsetClause Visitor::visitTypesafe(
     Parser::LimitOffsetClausesContext* ctx) {
   LimitOffsetClause clause{};
-  if (ctx->limitClause()) {
-    clause._limit = visitTypesafe(ctx->limitClause());
-  }
-  if (ctx->offsetClause()) {
-    clause._offset = visitTypesafe(ctx->offsetClause());
-  }
-  if (ctx->textLimitClause()) {
-    clause._textLimit = visitTypesafe(ctx->textLimitClause());
-  }
+  visitIf(&clause._limit, ctx->limitClause());
+  visitIf(&clause._offset, ctx->offsetClause());
+  visitIf(&clause._textLimit, ctx->textLimitClause());
   return clause;
 }
 
@@ -1282,5 +1276,13 @@ auto Visitor::visitOptional(Ctx ctx)
     return visitTypesafe(ctx);
   } else {
     return std::nullopt;
+  }
+}
+
+// ____________________________________________________________________________________
+template <typename Ctx>
+void Visitor::visitIf(auto* target, Ctx ctx) {
+  if (ctx) {
+    *target = visitTypesafe(ctx);
   }
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1253,9 +1253,9 @@ template <typename Out, bool isRecursive, typename FirstContext,
           typename... Context>
 Out Visitor::visitAlternative(FirstContext* ctx, Context*... ctxs) {
   if constexpr (!isRecursive) {
-    int validContexts =
+    int numValidContexts =
         (static_cast<bool>(ctx) + ... + static_cast<bool>(ctxs));
-    AD_CHECK(validContexts == 1);
+    AD_CHECK(numValidContexts == 1);
   }
   if (ctx) {
     return {visitTypesafe(ctx)};
@@ -1263,6 +1263,8 @@ Out Visitor::visitAlternative(FirstContext* ctx, Context*... ctxs) {
     if constexpr (sizeof...(Context) != 0) {
       return visitAlternative<Out, true>(ctxs...);
     } else {
+      // Unreachable because of the `AD_CHECK` above, but the `if constexpr` is
+      // still needed for the compilation of the base case.
       AD_FAIL()  // Should be unreachable.
     }
   }
@@ -1270,7 +1272,7 @@ Out Visitor::visitAlternative(FirstContext* ctx, Context*... ctxs) {
 
 // ____________________________________________________________________________________
 template <typename Ctx>
-auto Visitor::visitOptional(Ctx ctx)
+auto Visitor::visitOptional(Ctx* ctx)
     -> std::optional<decltype(visitTypesafe(ctx))> {
   if (ctx) {
     return visitTypesafe(ctx);
@@ -1281,7 +1283,7 @@ auto Visitor::visitOptional(Ctx ctx)
 
 // ____________________________________________________________________________________
 template <typename Ctx>
-void Visitor::visitIf(auto* target, Ctx ctx) {
+void Visitor::visitIf(auto* target, Ctx* ctx) {
   if (ctx) {
     *target = visitTypesafe(ctx);
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -877,8 +877,8 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   Out visitAlternative(FirstContext* ctx, Context*... ctxs);
 
   template <typename Ctx>
-  auto visitOptional(Ctx ctx) -> std::optional<decltype(visitTypesafe(ctx))>;
+  auto visitOptional(Ctx* ctx) -> std::optional<decltype(visitTypesafe(ctx))>;
 
   template <typename Ctx>
-  void visitIf(auto* target, Ctx ctx);
+  void visitIf(auto* target, Ctx* ctx);
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -878,6 +878,6 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   template <typename Out>
   Out visitAlternative();
 
-  template <typename Out, typename Ctx>
-  std::optional<Out> visitOptional(Ctx ctx);
+  template <typename Ctx>
+  auto visitOptional(Ctx ctx) -> std::optional<decltype(visitTypesafe(ctx))>;
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -872,11 +872,9 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   string visitTypesafe(Parser::PnameNsContext* ctx);
 
-  template <typename Out, typename FirstContext, typename... Context>
-  Out visitAlternative(FirstContext ctx, Context... ctxs);
-
-  template <typename Out>
-  Out visitAlternative();
+  template <typename Out, bool isRecursive = false, typename FirstContext,
+            typename... Context>
+  Out visitAlternative(FirstContext* ctx, Context*... ctxs);
 
   template <typename Ctx>
   auto visitOptional(Ctx ctx) -> std::optional<decltype(visitTypesafe(ctx))>;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -13,6 +13,7 @@
 #include "../../util/HashMap.h"
 #include "../../util/OverloadCallOperator.h"
 #include "../../util/StringUtils.h"
+#include "../Alias.h"
 #include "../ParsedQuery.h"
 #include "../RdfEscaping.h"
 #include "../data/BlankNode.h"
@@ -149,21 +150,20 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
     return visitTypesafe(ctx);
   }
 
-  std::variant<Variable, ParsedQuery::Alias> visitTypesafe(
-      Parser::VarOrAliasContext* ctx);
+  std::variant<Variable, Alias> visitTypesafe(Parser::VarOrAliasContext* ctx);
 
   Any visitAlias(Parser::AliasContext* ctx) override {
     return visitTypesafe(ctx);
   }
 
-  ParsedQuery::Alias visitTypesafe(Parser::AliasContext* ctx);
+  Alias visitTypesafe(Parser::AliasContext* ctx);
 
   Any visitAliasWithoutBrackets(
       Parser::AliasWithoutBracketsContext* ctx) override {
     return visitTypesafe(ctx);
   }
 
-  ParsedQuery::Alias visitTypesafe(Parser::AliasWithoutBracketsContext* ctx);
+  Alias visitTypesafe(Parser::AliasWithoutBracketsContext* ctx);
 
   Any visitConstructQuery(Parser::ConstructQueryContext* ctx) override {
     return visitTypesafe(ctx);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -479,7 +479,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   PropertyPath visitTypesafe(Parser::VerbPathContext* ctx);
 
   Any visitVerbSimple(Parser::VerbSimpleContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
 
   Variable visitTypesafe(Parser::VerbSimpleContext* ctx);
@@ -498,8 +498,10 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   ObjectList visitTypesafe(Parser::ObjectListPathContext* ctx);
 
   Any visitObjectPath(Parser::ObjectPathContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
+
+  VarOrTerm visitTypesafe(Parser::ObjectPathContext* ctx);
 
   Any visitPath(Parser::PathContext* ctx) override {
     // returns PropertyPath
@@ -534,7 +536,10 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   Any visitPathMod(Parser::PathModContext* ctx) override {
     // Handled in visitPathElt.
-    return visitChildren(ctx);
+    throw ParseException(
+        "PathMod should be handled by upper clauses. It should not be visited. "
+        "Got: " +
+        ctx->getText());
   }
 
   Any visitPathPrimary(Parser::PathPrimaryContext* ctx) override {
@@ -577,6 +582,8 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   Node visitTypesafe(Parser::BlankNodePropertyListContext* ctx);
 
   Any visitTriplesNodePath(Parser::TriplesNodePathContext* ctx) override {
+    // TODO<qup42> use visitAlternative when NotSupported Exceptions and return
+    // types are implemented.
     return visitChildren(ctx);
   }
 
@@ -604,7 +611,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   Node visitTypesafe(Parser::GraphNodeContext* ctx);
 
   Any visitGraphNodePath(Parser::GraphNodePathContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
 
   VarOrTerm visitTypesafe(Parser::GraphNodePathContext* ctx);
@@ -705,8 +712,11 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   ExpressionPtr visitTypesafe(Parser::AdditiveExpressionContext* ctx);
 
   Any visitStrangeMultiplicativeSubexprOfAdditive(
-      Parser::StrangeMultiplicativeSubexprOfAdditiveContext* context) override {
-    return visitChildren(context);
+      Parser::StrangeMultiplicativeSubexprOfAdditiveContext* ctx) override {
+    throw ParseException(
+        "StrangeMultiplicativeSubexprOfAdditiveContext must not be visited. "
+        "Got: " +
+        ctx->getText());
   }
 
   Any visitMultiplicativeExpression(
@@ -823,8 +833,10 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   bool visitTypesafe(Parser::BooleanLiteralContext* ctx);
 
   Any visitString(Parser::StringContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
+
+  string visitTypesafe(Parser::StringContext* ctx);
 
   Any visitIri(Parser::IriContext* ctx) override { return visitTypesafe(ctx); }
 
@@ -865,4 +877,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   template <typename Out>
   Out visitAlternative();
+
+  template <typename Out, typename Ctx>
+  std::optional<Out> visitOptional(Ctx ctx);
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -386,7 +386,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
     return visitTypesafe(ctx);
   }
 
-  Triples visitTypesafe(Parser::ConstructTemplateContext* ctx);
+  std::optional<Triples> visitTypesafe(Parser::ConstructTemplateContext* ctx);
 
   Any visitConstructTriples(Parser::ConstructTriplesContext* ctx) override {
     return visitTypesafe(ctx);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -878,4 +878,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   template <typename Ctx>
   auto visitOptional(Ctx ctx) -> std::optional<decltype(visitTypesafe(ctx))>;
+
+  template <typename Ctx>
+  void visitIf(auto* target, Ctx ctx);
 };

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -292,13 +292,7 @@ TEST(SparqlParser, BlankNodeLabelled) {
 }
 
 TEST(SparqlParser, ConstructTemplateEmpty) {
-  string input = "{}";
-  ParserAndVisitor p{input};
-
-  auto triples = p.parser_.constructTemplate()
-                     ->accept(&p.visitor_)
-                     .as<ad_utility::sparql_types::Triples>();
-  ASSERT_THAT(triples, IsEmpty());
+  expectCompleteParse(parseConstructTemplate("{}"), testing::Eq(std::nullopt));
 }
 
 TEST(SparqlParser, ConstructTriplesSingletonWithTerminator) {

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -6,6 +6,7 @@
 
 #include <gmock/gmock.h>
 
+#include "../src/parser/Alias.h"
 #include "../src/parser/data/VarOrTerm.h"
 #include "../src/util/TypeTraits.h"
 
@@ -237,7 +238,7 @@ MATCHER_P(IsExpressionGroupKey, expr, "") {
 }
 
 MATCHER_P2(IsAliasGroupKey, expr, variable, "") {
-  if (const auto alias = unwrapVariant<GroupKey, ParsedQuery::Alias>(arg)) {
+  if (const auto alias = unwrapVariant<GroupKey, Alias>(arg)) {
     return (alias->_expression.getDescriptor() == expr) &&
            (alias->_outVarName == variable);
   }


### PR DESCRIPTION
- use `visitAlternative` where currently possible
- implement `visitOptional` for clauses that are optional and return `std::optional<...>`
- some little general cleanup (more concise control flow, removal of some `visitChildren`)