### PR TITLE
Use the strong `Variable` type consistently in the SPARQL parser

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -140,17 +140,16 @@ void Bind::computeExpressionBind(
 
   auto visitor = [&]<sparqlExpression::SingleExpressionResult T>(
                      T&& singleResult) mutable {
-    constexpr static bool isVariable =
-        std::is_same_v<T, sparqlExpression::Variable>;
+    constexpr static bool isVariable = std::is_same_v<T, ::Variable>;
     constexpr static bool isStrongId =
         std::is_same_v<T, sparqlExpression::StrongIdWithResultType>;
     if constexpr (isVariable) {
-      auto column = getVariableColumns().at(singleResult._variable);
+      auto column = getVariableColumns().at(singleResult.name());
       for (size_t i = 0; i < inSize; ++i) {
         output(i, inCols) = output(i, column);
       }
       *resultType = evaluationContext._variableToColumnAndResultTypeMap
-                        .at(singleResult._variable)
+                        .at(singleResult.name())
                         .second;
     } else if constexpr (isStrongId) {
       for (size_t i = 0; i < inSize; ++i) {

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -4,11 +4,11 @@
 
 #include "Bind.h"
 
-#include "../util/Exception.h"
-#include "./sparqlExpressions/SparqlExpression.h"
-#include "./sparqlExpressions/SparqlExpressionGenerators.h"
-#include "CallFixedSize.h"
-#include "QueryExecutionTree.h"
+#include "engine/CallFixedSize.h"
+#include "engine/QueryExecutionTree.h"
+#include "engine/sparqlExpressions/SparqlExpression.h"
+#include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
+#include "util/Exception.h"
 
 // BIND adds exactly one new column
 size_t Bind::getResultWidth() const { return _subtree->getResultWidth() + 1; }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -67,7 +67,7 @@ string Bind::asStringImpl(size_t indent) const {
 ad_utility::HashMap<string, size_t> Bind::getVariableColumns() const {
   auto res = _subtree->getVariableColumns();
   // The new variable is always appended at the end.
-  res[_bind._target] = getResultWidth() - 1;
+  res[_bind._target.name()] = getResultWidth() - 1;
   return res;
 }
 

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -5,9 +5,9 @@
 #ifndef QLEVER_BIND_H
 #define QLEVER_BIND_H
 
-#include "../parser/ParsedQuery.h"
-#include "Operation.h"
-#include "sparqlExpressions/SparqlExpressionPimpl.h"
+#include "engine/Operation.h"
+#include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
+#include "parser/ParsedQuery.h"
 
 /// BIND operation, currently only supports a very limited subset of expressions
 class Bind : public Operation {

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -33,7 +33,9 @@ class Bind : public Operation {
       const override;
 
   // Returns the variable to which the expression will be bound
-  [[nodiscard]] const string& targetVariable() const { return _bind._target; }
+  [[nodiscard]] const string& targetVariable() const {
+    return _bind._target.name();
+  }
 
  protected:
   [[nodiscard]] vector<size_t> resultSortedOn() const override;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -233,12 +233,12 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           std::make_move_iterator(v._triples.begin()),
           std::make_move_iterator(v._triples.end()));
     } else if constexpr (std::is_same_v<p::Bind, std::decay_t<decltype(v)>>) {
-      if (boundVariables.count(v._target)) {
+      if (boundVariables.count(v._target.name())) {
         AD_THROW(ad_semsearch::Exception::BAD_QUERY,
                  "The target variable of a BIND must not be used before the "
                  "BIND clause");
       }
-      boundVariables.insert(v._target);
+      boundVariables.insert(v._target.name());
 
       // Assumption for now: BIND does not commute. This is always safe.
       auto lastRow = optimizeCommutativ(candidateTriples, candidatePlans,

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -515,7 +515,7 @@ bool QueryPlanner::checkUsePatternTrick(
     if (!countVariable.has_value()) {
       return false;
     }
-    counted_var_name = countVariable.value();
+    counted_var_name = countVariable.value().name();
     count_var_name = alias._outVarName;
   }
 
@@ -1011,7 +1011,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     plan._idsOfIncludedNodes = parent._idsOfIncludedNodes;
     plan._idsOfIncludedFilters = parent._idsOfIncludedFilters;
     if (pq._orderBy.size() == 1 && !pq._orderBy[0].isDescending_) {
-      size_t col = parent._qet->getVariableColumn(pq._orderBy[0].variable_);
+      size_t col =
+          parent._qet->getVariableColumn(pq._orderBy[0].variable_.name());
       const std::vector<size_t>& previousSortedOn =
           parent._qet->resultSortedOn();
       if (!previousSortedOn.empty() && col == previousSortedOn[0]) {
@@ -1024,8 +1025,9 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     } else {
       vector<pair<size_t, bool>> sortIndices;
       for (auto& ord : pq._orderBy) {
-        sortIndices.emplace_back(parent._qet->getVariableColumn(ord.variable_),
-                                 ord.isDescending_);
+        sortIndices.emplace_back(
+            parent._qet->getVariableColumn(ord.variable_.name()),
+            ord.isDescending_);
       }
       const std::vector<size_t>& previousSortedOn =
           parent._qet->resultSortedOn();

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -8,8 +8,9 @@
 #ifndef QLEVER_AGGREGATEEXPRESSION_H
 #define QLEVER_AGGREGATEEXPRESSION_H
 
-#include "./SparqlExpressionGenerators.h"
-#include "SparqlExpression.h"
+#include "engine/sparqlExpressions/SparqlExpression.h"
+#include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
+
 namespace sparqlExpression {
 
 // This can be used as the `FinalOperation` parameter to an

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -58,8 +58,8 @@ class AggregateExpression : public SparqlExpression {
   }
 
   // __________________________________________________________________________
-  [[nodiscard]] std::optional<string> getVariableForNonDistinctCountOrNullopt()
-      const override {
+  [[nodiscard]] std::optional<::Variable>
+  getVariableForNonDistinctCountOrNullopt() const override {
     // This behavior is not correct for the `COUNT` aggreate. The count is
     // therefore implemented in a separate `CountExpression` class, which
     // overrides this function.
@@ -172,8 +172,8 @@ inline auto count = [](const auto& a, const auto& b) -> int64_t {
 using CountExpressionBase = AGG_EXP<decltype(count), IsValidValueGetter>;
 class CountExpression : public CountExpressionBase {
   using CountExpressionBase::CountExpressionBase;
-  [[nodiscard]] std::optional<string> getVariableForNonDistinctCountOrNullopt()
-      const override {
+  [[nodiscard]] std::optional<::Variable>
+  getVariableForNonDistinctCountOrNullopt() const override {
     if (this->_distinct) {
       return std::nullopt;
     }

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -76,9 +76,9 @@ class LiteralExpression : public SparqlExpression {
 
  protected:
   // _________________________________________________________________________
-  std::optional<std::string> getVariableOrNullopt() const override {
+  std::optional<::Variable> getVariableOrNullopt() const override {
     if constexpr (std::is_same_v<T, Variable>) {
-      return _value._variable;
+      return ::Variable{_value._variable};
     }
     return std::nullopt;
   }

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -44,8 +44,8 @@ class LiteralExpression : public SparqlExpression {
 
   // Variables and string constants add their values.
   std::span<string> getStringLiteralsAndVariablesNonRecursive() override {
-    if constexpr (std::is_same_v<T, Variable>) {
-      return {&_value._variable, 1};
+    if constexpr (std::is_same_v<T, ::Variable>) {
+      return {&_value._name, 1};
     } else if constexpr (std::is_same_v<T, string>) {
       return {&_value, 1};
     } else {
@@ -55,8 +55,8 @@ class LiteralExpression : public SparqlExpression {
 
   // _________________________________________________________________________
   vector<std::string> getUnaggregatedVariables() override {
-    if constexpr (std::is_same_v<T, Variable>) {
-      return {_value._variable};
+    if constexpr (std::is_same_v<T, ::Variable>) {
+      return {_value.name()};
     } else {
       return {};
     }
@@ -64,9 +64,8 @@ class LiteralExpression : public SparqlExpression {
 
   // ______________________________________________________________________
   string getCacheKey(const VariableToColumnMap& varColMap) const override {
-    if constexpr (std::is_same_v<T, Variable>) {
-      return {"#column_" + std::to_string(varColMap.at(_value._variable)) +
-              "#"};
+    if constexpr (std::is_same_v<T, ::Variable>) {
+      return {"#column_" + std::to_string(varColMap.at(_value.name())) + "#"};
     } else if constexpr (std::is_same_v<T, string>) {
       return _value;
     } else {
@@ -77,8 +76,8 @@ class LiteralExpression : public SparqlExpression {
  protected:
   // _________________________________________________________________________
   std::optional<::Variable> getVariableOrNullopt() const override {
-    if constexpr (std::is_same_v<T, Variable>) {
-      return ::Variable{_value._variable};
+    if constexpr (std::is_same_v<T, ::Variable>) {
+      return _value;
     }
     return std::nullopt;
   }
@@ -92,7 +91,7 @@ class LiteralExpression : public SparqlExpression {
 using BoolExpression = detail::LiteralExpression<bool>;
 using IntExpression = detail::LiteralExpression<int64_t>;
 using DoubleExpression = detail::LiteralExpression<double>;
-using VariableExpression = detail::LiteralExpression<Variable>;
+using VariableExpression = detail::LiteralExpression<::Variable>;
 using StringOrIriExpression = detail::LiteralExpression<string>;
 }  // namespace sparqlExpression
 

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -8,7 +8,7 @@
 #ifndef QLEVER_LITERALEXPRESSION_H
 #define QLEVER_LITERALEXPRESSION_H
 
-#include "./SparqlExpression.h"
+#include "engine/sparqlExpressions/SparqlExpression.h"
 
 namespace sparqlExpression {
 namespace detail {

--- a/src/engine/sparqlExpressions/SampleExpression.cpp
+++ b/src/engine/sparqlExpressions/SampleExpression.cpp
@@ -22,7 +22,7 @@ ExpressionResult SampleExpression::evaluate(EvaluationContext* context) const {
     } else if constexpr (isVectorResult<T>) {
       AD_CHECK(!childResult.empty());
       return childResult[0];
-    } else if constexpr (std::is_same_v<T, Variable>) {
+    } else if constexpr (std::is_same_v<T, ::Variable>) {
       // TODO<joka921> Can't this be a simpler function (getIdAt)
       AD_CHECK(context->_endIndex > context->_beginIndex);
       EvaluationContext contextForSingleValue = *context;
@@ -31,7 +31,7 @@ ExpressionResult SampleExpression::evaluate(EvaluationContext* context) const {
           detail::getIdsFromVariable(childResult, &contextForSingleValue);
       return StrongIdWithResultType{
           idOfFirstAsVector[0],
-          context->_variableToColumnAndResultTypeMap.at(childResult._variable)
+          context->_variableToColumnAndResultTypeMap.at(childResult.name())
               .second};
     } else {
       static_assert(isConstantResult<T>);

--- a/src/engine/sparqlExpressions/SampleExpression.cpp
+++ b/src/engine/sparqlExpressions/SampleExpression.cpp
@@ -7,7 +7,7 @@
 
 #include "./SampleExpression.h"
 
-#include "./SparqlExpressionGenerators.h"
+#include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 
 using namespace sparqlExpression;
 using namespace sparqlExpression::detail;

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -19,6 +19,7 @@
 #include "./SparqlExpressionTypes.h"
 #include "./SparqlExpressionValueGetters.h"
 #include "SetOfIntervals.h"
+#include "parser/data/Variable.h"
 
 namespace sparqlExpression {
 
@@ -78,7 +79,7 @@ class SparqlExpression {
   /// For the pattern trick we need to know, whether this expression
   /// is a non-distinct count of a single variable. In this case we return
   /// the variable. Otherwise we return std::nullopt.
-  virtual std::optional<string> getVariableForNonDistinctCountOrNullopt()
+  virtual std::optional<::Variable> getVariableForNonDistinctCountOrNullopt()
       const {
     return std::nullopt;
   }
@@ -86,7 +87,7 @@ class SparqlExpression {
   /// Helper function for getVariableForNonDistinctCountOrNullopt() : If this
   /// expression is a single variable, return the name of this variable.
   /// Otherwise, return std::nullopt.
-  virtual std::optional<string> getVariableOrNullopt() const {
+  virtual std::optional<::Variable> getVariableOrNullopt() const {
     return std::nullopt;
   }
 

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -11,15 +11,15 @@
 #include <variant>
 #include <vector>
 
-#include "../../global/Id.h"
-#include "../../util/ConstexprSmallString.h"
-#include "../CallFixedSize.h"
-#include "../QueryExecutionContext.h"
-#include "../ResultTable.h"
-#include "./SparqlExpressionTypes.h"
-#include "./SparqlExpressionValueGetters.h"
-#include "SetOfIntervals.h"
+#include "engine/CallFixedSize.h"
+#include "engine/QueryExecutionContext.h"
+#include "engine/ResultTable.h"
+#include "engine/sparqlExpressions/SetOfIntervals.h"
+#include "engine/sparqlExpressions/SparqlExpressionTypes.h"
+#include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
+#include "global/Id.h"
 #include "parser/data/Variable.h"
+#include "util/ConstexprSmallString.h"
 
 namespace sparqlExpression {
 

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -121,7 +121,7 @@ inline auto valueGetterGenerator =
         ValueGetter&& valueGetter)
     -> cppcoro::generator<std::invoke_result_t<ValueGetter,
                                                typename decltype(makeGenerator(
-                                                   std::declval<Input>(), 0,
+                                                   input, 0,
                                                    nullptr))::value_type,
                                                EvaluationContext*>> {
   for (auto singleInput :

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -8,8 +8,8 @@
 #ifndef QLEVER_SPARQLEXPRESSIONGENERATORS_H
 #define QLEVER_SPARQLEXPRESSIONGENERATORS_H
 
-#include "../../util/Generator.h"
-#include "./SparqlExpression.h"
+#include "engine/sparqlExpressions/SparqlExpression.h"
+#include "util/Generator.h"
 
 namespace sparqlExpression::detail {
 

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -120,9 +120,7 @@ inline auto valueGetterGenerator =
         size_t numElements, EvaluationContext* context, Input&& input,
         ValueGetter&& valueGetter)
     -> cppcoro::generator<std::invoke_result_t<ValueGetter,
-                                               typename decltype(makeGenerator(
-                                                   input, 0,
-                                                   nullptr))::value_type,
+                                               typename decltype(makeGenerator(AD_FWD(input), 0, nullptr))::value_type,
                                                EvaluationContext*>> {
   for (auto singleInput :
        makeGenerator(std::forward<Input>(input), numElements, context)) {

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -37,13 +37,13 @@ std::vector<std::string> SparqlExpressionPimpl::getUnaggregatedVariables()
 }
 
 // ___________________________________________________________________________
-std::optional<std::string>
+std::optional<::Variable>
 SparqlExpressionPimpl::getVariableForNonDistinctCountOrNullopt() const {
   return _pimpl->getVariableForNonDistinctCountOrNullopt();
 }
 
 // ___________________________________________________________________________
-std::optional<std::string> SparqlExpressionPimpl::getVariableOrNullopt() const {
+std::optional<::Variable> SparqlExpressionPimpl::getVariableOrNullopt() const {
   return _pimpl->getVariableOrNullopt();
 }
 

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -3,7 +3,7 @@
 
 #include "SparqlExpressionPimpl.h"
 
-#include "SparqlExpression.h"
+#include "engine/sparqlExpressions/SparqlExpression.h"
 
 namespace sparqlExpression {
 

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -7,8 +7,9 @@
 #include <memory>
 #include <vector>
 
-#include "../../util/HashMap.h"
-#include "../../util/HashSet.h"
+#include "parser/data/Variable.h"
+#include "util/HashMap.h"
+#include "util/HashSet.h"
 
 namespace sparqlExpression {
 
@@ -47,14 +48,14 @@ class SparqlExpressionPimpl {
   // If this expression is a non-distinct count of a single variable,
   // return that variable, else return std::nullopt. This is needed by the
   // pattern trick.
-  [[nodiscard]] std::optional<std::string>
+  [[nodiscard]] std::optional<::Variable>
   getVariableForNonDistinctCountOrNullopt() const;
 
   // If this expression is a single variable, return that variable, else return
   // std::nullopt. Knowing this enables some optimizations because we can
   // directly handle these trivial "expressions" without using the
   // `SparqlExpression` module.
-  [[nodiscard]] std::optional<std::string> getVariableOrNullopt() const;
+  [[nodiscard]] std::optional<::Variable> getVariableOrNullopt() const;
 
   // The implementation of these methods is small and straightforward, but
   // has to be in the .cpp file because `SparqlExpression` is only forward

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -6,15 +6,16 @@
 #ifndef QLEVER_SPARQLEXPRESSIONTYPES_H
 #define QLEVER_SPARQLEXPRESSIONTYPES_H
 
-#include "../../global/Id.h"
-#include "../../util/AllocatorWithLimit.h"
-#include "../../util/ConstexprSmallString.h"
-#include "../../util/Generator.h"
-#include "../../util/HashMap.h"
-#include "../../util/TypeTraits.h"
-#include "../QueryExecutionContext.h"
-#include "../ResultTable.h"
 #include "SetOfIntervals.h"
+#include "engine/QueryExecutionContext.h"
+#include "engine/ResultTable.h"
+#include "global/Id.h"
+#include "parser/data/Variable.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/ConstexprSmallString.h"
+#include "util/Generator.h"
+#include "util/HashMap.h"
+#include "util/TypeTraits.h"
 
 namespace sparqlExpression {
 
@@ -190,12 +191,6 @@ struct EvaluationContext {
         _localVocab{localVocab} {}
 };
 
-/// Strong type for a Sparql Variable, e.g. "?x"
-struct Variable {
-  std::string _variable;
-  bool operator==(const Variable&) const = default;
-};
-
 /// The result of an expression can either be a vector of bool/double/int/string
 /// a variable (e.g. in BIND (?x as ?y)) or a "Set" of indices, which identifies
 /// the row indices in which a boolean expression evaluates to "true". Constant
@@ -209,7 +204,7 @@ using ConstantTypesAsVector =
 
 // Each type in this tuple also is a possible expression result type.
 using OtherTypes =
-    std::tuple<ad_utility::SetOfIntervals, StrongIdWithResultType, Variable>;
+    std::tuple<ad_utility::SetOfIntervals, StrongIdWithResultType, ::Variable>;
 
 using AllTypesAsTuple =
     ad_utility::TupleCat<ConstantTypes, ConstantTypesAsVector, OtherTypes>;

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -6,9 +6,9 @@
 #ifndef QLEVER_SPARQLEXPRESSIONTYPES_H
 #define QLEVER_SPARQLEXPRESSIONTYPES_H
 
-#include "SetOfIntervals.h"
 #include "engine/QueryExecutionContext.h"
 #include "engine/ResultTable.h"
+#include "engine/sparqlExpressions/SetOfIntervals.h"
 #include "global/Id.h"
 #include "parser/data/Variable.h"
 #include "util/AllocatorWithLimit.h"

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -119,13 +119,13 @@ struct TransPath {
 // A SPARQL Bind construct.
 struct Bind {
   sparqlExpression::SparqlExpressionPimpl _expression;
-  std::string _target;  // the variable to which the expression will be bound
+  Variable _target;  // the variable to which the expression will be bound
 
   // Return all the strings contained in the BIND expression (variables,
   // constants, etc. Is required e.g. by ParsedQuery::expandPrefix.
   std::vector<std::string*> strings() {
     auto r = _expression.strings();
-    r.push_back(&_target);
+    r.push_back(&_target._name);
     return r;
   }
 
@@ -138,7 +138,7 @@ struct Bind {
 
   [[nodiscard]] string getDescriptor() const {
     auto inner = _expression.getDescriptor();
-    return "BIND (" + inner + " AS " + _target + ")";
+    return "BIND (" + inner + " AS " + _target.name() + ")";
   }
 };
 

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -115,8 +115,8 @@ Variable ParsedQuery::addInternalBind(
     sparqlExpression::SparqlExpressionPimpl expression) {
   // Internal variable name to which the result of the helper bind is
   // assigned.
-  std::string targetVariable =
-      INTERNAL_VARIABLE_PREFIX + std::to_string(numInternalVariables_);
+  auto targetVariable = Variable{INTERNAL_VARIABLE_PREFIX +
+                                 std::to_string(numInternalVariables_)};
   numInternalVariables_++;
   parsedQuery::Bind bind{std::move(expression), targetVariable};
   _rootGraphPattern._graphPatterns.emplace_back(std::move(bind));
@@ -125,7 +125,7 @@ Variable ParsedQuery::addInternalBind(
   // TODO<qup42, joka921> Implement "internal" variables, that can't be
   //  selected at all and can never interfere with variables from the
   //  query.
-  return Variable{std::move(targetVariable)};
+  return targetVariable;
 }
 
 // ________________________________________________________________________
@@ -141,7 +141,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
       };
   auto processAlias = [this](Alias groupKey) {
     parsedQuery::Bind helperBind{std::move(groupKey._expression),
-                                 groupKey._outVarName};
+                                 Variable{groupKey._outVarName}};
     _rootGraphPattern._graphPatterns.emplace_back(std::move(helperBind));
     registerVariableVisibleInQueryBody(Variable{groupKey._outVarName});
     _groupByVariables.emplace_back(groupKey._outVarName);

--- a/src/parser/data/OrderKey.h
+++ b/src/parser/data/OrderKey.h
@@ -23,11 +23,11 @@ class ExpressionOrderKey {
 /// Store a variable that appeared in an ORDER BY clause.
 class VariableOrderKey {
  public:
-  std::string variable_;
   bool isDescending_;
+  Variable variable_;
   // ___________________________________________________________________________
-  explicit VariableOrderKey(std::string variable, bool isDescending = false)
-      : variable_{std::move(variable)}, isDescending_{isDescending} {}
+  explicit VariableOrderKey(Variable variable, bool isDescending = false)
+      : isDescending_{isDescending}, variable_{std::move(variable)} {}
 
   bool operator==(const VariableOrderKey&) const = default;
 };

--- a/src/parser/data/OrderKey.h
+++ b/src/parser/data/OrderKey.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <variant>
 
-#include "../../engine/sparqlExpressions/SparqlExpressionPimpl.h"
+#include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 
 /// Store an expression that appeared in an ORDER BY clause.
 class ExpressionOrderKey {

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -13,9 +13,9 @@
 #include "index/Index.h"
 
 class Variable {
+ public:
   std::string _name;
 
- public:
   explicit Variable(std::string name) : _name{std::move(name)} {
     // verify variable name starts with ? or $ and continues without any
     // special characters. This is weaker than the SPARQL grammar,

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -621,7 +621,7 @@ OrderKey Visitor::visitTypesafe(Parser::OrderConditionContext* ctx) {
   };
 
   if (ctx->var()) {
-    return VariableOrderKey(ctx->var()->getText());
+    return VariableOrderKey(visitTypesafe(ctx->var()));
   } else if (ctx->constraint()) {
     return visitExprOrderKey(false, ctx->constraint());
   } else if (ctx->brackettedExpression()) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1348,8 +1348,7 @@ ExpressionPtr Visitor::visitTypesafe(Parser::PrimaryExpressionContext* ctx) {
   } else if (ctx->booleanLiteral()) {
     return make_unique<BoolExpression>(visitTypesafe(ctx->booleanLiteral()));
   } else if (ctx->var()) {
-    return make_unique<VariableExpression>(
-        sparqlExpression::Variable{ctx->var()->getText()});
+    return make_unique<VariableExpression>(visitTypesafe(ctx->var()));
   } else {
     return visitAlternative<ExpressionPtr>(
         ctx->builtInCall(), ctx->iriOrFunction(), ctx->brackettedExpression());

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -197,7 +197,7 @@ Variable Visitor::visitTypesafe(Parser::VarContext* ctx) {
 GraphPatternOperation Visitor::visitTypesafe(Parser::BindContext* ctx) {
   addVisibleVariable(ctx->var()->getText());
   return GraphPatternOperation{
-      Bind{{visitTypesafe(ctx->expression())}, ctx->var()->getText()}};
+      Bind{{visitTypesafe(ctx->expression())}, visitTypesafe(ctx->var())}};
 }
 
 // ____________________________________________________________________________________

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -429,8 +429,8 @@ TEST(SparqlParser, VariableWithDollarSign) {
 
 TEST(SparqlParser, Bind) {
   auto expectBind = ExpectCompleteParse<&Parser::bind>{};
-  expectBind("BIND (10 - 5 as ?a)", m::Bind("?a", "10-5"));
-  expectBind("bInD (?age - 10 As ?s)", m::Bind("?s", "?age-10"));
+  expectBind("BIND (10 - 5 as ?a)", m::Bind(Variable{"?a"}, "10-5"));
+  expectBind("bInD (?age - 10 As ?s)", m::Bind(Variable{"?s"}, "?age-10"));
 }
 
 TEST(SparqlParser, Integer) {
@@ -785,7 +785,7 @@ TEST(SparqlParser, GroupGraphPattern) {
       "{ FILTER (?a = 10) }",
       m::GraphPattern(false, {{SparqlFilter::FilterType::EQ, "?a", "10"}}));
   expectGraphPattern("{ BIND (?f - ?b as ?c) }",
-                     m::GraphPattern(m::Bind("?c", "?f-?b")));
+                     m::GraphPattern(m::Bind(Variable{"?c"}, "?f-?b")));
   expectGraphPattern("{ VALUES (?a ?b) { (<foo> <bar>) (<a> <b>) } }",
                      m::GraphPattern(m::InlineData(
                          {"?a", "?b"}, {{"<foo>", "<bar>"}, {"<a>", "<b>"}})));
@@ -820,10 +820,10 @@ TEST(SparqlParser, GroupGraphPattern) {
                       {"?c", CONTAINS_WORD_PREDICATE, "coca* abuse"}})));
   expectGraphPattern("{?x <is-a> <Actor> . BIND(10 - ?foo as ?y) }",
                      m::GraphPattern(m::Triples({{"?x", "<is-a>", "<Actor>"}}),
-                                     m::Bind("?y", "10-?foo")));
+                                     m::Bind(Variable{"?y"}, "10-?foo")));
   expectGraphPattern("{?x <is-a> <Actor> . BIND(10 - ?foo as ?y) . ?a ?b ?c }",
                      m::GraphPattern(m::Triples({{"?x", "<is-a>", "<Actor>"}}),
-                                     m::Bind("?y", "10-?foo"),
+                                     m::Bind(Variable{"?y"}, "10-?foo"),
                                      m::Triples({{"?a", "?b", "?c"}})));
   expectGraphPattern(
       "{?x <is-a> <Actor> . OPTIONAL { ?x <foo> <bar> } }",

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -467,10 +467,13 @@ TEST(SparqlParser, OrderCondition) {
   auto expectOrderCondition = ExpectCompleteParse<&Parser::orderCondition>{};
   auto expectOrderConditionFails = ExpectParseFails<&Parser::orderCondition>();
   // var
-  expectOrderCondition("?test", m::VariableOrderKeyVariant("?test", false));
+  expectOrderCondition("?test",
+                       m::VariableOrderKeyVariant(Variable{"?test"}, false));
   // brackettedExpression
-  expectOrderCondition("DESC (?foo)", m::VariableOrderKeyVariant("?foo", true));
-  expectOrderCondition("ASC (?bar)", m::VariableOrderKeyVariant("?bar", false));
+  expectOrderCondition("DESC (?foo)",
+                       m::VariableOrderKeyVariant(Variable{"?foo"}, true));
+  expectOrderCondition("ASC (?bar)",
+                       m::VariableOrderKeyVariant(Variable{"?bar"}, false));
   expectOrderCondition("ASC(?test - 5)",
                        m::ExpressionOrderKey("?test-5", false));
   expectOrderCondition("DESC (10 || (5 && ?foo))",
@@ -484,7 +487,7 @@ TEST(SparqlParser, OrderCondition) {
 TEST(SparqlParser, OrderClause) {
   expectCompleteParse(
       parse<&Parser::orderClause>("ORDER BY ?test DESC(?foo - 5)"),
-      m::OrderKeys({VariableOrderKey{"?test", false},
+      m::OrderKeys({VariableOrderKey{Variable{"?test"}, false},
                     m::ExpressionOrderKeyTest{"?foo-5", true}}));
 }
 
@@ -534,7 +537,7 @@ TEST(SparqlParser, SolutionModifier) {
       "OFFSET 2",
       m::SolutionModifier({Var{"?var"}, "?b-10"},
                           {{SparqlFilter::FilterType::NE, "?var", "10"}},
-                          {VOK{"?var", false}}, {10, 1, 2}));
+                          {VOK{Variable{"?var"}, false}}, {10, 1, 2}));
   expectSolutionModifier(
       "GROUP BY ?var HAVING (?foo < ?bar) ORDER BY (5 - ?var) TEXTLIMIT 21 "
       "LIMIT 2",

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -59,7 +59,8 @@ std::ostream& operator<<(std::ostream& out, const VarOrTerm& varOrTerm) {
 
 namespace parsedQuery {
 std::ostream& operator<<(std::ostream& out, const parsedQuery::Bind& bind) {
-  out << "Bind " << bind._expression.getDescriptor() << " as " << bind._target;
+  out << "Bind " << bind._expression.getDescriptor() << " as "
+      << bind._target.name();
   return out;
 }
 
@@ -311,7 +312,7 @@ auto BindExpression =
   return AD_FIELD(p::Bind, _expression, detail::Expression(expression));
 };
 
-auto Bind = [](const string& variable, const string& expression)
+auto Bind = [](const ::Variable& variable, const string& expression)
     -> testing::Matcher<const p::GraphPatternOperation&> {
   return detail::GraphPatternOperation<p::Bind>(
       testing::AllOf(BindExpression(expression),

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -75,7 +75,7 @@ std::ostream& operator<<(std::ostream& out, const parsedQuery::Values& values) {
 
 std::ostream& operator<<(std::ostream& out, const VariableOrderKey& orderkey) {
   out << "Order " << (orderkey.isDescending_ ? "DESC" : "ASC") << " by "
-      << orderkey.variable_;
+      << orderkey.variable_.name();
   return out;
 }
 
@@ -328,15 +328,15 @@ auto LimitOffset =
 };
 
 auto VariableOrderKey =
-    [](const string& key,
+    [](const ::Variable& variable,
        bool desc) -> testing::Matcher<const ::VariableOrderKey&> {
   return testing::AllOf(
-      AD_FIELD(::VariableOrderKey, variable_, testing::Eq(key)),
+      AD_FIELD(::VariableOrderKey, variable_, testing::Eq(variable)),
       AD_FIELD(::VariableOrderKey, isDescending_, testing::Eq(desc)));
 };
 
 auto VariableOrderKeyVariant =
-    [](const string& key, bool desc) -> testing::Matcher<const OrderKey&> {
+    [](const ::Variable& key, bool desc) -> testing::Matcher<const OrderKey&> {
   return testing::VariantWith<::VariableOrderKey>(VariableOrderKey(key, desc));
 };
 

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -309,8 +309,9 @@ auto BindExpression = [](const string& expression) -> Matcher<const p::Bind&> {
   return AD_FIELD(p::Bind, _expression, detail::Expression(expression));
 };
 
-auto Bind = [](const ::Variable& variable, const string& expression)
-    -> testing::Matcher<const p::GraphPatternOperation&> {
+auto Bind =
+    [](const ::Variable& variable,
+       const string& expression) -> Matcher<const p::GraphPatternOperation&> {
   return detail::GraphPatternOperation<p::Bind>(
       testing::AllOf(BindExpression(expression),
                      AD_FIELD(p::Bind, _target, testing::Eq(variable))));
@@ -324,16 +325,15 @@ auto LimitOffset = [](uint64_t limit, uint64_t textLimit,
       AD_FIELD(LimitOffsetClause, _offset, testing::Eq(offset)));
 };
 
-auto VariableOrderKey =
-    [](const ::Variable& variable,
-       bool desc) -> testing::Matcher<const ::VariableOrderKey&> {
+auto VariableOrderKey = [](const ::Variable& variable,
+                           bool desc) -> Matcher<const ::VariableOrderKey&> {
   return testing::AllOf(
       AD_FIELD(::VariableOrderKey, variable_, testing::Eq(variable)),
       AD_FIELD(::VariableOrderKey, isDescending_, testing::Eq(desc)));
 };
 
-auto VariableOrderKeyVariant =
-    [](const ::Variable& key, bool desc) -> testing::Matcher<const OrderKey&> {
+auto VariableOrderKeyVariant = [](const ::Variable& key,
+                                  bool desc) -> Matcher<const OrderKey&> {
   return testing::VariantWith<::VariableOrderKey>(VariableOrderKey(key, desc));
 };
 

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -6,9 +6,9 @@
 
 #include <variant>
 
-#include "../src/global/Constants.h"
-#include "../src/parser/SparqlParser.h"
 #include "SparqlAntlrParserTestHelpers.h"
+#include "global/Constants.h"
+#include "parser/SparqlParser.h"
 
 namespace m = matchers;
 namespace p = parsedQuery;

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -460,7 +460,7 @@ TEST(ParserTest, testParse) {
 
       ASSERT_EQ(10u, pq._limitOffset._limit);
       ASSERT_EQ(false, pq._orderBy[0].isDescending_);
-      ASSERT_EQ("?movie", pq._orderBy[0].variable_);
+      ASSERT_EQ(Variable{"?movie"}, pq._orderBy[0].variable_);
 
       auto sc = get<p::SelectClause>(pq._clause);
       ASSERT_EQ(true, sc.reduced_);
@@ -492,7 +492,7 @@ TEST(ParserTest, testParse) {
 
       ASSERT_EQ(10u, pq._limitOffset._limit);
       ASSERT_EQ(true, pq._orderBy[0].isDescending_);
-      ASSERT_EQ("?movie", pq._orderBy[0].variable_);
+      ASSERT_EQ(Variable{"?movie"}, pq._orderBy[0].variable_);
 
       auto sc = get<ParsedQuery::SelectClause>(pq._clause);
       ASSERT_EQ(true, sc.distinct_);
@@ -534,7 +534,7 @@ TEST(ParserTest, testParse) {
 
       ASSERT_EQ(20u, pq._limitOffset._limit);
       ASSERT_EQ(true, pq._orderBy[0].isDescending_);
-      ASSERT_EQ("?movie", pq._orderBy[0].variable_);
+      ASSERT_EQ(Variable{"?movie"}, pq._orderBy[0].variable_);
 
       auto sc = get<ParsedQuery::SelectClause>(pq._clause);
       ASSERT_EQ(true, sc.distinct_);
@@ -571,7 +571,8 @@ TEST(ParserTest, testParse) {
       ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
                 parsed_sub_query.get()._limitOffset._limit);
       ASSERT_EQ(true, parsed_sub_query.get()._orderBy[0].isDescending_);
-      ASSERT_EQ("?director", parsed_sub_query.get()._orderBy[0].variable_);
+      ASSERT_EQ(Variable{"?director"},
+                parsed_sub_query.get()._orderBy[0].variable_);
 
       auto sc_subquery =
           get<ParsedQuery::SelectClause>(parsed_sub_query.get()._clause);
@@ -619,7 +620,7 @@ TEST(ParserTest, testParse) {
 
       ASSERT_EQ(20u, pq._limitOffset._limit);
       ASSERT_EQ(true, pq._orderBy[0].isDescending_);
-      ASSERT_EQ("?movie", pq._orderBy[0].variable_);
+      ASSERT_EQ(Variable{"?movie"}, pq._orderBy[0].variable_);
 
       auto sc = get<ParsedQuery::SelectClause>(pq._clause);
       ASSERT_EQ(true, sc.distinct_);
@@ -652,7 +653,8 @@ TEST(ParserTest, testParse) {
       ASSERT_EQ(std::numeric_limits<uint64_t>::max(),
                 parsed_sub_query.get()._limitOffset._limit);
       ASSERT_EQ(true, parsed_sub_query.get()._orderBy[0].isDescending_);
-      ASSERT_EQ("?director", parsed_sub_query.get()._orderBy[0].variable_);
+      ASSERT_EQ(Variable{"?director"},
+                parsed_sub_query.get()._orderBy[0].variable_);
 
       auto sc_subquery =
           get<ParsedQuery::SelectClause>(parsed_sub_query.get()._clause);
@@ -922,7 +924,7 @@ TEST(ParserTest, testSolutionModifiers) {
     ASSERT_EQ(10u, pq._limitOffset._limit);
     ASSERT_EQ(15u, pq._limitOffset._offset);
     ASSERT_EQ(size_t(1), pq._orderBy.size());
-    ASSERT_EQ("?y", pq._orderBy[0].variable_);
+    ASSERT_EQ(Variable{"?y"}, pq._orderBy[0].variable_);
     ASSERT_FALSE(pq._orderBy[0].isDescending_);
     ASSERT_TRUE(selectClause.distinct_);
     ASSERT_FALSE(selectClause.reduced_);
@@ -946,9 +948,9 @@ TEST(ParserTest, testSolutionModifiers) {
     ASSERT_EQ(10u, pq._limitOffset._limit);
     ASSERT_EQ(15u, pq._limitOffset._offset);
     ASSERT_EQ(size_t(2), pq._orderBy.size());
-    ASSERT_EQ("?y", pq._orderBy[0].variable_);
+    ASSERT_EQ(Variable{"?y"}, pq._orderBy[0].variable_);
     ASSERT_FALSE(pq._orderBy[0].isDescending_);
-    ASSERT_EQ("?ql_textscore_x", pq._orderBy[1].variable_);
+    ASSERT_EQ(Variable{"?ql_textscore_x"}, pq._orderBy[1].variable_);
     ASSERT_TRUE(pq._orderBy[1].isDescending_);
     ASSERT_TRUE(selectClause.distinct_);
     ASSERT_FALSE(selectClause.reduced_);
@@ -969,9 +971,9 @@ TEST(ParserTest, testSolutionModifiers) {
     ASSERT_EQ(10u, pq._limitOffset._limit);
     ASSERT_EQ(15u, pq._limitOffset._offset);
     ASSERT_EQ(size_t(2), pq._orderBy.size());
-    ASSERT_EQ("?x", pq._orderBy[0].variable_);
+    ASSERT_EQ(Variable{"?x"}, pq._orderBy[0].variable_);
     ASSERT_TRUE(pq._orderBy[0].isDescending_);
-    ASSERT_EQ("?y", pq._orderBy[1].variable_);
+    ASSERT_EQ(Variable{"?y"}, pq._orderBy[1].variable_);
     ASSERT_FALSE(pq._orderBy[1].isDescending_);
     ASSERT_FALSE(selectClause.distinct_);
     ASSERT_TRUE(selectClause.reduced_);
@@ -1045,7 +1047,7 @@ TEST(ParserTest, testSolutionModifiers) {
     ASSERT_EQ(1u, pq.children().size());
     ASSERT_EQ(1u, pq._orderBy.size());
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?r"}}));
-    ASSERT_EQ("?avg", pq._orderBy[0].variable_);
+    ASSERT_EQ(Variable{"?avg"}, pq._orderBy[0].variable_);
     ASSERT_FALSE(pq._orderBy[0].isDescending_);
   }
 
@@ -1059,7 +1061,7 @@ TEST(ParserTest, testSolutionModifiers) {
                   .parse();
     ASSERT_EQ(1u, pq._orderBy.size());
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?r"}}));
-    ASSERT_EQ("?count", pq._orderBy[0].variable_);
+    ASSERT_EQ(Variable{"?count"}, pq._orderBy[0].variable_);
     ASSERT_FALSE(pq._orderBy[0].isDescending_);
   }
 
@@ -1123,7 +1125,7 @@ TEST(ParserTest, Order) {
         SparqlParser("SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY ?x")
             .parse();
     ASSERT_EQ(pq._orderBy.size(), 1);
-    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey("?x", false));
+    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?x"}, false));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
     ASSERT_TRUE(holds_alternative<p::BasicGraphPattern>(
         pq._rootGraphPattern._graphPatterns[0]));
@@ -1134,7 +1136,7 @@ TEST(ParserTest, Order) {
             "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY ASC(?y)")
             .parse();
     ASSERT_EQ(pq._orderBy.size(), 1);
-    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey("?y", false));
+    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?y"}, false));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
     ASSERT_TRUE(holds_alternative<p::BasicGraphPattern>(
         pq._rootGraphPattern._graphPatterns[0]));
@@ -1145,7 +1147,7 @@ TEST(ParserTest, Order) {
             "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY DESC(?foo)")
             .parse();
     ASSERT_EQ(pq._orderBy.size(), 1);
-    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey("?foo", true));
+    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?foo"}, true));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
     ASSERT_TRUE(holds_alternative<p::BasicGraphPattern>(
         pq._rootGraphPattern._graphPatterns[0]));
@@ -1156,7 +1158,7 @@ TEST(ParserTest, Order) {
             "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x ORDER BY ?x")
             .parse();
     ASSERT_EQ(pq._orderBy.size(), 1);
-    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey("?x", false));
+    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?x"}, false));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
     ASSERT_TRUE(holds_alternative<p::BasicGraphPattern>(
         pq._rootGraphPattern._graphPatterns[0]));
@@ -1167,7 +1169,7 @@ TEST(ParserTest, Order) {
                          "?y } GROUP BY ?x ORDER BY ?c")
                          .parse();
     ASSERT_EQ(pq._orderBy.size(), 1);
-    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey("?c", false));
+    EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?c"}, false));
   }
   {
     ParsedQuery pq =
@@ -1179,7 +1181,7 @@ TEST(ParserTest, Order) {
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
     ASSERT_EQ(helperBind._expression.getDescriptor(), "?x-?y");
-    ASSERT_EQ(pq._orderBy[0].variable_, helperBind._target);
+    ASSERT_EQ(pq._orderBy[0].variable_.name(), helperBind._target);
   }
   {
     // Ordering by variables that are not grouped is not allowed.

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -1107,7 +1107,7 @@ TEST(ParserTest, Bind) {
   p::GraphPatternOperation child = pq.children()[0];
   ASSERT_TRUE(holds_alternative<p::Bind>(child));
   p::Bind bind = get<p::Bind>(child);
-  ASSERT_EQ(bind._target, "?a");
+  ASSERT_EQ(bind._target, Variable{"?a"});
   ASSERT_EQ(bind._expression.getDescriptor(), "10-5");
 }
 
@@ -1181,7 +1181,7 @@ TEST(ParserTest, Order) {
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
     ASSERT_EQ(helperBind._expression.getDescriptor(), "?x-?y");
-    ASSERT_EQ(pq._orderBy[0].variable_.name(), helperBind._target);
+    ASSERT_EQ(pq._orderBy[0].variable_, helperBind._target);
   }
   {
     // Ordering by variables that are not grouped is not allowed.
@@ -1231,8 +1231,7 @@ TEST(ParserTest, Group) {
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
     ASSERT_THAT(helperBind, m::BindExpression("?x-?y"));
-    EXPECT_THAT(pq, m::GroupByVariables(
-                        {Variable{helperBind._target}, Variable{"?x"}}));
+    EXPECT_THAT(pq, m::GroupByVariables({helperBind._target, Variable{"?x"}}));
   }
   {
     // grouping by an expression with an alias
@@ -1241,7 +1240,7 @@ TEST(ParserTest, Group) {
                          "- ?y AS ?foo) ?x")
                          .parse();
     EXPECT_THAT(pq._rootGraphPattern._graphPatterns[1],
-                m::Bind("?foo", "?x-?y"));
+                m::Bind(Variable{"?foo"}, "?x-?y"));
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?foo"}, Variable{"?x"}}));
   }
   {
@@ -1254,8 +1253,7 @@ TEST(ParserTest, Group) {
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
     ASSERT_THAT(helperBind, m::BindExpression("COUNT(?x)"));
-    EXPECT_THAT(pq, m::GroupByVariables(
-                        {Variable{helperBind._target}, Variable{"?x"}}));
+    EXPECT_THAT(pq, m::GroupByVariables({helperBind._target, Variable{"?x"}}));
   }
   {
     // grouping by a function call
@@ -1271,8 +1269,7 @@ TEST(ParserTest, Group) {
         helperBind,
         m::BindExpression(
             "<http://www.opengis.net/def/function/geosparql/latitude>(?test)"));
-    EXPECT_THAT(pq, m::GroupByVariables(
-                        {Variable{helperBind._target}, Variable{"?x"}}));
+    EXPECT_THAT(pq, m::GroupByVariables({helperBind._target, Variable{"?x"}}));
   }
   {
     // selection of a variable that is not grouped/aggregated


### PR DESCRIPTION
Use strong type for variables in `VariableOrderKey` and `ParsedQuery::Bind`. This means using `Variable` and not `std::string`.