### PR TITLE
Bugfix: catch exceptions that occur in the pattern trick computation

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -707,6 +707,44 @@ queries:
       - contains_row: ["<label>", 134]
 
 
+  - query : count-available-predicates-wrong-datatype
+    type: no-text
+    sparql: |
+      SELECT ?p (COUNT(?p) as ?count) WHERE {
+        ?h1 ql:has-predicate ?p .
+        ?a <Height> ?h1 .
+        ?a <Profession> ?profession .
+      }
+      GROUP BY ?p
+    checks:
+      - num_rows: 0
+      - num_cols: 2
+      - selected: ["?p", "?count"]
+
+
+  - query : count-available-predicates-mixed-datatypes
+    type: no-text
+    sparql: |
+      SELECT ?p (COUNT(?p) as ?count) WHERE {
+        ?a ql:has-predicate ?p .
+        {
+          ?a <Height> ?h1 .
+          ?a <Profession> ?profession .
+        } UNION {
+          # the heights have no predicates (see the two queries above)
+          ?x <Height> ?a
+        }
+      }
+      GROUP BY ?p
+    checks:
+      - num_rows: 109
+      - num_cols: 2
+      - selected: ["?p", "?count"]
+      - contains_row: ["<Film_appeared_in>", 56]
+      - contains_row: ["<Patent>", 2]
+      - contains_row: ["<label>", 134]
+
+
   - query : count-available-predicates-on-single-entity
     type: no-text
     sparql: |

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -322,11 +322,8 @@ void CountAvailablePredicates::computePatternTrick(
 
   LOG(DEBUG) << "Converting PatternMap to vector" << std::endl;
   // flatten into a vector, to make iterable
-  std::vector<std::pair<size_t, size_t>> patternVec;
-  patternVec.reserve(patternCounts.size());
-  for (const auto& p : patternCounts) {
-    patternVec.push_back(p);
-  }
+  const std::vector<std::pair<size_t, size_t>> patternVec(patternCounts.begin(),
+                                                          patternCounts.end());
 
   LOG(DEBUG) << "Start translating pattern counts to predicate counts"
              << std::endl;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -282,7 +282,12 @@ void CountAvailablePredicates::computePatternTrick(
       if (inputIdx > 0 && subjectId == input(inputIdx - 1, subjectColumn)) {
         continue;
       }
-      AD_CHECK(subjectId.getDatatype() == Datatype::VocabIndex);
+      if (subjectId.getDatatype() != Datatype::VocabIndex) {
+        // Ignore numeric literals and other types that are folded into
+        // the value IDs. They can never be subjects and thus also have no
+        // patterns.
+        continue;
+      }
       auto subject = subjectId.getVocabIndex().get();
 
       if (subject < hasPattern.size() && hasPattern[subject] != NO_PATTERN) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -908,8 +908,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
       // interested in their predicates.
       auto subjectColumn =
           parent._qet->getVariableColumn(patternTrickTriple._s.getString());
-      LOG(INFO) << "Subject column of CountAvailablePredicate is "
-                << subjectColumn << std::endl;
       const std::vector<size_t>& resultSortedOn =
           parent._qet->getRootOperation()->getResultSortedOn();
       bool isSorted =

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -906,23 +906,14 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
     for (const auto& parent : *previous) {
       // Determine the column containing the subjects for which we are
       // interested in their predicates.
-      auto it = parent._qet->getVariableColumns().find(
-          patternTrickTriple._s.getString());
-      if (it == parent._qet->getVariableColumns().end()) {
-        AD_THROW(ad_semsearch::Exception::BAD_QUERY,
-                 "The root operation of the "
-                 "query excecution tree does "
-                 "not contain a column for "
-                 "variable " +
-                     patternTrickTriple._s.toString() +
-                     " required by the pattern "
-                     "trick.");
-      }
-      size_t subjectColumn = it->second;
+      auto subjectColumn =
+          parent._qet->getVariableColumn(patternTrickTriple._s.getString());
+      LOG(INFO) << "Subject column of CountAvailablePredicate is "
+                << subjectColumn << std::endl;
       const std::vector<size_t>& resultSortedOn =
           parent._qet->getRootOperation()->getResultSortedOn();
       bool isSorted =
-          resultSortedOn.size() > 0 && resultSortedOn[0] == subjectColumn;
+          !resultSortedOn.empty() && resultSortedOn[0] == subjectColumn;
       // a and b need to be ordered properly first
       vector<pair<size_t, bool>> sortIndices = {
           std::make_pair(subjectColumn, false)};


### PR DESCRIPTION
Previously, calling the pattern trick on a variable that was bound to at least one ValueId that was not a vocabulary entry, 
would immediately crash the engine because of an exception inside an OpenMP contest, that cannot be caught.
* These Ids are no longer considered as errors, but simply ignored (they have no pattern).
* Add another fix that hopefully fixes the spurious E2e test fails in the current master.