### PR TITLE
Remove the redundant -l option from IndexBuilderMain

### DIFF
--- a/src/index/Index.Text.cpp
+++ b/src/index/Index.Text.cpp
@@ -104,9 +104,8 @@ void Index::addTextFromContextFile(const string& contextFile,
   LOG(DEBUG) << "Reloading the RDF vocabulary ..." << std::endl;
   _vocab = RdfsVocabulary{};
   readConfiguration();
-  _vocab.readFromFile(
-      _onDiskBase + INTERNAL_VOCAB_SUFFIX,
-      _onDiskLiterals ? _onDiskBase + EXTERNAL_VOCAB_SUFFIX : "");
+  _vocab.readFromFile(_onDiskBase + INTERNAL_VOCAB_SUFFIX,
+                      _onDiskBase + EXTERNAL_VOCAB_SUFFIX);
 
   // Build the text vocabulary (first scan over the text records).
   LOG(INFO) << "Building text vocabulary ..." << std::endl;

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -341,8 +341,6 @@ class Index {
 
   void setLoadAllPermutations(bool loadAllPermutations);
 
-  void setOnDiskLiterals(bool onDiskLiterals);
-
   void setKeepTempFiles(bool keepTempFiles);
 
   uint64_t& stxxlMemoryInBytes() { return _stxxlMemoryInBytes; }
@@ -506,7 +504,6 @@ class Index {
   TurtleParserIntegerOverflowBehavior _turtleParserIntegerOverflowBehavior =
       TurtleParserIntegerOverflowBehavior::Error;
   bool _turtleParserSkipIllegalLiterals = false;
-  bool _onDiskLiterals = false;
   bool _keepTempFiles = false;
   uint64_t _stxxlMemoryInBytes = DEFAULT_STXXL_MEMORY_IN_BYTES;
   json _configurationJson;

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -161,8 +161,7 @@ int main(int argc, char** argv) {
   if (onDiskLiterals) {
     LOG(WARN) << EMPH_ON
               << "Warning, the -l command line option has no effect anymore "
-                 "and will be removed from a "
-                 "future version of QLever"
+                 "and will be removed from a future version of QLever"
               << EMPH_OFF << std::endl;
   }
 

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -118,8 +118,8 @@ int main(int argc, char** argv) {
 
   // Options for the knowledge graph index.
   add("externalize-literals,l", po::bool_switch(&onDiskLiterals),
-      "Externalize parts of the knowledge graph vocabulary, according to the "
-      "rules specified in the `settings-file` JSON.");
+      "An unused and deprecated option that will be removed from a future "
+      "version of qlever");
   add("settings-file,s", po::value(&settingsFile),
       "A JSON file, where various settings can be specified (see the QLever "
       "documentation).");
@@ -158,6 +158,14 @@ int main(int argc, char** argv) {
         1024ul * 1024ul * 1024ul * stxxlMemoryGB.value();
   }
 
+  if (onDiskLiterals) {
+    LOG(WARN) << EMPH_ON
+              << "Warning, the -l command line option has no effect anymore "
+                 "and will be removed from a "
+                 "future version of QLever"
+              << EMPH_OFF << std::endl;
+  }
+
   // If no text index name was specified, take the part of the wordsfile after
   // the last slash.
   if (textIndexName.empty() && !wordsfile.empty()) {
@@ -186,7 +194,6 @@ int main(int argc, char** argv) {
     index.setKbName(kbIndexName);
     index.setTextName(textIndexName);
     index.setUsePatterns(!noPatterns);
-    index.setOnDiskLiterals(onDiskLiterals);
     index.setOnDiskBase(baseName);
     index.setKeepTempFiles(keepTemporaryFiles);
     index.setSettingsFile(settingsFile);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -576,7 +576,6 @@ TEST(IndexTest, TripleToInternalRepresentation) {
   }
   {
     Index index;
-    index.setOnDiskLiterals(true);
     index.getNonConstVocabForTesting().initializeExternalizePrefixes(
         std::vector{"<subj"s});
     TurtleTriple turtleTriple{"<subject>", "<predicate>", "\"literal\"@fr"};


### PR DESCRIPTION
It has been replaced by more fine-grained externalization options.