### PR TITLE
Make several tests faster, especially in DEBUG mode

### DIFF
--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -33,8 +33,8 @@ static const size_t PARSER_MIN_TRIPLES_AT_ONCE = 100'000;
 // When reading from a file, Chunks of this size will
 // be fed to the parser at once (100 MiB)
 inline std::atomic<size_t>& FILE_BUFFER_SIZE() {
-    static std::atomic<size_t> fileBufferSize = 100 * (1ul << 20);
-    return fileBufferSize;
+  static std::atomic<size_t> fileBufferSize = 100 * (1ul << 20);
+  return fileBufferSize;
 }
 
 // When the BZIP2 parser encouters a parsing exception it will increase its

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -32,7 +32,10 @@ static const size_t PARSER_MIN_TRIPLES_AT_ONCE = 100'000;
 
 // When reading from a file, Chunks of this size will
 // be fed to the parser at once (100 MiB)
-static const size_t FILE_BUFFER_SIZE = 100 * (1ul << 20);
+inline std::atomic<size_t>& FILE_BUFFER_SIZE() {
+    static std::atomic<size_t> fileBufferSize = 100 * (1ul << 20);
+    return fileBufferSize;
+}
 
 // When the BZIP2 parser encouters a parsing exception it will increase its
 // buffer and try again (we have no other way currently to determine if the

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -524,7 +524,7 @@ class TurtleStreamParser : public TurtleParser<Tokenizer_T> {
   std::unique_ptr<ParallelBuffer> _fileBuffer;
   // this many characters will be buffered at once,
   // defaults to a global constant
-  size_t _bufferSize = FILE_BUFFER_SIZE;
+  size_t _bufferSize = FILE_BUFFER_SIZE();
 
   // that many bytes were already parsed before dealing with the current batch
   // in member _byteVec
@@ -632,7 +632,8 @@ class TurtleParallelParser : public TurtleParser<Tokenizer_T> {
 
   // this many characters will be buffered at once,
   // defaults to a global constant
-  size_t _bufferSize = FILE_BUFFER_SIZE;
+  size_t _bufferSize = FILE_BUFFER_SIZE();
+
   ParallelBufferWithEndRegex _fileBuffer{_bufferSize, "\\. *(\\n)"};
 
   ad_utility::TaskQueue<true> tripleCollector{QUEUE_SIZE_AFTER_PARALLEL_PARSING,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,7 @@ addLinkAndDiscoverTestSerial(BufferedVectorTest absl::strings)
 
 addLinkAndDiscoverTest(UnionTest engine)
 
-add_executable(TokenTest TokenTest.cpp TokenTestCtreHelper.cpp SelectClauseTest.cpp)
+add_executable(TokenTest TokenTest.cpp TokenTestCtreHelper.cpp)
 linkAndDiscoverTest(TokenTest parser re2 ${ICU_LIBRARIES})
 
 addLinkAndDiscoverTest(TurtleParserTest parser absl::flat_hash_map re2)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -226,7 +226,6 @@ addLinkAndDiscoverTest(TripleObjectTest absl::strings)
 
 addLinkAndDiscoverTest(ValueIdTest absl::flat_hash_set)
 
-#addLinkAndDiscoverTest(ValueIdComparatorsTest)
 
 addLinkAndDiscoverTest(LambdaHelpersTest)
 

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -114,7 +114,7 @@ TEST(ConcurrentCache, sequentialPinnedComputation) {
   SimpleConcurrentLruCache a{3ul};
   ad_utility::Timer t;
   t.start();
-  // Fake computation that takes 100ms and returns value "3", which is then
+  // Fake computation that takes 5ms and returns value "3", which is then
   // stored under key 3.
   auto result = a.computeOncePinned(3, waiting_function("3"s, 5));
   t.stop();
@@ -147,7 +147,7 @@ TEST(ConcurrentCache, sequentialPinnedUpgradeComputation) {
   SimpleConcurrentLruCache a{3ul};
   ad_utility::Timer t;
   t.start();
-  // Fake computation that takes 100ms and returns value "3", which is then
+  // Fake computation that takes 5ms and returns value "3", which is then
   // stored under key 3.
   auto result = a.computeOnce(3, waiting_function("3"s, 5));
   t.stop();

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -82,13 +82,13 @@ TEST(ConcurrentCache, sequentialComputation) {
   SimpleConcurrentLruCache a{3ul};
   ad_utility::Timer t;
   t.start();
-  // Fake computation that takes 100ms and returns value "3", which is then
+  // Fake computation that takes 5ms and returns value "3", which is then
   // stored under key 3.
-  auto result = a.computeOnce(3, waiting_function("3"s, 100));
+  auto result = a.computeOnce(3, waiting_function("3"s, 5));
   t.stop();
   ASSERT_EQ("3"s, *result._resultPointer);
   ASSERT_FALSE(result._wasCached);
-  ASSERT_GE(t.msecs(), 100);
+  ASSERT_GE(t.msecs(), 5);
   ASSERT_EQ(1ul, a.numNonPinnedEntries());
   ASSERT_EQ(0ul, a.numPinnedEntries());
   // No other results currently being computed
@@ -97,7 +97,7 @@ TEST(ConcurrentCache, sequentialComputation) {
   t.reset();
   t.start();
   // takes 0 msecs to compute, as the request is served from the cache.
-  auto result2 = a.computeOnce(3, waiting_function("3"s, 100));
+  auto result2 = a.computeOnce(3, waiting_function("3"s, 5));
   t.stop();
   // computing result again: still yields "3", was cached and takes 0
   // milliseconds (result is read from cache)
@@ -116,11 +116,11 @@ TEST(ConcurrentCache, sequentialPinnedComputation) {
   t.start();
   // Fake computation that takes 100ms and returns value "3", which is then
   // stored under key 3.
-  auto result = a.computeOncePinned(3, waiting_function("3"s, 100));
+  auto result = a.computeOncePinned(3, waiting_function("3"s, 5));
   t.stop();
   ASSERT_EQ("3"s, *result._resultPointer);
   ASSERT_FALSE(result._wasCached);
-  ASSERT_GE(t.msecs(), 100);
+  ASSERT_GE(t.msecs(), 5);
   ASSERT_EQ(1ul, a.numPinnedEntries());
   ASSERT_EQ(0ul, a.numNonPinnedEntries());
   // No other results currently being computed
@@ -130,7 +130,7 @@ TEST(ConcurrentCache, sequentialPinnedComputation) {
   t.start();
   // takes 0 msecs to compute, as the request is served from the cache.
   // we don't request a pin, but the original computation was pinned
-  auto result2 = a.computeOnce(3, waiting_function("3"s, 100));
+  auto result2 = a.computeOnce(3, waiting_function("3"s, 5));
   t.stop();
   // computing result again: still yields "3", was cached and takes 0
   // milliseconds (result is read from cache)
@@ -149,11 +149,11 @@ TEST(ConcurrentCache, sequentialPinnedUpgradeComputation) {
   t.start();
   // Fake computation that takes 100ms and returns value "3", which is then
   // stored under key 3.
-  auto result = a.computeOnce(3, waiting_function("3"s, 100));
+  auto result = a.computeOnce(3, waiting_function("3"s, 5));
   t.stop();
   ASSERT_EQ("3"s, *result._resultPointer);
   ASSERT_FALSE(result._wasCached);
-  ASSERT_GE(t.msecs(), 100);
+  ASSERT_GE(t.msecs(), 5);
   ASSERT_EQ(0ul, a.numPinnedEntries());
   ASSERT_EQ(1ul, a.numNonPinnedEntries());
   // No other results currently being computed
@@ -164,7 +164,7 @@ TEST(ConcurrentCache, sequentialPinnedUpgradeComputation) {
   // takes 0 msecs to compute, as the request is served from the cache.
   // request a pin, the result should be read from the cache and upgraded
   // to a pinned result.
-  auto result2 = a.computeOncePinned(3, waiting_function("3"s, 100));
+  auto result2 = a.computeOncePinned(3, waiting_function("3"s, 5));
   t.stop();
   // computing result again: still yields "3", was cached and takes 0
   // milliseconds (result is read from cache)
@@ -181,7 +181,7 @@ TEST(ConcurrentCache, concurrentComputation) {
   auto a = SimpleConcurrentLruCache(3ul);
   StartStopSignal signal;
   auto compute = [&a, &signal]() {
-    return a.computeOnce(3, waiting_function("3"s, 100, &signal));
+    return a.computeOnce(3, waiting_function("3"s, 5, &signal));
   };
   auto resultFuture = std::async(std::launch::async, compute);
   signal._hasStartedSignal.wait();
@@ -209,7 +209,7 @@ TEST(ConcurrentCache, concurrentPinnedComputation) {
   auto a = SimpleConcurrentLruCache(3ul);
   StartStopSignal signal;
   auto compute = [&a, &signal]() {
-    return a.computeOncePinned(3, waiting_function("3"s, 100, &signal));
+    return a.computeOncePinned(3, waiting_function("3"s, 5, &signal));
   };
   auto resultFuture = std::async(std::launch::async, compute);
   signal._hasStartedSignal.wait();
@@ -239,7 +239,7 @@ TEST(ConcurrentCache, concurrentPinnedUpgradeComputation) {
   auto a = SimpleConcurrentLruCache(3ul);
   StartStopSignal signal;
   auto compute = [&a, &signal]() {
-    return a.computeOnce(3, waiting_function("3"s, 100, &signal));
+    return a.computeOnce(3, waiting_function("3"s, 5, &signal));
   };
   auto resultFuture = std::async(std::launch::async, compute);
   signal._hasStartedSignal.wait();
@@ -254,7 +254,7 @@ TEST(ConcurrentCache, concurrentPinnedUpgradeComputation) {
   // this call waits for the background task to compute, and then fetches the
   // result. After this call completes, nothing is in progress and the result
   // is cached.
-  auto result = a.computeOncePinned(3, waiting_function("3"s, 100));
+  auto result = a.computeOncePinned(3, waiting_function("3"s, 5));
   ASSERT_EQ(0ul, a.numNonPinnedEntries());
   ASSERT_EQ(1ul, a.numPinnedEntries());
   ASSERT_TRUE(a.getStorage().wlock()->_inProgress.empty());
@@ -269,10 +269,10 @@ TEST(ConcurrentCache, abort) {
   auto a = SimpleConcurrentLruCache(3ul);
   StartStopSignal signal;
   auto compute = [&a, &signal]() {
-    return a.computeOnce(3, waiting_function("3"s, 100, &signal));
+    return a.computeOnce(3, waiting_function("3"s, 5, &signal));
   };
   auto computeWithError = [&a, &signal]() {
-    return a.computeOnce(3, wait_and_throw_function(100, &signal));
+    return a.computeOnce(3, wait_and_throw_function(5, &signal));
   };
   auto fut = std::async(std::launch::async, computeWithError);
   signal._hasStartedSignal.wait();
@@ -293,10 +293,10 @@ TEST(ConcurrentCache, abortPinned) {
   auto a = SimpleConcurrentLruCache(3ul);
   StartStopSignal signal;
   auto compute = [&]() {
-    return a.computeOncePinned(3, waiting_function("3"s, 100, &signal));
+    return a.computeOncePinned(3, waiting_function("3"s, 5, &signal));
   };
   auto computeWithError = [&a, &signal]() {
-    return a.computeOncePinned(3, wait_and_throw_function(100, &signal));
+    return a.computeOncePinned(3, wait_and_throw_function(5, &signal));
   };
   auto fut = std::async(std::launch::async, computeWithError);
   signal._hasStartedSignal.wait();

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -2,12 +2,11 @@
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 
-#include <gtest/gtest.h>
-
 #include <cstdio>
 
-#include "../src/engine/GroupBy.h"
 #include "./IndexTestHelpers.h"
+#include "engine/GroupBy.h"
+#include "gtest/gtest.h"
 #include "index/ConstantsIndexBuilding.h"
 
 ad_utility::AllocatorWithLimit<Id>& allocator() {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -8,6 +8,7 @@
 
 #include "../src/engine/GroupBy.h"
 #include "./IndexTestHelpers.h"
+#include "index/ConstantsIndexBuilding.h"
 
 ad_utility::AllocatorWithLimit<Id>& allocator() {
   static ad_utility::AllocatorWithLimit<Id> a{
@@ -23,6 +24,7 @@ auto I = [](const auto& id) { return Id::makeFromInt(id); };
 class GroupByTest : public ::testing::Test {
  public:
   GroupByTest() {
+    FILE_BUFFER_SIZE() = 1000;
     // Create the index. The full index creation is run here to allow for
     // loading a docsDb file, which is not otherwise accessible
     std::string docsFileContent = "0\tExert 1\n1\tExert 2\n2\tExert3";

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -52,6 +52,7 @@ void writeStxxlConfigFile(const string& location, const string& tail) {
 }
 
 TEST(IndexTest, createFromTurtleTest) {
+  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
   string location = "./";
   string tail = "";
   writeStxxlConfigFile(location, tail);
@@ -249,6 +250,7 @@ class CreatePatternsFixture : public testing::Test {
 };
 
 TEST_F(CreatePatternsFixture, createPatterns) {
+  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
   {
     LOG(DEBUG) << "Testing createPatterns with ttl file..." << std::endl;
     std::ofstream f(inputFilename);
@@ -305,6 +307,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
 }
 
 TEST(IndexTest, createFromOnDiskIndexTest) {
+  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
   string location = "./";
   string tail = "";
   writeStxxlConfigFile(location, tail);
@@ -356,6 +359,7 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
 };
 
 TEST(IndexTest, scanTest) {
+  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
   string location = "./";
   string tail = "";
   writeStxxlConfigFile(location, tail);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -52,7 +52,7 @@ void writeStxxlConfigFile(const string& location, const string& tail) {
 }
 
 TEST(IndexTest, createFromTurtleTest) {
-  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
+  FILE_BUFFER_SIZE() = 1000;  // Increase performance in debug mode.
   string location = "./";
   string tail = "";
   writeStxxlConfigFile(location, tail);
@@ -250,7 +250,7 @@ class CreatePatternsFixture : public testing::Test {
 };
 
 TEST_F(CreatePatternsFixture, createPatterns) {
-  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
+  FILE_BUFFER_SIZE() = 1000;  // Increase performance in debug mode.
   {
     LOG(DEBUG) << "Testing createPatterns with ttl file..." << std::endl;
     std::ofstream f(inputFilename);
@@ -307,7 +307,7 @@ TEST_F(CreatePatternsFixture, createPatterns) {
 }
 
 TEST(IndexTest, createFromOnDiskIndexTest) {
-  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
+  FILE_BUFFER_SIZE() = 1000;  // Increase performance in debug mode.
   string location = "./";
   string tail = "";
   writeStxxlConfigFile(location, tail);
@@ -359,7 +359,7 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
 };
 
 TEST(IndexTest, scanTest) {
-  FILE_BUFFER_SIZE() = 1000; // Increase performance in debug mode.
+  FILE_BUFFER_SIZE() = 1000;  // Increase performance in debug mode.
   string location = "./";
   string tail = "";
   writeStxxlConfigFile(location, tail);

--- a/test/MilestoneIdTest.cpp
+++ b/test/MilestoneIdTest.cpp
@@ -22,8 +22,10 @@ void testMilestoneIds() {
 TEST(MilestoneId, OnlyMilestoneIds) {
   testMilestoneIds<256>();
   testMilestoneIds<257>();
+#ifdef QLEVER_RUN_EXPENSIVE_TESTS
   testMilestoneIds<1024 * 1024>();
   testMilestoneIds<1024 * 1024 + 53>();
+#endif
 }
 
 template <uint64_t distance>
@@ -45,8 +47,11 @@ void testConsecutiveIds() {
 TEST(MilestoneId, ConsecutiveIds) {
   testConsecutiveIds<256>();
   testConsecutiveIds<257>();
+
+#ifdef QLEVER_RUN_EXPENSIVE_TESTS
   testConsecutiveIds<1024 * 1024>();
   testConsecutiveIds<1024 * 1024 + 53>();
+#endif
 }
 
 template <uint64_t distance>

--- a/test/NBitIntegerTest.cpp
+++ b/test/NBitIntegerTest.cpp
@@ -9,6 +9,13 @@
 #include "../src/util/Generator.h"
 #include "../src/util/NBitInteger.h"
 
+// Enabling cheaper unit tests when building in Debug mode
+#ifdef QLEVER_RUN_EXPENSIVE_TESTS
+static constexpr int numElements = 100;
+#else
+static constexpr int numElements = 5;
+#endif
+
 auto testToFrom = []<size_t N>(int64_t x) {
   using I = ad_utility::NBitInteger<N>;
   if (x >= I::min() && x <= I::max()) {
@@ -50,11 +57,11 @@ cppcoro::generator<int64_t> valuesNearLimits() {
   constexpr static auto globalMax = std::numeric_limits<int64_t>::max();
 
   constexpr static auto aBitLessThanMin =
-      min - globalMin > 100 ? min - 100 : globalMin;
-  constexpr static auto aBitMoreThanMin = min + 100;
-  constexpr static auto aBitLessThanMax = max - 100;
+      min - globalMin > numElements ? min - numElements : globalMin;
+  constexpr static auto aBitMoreThanMin = min + numElements;
+  constexpr static auto aBitLessThanMax = max - numElements;
   constexpr static auto aBitMoreThanMax =
-      globalMax - max > 100 ? max + 100 : globalMax;
+      globalMax - max > numElements ? max + numElements : globalMax;
 
   for (auto i = aBitLessThanMin; i < aBitMoreThanMin; ++i) {
     co_yield i;
@@ -133,16 +140,16 @@ void testAllN(auto function, auto... args) {
 // 100 values near int64_t::max();
 auto valuesNearCornercasesInt64 = []() -> cppcoro::generator<int64_t> {
   int64_t max = std::numeric_limits<int64_t>::max();
-  for (auto i = max - 100; i < max; ++i) {
+  for (auto i = max - numElements; i < max; ++i) {
     co_yield i + 1;
   }
 
-  for (auto i = -100; i < 100; ++i) {
+  for (auto i = -numElements; i < numElements; ++i) {
     co_yield i;
   }
 
   int64_t min = std::numeric_limits<int64_t>::min();
-  for (auto i = min; i <= min + 100; ++i) {
+  for (auto i = min; i <= min + numElements; ++i) {
     co_yield i;
   }
 };

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -274,7 +274,7 @@ TEST(Serializer, ManyTrivialDatatypes) {
     std::vector<double> doubles;
     std::vector<float> floats;
 
-  // Enabling cheaper unit tests when building in Debug mode
+    // Enabling cheaper unit tests when building in Debug mode
 #ifdef QLEVER_RUN_EXPENSIVE_TESTS
     static constexpr int numIterations = 300'000;
 #else

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -274,7 +274,12 @@ TEST(Serializer, ManyTrivialDatatypes) {
     std::vector<double> doubles;
     std::vector<float> floats;
 
-    const int numIterations = 300'000;
+  // Enabling cheaper unit tests when building in Debug mode
+#ifdef QLEVER_RUN_EXPENSIVE_TESTS
+    static constexpr int numIterations = 300'000;
+#else
+    static constexpr int numIterations = 300;
+#endif
 
     for (int i = 0; i < numIterations; ++i) {
       ints.push_back(static_cast<int>(r()));


### PR DESCRIPTION
Mostly, use smaller buffers for input files, or smaller sizes of random or not so random test inputs.