### PR TITLE
Fix a typo in a field name of the error response JSON

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -491,7 +491,7 @@ json Server::composeErrorResponseJson(
   if (metadata.has_value()) {
     auto& value = metadata.value();
     j["metadata"]["startIndex"] = value.startIndex_;
-    j["metadata"]["stopIndex_"] = value.stopIndex_;
+    j["metadata"]["stopIndex"] = value.stopIndex_;
     // The ANTLR parser may not see the whole query. (The reason is value mixing
     // of the old and new parser.) To detect/work with this we also transmit
     // what ANTLR saw as query.


### PR DESCRIPTION
Fixed a typo in the error response JSON introduced by #741.