### PR TITLE
Make expressions aware of the variables they contain

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -626,8 +626,8 @@ bool QueryPlanner::checkUsePatternTrick(
           } else if constexpr (std::is_same_v<T, p::Bind>) {
             // If the object variable of ql:has-predicate is used somewhere in a
             // BIND, we cannot use the pattern trick.
-            for (const std::string* v : arg.strings()) {
-              if (*v == t._o) {
+            for (const auto* v : arg.containedVariables()) {
+              if (v->_name == t._o) {
                 usePatternTrick = false;
                 break;
               }
@@ -690,8 +690,8 @@ bool QueryPlanner::checkUsePatternTrick(
             } else if constexpr (std::is_same_v<T, p::Bind>) {
               // If the object variable of ql:has-predicate is used somewhere in
               // a BIND, we cannot use the pattern trick.
-              for (const std::string* v : arg.strings()) {
-                if (*v == t._o) {
+              for (const auto* v : arg.containedVariables()) {
+                if (v->_name == t._o) {
                   usePatternTrick = false;
                   break;
                 }

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -43,10 +43,8 @@ class LiteralExpression : public SparqlExpression {
   std::span<SparqlExpression::Ptr> children() override { return {}; }
 
   // Variables and string constants add their values.
-  std::span<string> getStringLiteralsAndVariablesNonRecursive() override {
+  std::span<const Variable> getContainedVariablesNonRecursive() const override {
     if constexpr (std::is_same_v<T, ::Variable>) {
-      return {&_value._name, 1};
-    } else if constexpr (std::is_same_v<T, string>) {
       return {&_value, 1};
     } else {
       return {};

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -39,16 +39,16 @@ class SparqlExpression {
 
   /// Return all variables and IRIs, needed for certain parser methods.
   /// TODO<joka921> should be called getStringLiteralsAndVariables
-  virtual vector<string*> strings() final {
-    vector<string*> result;
+  virtual vector<const Variable*> containedVariables() const final {
+    vector<const Variable*> result;
     // Recursively aggregate the strings from all children.
-    for (auto& child : children()) {
-      auto childStrings = child->strings();
+    for (const auto& child : children()) {
+      auto childStrings = child->containedVariables();
       result.insert(result.end(), childStrings.begin(), childStrings.end());
     }
 
     // Add the strings from this expression.
-    auto locallyAdded = getStringLiteralsAndVariablesNonRecursive();
+    auto locallyAdded = getContainedVariablesNonRecursive();
     for (auto& el : locallyAdded) {
       result.push_back(&el);
     }
@@ -97,11 +97,15 @@ class SparqlExpression {
  private:
   // Get the direct child expressions.
   virtual std::span<SparqlExpression::Ptr> children() = 0;
+  virtual std::span<const SparqlExpression::Ptr> children() const final {
+    auto children = const_cast<SparqlExpression&>(*this).children();
+    return {children.data(), children.size()};
+  }
 
   // Helper function for strings(). Get all variables, iris, and string literals
   // that are included in this expression directly, ignoring possible child
   // expressions.
-  virtual std::span<string> getStringLiteralsAndVariablesNonRecursive() {
+  virtual std::span<const Variable> getContainedVariablesNonRecursive() const {
     // Default implementation: This expression adds no strings or variables.
     return {};
   }

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -43,8 +43,9 @@ class SparqlExpression {
     vector<const Variable*> result;
     // Recursively aggregate the strings from all children.
     for (const auto& child : children()) {
-      auto childStrings = child->containedVariables();
-      result.insert(result.end(), childStrings.begin(), childStrings.end());
+      auto variablesFromChild = child->containedVariables();
+      result.insert(result.end(), variablesFromChild.begin(),
+                    variablesFromChild.end());
     }
 
     // Add the strings from this expression.

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -16,8 +16,8 @@ SparqlExpressionPimpl::SparqlExpressionPimpl(
 SparqlExpressionPimpl::~SparqlExpressionPimpl() = default;
 
 // ___________________________________________________________________________
-std::vector<std::string*> SparqlExpressionPimpl::strings() {
-  return _pimpl->strings();
+std::vector<const Variable*> SparqlExpressionPimpl::containedVariables() const {
+  return _pimpl->containedVariables();
 }
 
 // ____________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -69,7 +69,7 @@ class SparqlExpressionPimpl {
   SparqlExpressionPimpl(const SparqlExpressionPimpl&);
   SparqlExpressionPimpl& operator=(const SparqlExpressionPimpl&);
 
-  std::vector<std::string*> strings();
+  std::vector<const Variable*> containedVariables() const;
 
   SparqlExpression* getPimpl() { return _pimpl.get(); }
   [[nodiscard]] const SparqlExpression* getPimpl() const {

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -121,19 +121,11 @@ struct Bind {
   sparqlExpression::SparqlExpressionPimpl _expression;
   Variable _target;  // the variable to which the expression will be bound
 
-  // Return all the strings contained in the BIND expression (variables,
-  // constants, etc. Is required e.g. by ParsedQuery::expandPrefix.
-  std::vector<std::string*> strings() {
-    auto r = _expression.strings();
-    r.push_back(&_target._name);
+  // Return all the variables that are used in the BIND expression (the target variable as well as all variables from the expression).
+  std::vector<const Variable*> containedVariables() const {
+    auto r = _expression.containedVariables();
+    r.push_back(&_target);
     return r;
-  }
-
-  // Const overload, needed by the query planner. The actual behavior is
-  // always const, so this is fine.
-  [[nodiscard]] std::vector<const string*> strings() const {
-    auto r = const_cast<Bind*>(this)->strings();
-    return {r.begin(), r.end()};
   }
 
   [[nodiscard]] string getDescriptor() const {

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -121,7 +121,8 @@ struct Bind {
   sparqlExpression::SparqlExpressionPimpl _expression;
   Variable _target;  // the variable to which the expression will be bound
 
-  // Return all the variables that are used in the BIND expression (the target variable as well as all variables from the expression).
+  // Return all the variables that are used in the BIND expression (the target
+  // variable as well as all variables from the expression).
   std::vector<const Variable*> containedVariables() const {
     auto r = _expression.containedVariables();
     r.push_back(&_target);

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -45,7 +45,7 @@ bool contains_if(const Container& container, const Predicate& predicate) {
  * @param destination Vector& to which to append
  * @param source Vector&& to append
  */
-template <typename T, ad_utility::SimilarTo<std::vector<T>> U>
+template <typename T, typename U>
 void appendVector(std::vector<T>& destination, U&& source) {
   if constexpr (std::is_rvalue_reference_v<U&&>) {
     destination.insert(destination.end(),

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -45,7 +45,7 @@ bool contains_if(const Container& container, const Predicate& predicate) {
  * @param destination Vector& to which to append
  * @param source Vector&& to append
  */
-template <typename T, typename U>
+template <typename T, ad_utility::SimilarTo<std::vector<T>> U>
 void appendVector(std::vector<T>& destination, U&& source) {
   if constexpr (std::is_rvalue_reference_v<U&&>) {
     destination.insert(destination.end(),


### PR DESCRIPTION
This is important for checking whether the pattern trick can be applied and to perform checks concerning the validity of a SparqlQuery early on during parsing.