### PR TITLE
For subqueries, keep one query plan per ordering

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1260,8 +1260,9 @@ queries:
   #  checks:
   #    - selected: ["?count"]
 
-  # One of the following two queries used to throw an exception
-  # about no execution tree being found
+  # For both of the following two queries to work, the query optimizer must
+  # produce two query plans for the result of the subquery (it used to
+  # produce only one).
   - query: subquery-one-triple-1
     type: no-text
     sparql: |

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1259,3 +1259,36 @@ queries:
   #    GROUP BY SUBSTR(?scientist, 0, 2)
   #  checks:
   #    - selected: ["?count"]
+
+  # One of the following two queries used to throw an exception
+  # about no execution tree being found
+  - query: subquery-one-triple-1
+    type: no-text
+    sparql: |
+      SELECT (COUNT(?x) as ?count) ?place WHERE {
+          {SELECT * WHERE {?x <is-a> ?y}} .
+          ?x <Place_of_birth> ?place .
+      }
+      GROUP BY ?place
+      ORDER BY DESC(?count)
+    checks:
+      - num_cols: 2
+      #- num_rows : 5295 #greater than current limit
+      - selected: [ "?count", "?place" ]
+      - contains_row: [ 2476, "<New_York_City>" ]
+      - order_numeric: { "dir": "DESC", "var": "?count" }
+  - query: subquery-one-triple-2
+    type: no-text
+    sparql: |
+      SELECT (COUNT(?x) as ?count) ?y WHERE {
+                {SELECT * WHERE {?x <is-a> ?y}} .
+                <Albert_Einstein> <is-a> ?y .
+            }
+            GROUP BY ?y
+            ORDER BY DESC(?count)
+    checks:
+      - num_cols: 2
+      #- num_rows : 5295 #greater than current limit
+      - selected: [ "?count", "?y" ]
+      - contains_row: [ 1398, "<Educator>" ]
+      - order_numeric: { "dir": "DESC", "var": "?count" }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -48,7 +48,8 @@ QueryPlanner::QueryPlanner(QueryExecutionContext* qec)
     : _qec(qec), _internalVarCount(0), _enablePatternTrick(true) {}
 
 // _____________________________________________________________________________
-QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) {
+std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createExecutionTrees(
+    ParsedQuery& pq) {
   // Look for ql:has-predicate to determine if the pattern trick should be used.
   // If the pattern trick is used the ql:has-predicate triple will be removed
   // from the list of where clause triples. Otherwise the ql:has-relation triple
@@ -115,16 +116,24 @@ QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) {
   }
 
   AD_CHECK_GT(lastRow.size(), 0);
-  auto minInd = findCheapestExecutionTree(lastRow);
   if (pq._rootGraphPattern._optional) {
-    lastRow[minInd].type = SubtreePlan::OPTIONAL;
+    for (auto& plan : lastRow) {
+      plan.type = SubtreePlan::OPTIONAL;
+    }
   }
 
-  SubtreePlan final = lastRow[minInd];
-  final._qet->setTextLimit(pq._limitOffset._textLimit);
+  for (auto& plan : lastRow) {
+    plan._qet->setTextLimit(pq._limitOffset._textLimit);
+  }
+  return lastRow;
+}
 
+// _____________________________________________________________________
+QueryExecutionTree QueryPlanner::createExecutionTree(ParsedQuery& pq) {
+  auto lastRow = createExecutionTrees(pq);
+  auto minInd = findCheapestExecutionTree(lastRow);
   LOG(DEBUG) << "Done creating execution plan.\n";
-  return *final._qet;
+  return *lastRow[minInd]._qet;
 }
 
 std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
@@ -331,12 +340,12 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
       } else if constexpr (std::is_same_v<T, GraphPatternOperation::Subquery>) {
         // TODO<joka921> We currently do not optimize across subquery borders
         // but abuse them as "optimization hints". In theory, one could even
-        // remove the ORDER BY clauses of a subquery if we can prove, that
+        // remove the ORDER BY clauses of a subquery if we can prove that
         // the results will be reordered anyway.
-        SubtreePlan plan(_qec);
-        plan._qet = std::make_shared<QueryExecutionTree>(
-            createExecutionTree(arg._subquery));
-        joinCandidates(std::vector{std::move(plan)});
+
+        // Use the complete last row of the dynamic programming of the subquery
+        // which might have different sortings.
+        joinCandidates(createExecutionTrees(arg._subquery));
       } else if constexpr (std::is_same_v<T,
                                           GraphPatternOperation::TransPath>) {
         // TODO<kramerfl> This is obviously how you set up transitive paths.

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -343,8 +343,8 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         // remove the ORDER BY clauses of a subquery if we can prove that
         // the results will be reordered anyway.
 
-        // Use the complete last row of the dynamic programming of the subquery
-        // which might have different sortings.
+        // For a subquery, make sure that one optimal result for each ordering
+        // of the result (by a single column) is contained.
         joinCandidates(createExecutionTrees(arg._subquery));
       } else if constexpr (std::is_same_v<T,
                                           GraphPatternOperation::TransPath>) {

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -15,6 +15,8 @@ class QueryPlanner {
  public:
   explicit QueryPlanner(QueryExecutionContext* qec);
 
+  // Create the best execution tree for the given query according to the
+  // optimization algorithm an cost estimates of the QueryPlanner.
   QueryExecutionTree createExecutionTree(ParsedQuery& pq);
 
   class TripleGraph {
@@ -187,7 +189,11 @@ class QueryPlanner {
 
   void setEnablePatternTrick(bool enablePatternTrick);
 
-  // TODO comment
+  // Create a set of possible execution trees for the given parsed query. The
+  // best (cheapest) execution tree according to the QueryPlanner is part of
+  // that set. Typically, when the query has no `ORDER BY` clause the created
+  // plans produce different sortings of the query result which is relevant,
+  // when the query is actually used as a subquery.
   std::vector<SubtreePlan> createExecutionTrees(ParsedQuery& pq);
 
  private:

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -187,6 +187,9 @@ class QueryPlanner {
 
   void setEnablePatternTrick(bool enablePatternTrick);
 
+  // TODO comment
+  std::vector<SubtreePlan> createExecutionTrees(ParsedQuery& pq);
+
  private:
   QueryExecutionContext* _qec;
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -16,7 +16,7 @@ class QueryPlanner {
   explicit QueryPlanner(QueryExecutionContext* qec);
 
   // Create the best execution tree for the given query according to the
-  // optimization algorithm an cost estimates of the QueryPlanner.
+  // optimization algorithm and cost estimates of the QueryPlanner.
   QueryExecutionTree createExecutionTree(ParsedQuery& pq);
 
   class TripleGraph {
@@ -191,9 +191,11 @@ class QueryPlanner {
 
   // Create a set of possible execution trees for the given parsed query. The
   // best (cheapest) execution tree according to the QueryPlanner is part of
-  // that set. Typically, when the query has no `ORDER BY` clause the created
-  // plans produce different sortings of the query result which is relevant,
-  // when the query is actually used as a subquery.
+  // that set. When the query has no `ORDER BY` clause, the set contains on
+  // optimal execution tree for each possible ordering (by one column) of the
+  // result. This is relevant for subqueries, which are currently optimized
+  // independently from the rest of the query, but where it depends on the rest
+  // of the query, which ordering of the result is best.
   std::vector<SubtreePlan> createExecutionTrees(ParsedQuery& pq);
 
  private:

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -191,7 +191,7 @@ class QueryPlanner {
 
   // Create a set of possible execution trees for the given parsed query. The
   // best (cheapest) execution tree according to the QueryPlanner is part of
-  // that set. When the query has no `ORDER BY` clause, the set contains on
+  // that set. When the query has no `ORDER BY` clause, the set contains one
   // optimal execution tree for each possible ordering (by one column) of the
   // result. This is relevant for subqueries, which are currently optimized
   // independently from the rest of the query, but where it depends on the rest

--- a/src/web/script.js
+++ b/src/web/script.js
@@ -34,6 +34,7 @@ $(document).ready(function () {
     $("#runbtn").click(function () {
         var q = encodeURIComponent($("#query").val());
         var queryString = "?query=" + q;
+        queryString += "&action=qlever_json_export";
         if ($("#clear").prop('checked')) {
             queryString += "&cmd=clear-cache";
         }


### PR DESCRIPTION
Fixes #729 
Until now the query planner created exactly one possible execution tree for a subquery (the cheapest one). 
This was problematic in two ways:
1. Sometimes trees were discarded that were a little bit more expensive, but were already sorted in a way that the outer query
   Could use for further joins.
2. When the subquery consisted of only one triple, sometimes no query plan was found at all because the query planner always discards the pattern "Index Scan + subsequent sorting" (issue #729)