### PR TITLE
Make it possible to turn off the compilation info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,11 +210,19 @@ message(STATUS ---)
 include_directories(src)
 
 # Run the script `CompilationInfo.cmake` that creates the file `CompilationInfo.cpp`
-# with the current git hash and the curent time and date. The first output which is
-# never created is necessary s.t. the command is never cached and always rerun.
-add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/FileThatNeverExists.cpp"
-                          "${CMAKE_CURRENT_BINARY_DIR}/CompilationInfo.cpp"
-                   COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/CompilationInfo.cmake)
+# with the current git hash and the curent time and date.q When specifying
+# `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to CMAKE the
+if (NOT DONT_UPDATE_COMPILATION_INFO)
+    # The first output which is never created is necessary s.t. the command is never cached and
+    # always rerun.
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/FileThatNeverExists.cpp"
+                              "${CMAKE_CURRENT_BINARY_DIR}/CompilationInfo.cpp"
+                       COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/CompilationInfo.cmake)
+else()
+    add_custom_command(OUTPUT
+            "${CMAKE_CURRENT_BINARY_DIR}/CompilationInfo.cpp"
+            COMMAND cmake -P ${CMAKE_CURRENT_SOURCE_DIR}/CompilationInfo.cmake)
+endif()
 
 set(LOG_LEVEL_FATAL 0)
 set(LOG_LEVEL_ERROR 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,10 +210,10 @@ message(STATUS ---)
 include_directories(src)
 
 # Run the script `CompilationInfo.cmake` that creates the file `CompilationInfo.cpp`
-# with the current git hash and the curent time and date.q When specifying
+# with the current git hash and the curent time and date. When specifying
 # `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to CMAKE, the compilation info is
-# never updated. This is useful during development to avoid unnecessary relinking of unchanged
-# binaries.
+# never updated. This is useful during development to avoid a relinking of the binaries for
+# every compilation.
 if (NOT DONT_UPDATE_COMPILATION_INFO)
     # The first output which is never created is necessary s.t. the command is never cached and
     # always rerun.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ include_directories(src)
 
 # Run the script `CompilationInfo.cmake` that creates the file `CompilationInfo.cpp`
 # with the current git hash and the curent time and date. When specifying
-# `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to CMAKE, the compilation info is
+# `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to `cmake`, the compilation info is
 # never updated. This is useful during development to avoid a relinking of the binaries for
 # every compilation.
 if (NOT DONT_UPDATE_COMPILATION_INFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,9 @@ include_directories(src)
 
 # Run the script `CompilationInfo.cmake` that creates the file `CompilationInfo.cpp`
 # with the current git hash and the curent time and date.q When specifying
-# `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to CMAKE the
+# `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to CMAKE, the compilation info is
+# never updated. This is useful during development to avoid unnecessary relinking of unchanged
+# binaries.
 if (NOT DONT_UPDATE_COMPILATION_INFO)
     # The first output which is never created is necessary s.t. the command is never cached and
     # always rerun.


### PR DESCRIPTION
This is handy during development because it avoids unnecessary relinking.