### PR TITLE
Clean up and simplify the runtime info code further

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -1,6 +1,6 @@
-//
-// Created by johannes on 19.04.20.
-//
+//  Copyright 2020, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #include "Bind.h"
 
@@ -84,9 +84,6 @@ void Bind::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "Got input to Bind operation." << endl;
-
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
 
   result->_idTable.setCols(getResultWidth());
   result->_resultTypes = subRes->_resultTypes;

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -36,7 +36,7 @@ add_library(engine
         ../util/Random.h
         Minus.h Minus.cpp
         ResultType.h
-        ../util/Parameters.h)
+        ../util/Parameters.h RuntimeInformation.cpp)
 
 
 target_link_libraries(engine index parser sparqlExpressions httpServer SortPerformanceEstimator absl::flat_hash_set ${ICU_LIBRARIES} boost_iostreams)

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -168,7 +168,6 @@ void CountAvailablePredicates::computeResult(ResultTable* result) {
         &result->_idTable, hasPattern, hasPredicate, patterns);
   } else {
     std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-    runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -43,8 +43,6 @@ void Distinct::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "Distinct result computation..." << endl;
   result->_idTable.setCols(subRes->_idTable.cols());
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -185,9 +185,6 @@ void Filter::computeResultDynamicValue(IdTable* dynResult, size_t lhsInd,
 void Filter::computeResult(ResultTable* result) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.setDescriptor(getDescriptor());
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "Filter result computation..." << endl;
   result->_idTable.setCols(subRes->_idTable.cols());
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -300,9 +300,6 @@ void GroupBy::computeResult(ResultTable* result) {
                                    _varColMap.find(alias._outVarName)->second});
   }
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
-
   // populate the result type vector
   result->_resultTypes.resize(result->_idTable.cols());
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -231,11 +231,8 @@ void HasPredicateScan::computeResult(ResultTable* result) {
   const CompactVectorOfStrings<Id>& hasPredicate = getIndex().getHasPredicate();
   const CompactVectorOfStrings<Id>& patterns = getIndex().getPatterns();
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-
   switch (_type) {
     case ScanType::FREE_S: {
-      runtimeInfo.setDescriptor("HasPredicateScan free subject: " + _subject);
       Id objectId;
       if (!getIndex().getId(_object, &objectId)) {
         AD_THROW(ad_semsearch::Exception::BAD_INPUT,
@@ -245,7 +242,6 @@ void HasPredicateScan::computeResult(ResultTable* result) {
                                      patterns);
     } break;
     case ScanType::FREE_O: {
-      runtimeInfo.setDescriptor("HasPredicateScan free object: " + _object);
       Id subjectId;
       if (!getIndex().getId(_subject, &subjectId)) {
         AD_THROW(ad_semsearch::Exception::BAD_INPUT,
@@ -255,7 +251,6 @@ void HasPredicateScan::computeResult(ResultTable* result) {
                                      hasPredicate, patterns);
     } break;
     case ScanType::FULL_SCAN:
-      runtimeInfo.setDescriptor("HasPredicateScan full scan");
       HasPredicateScan::computeFullScan(result, hasPattern, hasPredicate,
                                         patterns,
                                         getIndex().getHasPredicateFullSize());
@@ -272,9 +267,6 @@ void HasPredicateScan::computeResult(ResultTable* result) {
       CALL_FIXED_SIZE_2(inWidth, outWidth, HasPredicateScan::computeSubqueryS,
                         &result->_idTable, subresult->_idTable,
                         _subtreeColIndex, hasPattern, hasPredicate, patterns);
-      runtimeInfo.setDescriptor("HasPredicateScan with a subquery on " +
-                                _subject);
-      runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
       break;
   }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -65,8 +65,6 @@ string Join::getDescriptor() const {
 
 // _____________________________________________________________________________
 void Join::computeResult(ResultTable* result) {
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   size_t leftWidth = _left->getResultWidth();
   size_t rightWidth = _right->getResultWidth();
@@ -97,7 +95,6 @@ void Join::computeResult(ResultTable* result) {
 
   LOG(TRACE) << "Computing left side..." << endl;
   shared_ptr<const ResultTable> leftRes = _left->getResult();
-  runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
 
   // TODO<joka921> Currently the _resultTypes are set incorrectly in case
   // of early stopping. For now, early stopping is thus disabled.
@@ -117,7 +114,6 @@ void Join::computeResult(ResultTable* result) {
 
   LOG(TRACE) << "Computing right side..." << endl;
   shared_ptr<const ResultTable> rightRes = _right->getResult();
-  runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
 
   LOG(DEBUG) << "Computing Join result..." << endl;
 
@@ -246,7 +242,6 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) {
     result->_idTable.setCols(_right->getResultWidth() + 2);
     result->_sortedBy = {2 + _rightJoinCol};
     shared_ptr<const ResultTable> nonDummyRes = _right->getResult();
-    getRuntimeInfo().addChild(_right->getRootOperation()->getRuntimeInfo());
     result->_resultTypes.reserve(result->_idTable.cols());
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
     result->_resultTypes.push_back(ResultTable::ResultType::KB);
@@ -261,7 +256,6 @@ void Join::computeResultForJoinWithFullScanDummy(ResultTable* result) {
     result->_sortedBy = {_leftJoinCol};
 
     shared_ptr<const ResultTable> nonDummyRes = _left->getResult();
-    getRuntimeInfo().addChild(_left->getRootOperation()->getRuntimeInfo());
     result->_resultTypes.reserve(result->_idTable.cols());
     result->_resultTypes.insert(result->_resultTypes.end(),
                                 nonDummyRes->_resultTypes.begin(),

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -48,15 +48,11 @@ void Minus::computeResult(ResultTable* result) {
   AD_CHECK(result);
   LOG(DEBUG) << "Minus result computation..." << endl;
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
   result->_sortedBy = resultSortedOn();
   result->_idTable.setCols(getResultWidth());
 
   const auto leftResult = _left->getResult();
   const auto rightResult = _right->getResult();
-
-  runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
-  runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
 
   LOG(DEBUG) << "Minus subresult computation done." << std::endl;
 

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -75,7 +75,6 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
   AD_CHECK(result);
   LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
   result->_sortedBy = resultSortedOn();
   result->_idTable.setCols(getResultWidth());
 
@@ -83,9 +82,6 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
 
   const auto leftResult = _left->getResult();
   const auto rightResult = _right->getResult();
-
-  runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
-  runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
 
   LOG(DEBUG) << "MultiColumnJoin subresult computation done." << std::endl;
 

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -140,7 +140,7 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
     return result._resultPointer->_resultTable;
   } catch (const ad_semsearch::AbortException& e) {
     // A child Operation was aborted, do not print the information again.
-    _runtimeInfo.status_ = RuntimeInformation::failedBecauseChildFailed;
+    _runtimeInfo.status_ = RuntimeInformation::Status::failedBecauseChildFailed;
     throw;
   } catch (const ad_utility::WaitedForResultWhichThenFailedException& e) {
     // Here and in the following, show the detailed information (it's the
@@ -184,7 +184,7 @@ void Operation::updateRuntimeInformationOnSuccess(
   _runtimeInfo.numRows_ = resultTable.size();
   _runtimeInfo.wasCached_ = wasCached;
 
-  _runtimeInfo.status_ = RuntimeInformation::completed;
+  _runtimeInfo.status_ = RuntimeInformation::Status::completed;
 
   // If the result was read from the cache, then we need the additional
   // runtime info for the correct child information etc.
@@ -229,7 +229,7 @@ void Operation::updateRuntimeInformationOnFailure(size_t timeInMilliseconds) {
   }
 
   _runtimeInfo.totalTime_ = timeInMilliseconds;
-  _runtimeInfo.status_ = RuntimeInformation::failed;
+  _runtimeInfo.status_ = RuntimeInformation::Status::failed;
 }
 
 // __________________________________________________________________

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -200,8 +200,9 @@ void Operation::updateRuntimeInformationOnSuccess(
     // the correct information about the children computations.
     _runtimeInfo.children_ = std::move(runtimeInfo->children_);
   } else {
-    // The result was computed by this operation (not read from the cache). Therefore, for each child of this operation
-    // the correct runtime is available.
+    // The result was computed by this operation (not read from the cache).
+    // Therefore, for each child of this operation the correct runtime is
+    // available.
     _runtimeInfo.children_.clear();
     for (auto* child : getChildren()) {
       AD_CHECK(child);

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -200,10 +200,10 @@ void Operation::updateRuntimeInformationOnSuccess(
     // the correct information about the children computations.
     _runtimeInfo.children_ = std::move(runtimeInfo->children_);
   } else {
-    // The result was computed by this instance, so we can use the information
-    // on the children.
+    // The result was computed by this operation (not read from the cache). Therefore, for each child of this operation
+    // the correct runtime is available.
+    _runtimeInfo.children_.clear();
     for (auto* child : getChildren()) {
-      _runtimeInfo.children_.clear();
       AD_CHECK(child);
       _runtimeInfo.children_.push_back(
           child->getRootOperation()->getRuntimeInfo());

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -98,7 +98,7 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
     ad_utility::OnDestruction onDestruction{[&]() {
       if (std::uncaught_exceptions()) {
         timer.stop();
-        updateRuntimeInformationOnFailure(true, timer.msecs());
+        updateRuntimeInformationOnFailure(timer.msecs());
       }
     }};
     auto computeLambda = [this, &timer] {
@@ -109,7 +109,6 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
             "functionality, before " +
             getDescriptor());
       }
-      _runtimeInfo.children().clear();
       computeResult(val._resultTable.get());
       if (_timeoutTimer->wlock()->hasTimedOut()) {
         throw ad_utility::TimeoutException(
@@ -117,7 +116,6 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
             ". This timeout was not caught inside the actual computation, "
             "which indicates insufficient timeout functionality.");
       }
-      _runtimeInfo.setRows(val._resultTable->_idTable.size());
       // Make sure that the results that are written to the cache have the
       // correct runtimeInfo. The children of the runtime info are already set
       // correctly because the result was computed, so we can pass `nullopt` as
@@ -142,7 +140,7 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
     return result._resultPointer->_resultTable;
   } catch (const ad_semsearch::AbortException& e) {
     // A child Operation was aborted, do not print the information again.
-    _runtimeInfo.addDetail("status", "failed because child failed");
+    _runtimeInfo.status_ = RuntimeInformation::failedBecauseChildFailed;
     throw;
   } catch (const ad_utility::WaitedForResultWhichThenFailedException& e) {
     // Here and in the following, show the detailed information (it's the
@@ -182,30 +180,34 @@ void Operation::checkTimeout() const {
 void Operation::updateRuntimeInformationOnSuccess(
     const ResultTable& resultTable, bool wasCached, size_t timeInMilliseconds,
     std::optional<RuntimeInformation> runtimeInfo) {
-  // The column names might differ between a cached result and this operation,
-  // so we have to take the local ones.
-  _runtimeInfo.setColumnNames(getVariableColumns());
+  _runtimeInfo.time_ = timeInMilliseconds;
+  _runtimeInfo.rows_ = resultTable.size();
+  _runtimeInfo.wasCached_ = wasCached;
 
-  _runtimeInfo.setCols(getResultWidth());
-  _runtimeInfo.setDescriptor(getDescriptor());
-
-  _runtimeInfo.setTime(timeInMilliseconds);
-  _runtimeInfo.setRows(resultTable.size());
-  _runtimeInfo.setWasCached(wasCached);
-
-  _runtimeInfo.addDetail("status", "completed");
+  _runtimeInfo.status_ = RuntimeInformation::completed;
 
   // If the result was read from the cache, then we need the additional
   // runtime info for the correct child information etc.
   AD_CHECK(!wasCached || runtimeInfo.has_value());
 
   if (runtimeInfo.has_value()) {
-    _runtimeInfo.addDetail("original_total_time", runtimeInfo->getTime());
-    _runtimeInfo.addDetail("original_operation_time",
-                           runtimeInfo->getOperationTime());
+    if (wasCached) {
+      _runtimeInfo.originalTime_ = runtimeInfo->time_;
+      _runtimeInfo.originalOperationTime_ = runtimeInfo->getOperationTime();
+      _runtimeInfo.details_ = std::move(runtimeInfo->details_);
+    }
     // Only the result that was actually computed (or read from cache) knows
     // the correct information about the children computations.
-    _runtimeInfo.children() = std::move(runtimeInfo->children());
+    _runtimeInfo.children_ = std::move(runtimeInfo->children_);
+  } else {
+    // The result was computed by this instance, so we can use the information
+    // on the children.
+    for (auto* child : getChildren()) {
+      _runtimeInfo.children_.clear();
+      AD_CHECK(child);
+      _runtimeInfo.children_.push_back(
+          child->getRootOperation()->getRuntimeInfo());
+    }
   }
 }
 
@@ -220,28 +222,14 @@ void Operation::updateRuntimeInformationOnSuccess(
 }
 
 // _______________________________________________________________________
-void Operation::updateRuntimeInformationOnFailure(
-    bool failureCausedByThisOperation, size_t timeInMilliseconds) {
-  // The column names might differ between a cached result and this operation,
-  // so we have to take the local ones.
-  _runtimeInfo.setColumnNames(getVariableColumns());
-
-  _runtimeInfo.setCols(getResultWidth());
-  _runtimeInfo.setDescriptor(getDescriptor());
-
-  _runtimeInfo.children().clear();
+void Operation::updateRuntimeInformationOnFailure(size_t timeInMilliseconds) {
+  _runtimeInfo.children_.clear();
   for (auto child : getChildren()) {
-    _runtimeInfo.children().push_back(child->getRootOperation()->_runtimeInfo);
+    _runtimeInfo.children_.push_back(child->getRootOperation()->_runtimeInfo);
   }
 
-  _runtimeInfo.setTime(timeInMilliseconds);
-  _runtimeInfo.setRows(0);
-  _runtimeInfo.setWasCached(false);
-  if (failureCausedByThisOperation) {
-    _runtimeInfo.addDetail("status", "failed");
-  } else {
-    _runtimeInfo.addDetail("status", "failed because child failed");
-  }
+  _runtimeInfo.time_ = timeInMilliseconds;
+  _runtimeInfo.status_ = RuntimeInformation::failed;
 }
 
 // __________________________________________________________________
@@ -250,39 +238,34 @@ void Operation::createRuntimeInfoFromEstimates() {
   _runtimeInfo = RuntimeInformation{};
   _runtimeInfo.setColumnNames(getVariableColumns());
   const auto numCols = getResultWidth();
-  _runtimeInfo.setCols(numCols);
-  _runtimeInfo.setDescriptor(getDescriptor());
+  _runtimeInfo.cols_ = numCols;
+  _runtimeInfo.descriptor_ = getDescriptor();
 
   for (const auto& child : getChildren()) {
     AD_CHECK(child);
     child->getRootOperation()->createRuntimeInfoFromEstimates();
-    _runtimeInfo.children().push_back(
+    _runtimeInfo.children_.push_back(
         child->getRootOperation()->getRuntimeInfo());
   }
 
-  _runtimeInfo.setCostEstimate(getCostEstimate());
-  _runtimeInfo.setSizeEstimate(getSizeEstimate());
-  _runtimeInfo.setTime(0);
-  _runtimeInfo.setRows(0);
+  _runtimeInfo.costEstimate_ = getCostEstimate();
+  _runtimeInfo.sizeEstimate_ = getSizeEstimate();
 
   std::vector<float> multiplicityEstimates;
   multiplicityEstimates.reserve(numCols);
   for (size_t i = 0; i < numCols; ++i) {
     multiplicityEstimates.push_back(getMultiplicity(i));
   }
-  _runtimeInfo.addDetail("multiplicity-estimates", multiplicityEstimates);
+  _runtimeInfo.multiplictyEstimates_ = multiplicityEstimates;
 
   auto cachedResult =
       _executionContext->getQueryTreeCache().resultAt(asString());
   if (cachedResult) {
-    _runtimeInfo.setWasCached(true);
-    _runtimeInfo.setRows(cachedResult->_resultTable->size());
-    _runtimeInfo.addDetail("original_total_time",
-                           cachedResult->_runtimeInfo.getTime());
-    _runtimeInfo.addDetail("original_operation_time",
-                           cachedResult->_runtimeInfo.getOperationTime());
-  } else {
-    _runtimeInfo.setWasCached(false);
+    _runtimeInfo.wasCached_ = true;
+
+    _runtimeInfo.rows_ = cachedResult->_resultTable->size();
+    _runtimeInfo.originalTime_ = cachedResult->_runtimeInfo.time_;
+    _runtimeInfo.originalOperationTime_ =
+        cachedResult->_runtimeInfo.getOperationTime();
   }
-  _runtimeInfo.addDetail("status", "not started");
 }

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -207,11 +207,8 @@ class Operation {
       std::optional<RuntimeInformation> runtimeInfo) final;
 
   // Create the runtime information in case the evaluation of this operation has
-  // failed. The first argument specifies whether this Operation caused the
-  // failure (true) or whether the failure is propagated form a failed child
-  // Operation (false).
-  void updateRuntimeInformationOnFailure(bool failureCausedByThisOperation,
-                                         size_t timeInMilliseconds);
+  // failed.
+  void updateRuntimeInformationOnFailure(size_t timeInMilliseconds);
 
   // Recursively call a function on all children.
   template <typename F>

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -79,8 +79,6 @@ void OptionalJoin::computeResult(ResultTable* result) {
   AD_CHECK(result);
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-
   result->_sortedBy = resultSortedOn();
   result->_idTable.setCols(getResultWidth());
 
@@ -89,8 +87,6 @@ void OptionalJoin::computeResult(ResultTable* result) {
   const auto leftResult = _left->getResult();
   const auto rightResult = _right->getResult();
 
-  runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
-  runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "OptionalJoin subresult computation done." << std::endl;
 
   // compute the result types

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -95,8 +95,6 @@ void OrderBy::computeResult(ResultTable* result) {
         std::to_string(sortEstimateCancellationFactor));
   }
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
   LOG(DEBUG) << "OrderBy result computation..." << endl;
   result->_idTable.setCols(subRes->_idTable.cols());
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -4,3 +4,148 @@
 //   2022-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
 
 #include <engine/RuntimeInformation.h>
+#include <util/Exception.h>
+#include <util/Log.h>
+
+// ________________________________________________________________________________________________________________
+std::string RuntimeInformation::toString() const {
+  std::ostringstream buffer;
+  // imbue with the same locale as std::cout which uses for exanoke
+  // thousands separators
+  buffer.imbue(ad_utility::commaLocale);
+  // So floats use fixed precision
+  buffer << std::fixed << std::setprecision(2);
+  writeToStream(buffer);
+  return std::move(buffer).str();
+}
+
+namespace {
+// A small formatting helper used inside RuntimeInformation::writeToStream
+std::string indentStr(size_t indent) {
+  std::string ind;
+  for (size_t i = 0; i < indent; i++) {
+    ind += "│  ";
+  }
+  return ind;
+}
+}
+
+// ________________________________________________________________________________________________________________
+void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
+  using json = nlohmann::json;
+  out << indentStr(indent) << '\n';
+  out << indentStr(indent - 1) << "├─ " << descriptor_ << '\n';
+  out << indentStr(indent) << "result_size: " << rows_ << " x " << cols_
+      << '\n';
+  out << indentStr(indent) << "columns: " << absl::StrJoin(columnNames_, ", ")
+      << '\n';
+  out << indentStr(indent) << "total_time: " << time_ << " ms" << '\n';
+  out << indentStr(indent) << "operation_time: " << getOperationTime()
+      << " ms" << '\n';
+  out << indentStr(indent) << "cached: " << ((wasCached_) ? "true" : "false")
+      << '\n';
+  if (wasCached_) {
+    out << indentStr(indent) << "original_total_time: " << originalTime_ << " ms" << '\n';
+    out << indentStr(indent) << "original_operation_time: " << originalOperationTime_
+        << " ms" << '\n';
+  }
+  for (const auto& el : details_.items()) {
+    out << indentStr(indent) << "  " << el.key() << ": ";
+    // We want to print doubles with fixed precision and stream ints as their
+    // native type so they get thousands separators. For everything else we
+    // let nlohmann::json handle it
+    if (el.value().type() == json::value_t::number_float) {
+      out << ad_utility::to_string(el.value().get<double>(), 2);
+    } else if (el.value().type() == json::value_t::number_unsigned) {
+      out << el.value().get<uint64_t>();
+    } else if (el.value().type() == json::value_t::number_integer) {
+      out << el.value().get<int64_t>();
+    } else {
+      out << el.value();
+    }
+    if (el.key().ends_with("Time")) {
+      out << " ms";
+    }
+    out << '\n';
+  }
+  if (!children_.empty()) {
+    out << indentStr(indent) << "┬\n";
+    for (const RuntimeInformation& child : children_) {
+      child.writeToStream(out, indent + 1);
+    }
+  }
+}
+
+// ________________________________________________________________________________________________________________
+void RuntimeInformation::setColumnNames(
+    const ad_utility::HashMap<std::string, size_t>& columnMap) {
+  columnNames_.resize(columnMap.size());
+  for (const auto& [variable, columnIndex] : columnMap) {
+    AD_CHECK(columnIndex < columnNames_.size());
+    columnNames_[columnIndex] = variable;
+  }
+}
+
+// ________________________________________________________________________________________________________________
+double RuntimeInformation::getOperationTime() const {
+  if (wasCached_) {
+    return time_;
+  } else {
+    return time_ - getChildrenTime();
+  }
+}
+
+// ________________________________________________________________________________________________________________
+size_t RuntimeInformation::getOperationCostEstimate() const {
+  size_t result = costEstimate_;
+  for (const auto& child : children_) {
+    result -= child.costEstimate_;
+  }
+  return result;
+}
+
+// ________________________________________________________________________________________________________________
+double RuntimeInformation::getChildrenTime() const {
+  double sum = 0;
+  for (const RuntimeInformation& child : children_) {
+    sum += child.time_;
+  }
+  return sum;
+}
+
+// ________________________________________________________________________________________________________________
+std::string_view RuntimeInformation::toString(Status status) {
+  switch (status) {
+    case completed:
+      return "completed";
+    case notStarted:
+      return "not started";
+    case failed:
+      return "failed";
+    case failedBecauseChildFailed:
+      return "failed because child failed";
+    default:
+    AD_FAIL();
+  }
+}
+
+// ________________________________________________________________________________________________________________
+void to_json (nlohmann::ordered_json& j, const RuntimeInformation& rti) {
+   j = nlohmann::ordered_json {
+      {"description", rti.descriptor_},
+      {"result_rows", rti.rows_},
+      {"result_cols", rti.cols_},
+      {"column_names", rti.columnNames_},
+      {"total_time", rti.time_},
+      {"operation_time", rti.getOperationTime()},
+      {"original_total_time", rti.originalTime_},
+      {"original_operation_time", rti.originalOperationTime_},
+      {"was_cached", rti.wasCached_},
+      {"details", rti.details_},
+      {"estimated_total_cost", rti.costEstimate_},
+      {"estimated_operation_cost", rti.getOperationCostEstimate()},
+      {"estimated_column_multiplicities", rti.multiplictyEstimates_},
+      {"estimated_size", rti.sizeEstimate_},
+      {"status", RuntimeInformation::toString(rti.status_)},
+      {"children", rti.children_}};
+}

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -1,0 +1,6 @@
+// Copyright 2022, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author:
+//   2022-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+
+#include <engine/RuntimeInformation.h>

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -13,9 +13,12 @@
 #include <string>
 #include <vector>
 
-/// A class to store information about the status of an operation (result size, time to compute, status, etc.). Also contains the functionality to print that information nicely formatted and to export it to JSON.
+/// A class to store information about the status of an operation (result size,
+/// time to compute, status, etc.). Also contains the functionality to print
+/// that information nicely formatted and to export it to JSON.
 class RuntimeInformation {
  public:
+  /// The computation status of an operation
   enum struct Status {
     notStarted,
     completed,
@@ -25,45 +28,70 @@ class RuntimeInformation {
   using enum Status;
 
   // Public members
-  double time_ = 0.0;
 
-  // In case this operation was read from the cache, we will store the time
-  // information about the original computation in the following two members
-  double originalTime_ = 0.0;
+  /// The total time spent computing this operation. This includes the
+  /// computation of the children.
+  double totalTime_ = 0.0;
+
+  /// In case this operation was read from the cache, we will store the time
+  /// information about the original computation in the following two members
+  double originalTotalTime_ = 0.0;
   double originalOperationTime_ = 0.0;
 
+  /// The estimated cost, size, and column multiplicities of the operation.
   size_t costEstimate_ = 0;
-  size_t rows_ = 0;
   size_t sizeEstimate_ = 0;
-  size_t cols_ = 0;
+  std::vector<float> multiplicityEstimates_;
 
-  std::vector<float> multiplictyEstimates_;
-  bool wasCached_ = false;
-  std::string descriptor_;
-  std::vector<std::string> columnNames_;
-  std::vector<RuntimeInformation> children_;
+  /// The actual number of rows and columns in the result.
+  size_t numRows_ = 0;
+  size_t numCols_ = 0;
+
+  /// The status of the operation.
   Status status_ = Status::notStarted;
+
+  /// Was the result of the operation read from the cache or actually computed.
+  bool wasCached_ = false;
+
+  /// A short human-readable string that identifies the operation.
+  std::string descriptor_;
+
+  /// The names of the variables that are stored in the columsn of the result.
+  std::vector<std::string> columnNames_;
+
+  /// The child operations of this operation.
+  std::vector<RuntimeInformation> children_;
+
+  /// A key-value map of various other information that might be different for
+  /// different types of operations.
   nlohmann::json details_;
 
+  // Default constructor.
   RuntimeInformation() = default;
 
+  /// Formatted output to  std::string and streams.
   [[nodiscard]] std::string toString() const;
-
   void writeToStream(std::ostream& out, size_t indent = 1) const;
 
-  friend void to_json (nlohmann::ordered_json& j, const RuntimeInformation& rti);
+  /// Output as json. The signature of this function is mandated by the json
+  /// library to allow for implicit conversion.
+  friend void to_json(nlohmann::ordered_json& j, const RuntimeInformation& rti);
 
+  /// Set the names of the columns from the HashMap format that is used in the
+  /// rest of the Qlever code.
   void setColumnNames(
       const ad_utility::HashMap<std::string, size_t>& columnMap);
 
+  /// Get the time spent computing the operation. This is the total time minus
+  /// the time spent computing the children.
   [[nodiscard]] double getOperationTime() const;
 
+  /// Get the cost estimate for this operation. This is the total cost estimate
+  /// minus the sum of the cost estimates of all children.
   [[nodiscard]] size_t getOperationCostEstimate() const;
 
-  // The time spend in children
-  [[nodiscard]] double getChildrenTime() const;
-
-
+  /// Add a key-value pair to the `details` section of the output. `value` may
+  /// be any type that can be implicitly converted to `nlohmann::json`.
   template <typename T>
   void addDetail(const std::string& key, const T& value) {
     details_[key] = value;

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -7,22 +7,15 @@
 
 #include <absl/strings/str_join.h>
 #include <util/HashMap.h>
-#include <util/StringUtils.h>
-#include <util/Timer.h>
 #include <util/json.h>
 
 #include <iostream>
 #include <string>
 #include <vector>
 
+/// A class to store information about the status of an operation (result size, time to compute, status, etc.). Also contains the functionality to print that information nicely formatted and to export it to JSON.
 class RuntimeInformation {
  public:
-  // Ordered JSON that preserves the insertion order.
-  // This helps to make the JSON more readable as it forces children to be
-  // printed after their parents. See also
-  // https://github.com/nlohmann/json/issues/485#issuecomment-333652309
-  using ordered_json = nlohmann::ordered_json;
-
   enum struct Status {
     notStarted,
     completed,
@@ -52,99 +45,24 @@ class RuntimeInformation {
   Status status_ = Status::notStarted;
   nlohmann::json details_;
 
-  friend inline void to_json(RuntimeInformation::ordered_json& j,
-                             const RuntimeInformation& rti);
-
   RuntimeInformation() = default;
 
-  std::string toString() const {
-    std::ostringstream buffer;
-    // imbue with the same locale as std::cout which uses for exanoke
-    // thousands separators
-    buffer.imbue(ad_utility::commaLocale);
-    // So floats use fixed precision
-    buffer << std::fixed << std::setprecision(2);
-    writeToStream(buffer);
-    return std::move(buffer).str();
-  }
+  [[nodiscard]] std::string toString() const;
 
-  void writeToStream(std::ostream& out, size_t indent = 1) const {
-    out << indentStr(indent) << '\n';
-    out << indentStr(indent - 1) << "├─ " << descriptor_ << '\n';
-    out << indentStr(indent) << "result_size: " << rows_ << " x " << cols_
-        << '\n';
-    out << indentStr(indent) << "columns: " << absl::StrJoin(columnNames_, ", ")
-        << '\n';
-    out << indentStr(indent) << "total_time: " << time_ << " ms" << '\n';
-    out << indentStr(indent) << "operation_time: " << getOperationTime()
-        << " ms" << '\n';
-    out << indentStr(indent) << "cached: " << ((wasCached_) ? "true" : "false")
-        << '\n';
-    if (wasCached_) {
-      out << indentStr(indent) << "original_total_time: " << originalTime__ << " ms" << '\n';
-      out << indentStr(indent) << "original_operation_time: " << originalOperationTime_
-          << " ms" << '\n';
-    }
-    for (const auto& el : details_.items()) {
-      out << indentStr(indent) << "  " << el.key() << ": ";
-      // We want to print doubles with fixed precision and stream ints as their
-      // native type so they get thousands separators. For everything else we
-      // let nlohmann::json handle it
-      if (el.value().type() == json::value_t::number_float) {
-        out << ad_utility::to_string(el.value().get<double>(), 2);
-      } else if (el.value().type() == json::value_t::number_unsigned) {
-        out << el.value().get<uint64_t>();
-      } else if (el.value().type() == json::value_t::number_integer) {
-        out << el.value().get<int64_t>();
-      } else {
-        out << el.value();
-      }
-      if (el.key().ends_with("Time")) {
-        out << " ms";
-      }
-      out << '\n';
-    }
-    if (!children_.empty()) {
-      out << indentStr(indent) << "┬\n";
-      for (const RuntimeInformation& child : children_) {
-        child.writeToStream(out, indent + 1);
-      }
-    }
-  }
+  void writeToStream(std::ostream& out, size_t indent = 1) const;
+
+  friend void to_json (nlohmann::ordered_json& j, const RuntimeInformation& rti);
 
   void setColumnNames(
-      const ad_utility::HashMap<std::string, size_t>& columnMap) {
-    columnNames_.resize(columnMap.size());
-    for (const auto& [variable, columnIndex] : columnMap) {
-      AD_CHECK(columnIndex < columnNames_.size());
-      columnNames_[columnIndex] = variable;
-    }
-  }
+      const ad_utility::HashMap<std::string, size_t>& columnMap);
 
-  double getOperationTime() const {
-    if (wasCached_) {
-      return time_;
-    } else {
-      return time_ - getChildrenTime();
-    }
-  }
+  [[nodiscard]] double getOperationTime() const;
 
-  size_t getOperationCostEstimate() const {
-    size_t result = costEstimate_;
-    for (const auto& child : children_) {
-      result -= child.costEstimate_;
-    }
-    return result;
-  }
+  [[nodiscard]] size_t getOperationCostEstimate() const;
 
   // The time spend in children
-  double getChildrenTime() const {
-    double sum = 0;
-    for (const RuntimeInformation& child : children_) {
-      sum += child.time_;
-    }
-    return sum;
-  }
+  [[nodiscard]] double getChildrenTime() const;
+
 
   template <typename T>
   void addDetail(const std::string& key, const T& value) {
@@ -152,47 +70,5 @@ class RuntimeInformation {
   }
 
  private:
-  static std::string indentStr(size_t indent) {
-    std::string ind;
-    for (size_t i = 0; i < indent; i++) {
-      ind += "│  ";
-    }
-    return ind;
-  }
-
-  static std::string_view toString(Status status) {
-    switch (status) {
-      case completed:
-        return "completed";
-      case notStarted:
-        return "not started";
-      case failed:
-        return "failed";
-      case failedBecauseChildFailed:
-        return "failed because child failed";
-      default:
-        AD_FAIL();
-    }
-  }
+  static std::string_view toString(Status status);
 };
-
-inline void to_json(RuntimeInformation::ordered_json& j,
-                    const RuntimeInformation& rti) {
-  j = RuntimeInformation::ordered_json{
-      {"description", rti.descriptor_},
-      {"result_rows", rti.rows_},
-      {"result_cols", rti.cols_},
-      {"column_names", rti.columnNames_},
-      {"total_time", rti.time_},
-      {"operation_time", rti.getOperationTime()},
-      {"original_total_time", rti.originalTime_},
-      {"original_operation_time", rti.originalOperationTime_},
-      {"was_cached", rti.wasCached_},
-      {"details", rti.details_},
-      {"estimated_total_cost", rti.costEstimate_},
-      {"estimated_operation_cost", rti.getOperationCostEstimate()},
-      {"estimated_column_multiplicities", rti.multiplictyEstimates_},
-      {"estimated_size", rti.sizeEstimate_},
-      {"status", RuntimeInformation::toString(rti.status_)},
-      {"children", rti.children_}};
-}

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -3,6 +3,7 @@
 // Author:
 //   2019      Florian Kramer (florian.kramer@neptun.uni-freiburg.de)
 //   2022-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+
 #pragma once
 
 #include <absl/strings/str_join.h>

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -365,7 +365,7 @@ Awaitable<json> Server::composeResponseQleverJson(
           std::vector<std::string>{"?subject", "?predicate", "?object"};
     }
 
-    j["runtimeInformation"] = RuntimeInformation::ordered_json(
+    j["runtimeInformation"] = nlohmann::ordered_json(
         qet.getRootOperation()->getRuntimeInfo());
 
     {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -365,8 +365,8 @@ Awaitable<json> Server::composeResponseQleverJson(
           std::vector<std::string>{"?subject", "?predicate", "?object"};
     }
 
-    j["runtimeInformation"] = nlohmann::ordered_json(
-        qet.getRootOperation()->getRuntimeInfo());
+    j["runtimeInformation"] =
+        nlohmann::ordered_json(qet.getRootOperation()->getRuntimeInfo());
 
     {
       size_t limit = std::min(query._limitOffset._limit, maxSend);

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -733,9 +733,8 @@ boost::asio::awaitable<void> Server::processQuery(
     auto errorResponseJson = composeErrorResponseJson(
         query, exceptionErrorMsg.value(), requestTimer);
     if (queryExecutionTree) {
-      errorResponseJson["runtimeInformation"] =
-          nlohmann::ordered_json(
-              queryExecutionTree->getRootOperation()->getRuntimeInfo());
+      errorResponseJson["runtimeInformation"] = nlohmann::ordered_json(
+          queryExecutionTree->getRootOperation()->getRuntimeInfo());
     }
     co_return co_await sendJson(errorResponseJson, http::status::bad_request);
   }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -734,7 +734,7 @@ boost::asio::awaitable<void> Server::processQuery(
         query, exceptionErrorMsg.value(), requestTimer);
     if (queryExecutionTree) {
       errorResponseJson["runtimeInformation"] =
-          RuntimeInformation::ordered_json(
+          nlohmann::ordered_json(
               queryExecutionTree->getRootOperation()->getRuntimeInfo());
     }
     co_return co_await sendJson(errorResponseJson, http::status::bad_request);

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -72,9 +72,6 @@ void Sort::computeResult(ResultTable* result) {
         std::to_string(sortEstimateCancellationFactor));
   }
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
-
   LOG(DEBUG) << "Sort result computation..." << endl;
   result->_idTable.setCols(subRes->_idTable.cols());
   result->_resultTypes.insert(result->_resultTypes.end(),

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -83,9 +83,6 @@ void TextOperationWithFilter::computeResult(ResultTable* result) {
   result->_idTable.setCols(getResultWidth());
   shared_ptr<const ResultTable> filterResult = _filterResult->getResult();
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_filterResult->getRootOperation()->getRuntimeInfo());
-
   result->_resultTypes.reserve(result->_idTable.cols());
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);
   result->_resultTypes.push_back(ResultTable::ResultType::VERBATIM);

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -669,9 +669,6 @@ void TransitivePath::computeResult(ResultTable* result) {
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "TransitivePath subresult computation done." << std::endl;
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtree->getRootOperation()->getRuntimeInfo());
-
   result->_sortedBy = resultSortedOn();
   if (_leftIsVar || _leftSideTree != nullptr) {
     result->_resultTypes.push_back(subRes->getResultType(_leftSubCol));
@@ -693,7 +690,6 @@ void TransitivePath::computeResult(ResultTable* result) {
         result->_resultTypes.push_back(leftRes->getResultType(c));
       }
     }
-    runtimeInfo.addChild(_leftSideTree->getRootOperation()->getRuntimeInfo());
     int leftWidth = leftRes->_idTable.cols();
     CALL_FIXED_SIZE_3(subWidth, leftWidth, _resultWidth,
                       computeTransitivePathLeftBound, &result->_idTable,
@@ -707,7 +703,6 @@ void TransitivePath::computeResult(ResultTable* result) {
         result->_resultTypes.push_back(rightRes->getResultType(c));
       }
     }
-    runtimeInfo.addChild(_rightSideTree->getRootOperation()->getRuntimeInfo());
     int rightWidth = rightRes->_idTable.cols();
     CALL_FIXED_SIZE_3(subWidth, rightWidth, _resultWidth,
                       computeTransitivePathRightBound, &result->_idTable,

--- a/src/engine/TwoColumnJoin.cpp
+++ b/src/engine/TwoColumnJoin.cpp
@@ -103,9 +103,6 @@ void TwoColumnJoin::computeResult(ResultTable* result) {
     const auto leftResult = _left->getResult();
     const auto rightResult = _right->getResult();
     const auto& toFilter = rightFilter ? leftResult : rightResult;
-    RuntimeInformation& runtimeInfo = getRuntimeInfo();
-    runtimeInfo.addChild(_left->getRootOperation()->getRuntimeInfo());
-    runtimeInfo.addChild(_right->getRootOperation()->getRuntimeInfo());
     const IdTable& filter =
         rightFilter ? rightResult->_idTable : leftResult->_idTable;
     size_t jc1 = rightFilter ? _jc1Left : _jc1Right;

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -132,10 +132,6 @@ void Union::computeResult(ResultTable* result) {
   shared_ptr<const ResultTable> subRes2 = _subtrees[1]->getResult();
   LOG(DEBUG) << "Union subresult computation done." << std::endl;
 
-  RuntimeInformation& runtimeInfo = getRuntimeInfo();
-  runtimeInfo.addChild(_subtrees[0]->getRootOperation()->getRuntimeInfo());
-  runtimeInfo.addChild(_subtrees[1]->getRootOperation()->getRuntimeInfo());
-
   result->_sortedBy = resultSortedOn();
   for (const std::array<size_t, 2>& o : _columnOrigins) {
     if (o[0] != NO_COLUMN) {


### PR DESCRIPTION
- fields that are always needed no longer appear as "details"
- (if it works) no more need for each individual operation to add its children to the runtime
  during compilation.