### PR TITLE
Parse complete SPARQL  queries using ANTLR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
 endif ()
 
 if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND
-   (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12") AND
-   (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.1"))
+(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12") AND
+(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "12.2"))
     message(STATUS "Adding -Wno-restrict for g++12.0 because of false positives")
     add_compile_options(-Wno-restrict)
     else()

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1120,7 +1120,7 @@ queries:
     checks:
       - num_cols: 2
       - num_rows: 11
-      - selected: ["?x", "?t"]
+      - selected: [ "?x", "?t", "?ql_textscore_t" ]
       - contains_row: ["<Grete_Hermann>","Hermann's algorithm for primary decomposition is still in use now."]
 
 

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1120,7 +1120,7 @@ queries:
     checks:
       - num_cols: 2
       - num_rows: 11
-      - selected: [ "?x", "?t", "?ql_textscore_t" ]
+      - selected: [ "?x", "?ql_textscore_t", "?t" ]
       - contains_row: ["<Grete_Hermann>","Hermann's algorithm for primary decomposition is still in use now."]
 
 

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1118,10 +1118,10 @@ queries:
           ?t ql:contains-word "algo*"
       }
     checks:
-      - num_cols: 2
+      - num_cols: 3
       - num_rows: 11
       - selected: [ "?x", "?ql_textscore_t", "?t" ]
-      - contains_row: ["<Grete_Hermann>","Hermann's algorithm for primary decomposition is still in use now."]
+      - contains_row: [ "<Grete_Hermann>",null,"Hermann's algorithm for primary decomposition is still in use now." ]
 
 
   - query : select_asterisk_regex-lastname-stein

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -646,7 +646,7 @@ boost::asio::awaitable<void> Server::processQuery(
               << (pinResult ? " [pin result]" : "")
               << (pinSubtrees ? " [pin subresults]" : "") << "\n"
               << query << std::endl;
-    ParsedQuery pq = SparqlParser(query).parse();
+    ParsedQuery pq = SparqlParser::parseQuery(query);
 
     // The following code block determines the media type to be used for the
     // result. The media type is either determined by the "Accept:" header of

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -437,8 +437,8 @@ Awaitable<json> Server::composeResponseQleverJson(
           query.hasSelectClause()
               ? qet.writeResultAsQLeverJson(query.selectClause(), limit, offset,
                                             std::move(resultTable))
-              : qet.writeRdfGraphJson(query.constructClause(), limit, offset,
-                                      std::move(resultTable));
+              : qet.writeRdfGraphJson(query.constructClause().triples_, limit,
+                                      offset, std::move(resultTable));
       requestTimer.stop();
     }
     j["resultsize"] = query.hasSelectClause() ? resultSize : j["res"].size();
@@ -510,11 +510,11 @@ Server::composeResponseSepValues(const ParsedQuery& query,
   auto compute = [&] {
     size_t limit = query._limitOffset._limit;
     size_t offset = query._limitOffset._offset;
-    return query.hasSelectClause()
-               ? qet.generateResults<format>(query.selectClause(), limit,
-                                             offset)
-               : qet.writeRdfGraphSeparatedValues<format>(
-                     query.constructClause(), limit, offset, qet.getResult());
+    return query.hasSelectClause() ? qet.generateResults<format>(
+                                         query.selectClause(), limit, offset)
+                                   : qet.writeRdfGraphSeparatedValues<format>(
+                                         query.constructClause().triples_,
+                                         limit, offset, qet.getResult());
   };
   return computeInNewThread(compute);
 }
@@ -530,8 +530,8 @@ ad_utility::streams::stream_generator Server::composeTurtleResponse(
   }
   size_t limit = query._limitOffset._limit;
   size_t offset = query._limitOffset._offset;
-  return qet.writeRdfGraphTurtle(query.constructClause(), limit, offset,
-                                 qet.getResult());
+  return qet.writeRdfGraphTurtle(query.constructClause().triples_, limit,
+                                 offset, qet.getResult());
 }
 
 // _____________________________________________________________________________

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -19,6 +19,10 @@ add_library(parser
         SparqlParserHelpers.h SparqlParserHelpers.cpp
         TripleComponent.h
         GraphPatternOperation.cpp
-        PropertyPath.h PropertyPath.cpp Alias.h data/SolutionModifiers.h data/LimitOffsetClause.h data/SparqlFilter.h data/SparqlFilter.cpp data/OrderKey.h data/GroupKey.h ParseException.cpp SelectClause.cpp SelectClause.h GraphPatternOperation.cpp GraphPatternOperation.h GraphPattern.cpp GraphPattern.h)
+        PropertyPath.h PropertyPath.cpp Alias.h data/SolutionModifiers.h
+        data/LimitOffsetClause.h data/SparqlFilter.h data/SparqlFilter.cpp
+        data/OrderKey.h data/GroupKey.h ParseException.cpp SelectClause.cpp
+        SelectClause.h GraphPatternOperation.cpp GraphPatternOperation.h
+        GraphPattern.cpp GraphPattern.h ConstructClause.h)
 target_link_libraries(parser sparqlParser parserData sparqlExpressions rdfEscaping re2 absl::flat_hash_map util)
 

--- a/src/parser/ConstructClause.h
+++ b/src/parser/ConstructClause.h
@@ -15,16 +15,16 @@ struct ConstructClause : ClauseBase {
   explicit ConstructClause(ad_utility::sparql_types::Triples triples)
       : triples_(std::move(triples)) {}
 
-  vector<const Variable*> containedVariables() {
-    vector<const Variable*> out;
+  // Yields all variables that appear in this `ConstructClause`. Variables that
+  // appear multiple times are also yielded multiple times.
+  cppcoro::generator<const Variable> containedVariables() const {
     for (const auto& triple : triples_) {
       for (const auto& varOrTerm : triple) {
         if (auto variable = std::get_if<Variable>(&varOrTerm)) {
-          out.emplace_back(variable);
+          co_yield *variable;
         }
       }
     }
-    return out;
   }
 };
 }  // namespace parsedQuery

--- a/src/parser/ConstructClause.h
+++ b/src/parser/ConstructClause.h
@@ -14,5 +14,17 @@ struct ConstructClause : ClauseBase {
   ConstructClause() = default;
   explicit ConstructClause(ad_utility::sparql_types::Triples triples)
       : triples_(std::move(triples)) {}
+
+  vector<const Variable*> containedVariables() {
+    vector<const Variable*> out;
+    for (const auto& triple : triples_) {
+      for (const auto& varOrTerm : triple) {
+        if (auto variable = std::get_if<Variable>(&varOrTerm)) {
+          out.emplace_back(variable);
+        }
+      }
+    }
+    return out;
+  }
 };
 }  // namespace parsedQuery

--- a/src/parser/ConstructClause.h
+++ b/src/parser/ConstructClause.h
@@ -1,0 +1,18 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+
+#pragma once
+
+#include "parser/SelectClause.h"
+#include "parser/data/Types.h"
+
+namespace parsedQuery {
+struct ConstructClause : ClauseBase {
+  ad_utility::sparql_types::Triples triples_;
+
+  ConstructClause() = default;
+  explicit ConstructClause(ad_utility::sparql_types::Triples triples)
+      : triples_(std::move(triples)) {}
+};
+}  // namespace parsedQuery

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -46,7 +46,7 @@ string ParsedQuery::asString() const {
       os << "{";
     }
   } else if (hasConstructClause()) {
-    const auto& constructClause = this->constructClause();
+    const auto& constructClause = this->constructClause().triples_;
     os << "\n CONSTRUCT {\n\t";
     for (const auto& triple : constructClause) {
       os << triple[0].toSparql();
@@ -301,7 +301,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
       return;
     }
 
-    for (const auto& triple : constructClause()) {
+    for (const auto& triple : constructClause().triples_) {
       for (const auto& varOrTerm : triple) {
         if (auto variable = std::get_if<Variable>(&varOrTerm)) {
           if (!ad_utility::contains(_groupByVariables, *variable)) {

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -133,7 +133,8 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
           const sparqlExpression::SparqlExpressionPimpl& expression,
           const std::string& locationDescription) {
         for (const auto* var : expression.containedVariables()) {
-          checkVariableIsVisible(*var, locationDescription);
+          checkVariableIsVisible(*var, locationDescription + " in Expression " +
+                                           expression.getDescriptor());
         }
       };
 

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -125,7 +125,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
     if (!ad_utility::contains(getVisibleVariables(), var)) {
       throw ParseException("Variable " + var.name() + " was used in " +
                            locationDescription +
-                           " is not visible in the Query Body.");
+                           ", but is not visible in the Query Body.");
     }
   };
   auto checkUsedVariablesAreVisible =

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -22,16 +22,6 @@ using std::vector;
 string ParsedQuery::asString() const {
   std::ostringstream os;
 
-  // PREFIX
-  os << "PREFIX: {";
-  for (size_t i = 0; i < _prefixes.size(); ++i) {
-    os << "\n\t" << _prefixes[i].asString();
-    if (i + 1 < _prefixes.size()) {
-      os << ',';
-    }
-  }
-  os << "\n}";
-
   bool usesSelect = hasSelectClause();
   bool usesAsterisk = usesSelect && selectClause().isAsterisk();
 
@@ -328,8 +318,6 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
 }
 
 void ParsedQuery::merge(const ParsedQuery& p) {
-  _prefixes.insert(_prefixes.begin(), p._prefixes.begin(), p._prefixes.end());
-
   auto& children = _rootGraphPattern._graphPatterns;
   auto& otherChildren = p._rootGraphPattern._graphPatterns;
   children.insert(children.end(), otherChildren.begin(), otherChildren.end());

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -167,6 +167,8 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
   }
 
   // Process havingClause
+  // TODO<joka921, qup42> as soon as FILTER and HAVING support proper
+  //  expressions, also add similar sanity checks for the HAVING clause here.
   _havingClauses = std::move(modifiers.havingClauses_);
 
   // Process orderClause
@@ -322,6 +324,27 @@ void ParsedQuery::merge(const ParsedQuery& p) {
   // update the ids
   _numGraphPatterns = 0;
   _rootGraphPattern.recomputeIds(&_numGraphPatterns);
+}
+
+// _____________________________________________________________________________
+const std::vector<Variable>& ParsedQuery::getVisibleVariables() {
+  return std::visit(&parsedQuery::ClauseBase::getVisibleVariables, _clause);
+}
+
+// _____________________________________________________________________________
+void ParsedQuery::registerVariablesVisibleInQueryBody(
+    const vector<Variable>& variables) {
+  for (const auto& var : variables) {
+    registerVariableVisibleInQueryBody(var);
+  }
+}
+
+// _____________________________________________________________________________
+void ParsedQuery::registerVariableVisibleInQueryBody(const Variable& variable) {
+  auto addVariable = [&variable](auto& clause) {
+    clause.addVisibleVariable(variable);
+  };
+  std::visit(addVariable, _clause);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -298,17 +298,13 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
       return;
     }
 
-    for (const auto& triple : constructClause().triples_) {
-      for (const auto& varOrTerm : triple) {
-        if (auto variable = std::get_if<Variable>(&varOrTerm)) {
-          if (!ad_utility::contains(_groupByVariables, *variable)) {
-            throw ParseException("Variable " + variable->name() +
-                                 " is used but not "
-                                 "aggregated despite the query not being "
-                                 "grouped by " +
-                                 variable->name() + ".");
-          }
-        }
+    for (const auto* variable : constructClause().containedVariables()) {
+      if (!ad_utility::contains(_groupByVariables, *variable)) {
+        throw ParseException("Variable " + variable->name() +
+                             " is used but not "
+                             "aggregated despite the query not being "
+                             "grouped by " +
+                             variable->name() + ".");
       }
     }
   }

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -328,7 +328,7 @@ void ParsedQuery::merge(const ParsedQuery& p) {
 }
 
 // _____________________________________________________________________________
-const std::vector<Variable>& ParsedQuery::getVisibleVariables() {
+const std::vector<Variable>& ParsedQuery::getVisibleVariables() const {
   return std::visit(&parsedQuery::ClauseBase::getVisibleVariables, _clause);
 }
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -92,9 +92,6 @@ class ParsedQuery {
 
   ParsedQuery() = default;
 
-  // The ql prefix for QLever specific additions is always defined.
-  vector<SparqlPrefix> _prefixes = {SparqlPrefix(
-      INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI)};
   GraphPattern _rootGraphPattern;
   vector<SparqlFilter> _havingClauses;
   size_t _numGraphPatterns = 1;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -137,7 +137,7 @@ class ParsedQuery {
     auto addVariable = [&variable](auto& clause) {
       clause.addVisibleVariable(variable);
     };
-    std::visit(ad_utility::OverloadCallOperator{addVariable}, _clause);
+    std::visit(addVariable, _clause);
   }
 
   // Add variables, that were found in the SubQuery body.
@@ -149,14 +149,7 @@ class ParsedQuery {
 
   // Returns all variables that are visible in the Query Body.
   const std::vector<Variable>& getVisibleVariables() {
-    // TODO: clang-tidy was complaining with visit.
-    if (hasSelectClause()) {
-      return selectClause().getVisibleVariables();
-    } else if (hasConstructClause()) {
-      return constructClause().getVisibleVariables();
-    } else {
-      AD_FAIL();
-    }
+    return std::visit(&parsedQuery::ClauseBase::getVisibleVariables, _clause);
   }
 
   auto& children() { return _rootGraphPattern._graphPatterns; }

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -139,7 +139,7 @@ class ParsedQuery {
   void registerVariablesVisibleInQueryBody(const vector<Variable>& variables);
 
   // Returns all variables that are visible in the Query Body.
-  const std::vector<Variable>& getVisibleVariables();
+  const std::vector<Variable>& getVisibleVariables() const;
 
   auto& children() { return _rootGraphPattern._graphPatterns; }
   [[nodiscard]] const auto& children() const {

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -9,27 +9,28 @@
 #include <variant>
 #include <vector>
 
-#include "../engine/ResultType.h"
-#include "../engine/sparqlExpressions/SparqlExpressionPimpl.h"
-#include "../util/Algorithm.h"
-#include "../util/Exception.h"
-#include "../util/HashMap.h"
-#include "../util/OverloadCallOperator.h"
-#include "../util/StringUtils.h"
-#include "./TripleComponent.h"
-#include "Alias.h"
-#include "ParseException.h"
-#include "PropertyPath.h"
-#include "data/GroupKey.h"
-#include "data/LimitOffsetClause.h"
-#include "data/OrderKey.h"
-#include "data/SolutionModifiers.h"
-#include "data/SparqlFilter.h"
-#include "data/Types.h"
-#include "data/VarOrTerm.h"
+#include "engine/ResultType.h"
+#include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
+#include "parser/Alias.h"
+#include "parser/ConstructClause.h"
 #include "parser/GraphPattern.h"
 #include "parser/GraphPatternOperation.h"
+#include "parser/ParseException.h"
+#include "parser/PropertyPath.h"
 #include "parser/SelectClause.h"
+#include "parser/TripleComponent.h"
+#include "parser/data/GroupKey.h"
+#include "parser/data/LimitOffsetClause.h"
+#include "parser/data/OrderKey.h"
+#include "parser/data/SolutionModifiers.h"
+#include "parser/data/SparqlFilter.h"
+#include "parser/data/Types.h"
+#include "parser/data/VarOrTerm.h"
+#include "util/Algorithm.h"
+#include "util/Exception.h"
+#include "util/HashMap.h"
+#include "util/OverloadCallOperator.h"
+#include "util/StringUtils.h"
 
 using std::string;
 using std::vector;
@@ -88,7 +89,7 @@ class ParsedQuery {
 
   using SelectClause = parsedQuery::SelectClause;
 
-  using ConstructClause = ad_utility::sparql_types::Triples;
+  using ConstructClause = parsedQuery::ConstructClause;
 
   ParsedQuery() = default;
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -132,15 +132,12 @@ class ParsedQuery {
     return std::get<ConstructClause>(_clause);
   }
 
-  // Add a variable, that was found in the SubQuery body.
+  // Add a variable, that was found in the query body.
   void registerVariableVisibleInQueryBody(const Variable& variable) {
-    auto addVariable = [&variable](auto& clause) {
-      clause.addVisibleVariable(variable);
-    };
-    std::visit(addVariable, _clause);
+    std::visit(&parsedQuery::ClauseBase::addVisibleVariable, _clause);
   }
 
-  // Add variables, that were found in the SubQuery body.
+  // Add variables, that were found in the query body.
   void registerVariablesVisibleInQueryBody(const vector<Variable>& variables) {
     for (const auto& var : variables) {
       registerVariableVisibleInQueryBody(var);

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -133,21 +133,13 @@ class ParsedQuery {
   }
 
   // Add a variable, that was found in the query body.
-  void registerVariableVisibleInQueryBody(const Variable& variable) {
-    std::visit(&parsedQuery::ClauseBase::addVisibleVariable, _clause);
-  }
+  void registerVariableVisibleInQueryBody(const Variable& variable);
 
   // Add variables, that were found in the query body.
-  void registerVariablesVisibleInQueryBody(const vector<Variable>& variables) {
-    for (const auto& var : variables) {
-      registerVariableVisibleInQueryBody(var);
-    }
-  }
+  void registerVariablesVisibleInQueryBody(const vector<Variable>& variables);
 
   // Returns all variables that are visible in the Query Body.
-  const std::vector<Variable>& getVisibleVariables() {
-    return std::visit(&parsedQuery::ClauseBase::getVisibleVariables, _clause);
-  }
+  const std::vector<Variable>& getVisibleVariables();
 
   auto& children() { return _rootGraphPattern._graphPatterns; }
   [[nodiscard]] const auto& children() const {

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -11,6 +11,8 @@
 using namespace parsedQuery;
 
 // ____________________________________________________________________
+// TODO<joka921, qup42> use a better mechanism to remove duplicates in the
+//  visible variables while still keeping the order.
 void ClauseBase::addVisibleVariable(const Variable& variable) {
   if (!ad_utility::contains(visibleVariables_, variable)) {
     visibleVariables_.emplace_back(variable);

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -19,7 +19,7 @@ void ClauseBase::addVisibleVariable(const Variable& variable) {
   }
 }
 
-const vector<Variable>& ClauseBase::getVisibleVariables() {
+const vector<Variable>& ClauseBase::getVisibleVariables() const {
   return visibleVariables_;
 }
 

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -9,6 +9,18 @@
 #include "util/OverloadCallOperator.h"
 
 using namespace parsedQuery;
+
+// ____________________________________________________________________
+void ClauseBase::addVisibleVariable(const Variable& variable) {
+  if (!ad_utility::contains(visibleVariables_, variable)) {
+    visibleVariables_.emplace_back(variable);
+  }
+}
+
+const vector<Variable>& ClauseBase::getVisibleVariables() {
+  return visibleVariables_;
+}
+
 // ____________________________________________________________________
 [[nodiscard]] bool SelectClause::isAsterisk() const {
   return std::holds_alternative<Asterisk>(varsAndAliasesOrAsterisk_);
@@ -40,17 +52,6 @@ void SelectClause::setSelected(std::vector<Variable> variables) {
   std::vector<VarOrAlias> v(std::make_move_iterator(variables.begin()),
                             std::make_move_iterator(variables.end()));
   setSelected(v);
-}
-
-// ____________________________________________________________________
-void SelectClause::addVisibleVariable(const Variable& variable) {
-  if (!ad_utility::contains(visibleVariables_, variable)) {
-    visibleVariables_.emplace_back(variable);
-  }
-}
-
-const vector<Variable>& SelectClause::getVisibleVariables() {
-  return visibleVariables_;
 }
 
 // ____________________________________________________________________

--- a/src/parser/SelectClause.h
+++ b/src/parser/SelectClause.h
@@ -23,7 +23,7 @@ struct ClauseBase {
   void addVisibleVariable(const Variable& variable);
 
   // Get all the variables that are visible in the query body.
-  const std::vector<Variable>& getVisibleVariables();
+  const std::vector<Variable>& getVisibleVariables() const;
 };
 
 /// The `SELECT` clause of a  SPARQL query. It contains the selected variables

--- a/src/parser/SelectClause.h
+++ b/src/parser/SelectClause.h
@@ -13,6 +13,7 @@
 
 namespace parsedQuery {
 
+/// Base class for common functionality of `SelectClause` and `ConstructClause`.
 struct ClauseBase {
   // The variables that are visible in the query body. Will be used in the case
   // of `SELECT *` and to check invariants of the `ParsedQuery`.

--- a/src/parser/SelectClause.h
+++ b/src/parser/SelectClause.h
@@ -13,10 +13,22 @@
 
 namespace parsedQuery {
 
+struct ClauseBase {
+  // The variables that are visible in the query body. Will be used in the case
+  // of `SELECT *` and to check invariants of the `ParsedQuery`.
+  std::vector<Variable> visibleVariables_;
+
+  // Add a variable that is visible in the query body.
+  void addVisibleVariable(const Variable& variable);
+
+  // Get all the variables that are visible in the query body.
+  const std::vector<Variable>& getVisibleVariables();
+};
+
 /// The `SELECT` clause of a  SPARQL query. It contains the selected variables
 /// and aliases. If all variables are selected via `SELECT *` then this class
 /// also stores the variables to which the `*` will expand.
-struct SelectClause {
+struct SelectClause : ClauseBase {
   bool reduced_ = false;
   bool distinct_ = false;
 
@@ -31,10 +43,6 @@ struct SelectClause {
 
   // The `char` means `SELECT *`.
   std::variant<VarsAndAliases, Asterisk> varsAndAliasesOrAsterisk_;
-
-  // The variables that are visible in the query body. Will be used in the case
-  // of `SELECT *` and to check invariants of the `ParsedQuery`.
-  std::vector<Variable> visibleVariables_;
 
  public:
   /// If true, then this `SelectClause` represents `SELECT *`. If false,
@@ -54,12 +62,6 @@ struct SelectClause {
   // Overload of `setSelected` (see above) for the simple case, where only
   // variables and no aliases are selected.
   void setSelected(std::vector<Variable> variables);
-
-  // Add a variable that is visible in the query body.
-  void addVisibleVariable(const Variable& variable);
-
-  // Get all the variables that are visible in the query body.
-  const std::vector<Variable>& getVisibleVariables();
 
   /// Get all the selected variables. This includes the variables to which
   /// aliases are bound. For example for `SELECT ?x (?a + ?b AS ?c)`,

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -25,13 +25,10 @@ ParsedQuery SparqlParser::parseQuery(std::string query) {
       std::move(query),
       {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
   auto resultOfParseAndRemainingText = p.parseTypesafe(&AntlrParser::query);
-  if (!resultOfParseAndRemainingText.remainingText_.empty()) {
-    // TODO: add Exception Metadata
-    throw ParseException(
-        "A query was successfully parsed, but the following remainder of the "
-        "input was ignored by the parsed: " +
-        resultOfParseAndRemainingText.remainingText_);
-  }
+  // The query rule ends with <EOF> so the parse always has to consume the whole
+  // input. If this is not the case a ParseException should have been thrown at
+  // an earlier point.
+  AD_CHECK(!resultOfParseAndRemainingText.remainingText_.empty());
   return std::move(resultOfParseAndRemainingText.resultOfParse_);
 }
 

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -20,9 +20,10 @@ SparqlParser::SparqlParser(const string& query) : lexer_(query), query_(query) {
 }
 
 // _____________________________________________________________________________
-ParsedQuery SparqlParser::parseQuery(std::string_view query) {
+ParsedQuery SparqlParser::parseQuery(std::string query) {
   sparqlParserHelpers::ParserAndVisitor p{
-      query, {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      std::move(query),
+      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
   auto resultOfParseAndRemainingText = p.parseTypesafe(&AntlrParser::query);
   if (!resultOfParseAndRemainingText.remainingText_.empty()) {
     // TODO: add Exception Metadata

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -19,14 +19,17 @@ SparqlParser::SparqlParser(const string& query) : lexer_(query), query_(query) {
   LOG(DEBUG) << "Parsing " << query << std::endl;
 }
 
+// _____________________________________________________________________________
 ParsedQuery SparqlParser::parseQuery(std::string_view query) {
   sparqlParserHelpers::ParserAndVisitor p{
       query, {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
   auto resultOfParseAndRemainingText = p.parseTypesafe(&AntlrParser::query);
   if (!resultOfParseAndRemainingText.remainingText_.empty()) {
     // TODO: add Exception Metadata
-    throw ParseException("Query couldn't be parsed completely. Trailing: " +
-                         resultOfParseAndRemainingText.remainingText_);
+    throw ParseException(
+        "A query was successfully parsed, but the following remainder of the "
+        "input was ignored by the parsed: " +
+        resultOfParseAndRemainingText.remainingText_);
   }
   return std::move(resultOfParseAndRemainingText.resultOfParse_);
 }

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -28,7 +28,7 @@ ParsedQuery SparqlParser::parseQuery(std::string query) {
   // The query rule ends with <EOF> so the parse always has to consume the whole
   // input. If this is not the case a ParseException should have been thrown at
   // an earlier point.
-  AD_CHECK(!resultOfParseAndRemainingText.remainingText_.empty());
+  AD_CHECK(resultOfParseAndRemainingText.remainingText_.empty());
   return std::move(resultOfParseAndRemainingText.resultOfParse_);
 }
 

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -15,8 +15,6 @@
 
 using std::string;
 
-enum QueryType { CONSTRUCT_QUERY, SELECT_QUERY };
-
 // A simple parser of SPARQL.
 // No supposed to feature the complete query language.
 class SparqlParser {
@@ -38,14 +36,4 @@ class SparqlParser {
   SparqlLexer lexer_;
   string query_;
   SparqlFilter parseRegexFilter(bool expectKeyword);
-
-  // Parse the clause with the given explicitly specified prefixes and query
-  // string.
-  template <typename ContextType>
-  static auto parseWithAntlr(ContextType* (SparqlAutomaticParser::*F)(void),
-                             SparqlQleverVisitor::PrefixMap prefixMap,
-                             std::string_view query)
-      -> decltype((std::declval<sparqlParserHelpers::ParserAndVisitor>())
-                      .parseTypesafe(F)
-                      .resultOfParse_);
 };

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -32,9 +32,6 @@ class SparqlParser {
       const SparqlQleverVisitor::PrefixMap& prefixMap);
 
  private:
-  void parseQuery(ParsedQuery* query, QueryType queryType);
-  void parseWhere(ParsedQuery* query);
-  void parseSolutionModifiers(ParsedQuery* query);
   // Returns true if it found a filter
   std::optional<SparqlFilter> parseFilter(bool failOnNoFilter = true);
 
@@ -42,23 +39,12 @@ class SparqlParser {
   string query_;
   SparqlFilter parseRegexFilter(bool expectKeyword);
 
-  // Helper function that converts the prefix map from `parsedQuery` (a vector
-  // of pairs of prefix and IRI) to the prefix map we need for the
-  // `SparqlQleverVisitor` (a hash map from prefixes to IRIs).
-  static SparqlQleverVisitor::PrefixMap getPrefixMap(
-      const ParsedQuery& parsedQuery);
-  // Parse the clause with the prefixes of the given ParsedQuery.
+  // Parse the clause with the given explicitly specified prefixes and query
+  // string.
   template <typename ContextType>
   auto parseWithAntlr(ContextType* (SparqlAutomaticParser::*F)(void),
-                      const ParsedQuery& parsedQuery)
-      -> decltype((std::declval<sparqlParserHelpers::ParserAndVisitor>())
-                      .parseTypesafe(F)
-                      .resultOfParse_);
-
-  // Parse the clause with the given explicitly specified prefixes.
-  template <typename ContextType>
-  auto parseWithAntlr(ContextType* (SparqlAutomaticParser::*F)(void),
-                      SparqlQleverVisitor::PrefixMap prefixMap)
+                      SparqlQleverVisitor::PrefixMap prefixMap,
+                      std::string query)
       -> decltype((std::declval<sparqlParserHelpers::ParserAndVisitor>())
                       .parseTypesafe(F)
                       .resultOfParse_);

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -20,7 +20,7 @@ using std::string;
 class SparqlParser {
  public:
   explicit SparqlParser(const string& query);
-  static ParsedQuery parseQuery(std::string_view query);
+  static ParsedQuery parseQuery(std::string query);
 
   /// Parse the expression of a filter statement (without the `FILTER` keyword).
   /// This helper method is needed as long as the set of expressions supported

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -22,7 +22,7 @@ enum QueryType { CONSTRUCT_QUERY, SELECT_QUERY };
 class SparqlParser {
  public:
   explicit SparqlParser(const string& query);
-  ParsedQuery parse();
+  static ParsedQuery parseQuery(std::string_view query);
 
   /// Parse the expression of a filter statement (without the `FILTER` keyword).
   /// This helper method is needed as long as the set of expressions supported
@@ -42,9 +42,9 @@ class SparqlParser {
   // Parse the clause with the given explicitly specified prefixes and query
   // string.
   template <typename ContextType>
-  auto parseWithAntlr(ContextType* (SparqlAutomaticParser::*F)(void),
-                      SparqlQleverVisitor::PrefixMap prefixMap,
-                      std::string query)
+  static auto parseWithAntlr(ContextType* (SparqlAutomaticParser::*F)(void),
+                             SparqlQleverVisitor::PrefixMap prefixMap,
+                             std::string_view query)
       -> decltype((std::declval<sparqlParserHelpers::ParserAndVisitor>())
                       .parseTypesafe(F)
                       .resultOfParse_);

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -15,8 +15,12 @@
 
 using std::string;
 
-// A simple parser of SPARQL.
-// No supposed to feature the complete query language.
+// The SPARQL parser used by QLever. The actual parsing is delegated to a parser
+// that is based on ANTLR4, which recognises the complete SPARQL 1.1 QL grammar.
+// For valid SPARQL queries that are not supported by QLever a reasonable error
+// message is given. The only thing that is still parsed manually by this class
+// are FILTER clauses, because QLever doesn't support arbitrary expressions in
+// filters yet.
 class SparqlParser {
  public:
   explicit SparqlParser(const string& query);

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -10,8 +10,8 @@ namespace sparqlParserHelpers {
 using std::string;
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string input)
-    : input_{std::move(input)}, visitor_{} {
+ParserAndVisitor::ParserAndVisitor(string_view input)
+    : input_{input}, visitor_{} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
   // propagate them to the user.
@@ -22,9 +22,9 @@ ParserAndVisitor::ParserAndVisitor(string input)
 }
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string input,
+ParserAndVisitor::ParserAndVisitor(string_view input,
                                    SparqlQleverVisitor::PrefixMap prefixes)
-    : ParserAndVisitor{std::move(input)} {
+    : ParserAndVisitor{input} {
   visitor_.setPrefixMapManually(std::move(prefixes));
 }
 }  // namespace sparqlParserHelpers

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -10,8 +10,8 @@ namespace sparqlParserHelpers {
 using std::string;
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string_view input)
-    : input_{input}, visitor_{} {
+ParserAndVisitor::ParserAndVisitor(string input)
+    : input_{std::move(input)}, visitor_{} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
   // propagate them to the user.
@@ -22,9 +22,9 @@ ParserAndVisitor::ParserAndVisitor(string_view input)
 }
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string_view input,
+ParserAndVisitor::ParserAndVisitor(string input,
                                    SparqlQleverVisitor::PrefixMap prefixes)
-    : ParserAndVisitor{input} {
+    : ParserAndVisitor{std::move(input)} {
   visitor_.setPrefixMapManually(std::move(prefixes));
 }
 }  // namespace sparqlParserHelpers

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -28,7 +28,7 @@ struct ResultOfParseAndRemainingText {
 
 struct ParserAndVisitor {
  private:
-  string_view input_;
+  string input_;
   antlr4::ANTLRInputStream stream_{input_};
   SparqlAutomaticLexer lexer_{&stream_};
   antlr4::CommonTokenStream tokens_{&lexer_};
@@ -37,8 +37,8 @@ struct ParserAndVisitor {
  public:
   SparqlAutomaticParser parser_{&tokens_};
   SparqlQleverVisitor visitor_;
-  explicit ParserAndVisitor(string_view input);
-  ParserAndVisitor(string_view input, SparqlQleverVisitor::PrefixMap prefixes);
+  explicit ParserAndVisitor(string input);
+  ParserAndVisitor(string input, SparqlQleverVisitor::PrefixMap prefixes);
 
   template <typename ContextType>
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -28,7 +28,7 @@ struct ResultOfParseAndRemainingText {
 
 struct ParserAndVisitor {
  private:
-  string input_;
+  string_view input_;
   antlr4::ANTLRInputStream stream_{input_};
   SparqlAutomaticLexer lexer_{&stream_};
   antlr4::CommonTokenStream tokens_{&lexer_};
@@ -37,8 +37,8 @@ struct ParserAndVisitor {
  public:
   SparqlAutomaticParser parser_{&tokens_};
   SparqlQleverVisitor visitor_;
-  explicit ParserAndVisitor(string input);
-  ParserAndVisitor(string input, SparqlQleverVisitor::PrefixMap prefixes);
+  explicit ParserAndVisitor(string_view input);
+  ParserAndVisitor(string_view input, SparqlQleverVisitor::PrefixMap prefixes);
 
   template <typename ContextType>
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -127,18 +127,6 @@ PathTuples joinPredicateAndObject(VarOrPath predicate, ObjectList objectList) {
   return tuples;
 }
 
-namespace {
-// Converts the PrefixMap to the legacy data format used by ParsedQuery
-vector<SparqlPrefix> convertPrefixMap(
-    const SparqlQleverVisitor::PrefixMap& map) {
-  vector<SparqlPrefix> prefixes;
-  for (auto const& [label, iri] : map) {
-    prefixes.emplace_back(label, iri);
-  }
-  return prefixes;
-}
-}  // namespace
-
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
   // The prologue (BASE and PREFIX declarations)  only affects the internal
@@ -147,7 +135,6 @@ ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
   auto query =
       visitAlternative<ParsedQuery>(ctx->selectQuery(), ctx->constructQuery());
   query._originalString = ctx->getText();
-  query._prefixes = convertPrefixMap(_prefixMap);
 
   return query;
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -180,15 +180,17 @@ ParsedQuery Visitor::visitTypesafe(Parser::ConstructQueryContext* ctx) {
   ParsedQuery query;
   // TODO: clean up
   if (ctx->constructTemplate()) {
-    query._clause = visitTypesafe(ctx->constructTemplate()).value_or(Triples{});
+    query._clause = visitTypesafe(ctx->constructTemplate())
+                        .value_or(parsedQuery::ConstructClause{});
     auto [pattern, visibleVariables] = visitTypesafe(ctx->whereClause());
     query._rootGraphPattern = std::move(pattern);
     query.registerVariablesVisibleInQueryBody(visibleVariables);
   } else {
     if (ctx->triplesTemplate()) {
-      query._clause = visitTypesafe(ctx->triplesTemplate());
+      query._clause =
+          parsedQuery::ConstructClause{visitTypesafe(ctx->triplesTemplate())};
     } else {
-      query._clause = Triples{};
+      query._clause = parsedQuery::ConstructClause{};
     }
   }
   query.addSolutionModifiers(visitTypesafe(ctx->solutionModifier()));
@@ -471,9 +473,13 @@ vector<GroupKey> Visitor::visitTypesafe(Parser::GroupClauseContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-std::optional<Triples> Visitor::visitTypesafe(
+std::optional<parsedQuery::ConstructClause> Visitor::visitTypesafe(
     Parser::ConstructTemplateContext* ctx) {
-  return visitOptional(ctx->constructTriples());
+  if (ctx->constructTriples()) {
+    return parsedQuery::ConstructClause{visitTypesafe(ctx->constructTriples())};
+  } else {
+    return std::nullopt;
+  }
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -131,6 +131,7 @@ ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
   // state of the visitor.
   visitTypesafe(ctx->prologue());
   ParsedQuery query;
+  // TODO<joka921, qup42> Check if there are more instances of this pattern (like `visitAlternative`, but with a custom error message), that would justify extracting this pattern.
   if (ctx->selectQuery()) {
     query = visitTypesafe(ctx->selectQuery());
   } else if (ctx->constructQuery()) {
@@ -945,6 +946,7 @@ Node Visitor::visitTypesafe(Parser::ObjectRContext* ctx) {
 // ___________________________________________________________________________
 vector<TripleWithPropertyPath> SparqlQleverVisitor::visitTypesafe(
     SparqlAutomaticParser::TriplesSameSubjectPathContext* ctx) {
+// If a triple `?var ql:contains-word "words"` or `?var ql:contains-entity <entity>` is contained in the query, then the variable `?ql_textscore_var` is implicitly created and visible in the query body.
   auto setTextscoreVisibleIfPresent = [this](VarOrTerm& subject,
                                              VarOrPath& predicate) {
     if (auto* var = std::get_if<Variable>(&subject)) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -141,7 +141,7 @@ ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
     reportError(ctx, "QLever only supports SELECT and CONSTRUCT queries.");
   }
 
-  query._originalString = ctx->getText();
+  query._originalString = ctx->getStart()->getInputStream()->toString();
 
   return query;
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -831,25 +831,28 @@ vector<Visitor::ExpressionPtr> Visitor::visitTypesafe(
   return visitVector(ctx->expression());
 }
 
-// ____________________________________________________________________________________
-Triples Visitor::visitTypesafe(Parser::ConstructTriplesContext* ctx) {
+template <typename Context>
+Triples Visitor::parseTriplesConstruction(Context* ctx,
+                                          Context* (Context::*F)(void)) {
   auto result = visitTypesafe(ctx->triplesSameSubject());
-  if (ctx->constructTriples()) {
-    auto newTriples = visitTypesafe(ctx->constructTriples());
+  Context* subContext = std::invoke(F, ctx);
+  if (subContext) {
+    auto newTriples = visitTypesafe(subContext);
     ad_utility::appendVector(result, std::move(newTriples));
   }
   return result;
 }
 
 // ____________________________________________________________________________________
+Triples Visitor::visitTypesafe(Parser::ConstructTriplesContext* ctx) {
+  return parseTriplesConstruction(
+      ctx, &Parser::ConstructTriplesContext::constructTriples);
+}
+
+// ____________________________________________________________________________________
 Triples Visitor::visitTypesafe(Parser::TriplesTemplateContext* ctx) {
-  // TODO: generalize. See ConstructTriplesContext
-  auto result = visitTypesafe(ctx->triplesSameSubject());
-  if (ctx->triplesTemplate()) {
-    auto newTriples = visitTypesafe(ctx->triplesTemplate());
-    ad_utility::appendVector(result, std::move(newTriples));
-  }
-  return result;
+  return parseTriplesConstruction(
+      ctx, &Parser::TriplesTemplateContext::triplesTemplate);
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -131,7 +131,9 @@ ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
   // state of the visitor.
   visitTypesafe(ctx->prologue());
   ParsedQuery query;
-  // TODO<joka921, qup42> Check if there are more instances of this pattern (like `visitAlternative`, but with a custom error message), that would justify extracting this pattern.
+  // TODO<joka921, qup42> Check if there are more instances of this pattern
+  //  (like `visitAlternative`, but with a custom error message), that would
+  //  justify extracting this pattern.
   if (ctx->selectQuery()) {
     query = visitTypesafe(ctx->selectQuery());
   } else if (ctx->constructQuery()) {
@@ -946,7 +948,9 @@ Node Visitor::visitTypesafe(Parser::ObjectRContext* ctx) {
 // ___________________________________________________________________________
 vector<TripleWithPropertyPath> SparqlQleverVisitor::visitTypesafe(
     SparqlAutomaticParser::TriplesSameSubjectPathContext* ctx) {
-// If a triple `?var ql:contains-word "words"` or `?var ql:contains-entity <entity>` is contained in the query, then the variable `?ql_textscore_var` is implicitly created and visible in the query body.
+  // If a triple `?var ql:contains-word "words"` or `?var ql:contains-entity
+  // <entity>` is contained in the query, then the variable `?ql_textscore_var`
+  // is implicitly created and visible in the query body.
   auto setTextscoreVisibleIfPresent = [this](VarOrTerm& subject,
                                              VarOrPath& predicate) {
     if (auto* var = std::get_if<Variable>(&subject)) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -186,7 +186,6 @@ ParsedQuery Visitor::visitTypesafe(Parser::ConstructQueryContext* ctx) {
                 "QLever currently doesn't support FROM clauses");
   }
   ParsedQuery query;
-  // TODO: clean up the construction of a ConstructClause.
   if (ctx->constructTemplate()) {
     query._clause = visitTypesafe(ctx->constructTemplate())
                         .value_or(parsedQuery::ConstructClause{});
@@ -194,12 +193,8 @@ ParsedQuery Visitor::visitTypesafe(Parser::ConstructQueryContext* ctx) {
     query._rootGraphPattern = std::move(pattern);
     query.registerVariablesVisibleInQueryBody(visibleVariables);
   } else {
-    if (ctx->triplesTemplate()) {
-      query._clause =
-          parsedQuery::ConstructClause{visitTypesafe(ctx->triplesTemplate())};
-    } else {
-      query._clause = parsedQuery::ConstructClause{};
-    }
+    query._clause = parsedQuery::ConstructClause{
+        visitOptional(ctx->triplesTemplate()).value_or(Triples{})};
   }
   query.addSolutionModifiers(visitTypesafe(ctx->solutionModifier()));
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -945,4 +945,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
   [[noreturn]] void reportError(antlr4::ParserRuleContext* ctx,
                                 const std::string& msg);
+
+  template <typename Context>
+  Triples parseTriplesConstruction(Context* ctx, Context* (Context::*F)(void));
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -12,6 +12,7 @@
 #include "engine/sparqlExpressions/SampleExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/Alias.h"
+#include "parser/ConstructClause.h"
 #include "parser/ParsedQuery.h"
 #include "parser/RdfEscaping.h"
 #include "parser/data/BlankNode.h"
@@ -446,7 +447,8 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
     return visitTypesafe(ctx);
   }
 
-  std::optional<Triples> visitTypesafe(Parser::ConstructTemplateContext* ctx);
+  std::optional<parsedQuery::ConstructClause> visitTypesafe(
+      Parser::ConstructTemplateContext* ctx);
 
   Any visitConstructTriples(Parser::ConstructTriplesContext* ctx) override {
     return visitTypesafe(ctx);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -948,6 +948,8 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   [[noreturn]] void reportError(antlr4::ParserRuleContext* ctx,
                                 const std::string& msg);
 
+  // Parse both `ConstructTriplesContext` and `TriplesTemplateContext` because
+  // they have the same structure.
   template <typename Context>
-  Triples parseTriplesConstruction(Context* ctx, Context* (Context::*F)(void));
+  Triples parseTriplesConstruction(Context* ctx);
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -123,7 +123,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
     return visitTypesafe(ctx);
   }
 
-  std::variant<ParsedQuery, Triples> visitTypesafe(Parser::QueryContext* ctx);
+  ParsedQuery visitTypesafe(Parser::QueryContext* ctx);
 
   // ___________________________________________________________________________
   Any visitPrologue(Parser::PrologueContext* ctx) override {
@@ -188,7 +188,7 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
     return visitTypesafe(ctx);
   }
 
-  Triples visitTypesafe(Parser::ConstructQueryContext* ctx);
+  ParsedQuery visitTypesafe(Parser::ConstructQueryContext* ctx);
 
   Any visitDescribeQuery(Parser::DescribeQueryContext* ctx) override {
     // TODO: unsupported
@@ -297,8 +297,10 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
       Parser::ValuesClauseContext* ctx);
 
   Any visitTriplesTemplate(Parser::TriplesTemplateContext* ctx) override {
-    return visitChildren(ctx);
+    return visitTypesafe(ctx);
   }
+
+  Triples visitTypesafe(Parser::TriplesTemplateContext* ctx);
 
   Any visitGroupGraphPattern(Parser::GroupGraphPatternContext* ctx) override {
     return visitTypesafe(ctx);

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -40,6 +40,21 @@ bool contains_if(const Container& container, const Predicate& predicate) {
 }
 
 /**
+ * Checks whether a container is contained in another container.
+ *
+ * @param container Container& Container to check
+ * @param containedContainer Container& Container where other container has to
+ * be contained in
+ * @return bool
+ */
+template <typename Container>
+inline bool includes(const Container& container,
+                     const Container& containedContainer) {
+  return std::includes(container.begin(), container.end(),
+                       containedContainer.begin(), containedContainer.end());
+}
+
+/**
  * Appends the second vector to the first one.
  *
  * @param destination Vector& to which to append

--- a/test/ParseExceptionTest.cpp
+++ b/test/ParseExceptionTest.cpp
@@ -31,13 +31,10 @@ void expectParseExceptionWithMetadata(
 }
 
 TEST(ParseException, MetadataGeneration) {
-  // The SparqlLexer changes the input that has already been read into a token
-  // when it is outputted with getUnconsumedInput (which is used for ANtLR).
   // A is not a valid argument for select.
   expectParseExceptionWithMetadata(
       "SELECT A ?a WHERE { ?a ?b ?c }",
       {{"SELECT A ?a WHERE { ?a ?b ?c }", 7, 7, 1, 7}});
-  // The ANTLR Parser currently doesn't always have the whole query.
   // Error is the undefined Prefix "a".
   expectParseExceptionWithMetadata(
       "SELECT * WHERE { ?a a:b ?b }",

--- a/test/ParseExceptionTest.cpp
+++ b/test/ParseExceptionTest.cpp
@@ -33,18 +33,18 @@ TEST(ParseException, MetadataGeneration) {
   // A is not a valid argument for select.
   expectParseExceptionWithMetadata(
       "SELECT A ?a WHERE { ?a ?b ?c }",
-      {{"select   A ?a WHERE { ?a ?b ?c }", 9, 9, 1, 9}});
+      {{"SELECT A ?a WHERE { ?a ?b ?c }", 7, 7, 1, 7}});
   // The ANTLR Parser currently doesn't always have the whole query.
   // Error is the undefined Prefix "a".
   expectParseExceptionWithMetadata(
       "SELECT * WHERE { ?a a:b ?b }",
-      {{"select   * WHERE { ?a a:b ?b }", 22, 24, 1, 22}});
+      {{"SELECT * WHERE { ?a a:b ?b }", 20, 22, 1, 20}});
   // "%" doesn't match any valid token. So in this case we will get an Error
   // from the Lexer.
   expectParseExceptionWithMetadata("SELECT * WHERE { % }",
-                                   {{"select   * WHERE { % }", 19, 19, 1, 19}});
+                                   {{"SELECT * WHERE { % }", 17, 17, 1, 17}});
   // Error is the undefined Prefix "f".
   expectParseExceptionWithMetadata(
       "SELECT * WHERE {\n ?a ?b ?c . \n f:d ?d ?e\n}",
-      {{"select   * WHERE {\n ?a ?b ?c . \n f:d ?d ?e\n}", 33, 35, 3, 1}});
+      {{"SELECT * WHERE {\n ?a ?b ?c . \n f:d ?d ?e\n}", 31, 33, 3, 1}});
 }

--- a/test/ParseExceptionTest.cpp
+++ b/test/ParseExceptionTest.cpp
@@ -7,6 +7,7 @@
 #include "SparqlAntlrParserTestHelpers.h"
 #include "parser/ParseException.h"
 #include "parser/SparqlParser.h"
+#include "util/SourceLocation.h"
 
 TEST(ParseException, coloredError) {
   auto exampleQuery = "SELECT A ?var WHERE";
@@ -17,7 +18,9 @@ TEST(ParseException, coloredError) {
 }
 
 void expectParseExceptionWithMetadata(
-    const string& input, const std::optional<ExceptionMetadata>& metadata) {
+    const string& input, const std::optional<ExceptionMetadata>& metadata,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
+  auto trace = generateLocationTrace(l);
   try {
     SparqlParser(input).parse();
     FAIL();  // Should be unreachable.

--- a/test/ParseExceptionTest.cpp
+++ b/test/ParseExceptionTest.cpp
@@ -22,7 +22,7 @@ void expectParseExceptionWithMetadata(
     ad_utility::source_location l = ad_utility::source_location::current()) {
   auto trace = generateLocationTrace(l);
   try {
-    SparqlParser(input).parse();
+    SparqlParser::parseQuery(input);
     FAIL();  // Should be unreachable.
   } catch (const ParseException& e) {
     // The constructor has to be bracketed because EXPECT_EQ is a macro.

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -17,14 +17,13 @@ TEST(QueryPlannerTest, createTripleGraph) {
 
   try {
     {
-      ParsedQuery pq = SparqlParser(
-                           "PREFIX : <http://rdf.myprefix.com/>\n"
-                           "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
-                           "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
-                           "SELECT ?x ?z \n "
-                           "WHERE \t {?x :myrel ?y. ?y ns:myrel ?z.?y xxx:rel2 "
-                           "<http://abc.de>}")
-                           .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "PREFIX : <http://rdf.myprefix.com/>\n"
+          "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
+          "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
+          "SELECT ?x ?z \n "
+          "WHERE \t {?x :myrel ?y. ?y ns:myrel ?z.?y xxx:rel2 "
+          "<http://abc.de>}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(
           &pq._rootGraphPattern._graphPatterns[0].getBasic());
@@ -52,9 +51,8 @@ TEST(QueryPlannerTest, createTripleGraph) {
     }
 
     {
-      ParsedQuery pq =
-          SparqlParser("SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}")
-              .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       TripleGraph expected =
@@ -75,10 +73,9 @@ TEST(QueryPlannerTest, createTripleGraph) {
     }
 
     {
-      ParsedQuery pq = SparqlParser(
-                           "SELECT ?x WHERE { ?x <is-a> <Book> . \n"
-                           "?x <Author> <Anthony_Newman_(Author)> }")
-                           .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "SELECT ?x WHERE { ?x <is-a> <Book> . \n"
+          "?x <Author> <Anthony_Newman_(Author)> }");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
 
@@ -108,9 +105,8 @@ TEST(QueryPlannerTest, createTripleGraph) {
 TEST(QueryPlannerTest, testCpyCtorWithKeepNodes) {
   try {
     {
-      ParsedQuery pq =
-          SparqlParser("SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}")
-              .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(2u, tg._nodeMap.find(0)->second->_variables.size());
@@ -170,9 +166,8 @@ TEST(QueryPlannerTest, testCpyCtorWithKeepNodes) {
 TEST(QueryPlannerTest, testBFSLeaveOut) {
   try {
     {
-      ParsedQuery pq =
-          SparqlParser("SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}")
-              .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "SELECT ?x WHERE {?x ?p <X>. ?x ?p2 <Y>. <X> ?p <Y>}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(3u, tg._adjLists.size());
@@ -191,9 +186,8 @@ TEST(QueryPlannerTest, testBFSLeaveOut) {
       ASSERT_EQ(1u, out.size());
     }
     {
-      ParsedQuery pq =
-          SparqlParser("SELECT ?x WHERE {<A> <B> ?x. ?x <C> ?y. ?y <X> <Y>}")
-              .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "SELECT ?x WHERE {<A> <B> ?x. ?x <C> ?y. ?y <X> <Y>}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ad_utility::HashSet<size_t> lo;
@@ -226,11 +220,9 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
   try {
     {
       {
-        ParsedQuery pq =
-            SparqlParser(
-                "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
-                "ql:contains-word \"abc\"}")
-                .parse();
+        ParsedQuery pq = SparqlParser::parseQuery(
+            "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
+            "ql:contains-word \"abc\"}");
         QueryPlanner qp(nullptr);
         auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
@@ -264,13 +256,11 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
         ASSERT_TRUE(tg.isSimilar(expected));
       }
       {
-        ParsedQuery pq =
-            SparqlParser(
-                "SELECT ?x WHERE {?x <p> <X>. ?c "
-                "<QLever-internal-function/contains-entity> ?x. ?c "
-                "<QLever-internal-function/contains-word> \"abc\" . ?c "
-                "ql:contains-entity ?y}")
-                .parse();
+        ParsedQuery pq = SparqlParser::parseQuery(
+            "SELECT ?x WHERE {?x <p> <X>. ?c "
+            "<QLever-internal-function/contains-entity> ?x. ?c "
+            "<QLever-internal-function/contains-word> \"abc\" . ?c "
+            "ql:contains-entity ?y}");
         QueryPlanner qp(nullptr);
         auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
@@ -307,12 +297,10 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
         ASSERT_TRUE(tg.isSimilar(expected));
       }
       {
-        ParsedQuery pq =
-            SparqlParser(
-                "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
-                "ql:contains-word \"abc\" . ?c ql:contains-entity ?y. ?y <P2> "
-                "<X2>}")
-                .parse();
+        ParsedQuery pq = SparqlParser::parseQuery(
+            "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
+            "ql:contains-word \"abc\" . ?c ql:contains-entity ?y. ?y <P2> "
+            "<X2>}");
         QueryPlanner qp(nullptr);
         auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
@@ -354,12 +342,10 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
         ASSERT_TRUE(tg.isSimilar(expected));
       }
       {
-        ParsedQuery pq =
-            SparqlParser(
-                "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
-                "ql:contains-word \"abc\" . ?c ql:contains-entity ?y. ?c2 "
-                "ql:contains-entity ?y. ?c2 ql:contains-word \"xx\"}")
-                .parse();
+        ParsedQuery pq = SparqlParser::parseQuery(
+            "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
+            "ql:contains-word \"abc\" . ?c ql:contains-entity ?y. ?c2 "
+            "ql:contains-entity ?y. ?c2 ql:contains-word \"xx\"}");
         QueryPlanner qp(nullptr);
         auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         TripleGraph expected = TripleGraph(std::vector<std::pair<
@@ -436,13 +422,11 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
         ASSERT_TRUE(tg.isSimilar(expected2));
       }
       {
-        ParsedQuery pq =
-            SparqlParser(
-                "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
-                "ql:contains-word \"abc\" . ?c ql:contains-entity ?y. ?c2 "
-                "ql:contains-entity ?y. ?c2 ql:contains-word \"xx\". ?y <P2> "
-                "<X2>}")
-                .parse();
+        ParsedQuery pq = SparqlParser::parseQuery(
+            "SELECT ?x WHERE {?x <p> <X>. ?c ql:contains-entity ?x. ?c "
+            "ql:contains-word \"abc\" . ?c ql:contains-entity ?y. ?c2 "
+            "ql:contains-entity ?y. ?c2 ql:contains-word \"xx\". ?y <P2> "
+            "<X2>}");
         QueryPlanner qp(nullptr);
         auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
         ASSERT_EQ(
@@ -506,11 +490,10 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
 }
 
 TEST(QueryPlannerTest, testSPX) {
-  ParsedQuery pq = SparqlParser(
-                       "PREFIX : <http://rdf.myprefix.com/>\n"
-                       "SELECT ?x \n "
-                       "WHERE \t {?x :myrel :obj}")
-                       .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX : <http://rdf.myprefix.com/>\n"
+      "SELECT ?x \n "
+      "WHERE \t {?x :myrel :obj}");
   QueryPlanner qp(nullptr);
   QueryExecutionTree qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
@@ -520,11 +503,10 @@ TEST(QueryPlannerTest, testSPX) {
 }
 
 TEST(QueryPlannerTest, testXPO) {
-  ParsedQuery pq = SparqlParser(
-                       "PREFIX : <http://rdf.myprefix.com/>\n"
-                       "SELECT ?x \n "
-                       "WHERE \t {:subj :myrel ?x}")
-                       .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX : <http://rdf.myprefix.com/>\n"
+      "SELECT ?x \n "
+      "WHERE \t {:subj :myrel ?x}");
   QueryPlanner qp(nullptr);
   QueryExecutionTree qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
@@ -534,11 +516,10 @@ TEST(QueryPlannerTest, testXPO) {
 }
 
 TEST(QueryPlannerTest, testSP_free_) {
-  ParsedQuery pq = SparqlParser(
-                       "PREFIX : <http://rdf.myprefix.com/>\n"
-                       "SELECT ?x \n "
-                       "WHERE \t {?x :myrel ?y}")
-                       .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX : <http://rdf.myprefix.com/>\n"
+      "SELECT ?x \n "
+      "WHERE \t {?x :myrel ?y}");
   QueryPlanner qp(nullptr);
   QueryExecutionTree qet = qp.createExecutionTree(pq);
   ASSERT_EQ(
@@ -549,11 +530,10 @@ TEST(QueryPlannerTest, testSP_free_) {
 
 TEST(QueryPlannerTest, testSPX_SPX) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "PREFIX : <pre/>\n"
-                         "SELECT ?x \n "
-                         "WHERE \t {:s1 :r ?x. :s2 :r ?x}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX : <pre/>\n"
+        "SELECT ?x \n "
+        "WHERE \t {:s1 :r ?x. :s2 :r ?x}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -573,11 +553,10 @@ TEST(QueryPlannerTest, testSPX_SPX) {
 
 TEST(QueryPlannerTest, test_free_PX_SPX) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "PREFIX : <pre/>\n"
-                         "SELECT ?x ?y \n "
-                         "WHERE  {?y :r ?x . :s2 :r ?x}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX : <pre/>\n"
+        "SELECT ?x ?y \n "
+        "WHERE  {?y :r ?x . :s2 :r ?x}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -597,11 +576,10 @@ TEST(QueryPlannerTest, test_free_PX_SPX) {
 
 TEST(QueryPlannerTest, test_free_PX__free_PX) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "PREFIX : <pre/>\n"
-                         "SELECT ?x ?y ?z \n "
-                         "WHERE {?y :r ?x. ?z :r ?x}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX : <pre/>\n"
+        "SELECT ?x ?y ?z \n "
+        "WHERE {?y :r ?x. ?z :r ?x}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -621,13 +599,11 @@ TEST(QueryPlannerTest, test_free_PX__free_PX) {
 
 TEST(QueryPlannerTest, testActorsBornInEurope) {
   try {
-    ParsedQuery pq =
-        SparqlParser(
-            "PREFIX : <pre/>\n"
-            "SELECT ?a \n "
-            "WHERE {?a :profession :Actor . ?a :born-in ?c. ?c :in :Europe}\n"
-            "ORDER BY ?a")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX : <pre/>\n"
+        "SELECT ?a \n "
+        "WHERE {?a :profession :Actor . ?a :born-in ?c. ?c :in :Europe}\n"
+        "ORDER BY ?a");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(18340u, qet.getCostEstimate());
@@ -655,15 +631,13 @@ TEST(QueryPlannerTest, testActorsBornInEurope) {
 TEST(QueryPlannerTest, testStarTwoFree) {
   try {
     {
-      ParsedQuery pq =
-          SparqlParser(
-              "PREFIX : <http://rdf.myprefix.com/>\n"
-              "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
-              "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
-              "SELECT ?x ?z \n "
-              "WHERE \t {?x :myrel ?y. ?y ns:myrel ?z. ?y xxx:rel2 "
-              "<http://abc.de>}")
-              .parse();
+      ParsedQuery pq = SparqlParser::parseQuery(
+          "PREFIX : <http://rdf.myprefix.com/>\n"
+          "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
+          "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
+          "SELECT ?x ?z \n "
+          "WHERE \t {?x :myrel ?y. ?y ns:myrel ?z. ?y xxx:rel2 "
+          "<http://abc.de>}");
       QueryPlanner qp(nullptr);
       QueryExecutionTree qet = qp.createExecutionTree(pq);
       ASSERT_EQ(
@@ -689,11 +663,10 @@ TEST(QueryPlannerTest, testStarTwoFree) {
 
 TEST(QueryPlannerTest, testFilterAfterSeed) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x ?y ?z WHERE {"
-                         "?x <r> ?y . ?y <r> ?z . "
-                         "FILTER(?x != ?y) }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y ?z WHERE {"
+        "?x <r> ?y . ?y <r> ?z . "
+        "FILTER(?x != ?y) }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -715,11 +688,10 @@ TEST(QueryPlannerTest, testFilterAfterSeed) {
 
 TEST(QueryPlannerTest, testFilterAfterJoin) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x ?y ?z WHERE {"
-                         "?x <r> ?y . ?y <r> ?z . "
-                         "FILTER(?x != ?z) }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y ?z WHERE {"
+        "?x <r> ?y . ?y <r> ?z . "
+        "FILTER(?x != ?z) }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -741,10 +713,9 @@ TEST(QueryPlannerTest, testFilterAfterJoin) {
 
 TEST(QueryPlannerTest, threeVarTriples) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x ?p ?o WHERE {"
-                         "<s> <p> ?x . ?x ?p ?o }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?p ?o WHERE {"
+        "<s> <p> ?x . ?x ?p ?o }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -763,10 +734,9 @@ TEST(QueryPlannerTest, threeVarTriples) {
   }
 
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x ?p ?o WHERE {"
-                         "<s> ?x <o> . ?x ?p ?o }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?p ?o WHERE {"
+        "<s> ?x <o> . ?x ?p ?o }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -785,10 +755,9 @@ TEST(QueryPlannerTest, threeVarTriples) {
   }
 
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?s ?p ?o WHERE {"
-                         "<s> <p> ?p . ?s ?p ?o }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?s ?p ?o WHERE {"
+        "<s> <p> ?p . ?s ?p ?o }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -809,10 +778,9 @@ TEST(QueryPlannerTest, threeVarTriples) {
 
 TEST(QueryPlannerTest, threeVarTriplesTCJ) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x ?p ?o WHERE {"
-                         "<s> ?p ?x . ?x ?p ?o }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?p ?o WHERE {"
+        "<s> ?p ?x . ?x ?p ?o }");
     QueryPlanner qp(nullptr);
     ASSERT_THROW(qp.createExecutionTree(pq), ad_semsearch::Exception);
   } catch (const ad_semsearch::Exception& e) {
@@ -824,10 +792,9 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
   }
 
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?s ?p ?o WHERE {"
-                         "?s ?p ?o . ?s ?p <x> }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?s ?p ?o WHERE {"
+        "?s ?p ?o . ?s ?p <x> }");
     QueryPlanner qp(nullptr);
     ASSERT_THROW(QueryExecutionTree qet = qp.createExecutionTree(pq),
                  ad_semsearch::Exception);
@@ -842,10 +809,9 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
 
 TEST(QueryPlannerTest, threeVarXthreeVarException) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?s ?s2 WHERE {"
-                         "?s ?p ?o . ?s2 ?p ?o }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?s ?s2 WHERE {"
+        "?s ?p ?o . ?s2 ?p ?o }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     FAIL() << "Was expecting exception, but got" << qet.asString() << std::endl;
@@ -863,10 +829,9 @@ TEST(QueryPlannerTest, threeVarXthreeVarException) {
 
 TEST(QueryExecutionTreeTest, testBooksbyNewman) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x WHERE { ?x <is-a> <Book> . "
-                         "?x <Author> <Anthony_Newman_(Author)> }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <is-a> <Book> . "
+        "?x <Author> <Anthony_Newman_(Author)> }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -887,13 +852,12 @@ TEST(QueryExecutionTreeTest, testBooksbyNewman) {
 
 TEST(QueryExecutionTreeTest, testBooksGermanAwardNomAuth) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x ?y WHERE { "
-                         "?x <is-a> <Person> . "
-                         "?x <Country_of_nationality> <Germany> . "
-                         "?x <Author> ?y . "
-                         "?y <is-a> <Award-Nominated_Work> }")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y WHERE { "
+        "?x <is-a> <Person> . "
+        "?x <Country_of_nationality> <Germany> . "
+        "?x <Author> ?y . "
+        "?y <is-a> <Award-Nominated_Work> }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_GT(qet.asString().size(), 0u);
@@ -909,12 +873,10 @@ TEST(QueryExecutionTreeTest, testBooksGermanAwardNomAuth) {
 
 TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
   try {
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?a \n "
-            "WHERE  {?a <is-a> <Plant> . ?c ql:contains-entity ?a. "
-            "?c ql:contains-word \"edible leaves\"} TEXTLIMIT 5")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?a \n "
+        "WHERE  {?a <is-a> <Plant> . ?c ql:contains-entity ?a. "
+        "?c ql:contains-word \"edible leaves\"} TEXTLIMIT 5");
     QueryPlanner qp(nullptr);
     QueryPlanner::TripleGraph tg =
         qp.createTripleGraph(&pq.children()[0].getBasic());
@@ -938,10 +900,9 @@ TEST(QueryExecutionTreeTest, testPlantsEdibleLeaves) {
 
 TEST(QueryExecutionTreeTest, testTextQuerySE) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?c \n "
-                         "WHERE  {?c ql:contains-word \"search engine\"}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?c \n "
+        "WHERE  {?c ql:contains-word \"search engine\"}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -960,16 +921,15 @@ TEST(QueryExecutionTreeTest, testTextQuerySE) {
 
 TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "PREFIX : <>\n"
-                         "SELECT ?x ?y ?c\n "
-                         "WHERE \t {"
-                         "?x :Place_of_birth ?y ."
-                         "?y :Contained_by :Europe ."
-                         "?c ql:contains-entity ?x ."
-                         "?c ql:contains-word \"cocaine\" ."
-                         "}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX : <>\n"
+        "SELECT ?x ?y ?c\n "
+        "WHERE \t {"
+        "?x :Place_of_birth ?y ."
+        "?y :Contained_by :Europe ."
+        "?c ql:contains-entity ?x ."
+        "?c ql:contains-word \"cocaine\" ."
+        "}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -996,15 +956,14 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
 
 TEST(QueryExecutionTreeTest, testCoOccFreeVar) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "PREFIX : <>"
-                         "SELECT ?x ?y WHERE {"
-                         "?x :is-a :Politician ."
-                         "?c ql:contains-entity ?x ."
-                         "?c ql:contains-word \"friend*\" ."
-                         "?c ql:contains-entity ?y ."
-                         "}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX : <>"
+        "SELECT ?x ?y WHERE {"
+        "?x :is-a :Politician ."
+        "?c ql:contains-entity ?x ."
+        "?c ql:contains-word \"friend*\" ."
+        "?c ql:contains-entity ?y ."
+        "}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -1025,17 +984,16 @@ TEST(QueryExecutionTreeTest, testCoOccFreeVar) {
 
 TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
   try {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?p ?s \n "
-                         "WHERE {"
-                         "?a <is-a> <Politician> . "
-                         "?c ql:contains-entity ?a ."
-                         "?c ql:contains-word \"friend*\" ."
-                         "?c ql:contains-entity ?s ."
-                         "?s <is-a> <Scientist> ."
-                         "?c2 ql:contains-entity ?s ."
-                         "?c2 ql:contains-word \"manhattan project\"}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?p ?s \n "
+        "WHERE {"
+        "?a <is-a> <Politician> . "
+        "?c ql:contains-entity ?a ."
+        "?c ql:contains-word \"friend*\" ."
+        "?c ql:contains-entity ?s ."
+        "?s <is-a> <Scientist> ."
+        "?c2 ql:contains-entity ?s ."
+        "?c2 ql:contains-word \"manhattan project\"}");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
@@ -1064,11 +1022,9 @@ TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
 
 TEST(QueryExecutionTreeTest, testCyclicQuery) {
   try {
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x ?y ?m WHERE { ?x <Spouse_(or_domestic_partner)> ?y . "
-            "?x <Film_performance> ?m . ?y <Film_performance> ?m }")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y ?m WHERE { ?x <Spouse_(or_domestic_partner)> ?y . "
+        "?x <Film_performance> ?m . ?y <Film_performance> ?m }");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
 
@@ -1186,21 +1142,19 @@ qet-width: 3
 
 TEST(QueryExecutionTreeTest, testFormerSegfaultTriFilter) {
   try {
-    ParsedQuery pq =
-        SparqlParser(
-            "PREFIX fb: <http://rdf.freebase.com/ns/>\n"
-            "SELECT DISTINCT ?1 ?0 WHERE {\n"
-            "fb:m.0fkvn fb:government.government_office_category.officeholders "
-            "?0 "
-            ".\n"
-            "?0 fb:government.government_position_held.jurisdiction_of_office "
-            "fb:m.0vmt .\n"
-            "?0 fb:government.government_position_held.office_holder ?1 .\n"
-            "FILTER (?1 != fb:m.0fkvn) .\n"
-            "FILTER (?1 != fb:m.0vmt) .\n"
-            "FILTER (?1 != fb:m.018mts)"
-            "} LIMIT 300")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "PREFIX fb: <http://rdf.freebase.com/ns/>\n"
+        "SELECT DISTINCT ?1 ?0 WHERE {\n"
+        "fb:m.0fkvn fb:government.government_office_category.officeholders "
+        "?0 "
+        ".\n"
+        "?0 fb:government.government_position_held.jurisdiction_of_office "
+        "fb:m.0vmt .\n"
+        "?0 fb:government.government_position_held.office_holder ?1 .\n"
+        "FILTER (?1 != fb:m.0fkvn) .\n"
+        "FILTER (?1 != fb:m.0vmt) .\n"
+        "FILTER (?1 != fb:m.018mts)"
+        "} LIMIT 300");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_TRUE(qet.varCovered("?1"));
@@ -1218,10 +1172,9 @@ TEST(QueryPlannerTest, testSimpleOptional) {
   try {
     QueryPlanner qp(nullptr);
 
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?a ?b \n "
-                         "WHERE  {?a <rel1> ?b . OPTIONAL { ?a <rel2> ?c }}")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?a ?b \n "
+        "WHERE  {?a <rel1> ?b . OPTIONAL { ?a <rel2> ?c }}");
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  OPTIONAL_JOIN\n  {\n    SCAN PSO with P = \"<rel1>\"\n    "
@@ -1231,11 +1184,10 @@ TEST(QueryPlannerTest, testSimpleOptional) {
 
         qet.asString());
 
-    ParsedQuery pq2 = SparqlParser(
-                          "SELECT ?a ?b \n "
-                          "WHERE  {?a <rel1> ?b . "
-                          "OPTIONAL { ?a <rel2> ?c }} ORDER BY ?b")
-                          .parse();
+    ParsedQuery pq2 = SparqlParser::parseQuery(
+        "SELECT ?a ?b \n "
+        "WHERE  {?a <rel1> ?b . "
+        "OPTIONAL { ?a <rel2> ?c }} ORDER BY ?b");
     QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
     ASSERT_EQ(
         "{\n  SORT / ORDER BY on columns:asc(1) \n  {\n    OPTIONAL_JOIN\n    "

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -46,7 +46,7 @@ auto IndexScan(TripleComponent subject, std::string predicate,
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`
 QueryExecutionTree parseAndPlan(std::string query) {
-  ParsedQuery pq = SparqlParser{std::move(query)}.parse();
+  ParsedQuery pq = SparqlParser::parseQuery(std::move(query));
   // TODO<joka921> make it impossible to pass `nullptr` here, properly mock a
   // queryExecutionContext.
   return QueryPlanner{nullptr}.createExecutionTree(pq);

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -198,25 +198,22 @@ TEST(SparqlParser, ComplexConstructTemplate) {
   };
   expectCompleteParse(
       parse<&Parser::constructTemplate>(input),
-      testing::Optional(testing::Field(
-          "triples_", &parsedQuery::ConstructClause::triples_,
-          ElementsAre(
-              ElementsAre(Blank("0"), Var("?a"), Blank("3")),
-              ElementsAre(Blank("1"), m::Iri(first), Blank("2")),
-              ElementsAre(Blank("1"), m::Iri(rest), m::Iri(nil)),
-              ElementsAre(Blank("2"), m::Iri(first), Var("?c")),
-              ElementsAre(Blank("2"), m::Iri(rest), m::Iri(nil)),
-              ElementsAre(Blank("3"), m::Iri(first), Var("?b")),
-              ElementsAre(Blank("3"), m::Iri(rest), Blank("1")),
-              ElementsAre(Blank("0"), Var("?d"), Blank("4")),
-              ElementsAre(Blank("4"), Var("?e"), Blank("5")),
-              ElementsAre(Blank("5"), Var("?f"), Var("?g")),
-              ElementsAre(
-                  m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
-                         "#something>"),
-                  m::Iri(type),
-                  m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
-                         "#somethingelse>"))))));
+      m::ConstructClause(ElementsAre(
+          ElementsAre(Blank("0"), Var("?a"), Blank("3")),
+          ElementsAre(Blank("1"), m::Iri(first), Blank("2")),
+          ElementsAre(Blank("1"), m::Iri(rest), m::Iri(nil)),
+          ElementsAre(Blank("2"), m::Iri(first), Var("?c")),
+          ElementsAre(Blank("2"), m::Iri(rest), m::Iri(nil)),
+          ElementsAre(Blank("3"), m::Iri(first), Var("?b")),
+          ElementsAre(Blank("3"), m::Iri(rest), Blank("1")),
+          ElementsAre(Blank("0"), Var("?d"), Blank("4")),
+          ElementsAre(Blank("4"), Var("?e"), Blank("5")),
+          ElementsAre(Blank("5"), Var("?f"), Var("?g")),
+          ElementsAre(m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
+                             "#something>"),
+                      m::Iri(type),
+                      m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
+                             "#somethingelse>")))));
 }
 
 TEST(SparqlParser, GraphTerm) {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -192,28 +192,26 @@ TEST(SparqlParser, ComplexConstructTemplate) {
       "<http://wallscope.co.uk/resource/olympics/medal/#something> a "
       "<http://wallscope.co.uk/resource/olympics/medal/#somethingelse> }";
 
-  auto Var = m::VariableVariant;
-  auto Blank = [](const std::string& label) {
-    return m::BlankNode(true, label);
-  };
+  using Var = Variable;
+  auto Blank = [](const std::string& label) { return BlankNode(true, label); };
   expectCompleteParse(
       parse<&Parser::constructTemplate>(input),
-      m::ConstructClause(ElementsAre(
-          ElementsAre(Blank("0"), Var("?a"), Blank("3")),
-          ElementsAre(Blank("1"), m::Iri(first), Blank("2")),
-          ElementsAre(Blank("1"), m::Iri(rest), m::Iri(nil)),
-          ElementsAre(Blank("2"), m::Iri(first), Var("?c")),
-          ElementsAre(Blank("2"), m::Iri(rest), m::Iri(nil)),
-          ElementsAre(Blank("3"), m::Iri(first), Var("?b")),
-          ElementsAre(Blank("3"), m::Iri(rest), Blank("1")),
-          ElementsAre(Blank("0"), Var("?d"), Blank("4")),
-          ElementsAre(Blank("4"), Var("?e"), Blank("5")),
-          ElementsAre(Blank("5"), Var("?f"), Var("?g")),
-          ElementsAre(m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
-                             "#something>"),
-                      m::Iri(type),
-                      m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
-                             "#somethingelse>")))));
+      m::ConstructClause(
+          {{Blank("0"), Var("?a"), Blank("3")},
+           {Blank("1"), Iri(first), Blank("2")},
+           {Blank("1"), Iri(rest), Iri(nil)},
+           {Blank("2"), Iri(first), Var("?c")},
+           {Blank("2"), Iri(rest), Iri(nil)},
+           {Blank("3"), Iri(first), Var("?b")},
+           {Blank("3"), Iri(rest), Blank("1")},
+           {Blank("0"), Var("?d"), Blank("4")},
+           {Blank("4"), Var("?e"), Blank("5")},
+           {Blank("5"), Var("?f"), Var("?g")},
+           {Iri("<http://wallscope.co.uk/resource/olympics/medal/"
+                "#something>"),
+            Iri(type),
+            Iri("<http://wallscope.co.uk/resource/olympics/medal/"
+                "#somethingelse>")}}));
 }
 
 TEST(SparqlParser, GraphTerm) {
@@ -930,11 +928,47 @@ TEST(SparqlParser, SelectQuery) {
   expectSelectQueryFails("SELECT * FROM  WHERE <foo> { ?x ?y ?z }");
 }
 
+TEST(SparqlParser, ConstructQuery) {
+  auto expectConstructQuery = ExpectCompleteParse<&Parser::constructQuery>{
+      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+  auto expectConstructQueryFails = ExpectParseFails<&Parser::constructQuery>{};
+  expectConstructQuery(
+      "CONSTRUCT { } WHERE { ?a ?b ?c }",
+      m::ConstructQuery({}, m::GraphPattern(m::Triples({{"?a", "?b", "?c"}}))));
+  expectConstructQuery("CONSTRUCT { ?a <foo> ?c . } WHERE { ?a ?b ?c }",
+                       testing::AllOf(m::ConstructQuery(
+                           {{Variable{"?a"}, Iri{"<foo>"}, Variable{"?c"}}},
+                           m::GraphPattern(m::Triples({{"?a", "?b", "?c"}})))));
+  expectConstructQuery(
+      "CONSTRUCT { ?a <foo> ?c . <bar> ?b <baz> } WHERE { ?a ?b ?c . FILTER(?a "
+      "> 0) .}",
+      m::ConstructQuery(
+          {{Variable{"?a"}, Iri{"<foo>"}, Variable{"?c"}},
+           {Iri{"<bar>"}, Variable{"?b"}, Iri{"<baz>"}}},
+          m::GraphPattern(false, {{SparqlFilter::FilterType::GT, "?a", "0"}},
+                          m::Triples({{"?a", "?b", "?c"}}))));
+  expectConstructQuery(
+      "CONSTRUCT { ?a <foo> ?c . } WHERE { ?a ?b ?c } ORDER BY ?a LIMIT 10",
+      testing::AllOf(
+          m::ConstructQuery({{Variable{"?a"}, Iri{"<foo>"}, Variable{"?c"}}},
+                            m::GraphPattern(m::Triples({{"?a", "?b", "?c"}}))),
+          m::pq::LimitOffset({10}),
+          m::pq::OrderKeys({{Variable{"?a"}, false}})));
+  // This case of the grammar is not useful without Datasets, but we still
+  // support it.
+  expectConstructQuery(
+      "CONSTRUCT WHERE { ?a <foo> ?b }",
+      m::ConstructQuery({{Variable{"?a"}, Iri{"<foo>"}, Variable{"?b"}}},
+                        m::GraphPattern()));
+  // Datasets are not supported.
+  expectConstructQueryFails("CONSTRUCT { } FROM <foo> WHERE { ?a ?b ?c }");
+  expectConstructQueryFails("CONSTRUCT FROM <foo> WHERE { }");
+}
+
 TEST(SparqlParser, Query) {
   auto expectQuery = ExpectCompleteParse<&Parser::query>{
       {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
   auto expectQueryFails = ExpectParseFails<&Parser::query>{};
-  // TODO: re-add simple tests that also assert the ParsedQuery.
   // Test that `_originalString` is correctly set.
   expectQuery("SELECT * WHERE { ?a <bar> ?foo }",
               testing::AllOf(
@@ -951,9 +985,18 @@ TEST(SparqlParser, Query) {
       "PREFIX a: <foo> SELECT (COUNT(?y) as ?a) WHERE { ?x ?y ?z } GROUP BY ?x",
       m::pq::OriginalString("PREFIX a: <foo> SELECT (COUNT(?y) as ?a) WHERE { "
                             "?x ?y ?z } GROUP BY ?x"));
-  expectQuery("CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } LIMIT 10",
-              m::pq::OriginalString(
-                  "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } LIMIT 10"));
+  expectQuery(
+      "CONSTRUCT { ?a <foo> ?c . } WHERE { ?a ?b ?c }",
+      m::ConstructQuery({{Variable{"?a"}, Iri{"<foo>"}, Variable{"?c"}}},
+                        m::GraphPattern(m::Triples({{"?a", "?b", "?c"}}))));
+  expectQuery(
+      "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } LIMIT 10",
+      testing::AllOf(
+          m::ConstructQuery({{Variable{"?x"}, Iri{"<foo>"}, Iri{"<bar>"}}},
+                            m::GraphPattern(m::Triples({{"?x", "?y", "?z"}}))),
+          m::pq::OriginalString(
+              "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } LIMIT 10"),
+          m::pq::LimitOffset({10})));
   // Describe and Ask Queries are not supported.
   expectQueryFails("DESCRIBE *");
   expectQueryFails("ASK WHERE { ?x <foo> <bar> }");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -911,15 +911,15 @@ TEST(SparqlParser, SelectQuery) {
   // Grouping by a variable or expression which contains a variable
   // that is not visible in the query body is not allowed.
   expectSelectQueryFails("SELECT ?x WHERE { ?a ?b ?c } GROUP BY ?x");
-  expectSelectQueryFails(
-      "SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP BY (?x - 10)");
+  // expectSelectQueryFails(
+  //     "SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP BY (?x - 10)");
   // Ordering by a variable or expression which contains a variable that is not
   // visible in the query body is not allowed.
   // expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY ?x");
   // expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY (?x - 10)");
   // All variables used in an aggregate must be visible in the query body.
-  // expectSelectQueryFails(
-  //    "SELECT (COUNT(?x) as ?y) WHERE { ?a ?b ?c } GROUP BY ?a");
+  expectSelectQueryFails(
+      "SELECT (COUNT(?x) as ?y) WHERE { ?a ?b ?c } GROUP BY ?a");
   // `SELECT *` is not allowed while grouping.
   expectSelectQueryFails("SELECT * WHERE { ?x ?y ?z } GROUP BY ?x");
   // `?x` is selected twice. Once as variable and once as the result of an

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -905,8 +905,6 @@ TEST(SparqlParser, SelectQuery) {
           m::SelectQuery(m::Select({Variable{"?x"}}), DummyGraphPatternMatcher),
           m::pq::Having({{SparqlFilter::FilterType::GT, "?x", "5"}}),
           m::pq::OrderKeys({{Variable{"?y"}, false}})));
-  // TODO<qup42, joka921> enable Tests once the corresponding checks are
-  //  implemented.
 
   // Grouping by a variable or expression which contains a variable
   // that is not visible in the query body is not allowed.
@@ -915,7 +913,7 @@ TEST(SparqlParser, SelectQuery) {
       "SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP BY (?x - 10)");
   // Ordering by a variable or expression which contains a variable that is not
   // visible in the query body is not allowed.
-  // expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY ?x");
+  expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY ?x");
   expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY (?x - 10)");
   // All variables used in an aggregate must be visible in the query body.
   expectSelectQueryFails(
@@ -936,9 +934,14 @@ TEST(SparqlParser, Query) {
   auto expectQuery = ExpectCompleteParse<&Parser::query>{
       {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
   auto expectQueryFails = ExpectParseFails<&Parser::query>{};
+  // TODO: re-add simple tests that also assert the ParsedQuery.
   // Test that `_originalString` is correctly set.
   expectQuery("SELECT * WHERE { ?a <bar> ?foo }",
-              m::pq::OriginalString("SELECT * WHERE { ?a <bar> ?foo }"));
+              testing::AllOf(
+                  m::SelectQuery(
+                      m::AsteriskSelect(),
+                      m::GraphPattern(m::Triples({{"?a", "<bar>", "?foo"}}))),
+                  m::pq::OriginalString("SELECT * WHERE { ?a <bar> ?foo }")));
   expectQuery("SELECT * WHERE { ?x ?y ?z }",
               m::pq::OriginalString("SELECT * WHERE { ?x ?y ?z }"));
   expectQuery(

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -975,7 +975,8 @@ TEST(SparqlParser, Query) {
                   m::SelectQuery(
                       m::AsteriskSelect(),
                       m::GraphPattern(m::Triples({{"?a", "<bar>", "?foo"}}))),
-                  m::pq::OriginalString("SELECT * WHERE { ?a <bar> ?foo }")));
+                  m::pq::OriginalString("SELECT * WHERE { ?a <bar> ?foo }"),
+                  m::VisibleVariables({Variable{"?a"}, Variable{"?foo"}})));
   expectQuery("SELECT * WHERE { ?x ?y ?z }",
               m::pq::OriginalString("SELECT * WHERE { ?x ?y ?z }"));
   expectQuery(
@@ -987,8 +988,11 @@ TEST(SparqlParser, Query) {
                             "?x ?y ?z } GROUP BY ?x"));
   expectQuery(
       "CONSTRUCT { ?a <foo> ?c . } WHERE { ?a ?b ?c }",
-      m::ConstructQuery({{Variable{"?a"}, Iri{"<foo>"}, Variable{"?c"}}},
-                        m::GraphPattern(m::Triples({{"?a", "?b", "?c"}}))));
+      testing::AllOf(
+          m::ConstructQuery({{Variable{"?a"}, Iri{"<foo>"}, Variable{"?c"}}},
+                            m::GraphPattern(m::Triples({{"?a", "?b", "?c"}}))),
+          m::VisibleVariables(
+              {Variable{"?a"}, Variable{"?b"}, Variable{"?c"}})));
   expectQuery(
       "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } LIMIT 10",
       testing::AllOf(
@@ -996,7 +1000,9 @@ TEST(SparqlParser, Query) {
                             m::GraphPattern(m::Triples({{"?x", "?y", "?z"}}))),
           m::pq::OriginalString(
               "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } LIMIT 10"),
-          m::pq::LimitOffset({10})));
+          m::pq::LimitOffset({10}),
+          m::VisibleVariables(
+              {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}})));
   // Describe and Ask Queries are not supported.
   expectQueryFails("DESCRIBE *");
   expectQueryFails("ASK WHERE { ?x <foo> <bar> }");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "SparqlAntlrParserTestHelpers.h"
+#include "parser/ConstructClause.h"
 #include "parser/SparqlParserHelpers.h"
 #include "parser/sparqlParser/SparqlQleverVisitor.h"
 #include "util/SourceLocation.h"
@@ -197,22 +198,25 @@ TEST(SparqlParser, ComplexConstructTemplate) {
   };
   expectCompleteParse(
       parse<&Parser::constructTemplate>(input),
-      testing::Optional(ElementsAre(
-          ElementsAre(Blank("0"), Var("?a"), Blank("3")),
-          ElementsAre(Blank("1"), m::Iri(first), Blank("2")),
-          ElementsAre(Blank("1"), m::Iri(rest), m::Iri(nil)),
-          ElementsAre(Blank("2"), m::Iri(first), Var("?c")),
-          ElementsAre(Blank("2"), m::Iri(rest), m::Iri(nil)),
-          ElementsAre(Blank("3"), m::Iri(first), Var("?b")),
-          ElementsAre(Blank("3"), m::Iri(rest), Blank("1")),
-          ElementsAre(Blank("0"), Var("?d"), Blank("4")),
-          ElementsAre(Blank("4"), Var("?e"), Blank("5")),
-          ElementsAre(Blank("5"), Var("?f"), Var("?g")),
-          ElementsAre(m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
-                             "#something>"),
-                      m::Iri(type),
-                      m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
-                             "#somethingelse>")))));
+      testing::Optional(testing::Field(
+          "triples_", &parsedQuery::ConstructClause::triples_,
+          ElementsAre(
+              ElementsAre(Blank("0"), Var("?a"), Blank("3")),
+              ElementsAre(Blank("1"), m::Iri(first), Blank("2")),
+              ElementsAre(Blank("1"), m::Iri(rest), m::Iri(nil)),
+              ElementsAre(Blank("2"), m::Iri(first), Var("?c")),
+              ElementsAre(Blank("2"), m::Iri(rest), m::Iri(nil)),
+              ElementsAre(Blank("3"), m::Iri(first), Var("?b")),
+              ElementsAre(Blank("3"), m::Iri(rest), Blank("1")),
+              ElementsAre(Blank("0"), Var("?d"), Blank("4")),
+              ElementsAre(Blank("4"), Var("?e"), Blank("5")),
+              ElementsAre(Blank("5"), Var("?f"), Var("?g")),
+              ElementsAre(
+                  m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
+                         "#something>"),
+                  m::Iri(type),
+                  m::Iri("<http://wallscope.co.uk/resource/olympics/medal/"
+                         "#somethingelse>"))))));
 }
 
 TEST(SparqlParser, GraphTerm) {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -912,12 +912,12 @@ TEST(SparqlParser, SelectQuery) {
   // Grouping by a variable or expression which contains a variable
   // that is not visible in the query body is not allowed.
   expectSelectQueryFails("SELECT ?x WHERE { ?a ?b ?c } GROUP BY ?x");
-  // expectSelectQueryFails(
-  //     "SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP BY (?x - 10)");
+  expectSelectQueryFails(
+      "SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP BY (?x - 10)");
   // Ordering by a variable or expression which contains a variable that is not
   // visible in the query body is not allowed.
   // expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY ?x");
-  // expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY (?x - 10)");
+  expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY (?x - 10)");
   // All variables used in an aggregate must be visible in the query body.
   expectSelectQueryFails(
       "SELECT (COUNT(?x) as ?y) WHERE { ?a ?b ?c } GROUP BY ?a");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -911,8 +911,8 @@ TEST(SparqlParser, SelectQuery) {
   // Grouping by a variable or expression which contains a variable
   // that is not visible in the query body is not allowed.
   expectSelectQueryFails("SELECT ?x WHERE { ?a ?b ?c } GROUP BY ?x");
-  // expectSelectQueryFails("SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP
-  // BY (?x - 10)");
+  expectSelectQueryFails(
+      "SELECT (COUNT(?a) as ?d) WHERE { ?a ?b ?c } GROUP BY (?x - 10)");
   // Ordering by a variable or expression which contains a variable that is not
   // visible in the query body is not allowed.
   // expectSelectQueryFails("SELECT ?a WHERE { ?a ?b ?c } ORDER BY ?x");

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -289,10 +289,10 @@ auto Literal = [](const std::string& value) {
 
 // _____________________________________________________________________________
 
-auto ConstructClause =
-    [](const Matcher<const ad_utility::sparql_types::Triples&>& m)
+auto ConstructClause = [](const std::vector<std::array<VarOrTerm, 3>>& elems)
     -> Matcher<const std::optional<parsedQuery::ConstructClause>&> {
-  return testing::Optional(AD_FIELD(parsedQuery::ConstructClause, triples_, m));
+  return testing::Optional(
+      AD_FIELD(parsedQuery::ConstructClause, triples_, testing::Eq(elems)));
 };
 
 // _____________________________________________________________________________
@@ -584,6 +584,11 @@ auto Minus = [](auto&& subMatcher) -> Matcher<const p::GraphPatternOperation&> {
       AD_FIELD(p::Minus, _child, subMatcher));
 };
 
+auto RootGraphPattern = [](const Matcher<const p::GraphPattern&>& m)
+    -> Matcher<const ::ParsedQuery&> {
+  return AD_FIELD(ParsedQuery, _rootGraphPattern, m);
+};
+
 template <auto SubMatcherLambda>
 struct MatcherWithDefaultFilters {
   Matcher<const p::GraphPatternOperation&> operator()(
@@ -677,7 +682,7 @@ auto SelectQuery =
   return testing::AllOf(
       AD_PROPERTY(ParsedQuery, hasSelectClause, testing::IsTrue()),
       AD_PROPERTY(ParsedQuery, selectClause, selectMatcher),
-      AD_FIELD(ParsedQuery, _rootGraphPattern, graphPatternMatcher));
+      RootGraphPattern(graphPatternMatcher));
 };
 
 namespace pq {
@@ -704,6 +709,18 @@ auto OrderKeys =
 };
 auto GroupKeys = GroupByVariables;
 }  // namespace pq
+
+// _____________________________________________________________________________
+auto ConstructQuery(const std::vector<std::array<VarOrTerm, 3>>& elems,
+                    const Matcher<const p::GraphPattern&>& m)
+    -> Matcher<const ParsedQuery&> {
+  return testing::AllOf(
+      AD_PROPERTY(ParsedQuery, hasConstructClause, testing::IsTrue()),
+      AD_PROPERTY(
+          ParsedQuery, constructClause,
+          AD_FIELD(parsedQuery::ConstructClause, triples_, testing::Eq(elems))),
+      RootGraphPattern(m));
+}
 
 }  // namespace matchers
 

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -289,6 +289,13 @@ auto Literal = [](const std::string& value) {
 
 // _____________________________________________________________________________
 
+auto ConstructClause =
+    [](const Matcher<const ad_utility::sparql_types::Triples&>& m)
+    -> Matcher<const std::optional<parsedQuery::ConstructClause>&> {
+  return testing::Optional(AD_FIELD(parsedQuery::ConstructClause, triples_, m));
+};
+
+// _____________________________________________________________________________
 namespace detail {
 auto Expression = [](const std::string& descriptor)
     -> Matcher<const sparqlExpression::SparqlExpressionPimpl&> {

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -722,6 +722,12 @@ auto ConstructQuery(const std::vector<std::array<VarOrTerm, 3>>& elems,
       RootGraphPattern(m));
 }
 
+// _____________________________________________________________________________
+auto VisibleVariables =
+    [](const std::vector<::Variable>& elems) -> Matcher<const ParsedQuery&> {
+  return AD_PROPERTY(ParsedQuery, getVisibleVariables, testing::Eq(elems));
+};
+
 }  // namespace matchers
 
 #undef AD_PROPERTY

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -856,7 +856,7 @@ TEST(ParserTest, testSolutionModifiers) {
   {
     auto pq = SparqlParser::parseQuery(
         "SELECT DISTINCT ?x ?ql_textscore_x ?y WHERE \t {?x "
-        "<test:myrel> ?y}\n"
+        "ql:contains-entity ?y}\n"
         "ORDER BY ASC(?y) DESC(?ql_textscore_x) LIMIT 10 OFFSET 15");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -16,7 +16,7 @@ namespace p = parsedQuery;
 TEST(ParserTest, testParse) {
   try {
     {
-      auto pq = SparqlParser("SELECT ?x WHERE {?x ?y ?z}").parse();
+      auto pq = SparqlParser::parseQuery("SELECT ?x WHERE {?x ?y ?z}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause = pq.selectClause();
       ASSERT_EQ(1u, pq._prefixes.size());
@@ -28,14 +28,13 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "PREFIX : <http://rdf.myprefix.com/>\n"
-                    "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
-                    "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
-                    "SELECT ?x ?z \n "
-                    "WHERE \t {?x :myrel ?y. ?y ns:myrel ?z.?y <nsx:rel2> "
-                    "<http://abc.de>}")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "PREFIX : <http://rdf.myprefix.com/>\n"
+          "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
+          "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
+          "SELECT ?x ?z \n "
+          "WHERE \t {?x :myrel ?y. ?y ns:myrel ?z.?y <nsx:rel2> "
+          "<http://abc.de>}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause2 = pq.selectClause();
       ASSERT_EQ(4u, pq._prefixes.size());
@@ -67,14 +66,13 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "PREFIX : <http://rdf.myprefix.com/>\n"
-                    "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
-                    "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
-                    "SELECT ?x ?z \n "
-                    "WHERE \t {\n?x :myrel ?y. ?y ns:myrel ?z.\n?y <nsx:rel2> "
-                    "<http://abc.de>\n}")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "PREFIX : <http://rdf.myprefix.com/>\n"
+          "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
+          "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
+          "SELECT ?x ?z \n "
+          "WHERE \t {\n?x :myrel ?y. ?y ns:myrel ?z.\n?y <nsx:rel2> "
+          "<http://abc.de>\n}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause = pq.selectClause();
       ASSERT_EQ(4u, pq._prefixes.size());
@@ -106,12 +104,11 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "PREFIX ns: <http://ns/>"
-                    "SELECT ?x ?z \n "
-                    "WHERE \t {\n?x <Directed_by> ?y. ?y ns:myrel.extend ?z.\n"
-                    "?y <nsx:rel2> \"Hello... World\"}")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "PREFIX ns: <http://ns/>"
+          "SELECT ?x ?z \n "
+          "WHERE \t {\n?x <Directed_by> ?y. ?y ns:myrel.extend ?z.\n"
+          "?y <nsx:rel2> \"Hello... World\"}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause = pq.selectClause();
       ASSERT_EQ(2u, pq._prefixes.size());
@@ -136,10 +133,9 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
-                    "?y <is-a> <Actor> . FILTER(?y < ?x)} LIMIT 10")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
+          "?y <is-a> <Actor> . FILTER(?y < ?x)} LIMIT 10");
       ASSERT_EQ(1u, pq.children().size());
       const auto& triples = pq.children()[0].getBasic()._triples;
       auto filters = pq._rootGraphPattern._filters;
@@ -154,10 +150,9 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
-                    "?y <is-a> <Actor>} LIMIT 10")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
+          "?y <is-a> <Actor>} LIMIT 10");
       ASSERT_EQ(1u, pq.children().size());
       const auto& triples = pq.children()[0].getBasic()._triples;
       auto filters = pq._rootGraphPattern._filters;
@@ -169,11 +164,10 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
-                    "?y <is-a> <Actor>. ?c ql:contains-entity ?x."
-                    "?c ql:contains-word \"coca* abuse\"} LIMIT 10")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT ?x ?y WHERE {?x <is-a> <Actor> .  FILTER(?x != ?y)."
+          "?y <is-a> <Actor>. ?c ql:contains-entity ?x."
+          "?c ql:contains-word \"coca* abuse\"} LIMIT 10");
       ASSERT_EQ(1u, pq.children().size());
       const auto& triples = pq.children()[0].getBasic()._triples;
       auto filters = pq._rootGraphPattern._filters;
@@ -191,31 +185,29 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "PREFIX : <>\n"
-                    "SELECT ?x ?y ?z ?c ?ql_textscore_c ?c WHERE {\n"
-                    "?x :is-a :Politician .\n"
-                    "?c ql:contains-entity ?x .\n"
-                    "?c ql:contains-word \"friend\" .\n"
-                    "?c ql:contains-entity ?y .\n"
-                    "?y :is-a :Scientist .\n"
-                    "FILTER(?x != ?y) .\n"
-                    "} ORDER BY ?c")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "PREFIX : <>\n"
+          "SELECT ?x ?y ?z ?c ?ql_textscore_c ?c WHERE {\n"
+          "?x :is-a :Politician .\n"
+          "?c ql:contains-entity ?x .\n"
+          "?c ql:contains-word \"friend\" .\n"
+          "?c ql:contains-entity ?y .\n"
+          "?y :is-a :Scientist .\n"
+          "FILTER(?x != ?y) .\n"
+          "} ORDER BY ?c");
       ASSERT_EQ(1u, pq._rootGraphPattern._filters.size());
 
       // shouldn't have more checks??
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT ?x ?z WHERE {\n"
-                    "  ?x <test> ?y .\n"
-                    "  OPTIONAL {\n"
-                    "    ?y <test2> ?z .\n"
-                    "  }\n"
-                    "}")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT ?x ?z WHERE {\n"
+          "  ?x <test> ?y .\n"
+          "  OPTIONAL {\n"
+          "    ?y <test2> ?z .\n"
+          "  }\n"
+          "}");
 
       ASSERT_EQ(2u, pq.children().size());
       const auto& opt =
@@ -232,21 +224,20 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT ?x ?z WHERE {\n"
-                    "  ?x <test> ?y .\n"
-                    "  OPTIONAL {\n"
-                    "    ?y <test2> ?z .\n"
-                    "    optional {\n"
-                    "      ?a ?b ?c .\n"
-                    "      FILTER(?c > 3)\n"
-                    "    }\n"
-                    "    optional {\n"
-                    "      ?d ?e ?f\n"
-                    "    }\n"
-                    "  }\n"
-                    "}")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT ?x ?z WHERE {\n"
+          "  ?x <test> ?y .\n"
+          "  OPTIONAL {\n"
+          "    ?y <test2> ?z .\n"
+          "    optional {\n"
+          "      ?a ?b ?c .\n"
+          "      FILTER(?c > 3)\n"
+          "    }\n"
+          "    optional {\n"
+          "      ?d ?e ?f\n"
+          "    }\n"
+          "  }\n"
+          "}");
       ASSERT_EQ(2u, pq._rootGraphPattern._graphPatterns.size());
       const auto& optA = std::get<p::Optional>(
           pq._rootGraphPattern._graphPatterns[1]);  // throws on error
@@ -268,13 +259,12 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT ?a WHERE {\n"
-                    "  VALUES ?a { <1> \"2\"}\n"
-                    "  VALUES (?b ?c) {(<1> <2>) (\"1\" \"2\")}\n"
-                    "  ?a <rel> ?b ."
-                    "}")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT ?a WHERE {\n"
+          "  VALUES ?a { <1> \"2\"}\n"
+          "  VALUES (?b ?c) {(<1> <2>) (\"1\" \"2\")}\n"
+          "  ?a <rel> ?b ."
+          "}");
       ASSERT_EQ(3u, pq._rootGraphPattern._graphPatterns.size());
       const auto& c = pq.children()[2].getBasic();
       ASSERT_EQ(1u, c._triples.size());
@@ -294,14 +284,13 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    R"(SELECT ?a ?b ?c WHERE {
+      auto pq = SparqlParser::parseQuery(
+          R"(SELECT ?a ?b ?c WHERE {
                         VALUES ?a { <Albert_Einstein>}
                         VALUES (?b ?c) {
         (<Marie_Curie> <Joseph_Jacobson>) (<Freiherr> <Lord_of_the_Isles>) }
                         }
-                    )")
-                    .parse();
+                    )");
 
       ASSERT_EQ(2u, pq.children().size());
       ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
@@ -321,15 +310,14 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    ""
-                    "PREFIX wd: <http://www.wikidata.org/entity/>\n"
-                    "PREFIX wdt: <http://www.wikidata.org/prop/direct/>\n"
-                    "SELECT ?city WHERE {\n"
-                    "  VALUES ?citytype { wd:Q515 wd:Q262166}\n"
-                    "  ?city wdt:P31 ?citytype .\n"
-                    "}\n")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          ""
+          "PREFIX wd: <http://www.wikidata.org/entity/>\n"
+          "PREFIX wdt: <http://www.wikidata.org/prop/direct/>\n"
+          "SELECT ?city WHERE {\n"
+          "  VALUES ?citytype { wd:Q515 wd:Q262166}\n"
+          "  ?city wdt:P31 ?citytype .\n"
+          "}\n");
 
       ASSERT_EQ(2u, pq.children().size());
       const auto& c = pq.children()[1].getBasic();
@@ -357,7 +345,7 @@ TEST(ParserTest, testParse) {
      // C++ exception with description "ParseException, cause:
      // Expected a token of type AGGREGATE but got a token of
      // type RDFLITERAL (() in the input at pos 373 : (YEAR(?year))
-      auto pq = SparqlParser(
+      auto pq = SparqlParser::parseQuery(
                     "SELECT DISTINCT * WHERE { \n"
                     "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
                     "\t{ \n"
@@ -371,11 +359,11 @@ TEST(ParserTest, testParse) {
                     "} \n"
                     "LIMIT 10 \n"
                     "ORDER BY DESC(?movie) ASC(?year) \n")
-                    .parse();
+                    ;
     }
 
     {
-      auto pq = SparqlParser(
+      auto pq = SparqlParser::parseQuery(
                 "SELECT * WHERE { \n"
                 "  VALUES ?x { 1 2 3 4 } .\n"
                 "\t{ \n"
@@ -390,11 +378,11 @@ TEST(ParserTest, testParse) {
                 "LIMIT 5 \n"
                 "OFFSET 2 \n"
                 "ORDER BY DESC(?x) ASC(?concat) \n")
-                .parse();
+                ;
     }
 
      {
-        auto pq = SparqlParser(
+        auto pq = SparqlParser::parseQuery(
                "SELECT REDUCED * WHERE { \n"
                "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
                "\t{ \n"
@@ -410,11 +398,11 @@ TEST(ParserTest, testParse) {
                "} \n"
                "LIMIT 10 \n"
                "ORDER BY DESC(?movie) ASC(?year) \n")
-               .parse();
+               ;
     }
 
     {
-        auto pq = SparqlParser(
+        auto pq = SparqlParser::parseQuery(
                "SELECT DISTINCT * WHERE { \n"
                "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
                "\t{ \n"
@@ -429,18 +417,17 @@ TEST(ParserTest, testParse) {
                "LIMIT 20 \n"
                "OFFSET 3 \n"
                "ORDER BY DESC(?movie)\n")
-               .parse();
+               ;
     }
     */
 
     {
-      auto pq = SparqlParser(
-                    "SELECT REDUCED * WHERE { \n"
-                    "  ?movie <directed-by> ?director .\n"
-                    "} \n"
-                    "ORDER BY ASC(?movie)\n"
-                    "LIMIT 10 \n")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT REDUCED * WHERE { \n"
+          "  ?movie <directed-by> ?director .\n"
+          "} \n"
+          "ORDER BY ASC(?movie)\n"
+          "LIMIT 10 \n");
       ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(1u, pq._rootGraphPattern._graphPatterns.size());
 
@@ -465,13 +452,12 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT DISTINCT * WHERE { \n"
-                    "  ?movie <directed-by> ?director .\n"
-                    "} \n"
-                    "ORDER BY DESC(?movie)\n"
-                    "LIMIT 10 \n")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT DISTINCT * WHERE { \n"
+          "  ?movie <directed-by> ?director .\n"
+          "} \n"
+          "ORDER BY DESC(?movie)\n"
+          "LIMIT 10 \n");
 
       ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(1u, pq._rootGraphPattern._graphPatterns.size());
@@ -497,22 +483,21 @@ TEST(ParserTest, testParse) {
     }
 
     {
-      auto pq = SparqlParser(
-                    "SELECT DISTINCT * WHERE { \n"
-                    "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
-                    "\t{ \n"
-                    "\t SELECT * WHERE { \n"
-                    "\t\t\t ?movie <directed-by> ?director .\n"
-                    "\t\t\t ?movie <from-year> ?year .\n"
-                    "\t\t\t FILTER(?year > \"00-00-2000\") ."
-                    "\t\t } \n"
-                    "\t\t ORDER BY DESC(?director) \n"
-                    "\t} \n"
-                    "} \n"
-                    "ORDER BY DESC(?movie)\n"
-                    "LIMIT 20 \n"
-                    "OFFSET 3 \n")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT DISTINCT * WHERE { \n"
+          "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
+          "\t{ \n"
+          "\t SELECT * WHERE { \n"
+          "\t\t\t ?movie <directed-by> ?director .\n"
+          "\t\t\t ?movie <from-year> ?year .\n"
+          "\t\t\t FILTER(?year > \"00-00-2000\") ."
+          "\t\t } \n"
+          "\t\t ORDER BY DESC(?director) \n"
+          "\t} \n"
+          "} \n"
+          "ORDER BY DESC(?movie)\n"
+          "LIMIT 20 \n"
+          "OFFSET 3 \n");
 
       ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(2u, pq._rootGraphPattern._graphPatterns.size());
@@ -579,26 +564,25 @@ TEST(ParserTest, testParse) {
 
     {
       // Query proving Select * working for n-subQuery
-      auto pq = SparqlParser(
-                    "SELECT DISTINCT * WHERE { \n"
-                    "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
-                    "\t{ \n"
-                    "\t SELECT * WHERE { \n"
-                    "\t\t\t ?movie <directed-by> ?director .\n"
-                    "\t\t\t { \n"
-                    "\t\t\t\t SELECT ?year WHERE { \n"
-                    "\t\t\t\t\t ?movie <from-year> ?year . \n"
-                    "\t\t\t\t\t } \n"
-                    "\t\t\t } \n"
-                    "\t\t\t FILTER(?year > \"00-00-2000\") ."
-                    "\t\t } \n"
-                    "\t\t ORDER BY DESC(?director) \n"
-                    "\t} \n"
-                    "} \n"
-                    "ORDER BY DESC(?movie)\n"
-                    "LIMIT 20 \n"
-                    "OFFSET 3 \n")
-                    .parse();
+      auto pq = SparqlParser::parseQuery(
+          "SELECT DISTINCT * WHERE { \n"
+          "  ?movie <directed-by> <Scott%2C%20Ridley> .\n"
+          "\t{ \n"
+          "\t SELECT * WHERE { \n"
+          "\t\t\t ?movie <directed-by> ?director .\n"
+          "\t\t\t { \n"
+          "\t\t\t\t SELECT ?year WHERE { \n"
+          "\t\t\t\t\t ?movie <from-year> ?year . \n"
+          "\t\t\t\t\t } \n"
+          "\t\t\t } \n"
+          "\t\t\t FILTER(?year > \"00-00-2000\") ."
+          "\t\t } \n"
+          "\t\t ORDER BY DESC(?director) \n"
+          "\t} \n"
+          "} \n"
+          "ORDER BY DESC(?movie)\n"
+          "LIMIT 20 \n"
+          "OFFSET 3 \n");
 
       ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(2u, pq._rootGraphPattern._graphPatterns.size());
@@ -692,60 +676,50 @@ TEST(ParserTest, testParse) {
     // TODO<RobinTF>  Also add checks for the correct semantics.
     {
       // Check Parse Construct (1)
-      auto pq_1 = SparqlParser(
+      auto pq_1 = SparqlParser::parseQuery(
           "PREFIX foaf:   <http://xmlns.com/foaf/0.1/> \n"
           "PREFIX org:    <http://example.com/ns#> \n"
           "CONSTRUCT { ?x foaf:name ?name } \n"
           "WHERE  { ?x org:employeeName ?name }");
-      pq_1.parse();
 
       // Check Parse Construct (2)
-      auto pq_2 = SparqlParser(
+      auto pq_2 = SparqlParser::parseQuery(
           "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
           "PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>\n"
           "CONSTRUCT   { <http://example.org/person#Alice> vcard:FN ?name }\n"
           "WHERE       { ?x foaf:name ?name } ");
-      pq_2.parse();
     }
 
     {
       // Check if the correct ParseException is thrown after
       // GroupBy with Select '*'
-      auto pq = SparqlParser(
-          "SELECT DISTINCT * WHERE { \n"
-          "  ?a <b> ?c .\n"
-          "} \n"
-          "GROUP BY ?a ?c \n");
-      ASSERT_THROW(pq.parse(), ParseException);
+      ASSERT_THROW(
+          SparqlParser::parseQuery(
+              "SELECT DISTINCT * WHERE { \n?a <b> ?c .\n} \nGROUP BY ?a ?c \n"),
+          ParseException);
     }
 
     {
       // Check if the correct ParseException is thrown after:
       // Select [var_name]+ '*'
-      auto pq = SparqlParser(
-          "SELECT DISTINCT ?a * WHERE { \n"
-          "  ?a <b> ?c .\n"
-          "} \n");
-      ASSERT_THROW(pq.parse(), ParseException);
+      ASSERT_THROW(SparqlParser::parseQuery(
+                       "SELECT DISTINCT ?a * WHERE { \n?a <b> ?c .\n} \n"),
+                   ParseException);
     }
 
     {
       // Check if the correct ParseException is thrown after:
       // Select '*' [var_name]+
-      auto pq = SparqlParser(
-          "SELECT DISTINCT * ?a WHERE { \n"
-          "  ?a <b> ?c .\n"
-          "} \n");
-      ASSERT_THROW(pq.parse(), ParseException);
+      ASSERT_THROW(SparqlParser::parseQuery(
+                       "SELECT DISTINCT * ?a WHERE { \n?a <b> ?c .\n} \n"),
+                   ParseException);
     }
 
     {
       // Check if the correct ParseException is thrown after: Select ['*']{2,}
-      auto pq = SparqlParser(
-          "SELECT DISTINCT * * WHERE { \n"
-          "  ?a <b> ?c .\n"
-          "} \n");
-      ASSERT_THROW(pq.parse(), ParseException);
+      ASSERT_THROW(SparqlParser::parseQuery(
+                       "SELECT DISTINCT * * WHERE { \n?a <b> ?c .\n} \n"),
+                   ParseException);
     }
 
   } catch (const ad_semsearch::Exception& e) {
@@ -754,22 +728,20 @@ TEST(ParserTest, testParse) {
 }
 
 TEST(ParserTest, testFilterWithoutDot) {
-  ParsedQuery pq =
-      SparqlParser(
-          "PREFIX fb: <http://rdf.freebase.com/ns/>\n"
-          "\n"
-          "SELECT DISTINCT ?1 WHERE {\n"
-          " fb:m.0fkvn fb:government.government_office_category.officeholders "
-          "?0 "
-          ".\n"
-          " ?0 fb:government.government_position_held.jurisdiction_of_office "
-          "fb:m.0vmt .\n"
-          " ?0 fb:government.government_position_held.office_holder ?1 .\n"
-          " FILTER (?1 != fb:m.0fkvn)\n"
-          " FILTER (?1 != fb:m.0vmt)\n"
-          "FILTER (?1 != fb:m.018mts) \n"
-          "} LIMIT 300")
-          .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX fb: <http://rdf.freebase.com/ns/>\n"
+      "\n"
+      "SELECT DISTINCT ?1 WHERE {\n"
+      " fb:m.0fkvn fb:government.government_office_category.officeholders "
+      "?0 "
+      ".\n"
+      " ?0 fb:government.government_position_held.jurisdiction_of_office "
+      "fb:m.0vmt .\n"
+      " ?0 fb:government.government_position_held.office_holder ?1 .\n"
+      " FILTER (?1 != fb:m.0fkvn)\n"
+      " FILTER (?1 != fb:m.0vmt)\n"
+      "FILTER (?1 != fb:m.018mts) \n"
+      "} LIMIT 300");
   ASSERT_TRUE(pq.hasSelectClause());
   const auto& selectClause = pq.selectClause();
   ASSERT_EQ(2u, pq._prefixes.size());
@@ -791,13 +763,12 @@ TEST(ParserTest, testFilterWithoutDot) {
 }
 
 TEST(ParserTest, testExpandPrefixes) {
-  ParsedQuery pq = SparqlParser(
-                       "PREFIX : <http://rdf.myprefix.com/>\n"
-                       "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
-                       "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
-                       "SELECT ?x ?z \n WHERE \t {?x :myrel ?y. ?y ns:myrel "
-                       "?z.?y <nsx:rel2> <http://abc.de>}")
-                       .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX : <http://rdf.myprefix.com/>\n"
+      "PREFIX ns: <http://rdf.myprefix.com/ns/>\n"
+      "PREFIX xxx: <http://rdf.myprefix.com/xxx/>\n"
+      "SELECT ?x ?z \n WHERE \t {?x :myrel ?y. ?y ns:myrel "
+      "?z.?y <nsx:rel2> <http://abc.de>}");
   ASSERT_TRUE(pq.hasSelectClause());
   const auto& selectClause = pq.selectClause();
   ASSERT_EQ(1u, pq.children().size());
@@ -828,11 +799,9 @@ TEST(ParserTest, testExpandPrefixes) {
 }
 
 TEST(ParserTest, testLiterals) {
-  ParsedQuery pq =
-      SparqlParser(
-          "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT * WHERE { "
-          "true <test:myrel> 10 . 10.2 <test:myrel> \"2000-00-00\"^^xsd:date }")
-          .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> SELECT * WHERE { "
+      "true <test:myrel> 10 . 10.2 <test:myrel> \"2000-00-00\"^^xsd:date }");
   ASSERT_TRUE(pq.hasSelectClause());
   const auto& selectClause = pq.selectClause();
   ASSERT_EQ(1u, pq.children().size());
@@ -852,7 +821,7 @@ TEST(ParserTest, testLiterals) {
 TEST(ParserTest, testSolutionModifiers) {
   {
     ParsedQuery pq =
-        SparqlParser("SELECT ?x WHERE \t {?x <test:myrel> ?y}").parse();
+        SparqlParser::parseQuery("SELECT ?x WHERE \t {?x <test:myrel> ?y}");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -868,8 +837,8 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser("SELECT ?x WHERE \t {?x <test:myrel> ?y} LIMIT 10")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE \t {?x <test:myrel> ?y} LIMIT 10");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq._prefixes.size());
@@ -885,10 +854,9 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "SELECT ?x WHERE \t {?x <test:myrel> ?y}\n"
-                  "LIMIT 10 OFFSET 15")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE \t {?x <test:myrel> ?y}\n"
+        "LIMIT 10 OFFSET 15");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -904,10 +872,9 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "SELECT DISTINCT ?x ?y WHERE \t {?x <test:myrel> ?y}\n"
-                  "ORDER BY ?y LIMIT 10 OFFSET 15")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT DISTINCT ?x ?y WHERE \t {?x <test:myrel> ?y}\n"
+        "ORDER BY ?y LIMIT 10 OFFSET 15");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -925,11 +892,10 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "SELECT DISTINCT ?x ?ql_textscore_x ?y WHERE \t {?x "
-                  "<test:myrel> ?y}\n"
-                  "ORDER BY ASC(?y) DESC(?ql_textscore_x) LIMIT 10 OFFSET 15")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT DISTINCT ?x ?ql_textscore_x ?y WHERE \t {?x "
+        "<test:myrel> ?y}\n"
+        "ORDER BY ASC(?y) DESC(?ql_textscore_x) LIMIT 10 OFFSET 15");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -951,10 +917,9 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "SELECT REDUCED ?x ?y WHERE \t {?x <test:myrel> ?y}\n"
-                  "ORDER BY DESC(?x) ASC(?y) LIMIT 10 OFFSET 15")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT REDUCED ?x ?y WHERE \t {?x <test:myrel> ?y}\n"
+        "ORDER BY DESC(?x) ASC(?y) LIMIT 10 OFFSET 15");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -974,20 +939,19 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq =
-        SparqlParser("SELECT ?x ?y WHERE {?x <is-a> <Actor>} LIMIT 10").parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y WHERE {?x <is-a> <Actor>} LIMIT 10");
     ASSERT_EQ(10u, pq._limitOffset._limit);
   }
 
   {
-    auto pq = SparqlParser(
-                  "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>"
-                  "SELECT DISTINCT ?movie WHERE { \n"
-                  "\n"
-                  "?movie <from-year> \"2000-00-00\"^^xsd:date .\n"
-                  "\n"
-                  "?movie <directed-by> <Scott%2C%20Ridley> .   }  LIMIT 50")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>"
+        "SELECT DISTINCT ?movie WHERE { \n"
+        "\n"
+        "?movie <from-year> \"2000-00-00\"^^xsd:date .\n"
+        "\n"
+        "?movie <directed-by> <Scott%2C%20Ridley> .   }  LIMIT 50");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -1005,14 +969,13 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "PREFIX xsd: <http://www.w3.org/2010/XMLSchema#>"
-                  "SELECT DISTINCT ?movie WHERE { \n"
-                  "\n"
-                  "?movie <from-year> \"00-00-2000\"^^xsd:date .\n"
-                  "\n"
-                  "?movie <directed-by> <Scott%2C%20Ridley> .   }  LIMIT 50")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "PREFIX xsd: <http://www.w3.org/2010/XMLSchema#>"
+        "SELECT DISTINCT ?movie WHERE { \n"
+        "\n"
+        "?movie <from-year> \"00-00-2000\"^^xsd:date .\n"
+        "\n"
+        "?movie <directed-by> <Scott%2C%20Ridley> .   }  LIMIT 50");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
@@ -1031,13 +994,12 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "SELECT ?r (AVG(?r) as ?avg) WHERE {"
-                  "?a <http://schema.org/name> ?b ."
-                  "?a ql:has-relation ?r }"
-                  "GROUP BY ?r "
-                  "ORDER BY ?avg")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT ?r (AVG(?r) as ?avg) WHERE {"
+        "?a <http://schema.org/name> ?b ."
+        "?a ql:has-relation ?r }"
+        "GROUP BY ?r "
+        "ORDER BY ?avg");
     ASSERT_EQ(1u, pq.children().size());
     ASSERT_EQ(1u, pq._orderBy.size());
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?r"}}));
@@ -1046,13 +1008,12 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq = SparqlParser(
-                  "SELECT ?r (COUNT(DISTINCT ?r) as ?count) WHERE {"
-                  "?a <http://schema.org/name> ?b ."
-                  "?a ql:has-relation ?r }"
-                  "GROUP BY ?r "
-                  "ORDER BY ?count")
-                  .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT ?r (COUNT(DISTINCT ?r) as ?count) WHERE {"
+        "?a <http://schema.org/name> ?b ."
+        "?a ql:has-relation ?r }"
+        "GROUP BY ?r "
+        "ORDER BY ?count");
     ASSERT_EQ(1u, pq._orderBy.size());
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?r"}}));
     ASSERT_EQ(Variable{"?count"}, pq._orderBy[0].variable_);
@@ -1060,14 +1021,12 @@ TEST(ParserTest, testSolutionModifiers) {
   }
 
   {
-    auto pq =
-        SparqlParser(
-            "SELECT ?r (GROUP_CONCAT(?r;SEPARATOR=\"Cake\") as ?concat) WHERE {"
-            "?a <http://schema.org/name> ?b ."
-            "?a ql:has-relation ?r }"
-            "GROUP BY ?r "
-            "ORDER BY ?concat")
-            .parse();
+    auto pq = SparqlParser::parseQuery(
+        "SELECT ?r (GROUP_CONCAT(?r;SEPARATOR=\"Cake\") as ?concat) WHERE {"
+        "?a <http://schema.org/name> ?b ."
+        "?a ql:has-relation ?r }"
+        "GROUP BY ?r "
+        "ORDER BY ?concat");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& aliases = pq.selectClause().getAliases();
     ASSERT_EQ(1u, aliases.size());
@@ -1077,10 +1036,8 @@ TEST(ParserTest, testSolutionModifiers) {
 }
 
 TEST(ParserTest, testGroupByAndAlias) {
-  ParsedQuery pq =
-      SparqlParser(
-          "SELECT (COUNT(?a) as ?count) WHERE { ?b <rel> ?a } GROUP BY ?b")
-          .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "SELECT (COUNT(?a) as ?count) WHERE { ?b <rel> ?a } GROUP BY ?b");
   ASSERT_TRUE(pq.hasSelectClause());
   const auto& selectClause = pq.selectClause();
   ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
@@ -1095,7 +1052,7 @@ TEST(ParserTest, testGroupByAndAlias) {
 
 TEST(ParserTest, Bind) {
   ParsedQuery pq =
-      SparqlParser("SELECT ?a WHERE { BIND (10 - 5 as ?a) . }").parse();
+      SparqlParser::parseQuery("SELECT ?a WHERE { BIND (10 - 5 as ?a) . }");
   ASSERT_TRUE(pq.hasSelectClause());
   ASSERT_EQ(pq.children().size(), 1);
   p::GraphPatternOperation child = pq.children()[0];
@@ -1108,16 +1065,15 @@ TEST(ParserTest, Bind) {
 TEST(ParserTest, Order) {
   {
     ParsedQuery pq =
-        SparqlParser("SELECT ?x ?y WHERE { ?x <test/myrel> ?y }").parse();
+        SparqlParser::parseQuery("SELECT ?x ?y WHERE { ?x <test/myrel> ?y }");
     ASSERT_TRUE(pq._orderBy.empty());
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
     ASSERT_TRUE(holds_alternative<p::BasicGraphPattern>(
         pq._rootGraphPattern._graphPatterns[0]));
   }
   {
-    ParsedQuery pq =
-        SparqlParser("SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY ?x")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY ?x");
     ASSERT_EQ(pq._orderBy.size(), 1);
     EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?x"}, false));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
@@ -1125,10 +1081,8 @@ TEST(ParserTest, Order) {
         pq._rootGraphPattern._graphPatterns[0]));
   }
   {
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY ASC(?y)")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY ASC(?y)");
     ASSERT_EQ(pq._orderBy.size(), 1);
     EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?y"}, false));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
@@ -1136,10 +1090,8 @@ TEST(ParserTest, Order) {
         pq._rootGraphPattern._graphPatterns[0]));
   }
   {
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY DESC(?x)")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY DESC(?x)");
     ASSERT_EQ(pq._orderBy.size(), 1);
     EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?x"}, true));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
@@ -1147,10 +1099,8 @@ TEST(ParserTest, Order) {
         pq._rootGraphPattern._graphPatterns[0]));
   }
   {
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x ORDER BY ?x")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x ORDER BY ?x");
     ASSERT_EQ(pq._orderBy.size(), 1);
     EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?x"}, false));
     ASSERT_EQ(pq._rootGraphPattern._graphPatterns.size(), 1);
@@ -1158,18 +1108,15 @@ TEST(ParserTest, Order) {
         pq._rootGraphPattern._graphPatterns[0]));
   }
   {
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x (COUNT(?y) as ?c) WHERE { ?x <test/myrel> "
-                         "?y } GROUP BY ?x ORDER BY ?c")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x (COUNT(?y) as ?c) WHERE { ?x <test/myrel> "
+        "?y } GROUP BY ?x ORDER BY ?c");
     ASSERT_EQ(pq._orderBy.size(), 1);
     EXPECT_THAT(pq._orderBy[0], m::VariableOrderKey(Variable{"?c"}, false));
   }
   {
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY (?x - ?y)")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } ORDER BY (?x - ?y)");
     ASSERT_EQ(pq._orderBy.size(), 1);
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
@@ -1180,47 +1127,42 @@ TEST(ParserTest, Order) {
   {
     // Ordering by variables that are not grouped is not allowed.
     EXPECT_THROW(
-        SparqlParser(
-            "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x ORDER BY ?y")
-            .parse(),
+        SparqlParser::parseQuery(
+            "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x ORDER BY ?y"),
         ParseException);
   }
   {
     // Ordering by an expression while grouping is currently not supported.
-    EXPECT_THROW(SparqlParser("SELECT ?y WHERE { ?x <test/myrel> ?y } GROUP BY "
-                              "?y ORDER BY (?x - ?y)")
-                     .parse(),
+    EXPECT_THROW(SparqlParser::parseQuery(
+                     "SELECT ?y WHERE { ?x <test/myrel> ?y } GROUP BY "
+                     "?y ORDER BY (?x - ?y)"),
                  ParseException);
   }
   {
     // Ordering by an expression while grouping is currently not supported.
-    EXPECT_THROW(SparqlParser("SELECT ?y WHERE { ?x <test/myrel> ?y } GROUP BY "
-                              "?y ORDER BY (2 * ?y)")
-                     .parse(),
+    EXPECT_THROW(SparqlParser::parseQuery(
+                     "SELECT ?y WHERE { ?x <test/myrel> ?y } GROUP BY "
+                     "?y ORDER BY (2 * ?y)"),
                  ParseException);
   }
 }
 
 TEST(ParserTest, Group) {
   {
-    ParsedQuery pq =
-        SparqlParser("SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?x");
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?x"}}));
   }
   {
     // grouping by a variable
-    ParsedQuery pq =
-        SparqlParser("SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?y ?x")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY ?y ?x");
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?y"}, Variable{"?x"}}));
   }
   {
     // grouping by an expression
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY (?x - ?y) ?x")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY (?x - ?y) ?x");
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
@@ -1229,20 +1171,17 @@ TEST(ParserTest, Group) {
   }
   {
     // grouping by an expression with an alias
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY (?x "
-                         "- ?y AS ?foo) ?x")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY (?x "
+        "- ?y AS ?foo) ?x");
     EXPECT_THAT(pq._rootGraphPattern._graphPatterns[1],
                 m::Bind(Variable{"?foo"}, "?x-?y"));
     EXPECT_THAT(pq, m::GroupByVariables({Variable{"?foo"}, Variable{"?x"}}));
   }
   {
     // grouping by a builtin call
-    ParsedQuery pq =
-        SparqlParser(
-            "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY COUNT(?x) ?x")
-            .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY COUNT(?x) ?x");
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
@@ -1251,34 +1190,30 @@ TEST(ParserTest, Group) {
   }
   {
     // grouping by a function call
-    ParsedQuery pq = SparqlParser(
-                         "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY "
-                         "<http://www.opengis.net/def/function/geosparql/"
-                         "latitude> (?test) ?x")
-                         .parse();
+    ParsedQuery pq = SparqlParser::parseQuery(
+        "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY "
+        "<http://www.opengis.net/def/function/geosparql/"
+        "latitude> (?y) ?x");
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
     ASSERT_THAT(
         helperBind,
         m::BindExpression(
-            "<http://www.opengis.net/def/function/geosparql/latitude>(?test)"));
+            "<http://www.opengis.net/def/function/geosparql/latitude>(?y)"));
     EXPECT_THAT(pq, m::GroupByVariables({helperBind._target, Variable{"?x"}}));
   }
   {
     // selection of a variable that is not grouped/aggregated
-    EXPECT_THROW(
-        SparqlParser("SELECT ?x ?y WHERE { ?x <test/myrel> ?y } GROUP BY ?x")
-            .parse(),
-        ParseException);
+    EXPECT_THROW(SparqlParser::parseQuery(
+                     "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } GROUP BY ?x"),
+                 ParseException);
   }
 }
 
 TEST(ParserTest, Prefix) {
-  ParsedQuery pq =
-      SparqlParser(
-          "PREFIX descriptor: <foo> SELECT ?var WHERE { ?var <bar> <foo> }")
-          .parse();
+  ParsedQuery pq = SparqlParser::parseQuery(
+      "PREFIX descriptor: <foo> SELECT ?var WHERE { ?var <bar> <foo> }");
   ASSERT_THAT(pq._prefixes,
               testing::UnorderedElementsAre(
                   SparqlPrefix{"ql", "<QLever-internal-function/>"},
@@ -1299,10 +1234,8 @@ TEST(ParserTest, ParseFilterExpression) {
 
 TEST(ParserTest, LanguageFilterPostProcessing) {
   {
-    ParsedQuery q =
-        SparqlParser(
-            "SELECT * WHERE {?x <label> ?y . FILTER (LANG(?y) = \"en\")}")
-            .parse();
+    ParsedQuery q = SparqlParser::parseQuery(
+        "SELECT * WHERE {?x <label> ?y . FILTER (LANG(?y) = \"en\")}");
     ASSERT_TRUE(q._rootGraphPattern._filters.empty());
     const auto& triples =
         q._rootGraphPattern._graphPatterns[0].getBasic()._triples;
@@ -1311,10 +1244,8 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
               triples[0]);
   }
   {
-    ParsedQuery q =
-        SparqlParser(
-            "SELECT * WHERE {<somebody> ?p ?y . FILTER (LANG(?y) = \"en\")}")
-            .parse();
+    ParsedQuery q = SparqlParser::parseQuery(
+        "SELECT * WHERE {<somebody> ?p ?y . FILTER (LANG(?y) = \"en\")}");
     ASSERT_TRUE(q._rootGraphPattern._filters.empty());
     const auto& triples =
         q._rootGraphPattern._graphPatterns[0].getBasic()._triples;

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -19,7 +19,6 @@ TEST(ParserTest, testParse) {
       auto pq = SparqlParser::parseQuery("SELECT ?x WHERE {?x ?y ?z}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause = pq.selectClause();
-      ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
       ASSERT_EQ(1u, pq._rootGraphPattern._graphPatterns.size());
       ASSERT_EQ(
@@ -37,19 +36,10 @@ TEST(ParserTest, testParse) {
           "<http://abc.de>}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause2 = pq.selectClause();
-      ASSERT_EQ(4u, pq._prefixes.size());
       ASSERT_EQ(2u, selectClause2.getSelectedVariables().size());
       ASSERT_EQ(1u, pq.children().size());
       const auto& triples = pq.children()[0].getBasic()._triples;
       ASSERT_EQ(3u, triples.size());
-
-      ASSERT_THAT(pq._prefixes,
-                  testing::UnorderedElementsAre(
-                      SparqlPrefix{INTERNAL_PREDICATE_PREFIX_NAME,
-                                   INTERNAL_PREDICATE_PREFIX_IRI},
-                      SparqlPrefix{"", "<http://rdf.myprefix.com/>"},
-                      SparqlPrefix{"ns", "<http://rdf.myprefix.com/ns/>"},
-                      SparqlPrefix{"xxx", "<http://rdf.myprefix.com/xxx/>"}));
       ASSERT_EQ(Variable{"?x"}, selectClause2.getSelectedVariables()[0]);
       ASSERT_EQ(Variable{"?z"}, selectClause2.getSelectedVariables()[1]);
       ASSERT_EQ("?x", triples[0]._s);
@@ -75,19 +65,10 @@ TEST(ParserTest, testParse) {
           "<http://abc.de>\n}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause = pq.selectClause();
-      ASSERT_EQ(4u, pq._prefixes.size());
       ASSERT_EQ(2u, selectClause.getSelectedVariables().size());
       ASSERT_EQ(1u, pq.children().size());
       const auto& triples = pq.children()[0].getBasic()._triples;
       ASSERT_EQ(3u, triples.size());
-
-      ASSERT_THAT(pq._prefixes,
-                  testing::UnorderedElementsAre(
-                      SparqlPrefix{INTERNAL_PREDICATE_PREFIX_NAME,
-                                   INTERNAL_PREDICATE_PREFIX_IRI},
-                      SparqlPrefix{"", "<http://rdf.myprefix.com/>"},
-                      SparqlPrefix{"ns", "<http://rdf.myprefix.com/ns/>"},
-                      SparqlPrefix{"xxx", "<http://rdf.myprefix.com/xxx/>"}));
       ASSERT_EQ(Variable{"?x"}, selectClause.getSelectedVariables()[0]);
       ASSERT_EQ(Variable{"?z"}, selectClause.getSelectedVariables()[1]);
       ASSERT_EQ("?x", triples[0]._s);
@@ -111,7 +92,6 @@ TEST(ParserTest, testParse) {
           "?y <nsx:rel2> \"Hello... World\"}");
       ASSERT_TRUE(pq.hasSelectClause());
       const auto& selectClause = pq.selectClause();
-      ASSERT_EQ(2u, pq._prefixes.size());
       ASSERT_EQ(2u, selectClause.getSelectedVariables().size());
       ASSERT_EQ(1u, pq.children().size());
       const auto& triples = pq.children()[0].getBasic()._triples;
@@ -428,7 +408,6 @@ TEST(ParserTest, testParse) {
           "} \n"
           "ORDER BY ASC(?movie)\n"
           "LIMIT 10 \n");
-      ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(1u, pq._rootGraphPattern._graphPatterns.size());
 
       const auto& c = pq.children()[0].getBasic();
@@ -459,7 +438,6 @@ TEST(ParserTest, testParse) {
           "ORDER BY DESC(?movie)\n"
           "LIMIT 10 \n");
 
-      ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(1u, pq._rootGraphPattern._graphPatterns.size());
 
       const auto& c = pq.children()[0].getBasic();
@@ -499,7 +477,6 @@ TEST(ParserTest, testParse) {
           "LIMIT 20 \n"
           "OFFSET 3 \n");
 
-      ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(2u, pq._rootGraphPattern._graphPatterns.size());
 
       const auto& c = pq.children()[0].getBasic();
@@ -584,7 +561,6 @@ TEST(ParserTest, testParse) {
           "LIMIT 20 \n"
           "OFFSET 3 \n");
 
-      ASSERT_EQ(1u, pq._prefixes.size());
       ASSERT_EQ(2u, pq._rootGraphPattern._graphPatterns.size());
 
       const auto& c = pq.children()[0].getBasic();
@@ -744,7 +720,6 @@ TEST(ParserTest, testFilterWithoutDot) {
       "} LIMIT 300");
   ASSERT_TRUE(pq.hasSelectClause());
   const auto& selectClause = pq.selectClause();
-  ASSERT_EQ(2u, pq._prefixes.size());
   ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
   ASSERT_EQ(1u, pq.children().size());
   const auto& c = pq.children()[0].getBasic();
@@ -773,16 +748,8 @@ TEST(ParserTest, testExpandPrefixes) {
   const auto& selectClause = pq.selectClause();
   ASSERT_EQ(1u, pq.children().size());
   const auto& c = pq.children()[0].getBasic();
-  ASSERT_EQ(4u, pq._prefixes.size());
   ASSERT_EQ(2u, selectClause.getSelectedVariables().size());
   ASSERT_EQ(3u, c._triples.size());
-  ASSERT_THAT(pq._prefixes,
-              testing::UnorderedElementsAre(
-                  SparqlPrefix{INTERNAL_PREDICATE_PREFIX_NAME,
-                               INTERNAL_PREDICATE_PREFIX_IRI},
-                  SparqlPrefix{"", "<http://rdf.myprefix.com/>"},
-                  SparqlPrefix{"ns", "<http://rdf.myprefix.com/ns/>"},
-                  SparqlPrefix{"xxx", "<http://rdf.myprefix.com/xxx/>"}));
   ASSERT_EQ(Variable{"?x"}, selectClause.getSelectedVariables()[0]);
   ASSERT_EQ(Variable{"?z"}, selectClause.getSelectedVariables()[1]);
   ASSERT_EQ("?x", c._triples[0]._s);
@@ -806,7 +773,6 @@ TEST(ParserTest, testLiterals) {
   const auto& selectClause = pq.selectClause();
   ASSERT_EQ(1u, pq.children().size());
   const auto& c = pq.children()[0].getBasic();
-  ASSERT_EQ(2u, pq._prefixes.size());
   ASSERT_TRUE(selectClause.isAsterisk());
   ASSERT_EQ(2u, c._triples.size());
   ASSERT_EQ("\"true\"^^<http://www.w3.org/2001/XMLSchema#boolean>",
@@ -826,7 +792,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(std::numeric_limits<uint64_t>::max(), pq._limitOffset._limit);
@@ -841,7 +806,6 @@ TEST(ParserTest, testSolutionModifiers) {
         "SELECT ?x WHERE \t {?x <test:myrel> ?y} LIMIT 10");
     ASSERT_TRUE(pq.hasSelectClause());
     const auto& selectClause = pq.selectClause();
-    ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
@@ -861,7 +825,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(10u, pq._limitOffset._limit);
@@ -879,7 +842,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(2u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(10u, pq._limitOffset._limit);
@@ -900,7 +862,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(3u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(Variable{"?ql_textscore_x"},
               selectClause.getSelectedVariables()[1]);
@@ -924,7 +885,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(1u, pq._prefixes.size());
     ASSERT_EQ(2u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(10u, pq._limitOffset._limit);
@@ -956,7 +916,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(2u, pq._prefixes.size());
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(Variable{"?movie"}, selectClause.getSelectedVariables()[0]);
     ASSERT_EQ(2u, c._triples.size());
@@ -980,7 +939,6 @@ TEST(ParserTest, testSolutionModifiers) {
     const auto& selectClause = pq.selectClause();
     ASSERT_EQ(1u, pq.children().size());
     const auto& c = pq.children()[0].getBasic();
-    ASSERT_EQ(2u, pq._prefixes.size());
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(Variable{"?movie"}, selectClause.getSelectedVariables()[0]);
     ASSERT_EQ(2u, c._triples.size());
@@ -1209,15 +1167,6 @@ TEST(ParserTest, Group) {
                      "SELECT ?x ?y WHERE { ?x <test/myrel> ?y } GROUP BY ?x"),
                  ParseException);
   }
-}
-
-TEST(ParserTest, Prefix) {
-  ParsedQuery pq = SparqlParser::parseQuery(
-      "PREFIX descriptor: <foo> SELECT ?var WHERE { ?var <bar> <foo> }");
-  ASSERT_THAT(pq._prefixes,
-              testing::UnorderedElementsAre(
-                  SparqlPrefix{"ql", "<QLever-internal-function/>"},
-                  SparqlPrefix{"descriptor", "<foo>"}));
 }
 
 TEST(ParserTest, ParseFilterExpression) {


### PR DESCRIPTION
Complete the last two pieces of query parsing in ANTLR: `ConstructQuery` and `Query`.

TODO:
- [x] Tests
- [ ] resolve the introduced Todos