### PR TITLE
Improve parsing of numeric literals in the Sparql parser

### DIFF
--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -141,6 +141,9 @@ inline auto parsePrefixedName = std::bind_front(
 inline auto parseIriref =
     std::bind_front(parseFront, &SparqlAutomaticParser::iriref, "iriRef");
 
+inline auto parseNumericLiteral = std::bind_front(
+    parseFront, &SparqlAutomaticParser::numericLiteral, "numericLiteral");
+
 }  // namespace sparqlParserHelpers
 
 #endif  // QLEVER_SPARQLPARSERHELPERS_H

--- a/src/parser/data/Literal.h
+++ b/src/parser/data/Literal.h
@@ -28,6 +28,10 @@ class Literal {
   explicit Literal(T&& t)
       : _stringRepresentation(toString(std::forward<T>(t))) {}
 
+  Literal(std::variant<int64_t, double> t) {
+    std::visit([this](auto& x) { _stringRepresentation = toString(x); }, t);
+  }
+
   static_assert(!ad_utility::Streamable<Literal>,
                 "If Literal satisfies the Streamable concept, copy and move "
                 "constructors are hidden, leading to unexpected behaviour");

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1060,12 +1060,10 @@ ExpressionPtr Visitor::visitTypesafe(Parser::PrimaryExpressionContext* ctx) {
         ad_utility::OverloadCallOperator{integralWrapper, doubleWrapper},
         visitTypesafe(ctx->numericLiteral()));
   } else if (ctx->booleanLiteral()) {
-    auto b = visitTypesafe(ctx->booleanLiteral());
-    return make_unique<BoolExpression>(b);
+    return make_unique<BoolExpression>(visitTypesafe(ctx->booleanLiteral()));
   } else if (ctx->var()) {
-    sparqlExpression::Variable v;
-    v._variable = ctx->var()->getText();
-    return make_unique<VariableExpression>(v);
+    return make_unique<VariableExpression>(
+        sparqlExpression::Variable{ctx->var()->getText()});
   } else {
     return visitAlternative<ExpressionPtr>(
         ctx->builtInCall(), ctx->iriOrFunction(), ctx->brackettedExpression());
@@ -1205,7 +1203,7 @@ std::variant<int64_t, double> parseNumericLiteral(Ctx* ctx, bool parseAsInt) {
     }
   } catch (const std::out_of_range& range) {
     throw ParseException("Could not parse Numeric Literal \"" + ctx->getText() +
-                         "\". Is is out of range. Reason: " + range.what());
+                         "\". It is out of range. Reason: " + range.what());
   }
 }
 }  // namespace

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -783,38 +783,35 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   std::string visitTypesafe(Parser::RdfLiteralContext* ctx);
 
   Any visitNumericLiteral(Parser::NumericLiteralContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
+
+  std::variant<int64_t, double> visitTypesafe(
+      Parser::NumericLiteralContext* ctx);
 
   Any visitNumericLiteralUnsigned(
       Parser::NumericLiteralUnsignedContext* ctx) override {
-    // TODO: refactor to return variant
-    if (ctx->INTEGER()) {
-      return std::stoull(ctx->getText());
-    } else {
-      return std::stod(ctx->getText());
-    }
+    return visitTypesafe(ctx);
   }
+
+  std::variant<int64_t, double> visitTypesafe(
+      Parser::NumericLiteralUnsignedContext* ctx);
 
   Any visitNumericLiteralPositive(
       Parser::NumericLiteralPositiveContext* ctx) override {
-    // TODO: refactor to return variant
-    if (ctx->INTEGER_POSITIVE()) {
-      return std::stoull(ctx->getText());
-    } else {
-      return std::stod(ctx->getText());
-    }
+    return visitTypesafe(ctx);
   }
+
+  std::variant<int64_t, double> visitTypesafe(
+      Parser::NumericLiteralPositiveContext* ctx);
 
   Any visitNumericLiteralNegative(
       Parser::NumericLiteralNegativeContext* ctx) override {
-    // TODO: refactor to return variant
-    if (ctx->INTEGER_NEGATIVE()) {
-      return std::stoll(ctx->getText());
-    } else {
-      return std::stod(ctx->getText());
-    }
+    return visitTypesafe(ctx);
   }
+
+  std::variant<int64_t, double> visitTypesafe(
+      Parser::NumericLiteralNegativeContext* ctx);
 
   Any visitBooleanLiteral(Parser::BooleanLiteralContext* ctx) override {
     return visitTypesafe(ctx);

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -20,14 +20,14 @@ using namespace sparqlParserHelpers;
 
 template <typename T>
 void testNumericLiteral(const std::string& input, T target) {
-  ParserAndVisitor p(input);
-  auto literalContext = p.parser_.numericLiteral();
-  auto result = p.visitor_.visitNumericLiteral(literalContext).as<T>();
+  auto result = sparqlParserHelpers::parseNumericLiteral(input);
+  ASSERT_EQ(result.remainingText_.size(), 0);
+  auto value = get<T>(result.resultOfParse_);
 
   if constexpr (std::is_floating_point_v<T>) {
-    ASSERT_FLOAT_EQ(target, result);
+    ASSERT_FLOAT_EQ(target, value);
   } else {
-    ASSERT_EQ(target, result);
+    ASSERT_EQ(target, value);
   }
 }
 
@@ -44,9 +44,9 @@ TEST(SparqlParser, NumericLiterals) {
   testNumericLiteral("3.0", 3.0);
   testNumericLiteral("3.0e2", 300.0);
   testNumericLiteral("3.0e-2", 0.030);
-  testNumericLiteral("3", 3ull);
+  testNumericLiteral("3", (int64_t)3ll);
   testNumericLiteral("-3.0", -3.0);
-  testNumericLiteral("-3", -3ll);
+  testNumericLiteral("-3", (int64_t)-3ll);
 
   // TODO<joka921> : Unit tests with random numbers
 }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -25,7 +25,7 @@ void testNumericLiteral(const std::string& input, T target) {
   auto value = get<T>(result.resultOfParse_);
 
   if constexpr (std::is_floating_point_v<T>) {
-    ASSERT_FLOAT_EQ(target, value);
+    ASSERT_DOUBLE_EQ(target, value);
   } else {
     ASSERT_EQ(target, value);
   }
@@ -47,8 +47,15 @@ TEST(SparqlParser, NumericLiterals) {
   testNumericLiteral("3", (int64_t)3ll);
   testNumericLiteral("-3.0", -3.0);
   testNumericLiteral("-3", (int64_t)-3ll);
-
-  // TODO<joka921> : Unit tests with random numbers
+  testNumericLiteral("+3", (int64_t)3ll);
+  testNumericLiteral("+3.02", 3.02);
+  testNumericLiteral("+3.1234e12", 3123400000000.0);
+  testNumericLiteral(".234", 0.234);
+  testNumericLiteral("+.0123", 0.0123);
+  testNumericLiteral("-.5123", -0.5123);
+  testNumericLiteral(".234e4", 2340.0);
+  testNumericLiteral("+.0123E-3", 0.0000123);
+  testNumericLiteral("-.5123E12", -512300000000.0);
 }
 
 TEST(SparqlParser, Prefix) {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -40,6 +40,13 @@ using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::SizeIs;
 
+namespace {
+template <typename Exception = ParseException>
+void expectNumericLiteralFails(const string& input) {
+  EXPECT_THROW(parseNumericLiteral(input), Exception) << input;
+}
+}  // namespace
+
 TEST(SparqlParser, NumericLiterals) {
   testNumericLiteral("3.0", 3.0);
   testNumericLiteral("3.0e2", 300.0);
@@ -56,6 +63,10 @@ TEST(SparqlParser, NumericLiterals) {
   testNumericLiteral(".234e4", 2340.0);
   testNumericLiteral("+.0123E-3", 0.0000123);
   testNumericLiteral("-.5123E12", -512300000000.0);
+  expectNumericLiteralFails("1000000000000000000000000000000000000");
+  expectNumericLiteralFails("-99999999999999999999");
+  expectNumericLiteralFails("12E400");
+  expectNumericLiteralFails("-4.2E550");
 }
 
 TEST(SparqlParser, Prefix) {


### PR DESCRIPTION
Numeric Literals are now parsed into `variant<int64_t, double>`. Cleaned up the code that previously handled the numeric literals `Any`. AFAIK to be standard compliant we'd need integers with arbitrary size. So removing 1 Bit in the unsigned case shouldn't make that big of a difference. Even more so since they already were converted to `int64_t` in some cases.

TODO:
- [x] touch up of the `NumericLiterals` tests