### PR TITLE
Update clang-format to version 14

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y clang-format-13
+        run: sudo apt-get install -y clang-format-14
 
       - name: Run the format checker
         run: ${{github.workspace}}/misc/format-check.sh

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,12 +12,12 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y clang-format-11
+        run: sudo apt-get install -y clang-format-13
 
       - name: Run the format checker
         run: ${{github.workspace}}/misc/format-check.sh

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -9,7 +9,7 @@ done <sourcelist
 
 ERROR=0
 for source in "${SOURCE_FILES[@]}" ;do
-	clang-format-11 -output-replacements-xml $source | grep "<replacement " &> /dev/null
+	clang-format-13 -output-replacements-xml $source | grep "<replacement " &> /dev/null
 	HAS_WRONG_FILES=$?
 	if [ $HAS_WRONG_FILES -ne 1 ] ; then
 		# Print an error and exit
@@ -17,8 +17,8 @@ for source in "${SOURCE_FILES[@]}" ;do
 		printf "The source file \x1b[m$source\x1b[31m does not match the code style\n"
 		printf "Use clang-format with the .clang-format provided in the QLever\n"
 		printf "repository's root to ensure all code files are formatted "
-		printf "properly. We currently use the clang-format-11\n"
-		printf "(can be installed as \"clang-format-11\" in Ubuntu 20.04.\n"
+		printf "properly. We currently use  clang-format 13\n"
+		printf "(can be installed as \"clang-format-13\" in Ubuntu 22.04.\n"
 		printf "\x1b[m"
 		ERROR=1
 	fi

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -9,7 +9,7 @@ done <sourcelist
 
 ERROR=0
 for source in "${SOURCE_FILES[@]}" ;do
-	clang-format-13 -output-replacements-xml $source | grep "<replacement " &> /dev/null
+	clang-format-14 -output-replacements-xml $source | grep "<replacement " &> /dev/null
 	HAS_WRONG_FILES=$?
 	if [ $HAS_WRONG_FILES -ne 1 ] ; then
 		# Print an error and exit
@@ -17,8 +17,8 @@ for source in "${SOURCE_FILES[@]}" ;do
 		printf "The source file \x1b[m$source\x1b[31m does not match the code style\n"
 		printf "Use clang-format with the .clang-format provided in the QLever\n"
 		printf "repository's root to ensure all code files are formatted "
-		printf "properly. We currently use  clang-format 13\n"
-		printf "(can be installed as \"clang-format-13\" in Ubuntu 22.04.\n"
+		printf "properly. We currently use  clang-format 14\n"
+		printf "(can be installed as \"clang-format-14\" in Ubuntu 22.04.\n"
 		printf "\x1b[m"
 		ERROR=1
 	fi

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -17,8 +17,8 @@ for source in "${SOURCE_FILES[@]}" ;do
 		printf "The source file \x1b[m$source\x1b[31m does not match the code style\n"
 		printf "Use clang-format with the .clang-format provided in the QLever\n"
 		printf "repository's root to ensure all code files are formatted "
-		printf "properly. We currently use  clang-format 14\n"
-		printf "(can be installed as \"clang-format-14\" in Ubuntu 22.04.\n"
+		printf "properly. We currently use clang-format 14\n"
+		printf "(can be installed as \"clang-format-14\" on Ubuntu 22.04.\n"
 		printf "\x1b[m"
 		ERROR=1
 	fi

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
       &RuntimeParameters()};
 
   po::options_description options("Options for ServerMain");
-  auto add = [&options]<typename... Args>(Args && ... args) {
+  auto add = [&options]<typename... Args>(Args&&... args) {
     options.add_options()(std::forward<Args>(args)...);
   };
   add("help,h", "Produce this help message.");

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -461,7 +461,7 @@ ad_utility::streams::stream_generator QueryExecutionTree::generateResults(
                      "Cannot deduce output type.");
         }
       }
-      co_yield(j + 1 < selectedColumnIndices.size() ? sep : '\n');
+      co_yield (j + 1 < selectedColumnIndices.size() ? sep : '\n');
     }
   }
   LOG(DEBUG) << "Done creating readable result.\n";

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -461,7 +461,7 @@ ad_utility::streams::stream_generator QueryExecutionTree::generateResults(
                      "Cannot deduce output type.");
         }
       }
-      co_yield (j + 1 < selectedColumnIndices.size() ? sep : '\n');
+      co_yield j + 1 < selectedColumnIndices.size() ? sep : '\n';
     }
   }
   LOG(DEBUG) << "Done creating readable result.\n";

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -108,8 +108,8 @@ class AggregateExpression : public SparqlExpression {
       // would get the operand type, which is not necessarily the `ResultType`.
       // For example, in the COUNT aggregate we calculate a sum of boolean
       // values, but the result is not boolean.
-      using ResultType = std::decay_t<decltype(
-          aggregateOperation._function(std::move(*it), *it))>;
+      using ResultType = std::decay_t<decltype(aggregateOperation._function(
+          std::move(*it), *it))>;
       ResultType result = *it;
       for (++it; it != values.end(); ++it) {
         result =
@@ -134,8 +134,8 @@ class AggregateExpression : public SparqlExpression {
       using ResultType = std::decay_t<decltype(aggregateOperation._function(
           std::move(valueGetter(*it, context)), valueGetter(*it, context)))>;
       ResultType result = valueGetter(*it, context);
-      ad_utility::HashSetWithMemoryLimit<typename decltype(
-          operands)::value_type>
+      ad_utility::HashSetWithMemoryLimit<
+          typename decltype(operands)::value_type>
           uniqueHashSet({*it}, inputSize, context->_allocator);
       for (++it; it != operands.end(); ++it) {
         if (uniqueHashSet.insert(*it).second) {

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -133,11 +133,11 @@ inline auto valueGetterGenerator =
 /// Do the following `numItems` times: Obtain the next elements e_1, ..., e_n
 /// from the `generators` and yield `function(e_1, ..., e_n)`, also as a
 /// generator.
-inline auto applyFunction =
-    []<typename Function, typename... Generators>(
-        Function && function, size_t numItems, Generators... generators)
-        -> cppcoro::generator<std::invoke_result_t<
-            std::decay_t<Function>, typename Generators::value_type...>> {
+inline auto applyFunction = []<typename Function, typename... Generators>(
+                                Function&& function, size_t numItems,
+                                Generators... generators)
+    -> cppcoro::generator<std::invoke_result_t<
+        std::decay_t<Function>, typename Generators::value_type...>> {
   // A tuple holding one iterator to each of the generators.
   std::tuple iterators{generators.begin()...};
 

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -363,10 +363,10 @@ std::optional<ExpressionResult> evaluateOnSpecializedFunctionsIfPossible(
 /// `FunctionForSetOfIntervals` (which also has to appear at the end).
 template <size_t NumOperands, typename FunctionAndValueGettersT,
           typename... SpecializedFunctions>
-    requires ad_utility::isInstantiation<FunctionAndValueGetters,
-                                         FunctionAndValueGettersT> &&
-    (... && ad_utility::isInstantiation<SpecializedFunction,
-                                        SpecializedFunctions>)struct Operation {
+requires ad_utility::isInstantiation<FunctionAndValueGetters,
+                                     FunctionAndValueGettersT> &&
+    (...&& ad_utility::isInstantiation<SpecializedFunction,
+                                       SpecializedFunctions>)struct Operation {
  private:
   using OriginalValueGetters = typename FunctionAndValueGettersT::ValueGetters;
   static constexpr size_t NV = std::tuple_size_v<OriginalValueGetters>;

--- a/src/global/Pattern.h
+++ b/src/global/Pattern.h
@@ -133,8 +133,7 @@ class CompactVectorOfStrings {
    */
   template <typename T>
   requires requires(T t) {
-    { *(t.begin()->begin()) }
-    ->ad_utility::SimilarTo<data_type>;
+    { *(t.begin()->begin()) } -> ad_utility::SimilarTo<data_type>;
   }
   void build(const T& input) {
     // Also make room for the end offset of the last element.

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
 
   boost::program_options::options_description boostOptions(
       "Options for IndexBuilderMain");
-  auto add = [&boostOptions]<typename... Args>(Args && ... args) {
+  auto add = [&boostOptions]<typename... Args>(Args&&... args) {
     boostOptions.add_options()(std::forward<Args>(args)...);
   };
   add("help,h", "Produce this help message.");

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -4,6 +4,8 @@
 //          Johannes Kalmbach <johannes.kalmbach@gmail.com>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
+#include "./IndexImpl.h"
+
 #include <absl/strings/str_split.h>
 
 #include <algorithm>
@@ -16,7 +18,6 @@
 #include "../util/Conversions.h"
 #include "../util/Simple8bCode.h"
 #include "./FTSAlgorithms.h"
-#include "./IndexImpl.h"
 
 namespace {
 

--- a/src/index/vocabulary/CombinedVocabulary.h
+++ b/src/index/vocabulary/CombinedVocabulary.h
@@ -27,22 +27,17 @@ template <typename CombinedVocabulary, typename T>
 concept IndexConverterConcept = requires(const T& t, uint64_t i,
                                          const CombinedVocabulary& v) {
   // Return true, iff a word with ID `i` belongs to the first vocabulary.
-  { t.isInFirst(i, v) }
-  ->std::same_as<bool>;
+  { t.isInFirst(i, v) } -> std::same_as<bool>;
   // Transform a local ID from the first vocabulary to a global ID.
-  { t.localFirstToGlobal(i, v) }
-  ->std::convertible_to<uint64_t>;
+  { t.localFirstToGlobal(i, v) } -> std::convertible_to<uint64_t>;
   // Transform a local ID from the second vocabulary to a global ID.
-  { t.localSecondToGlobal(i, v) }
-  ->std::convertible_to<uint64_t>;
+  { t.localSecondToGlobal(i, v) } -> std::convertible_to<uint64_t>;
   // Transform a global ID to a local ID for the first vocabulary.
   // May only be called if `t.isInFirst(i, v)` is true.
-  { t.globalToLocalFirst(i, v) }
-  ->std::convertible_to<uint64_t>;
+  { t.globalToLocalFirst(i, v) } -> std::convertible_to<uint64_t>;
   // Transform a global ID to a local ID for the second vocabulary.
   // May only be called if `t.isInFirst(i, v)` is false.
-  { t.globalToLocalSecond(i, v) }
-  ->std::convertible_to<uint64_t>;
+  { t.globalToLocalSecond(i, v) } -> std::convertible_to<uint64_t>;
 };
 
 ///
@@ -63,11 +58,9 @@ class CombinedVocabulary {
 
  public:
   // Construct from pre-initialized vocabularies and `IndexConverter`.
-  CombinedVocabulary(
-      FirstVocabulary firstVocab, SecondVocabulary secondVocab,
-      IndexConverter
-          converter) requires IndexConverterConcept<CombinedVocabulary,
-                                                    IndexConverter>
+  CombinedVocabulary(FirstVocabulary firstVocab, SecondVocabulary secondVocab,
+                     IndexConverter converter) requires
+      IndexConverterConcept<CombinedVocabulary, IndexConverter>
       : _firstVocab{std::move(firstVocab)},
         _secondVocab{std::move(secondVocab)},
         _indexConverter{converter} {}

--- a/src/parser/ParallelParseBuffer.h
+++ b/src/parser/ParallelParseBuffer.h
@@ -58,8 +58,8 @@ class ParserBatcher {
   // The second requires evaluates to `true` only if the `Parser` type has a
   // getBatch() member function. The first requires enables this function only
   // if the second "requires" evaluates to true
-  std::optional<std::vector<TurtleTriple>> getBatch() requires requires(
-      Parser p) {
+  std::optional<std::vector<TurtleTriple>> getBatch() requires
+      requires(Parser p) {
     p.getBatch();
   }
   {

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -47,9 +47,7 @@ class TripleComponent {
   /// Assignment for types that can be directly assigned to the underlying
   /// variant.
   template <typename T>
-  requires requires(Variant v, T&& t) {
-    _variant = t;
-  }
+  requires requires(Variant v, T&& t) { _variant = t; }
   TripleComponent& operator=(T&& value) {
     _variant = AD_FWD(value);
     return *this;
@@ -67,9 +65,7 @@ class TripleComponent {
 
   /// Make a `TripleComponent` directly comparable to the underlying types.
   template <typename T>
-  requires requires(T&& t) {
-    _variant == t;
-  }
+  requires requires(T&& t) { _variant == t; }
   bool operator==(const T& other) const { return _variant == other; }
 
   /// Equality comparison between two `TripleComponent`s.

--- a/src/util/BatchedPipeline.h
+++ b/src/util/BatchedPipeline.h
@@ -167,8 +167,8 @@ class BatchedPipeline {
                 sizeof...(Transformers) + 1 == Parallelism);
 
   // the value type the previous pipeline stage delivers to us
-  using InT = std::decay_t<decltype(
-      std::declval<PreviousStage&>().pickupBatch().m_content[0])>;
+  using InT = std::decay_t<
+      decltype(std::declval<PreviousStage&>().pickupBatch().m_content[0])>;
 
   // the value type this BatchedPipeline produces
   using ResT = std::invoke_result_t<FirstTransformer, InT>;
@@ -459,8 +459,8 @@ template <class Pipeline>
 class BatchExtractor {
  public:
   /// The type of our elements after all transformations were applied
-  using ValueT = std::decay_t<decltype(
-      std::declval<Pipeline>().pickupBatch().m_content[0])>;
+  using ValueT = std::decay_t<
+      decltype(std::declval<Pipeline>().pickupBatch().m_content[0])>;
 
   /// Get the next completely transformed value from the pipeline. std::nullopt
   /// means that all elements have been extracted and the pipeline is exhausted.

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -132,14 +132,10 @@ class IteratorForAccessOperator {
 
   // Only allowed, if `RandomAccessContainer` yields references and not values
   template <typename A = Accessor, typename P = RandomAccessContainerPtr>
-  requires requires(A a, P p, uint64_t i) {
-    {&a(*p, i)};
-  }
+  requires requires(A a, P p, uint64_t i) { {&a(*p, i)}; }
   auto operator->() { return &(*(*this)); }
   template <typename A = Accessor, typename P = RandomAccessContainerPtr>
-  requires requires(A a, P p, uint64_t i) {
-    {&a(*p, i)};
-  }
+  requires requires(A a, P p, uint64_t i) { {&a(*p, i)}; }
   auto operator->() const { return &(*(*this)); }
 
   decltype(auto) operator[](difference_type n) const {

--- a/src/util/LambdaHelpers.h
+++ b/src/util/LambdaHelpers.h
@@ -29,9 +29,8 @@ struct AssignableLambdaImpl {
     return _lambda(AD_FWD(args)...);
   }
 
-  AssignableLambdaImpl& operator=(
-      const AssignableLambdaImpl&
-          other) requires std::is_copy_constructible_v<AssignableLambdaImpl> {
+  AssignableLambdaImpl& operator=(const AssignableLambdaImpl& other) requires
+      std::is_copy_constructible_v<AssignableLambdaImpl> {
     std::destroy_at(&_lambda);
     std::construct_at(&_lambda, other._lambda);
     return *this;

--- a/src/util/OnDestruction.h
+++ b/src/util/OnDestruction.h
@@ -12,7 +12,8 @@ namespace ad_utility {
 /// major difference to `absl::Cleanup`, the destructor of which is always
 /// noexcept, which will lead to the program being aborted when F throws.
 template <typename F>
-requires std::is_invocable_r_v<void, F> class OnDestruction {
+requires std::is_invocable_r_v<void, F>
+class OnDestruction {
  private:
   F f_;
 

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -63,8 +63,7 @@ template <typename S>
 concept WriteSerializer = requires(S s, const char* ptr, size_t numBytes) {
   {
     typename std::decay_t<S>::SerializerType {}
-  }
-  ->std::same_as<WriteSerializerTag>;
+    } -> std::same_as<WriteSerializerTag>;
   {s.serializeBytes(ptr, numBytes)};
 };
 
@@ -74,8 +73,7 @@ template <typename S>
 concept ReadSerializer = requires(S s, char* ptr, size_t numBytes) {
   {
     typename std::decay_t<S>::SerializerType {}
-  }
-  ->std::same_as<ReadSerializerTag>;
+    } -> std::same_as<ReadSerializerTag>;
   {s.serializeBytes(ptr, numBytes)};
 };
 
@@ -114,22 +112,21 @@ static constexpr bool SerializerMatchesConstness =
  * - The second argument to `serialize` is a `T`, `T&`, `const T&`, `T&&` etc.
  * - If the `arg` is const then the serializer is a `WriteSerializer`.
  */
-#define AD_SERIALIZE_FUNCTION(T)                                            \
-  template <ad_utility::serialization::Serializer S,                        \
-            ad_utility::SimilarTo<T> U>                                     \
-  requires ad_utility::serialization::SerializerMatchesConstness<S, U> void \
-  serialize(S& serializer, U&& arg)
+#define AD_SERIALIZE_FUNCTION(T)                                       \
+  template <ad_utility::serialization::Serializer S,                   \
+            ad_utility::SimilarTo<T> U>                                \
+  requires ad_utility::serialization::SerializerMatchesConstness<S, U> \
+  void serialize(S& serializer, U&& arg)
 
 /// Similar to `AD_SERIALIZE_FUNCTION` but defines a `friend` function to also
 /// access private members of a class. It is possible to declare the friend
 /// using `AD_SERIALIZE_FRIEND_FUNCTION(Type);` and to define it outside of the
 /// class with `AD_SERIALIZE_FUNCTION(Type){...}`
-#define AD_SERIALIZE_FRIEND_FUNCTION(T)                           \
-  template <ad_utility::serialization::Serializer S,              \
-            ad_utility::SimilarTo<T> U>                           \
-  requires ad_utility::serialization::SerializerMatchesConstness< \
-      S, U> friend void                                           \
-  serialize(S& serializer, U&& arg)
+#define AD_SERIALIZE_FRIEND_FUNCTION(T)                                \
+  template <ad_utility::serialization::Serializer S,                   \
+            ad_utility::SimilarTo<T> U>                                \
+  requires ad_utility::serialization::SerializerMatchesConstness<S, U> \
+  friend void serialize(S& serializer, U&& arg)
 
 /**
  * Define `serialize` functions for all types that fulfill the `Constraint`.

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -215,8 +215,9 @@ class Synchronized {
     return {ConstructWithMutex{}, mutex(), data_};
   }
 
- private : T data_;  // The data to which we synchronize the access.
-  Mutex m_;          // The used mutex
+ private:
+  T data_;   // The data to which we synchronize the access.
+  Mutex m_;  // The used mutex
 
   Mutex& mutex() const { return const_cast<Mutex&>(m_); }
 

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -215,9 +215,8 @@ class Synchronized {
     return {ConstructWithMutex{}, mutex(), data_};
   }
 
- private:
-  T data_;   // The data to which we synchronize the access.
-  Mutex m_;  // The used mutex
+ private : T data_;  // The data to which we synchronize the access.
+  Mutex m_;          // The used mutex
 
   Mutex& mutex() const { return const_cast<Mutex&>(m_); }
 

--- a/src/util/TransparentFunctors.h
+++ b/src/util/TransparentFunctors.h
@@ -28,8 +28,8 @@ namespace detail {
 // Implementation of `firstOfPair` (see below).
 struct FirstOfPairImpl {
   template <typename T>
-  requires similarToInstantiation<std::pair, T> constexpr decltype(auto)
-  operator()(T&& pair) const noexcept {
+  requires similarToInstantiation<std::pair, T>
+  constexpr decltype(auto) operator()(T&& pair) const noexcept {
     return AD_FWD(pair).first;
   }
 };
@@ -37,8 +37,8 @@ struct FirstOfPairImpl {
 // Implementation of `secondOfPair` (see below).
 struct SecondOfPairImpl {
   template <typename T>
-  requires similarToInstantiation<std::pair, T> constexpr decltype(auto)
-  operator()(T&& pair) const noexcept {
+  requires similarToInstantiation<std::pair, T>
+  constexpr decltype(auto) operator()(T&& pair) const noexcept {
     return AD_FWD(pair).second;
   }
 };

--- a/src/util/TupleForEach.h
+++ b/src/util/TupleForEach.h
@@ -10,7 +10,7 @@
 namespace ad_utility {
 template <typename Tuple, typename Function>
 void forEachInTuple(Tuple&& tuple, Function&& function) {
-  auto forEachInParamPack = [&]<typename... Ts>(Ts && ... parameters) {
+  auto forEachInParamPack = [&]<typename... Ts>(Ts&&... parameters) {
     (..., function(std::forward<Ts>(parameters)));
   };
   std::apply(forEachInParamPack, std::forward<Tuple>(tuple));
@@ -24,7 +24,7 @@ void forEachInTuple(Tuple&& tuple, Function&& function) {
 ///                 in the `tuple` and must always return the same type.
 template <typename Tuple, typename Function>
 auto tupleToArray(Tuple&& tuple, Function&& function) {
-  auto paramPackToArray = [&]<typename... Ts>(Ts && ... parameters) {
+  auto paramPackToArray = [&]<typename... Ts>(Ts&&... parameters) {
     return std::array{function(std::forward<Ts>(parameters))...};
   };
   return std::apply(paramPackToArray, std::forward<Tuple>(tuple));

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -33,7 +33,8 @@ struct IsInstantiationOf {
 // Example: LiftInnerTypes<std::variant,
 // std::vector>::TypeToLift<std::variant<A, B, C>>::LiftedType is
 // std::variant<std::vector<A>, std::vector<B>, std::vector<C>>
-template <template <typename...> typename Template, template <typename> typename TypeLifter>
+template <template <typename...> typename Template,
+          template <typename> typename TypeLifter>
 struct LiftInnerTypes {
   template <typename>
   struct TypeToLift {};
@@ -66,7 +67,8 @@ struct FirstWrapper : public std::type_identity<T> {};
 
 }  // namespace detail
 
-/// The concept is fulfilled iff `T` is an instantiation of `TemplatedType`. Examples:
+/// The concept is fulfilled iff `T` is an instantiation of `TemplatedType`.
+/// Examples:
 ///
 /// isInstantiation<std::vector, std::vector<int>> == true;
 /// isInstantiation<std::vector, const std::vector<int>&> == false;
@@ -80,7 +82,8 @@ concept isInstantiation =
 /// similarToInstantiation<std::vector, std::vector<int>> == true;
 /// similarToInstantiation<std::vector, const std::vector<int>&> == true;
 template <template <typename...> typename TemplatedType, typename T>
-concept similarToInstantiation = isInstantiation<TemplatedType, std::decay_t<T>>;
+concept similarToInstantiation =
+    isInstantiation<TemplatedType, std::decay_t<T>>;
 
 /// isVector<T> is true if and only if T is an instantiation of std::vector
 template <typename T>
@@ -97,7 +100,8 @@ constexpr static bool isVariant = isInstantiation<std::variant, T>;
 /// Two types are similar, if they are the same when we remove all cv (const or
 /// volatile) qualifiers and all references
 template <typename T, typename U>
-constexpr static bool isSimilar = std::is_same_v<std::decay_t<T>, std::decay_t<U>>;
+constexpr static bool isSimilar =
+    std::is_same_v<std::decay_t<T>, std::decay_t<U>>;
 
 /// A concept for similarity
 template <typename T, typename U>
@@ -110,13 +114,16 @@ template <typename... Ts>
 constexpr static bool isTypeContainedIn = false;
 
 template <typename T, typename... Ts>
-constexpr static bool isTypeContainedIn<T, std::tuple<Ts...>> = (... || isSimilar<T, Ts>);
+constexpr static bool isTypeContainedIn<T, std::tuple<Ts...>> =
+    (... || isSimilar<T, Ts>);
 
 template <typename T, typename... Ts>
-constexpr static bool isTypeContainedIn<T, std::variant<Ts...>> = (... || isSimilar<T, Ts>);
+constexpr static bool isTypeContainedIn<T, std::variant<Ts...>> =
+    (... || isSimilar<T, Ts>);
 
 template <typename T, typename... Ts>
-constexpr static bool isTypeContainedIn<T, std::pair<Ts...>> = (... || isSimilar<T, Ts>);
+constexpr static bool isTypeContainedIn<T, std::pair<Ts...>> =
+    (... || isSimilar<T, Ts>);
 
 /// A templated bool that is always false,
 /// independent of the template parameter.
@@ -127,16 +134,15 @@ constexpr static bool alwaysFalse = false;
 /// std::tuple<TypeLifter<A>, TypeLifter<B>,...>
 template <typename Tuple, template <typename> typename TypeLifter>
 requires isTuple<Tuple>
-using LiftedTuple =
-    typename detail::LiftInnerTypes<std::tuple, TypeLifter>::template TypeToLift<Tuple>::LiftedType;
+using LiftedTuple = typename detail::LiftInnerTypes<
+    std::tuple, TypeLifter>::template TypeToLift<Tuple>::LiftedType;
 
 /// From the type Variant (std::variant<A, B, C....>) creates the type
 /// std::variant<TypeLifter<A>, TypeLifter<B>,...>
 template <typename Variant, template <typename> typename TypeLifter>
 requires isVariant<Variant>
-using LiftedVariant =
-    typename detail::LiftInnerTypes<std::variant,
-                                    TypeLifter>::template TypeToLift<Variant>::LiftedType;
+using LiftedVariant = typename detail::LiftInnerTypes<
+    std::variant, TypeLifter>::template TypeToLift<Variant>::LiftedType;
 
 /// From the type std::tuple<A, B, ...> makes the type std::variant<A, B, ...>
 template <typename Tuple>
@@ -150,36 +156,41 @@ template <typename... Tuples>
 requires(...&& isTuple<Tuples>) using TupleCat =
     decltype(std::tuple_cat(std::declval<Tuples&>()...));
 
-/// A generalized version of std::visit that also supports non-variant parameters.
-/// Each `parameterOrVariant` of type T that is not a std::variant is converted to a
-/// `std::variant<T>`. Each `parameterOrVariant` that is a std::variant is left as-is. Then
-/// std::visit is called on the passed `Function` and the transformed parameters (which now are all
-/// variants). This has the effect that `Function` is called on the values contained in the passed
-/// variants and additionally with the non-variant parameters. Note that this currently only
-/// supports variant types that are direct instantiations of `std::variant`. If you want a different
-/// behavior, etc. also visit types that inherit from std::variant, or treat a parameter that is a
-/// std::variant as an "ordinary" parameter to the `Function`, you cannot use this function.
+/// A generalized version of std::visit that also supports non-variant
+/// parameters. Each `parameterOrVariant` of type T that is not a std::variant
+/// is converted to a `std::variant<T>`. Each `parameterOrVariant` that is a
+/// std::variant is left as-is. Then std::visit is called on the passed
+/// `Function` and the transformed parameters (which now are all variants). This
+/// has the effect that `Function` is called on the values contained in the
+/// passed variants and additionally with the non-variant parameters. Note that
+/// this currently only supports variant types that are direct instantiations of
+/// `std::variant`. If you want a different behavior, etc. also visit types that
+/// inherit from std::variant, or treat a parameter that is a std::variant as an
+/// "ordinary" parameter to the `Function`, you cannot use this function.
 inline auto visitWithVariantsAndParameters =
     []<typename Function, typename... ParametersOrVariants>(
-        Function && f, ParametersOrVariants&&... parametersOrVariants) {
-  auto liftToVariant = []<typename T>(T&& t) {
-    if constexpr (isVariant<T>) {
-      return std::forward<T>(t);
-    } else {
-      return std::variant<std::decay_t<T>>{std::forward<T>(t)};
-    }
-  };
-  return std::visit(f, liftToVariant(std::forward<ParametersOrVariants>(parametersOrVariants))...);
-};
+        Function&& f, ParametersOrVariants&&... parametersOrVariants) {
+      auto liftToVariant = []<typename T>(T&& t) {
+        if constexpr (isVariant<T>) {
+          return std::forward<T>(t);
+        } else {
+          return std::variant<std::decay_t<T>>{std::forward<T>(t)};
+        }
+      };
+      return std::visit(f, liftToVariant(std::forward<ParametersOrVariants>(
+                               parametersOrVariants))...);
+    };
 
 /// Apply `Function f` to each element of tuple. Returns a tuple of the results.
-/// Note: 1. The `Function` must not return void (otherwise this doesn't compile)
+/// Note: 1. The `Function` must not return void (otherwise this doesn't
+/// compile)
 ///       2. The order in which the function is called is unspecified.
 template <typename Function, typename Tuple>
 auto applyFunctionToEachElementOfTuple(Function&& f, Tuple&& tuple) {
-  auto transformer = [f = std::forward<Function>(f)]<typename... Args>(Args && ... args) {
-    return std::tuple{f(std::forward<Args>(args))...};
-  };
+  auto transformer =
+      [f = std::forward<Function>(f)]<typename... Args>(Args&&... args) {
+        return std::tuple{f(std::forward<Args>(args))...};
+      };
   return std::apply(transformer, std::forward<Tuple>(tuple));
 }
 
@@ -189,6 +200,7 @@ requires(sizeof...(Ts) > 0) using Last = typename detail::LastT<Ts...>::type;
 
 // Return the first type of variadic template arguments.
 template <typename... Ts>
-requires(sizeof...(Ts) > 0) using First = typename detail::FirstWrapper<Ts...>::type;
+requires(sizeof...(Ts) >
+         0) using First = typename detail::FirstWrapper<Ts...>::type;
 
 }  // namespace ad_utility

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -126,19 +126,22 @@ constexpr static bool alwaysFalse = false;
 /// From the type Tuple (std::tuple<A, B, C....>) creates the type
 /// std::tuple<TypeLifter<A>, TypeLifter<B>,...>
 template <typename Tuple, template <typename> typename TypeLifter>
-requires isTuple<Tuple> using LiftedTuple =
+requires isTuple<Tuple>
+using LiftedTuple =
     typename detail::LiftInnerTypes<std::tuple, TypeLifter>::template TypeToLift<Tuple>::LiftedType;
 
 /// From the type Variant (std::variant<A, B, C....>) creates the type
 /// std::variant<TypeLifter<A>, TypeLifter<B>,...>
 template <typename Variant, template <typename> typename TypeLifter>
-requires isVariant<Variant> using LiftedVariant =
+requires isVariant<Variant>
+using LiftedVariant =
     typename detail::LiftInnerTypes<std::variant,
                                     TypeLifter>::template TypeToLift<Variant>::LiftedType;
 
 /// From the type std::tuple<A, B, ...> makes the type std::variant<A, B, ...>
 template <typename Tuple>
-requires isTuple<Tuple> using TupleToVariant = typename detail::TupleToVariantImpl<Tuple>::type;
+requires isTuple<Tuple>
+using TupleToVariant = typename detail::TupleToVariantImpl<Tuple>::type;
 
 /// From the types X = std::tuple<A, ... , B>, , Y = std::tuple<C, ..., D>...
 /// makes the type TupleCat<X, Y> = std::tuple<A, ..., B, C, ..., D, ...> (works


### PR DESCRIPTION
* reformatted the code
* updated the github action
* the formatting is now better for "requires" clauses, because the old clang-format-11 was not aware of this C++-11 feature.