### PR TITLE
Allow a `BIND` statement at the beginning of a query

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1063,6 +1063,18 @@ queries:
       - order_string: { "dir": "ASC", "var": "?x" }
 
 
+  - query: bind-at-beginning
+    type: no-text
+    sparql: |
+      SELECT * WHERE {
+          BIND(<Scientist> AS ?x)
+      }
+    checks:
+      - num_cols: 1
+      - num_rows: 1
+      - selected: [ "?x" ]
+      - contains_row: [ "<Scientist>" ]
+
   - query : select_asterisk_prefix-filter-disjunction
     type: no-text
     sparql: |

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -1,0 +1,46 @@
+// Copyright 2022, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
+#pragma once
+
+#include <engine/Operation.h>
+
+/// The neutral element wrt `JOIN`. It contains one element, but binds no
+/// variables (which means it has 0 columns).
+class NeutralElementOperation : public Operation {
+ public:
+  explicit NeutralElementOperation(QueryExecutionContext* qec)
+      : Operation{qec} {}
+  std::vector<QueryExecutionTree*> getChildren() override { return {}; }
+
+ private:
+  // The individual implementation of `asString` (see above) that has to be
+  // customized by every child class.
+  [[nodiscard]] string asStringImpl(size_t) const override {
+    return "Neutral Element";
+  };
+
+ public:
+  [[nodiscard]] string getDescriptor() const override {
+    return "Neutral Element";
+  };
+  [[nodiscard]] size_t getResultWidth() const override { return 0; };
+  void setTextLimit(size_t) override{};
+  size_t getCostEstimate() override { return 0; }
+  size_t getSizeEstimate() override { return 1; }
+  float getMultiplicity(size_t) override { return 0; };
+  bool knownEmptyResult() override { return false; };
+  [[nodiscard]] ad_utility::HashMap<string, size_t> getVariableColumns()
+      const override {
+    return {};
+  };
+
+ protected:
+  [[nodiscard]] vector<size_t> resultSortedOn() const override { return {}; };
+
+ private:
+  void computeResult(ResultTable* result) override {
+    result->_idTable.setCols(0);
+    result->_idTable.resize(1);
+  }
+};

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -22,7 +22,7 @@ class NeutralElementOperation : public Operation {
 
  public:
   [[nodiscard]] string getDescriptor() const override {
-    return "Neutral Element";
+    return "NeutralElement";
   };
   [[nodiscard]] size_t getResultWidth() const override { return 0; };
   void setTextLimit(size_t) override{};

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -11,6 +11,7 @@
 #include <engine/GroupBy.h>
 #include <engine/HasPredicateScan.h>
 #include <engine/IndexScan.h>
+#include <engine/NeutralElementOperation.h>
 #include <engine/OrderBy.h>
 #include <engine/Sort.h>
 #include <engine/TransitivePath.h>
@@ -606,6 +607,8 @@ void QueryExecutionTree::setOperation(std::shared_ptr<Op> operation) {
     _type = HAS_PREDICATE_SCAN;
   } else if constexpr (std::is_same_v<Op, Filter>) {
     _type = FILTER;
+  } else if constexpr (std::is_same_v<Op, NeutralElementOperation>) {
+    _type = NEUTRAL_ELEMENT;
   } else {
     static_assert(ad_utility::alwaysFalse<Op>,
                   "New type of operation that was not yet registered");
@@ -625,3 +628,5 @@ template void QueryExecutionTree::setOperation(std::shared_ptr<GroupBy>);
 template void QueryExecutionTree::setOperation(
     std::shared_ptr<HasPredicateScan>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<Filter>);
+template void QueryExecutionTree::setOperation(
+    std::shared_ptr<NeutralElementOperation>);

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -55,7 +55,8 @@ class QueryExecutionTree {
     TRANSITIVE_PATH,
     VALUES,
     BIND,
-    MINUS
+    MINUS,
+    NEUTRAL_ELEMENT
   };
 
   enum class ExportSubFormat { CSV, TSV, BINARY };

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -18,6 +18,7 @@
 #include "Join.h"
 #include "Minus.h"
 #include "MultiColumnJoin.h"
+#include "NeutralElementOperation.h"
 #include "OptionalJoin.h"
 #include "OrderBy.h"
 #include "Sort.h"
@@ -230,9 +231,12 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         plan._idsOfIncludedFilters = a._idsOfIncludedFilters;
         candidatePlans.back().push_back(std::move(plan));
       }
-      // handle the case that the BIND clause is the first clause which means that `lastRow` is empty
+      // Handle the case that the BIND clause is the first clause which means
+      // that `lastRow` is empty.
       if (lastRow.empty()) {
-
+        auto neutralElement = makeExecutionTree<NeutralElementOperation>(_qec);
+        candidatePlans.back().push_back(
+            makeSubtreePlan<Bind>(_qec, std::move(neutralElement), v));
       }
       return;
     } else {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -230,6 +230,10 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         plan._idsOfIncludedFilters = a._idsOfIncludedFilters;
         candidatePlans.back().push_back(std::move(plan));
       }
+      // handle the case that the BIND clause is the first clause which means that `lastRow` is empty
+      if (lastRow.empty()) {
+
+      }
       return;
     } else {
       static_assert(


### PR DESCRIPTION
Fixes #743 .
Implement an operation that returns the neutral element wrt `JOIN`, namely a result with one row but no variable bindings.