### PR TITLE
Basic support of SERVICE clause

### DIFF
--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(engine
         Union.cpp Union.h
         MultiColumnJoin.cpp MultiColumnJoin.h
         TransitivePath.cpp TransitivePath.h
+        Service.cpp Service.h
         Values.cpp Values.h
         Bind.cpp Bind.h
         idTable/IdTable.h
@@ -38,6 +39,5 @@ add_library(engine
         ResultType.h
         ../util/Parameters.h RuntimeInformation.cpp CheckUsePatternTrick.cpp CheckUsePatternTrick.h
         VariableToColumnMap.cpp ExportQueryExecutionTrees.cpp )
-
 
 target_link_libraries(engine index parser sparqlExpressions http SortPerformanceEstimator absl::flat_hash_set ${ICU_LIBRARIES} boost_iostreams)

--- a/src/engine/CheckUsePatternTrick.cpp
+++ b/src/engine/CheckUsePatternTrick.cpp
@@ -66,7 +66,7 @@ bool isVariableContainedInGraphPatternOperation(
     } else if constexpr (std::is_same_v<T, p::Values>) {
       return ad_utility::contains(arg._inlineValues._variables, variable);
     } else if constexpr (std::is_same_v<T, p::Service>) {
-      return check(arg.graphPattern_);
+      return ad_utility::contains(arg.visibleVariables_, variable);
     } else {
       static_assert(std::is_same_v<T, p::TransPath>);
       // The `TransPath` is set up later in the query planning, when this

--- a/src/engine/CheckUsePatternTrick.cpp
+++ b/src/engine/CheckUsePatternTrick.cpp
@@ -65,6 +65,8 @@ bool isVariableContainedInGraphPatternOperation(
           });
     } else if constexpr (std::is_same_v<T, p::Values>) {
       return ad_utility::contains(arg._inlineValues._variables, variable);
+    } else if constexpr (std::is_same_v<T, p::Service>) {
+      return check(arg.graphPattern_);
     } else {
       static_assert(std::is_same_v<T, p::TransPath>);
       // The `TransPath` is set up later in the query planning, when this

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -76,6 +76,17 @@ LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(std::string&& word) {
 }
 
 // _____________________________________________________________________________
+std::optional<LocalVocabIndex> LocalVocab::getIndexOrNullopt(
+    const std::string& word) const {
+  auto localVocabIndex = wordsToIndexesMap_.find(word);
+  if (localVocabIndex != wordsToIndexesMap_.end()) {
+    return localVocabIndex->second;
+  } else {
+    return std::nullopt;
+  }
+}
+
+// _____________________________________________________________________________
 const std::string& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
   if (localVocabIndex.get() >= indexesToWordsMap_.size()) {
     throw std::runtime_error(absl::StrCat(

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -67,6 +67,11 @@ class LocalVocab {
   LocalVocabIndex getIndexAndAddIfNotContained(const std::string& word);
   LocalVocabIndex getIndexAndAddIfNotContained(std::string&& word);
 
+  // Get the index of a word in the local vocabulary, or std::nullopt if it is
+  // not contained. This is useful for testing.
+  std::optional<LocalVocabIndex> getIndexOrNullopt(
+      const std::string& word) const;
+
   // The number of words in the vocabulary.
   size_t size() const { return indexesToWordsMap_.size(); }
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -26,6 +26,7 @@
 #include "engine/NeutralElementOperation.h"
 #include "engine/OptionalJoin.h"
 #include "engine/OrderBy.h"
+#include "engine/Service.h"
 #include "engine/Sort.h"
 #include "engine/TextOperationWithFilter.h"
 #include "engine/TransitivePath.h"
@@ -191,6 +192,8 @@ void QueryExecutionTree::setOperation(std::shared_ptr<Op> operation) {
     _type = DISTINCT;
   } else if constexpr (std::is_same_v<Op, Values>) {
     _type = VALUES;
+  } else if constexpr (std::is_same_v<Op, Service>) {
+    _type = SERVICE;
   } else if constexpr (std::is_same_v<Op, TransitivePath>) {
     _type = TRANSITIVE_PATH;
   } else if constexpr (std::is_same_v<Op, OrderBy>) {
@@ -230,6 +233,7 @@ template void QueryExecutionTree::setOperation(std::shared_ptr<Bind>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<Sort>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<Distinct>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<Values>);
+template void QueryExecutionTree::setOperation(std::shared_ptr<Service>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<TransitivePath>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<OrderBy>);
 template void QueryExecutionTree::setOperation(std::shared_ptr<GroupBy>);

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -53,6 +53,7 @@ class QueryExecutionTree {
     MULTICOLUMN_JOIN,
     TRANSITIVE_PATH,
     VALUES,
+    SERVICE,
     BIND,
     MINUS,
     NEUTRAL_ELEMENT,

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -19,6 +19,7 @@
 #include <engine/OptionalJoin.h>
 #include <engine/OrderBy.h>
 #include <engine/QueryPlanner.h>
+#include <engine/Service.h>
 #include <engine/Sort.h>
 #include <engine/TextOperationWithFilter.h>
 #include <engine/TextOperationWithoutFilter.h>
@@ -445,7 +446,9 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         SubtreePlan valuesPlan =
             makeSubtreePlan<Values>(_qec, arg._inlineValues);
         joinCandidates(std::vector{std::move(valuesPlan)});
-
+      } else if constexpr (std::is_same_v<T, p::Service>) {
+        SubtreePlan servicePlan = makeSubtreePlan<Service>(_qec, arg);
+        joinCandidates(std::vector{std::move(servicePlan)});
       } else if constexpr (std::is_same_v<T, p::Bind>) {
         // The logic of the BIND operation is implemented in the joinCandidates
         // lambda. Reason: BIND does not add a new join operation like for the

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -1,0 +1,192 @@
+// Copyright 2022 - 2023, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Hannah Bast (bast@cs.uni-freiburg.de)
+
+#include "engine/Service.h"
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+
+#include "engine/CallFixedSize.h"
+#include "engine/Values.h"
+#include "engine/VariableToColumnMap.h"
+#include "parser/TokenizerCtre.h"
+#include "parser/TurtleParser.h"
+#include "util/Exception.h"
+#include "util/HashSet.h"
+#include "util/http/HttpClient.h"
+#include "util/http/HttpUtils.h"
+
+// ____________________________________________________________________________
+Service::Service(QueryExecutionContext* qec,
+                 parsedQuery::Service parsedServiceClause,
+                 GetTsvFunction getTsvFunction)
+    : Operation{qec},
+      parsedServiceClause_(parsedServiceClause),
+      getTsvFunction_(getTsvFunction) {}
+
+// ____________________________________________________________________________
+std::string Service::asStringImpl(size_t indent) const {
+  std::ostringstream os;
+  for (size_t i = 0; i < indent; ++i) {
+    os << " ";
+  }
+  // TODO: This duplicates code in GraphPatternOperation.cpp .
+  os << "SERVICE " << parsedServiceClause_.serviceIri_.toSparql() << " {\n"
+     << parsedServiceClause_.prologue_ << "\n"
+     << parsedServiceClause_.graphPatternAsString_ << "\n}\n";
+  return std::move(os).str();
+}
+
+// ____________________________________________________________________________
+std::string Service::getDescriptor() const {
+  return absl::StrCat("Service with IRI ",
+                      parsedServiceClause_.serviceIri_.toSparql());
+}
+
+// ____________________________________________________________________________
+size_t Service::getResultWidth() const {
+  return parsedServiceClause_.visibleVariables_.size();
+}
+
+// ____________________________________________________________________________
+std::vector<size_t> Service::resultSortedOn() const { return {}; }
+
+// ____________________________________________________________________________
+VariableToColumnMap Service::computeVariableToColumnMap() const {
+  VariableToColumnMap map;
+  const auto& visibleVariables = parsedServiceClause_.visibleVariables_;
+  for (size_t i = 0; i < visibleVariables.size(); i++) {
+    map[visibleVariables[i]] = i;
+  }
+  return map;
+}
+
+// ____________________________________________________________________________
+float Service::getMultiplicity([[maybe_unused]] size_t col) {
+  // TODO: For now, we don't have any information about the multiplicities at
+  // query planning time, so we just return `1` for each column.
+  return 1;
+}
+
+// ____________________________________________________________________________
+size_t Service::getSizeEstimate() {
+  // TODO: For now, we don't have any information about the result size at
+  // query planning time, so we just return `100'000`.
+  return 100'000;
+}
+
+// ____________________________________________________________________________
+size_t Service::getCostEstimate() {
+  // TODO: For now, we don't have any information about the cost at query
+  // planning time, so we just return ten times the estimated size.
+  return 10 * getSizeEstimate();
+}
+
+// ____________________________________________________________________________
+void Service::computeResult(ResultTable* result) {
+  // Get the URL of the SPARQL endpoint.
+  std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
+  AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&
+                    serviceIriString.ends_with(">"));
+  serviceIriString.remove_prefix(1);
+  serviceIriString.remove_suffix(1);
+  ad_utility::httpUtils::Url serviceUrl{serviceIriString};
+
+  // Construct the query to be sent to the SPARQL endpoint.
+  std::string variablesForSelectClause = absl::StrJoin(
+      parsedServiceClause_.visibleVariables_, " ", Variable::AbslFormatter);
+  std::string serviceQuery = absl::StrCat(
+      parsedServiceClause_.prologue_, "\nSELECT ", variablesForSelectClause,
+      " WHERE ", parsedServiceClause_.graphPatternAsString_);
+  LOG(INFO) << "Sending SERVICE query to remote endpoint "
+            << "(protocol: " << serviceUrl.protocolAsString()
+            << ", host: " << serviceUrl.host()
+            << ", port: " << serviceUrl.port()
+            << ", target: " << serviceUrl.target() << ")" << std::endl
+            << serviceQuery << std::endl;
+
+  // Send the query to the remote SPARQL endpoint via a POST request and get the
+  // result as TSV.
+  //
+  // TODO: We should support a timeout here.
+  //
+  // TODO: We ask for the result as TSV because that is a compact and
+  // easy-to-parse format. It might not be the best choice regarding robustness
+  // and portability though. In particular, we are not sure how deterministic
+  // the TSV output is with respect to the precise encoding of literals.
+  std::istringstream tsvResult =
+      getTsvFunction_(serviceUrl, boost::beast::http::verb::post, serviceQuery,
+                      "application/sparql-query", "text/tab-separated-values");
+  LOG(DEBUG) << "TSV result is:" << std::endl << tsvResult.str() << std::endl;
+
+  // The first line of the TSV result contains the variable names.
+  std::string tsvHeaderRow;
+  if (!std::getline(tsvResult, tsvHeaderRow)) {
+    throw std::runtime_error(absl::StrCat("Response from SPARQL endpoint ",
+                                          serviceUrl.host(), " is empty"));
+  }
+  LOG(INFO) << "Header row of TSV result: " << tsvHeaderRow << std::endl;
+
+  // Check that the variables in the header row agree with those requested by
+  // the SERVICE query.
+  std::string expectedHeaderRow = absl::StrJoin(
+      parsedServiceClause_.visibleVariables_, "\t", Variable::AbslFormatter);
+  if (tsvHeaderRow != expectedHeaderRow) {
+    throw std::runtime_error(absl::StrCat(
+        "Header row of TSV result for SERVICE query is \"", tsvHeaderRow,
+        "\", but expected \"", expectedHeaderRow, "\""));
+  }
+
+  // Set basic properties of the result table (the `_resultTypes` don't matter,
+  // as long as they have the right size, see `ResultTypes.h`).
+  result->_sortedBy = resultSortedOn();
+  result->_idTable.setNumColumns(getResultWidth());
+  result->_resultTypes.resize(parsedServiceClause_.visibleVariables_.size(),
+                              ResultTable::ResultType::KB);
+
+  // Fill the result table using the `writeTsvResult` method below.
+  size_t resWidth = getResultWidth();
+  CALL_FIXED_SIZE(resWidth, &Service::writeTsvResult, this,
+                  std::move(tsvResult), result);
+}
+
+// ____________________________________________________________________________
+template <size_t I>
+void Service::writeTsvResult(std::istringstream tsvResult,
+                             ResultTable* result) {
+  IdTableStatic<I> idTable = std::move(result->_idTable).toStatic<I>();
+  size_t rowIdx = 0;
+  std::vector<size_t> numLocalVocabPerColumn(idTable.numColumns());
+  std::string line;
+  std::string lastLine;
+  while (lastLine = std::move(line), std::getline(tsvResult, line)) {
+    // Print first line.
+    if (rowIdx == 0) {
+      LOG(INFO) << "First non-header row of TSV result: " << line << std::endl;
+    }
+    std::vector<std::string_view> valueStrings = absl::StrSplit(line, "\t");
+    AD_CONTRACT_CHECK(valueStrings.size() ==
+                      parsedServiceClause_.visibleVariables_.size());
+    idTable.emplace_back();
+    for (size_t colIdx = 0; colIdx < valueStrings.size(); colIdx++) {
+      TripleComponent tc = TurtleStringParser<TokenizerCtre>::parseTripleObject(
+          valueStrings[colIdx]);
+      Id id = std::move(tc).toValueId(getIndex().getVocab(),
+                                      result->localVocabNonConst());
+      idTable(rowIdx, colIdx) = id;
+      if (id.getDatatype() == Datatype::LocalVocabIndex) {
+        ++numLocalVocabPerColumn[colIdx];
+      }
+    }
+    rowIdx++;
+  }
+  if (idTable.size() > 1) {
+    LOG(INFO) << "Last non-header row of TSV result: " << lastLine << std::endl;
+  }
+  AD_CORRECTNESS_CHECK(rowIdx == idTable.size());
+  LOG(INFO) << "Number of rows in result: " << idTable.size() << std::endl;
+  LOG(INFO) << "Number of entries in local vocabulary per column: "
+            << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
+  result->_idTable = std::move(idTable).toDynamic();
+}

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -38,9 +38,6 @@ class Service : public Operation {
       std::string_view, std::string_view, std::string_view)>;
 
  private:
-  // For each column, its multiplicity.
-  std::vector<size_t> multiplicities_;
-
   // The parsed SERVICE clause.
   parsedQuery::Service parsedServiceClause_;
 
@@ -55,12 +52,12 @@ class Service : public Operation {
   // but in our tests (`ServiceTest`) we use a mock function that does not
   // require a running `HttpServer`.
   Service(QueryExecutionContext* qec, parsedQuery::Service parsedServiceClause,
-          GetTsvFunction getTsvFunction = &sendHttpOrHttpsRequest);
+          GetTsvFunction getTsvFunction = sendHttpOrHttpsRequest);
 
   // Methods inherited from base class `Operation`.
   std::string getDescriptor() const override;
   size_t getResultWidth() const override;
-  std::vector<size_t> resultSortedOn() const override;
+  std::vector<size_t> resultSortedOn() const override { return {}; }
   float getMultiplicity(size_t col) override;
   size_t getSizeEstimate() override;
   size_t getCostEstimate() override;
@@ -82,7 +79,8 @@ class Service : public Operation {
   // Compute the result using `getTsvFunction_`.
   void computeResult(ResultTable* result) override;
 
-  // Write the given TSV result to the given result object.
+  // Write the given TSV result to the given result object. The `I` is the width
+  // of the result table.
   //
   // NOTE: This is similar to `Values::writeValues`, except that we have to
   // parse TSV here and not a VALUES clause. Note that the only reason that

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -1,0 +1,93 @@
+// Copyright 2022 - 2023, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Hannah Bast (bast@cs.uni-freiburg.de)
+
+#pragma once
+
+#include <functional>
+
+#include "engine/Operation.h"
+#include "engine/Values.h"
+#include "parser/ParsedQuery.h"
+#include "util/http/HttpClient.h"
+
+// The SERVICE operation. Sends a query to the remote endpoint specified by the
+// service IRI, gets the result as TSV, parses it, and writes it into a result
+// table.
+//
+// TODO: The current implementation works, but is preliminary in several
+// respects:
+//
+// 1. Reading the result as TSV has potential problems (see comment in
+// `computeResult` for details).
+//
+// 2. There should be a timeout.
+//
+// 3. A variable in place of the IRI is not yet supported (see comment in
+// `computeResult` for details).
+//
+// 4. The SERVICE is currently executed *after* the query planning. The
+// estimates of the result size, cost, and multiplicities are therefore dummy
+// values.
+//
+class Service : public Operation {
+ public:
+  // The type of the function used to obtain the results, see below.
+  using GetTsvFunction = std::function<std::istringstream(
+      ad_utility::httpUtils::Url, const boost::beast::http::verb&,
+      std::string_view, std::string_view, std::string_view)>;
+
+ private:
+  // For each column, its multiplicity.
+  std::vector<size_t> multiplicities_;
+
+  // The parsed SERVICE clause.
+  parsedQuery::Service parsedServiceClause_;
+
+  // The function used to obtain the result from the remote endpoint.
+  GetTsvFunction getTsvFunction_;
+
+ public:
+  // Construct from parsed Service clause.
+  //
+  // NOTE: The third argument is the function used to obtain the result from the
+  // remote endpoint. The default is to use `httpUtils::sendHttpOrHttpsRequest`,
+  // but in our tests (`ServiceTest`) we use a mock function that does not
+  // require a running `HttpServer`.
+  Service(QueryExecutionContext* qec, parsedQuery::Service parsedServiceClause,
+          GetTsvFunction getTsvFunction = &sendHttpOrHttpsRequest);
+
+  // Methods inherited from base class `Operation`.
+  std::string getDescriptor() const override;
+  size_t getResultWidth() const override;
+  std::vector<size_t> resultSortedOn() const override;
+  float getMultiplicity(size_t col) override;
+  size_t getSizeEstimate() override;
+  size_t getCostEstimate() override;
+  VariableToColumnMap computeVariableToColumnMap() const override;
+
+  // Not relevant for SERVICE.
+  void setTextLimit([[maybe_unused]] size_t limit) override {}
+
+  // We know nothing about the result at query planning time.
+  bool knownEmptyResult() override { return false; }
+
+  // A SERVICE clause has no children.
+  vector<QueryExecutionTree*> getChildren() override { return {}; }
+
+ private:
+  // The string returned by this function is used as cache key.
+  std::string asStringImpl(size_t indent = 0) const override;
+
+  // Compute the result using `getTsvFunction_`.
+  void computeResult(ResultTable* result) override;
+
+  // Write the given TSV result to the given result object.
+  //
+  // NOTE: This is similar to `Values::writeValues`, except that we have to
+  // parse TSV here and not a VALUES clause. Note that the only reason that
+  // `tsvResult` is not `const` here is because the method iterates over the
+  // `std::istringstream` and thus changes it.
+  template <size_t I>
+  void writeTsvResult(std::istringstream tsvResult, ResultTable* result);
+};

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -90,6 +90,11 @@ void GraphPatternOperation::toString(std::ostringstream& os,
     } else if constexpr (std::is_same_v<T, Values>) {
       os << "VALUES (" << arg._inlineValues.variablesToString() << ") "
          << arg._inlineValues.valuesToString();
+    } else if constexpr (std::is_same_v<T, Service>) {
+      os << "SERVICE " << arg.serviceIri_.toSparql() << " {";
+      // TODO: In other places, the interface is `os << ...asString(indent)`.
+      arg.graphPattern_.toString(os, indentation);
+      os << "}";
     } else if constexpr (std::is_same_v<T, BasicGraphPattern>) {
       for (size_t i = 0; i + 1 < arg._triples.size(); ++i) {
         os << "\n";

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -91,10 +91,8 @@ void GraphPatternOperation::toString(std::ostringstream& os,
       os << "VALUES (" << arg._inlineValues.variablesToString() << ") "
          << arg._inlineValues.valuesToString();
     } else if constexpr (std::is_same_v<T, Service>) {
-      os << "SERVICE " << arg.serviceIri_.toSparql() << " {";
-      // TODO: In other places, the interface is `os << ...asString(indent)`.
-      arg.graphPattern_.toString(os, indentation);
-      os << "}";
+      os << "SERVICE " << arg.serviceIri_.toSparql() << " { "
+         << arg.graphPatternAsString_ << " }";
     } else if constexpr (std::is_same_v<T, BasicGraphPattern>) {
       for (size_t i = 0; i + 1 < arg._triples.size(); ++i) {
         os << "\n";

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -43,6 +43,25 @@ struct SparqlValues {
   std::string valuesToString() const;
 };
 
+/// A `SERVICE` clause.
+struct Service {
+ public:
+  // The visible variables of the service clause.
+  std::vector<Variable> visibleVariables_;
+  // The URL of the service clause.
+  Iri serviceIri_;
+  // The prologue (prefix definitions).
+  std::string prologue_;
+  // The body of the SPARQL query for the remote endpoint.
+  std::string graphPatternAsString_;
+  // The corresponding graph pattern from the parser.
+  //
+  // TODO: This is currently only used by `GraphPatternOperation::toString()`.
+  // What is the use of that function? Does it really need the `GraphPattern`
+  // object from the partse or would `graphPatternAsString_` do equally fine?
+  GraphPattern graphPattern_;
+};
+
 /// A `BasicGraphPattern` represents a consecutive block of triples.
 struct BasicGraphPattern {
   std::vector<SparqlTriple> _triples;
@@ -148,7 +167,7 @@ struct Bind {
 // class actually becomes `using GraphPatternOperation = std::variant<...>`
 using GraphPatternOperationVariant =
     std::variant<Optional, Union, Subquery, TransPath, Bind, BasicGraphPattern,
-                 Values, Minus, GroupGraphPattern>;
+                 Values, Service, Minus, GroupGraphPattern>;
 struct GraphPatternOperation
     : public GraphPatternOperationVariant,
       public VisitMixin<GraphPatternOperation, GraphPatternOperationVariant> {

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -54,12 +54,6 @@ struct Service {
   std::string prologue_;
   // The body of the SPARQL query for the remote endpoint.
   std::string graphPatternAsString_;
-  // The corresponding graph pattern from the parser.
-  //
-  // TODO: This is currently only used by `GraphPatternOperation::toString()`.
-  // What is the use of that function? Does it really need the `GraphPattern`
-  // object from the partse or would `graphPatternAsString_` do equally fine?
-  GraphPattern graphPattern_;
 };
 
 /// A `BasicGraphPattern` represents a consecutive block of triples.

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -398,6 +398,7 @@ void ParsedQuery::GraphPattern::recomputeIds(size_t* id_count) {
         arg._id = (*id_count)++;
       } else {
         static_assert(std::is_same_v<T, parsedQuery::Subquery> ||
+                      std::is_same_v<T, parsedQuery::Service> ||
                       std::is_same_v<T, parsedQuery::BasicGraphPattern> ||
                       std::is_same_v<T, parsedQuery::Bind>);
         // subquery children have their own id space

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -488,8 +488,8 @@ parsedQuery::Service Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
                            visibleVariablesServiceQuery.end());
   // Create suitable `parsedQuery::Service` object and return it.
   return {std::move(visibleVariablesServiceQuery), std::move(serviceIri),
-          prologueString_, getOriginalInputForContext(ctx->groupGraphPattern()),
-          std::move(graphPattern)};
+          prologueString_,
+          getOriginalInputForContext(ctx->groupGraphPattern())};
 }
 
 // ____________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/strings/str_join.h"
 #include "engine/sparqlExpressions/LangExpression.h"
 #include "engine/sparqlExpressions/RandomExpression.h"
 #include "engine/sparqlExpressions/RegexExpression.h"
@@ -34,6 +35,19 @@ using SparqlValues = parsedQuery::SparqlValues;
 
 using Visitor = SparqlQleverVisitor;
 using Parser = SparqlAutomaticParser;
+
+// _____________________________________________________________________________
+std::string Visitor::getOriginalInputForContext(
+    antlr4::ParserRuleContext* context) {
+  const auto& fullInput = context->getStart()->getInputStream()->toString();
+  size_t posBeg = context->getStart()->getStartIndex();
+  size_t posEnd = context->getStop()->getStopIndex();
+  // Note that `getUTF8Substring` returns a `std::string_view`. We copy this to
+  // a `std::string` because it's not clear whether the original string still
+  // exists when the result of this call is used. Not performance-critical.
+  return std::string{
+      ad_utility::getUTF8Substring(fullInput, posBeg, posEnd - posBeg + 1)};
+}
 
 // ___________________________________________________________________________
 ExpressionPtr Visitor::processIriFunctionCall(
@@ -82,7 +96,7 @@ void Visitor::addVisibleVariable(string var) {
 }
 
 void Visitor::addVisibleVariable(Variable var) {
-  visibleVariables_.back().emplace_back(std::move(var));
+  visibleVariables_.emplace_back(std::move(var));
 }
 
 // ___________________________________________________________________________
@@ -434,32 +448,79 @@ GraphPatternOperation Visitor::visit(Parser::OptionalGraphPatternContext* ctx) {
   return GraphPatternOperation{parsedQuery::Optional{std::move(pattern)}};
 }
 
-// ____________________________________________________________________________________
+// Parsing for the `serviceGraphPattern` rule.
+parsedQuery::Service Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
+  // If SILENT is specified, report that we do not support it yet.
+  //
+  // TODO: Support it, it's not hard. The semantics of SILENT is that if no
+  // result can be obtained from the remote endpoint, then do as if the SERVICE
+  // clause would not be there = the result is the neutral element.
+  if (ctx->SILENT()) {
+    reportNotSupported(ctx, "SILENT modifier in SERVICE is");
+  }
+  // Get the IRI and if a variable is specified, report that we do not support
+  // it yet.
+  //
+  // NOTE: According to the grammar, this should either be a `Variable` or an
+  // `Iri`, but due to (not very good) technical reasons, the `visit` returns a
+  // `std::variant<Variable, GraphTerm>`, where `GraphTerm` is a
+  // `std::variant<Literal, BlankNode, Iri>`, hence the `AD_CONTRACT_CHECK`.
+  //
+  // TODO: Also support variables. The semantics is to make a connection for
+  // each IRI matching the variable and take the union of the results.
+  VarOrTerm varOrIri = visit(ctx->varOrIri());
+  if (std::holds_alternative<Variable>(varOrIri)) {
+    reportNotSupported(ctx->varOrIri(), "Variable endpoint in SERVICE is");
+  }
+  AD_CONTRACT_CHECK(std::holds_alternative<Iri>(std::get<GraphTerm>(varOrIri)));
+  Iri serviceIri = std::get<Iri>(std::get<GraphTerm>(varOrIri));
+  // Parse the body of the SERVICE query. Add the visible variables from the
+  // SERVICE clause to the visible variables so far, but also remember them
+  // separately (with duplicates removed) because we need them in `Service.cpp`
+  // when computing the result for this operation.
+  std::vector<Variable> visibleVariablesSoFar = std::move(visibleVariables_);
+  parsedQuery::GraphPattern graphPattern = visit(ctx->groupGraphPattern());
+  std::vector<Variable> visibleVariablesServiceQuery =
+      ad_utility::removeDuplicates(std::move(visibleVariables_));
+  visibleVariables_ = std::move(visibleVariablesSoFar);
+  visibleVariables_.insert(visibleVariables_.end(),
+                           visibleVariablesServiceQuery.begin(),
+                           visibleVariablesServiceQuery.end());
+  // Create suitable `parsedQuery::Service` object and return it.
+  return {std::move(visibleVariablesServiceQuery), std::move(serviceIri),
+          prologueString_, getOriginalInputForContext(ctx->groupGraphPattern()),
+          std::move(graphPattern)};
+}
+
+// ____________________________________________________________________________
 parsedQuery::GraphPatternOperation Visitor::visit(
     Parser::GraphGraphPatternContext* ctx) {
   reportNotSupported(ctx, "Named Graphs (FROM, GRAPH) are");
 }
 
-// ____________________________________________________________________________________
-parsedQuery::GraphPatternOperation Visitor::visit(
-    Parser::ServiceGraphPatternContext* ctx) {
-  reportNotSupported(ctx, "Federated queries (SERVICE) are");
-}
-
-// ____________________________________________________________________________________
+// Parsing for the `expression` rule.
 sparqlExpression::SparqlExpression::Ptr Visitor::visit(
     Parser::ExpressionContext* ctx) {
   return visit(ctx->conditionalOrExpression());
 }
 
-// ____________________________________________________________________________________
+// Parsing for the `whereClause` rule.
 Visitor::PatternAndVisibleVariables Visitor::visit(
     Parser::WhereClauseContext* ctx) {
-  visibleVariables_.emplace_back();
-  auto pattern = visit(ctx->groupGraphPattern());
-  auto visible = std::move(visibleVariables_.back());
-  visibleVariables_.pop_back();
-  return {std::move(pattern), std::move(visible)};
+  // Get the variables visible in this WHERE clause separately from the visible
+  // variables so far because they might not all be visible in the outer query.
+  // Adding appropriately to the visible variables so far is then taken care of
+  // in `visit(SubSelectContext*)`.
+  std::vector<Variable> visibleVariablesSoFar = std::move(visibleVariables_);
+  auto graphPatternWhereClause = visit(ctx->groupGraphPattern());
+  // Using `std::exchange` as per Johannes' suggestion. I am slightly irritated
+  // that this calls the move constructor AND the move assignment operator for
+  // the second argument, since this is a potential performance issue (not in
+  // this case though).
+  auto visibleVariablesWhereClause =
+      std::exchange(visibleVariables_, std::move(visibleVariablesSoFar));
+  return {std::move(graphPatternWhereClause),
+          std::move(visibleVariablesWhereClause)};
 }
 
 // ____________________________________________________________________________________
@@ -585,6 +646,11 @@ string Visitor::visit(Parser::PnameNsContext* ctx) {
 void Visitor::visit(Parser::PrologueContext* ctx) {
   visitVector(ctx->baseDecl());
   visitVector(ctx->prefixDecl());
+  // Remember the whole prologue (we need this when we encounter a SERVICE
+  // clause, see `visit(ServiceGraphPatternContext*)` below.
+  if (ctx->getStart() && ctx->getStop()) {
+    prologueString_ = getOriginalInputForContext(ctx);
+  }
 }
 
 // ____________________________________________________________________________________
@@ -1764,7 +1830,6 @@ requires(!voidWhenVisited<Visitor, Ctx>) {
 }
 
 // ____________________________________________________________________________________
-
 template <typename Out, typename... Contexts>
 Out Visitor::visitAlternative(Contexts*... ctxs) {
   // Check that exactly one of the `ctxs` is not `nullptr`.
@@ -1809,7 +1874,7 @@ void Visitor::visitIf(Ctx* ctx) requires voidWhenVisited<Visitor, Ctx> {
 void Visitor::reportError(antlr4::ParserRuleContext* ctx,
                           const std::string& msg) {
   throw ParseException{
-      absl::StrCat("Clause \"", ctx->getText(), "\" at line ",
+      absl::StrCat("Clause \"", getOriginalInputForContext(ctx), "\" at line ",
                    ctx->getStart()->getLine(), ":",
                    ctx->getStart()->getCharPositionInLine(), " ", msg),
       generateMetadata(ctx)};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -272,6 +272,8 @@ addLinkAndDiscoverTestSerial(LocalVocabTest engine)
 
 addLinkAndDiscoverTestSerial(ValuesTest engine)
 
+addLinkAndDiscoverTestSerial(ServiceTest engine)
+
 addLinkAndDiscoverTest(HttpTest boost_iostreams http)
 
 addLinkAndDiscoverTest(CallFixedSizeTest)

--- a/test/CheckUsePatternTrickTest.cpp
+++ b/test/CheckUsePatternTrickTest.cpp
@@ -80,6 +80,7 @@ TEST(CheckUsePatternTrick, isVariableContainedInGraphPattern) {
   expectXYZContained("?x <is-a> ?z. BIND(?y AS ?t)");
   expectXYZContained("VALUES ?x {<a> <b>}. ?y <is-a> ?z");
   expectXYZContained("VALUES ?x {<a> <b>}. ?y <is-a> ?z");
+  expectXYZContained("?x <is-a> ?y { SERVICE <endpoint> { ?x ?y ?z } }");
 }
 
 TEST(CheckUsePatternTrick, isVariableContainedInGraphPatternIgnoredTriple) {

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -50,20 +50,35 @@ TEST(LocalVocab, constructionAndAccess) {
   ASSERT_TRUE(localVocab.empty());
 
   // Add the words from our test vocabulary and check that they get the expected
-  // local IDs.
+  // local vocab indexes.
   for (size_t i = 0; i < testWords.size(); ++i) {
     ASSERT_EQ(localVocab.getIndexAndAddIfNotContained(testWords[i]),
               LocalVocabIndex::make(i));
   }
   ASSERT_EQ(localVocab.size(), testWords.size());
 
-  // Check that we get the same IDs if we do this again, but that no new words
-  // will be added.
+  // Check that we get the same indexes if we do this again, but that no new
+  // words will be added.
   for (size_t i = 0; i < testWords.size(); ++i) {
     ASSERT_EQ(localVocab.getIndexAndAddIfNotContained(testWords[i]),
               LocalVocabIndex::make(i));
   }
   ASSERT_EQ(localVocab.size(), testWords.size());
+
+  // Check again that we get the right indexes, but with `getIndexOrNullopt`.
+  for (size_t i = 0; i < testWords.size(); ++i) {
+    std::optional<LocalVocabIndex> localVocabIndex =
+        localVocab.getIndexOrNullopt(testWords[i]);
+    ASSERT_TRUE(localVocabIndex.has_value());
+    ASSERT_EQ(localVocabIndex.value(), LocalVocabIndex::make(i));
+  }
+
+  // Check that `getIndexOrNullopt` returns `std::nullopt` for words that are
+  // not contained in the local vocab. This makes use of the fact that the words
+  // in our test vocabulary only contain digits as letters, see above.
+  for (size_t i = 0; i < testWords.size(); ++i) {
+    ASSERT_FALSE(localVocab.getIndexOrNullopt(testWords[i] + "A"));
+  }
 
   // Check that the lookup by ID gives the correct words.
   for (size_t i = 0; i < testWords.size(); ++i) {

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -93,7 +93,8 @@ TEST_F(ServiceTest, basicMethods) {
   ASSERT_EQ(serviceOp.getDescriptor(),
             "Service with IRI <http://localhorst/api>");
   ASSERT_TRUE(
-      serviceOp.asString().starts_with("SERVICE <http://localhorst/api>"));
+      serviceOp.asString(2).starts_with("  SERVICE <http://localhorst/api>"))
+      << serviceOp.asString(2);
   ASSERT_EQ(serviceOp.getResultWidth(), 2);
   ASSERT_EQ(serviceOp.getMultiplicity(0), 1);
   ASSERT_EQ(serviceOp.getMultiplicity(1), 1);
@@ -141,7 +142,7 @@ TEST_F(ServiceTest, computeResult) {
       testQec, parsedServiceClause,
       getTsvFunctionFactory(
           expectedUrl, expectedSparqlQuery,
-          "?y\t?x\n<x>\t<y>\n<bla>\t<bli>\n<blu>\n<bli>\t<blu>\n")};
+          "?x\t?y\n<x>\t<y>\n<bla>\t<bli>\n<blu>\n<bli>\t<blu>\n")};
   ASSERT_ANY_THROW(serviceOperation3.getResult());
 
   // CHECK 4: Returned TSV has correct format matching the query -> check that

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -1,0 +1,179 @@
+//  Copyright 2022 - 2023, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include <regex>
+
+#include "./HttpTestHelpers.h"
+#include "./IndexTestHelpers.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "absl/strings/str_split.h"
+#include "ctre/ctre.h"
+#include "engine/Service.h"
+#include "parser/GraphPatternOperation.h"
+#include "util/http/HttpUtils.h"
+
+// Fixture that sets up a test index and a factory for producing mocks for the
+// `getTsvFunction` needed by the `Service` operation.
+class ServiceTest : public ::testing::Test {
+ protected:
+  // Query execution context (with small test index) and allocator for testing,
+  // see `IndexTestHelpers.h`. Note that `getQec` returns a pointer to a static
+  // `QueryExecutionContext`, so no need to ever delete `testQec`.
+  QueryExecutionContext* testQec = ad_utility::testing::getQec();
+  ad_utility::AllocatorWithLimit<Id> testAllocator =
+      ad_utility::testing::makeAllocator();
+
+  // Factory for generating mocks of the `sendHttpOrHttpsRequest` function that
+  // is used by default by a `Service` operation (see the constructor in
+  // `Service.h`). Each mock does the following:
+  //
+  // 1. It tests that the request method is POST, the content-type header is
+  //    `application/sparql-query`, and the accept header is
+  //    `text/tab-separated-values` (our `Service` always does this).
+  //
+  // 2. It tests that the host and port are as expected.
+  //
+  // 3. It tests that the post data is as expected.
+  //
+  // 4. It returns the specified TSV.
+  //
+  // NOTE: In a previous version of this test, we set up an actual test server.
+  // The code can be found in the history of this PR.
+  static auto constexpr getTsvFunctionFactory =
+      [](const std::string& expectedUrl, const std::string& expectedSparqlQuery,
+         const std::string& predefinedResult) -> Service::GetTsvFunction {
+    return [=](ad_utility::httpUtils::Url url,
+               const boost::beast::http::verb& method,
+               std::string_view postData, std::string_view contentTypeHeader,
+               std::string_view acceptHeader) -> std::istringstream {
+      // Check that the request parameters are as expected.
+      //
+      // NOTE: The first three are hard-coded in `Service::computeResult`, but
+      // the host and port of the endpoint are derived from the IRI, so the last
+      // two checks are non-trivial.
+      EXPECT_EQ(method, http::verb::post);
+      EXPECT_EQ(contentTypeHeader, "application/sparql-query");
+      EXPECT_EQ(acceptHeader, "text/tab-separated-values");
+      EXPECT_EQ(url.asString(), expectedUrl);
+
+      // Check that the (whitespace-normalized) post data contains the expected
+      // query.
+      //
+      // NOTE: a SERVICE clause specifies only the body of a SPARQL query, from
+      // which `Service::computeResult` has to construct a full SPARQL query by
+      // adding `SELECT ... WHERE`, so this checks something non-trivial.
+      EXPECT_EQ(
+          std::regex_replace(std::string{postData}, std::regex{"\\s+"}, " "),
+          expectedSparqlQuery);
+
+      return std::istringstream{predefinedResult};
+    };
+  };
+};
+
+// Test basic methods of class `Service`.
+TEST_F(ServiceTest, basicMethods) {
+  // Construct a parsed SERVICE clause by hand. The fourth argument is the query
+  // body (empty in this case because this test is not about evaluating a
+  // query). The fourth argument plays no role in our test (and isn't really
+  // used in `parsedQuery::Service` either).
+  parsedQuery::Service parsedServiceClause{{Variable{"?x"}, Variable{"?y"}},
+                                           Iri{"<http://localhorst/api>"},
+                                           "PREFIX doof: <http://doof.org>",
+                                           "{ }",
+                                           parsedQuery::GraphPattern{}};
+  // Create an operation from this.
+  Service serviceOp{testQec, parsedServiceClause};
+
+  // Test the basic methods.
+  ASSERT_EQ(serviceOp.getDescriptor(),
+            "Service with IRI <http://localhorst/api>");
+  ASSERT_EQ(serviceOp.getResultWidth(), 2);
+  ASSERT_EQ(serviceOp.getMultiplicity(0), 1);
+  ASSERT_EQ(serviceOp.getMultiplicity(1), 1);
+  ASSERT_EQ(serviceOp.getSizeEstimate(), 100'000);
+  ASSERT_EQ(serviceOp.getCostEstimate(), 1'000'000);
+  VariableToColumnMap varToColMap = serviceOp.computeVariableToColumnMap();
+  ASSERT_EQ(varToColMap.size(), 2);
+  ASSERT_EQ(varToColMap.at(Variable{"?x"}), 0);
+  ASSERT_EQ(varToColMap.at(Variable{"?y"}), 1);
+  ASSERT_FALSE(serviceOp.knownEmptyResult());
+  ASSERT_EQ(serviceOp.getChildren(), std::vector<QueryExecutionTree*>{});
+}
+
+// Tests that `computeResult` behaves as expected.
+TEST_F(ServiceTest, computeResult) {
+  // Construct a parsed SERVICE clause by hand, see `basicMethods` test above.
+  parsedQuery::Service parsedServiceClause{{Variable{"?x"}, Variable{"?y"}},
+                                           Iri{"<http://localhorst/api>"},
+                                           "PREFIX doof: <http://doof.org>",
+                                           "{ }",
+                                           parsedQuery::GraphPattern{}};
+
+  // This is the (port-normalized) URL and (whitespace-normalized) SPARQL query
+  // we expect.
+  std::string expectedUrl = "http://localhorst:80/api";
+  std::string expectedSparqlQuery =
+      "PREFIX doof: <http://doof.org> SELECT ?x ?y WHERE { }";
+
+  // CHECK 1: Returned TSV is empty -> an exception should be thrown.
+  Service serviceOperation1{
+      testQec, parsedServiceClause,
+      getTsvFunctionFactory(expectedUrl, expectedSparqlQuery, "")};
+  ASSERT_THROW(serviceOperation1.getResult(), ad_utility::AbortException);
+
+  // CHECK 2: Header row of returned TSV is wrong (variables in wrong order) ->
+  // an exception should be thrown.
+  Service serviceOperation2{
+      testQec, parsedServiceClause,
+      getTsvFunctionFactory(
+          expectedUrl, expectedSparqlQuery,
+          "?y\t?x\n<x>\t<y>\n<bla>\t<bli>\n<blu>\t<bla>\n<bli>\t<blu>\n")};
+  ASSERT_THROW(serviceOperation2.getResult(), ad_utility::AbortException);
+
+  // CHECK 3: Returned TSV has correct format matching the query -> check that
+  // the result table returned by the operation corresponds to the contents of
+  // the TSV and its local vocabulary are correct.
+  Service serviceOperation3{
+      testQec, parsedServiceClause,
+      getTsvFunctionFactory(
+          expectedUrl, expectedSparqlQuery,
+          "?x\t?y\n<x>\t<y>\n<bla>\t<bli>\n<blu>\t<bla>\n<bli>\t<blu>\n")};
+  std::shared_ptr<const ResultTable> result = serviceOperation3.getResult();
+
+  // Check that `<x>` and `<y>` were contained in the original vocabulary and
+  // that `<bla>`, `<bli>`, `<blu>` were added to the (initially empty) local
+  // vocabulary.
+  VocabIndex idxX;
+  VocabIndex idxY;
+  EXPECT_TRUE(testQec->getIndex().getVocab().getId("<x>", &idxX));
+  EXPECT_TRUE(testQec->getIndex().getVocab().getId("<y>", &idxY));
+  LocalVocabIndex idxBla = LocalVocabIndex::make(0);
+  LocalVocabIndex idxBli = LocalVocabIndex::make(1);
+  LocalVocabIndex idxBlu = LocalVocabIndex::make(2);
+  EXPECT_EQ(result->localVocab().getWord(idxBla), "<bla>");
+  EXPECT_EQ(result->localVocab().getWord(idxBli), "<bli>");
+  EXPECT_EQ(result->localVocab().getWord(idxBlu), "<blu>");
+
+  // Check that the result table corresponds to the contents of the TSV.
+  EXPECT_TRUE(result);
+  EXPECT_EQ(result->_idTable.numColumns(), 2);
+  EXPECT_EQ(result->_idTable.numRows(), 4);
+  Id idX = Id::makeFromVocabIndex(idxX);
+  Id idY = Id::makeFromVocabIndex(idxY);
+  Id idBla = Id::makeFromLocalVocabIndex(idxBla);
+  Id idBli = Id::makeFromLocalVocabIndex(idxBli);
+  Id idBlu = Id::makeFromLocalVocabIndex(idxBlu);
+  auto checkRow = [&](size_t rowIdx, Id id1, Id id2) {
+    EXPECT_EQ(result->_idTable(rowIdx, 0), id1) << "at row " << rowIdx;
+    EXPECT_EQ(result->_idTable(rowIdx, 1), id2) << "at row " << rowIdx;
+  };
+  checkRow(0, idX, idY);
+  checkRow(1, idBla, idBli);
+  checkRow(2, idBlu, idBla);
+  checkRow(3, idBli, idBlu);
+}

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -853,8 +853,10 @@ TEST(SparqlParser, GroupGraphPattern) {
   // graphGraphPattern and serviceGraphPattern are not supported.
   expectGroupGraphPatternFails("{ GRAPH ?a { } }");
   expectGroupGraphPatternFails("{ GRAPH <foo> { } }");
-  expectGroupGraphPatternFails("{ SERVICE <foo> { } }");
-  expectGroupGraphPatternFails("{ SERVICE SILENT ?bar { } }");
+
+  // TODO: Add tests for parsing of SERVICE queries.
+  // expectGroupGraphPatternFails("{ SERVICE <foo> { } }");
+  // expectGroupGraphPatternFails("{ SERVICE SILENT ?bar { } }");
 }
 
 TEST(SparqlParser, RDFLiteral) {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -860,8 +860,8 @@ TEST(SparqlParser, GroupGraphPattern) {
                                  "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }")));
 
   // SERVICE with SILENT or a variable endpoint is not yet supported.
-  expectGroupGraphPatternFails("{ SERVICE SILENT <ep> { ?s ?p ?o} }");
-  expectGroupGraphPatternFails("{ SERVICE ?endpoint { ?s ?p ?o} }");
+  expectGroupGraphPatternFails("{ SERVICE SILENT <ep> { ?s ?p ?o } }");
+  expectGroupGraphPatternFails("{ SERVICE ?endpoint { ?s ?p ?o } }");
 
   // graphGraphPattern is not supported.
   expectGroupGraphPatternFails("{ GRAPH ?a { } }");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -854,7 +854,14 @@ TEST(SparqlParser, GroupGraphPattern) {
                      m::GraphPattern(m::Service(
                          Iri{"<endpoint>"}, {Var{"?s"}, Var{"?p"}, Var{"?o"}},
                          "{ ?s ?p ?o }")));
-  expectGroupGraphPatternFails("{ SERVICE SILENT ?bar { } }");
+  expectGraphPattern(
+      "{ SERVICE <ep> { { SELECT ?s ?o WHERE { ?s ?p ?o } } } }",
+      m::GraphPattern(m::Service(Iri{"<ep>"}, {Var{"?s"}, Var{"?o"}},
+                                 "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }")));
+
+  // SERVICE with SILENT or a variable endpoint is not yet supported.
+  expectGroupGraphPatternFails("{ SERVICE SILENT <ep> { ?s ?p ?o} }");
+  expectGroupGraphPatternFails("{ SERVICE ?endpoint { ?s ?p ?o} }");
 
   // graphGraphPattern is not supported.
   expectGroupGraphPatternFails("{ GRAPH ?a { } }");
@@ -1018,7 +1025,7 @@ TEST(SparqlParser, Query) {
 
   // Test that the prologue is parsed properly. We use `m::Service` here
   // because the parsing of a SERVICE clause is the only place where the
-  // prologue is explicitly passed on from the parser.
+  // prologue is explicitly passed on to a `parsedQuery::` object.
   expectQuery(
       "PREFIX doof: <http://doof.org/> "
       "SELECT * WHERE { SERVICE <endpoint> { ?s ?p ?o } }",

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -17,6 +17,7 @@
 #include "parser/ParsedQuery.h"
 #include "parser/SparqlParserHelpers.h"
 #include "parser/TripleComponent.h"
+#include "parser/data/Iri.h"
 #include "parser/data/OrderKey.h"
 #include "parser/data/VarOrTerm.h"
 #include "parser/data/Variable.h"
@@ -461,6 +462,20 @@ inline auto InlineData = [](const std::vector<::Variable>& vars,
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this
   //  becomes a trivial Eq matcher.
   return detail::GraphPatternOperation<p::Values>(Values(vars, values));
+};
+
+inline auto Service = [](const ::Iri& iri,
+                         const std::vector<::Variable>& variables,
+                         const std::string& graphPattern,
+                         const std::string& prologue =
+                             "") -> Matcher<const p::GraphPatternOperation&> {
+  auto serviceMatcher = testing::AllOf(
+      AD_FIELD(p::Service, serviceIri_, testing::Eq(iri)),
+      AD_FIELD(p::Service, visibleVariables_,
+               testing::UnorderedElementsAreArray(variables)),
+      AD_FIELD(p::Service, graphPatternAsString_, testing::Eq(graphPattern)),
+      AD_FIELD(p::Service, prologue_, testing::Eq(prologue)));
+  return detail::GraphPatternOperation<p::Service>(serviceMatcher);
 };
 
 namespace detail {


### PR DESCRIPTION
First working implementation of SERVICE

Basic principle: Send the query inside the SERVICE clause to the remote endpoint and turn the result into a VALUES clause, which is then processed using the (in the meantime already committed) code from #820 and #822 and the (soon to be committed) code from #823.

1. Update `parsedQuery::Values` to hold a table of `TripleComponent`s
 instead of `std::string`s as before. Modify the `SparqlQleverVisitor` accordingly.

2. Update the `Values : Operation` class to add OOV entries to the
 `LocalVocab` (any row containing an oov entry was ignored so far).
 Update the JOIN operation to propagate the localVocab if only of the
 operands has one (which is a frequent use case).

3. Used the occasion to create a separate `LocalVocab` class with basic
 functionality for adding words to a local vocabulary once.

4. Add a new class HttpClient which can open HTTP and HTTPS connections
 to a given host, and which can then send GET or POST requests, receive the result synchronously, and write it to a (potentially very large)
 string. Uses Boost.Beast, just like our HttpServer.

5. Wrote a test for our HttpServer and HttpClient. However, the test so far only tests the HTTP case because our HttpServer just does HTTP so
 far. Also used the occasion to rename util/HttpServer to util/http
 because httpServer was simply a misnomer. This change required very many
 small changes (in includes and in the various CMakeLists.txt).