### PR TITLE
Consider localVocab for `Values` clause

### DIFF
--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -50,8 +50,8 @@ class Values : public Operation {
   virtual void computeResult(ResultTable* result) override;
 
   template <size_t I>
-  void writeValues(IdTable* res, const Index& index,
-                   const SparqlValues& values);
+  void writeValues(IdTable* res, const Index& index, const SparqlValues& values,
+                   std::shared_ptr<ResultTable::LocalVocab> localVocab);
 
   /// remove all completely undefined values and variables
   /// throw if nothing remains


### PR DESCRIPTION
Works fine with value literals. For foreign IRIs or literals, works only if they don't take part in any other operation (like a JOIN or SORT). That's more a job for Johannes to fix that.