### PR TITLE
Proper error message when a file can't be opened

### DIFF
--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -19,8 +19,8 @@ int main(int argc, char** argv) {
   size_t numFiles = atoi(argv[2]);
 
   VocabularyMerger m;
-  std::ofstream file(basename + INTERNAL_VOCAB_SUFFIX);
-  AD_CHECK(file.is_open());
+
+  auto file = ad_utility::makeOfstream(basename + INTERNAL_VOCAB_SUFFIX);
   auto internalVocabularyAction = [&file](const auto& word) {
     file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
   };

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -264,7 +264,7 @@ void Filter::computeFilterRange(IdTableStatic<WIDTH>* res, size_t lhs,
     }
     default:
       // This should be unreachable.
-      AD_CHECK(false);
+      AD_FAIL();
   }
 }
 

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -184,7 +184,7 @@ class Filter : public Operation {
       case SparqlFilter::GE:
         return valueIdComparators::Comparison::GE;
       default:
-        AD_CHECK(false);
+        AD_FAIL();
     }
   }
 };

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -170,7 +170,7 @@ void GroupBy::processGroup(
           singleResult, *(outTable->_localVocab), false);
     } else {
       // This should never happen since aggregates always return constants.
-      AD_CHECK(false)
+      AD_FAIL()
     }
   };
 

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -198,7 +198,7 @@ void Minus::computeMinus(const IdTable& dynA, const IdTable& dynB,
           }
         } break;
         default:
-          AD_CHECK(false);
+          AD_FAIL();
       }
       checkTimeout();
     }

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -335,7 +335,7 @@ QueryExecutionTree::idToStringAndType(Id id,
       return std::pair{_qec->getIndex().getTextExcerpt(id.getTextRecordIndex()),
                        nullptr};
   }
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 // __________________________________________________________________________________________________________

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -699,7 +699,7 @@ boost::asio::awaitable<void> Server::processQuery(
       default:
         // This should never happen, because we have carefully restricted the
         // subset of mediaTypes that can occur here.
-        AD_CHECK(false);
+        AD_FAIL();
     }
     // Print the runtime info. This needs to be done after the query
     // was computed.

--- a/src/engine/TwoColumnJoin.h
+++ b/src/engine/TwoColumnJoin.h
@@ -55,7 +55,7 @@ class TwoColumnJoin : public Operation {
       return sizeEstimate;
     }
     // All cases should be covered now, so that we should never come here.
-    AD_CHECK(false);
+    AD_FAIL();
   }
 
   virtual bool knownEmptyResult() override {

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -26,7 +26,7 @@ double NumericValueGetter::operator()(StrongIdWithResultType strongId,
     case Datatype::TextRecordIndex:
       return std::numeric_limits<double>::quiet_NaN();
   }
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 // _____________________________________________________________________________
@@ -60,7 +60,7 @@ bool EffectiveBooleanValueGetter::operator()(StrongIdWithResultType strongId,
     case Datatype::TextRecordIndex:
       return true;
   }
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 // ____________________________________________________________________________
@@ -87,7 +87,7 @@ string StringValueGetter::operator()(StrongIdWithResultType strongId,
     case Datatype::TextRecordIndex:
       context->_qec.getIndex().getTextExcerpt(id.getTextRecordIndex());
   }
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 // ____________________________________________________________________________

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -224,7 +224,7 @@ class ValueId {
       case Datatype::TextRecordIndex:
         return std::invoke(visitor, getTextRecordIndex());
       default:
-        AD_CHECK(false);
+        AD_FAIL();
     }
   }
 

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -184,7 +184,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForDouble(
     rangeFilter.addEqual(beginOfNegatives, negativeEnd);
     rangeFilter.addSmaller(negativeEnd, end);
   } else {
-    AD_CHECK(false);
+    AD_FAIL();
   }
   return std::move(rangeFilter).getResult();
 }
@@ -233,7 +233,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForInt(
     rangeFilter.addEqual(eqBegin, eqEnd);
     rangeFilter.addGreater(eqEnd, end);
   } else {
-    AD_CHECK(false);
+    AD_FAIL();
   }
   return std::move(rangeFilter).getResult();
 }
@@ -314,7 +314,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
       return simplify(
           detail::getRangesForIndexTypes(begin, end, valueId, comparison));
   }
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 /// Similar to `getRangesForId` above but takes a range [valueIdBegin,
@@ -348,7 +348,7 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
       return simplifyRanges(detail::getRangesForIndexTypes(
           begin, end, valueIdBegin, valueIdEnd, comparison));
   }
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 namespace detail {
@@ -369,7 +369,7 @@ bool compareIdsImpl(ValueId a, ValueId b, auto comparator) {
     if constexpr (requires() { std::invoke(comparator, aValue, bValue); }) {
       return std::invoke(comparator, aValue, bValue);
     } else {
-      AD_CHECK(false);
+      AD_FAIL();
     }
   };
 
@@ -398,7 +398,7 @@ inline bool compareIds(ValueId a, ValueId b, Comparison comparison) {
     case Comparison::GT:
       return detail::compareIdsImpl(a, b, std::greater<>());
     default:
-      AD_CHECK(false);
+      AD_FAIL();
   }
 }
 
@@ -423,7 +423,7 @@ inline bool compareWithEqualIds(ValueId a, ValueId bBegin, ValueId bEnd,
     case Comparison::GT:
       return detail::compareIdsImpl(a, bEnd, std::greater_equal<>());
     default:
-      AD_CHECK(false);
+      AD_FAIL();
   }
 }
 

--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -278,7 +278,7 @@ void Index::processWordsForInvertedLists(const string& contextFile,
       if (!ret) {
         LOG(ERROR) << "ERROR: word \"" << line._word << "\" "
                    << "not found in textVocab. Terminating\n";
-        AD_CHECK(false);
+        AD_FAIL();
       }
       wordsInContext[wid] += line._score;
     }
@@ -559,7 +559,7 @@ void Index::calculateBlockBoundariesImpl(
     LOG(ERROR) << "You have chosen a locale where the prefixes aaaa, aaab, "
                   "..., zzzz are not alphabetically ordered. This is currently "
                   "unsupported when building a text index";
-    AD_CHECK(false);
+    AD_FAIL();
   }
 
   if (index._textVocab.size() == 0) {

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -220,7 +220,7 @@ class Index {
         return getTextExcerpt(id.getTextRecordIndex());
     }
     // should be unreachable because the enum is exhaustive.
-    AD_CHECK(false);
+    AD_FAIL();
   }
 
   bool getId(const string& element, Id* id) const {

--- a/src/index/PrefixHeuristic.cpp
+++ b/src/index/PrefixHeuristic.cpp
@@ -10,6 +10,7 @@
 #include "../parser/RdfEscaping.h"
 #include "../parser/Tokenizer.h"
 #include "../util/Exception.h"
+#include "../util/File.h"
 #include "../util/Log.h"
 #include "../util/StringUtils.h"
 
@@ -163,8 +164,7 @@ void TreeNode::penaltize() {
 std::vector<string> calculatePrefixes(const string& filename,
                                       size_t numPrefixes, size_t codelength,
                                       bool alwaysAddCode) {
-  std::ifstream ifs(filename);
-  AD_CHECK(ifs.is_open());
+  auto ifs = ad_utility::makeIfstream(filename);
 
   size_t MinPrefixLength = alwaysAddCode ? 1 : codelength + 1;
   size_t actualCodeLength = alwaysAddCode ? 0 : codelength;

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -37,7 +37,7 @@ void Vocabulary<S, C>::readFromFile(const string& fileName,
                    "uncompressed vocabulary. This is not valid and a "
                    "programming error. Terminating"
                 << std::endl;
-      AD_CHECK(false);
+      AD_FAIL();
     }
 
     LOG(DEBUG) << "Registering external vocabulary" << std::endl;

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -46,8 +46,8 @@ VocabularyMerger::VocMergeRes VocabularyMerger::mergeVocabulary(
   std::vector<uint64_t> numWordsLeftInPartialVocabulary;
 
   if (!_noIdMapsAndIgnoreExternalVocab) {
-    _outfileExternal.open(basename + EXTERNAL_LITS_TEXT_FILE_NAME);
-    AD_CHECK(_outfileExternal.is_open());
+    _outfileExternal =
+        ad_utility::makeOfstream(basename + EXTERNAL_LITS_TEXT_FILE_NAME);
   }
   std::vector<bool> endOfFile(numFiles, false);
 
@@ -269,7 +269,7 @@ void writeMappedIdsToExtVec(const auto& input,
       if (iterator == map.end()) {
         LOG(ERROR) << "not found in partial local vocabulary: " << curTriple[k]
                    << std::endl;
-        AD_CHECK(false);
+        AD_FAIL();
       }
       mappedTriple[k] =
           Id::makeFromVocabIndex(VocabIndex::make(iterator->second));

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -109,8 +109,7 @@ void VocabularyOnDisk::buildFromStringsAndIds(
 // _____________________________________________________________________________
 void VocabularyOnDisk::buildFromTextFile(const string& textFileName,
                                          const string& outFileName) {
-  std::ifstream infile(textFileName);
-  AD_CHECK(infile.is_open());
+  auto infile = ad_utility::makeIfstream(textFileName);
   auto lineGenerator =
       [&infile]() -> cppcoro::generator<std::pair<std::string_view, uint64_t>> {
     std::string word;

--- a/src/index/vocabulary/PrefixCompressor.h
+++ b/src/index/vocabulary/PrefixCompressor.h
@@ -80,7 +80,7 @@ class PrefixCompressor {
         LOG(ERROR)
             << "More than " << NUM_COMPRESSION_PREFIXES
             << " prefixes have been specified. This should never happen\n";
-        AD_CHECK(false);
+        AD_FAIL();
       }
       _prefixToCode[prefixIdx] = fulltext;
       _codeToPrefix.emplace_back(prefixIdx + MIN_COMPRESSION_PREFIX, fulltext);

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -181,7 +181,7 @@ void ParsedQuery::expandPrefixes() {
           arg._subquery.expandPrefixes();
         } else if constexpr (std::is_same_v<T,
                                             GraphPatternOperation::TransPath>) {
-          AD_CHECK(false);
+          AD_FAIL();
           // we may never be in an transitive path here or a
           // subquery?TODO<joka921, verify by florian> at least this
           // shoudn't have worked before

--- a/src/parser/RdfEscaping.cpp
+++ b/src/parser/RdfEscaping.cpp
@@ -138,7 +138,7 @@ void unescapeStringAndNumericEscapes(InputIterator beginIterator,
 
       default:
         // should never happen
-        AD_CHECK(false);
+        AD_FAIL();
     }
     beginIterator = nextBackslashIterator + numCharactersFromInput;
   }
@@ -170,7 +170,7 @@ std::string escapeNewlinesAndBackslashes(std::string_view literal) {
         result.append("\\\\");
         break;
       default:
-        AD_CHECK(false);
+        AD_FAIL();
     }
     literal.remove_prefix(pos + 1);
   }

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -69,7 +69,7 @@ void SparqlParser::parseQuery(ParsedQuery* query, QueryType queryType) {
     parseSelect(query);
   } else {
     // Unsupported query type
-    AD_CHECK(false);
+    AD_FAIL();
   }
 
   lexer_.expect("{");
@@ -126,7 +126,7 @@ void SparqlParser::parseQuery(ParsedQuery* query, QueryType queryType) {
       }
     } else {
       // Invalid clause type
-      AD_CHECK(false);
+      AD_FAIL();
     }
   }
   if (!query->hasSelectClause()) {

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -60,7 +60,7 @@ class Variable {
           return qecIndex.getTextExcerpt(id.getTextRecordIndex());
       }
       // The switch is exhaustive
-      AD_CHECK(false);
+      AD_FAIL();
     }
     return std::nullopt;
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -545,7 +545,7 @@ Triples Visitor::visitTypesafe(Parser::TriplesSameSubjectContext* ctx) {
     appendVector(triples, std::move(propertyList.second));
   } else {
     // Invalid grammar
-    AD_CHECK(false);
+    AD_FAIL();
   }
   return triples;
 }
@@ -831,7 +831,7 @@ Node Visitor::visitTypesafe(Parser::GraphNodeContext* ctx) {
   } else if (ctx->triplesNode()) {
     return visitTriplesNode(ctx->triplesNode()).as<Node>();
   } else {
-    AD_CHECK(false);
+    AD_FAIL();
   }
 }
 
@@ -976,7 +976,7 @@ ExpressionPtr Visitor::visitTypesafe(Parser::AdditiveExpressionContext* ctx) {
       result = createExpression<sparqlExpression::SubtractExpression>(
           std::move(result), std::move(*childIt));
     } else {
-      AD_CHECK(false);
+      AD_FAIL();
     }
     ++childIt;
     ++opIt;
@@ -1004,7 +1004,7 @@ ExpressionPtr Visitor::visitTypesafe(
       result = createExpression<sparqlExpression::DivideExpression>(
           std::move(result), std::move(*childIt));
     } else {
-      AD_CHECK(false);
+      AD_FAIL();
     }
     ++childIt;
     ++opIt;
@@ -1236,7 +1236,7 @@ BlankNode Visitor::visitTypesafe(Parser::BlankNodeContext* ctx) {
     return {false, label};
   }
   // invalid grammar
-  AD_CHECK(false);
+  AD_FAIL();
 }
 
 // ____________________________________________________________________________________

--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -64,7 +64,7 @@ inline const char* toTypeIri(NumericType type) {
       return XSD_DOUBLE_TYPE;
     default:
       // This should never happen
-      AD_CHECK(false);
+      AD_FAIL();
   }
 }
 

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -281,13 +281,14 @@ inline void deleteFile(const std::filesystem::path& path,
 }
 
 namespace detail {
-template <typename Stream>
+template <typename Stream, bool forWriting>
 Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
   Stream stream{path.string(), AD_FWD(args)...};
+  std::string_view mode = forWriting ? "for writing" : "for reading";
   if (!stream.is_open()) {
     std::string error =
-        absl::StrCat("Could not open file \"", path.string(),
-                     "\". Possible causes: The file does not exist or the "
+        absl::StrCat("Could not open file \"", path.string(), "\" ", mode,
+                     ". Possible causes: The file does not exist or the "
                      "permissions are wrong. The absolute path is \"",
                      std::filesystem::absolute(path).string(), "\".");
     throw std::runtime_error{error};
@@ -300,12 +301,12 @@ Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
 // additionals `args`. Throw an exception stating the filename and the absolute
 // path when the file can't be opened.
 std::ifstream makeIfstream(const std::filesystem::path& path, auto&&... args) {
-  return detail::makeFilestream<std::ifstream>(path, AD_FWD(args)...);
+  return detail::makeFilestream<std::ifstream, false>(path, AD_FWD(args)...);
 }
 
 // Similar to `makeIfstream`, but returns `std::ofstream`
 std::ofstream makeOfstream(const std::filesystem::path& path, auto&&... args) {
-  return detail::makeFilestream<std::ofstream>(path, AD_FWD(args)...);
+  return detail::makeFilestream<std::ofstream, true>(path, AD_FWD(args)...);
 }
 
 }  // namespace ad_utility

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -289,7 +289,7 @@ Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
     std::string error =
         absl::StrCat("Could not open file \"", path.string(), "\" ", mode,
                      ". Possible causes: The file does not exist or the "
-                     "permissions are wrong. The absolute path is \"",
+                     "permissions are insufficient. The absolute path is \"",
                      std::filesystem::absolute(path).string(), "\".");
     throw std::runtime_error{error};
   }

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -3,6 +3,7 @@
 // Author: Björn Buchhold <buchholb>
 
 #pragma once
+#include <absl/strings/str_cat.h>
 #include <assert.h>
 #include <errno.h>
 #include <stdio.h>
@@ -12,11 +13,13 @@
 #include <unistd.h>
 
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
 #include "./Exception.h"
+#include "./Forward.h"
 #include "Log.h"
 #include "Timer.h"
 
@@ -275,6 +278,34 @@ inline void deleteFile(const std::filesystem::path& path,
                 << std::endl;
     }
   }
+}
+
+namespace detail {
+template <typename Stream>
+Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
+  Stream stream{path.string(), AD_FWD(args)...};
+  if (!stream.is_open()) {
+    std::string error =
+        absl::StrCat("Could not open file \"", path.string(),
+                     "\". Possible causes: The file does not exist or the "
+                     "permissions are wrong. The absolute path is \"",
+                     std::filesystem::absolute(path).string(), "\".");
+    throw std::runtime_error{error};
+  }
+  return stream;
+}
+}  // namespace detail
+
+// Open and return a std::ifstream from a given filename and optional
+// additionals `args`. Throw an exception stating the filename and the absolute
+// path when the file can't be opened.
+std::ifstream makeIfstream(const std::filesystem::path& path, auto&&... args) {
+  return detail::makeFilestream<std::ifstream>(path, AD_FWD(args)...);
+}
+
+// Similar to `makeIfstream`, but returns `std::ofstream`
+std::ofstream makeOfstream(const std::filesystem::path& path, auto&&... args) {
+  return detail::makeFilestream<std::ofstream>(path, AD_FWD(args)...);
 }
 
 }  // namespace ad_utility

--- a/src/util/HttpServer/HttpParser/AcceptHeaderQleverVisitor.h
+++ b/src/util/HttpServer/HttpParser/AcceptHeaderQleverVisitor.h
@@ -111,12 +111,12 @@ class AcceptHeaderQleverVisitor : public AcceptHeaderVisitor {
   }
 
   antlrcpp::Any visitType(AcceptHeaderParser::TypeContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
   antlrcpp::Any visitSubtype(AcceptHeaderParser::SubtypeContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
@@ -147,19 +147,19 @@ class AcceptHeaderQleverVisitor : public AcceptHeaderVisitor {
   }
 
   antlrcpp::Any visitQvalue(AcceptHeaderParser::QvalueContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
   antlrcpp::Any visitAcceptExt(
       AcceptHeaderParser::AcceptExtContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
   antlrcpp::Any visitParameter(
       AcceptHeaderParser::ParameterContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
@@ -169,19 +169,19 @@ class AcceptHeaderQleverVisitor : public AcceptHeaderVisitor {
   }
 
   antlrcpp::Any visitTchar(AcceptHeaderParser::TcharContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
   antlrcpp::Any visitQuotedString(
       AcceptHeaderParser::QuotedStringContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 
   antlrcpp::Any visitQuoted_pair(
       AcceptHeaderParser::Quoted_pairContext* ctx) override {
-    AD_CHECK(false);  // Should be unreachable.
+    AD_FAIL();  // Should be unreachable.
     return visitChildren(ctx);
   }
 };

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -51,9 +51,9 @@ void MmapVector<T>::writeMetaDataToEnd() {
 // __________________________________________________________________________
 template <class T>
 void MmapVector<T>::readMetaDataFromEnd() {
-  std::ifstream fs(_filename, std::ios::binary | std::ios::ate);
+  auto fs =
+      ad_utility::makeIfstream(_filename, std::ios::binary | std::ios::ate);
   // since we do not know _bytesize yet we have to seek from the end
-  AD_CHECK(fs.is_open());
   static constexpr off_t metaDataSize = sizeof(_size) + sizeof(_capacity) +
                                         sizeof(_bytesize) +
                                         sizeof(MagicNumber) + sizeof(Version);
@@ -225,10 +225,7 @@ void MmapVector<T>::open(size_t size, string filename, AccessPattern pattern) {
 
   // open the file in case it does not exist yet
   // (data will be overwritten anyway)
-  {
-    std::ofstream ofs(_filename);
-    AD_CHECK(ofs.is_open());
-  }
+  { auto ofs = ad_utility::makeOfstream(_filename); }
   auto info = convertArraySizeToFileSize(std::max(size, MinCapacity));
   _bytesize = info._bytesize;
   _capacity = info._capacity;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,10 +101,10 @@ addLinkAndDiscoverTest(VocabularyGeneratorTest index)
 
 addLinkAndDiscoverTest(HasPredicateScanTest engine)
 
-addLinkAndDiscoverTest(MmapVectorTest)
+addLinkAndDiscoverTest(MmapVectorTest absl::strings)
 
 # BufferedVectorTest also uses conflicting filenames.
-addLinkAndDiscoverTestSerial(BufferedVectorTest)
+addLinkAndDiscoverTestSerial(BufferedVectorTest absl::strings)
 
 addLinkAndDiscoverTest(UnionTest engine)
 
@@ -192,7 +192,7 @@ addLinkAndDiscoverTest(MilestoneIdTest absl::strings)
 # TODO<qup42, joka921> fix this
 addLinkAndDiscoverTest(VocabularyOnDiskTest index)
 
-addLinkAndDiscoverTest(VocabularyTest index)
+addLinkAndDiscoverTest(VocabularyTest index absl::strings)
 
 addLinkAndDiscoverTest(IteratorTest)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,7 +70,7 @@ addLinkAndDiscoverTest(CacheTest absl::flat_hash_map)
 addLinkAndDiscoverTest(ConcurrentCacheTest absl::flat_hash_map)
 
 # This test also seems to use the same filenames and should be fixed.
-addLinkAndDiscoverTestSerial(FileTest)
+addLinkAndDiscoverTestSerial(FileTest absl::strings)
 
 addLinkAndDiscoverTest(Simple8bTest)
 

--- a/test/CompressorStreamTest.cpp
+++ b/test/CompressorStreamTest.cpp
@@ -34,7 +34,7 @@ class CompressorStreamTestFixture
       filterStream.push(io::zlib_decompressor());
     } else {
       // Unsupported decompression
-      AD_CHECK(false);
+      AD_FAIL();
     }
     filterStream.push(io::back_inserter(result));
 

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -195,3 +195,18 @@ TEST(File, move) {
   ad_utility::deleteFile(filename);
 }
 }  // namespace ad_utility
+
+TEST(File, makeFilestream) {
+  std::string filename = "makeFilstreamTest.dat";
+  ad_utility::makeOfstream(filename) << "helloAgain\n";
+  std::string s;
+  auto reader = ad_utility::makeIfstream(filename);
+  ASSERT_TRUE(reader.is_open());
+  ASSERT_TRUE(std::getline(reader, s));
+  ASSERT_EQ("helloAgain", s);
+  ASSERT_FALSE(std::getline(reader, s));
+
+  // Throw on nonexisting file
+  ASSERT_THROW(ad_utility::makeIfstream("nonExisting1620349.datxyz"),
+               std::runtime_error);
+}

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -159,8 +159,7 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
   VocabularyMerger::VocMergeRes res;
   {
     VocabularyMerger m;
-    std::ofstream file(_basePath + INTERNAL_VOCAB_SUFFIX);
-    AD_CHECK(file.is_open());
+    auto file = ad_utility::makeOfstream(_basePath + INTERNAL_VOCAB_SUFFIX);
     auto internalVocabularyAction = [&file](const auto& word) {
       file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
     };
@@ -202,8 +201,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
 
     {
       VocabularyMerger m;
-      std::ofstream file(basename + INTERNAL_VOCAB_SUFFIX);
-      AD_CHECK(file.is_open());
+      auto file = ad_utility::makeOfstream(basename + INTERNAL_VOCAB_SUFFIX);
       auto internalVocabularyAction = [&file](const auto& word) {
         file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
       };
@@ -246,8 +244,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
 
     {
       VocabularyMerger m;
-      std::ofstream file(basename + INTERNAL_VOCAB_SUFFIX);
-      AD_CHECK(file.is_open());
+      auto file = ad_utility::makeOfstream(basename + INTERNAL_VOCAB_SUFFIX);
       auto internalVocabularyAction = [&file](const auto& word) {
         file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
       };


### PR DESCRIPTION
replace AD_CHECK(someFile.is_open()) by functions
that open a filestream and throw a human-readable error
if something doesn't work.