### PR TITLE
Finalize Visitor Migration to Typesafe

### DIFF
--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -42,7 +42,7 @@ struct ParserAndVisitor {
 
   template <typename ContextType>
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {
-    auto resultOfParse = visitor_.visitTypesafe(std::invoke(F, parser_));
+    auto resultOfParse = visitor_.visit(std::invoke(F, parser_));
 
     auto remainingString =
         input_.substr(parser_.getCurrentToken()->getStartIndex());

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -126,18 +126,18 @@ PathTuples joinPredicateAndObject(VarOrPath predicate, ObjectList objectList) {
 }
 
 // ____________________________________________________________________________________
-ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
+ParsedQuery Visitor::visit(Parser::QueryContext* ctx) {
   // The prologue (BASE and PREFIX declarations)  only affects the internal
   // state of the visitor.
-  visitTypesafe(ctx->prologue());
+  visit(ctx->prologue());
   ParsedQuery query;
   // TODO<joka921, qup42> Check if there are more instances of this pattern
   //  (like `visitAlternative`, but with a custom error message), that would
   //  justify extracting this pattern.
   if (ctx->selectQuery()) {
-    query = visitTypesafe(ctx->selectQuery());
+    query = visit(ctx->selectQuery());
   } else if (ctx->constructQuery()) {
-    query = visitTypesafe(ctx->constructQuery());
+    query = visit(ctx->constructQuery());
   } else {
     reportError(ctx, "QLever only supports SELECT and CONSTRUCT queries.");
   }
@@ -148,7 +148,7 @@ ParsedQuery Visitor::visitTypesafe(Parser::QueryContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-SelectClause Visitor::visitTypesafe(Parser::SelectClauseContext* ctx) {
+SelectClause Visitor::visit(Parser::SelectClauseContext* ctx) {
   SelectClause select;
 
   select.distinct_ = static_cast<bool>(ctx->DISTINCT());
@@ -163,59 +163,89 @@ SelectClause Visitor::visitTypesafe(Parser::SelectClauseContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-VarOrAlias Visitor::visitTypesafe(Parser::VarOrAliasContext* ctx) {
+VarOrAlias Visitor::visit(Parser::VarOrAliasContext* ctx) {
   return visitAlternative<VarOrAlias>(ctx->var(), ctx->alias());
 }
 
 // ____________________________________________________________________________________
-Alias Visitor::visitTypesafe(Parser::AliasContext* ctx) {
+Alias Visitor::visit(Parser::AliasContext* ctx) {
   // A SPARQL alias has only one child, namely the contents within
   // parentheses.
-  return visitTypesafe(ctx->aliasWithoutBrackets());
+  return visit(ctx->aliasWithoutBrackets());
 }
 
 // ____________________________________________________________________________________
-Alias Visitor::visitTypesafe(Parser::AliasWithoutBracketsContext* ctx) {
-  return {{visitTypesafe(ctx->expression())}, visitTypesafe(ctx->var())};
+Alias Visitor::visit(Parser::AliasWithoutBracketsContext* ctx) {
+  return {{visit(ctx->expression())}, visit(ctx->var())};
 }
 
 // ____________________________________________________________________________________
-ParsedQuery Visitor::visitTypesafe(Parser::ConstructQueryContext* ctx) {
+ParsedQuery Visitor::visit(Parser::ConstructQueryContext* ctx) {
   if (!ctx->datasetClause().empty()) {
     reportError(ctx->datasetClause(0),
                 "QLever currently doesn't support FROM clauses");
   }
   ParsedQuery query;
   if (ctx->constructTemplate()) {
-    query._clause = visitTypesafe(ctx->constructTemplate())
+    query._clause = visit(ctx->constructTemplate())
                         .value_or(parsedQuery::ConstructClause{});
-    auto [pattern, visibleVariables] = visitTypesafe(ctx->whereClause());
+    auto [pattern, visibleVariables] = visit(ctx->whereClause());
     query._rootGraphPattern = std::move(pattern);
     query.registerVariablesVisibleInQueryBody(visibleVariables);
   } else {
     query._clause = parsedQuery::ConstructClause{
         visitOptional(ctx->triplesTemplate()).value_or(Triples{})};
   }
-  query.addSolutionModifiers(visitTypesafe(ctx->solutionModifier()));
+  query.addSolutionModifiers(visit(ctx->solutionModifier()));
 
   return query;
 }
 
 // ____________________________________________________________________________________
-Variable Visitor::visitTypesafe(Parser::VarContext* ctx) {
+void Visitor::visit(Parser::DescribeQueryContext* ctx) {
+  reportError(ctx, "DESCRIBE Queries are not supported.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::AskQueryContext* ctx) {
+  reportError(ctx, "ASK Queries are not supported.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::DatasetClauseContext* ctx) {
+  reportError(ctx, "FROM is not supported.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::DefaultGraphClauseContext* ctx) {
+  reportError(ctx, "FROM is not supported.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::NamedGraphClauseContext* ctx) {
+  reportError(ctx, "FROM is not supported.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::SourceSelectorContext* ctx) {
+  reportError(ctx, "FROM is not supported.");
+}
+
+// ____________________________________________________________________________________
+Variable Visitor::visit(Parser::VarContext* ctx) {
   return Variable{ctx->getText()};
 }
 
 // ____________________________________________________________________________________
-GraphPatternOperation Visitor::visitTypesafe(Parser::BindContext* ctx) {
+GraphPatternOperation Visitor::visit(Parser::BindContext* ctx) {
   addVisibleVariable(ctx->var()->getText());
   return GraphPatternOperation{
-      Bind{{visitTypesafe(ctx->expression())}, visitTypesafe(ctx->var())}};
+      Bind{{visit(ctx->expression())}, visit(ctx->var())}};
 }
 
 // ____________________________________________________________________________________
-GraphPatternOperation Visitor::visitTypesafe(Parser::InlineDataContext* ctx) {
-  Values values = visitTypesafe(ctx->dataBlock());
+GraphPatternOperation Visitor::visit(Parser::InlineDataContext* ctx) {
+  Values values = visit(ctx->dataBlock());
   for (const auto& variable : values._inlineValues._variables) {
     addVisibleVariable(variable);
   }
@@ -223,29 +253,29 @@ GraphPatternOperation Visitor::visitTypesafe(Parser::InlineDataContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Values Visitor::visitTypesafe(Parser::DataBlockContext* ctx) {
+Values Visitor::visit(Parser::DataBlockContext* ctx) {
   return visitAlternative<Values>(ctx->inlineDataOneVar(),
                                   ctx->inlineDataFull());
 }
 
 // ____________________________________________________________________________________
-std::optional<Values> Visitor::visitTypesafe(Parser::ValuesClauseContext* ctx) {
+std::optional<Values> Visitor::visit(Parser::ValuesClauseContext* ctx) {
   return visitOptional(ctx->dataBlock());
 }
 
 // ____________________________________________________________________________________
-GraphPattern Visitor::visitTypesafe(Parser::GroupGraphPatternContext* ctx) {
+GraphPattern Visitor::visit(Parser::GroupGraphPatternContext* ctx) {
   GraphPattern pattern;
   pattern._id = numGraphPatterns_++;
   if (ctx->subSelect()) {
-    auto [subquery, valuesOpt] = visitTypesafe(ctx->subSelect());
+    auto [subquery, valuesOpt] = visit(ctx->subSelect());
     pattern._graphPatterns.emplace_back(std::move(subquery));
     if (valuesOpt.has_value()) {
       pattern._graphPatterns.emplace_back(std::move(valuesOpt.value()));
     }
     return pattern;
   } else if (ctx->groupGraphPatternSub()) {
-    auto [subOps, filters] = visitTypesafe(ctx->groupGraphPatternSub());
+    auto [subOps, filters] = visit(ctx->groupGraphPatternSub());
 
     if (subOps.empty()) {
       reportError(ctx,
@@ -267,7 +297,7 @@ GraphPattern Visitor::visitTypesafe(Parser::GroupGraphPatternContext* ctx) {
   }
 }
 
-Visitor::OperationsAndFilters Visitor::visitTypesafe(
+Visitor::OperationsAndFilters Visitor::visit(
     Parser::GroupGraphPatternSubContext* ctx) {
   vector<GraphPatternOperation> ops;
   vector<SparqlFilter> filters;
@@ -280,7 +310,7 @@ Visitor::OperationsAndFilters Visitor::visitTypesafe(
   };
 
   if (ctx->triplesBlock()) {
-    ops.emplace_back(visitTypesafe(ctx->triplesBlock()));
+    ops.emplace_back(visit(ctx->triplesBlock()));
   }
   auto others = visitVector(ctx->graphPatternNotTriplesAndMaybeTriples());
   for (auto& [graphPattern, triples] : others) {
@@ -300,14 +330,14 @@ Visitor::OperationsAndFilters Visitor::visitTypesafe(
   return {std::move(ops), std::move(filters)};
 }
 
-Visitor::OperationOrFilterAndMaybeTriples Visitor::visitTypesafe(
+Visitor::OperationOrFilterAndMaybeTriples Visitor::visit(
     Parser::GraphPatternNotTriplesAndMaybeTriplesContext* ctx) {
-  return {visitTypesafe(ctx->graphPatternNotTriples()),
+  return {visit(ctx->graphPatternNotTriples()),
           visitOptional(ctx->triplesBlock())};
 }
 
 // ____________________________________________________________________________________
-BasicGraphPattern Visitor::visitTypesafe(Parser::TriplesBlockContext* ctx) {
+BasicGraphPattern Visitor::visit(Parser::TriplesBlockContext* ctx) {
   auto iri = [](const Iri& iri) -> TripleComponent { return iri.toSparql(); };
   auto blankNode = [](const BlankNode& blankNode) -> TripleComponent {
     return blankNode.toSparql();
@@ -366,15 +396,15 @@ BasicGraphPattern Visitor::visitTypesafe(Parser::TriplesBlockContext* ctx) {
   };
 
   BasicGraphPattern triples = {ad_utility::transform(
-      visitTypesafe(ctx->triplesSameSubjectPath()), convertAndRegisterTriple)};
+      visit(ctx->triplesSameSubjectPath()), convertAndRegisterTriple)};
   if (ctx->triplesBlock()) {
-    triples.appendTriples(visitTypesafe(ctx->triplesBlock()));
+    triples.appendTriples(visit(ctx->triplesBlock()));
   }
   return triples;
 }
 
 // ____________________________________________________________________________________
-Visitor::OperationOrFilter Visitor::visitTypesafe(
+Visitor::OperationOrFilter Visitor::visit(
     Parser::GraphPatternNotTriplesContext* ctx) {
   if (ctx->graphGraphPattern() || ctx->serviceGraphPattern()) {
     reportError(ctx,
@@ -387,30 +417,39 @@ Visitor::OperationOrFilter Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-GraphPatternOperation Visitor::visitTypesafe(
-    Parser::OptionalGraphPatternContext* ctx) {
-  auto pattern = visitTypesafe(ctx->groupGraphPattern());
+GraphPatternOperation Visitor::visit(Parser::OptionalGraphPatternContext* ctx) {
+  auto pattern = visit(ctx->groupGraphPattern());
   return GraphPatternOperation{parsedQuery::Optional{std::move(pattern)}};
 }
 
 // ____________________________________________________________________________________
-sparqlExpression::SparqlExpression::Ptr Visitor::visitTypesafe(
-    Parser::ExpressionContext* ctx) {
-  return visitTypesafe(ctx->conditionalOrExpression());
+void Visitor::visit(Parser::GraphGraphPatternContext* ctx) {
+  reportError(ctx, "Named Graphs (FROM, GRAPH) are not supported.");
 }
 
 // ____________________________________________________________________________________
-Visitor::PatternAndVisibleVariables Visitor::visitTypesafe(
+void Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
+  reportError(ctx, "Federated Queries (SERVICE) are not supported.");
+}
+
+// ____________________________________________________________________________________
+sparqlExpression::SparqlExpression::Ptr Visitor::visit(
+    Parser::ExpressionContext* ctx) {
+  return visit(ctx->conditionalOrExpression());
+}
+
+// ____________________________________________________________________________________
+Visitor::PatternAndVisibleVariables Visitor::visit(
     Parser::WhereClauseContext* ctx) {
   visibleVariables_.emplace_back();
-  auto pattern = visitTypesafe(ctx->groupGraphPattern());
+  auto pattern = visit(ctx->groupGraphPattern());
   auto visible = std::move(visibleVariables_.back());
   visibleVariables_.pop_back();
   return {std::move(pattern), std::move(visible)};
 }
 
 // ____________________________________________________________________________________
-SolutionModifiers Visitor::visitTypesafe(Parser::SolutionModifierContext* ctx) {
+SolutionModifiers Visitor::visit(Parser::SolutionModifierContext* ctx) {
   SolutionModifiers modifiers;
   visitIf(&modifiers.groupByVariables_, ctx->groupClause());
   visitIf(&modifiers.havingClauses_, ctx->havingClause());
@@ -420,8 +459,7 @@ SolutionModifiers Visitor::visitTypesafe(Parser::SolutionModifierContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-LimitOffsetClause Visitor::visitTypesafe(
-    Parser::LimitOffsetClausesContext* ctx) {
+LimitOffsetClause Visitor::visit(Parser::LimitOffsetClausesContext* ctx) {
   LimitOffsetClause clause{};
   visitIf(&clause._limit, ctx->limitClause());
   visitIf(&clause._offset, ctx->offsetClause());
@@ -430,7 +468,7 @@ LimitOffsetClause Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-vector<SparqlFilter> Visitor::visitTypesafe(Parser::HavingClauseContext* ctx) {
+vector<SparqlFilter> Visitor::visit(Parser::HavingClauseContext* ctx) {
   return visitVector(ctx->havingCondition());
 }
 
@@ -453,7 +491,7 @@ SparqlFilter parseFilter(auto* ctx,
 }  // namespace
 
 // ____________________________________________________________________________________
-SparqlFilter Visitor::visitTypesafe(Parser::HavingConditionContext* ctx) {
+SparqlFilter Visitor::visit(Parser::HavingConditionContext* ctx) {
   SparqlFilter filter = parseFilter(ctx, _prefixMap);
   if (filter._type == SparqlFilter::LANG_MATCHES) {
     throw ParseException(
@@ -466,27 +504,27 @@ SparqlFilter Visitor::visitTypesafe(Parser::HavingConditionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-vector<OrderKey> Visitor::visitTypesafe(Parser::OrderClauseContext* ctx) {
+vector<OrderKey> Visitor::visit(Parser::OrderClauseContext* ctx) {
   return visitVector(ctx->orderCondition());
 }
 
 // ____________________________________________________________________________________
-vector<GroupKey> Visitor::visitTypesafe(Parser::GroupClauseContext* ctx) {
+vector<GroupKey> Visitor::visit(Parser::GroupClauseContext* ctx) {
   return visitVector(ctx->groupCondition());
 }
 
 // ____________________________________________________________________________________
-std::optional<parsedQuery::ConstructClause> Visitor::visitTypesafe(
+std::optional<parsedQuery::ConstructClause> Visitor::visit(
     Parser::ConstructTemplateContext* ctx) {
   if (ctx->constructTriples()) {
-    return parsedQuery::ConstructClause{visitTypesafe(ctx->constructTriples())};
+    return parsedQuery::ConstructClause{visit(ctx->constructTriples())};
   } else {
     return std::nullopt;
   }
 }
 
 // ____________________________________________________________________________________
-string Visitor::visitTypesafe(Parser::StringContext* ctx) {
+string Visitor::visit(Parser::StringContext* ctx) {
   // TODO: The string rule also allow triple quoted strings with different
   //  escaping rules. These are currently not handled. They should be parsed
   //  into a typesafe format with a unique representation.
@@ -494,30 +532,30 @@ string Visitor::visitTypesafe(Parser::StringContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-string Visitor::visitTypesafe(Parser::IriContext* ctx) {
+string Visitor::visit(Parser::IriContext* ctx) {
   // TODO return an IRI, not a std::string.
   string langtag =
       ctx->PREFIX_LANGTAG() ? ctx->PREFIX_LANGTAG()->getText() : "";
   if (ctx->iriref()) {
-    return langtag + visitTypesafe(ctx->iriref());
+    return langtag + visit(ctx->iriref());
   } else {
     AD_CHECK(ctx->prefixedName())
-    return langtag + visitTypesafe(ctx->prefixedName());
+    return langtag + visit(ctx->prefixedName());
   }
 }
 
 // ____________________________________________________________________________________
-string Visitor::visitTypesafe(Parser::IrirefContext* ctx) {
+string Visitor::visit(Parser::IrirefContext* ctx) {
   return RdfEscaping::unescapeIriref(ctx->getText());
 }
 
 // ____________________________________________________________________________________
-string Visitor::visitTypesafe(Parser::PrefixedNameContext* ctx) {
+string Visitor::visit(Parser::PrefixedNameContext* ctx) {
   return visitAlternative<std::string>(ctx->pnameLn(), ctx->pnameNs());
 }
 
 // ____________________________________________________________________________________
-string Visitor::visitTypesafe(Parser::PnameLnContext* ctx) {
+string Visitor::visit(Parser::PnameLnContext* ctx) {
   string text = ctx->getText();
   auto pos = text.find(':');
   auto pnameNS = text.substr(0, pos);
@@ -534,7 +572,7 @@ string Visitor::visitTypesafe(Parser::PnameLnContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-string Visitor::visitTypesafe(Parser::PnameNsContext* ctx) {
+string Visitor::visit(Parser::PnameNsContext* ctx) {
   auto text = ctx->getText();
   auto prefix = text.substr(0, text.length() - 1);
   if (!_prefixMap.contains(prefix)) {
@@ -546,13 +584,13 @@ string Visitor::visitTypesafe(Parser::PnameNsContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-SparqlQleverVisitor::PrefixMap SparqlQleverVisitor::visitTypesafe(
+SparqlQleverVisitor::PrefixMap SparqlQleverVisitor::visit(
     SparqlAutomaticParser::PrologueContext* ctx) {
   if (!ctx->baseDecl().empty()) {
     reportError(ctx->baseDecl(0), "BaseDecl is not supported.");
   }
   for (const auto& prefix : ctx->prefixDecl()) {
-    visitTypesafe(prefix);
+    visit(prefix);
   }
   // TODO: we return a part of our internal state here. This will go away when
   //  queries can be parsed completely with ANTLR.
@@ -560,52 +598,51 @@ SparqlQleverVisitor::PrefixMap SparqlQleverVisitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-SparqlPrefix SparqlQleverVisitor::visitTypesafe(
+SparqlPrefix SparqlQleverVisitor::visit(
     SparqlAutomaticParser::BaseDeclContext* ctx) {
   reportError(ctx, "BaseDecl is not supported.");
 }
 
 // ____________________________________________________________________________________
-SparqlPrefix SparqlQleverVisitor::visitTypesafe(
+SparqlPrefix SparqlQleverVisitor::visit(
     SparqlAutomaticParser::PrefixDeclContext* ctx) {
   auto text = ctx->PNAME_NS()->getText();
   // Remove the ':' at the end of the PNAME_NS
   auto prefixLabel = text.substr(0, text.length() - 1);
-  auto prefixIri = visitTypesafe(ctx->iriref());
+  auto prefixIri = visit(ctx->iriref());
   _prefixMap[prefixLabel] = prefixIri;
   return {prefixLabel, prefixIri};
 }
 
 // ____________________________________________________________________________________
-ParsedQuery Visitor::visitTypesafe(Parser::SelectQueryContext* ctx) {
+ParsedQuery Visitor::visit(Parser::SelectQueryContext* ctx) {
   ParsedQuery query;
-  query._clause = visitTypesafe(ctx->selectClause());
+  query._clause = visit(ctx->selectClause());
   if (!ctx->datasetClause().empty()) {
     // TODO: see if it is possible to extend reportError s.t. it can also take
     //  vector<ParserRuleContext>.
     reportError(ctx->datasetClause(0),
                 "QLever currently doesn't support FROM clauses");
   }
-  auto [pattern, visibleVariables] = visitTypesafe(ctx->whereClause());
+  auto [pattern, visibleVariables] = visit(ctx->whereClause());
   query._rootGraphPattern = std::move(pattern);
   query.registerVariablesVisibleInQueryBody(visibleVariables);
-  query.addSolutionModifiers(visitTypesafe(ctx->solutionModifier()));
+  query.addSolutionModifiers(visit(ctx->solutionModifier()));
 
   return query;
 }
 
 // ____________________________________________________________________________________
-Visitor::SubQueryAndMaybeValues Visitor::visitTypesafe(
-    Parser::SubSelectContext* ctx) {
+Visitor::SubQueryAndMaybeValues Visitor::visit(Parser::SubSelectContext* ctx) {
   ParsedQuery query;
-  query._clause = visitTypesafe(ctx->selectClause());
-  auto [pattern, visibleVariables] = visitTypesafe(ctx->whereClause());
+  query._clause = visit(ctx->selectClause());
+  auto [pattern, visibleVariables] = visit(ctx->whereClause());
   query._rootGraphPattern = std::move(pattern);
   query.setNumInternalVariables(numInternalVariables_);
   query.registerVariablesVisibleInQueryBody(visibleVariables);
-  query.addSolutionModifiers(visitTypesafe(ctx->solutionModifier()));
+  query.addSolutionModifiers(visit(ctx->solutionModifier()));
   numInternalVariables_ = query.getNumInternalVariables();
-  auto values = visitTypesafe(ctx->valuesClause());
+  auto values = visit(ctx->valuesClause());
   // Variables that are selected in this query are visible in the parent query.
   for (const auto& variable : query.selectClause().getSelectedVariables()) {
     addVisibleVariable(variable);
@@ -615,13 +652,13 @@ Visitor::SubQueryAndMaybeValues Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-GroupKey Visitor::visitTypesafe(Parser::GroupConditionContext* ctx) {
+GroupKey Visitor::visit(Parser::GroupConditionContext* ctx) {
   // TODO<qup42> Deploy an abstraction `visitExpressionPimpl(someContext*)` that
   // performs exactly those two steps and is also used in all the other places
   // where we currently call
-  // `SparqlExpressionPimpl(visitTypesafe(ctx->something()))` manually.
+  // `SparqlExpressionPimpl(visit(ctx->something()))` manually.
   auto makeExpression = [&ctx, this](auto* subCtx) -> GroupKey {
-    auto expr = SparqlExpressionPimpl{visitTypesafe(subCtx)};
+    auto expr = SparqlExpressionPimpl{visit(subCtx)};
     expr.setDescriptor(ctx->getText());
     return expr;
   };
@@ -632,9 +669,9 @@ GroupKey Visitor::visitTypesafe(Parser::GroupConditionContext* ctx) {
     return (ctx->builtInCall() ? makeExpression(ctx->builtInCall())
                                : makeExpression(ctx->functionCall()));
   } else if (ctx->expression()) {
-    auto expr = SparqlExpressionPimpl{visitTypesafe(ctx->expression())};
+    auto expr = SparqlExpressionPimpl{visit(ctx->expression())};
     if (ctx->AS() && ctx->var()) {
-      return Alias{std::move(expr), visitTypesafe(ctx->var())};
+      return Alias{std::move(expr), visit(ctx->var())};
     } else {
       return expr;
     }
@@ -643,10 +680,10 @@ GroupKey Visitor::visitTypesafe(Parser::GroupConditionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-OrderKey Visitor::visitTypesafe(Parser::OrderConditionContext* ctx) {
+OrderKey Visitor::visit(Parser::OrderConditionContext* ctx) {
   auto visitExprOrderKey = [this](bool isDescending,
                                   auto* context) -> OrderKey {
-    auto expr = SparqlExpressionPimpl{visitTypesafe(context)};
+    auto expr = SparqlExpressionPimpl{visit(context)};
     if (auto exprIsVariable = expr.getVariableOrNullopt();
         exprIsVariable.has_value()) {
       return VariableOrderKey{exprIsVariable.value(), isDescending};
@@ -656,7 +693,7 @@ OrderKey Visitor::visitTypesafe(Parser::OrderConditionContext* ctx) {
   };
 
   if (ctx->var()) {
-    return VariableOrderKey(visitTypesafe(ctx->var()));
+    return VariableOrderKey(visit(ctx->var()));
   } else if (ctx->constraint()) {
     return visitExprOrderKey(false, ctx->constraint());
   } else if (ctx->brackettedExpression()) {
@@ -667,39 +704,37 @@ OrderKey Visitor::visitTypesafe(Parser::OrderConditionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-unsigned long long int Visitor::visitTypesafe(Parser::LimitClauseContext* ctx) {
-  return visitTypesafe(ctx->integer());
+unsigned long long int Visitor::visit(Parser::LimitClauseContext* ctx) {
+  return visit(ctx->integer());
 }
 
 // ____________________________________________________________________________________
-unsigned long long int Visitor::visitTypesafe(
-    Parser::OffsetClauseContext* ctx) {
-  return visitTypesafe(ctx->integer());
+unsigned long long int Visitor::visit(Parser::OffsetClauseContext* ctx) {
+  return visit(ctx->integer());
 }
 
 // ____________________________________________________________________________________
-unsigned long long int Visitor::visitTypesafe(
-    Parser::TextLimitClauseContext* ctx) {
-  return visitTypesafe(ctx->integer());
+unsigned long long int Visitor::visit(Parser::TextLimitClauseContext* ctx) {
+  return visit(ctx->integer());
 }
 
 // ____________________________________________________________________________________
-SparqlValues Visitor::visitTypesafe(Parser::InlineDataOneVarContext* ctx) {
+SparqlValues Visitor::visit(Parser::InlineDataOneVarContext* ctx) {
   SparqlValues values;
-  auto var = visitTypesafe(ctx->var());
+  auto var = visit(ctx->var());
   values._variables.push_back(var.name());
   if (ctx->dataBlockValue().empty())
     reportError(ctx,
                 "No values were specified in Values "
                 "clause. This is not supported by QLever.");
   for (auto& dataBlockValue : ctx->dataBlockValue()) {
-    values._values.push_back({visitTypesafe(dataBlockValue)});
+    values._values.push_back({visit(dataBlockValue)});
   }
   return values;
 }
 
 // ____________________________________________________________________________________
-SparqlValues Visitor::visitTypesafe(Parser::InlineDataFullContext* ctx) {
+SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
   SparqlValues values;
   if (ctx->dataBlockSingle().empty())
     reportError(ctx,
@@ -710,7 +745,7 @@ SparqlValues Visitor::visitTypesafe(Parser::InlineDataFullContext* ctx) {
                 "No variables were specified in Values "
                 "clause. This is not supported by QLever.");
   for (auto& var : ctx->var()) {
-    values._variables.push_back(visitTypesafe(var).name());
+    values._variables.push_back(visit(var).name());
   }
   values._values = visitVector(ctx->dataBlockSingle());
   if (std::any_of(values._values.begin(), values._values.end(),
@@ -725,8 +760,7 @@ SparqlValues Visitor::visitTypesafe(Parser::InlineDataFullContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-vector<std::string> Visitor::visitTypesafe(
-    Parser::DataBlockSingleContext* ctx) {
+vector<std::string> Visitor::visit(Parser::DataBlockSingleContext* ctx) {
   if (ctx->NIL())
     reportError(ctx,
                 "No values were specified in DataBlock."
@@ -735,12 +769,12 @@ vector<std::string> Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-std::string Visitor::visitTypesafe(Parser::DataBlockValueContext* ctx) {
+std::string Visitor::visit(Parser::DataBlockValueContext* ctx) {
   // Return a string
   if (ctx->iri()) {
-    return visitTypesafe(ctx->iri());
+    return visit(ctx->iri());
   } else if (ctx->rdfLiteral()) {
-    return visitTypesafe(ctx->rdfLiteral());
+    return visit(ctx->rdfLiteral());
   } else if (ctx->numericLiteral()) {
     // TODO implement
     reportError(ctx, "Numbers in values clauses are not supported.");
@@ -755,10 +789,9 @@ std::string Visitor::visitTypesafe(Parser::DataBlockValueContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-GraphPatternOperation Visitor::visitTypesafe(
-    Parser::MinusGraphPatternContext* ctx) {
+GraphPatternOperation Visitor::visit(Parser::MinusGraphPatternContext* ctx) {
   return GraphPatternOperation{
-      parsedQuery::Minus{visitTypesafe(ctx->groupGraphPattern())}};
+      parsedQuery::Minus{visit(ctx->groupGraphPattern())}};
 }
 
 // ____________________________________________________________________________________
@@ -771,7 +804,7 @@ GraphPattern wrap(GraphPatternOperation op) {
 }  // namespace
 
 // ____________________________________________________________________________________
-GraphPatternOperation Visitor::visitTypesafe(
+GraphPatternOperation Visitor::visit(
     Parser::GroupOrUnionGraphPatternContext* ctx) {
   auto children = visitVector(ctx->groupGraphPattern());
   if (children.size() > 1) {
@@ -793,25 +826,23 @@ GraphPatternOperation Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-SparqlFilter Visitor::visitTypesafe(Parser::FilterRContext* ctx) {
+SparqlFilter Visitor::visit(Parser::FilterRContext* ctx) {
   return parseFilter(ctx->constraint(), _prefixMap);
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::ConstraintContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::ConstraintContext* ctx) {
   return visitAlternative<ExpressionPtr>(
       ctx->brackettedExpression(), ctx->builtInCall(), ctx->functionCall());
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::FunctionCallContext* ctx) {
-  return processIriFunctionCall(visitTypesafe(ctx->iri()),
-                                visitTypesafe(ctx->argList()));
+ExpressionPtr Visitor::visit(Parser::FunctionCallContext* ctx) {
+  return processIriFunctionCall(visit(ctx->iri()), visit(ctx->argList()));
 }
 
 // ____________________________________________________________________________________
-vector<Visitor::ExpressionPtr> Visitor::visitTypesafe(
-    Parser::ArgListContext* ctx) {
+vector<Visitor::ExpressionPtr> Visitor::visit(Parser::ArgListContext* ctx) {
   // If no arguments, return empty expression vector.
   if (ctx->NIL()) {
     return std::vector<ExpressionPtr>{};
@@ -827,9 +858,16 @@ vector<Visitor::ExpressionPtr> Visitor::visitTypesafe(
   return visitVector(ctx->expression());
 }
 
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::ExpressionListContext* ctx) {
+  reportError(
+      ctx, "Expression List (CONCAT, COALESCE, IN, NOT IN) is not supported.");
+}
+
+// ____________________________________________________________________________________
 template <typename Context>
 Triples Visitor::parseTriplesConstruction(Context* ctx) {
-  auto result = visitTypesafe(ctx->triplesSameSubject());
+  auto result = visit(ctx->triplesSameSubject());
   Context* subContext = [](Context* ctx) -> Context* {
     if constexpr (std::is_same_v<Context, Parser::ConstructTriplesContext>) {
       return ctx->constructTriples();
@@ -839,38 +877,38 @@ Triples Visitor::parseTriplesConstruction(Context* ctx) {
     }
   }(ctx);
   if (subContext) {
-    auto newTriples = visitTypesafe(subContext);
+    auto newTriples = visit(subContext);
     ad_utility::appendVector(result, std::move(newTriples));
   }
   return result;
 }
 
 // ____________________________________________________________________________________
-Triples Visitor::visitTypesafe(Parser::ConstructTriplesContext* ctx) {
+Triples Visitor::visit(Parser::ConstructTriplesContext* ctx) {
   return parseTriplesConstruction(ctx);
 }
 
 // ____________________________________________________________________________________
-Triples Visitor::visitTypesafe(Parser::TriplesTemplateContext* ctx) {
+Triples Visitor::visit(Parser::TriplesTemplateContext* ctx) {
   return parseTriplesConstruction(ctx);
 }
 
 // ____________________________________________________________________________________
-Triples Visitor::visitTypesafe(Parser::TriplesSameSubjectContext* ctx) {
+Triples Visitor::visit(Parser::TriplesSameSubjectContext* ctx) {
   Triples triples;
   if (ctx->varOrTerm()) {
-    VarOrTerm subject = visitTypesafe(ctx->varOrTerm());
+    VarOrTerm subject = visit(ctx->varOrTerm());
     AD_CHECK(ctx->propertyListNotEmpty());
-    auto propertyList = visitTypesafe(ctx->propertyListNotEmpty());
+    auto propertyList = visit(ctx->propertyListNotEmpty());
     for (auto& tuple : propertyList.first) {
       triples.push_back({subject, std::move(tuple[0]), std::move(tuple[1])});
     }
     ad_utility::appendVector(triples, std::move(propertyList.second));
   } else if (ctx->triplesNode()) {
-    auto tripleNodes = visitTriplesNode(ctx->triplesNode()).as<Node>();
+    auto tripleNodes = visit(ctx->triplesNode());
     ad_utility::appendVector(triples, std::move(tripleNodes.second));
     AD_CHECK(ctx->propertyList());
-    auto propertyList = visitTypesafe(ctx->propertyList());
+    auto propertyList = visit(ctx->propertyList());
     for (auto& tuple : propertyList.first) {
       triples.push_back(
           {tripleNodes.first, std::move(tuple[0]), std::move(tuple[1])});
@@ -884,22 +922,21 @@ Triples Visitor::visitTypesafe(Parser::TriplesSameSubjectContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-PropertyList Visitor::visitTypesafe(Parser::PropertyListContext* ctx) {
-  return ctx->propertyListNotEmpty()
-             ? visitTypesafe(ctx->propertyListNotEmpty())
-             : PropertyList{Tuples{}, Triples{}};
+PropertyList Visitor::visit(Parser::PropertyListContext* ctx) {
+  return ctx->propertyListNotEmpty() ? visit(ctx->propertyListNotEmpty())
+                                     : PropertyList{Tuples{}, Triples{}};
 }
 
 // ____________________________________________________________________________________
-PropertyList Visitor::visitTypesafe(Parser::PropertyListNotEmptyContext* ctx) {
+PropertyList Visitor::visit(Parser::PropertyListNotEmptyContext* ctx) {
   Tuples triplesWithoutSubject;
   Triples additionalTriples;
   auto verbs = ctx->verb();
   auto objectLists = ctx->objectList();
   for (size_t i = 0; i < verbs.size(); i++) {
     // TODO use zip-style approach once C++ supports ranges
-    auto objectList = visitTypesafe(objectLists.at(i));
-    auto verb = visitTypesafe(verbs.at(i));
+    auto objectList = visit(objectLists.at(i));
+    auto verb = visit(verbs.at(i));
     for (auto& object : objectList.first) {
       triplesWithoutSubject.push_back({verb, std::move(object)});
     }
@@ -909,11 +946,11 @@ PropertyList Visitor::visitTypesafe(Parser::PropertyListNotEmptyContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-VarOrTerm Visitor::visitTypesafe(Parser::VerbContext* ctx) {
+VarOrTerm Visitor::visit(Parser::VerbContext* ctx) {
   // TODO<qup42, joka921> Is there a way to make this visitAlternative in the
   // presence of the a case?
   if (ctx->varOrIri()) {
-    return visitTypesafe(ctx->varOrIri());
+    return visit(ctx->varOrIri());
   } else if (ctx->getText() == "a") {
     // Special keyword 'a'
     return GraphTerm{Iri{"<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"}};
@@ -923,12 +960,12 @@ VarOrTerm Visitor::visitTypesafe(Parser::VerbContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ObjectList Visitor::visitTypesafe(Parser::ObjectListContext* ctx) {
+ObjectList Visitor::visit(Parser::ObjectListContext* ctx) {
   Objects objects;
   Triples additionalTriples;
   auto objectContexts = ctx->objectR();
   for (auto& objectContext : objectContexts) {
-    auto graphNode = visitTypesafe(objectContext);
+    auto graphNode = visit(objectContext);
     ad_utility::appendVector(additionalTriples, std::move(graphNode.second));
     objects.push_back(std::move(graphNode.first));
   }
@@ -936,12 +973,12 @@ ObjectList Visitor::visitTypesafe(Parser::ObjectListContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Node Visitor::visitTypesafe(Parser::ObjectRContext* ctx) {
-  return visitTypesafe(ctx->graphNode());
+Node Visitor::visit(Parser::ObjectRContext* ctx) {
+  return visit(ctx->graphNode());
 }
 
 // ___________________________________________________________________________
-vector<TripleWithPropertyPath> SparqlQleverVisitor::visitTypesafe(
+vector<TripleWithPropertyPath> SparqlQleverVisitor::visit(
     SparqlAutomaticParser::TriplesSameSubjectPathContext* ctx) {
   // If a triple `?var ql:contains-word "words"` or `?var ql:contains-entity
   // <entity>` is contained in the query, then the variable `?ql_textscore_var`
@@ -961,8 +998,8 @@ vector<TripleWithPropertyPath> SparqlQleverVisitor::visitTypesafe(
 
   if (ctx->varOrTerm()) {
     vector<TripleWithPropertyPath> triples;
-    auto subject = visitTypesafe(ctx->varOrTerm());
-    auto tuples = visitTypesafe(ctx->propertyListPathNotEmpty());
+    auto subject = visit(ctx->varOrTerm());
+    auto tuples = visit(ctx->propertyListPathNotEmpty());
     for (auto& [predicate, object] : tuples) {
       // TODO<clang,c++20> clang does not yet support emplace_back for
       // aggregates.
@@ -979,15 +1016,15 @@ vector<TripleWithPropertyPath> SparqlQleverVisitor::visitTypesafe(
 }
 
 // ___________________________________________________________________________
-std::optional<PathTuples> SparqlQleverVisitor::visitTypesafe(
+std::optional<PathTuples> SparqlQleverVisitor::visit(
     SparqlAutomaticParser::PropertyListPathContext* ctx) {
   return visitOptional(ctx->propertyListPathNotEmpty());
 }
 
 // ___________________________________________________________________________
-PathTuples SparqlQleverVisitor::visitTypesafe(
+PathTuples SparqlQleverVisitor::visit(
     SparqlAutomaticParser::PropertyListPathNotEmptyContext* ctx) {
-  PathTuples tuples = visitTypesafe(ctx->tupleWithPath());
+  PathTuples tuples = visit(ctx->tupleWithPath());
   vector<PathTuples> tuplesWithoutPaths = visitVector(ctx->tupleWithoutPath());
   for (auto& tuplesWithoutPath : tuplesWithoutPaths) {
     tuples.insert(tuples.end(), tuplesWithoutPath.begin(),
@@ -997,42 +1034,42 @@ PathTuples SparqlQleverVisitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::VerbPathContext* ctx) {
-  PropertyPath p = visitTypesafe(ctx->path());
+PropertyPath Visitor::visit(Parser::VerbPathContext* ctx) {
+  PropertyPath p = visit(ctx->path());
   // TODO move computeCanBeNull into PropertyPath constructor.
   p.computeCanBeNull();
   return p;
 }
 
 // ____________________________________________________________________________________
-Variable Visitor::visitTypesafe(Parser::VerbSimpleContext* ctx) {
-  return visitTypesafe(ctx->var());
+Variable Visitor::visit(Parser::VerbSimpleContext* ctx) {
+  return visit(ctx->var());
 }
 
 // ____________________________________________________________________________________
-PathTuples SparqlQleverVisitor::visitTypesafe(
+PathTuples SparqlQleverVisitor::visit(
     SparqlAutomaticParser::TupleWithoutPathContext* ctx) {
-  VarOrPath predicate = visitTypesafe(ctx->verbPathOrSimple());
-  ObjectList objectList = visitTypesafe(ctx->objectList());
+  VarOrPath predicate = visit(ctx->verbPathOrSimple());
+  ObjectList objectList = visit(ctx->objectList());
   return joinPredicateAndObject(predicate, objectList);
 }
 
 // ____________________________________________________________________________________
-PathTuples SparqlQleverVisitor::visitTypesafe(
+PathTuples SparqlQleverVisitor::visit(
     SparqlAutomaticParser::TupleWithPathContext* ctx) {
-  VarOrPath predicate = visitTypesafe(ctx->verbPathOrSimple());
-  ObjectList objectList = visitTypesafe(ctx->objectListPath());
+  VarOrPath predicate = visit(ctx->verbPathOrSimple());
+  ObjectList objectList = visit(ctx->objectListPath());
   return joinPredicateAndObject(predicate, objectList);
 }
 
 // ____________________________________________________________________________________
-VarOrPath Visitor::visitTypesafe(Parser::VerbPathOrSimpleContext* ctx) {
+VarOrPath Visitor::visit(Parser::VerbPathOrSimpleContext* ctx) {
   return visitAlternative<ad_utility::sparql_types::VarOrPath>(
       ctx->verbPath(), ctx->verbSimple());
 }
 
 // ___________________________________________________________________________
-ObjectList SparqlQleverVisitor::visitTypesafe(
+ObjectList SparqlQleverVisitor::visit(
     SparqlAutomaticParser::ObjectListPathContext* ctx) {
   // The second parameter is empty because collections and blank not paths,
   // which might add additional triples, are currently not supported.
@@ -1041,28 +1078,28 @@ ObjectList SparqlQleverVisitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-VarOrTerm Visitor::visitTypesafe(Parser::ObjectPathContext* ctx) {
-  return visitTypesafe(ctx->graphNodePath());
+VarOrTerm Visitor::visit(Parser::ObjectPathContext* ctx) {
+  return visit(ctx->graphNodePath());
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::PathContext* ctx) {
-  return visitTypesafe(ctx->pathAlternative());
+PropertyPath Visitor::visit(Parser::PathContext* ctx) {
+  return visit(ctx->pathAlternative());
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::PathAlternativeContext* ctx) {
+PropertyPath Visitor::visit(Parser::PathAlternativeContext* ctx) {
   return PropertyPath::makeAlternative(visitVector(ctx->pathSequence()));
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::PathSequenceContext* ctx) {
+PropertyPath Visitor::visit(Parser::PathSequenceContext* ctx) {
   return PropertyPath::makeSequence(visitVector(ctx->pathEltOrInverse()));
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::PathEltContext* ctx) {
-  PropertyPath p = visitTypesafe(ctx->pathPrimary());
+PropertyPath Visitor::visit(Parser::PathEltContext* ctx) {
+  PropertyPath p = visit(ctx->pathPrimary());
 
   if (ctx->pathMod()) {
     // TODO move case distinction +/*/? into PropertyPath.
@@ -1081,8 +1118,8 @@ PropertyPath Visitor::visitTypesafe(Parser::PathEltContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::PathEltOrInverseContext* ctx) {
-  PropertyPath p = visitTypesafe(ctx->pathElt());
+PropertyPath Visitor::visit(Parser::PathEltOrInverseContext* ctx) {
+  PropertyPath p = visit(ctx->pathElt());
 
   if (ctx->negationOperator) {
     p = PropertyPath::makeInverse(std::move(p));
@@ -1092,15 +1129,21 @@ PropertyPath Visitor::visitTypesafe(Parser::PathEltOrInverseContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(Parser::PathPrimaryContext* ctx) {
+void Visitor::visit(Parser::PathModContext*) {
+  // PathMod should be handled by upper clauses. It should not be visited.
+  AD_FAIL();
+}
+
+// ____________________________________________________________________________________
+PropertyPath Visitor::visit(Parser::PathPrimaryContext* ctx) {
   // TODO<qup42, joka921> Is there a way to make this visitAlternative in the
   // presence of the a case?
   if (ctx->iri()) {
-    return PropertyPath::fromIri(visitTypesafe(ctx->iri()));
+    return PropertyPath::fromIri(visit(ctx->iri()));
   } else if (ctx->path()) {
-    return visitTypesafe(ctx->path());
+    return visit(ctx->path());
   } else if (ctx->pathNegatedPropertySet()) {
-    return visitTypesafe(ctx->pathNegatedPropertySet());
+    return visit(ctx->pathNegatedPropertySet());
   } else if (ctx->getText() == "a") {
     // Special keyword 'a'
     return PropertyPath::fromIri(
@@ -1110,13 +1153,18 @@ PropertyPath Visitor::visitTypesafe(Parser::PathPrimaryContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visitTypesafe(
-    Parser::PathNegatedPropertySetContext* ctx) {
+PropertyPath Visitor::visit(Parser::PathNegatedPropertySetContext* ctx) {
   reportError(ctx, "\"!\" inside a property path is not supported by QLever.");
 }
 
 // ____________________________________________________________________________________
-unsigned long long int Visitor::visitTypesafe(Parser::IntegerContext* ctx) {
+void Visitor::visit(Parser::PathOneInPropertySetContext* ctx) {
+  reportError(
+      ctx, R"("!" and "^" inside a property path is not supported by QLever.)");
+}
+
+// ____________________________________________________________________________________
+unsigned long long int Visitor::visit(Parser::IntegerContext* ctx) {
   try {
     return std::stoull(ctx->getText());
   } catch (const std::out_of_range&) {
@@ -1128,16 +1176,16 @@ unsigned long long int Visitor::visitTypesafe(Parser::IntegerContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Node Visitor::visitTypesafe(Parser::TriplesNodeContext* ctx) {
+Node Visitor::visit(Parser::TriplesNodeContext* ctx) {
   return visitAlternative<Node>(ctx->collection(),
                                 ctx->blankNodePropertyList());
 }
 
 // ____________________________________________________________________________________
-Node Visitor::visitTypesafe(Parser::BlankNodePropertyListContext* ctx) {
+Node Visitor::visit(Parser::BlankNodePropertyListContext* ctx) {
   VarOrTerm var{GraphTerm{newBlankNode()}};
   Triples triples;
-  auto propertyList = visitTypesafe(ctx->propertyListNotEmpty());
+  auto propertyList = visit(ctx->propertyListNotEmpty());
   for (auto& tuple : propertyList.first) {
     triples.push_back({var, std::move(tuple[0]), std::move(tuple[1])});
   }
@@ -1146,14 +1194,28 @@ Node Visitor::visitTypesafe(Parser::BlankNodePropertyListContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Node Visitor::visitTypesafe(Parser::CollectionContext* ctx) {
+void Visitor::visit(Parser::TriplesNodePathContext* ctx) {
+  // TODO: should be moved into the children. But visitAlternative does not
+  //  support returning void.
+  throwCollectionsAndBlankNodePathsNotSupported(ctx);
+  AD_FAIL()  // Should be unreachable.
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::BlankNodePropertyListPathContext* ctx) {
+  throwCollectionsAndBlankNodePathsNotSupported(ctx);
+  AD_FAIL()  // Should be unreachable.
+}
+
+// ____________________________________________________________________________________
+Node Visitor::visit(Parser::CollectionContext* ctx) {
   Triples triples;
   VarOrTerm nextElement{
       GraphTerm{Iri{"<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>"}}};
   auto nodes = ctx->graphNode();
   for (auto context : Reversed{nodes}) {
     VarOrTerm currentVar{GraphTerm{newBlankNode()}};
-    auto graphNode = visitTypesafe(context);
+    auto graphNode = visit(context);
 
     triples.push_back(
         {currentVar,
@@ -1173,21 +1235,27 @@ Node Visitor::visitTypesafe(Parser::CollectionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Node Visitor::visitTypesafe(Parser::GraphNodeContext* ctx) {
+void Visitor::visit(Parser::CollectionPathContext* ctx) {
+  throwCollectionsAndBlankNodePathsNotSupported(ctx);
+  AD_FAIL()  // Should be unreachable.
+}
+
+// ____________________________________________________________________________________
+Node Visitor::visit(Parser::GraphNodeContext* ctx) {
   if (ctx->varOrTerm()) {
-    return {visitTypesafe(ctx->varOrTerm()), Triples{}};
+    return {visit(ctx->varOrTerm()), Triples{}};
   } else if (ctx->triplesNode()) {
-    return visitTriplesNode(ctx->triplesNode()).as<Node>();
+    return visit(ctx->triplesNode());
   } else {
     AD_FAIL();
   }
 }
 
 // ____________________________________________________________________________________
-VarOrTerm SparqlQleverVisitor::visitTypesafe(
+VarOrTerm SparqlQleverVisitor::visit(
     SparqlAutomaticParser::GraphNodePathContext* ctx) {
   if (ctx->varOrTerm()) {
-    return visitTypesafe(ctx->varOrTerm());
+    return visit(ctx->varOrTerm());
   } else if (ctx->triplesNodePath()) {
     throwCollectionsAndBlankNodePathsNotSupported(ctx->triplesNodePath());
   } else {
@@ -1196,30 +1264,30 @@ VarOrTerm SparqlQleverVisitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-VarOrTerm Visitor::visitTypesafe(Parser::VarOrTermContext* ctx) {
+VarOrTerm Visitor::visit(Parser::VarOrTermContext* ctx) {
   return visitAlternative<VarOrTerm>(ctx->var(), ctx->graphTerm());
 }
 
 // ____________________________________________________________________________________
-VarOrTerm Visitor::visitTypesafe(Parser::VarOrIriContext* ctx) {
+VarOrTerm Visitor::visit(Parser::VarOrIriContext* ctx) {
   if (ctx->var()) {
-    return visitTypesafe(ctx->var());
+    return visit(ctx->var());
   } else if (ctx->iri()) {
-    // TODO<qup42> If `visitTypesafe` returns an `Iri` and `VarOrTerm` can be
+    // TODO<qup42> If `visit` returns an `Iri` and `VarOrTerm` can be
     // constructed from an `Iri`, this whole function becomes
     // `visitAlternative`.
-    return GraphTerm{Iri{visitTypesafe(ctx->iri())}};
+    return GraphTerm{Iri{visit(ctx->iri())}};
   } else {
     AD_FAIL()  // Should be unreachable.
   }
 }
 
 // ____________________________________________________________________________________
-GraphTerm Visitor::visitTypesafe(Parser::GraphTermContext* ctx) {
+GraphTerm Visitor::visit(Parser::GraphTermContext* ctx) {
   if (ctx->blankNode()) {
-    return visitTypesafe(ctx->blankNode());
+    return visit(ctx->blankNode());
   } else if (ctx->iri()) {
-    return Iri{visitTypesafe(ctx->iri())};
+    return Iri{visit(ctx->iri())};
   } else if (ctx->NIL()) {
     return Iri{"<http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>"};
   } else {
@@ -1229,8 +1297,7 @@ GraphTerm Visitor::visitTypesafe(Parser::GraphTermContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(
-    Parser::ConditionalOrExpressionContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::ConditionalOrExpressionContext* ctx) {
   auto childContexts = ctx->conditionalAndExpression();
   auto children = visitVector(ctx->conditionalAndExpression());
   AD_CHECK(!children.empty());
@@ -1246,8 +1313,7 @@ ExpressionPtr Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(
-    Parser::ConditionalAndExpressionContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::ConditionalAndExpressionContext* ctx) {
   auto children = visitVector(ctx->valueLogical());
   AD_CHECK(!children.empty());
   auto result = std::move(children.front());
@@ -1262,16 +1328,16 @@ ExpressionPtr Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::ValueLogicalContext* ctx) {
-  return visitTypesafe(ctx->relationalExpression());
+ExpressionPtr Visitor::visit(Parser::ValueLogicalContext* ctx) {
+  return visit(ctx->relationalExpression());
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::RelationalExpressionContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::RelationalExpressionContext* ctx) {
   auto childContexts = ctx->numericExpression();
 
   if (childContexts.size() == 1) {
-    return visitTypesafe(childContexts[0]);
+    return visit(childContexts[0]);
   }
   if (false) {
     // TODO<joka921> Once we have reviewed and merged the EqualsExpression,
@@ -1296,12 +1362,12 @@ ExpressionPtr Visitor::visitTypesafe(Parser::RelationalExpressionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::NumericExpressionContext* ctx) {
-  return visitTypesafe(ctx->additiveExpression());
+ExpressionPtr Visitor::visit(Parser::NumericExpressionContext* ctx) {
+  return visit(ctx->additiveExpression());
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::AdditiveExpressionContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::AdditiveExpressionContext* ctx) {
   auto children = visitVector(ctx->multiplicativeExpression());
   auto opTypes = visitOperationTags(ctx->children, {"+", "-"});
 
@@ -1334,8 +1400,15 @@ ExpressionPtr Visitor::visitTypesafe(Parser::AdditiveExpressionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(
-    Parser::MultiplicativeExpressionContext* ctx) {
+void Visitor::visit(
+    Parser::StrangeMultiplicativeSubexprOfAdditiveContext* ctx) {
+  reportError(
+      ctx,
+      "StrangeMultiplicativeSubexprOfAdditiveContext must not be visited.");
+}
+
+// ____________________________________________________________________________________
+ExpressionPtr Visitor::visit(Parser::MultiplicativeExpressionContext* ctx) {
   auto children = visitVector(ctx->unaryExpression());
   auto opTypes = visitOperationTags(ctx->children, {"*", "/"});
 
@@ -1362,8 +1435,8 @@ ExpressionPtr Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::UnaryExpressionContext* ctx) {
-  auto child = visitTypesafe(ctx->primaryExpression());
+ExpressionPtr Visitor::visit(Parser::UnaryExpressionContext* ctx) {
+  auto child = visit(ctx->primaryExpression());
   if (ctx->children[0]->getText() == "-") {
     return createExpression<sparqlExpression::UnaryMinusExpression>(
         std::move(child));
@@ -1377,7 +1450,7 @@ ExpressionPtr Visitor::visitTypesafe(Parser::UnaryExpressionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::PrimaryExpressionContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::PrimaryExpressionContext* ctx) {
   using std::make_unique;
   using namespace sparqlExpression;
 
@@ -1394,11 +1467,11 @@ ExpressionPtr Visitor::visitTypesafe(Parser::PrimaryExpressionContext* ctx) {
     };
     return std::visit(
         ad_utility::OverloadCallOperator{integralWrapper, doubleWrapper},
-        visitTypesafe(ctx->numericLiteral()));
+        visit(ctx->numericLiteral()));
   } else if (ctx->booleanLiteral()) {
-    return make_unique<BoolExpression>(visitTypesafe(ctx->booleanLiteral()));
+    return make_unique<BoolExpression>(visit(ctx->booleanLiteral()));
   } else if (ctx->var()) {
-    return make_unique<VariableExpression>(visitTypesafe(ctx->var()));
+    return make_unique<VariableExpression>(visit(ctx->var()));
   } else {
     return visitAlternative<ExpressionPtr>(
         ctx->builtInCall(), ctx->iriOrFunction(), ctx->brackettedExpression());
@@ -1406,15 +1479,14 @@ ExpressionPtr Visitor::visitTypesafe(Parser::PrimaryExpressionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::BrackettedExpressionContext* ctx) {
-  return visitTypesafe(ctx->expression());
+ExpressionPtr Visitor::visit(Parser::BrackettedExpressionContext* ctx) {
+  return visit(ctx->expression());
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(
-    [[maybe_unused]] Parser::BuiltInCallContext* ctx) {
+ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
   if (ctx->aggregate()) {
-    return visitTypesafe(ctx->aggregate());
+    return visit(ctx->aggregate());
     // TODO: Implement built-in calls according to the following examples.
     //
     // } else if (ad_utility::getLowercase(ctx->children[0]->getText()) ==
@@ -1441,7 +1513,32 @@ ExpressionPtr Visitor::visitTypesafe(
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::AggregateContext* ctx) {
+void Visitor::visit(Parser::RegexExpressionContext* ctx) {
+  reportError(ctx, "The REGEX built in function is not yet implemented.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::SubstringExpressionContext* ctx) {
+  reportError(ctx, "The SUBSTR built in function is not yet implemented.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::StrReplaceExpressionContext* ctx) {
+  reportError(ctx, "The REPLACE built in function is not yet implemented.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::ExistsFuncContext* ctx) {
+  reportError(ctx, "The EXISTS built in function is not yet implemented.");
+}
+
+// ____________________________________________________________________________________
+void Visitor::visit(Parser::NotExistsFuncContext* ctx) {
+  reportError(ctx, "The NOT EXISTS built in function is not yet implemented.");
+}
+
+// ____________________________________________________________________________________
+ExpressionPtr Visitor::visit(Parser::AggregateContext* ctx) {
   using namespace sparqlExpression;
   // the only case that there is no child expression is COUNT(*), so we can
   // check this outside the if below.
@@ -1450,7 +1547,7 @@ ExpressionPtr Visitor::visitTypesafe(Parser::AggregateContext* ctx) {
                 "This parser currently doesn't support COUNT(*), please "
                 "specify an explicit expression for the COUNT");
   }
-  auto childExpression = visitTypesafe(ctx->expression());
+  auto childExpression = visit(ctx->expression());
   auto children = ctx->children;
   bool distinct = false;
   for (const auto& child : children) {
@@ -1485,7 +1582,7 @@ ExpressionPtr Visitor::visitTypesafe(Parser::AggregateContext* ctx) {
       // TODO: The string rule also allow triple quoted strings with different
       //  escaping rules. These are currently not handled. They should be parsed
       //  into a typesafe format with a unique representation.
-      separator = visitTypesafe(ctx->string());
+      separator = visit(ctx->string());
       // If there was a separator, we have to strip the quotation marks
       AD_CHECK(separator.size() >= 2);
       separator = separator.substr(1, separator.size() - 2);
@@ -1501,32 +1598,31 @@ ExpressionPtr Visitor::visitTypesafe(Parser::AggregateContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-ExpressionPtr Visitor::visitTypesafe(Parser::IriOrFunctionContext* ctx) {
+ExpressionPtr Visitor::visit(Parser::IriOrFunctionContext* ctx) {
   // Case 1: Just an IRI.
   if (ctx->argList() == nullptr) {
     return std::make_unique<sparqlExpression::StringOrIriExpression>(
         ctx->getText());
   }
   // Case 2: Function call, where the function name is an IRI.
-  return processIriFunctionCall(visitTypesafe(ctx->iri()),
-                                visitTypesafe(ctx->argList()));
+  return processIriFunctionCall(visit(ctx->iri()), visit(ctx->argList()));
 }
 
 // ____________________________________________________________________________________
-std::string Visitor::visitTypesafe(Parser::RdfLiteralContext* ctx) {
+std::string Visitor::visit(Parser::RdfLiteralContext* ctx) {
   // TODO: This should really be an RdfLiteral class that stores a unified
   //  version of the string, and the langtag/datatype separately.
-  string ret = visitTypesafe(ctx->string());
+  string ret = visit(ctx->string());
   if (ctx->LANGTAG()) {
     ret += ctx->LANGTAG()->getText();
   } else if (ctx->iri()) {
-    ret += ("^^" + visitTypesafe(ctx->iri()));
+    ret += ("^^" + visit(ctx->iri()));
   }
   return ret;
 }
 
 // ____________________________________________________________________________________
-std::variant<int64_t, double> Visitor::visitTypesafe(
+std::variant<int64_t, double> Visitor::visit(
     Parser::NumericLiteralContext* ctx) {
   return visitAlternative<std::variant<int64_t, double>>(
       ctx->numericLiteralUnsigned(), ctx->numericLiteralPositive(),
@@ -1551,30 +1647,30 @@ std::variant<int64_t, double> parseNumericLiteral(Ctx* ctx, bool parseAsInt) {
 }  // namespace
 
 // ____________________________________________________________________________________
-std::variant<int64_t, double> Visitor::visitTypesafe(
+std::variant<int64_t, double> Visitor::visit(
     Parser::NumericLiteralUnsignedContext* ctx) {
   return parseNumericLiteral(ctx, ctx->INTEGER());
 }
 
 // ____________________________________________________________________________________
-std::variant<int64_t, double> Visitor::visitTypesafe(
+std::variant<int64_t, double> Visitor::visit(
     Parser::NumericLiteralPositiveContext* ctx) {
   return parseNumericLiteral(ctx, ctx->INTEGER_POSITIVE());
 }
 
 // ____________________________________________________________________________________
-std::variant<int64_t, double> Visitor::visitTypesafe(
+std::variant<int64_t, double> Visitor::visit(
     Parser::NumericLiteralNegativeContext* ctx) {
   return parseNumericLiteral(ctx, ctx->INTEGER_NEGATIVE());
 }
 
 // ____________________________________________________________________________________
-bool Visitor::visitTypesafe(Parser::BooleanLiteralContext* ctx) {
+bool Visitor::visit(Parser::BooleanLiteralContext* ctx) {
   return ctx->getText() == "true";
 }
 
 // ____________________________________________________________________________________
-BlankNode Visitor::visitTypesafe(Parser::BlankNodeContext* ctx) {
+BlankNode Visitor::visit(Parser::BlankNodeContext* ctx) {
   if (ctx->ANON()) {
     return newBlankNode();
   }
@@ -1593,10 +1689,10 @@ BlankNode Visitor::visitTypesafe(Parser::BlankNodeContext* ctx) {
 
 template <typename Ctx>
 auto Visitor::visitVector(const std::vector<Ctx*>& childContexts)
-    -> std::vector<decltype(visitTypesafe(childContexts[0]))> {
-  std::vector<decltype(visitTypesafe(childContexts[0]))> children;
+    -> std::vector<decltype(visit(childContexts[0]))> {
+  std::vector<decltype(visit(childContexts[0]))> children;
   for (const auto& child : childContexts) {
-    children.emplace_back(std::move(visitTypesafe(child)));
+    children.emplace_back(std::move(visit(child)));
   }
   return children;
 }
@@ -1615,10 +1711,9 @@ Out Visitor::visitAlternative(Contexts*... ctxs) {
 
 // ____________________________________________________________________________________
 template <typename Ctx>
-auto Visitor::visitOptional(Ctx* ctx)
-    -> std::optional<decltype(visitTypesafe(ctx))> {
+auto Visitor::visitOptional(Ctx* ctx) -> std::optional<decltype(visit(ctx))> {
   if (ctx) {
-    return visitTypesafe(ctx);
+    return visit(ctx);
   } else {
     return std::nullopt;
   }
@@ -1628,7 +1723,7 @@ auto Visitor::visitOptional(Ctx* ctx)
 template <typename Target, typename Intermediate, typename Ctx>
 void Visitor::visitIf(Target* target, Ctx* ctx) {
   if (ctx) {
-    *target = Intermediate{visitTypesafe(ctx)};
+    *target = Intermediate{visit(ctx)};
   }
 }
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -1,5 +1,8 @@
-
-// Generated from SparqlAutomatic.g4 by ANTLR 4.9.2
+// Copyright 2021, University of Freiburg,
+// Chair of Algorithms and Data Structures
+// Authors:
+//   2021 - Johannes Kalmbach <kalmbacj@informatik.uni-freiburg.de>
+//   2022   Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 
 #pragma once
 
@@ -43,7 +46,7 @@ class Reversed {
  * extended to create a visitor which only needs to handle a subset of the
  * available methods.
  */
-class SparqlQleverVisitor : public SparqlAutomaticVisitor {
+class SparqlQleverVisitor {
   using GraphPatternOperation = parsedQuery::GraphPatternOperation;
   using Objects = ad_utility::sparql_types::Objects;
   using Tuples = ad_utility::sparql_types::Tuples;
@@ -55,7 +58,6 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   using Node = ad_utility::sparql_types::Node;
   using ObjectList = ad_utility::sparql_types::ObjectList;
   using PropertyList = ad_utility::sparql_types::PropertyList;
-  using Any = antlrcpp::Any;
   using OperationsAndFilters =
       std::pair<vector<GraphPatternOperation>, vector<SparqlFilter>>;
   using OperationOrFilterAndMaybeTriples =
@@ -82,20 +84,6 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   SparqlQleverVisitor(PrefixMap prefixMap) : _prefixMap{std::move(prefixMap)} {}
   using ExpressionPtr = sparqlExpression::SparqlExpression::Ptr;
 
-  // The inherited default behavior of `visitChildren` does not work with
-  // move-only types like `SparqlExpression::Ptr`. This overriding
-  // implementation adds std::move, but is otherwise the same as the default.
-  Any visitChildren(antlr4::tree::ParseTree* node) override {
-    Any result = nullptr;
-    size_t n = node->children.size();
-    for (size_t i = 0; i < n; i++) {
-      Any childResult = node->children[i]->accept(this);
-      result = std::move(childResult);
-    }
-
-    return result;
-  }
-
   void setPrefixMapManually(PrefixMap map) { _prefixMap = std::move(map); }
 
  private:
@@ -120,588 +108,211 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
 
  public:
   // ___________________________________________________________________________
-  Any visitQuery(Parser::QueryContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ParsedQuery visitTypesafe(Parser::QueryContext* ctx);
+  ParsedQuery visit(Parser::QueryContext* ctx);
 
   // ___________________________________________________________________________
-  Any visitPrologue(Parser::PrologueContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  PrefixMap visitTypesafe(SparqlAutomaticParser::PrologueContext* ctx);
+  PrefixMap visit(SparqlAutomaticParser::PrologueContext* ctx);
 
   // ___________________________________________________________________________
-  Any visitBaseDecl(Parser::BaseDeclContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  SparqlPrefix visitTypesafe(Parser::BaseDeclContext* ctx);
+  SparqlPrefix visit(Parser::BaseDeclContext* ctx);
 
   // ___________________________________________________________________________
-  Any visitPrefixDecl(Parser::PrefixDeclContext* ctx) override {
-    // This function only changes the state and the return is only for testing.
-    return visitTypesafe(ctx);
-  }
+  SparqlPrefix visit(Parser::PrefixDeclContext* ctx);
 
-  SparqlPrefix visitTypesafe(Parser::PrefixDeclContext* ctx);
+  ParsedQuery visit(Parser::SelectQueryContext* ctx);
 
-  Any visitSelectQuery(Parser::SelectQueryContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  SubQueryAndMaybeValues visit(Parser::SubSelectContext* ctx);
 
-  ParsedQuery visitTypesafe(Parser::SelectQueryContext* ctx);
+  parsedQuery::SelectClause visit(Parser::SelectClauseContext* ctx);
 
-  Any visitSubSelect(Parser::SubSelectContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  std::variant<Variable, Alias> visit(Parser::VarOrAliasContext* ctx);
 
-  SubQueryAndMaybeValues visitTypesafe(Parser::SubSelectContext* ctx);
+  Alias visit(Parser::AliasContext* ctx);
 
-  Any visitSelectClause(Parser::SelectClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  Alias visit(Parser::AliasWithoutBracketsContext* ctx);
 
-  parsedQuery::SelectClause visitTypesafe(Parser::SelectClauseContext* ctx);
+  ParsedQuery visit(Parser::ConstructQueryContext* ctx);
 
-  Any visitVarOrAlias(Parser::VarOrAliasContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::DescribeQueryContext* ctx);
 
-  std::variant<Variable, Alias> visitTypesafe(Parser::VarOrAliasContext* ctx);
+  [[noreturn]] void visit(Parser::AskQueryContext* ctx);
 
-  Any visitAlias(Parser::AliasContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::DatasetClauseContext* ctx);
 
-  Alias visitTypesafe(Parser::AliasContext* ctx);
+  [[noreturn]] void visit(Parser::DefaultGraphClauseContext* ctx);
 
-  Any visitAliasWithoutBrackets(
-      Parser::AliasWithoutBracketsContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::NamedGraphClauseContext* ctx);
 
-  Alias visitTypesafe(Parser::AliasWithoutBracketsContext* ctx);
+  [[noreturn]] void visit(Parser::SourceSelectorContext* ctx);
 
-  Any visitConstructQuery(Parser::ConstructQueryContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PatternAndVisibleVariables visit(Parser::WhereClauseContext* ctx);
 
-  ParsedQuery visitTypesafe(Parser::ConstructQueryContext* ctx);
+  SolutionModifiers visit(Parser::SolutionModifierContext* ctx);
 
-  Any visitDescribeQuery(Parser::DescribeQueryContext* ctx) override {
-    // TODO: unsupported
-    return visitChildren(ctx);
-  }
+  vector<GroupKey> visit(Parser::GroupClauseContext* ctx);
 
-  Any visitAskQuery(Parser::AskQueryContext* ctx) override {
-    // TODO: unsupported
-    return visitChildren(ctx);
-  }
+  GroupKey visit(Parser::GroupConditionContext* ctx);
 
-  Any visitDatasetClause(Parser::DatasetClauseContext* ctx) override {
-    // TODO: unsupported
-    return visitChildren(ctx);
-  }
+  vector<SparqlFilter> visit(Parser::HavingClauseContext* ctx);
 
-  Any visitDefaultGraphClause(Parser::DefaultGraphClauseContext* ctx) override {
-    return visitChildren(ctx);
-  }
+  SparqlFilter visit(Parser::HavingConditionContext* ctx);
 
-  Any visitNamedGraphClause(Parser::NamedGraphClauseContext* ctx) override {
-    return visitChildren(ctx);
-  }
+  vector<OrderKey> visit(Parser::OrderClauseContext* ctx);
 
-  Any visitSourceSelector(Parser::SourceSelectorContext* ctx) override {
-    return visitChildren(ctx);
-  }
+  OrderKey visit(Parser::OrderConditionContext* ctx);
 
-  Any visitWhereClause(Parser::WhereClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  LimitOffsetClause visit(Parser::LimitOffsetClausesContext* ctx);
 
-  PatternAndVisibleVariables visitTypesafe(Parser::WhereClauseContext* ctx);
+  unsigned long long int visit(Parser::LimitClauseContext* ctx);
 
-  Any visitSolutionModifier(Parser::SolutionModifierContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  unsigned long long int visit(Parser::OffsetClauseContext* ctx);
 
-  SolutionModifiers visitTypesafe(Parser::SolutionModifierContext* ctx);
+  unsigned long long int visit(Parser::TextLimitClauseContext* ctx);
 
-  Any visitGroupClause(Parser::GroupClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  std::optional<parsedQuery::Values> visit(Parser::ValuesClauseContext* ctx);
 
-  vector<GroupKey> visitTypesafe(Parser::GroupClauseContext* ctx);
+  Triples visit(Parser::TriplesTemplateContext* ctx);
 
-  Any visitGroupCondition(Parser::GroupConditionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ParsedQuery::GraphPattern visit(Parser::GroupGraphPatternContext* ctx);
 
-  GroupKey visitTypesafe(Parser::GroupConditionContext* ctx);
+  OperationsAndFilters visit(Parser::GroupGraphPatternSubContext* ctx);
 
-  Any visitHavingClause(Parser::HavingClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  vector<SparqlFilter> visitTypesafe(Parser::HavingClauseContext* ctx);
-
-  Any visitHavingCondition(Parser::HavingConditionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  SparqlFilter visitTypesafe(Parser::HavingConditionContext* ctx);
-
-  Any visitOrderClause(Parser::OrderClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  vector<OrderKey> visitTypesafe(Parser::OrderClauseContext* ctx);
-
-  Any visitOrderCondition(Parser::OrderConditionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  OrderKey visitTypesafe(Parser::OrderConditionContext* ctx);
-
-  Any visitLimitOffsetClauses(Parser::LimitOffsetClausesContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  LimitOffsetClause visitTypesafe(Parser::LimitOffsetClausesContext* ctx);
-
-  Any visitLimitClause(Parser::LimitClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  unsigned long long int visitTypesafe(Parser::LimitClauseContext* ctx);
-
-  Any visitOffsetClause(Parser::OffsetClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  unsigned long long int visitTypesafe(Parser::OffsetClauseContext* ctx);
-
-  Any visitTextLimitClause(Parser::TextLimitClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  unsigned long long int visitTypesafe(Parser::TextLimitClauseContext* ctx);
-
-  Any visitValuesClause(Parser::ValuesClauseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::optional<parsedQuery::Values> visitTypesafe(
-      Parser::ValuesClauseContext* ctx);
-
-  Any visitTriplesTemplate(Parser::TriplesTemplateContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  Triples visitTypesafe(Parser::TriplesTemplateContext* ctx);
-
-  Any visitGroupGraphPattern(Parser::GroupGraphPatternContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ParsedQuery::GraphPattern visitTypesafe(
-      Parser::GroupGraphPatternContext* ctx);
-
-  Any visitGroupGraphPatternSub(
-      Parser::GroupGraphPatternSubContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  OperationsAndFilters visitTypesafe(Parser::GroupGraphPatternSubContext* ctx);
-
-  Any visitGraphPatternNotTriplesAndMaybeTriples(
-      Parser::GraphPatternNotTriplesAndMaybeTriplesContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  OperationOrFilterAndMaybeTriples visitTypesafe(
+  OperationOrFilterAndMaybeTriples visit(
       Parser::GraphPatternNotTriplesAndMaybeTriplesContext* ctx);
 
-  Any visitTriplesBlock(Parser::TriplesBlockContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  parsedQuery::BasicGraphPattern visitTypesafe(
-      Parser::TriplesBlockContext* ctx);
-
-  Any visitGraphPatternNotTriples(
-      Parser::GraphPatternNotTriplesContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  parsedQuery::BasicGraphPattern visit(Parser::TriplesBlockContext* ctx);
 
   // Filter clauses are no independent graph patterns themselves, but their
   // scope is always the complete graph pattern enclosing them.
-  OperationOrFilter visitTypesafe(Parser::GraphPatternNotTriplesContext* ctx);
+  OperationOrFilter visit(Parser::GraphPatternNotTriplesContext* ctx);
 
-  Any visitOptionalGraphPattern(
-      Parser::OptionalGraphPatternContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  parsedQuery::GraphPatternOperation visitTypesafe(
+  parsedQuery::GraphPatternOperation visit(
       Parser::OptionalGraphPatternContext* ctx);
 
-  Any visitGraphGraphPattern(Parser::GraphGraphPatternContext* ctx) override {
-    return visitChildren(ctx);
-  }
+  [[noreturn]] void visit(Parser::GraphGraphPatternContext* ctx);
 
-  Any visitServiceGraphPattern(
-      Parser::ServiceGraphPatternContext* ctx) override {
-    return visitChildren(ctx);
-  }
+  [[noreturn]] void visit(Parser::ServiceGraphPatternContext* ctx);
 
-  Any visitBind(Parser::BindContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  parsedQuery::GraphPatternOperation visit(Parser::BindContext* ctx);
 
-  parsedQuery::GraphPatternOperation visitTypesafe(Parser::BindContext* ctx);
+  parsedQuery::GraphPatternOperation visit(Parser::InlineDataContext* ctx);
 
-  Any visitInlineData(Parser::InlineDataContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  parsedQuery::Values visit(Parser::DataBlockContext* ctx);
 
-  parsedQuery::GraphPatternOperation visitTypesafe(
-      Parser::InlineDataContext* ctx);
+  parsedQuery::SparqlValues visit(Parser::InlineDataOneVarContext* ctx);
 
-  Any visitDataBlock(Parser::DataBlockContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  parsedQuery::SparqlValues visit(Parser::InlineDataFullContext* ctx);
 
-  parsedQuery::Values visitTypesafe(Parser::DataBlockContext* ctx);
+  vector<std::string> visit(Parser::DataBlockSingleContext* ctx);
 
-  Any visitInlineDataOneVar(Parser::InlineDataOneVarContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  std::string visit(Parser::DataBlockValueContext* ctx);
 
-  parsedQuery::SparqlValues visitTypesafe(Parser::InlineDataOneVarContext* ctx);
+  GraphPatternOperation visit(Parser::MinusGraphPatternContext* ctx);
 
-  Any visitInlineDataFull(Parser::InlineDataFullContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  GraphPatternOperation visit(Parser::GroupOrUnionGraphPatternContext* ctx);
 
-  parsedQuery::SparqlValues visitTypesafe(Parser::InlineDataFullContext* ctx);
+  SparqlFilter visit(Parser::FilterRContext* ctx);
 
-  Any visitDataBlockSingle(Parser::DataBlockSingleContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ExpressionPtr visit(Parser::ConstraintContext* ctx);
 
-  vector<std::string> visitTypesafe(Parser::DataBlockSingleContext* ctx);
+  ExpressionPtr visit(SparqlAutomaticParser::FunctionCallContext* ctx);
 
-  Any visitDataBlockValue(Parser::DataBlockValueContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
 
-  std::string visitTypesafe(Parser::DataBlockValueContext* ctx);
+  [[noreturn]] void visit(Parser::ExpressionListContext* ctx);
 
-  Any visitMinusGraphPattern(Parser::MinusGraphPatternContext* ctx) override {
-    return visitChildren(ctx);
-  }
-
-  GraphPatternOperation visitTypesafe(Parser::MinusGraphPatternContext* ctx);
-
-  Any visitGroupOrUnionGraphPattern(
-      Parser::GroupOrUnionGraphPatternContext* ctx) override {
-    return visitChildren(ctx);
-  }
-
-  GraphPatternOperation visitTypesafe(
-      Parser::GroupOrUnionGraphPatternContext* ctx);
-
-  Any visitFilterR(Parser::FilterRContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  SparqlFilter visitTypesafe(Parser::FilterRContext* ctx);
-
-  Any visitConstraint(Parser::ConstraintContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::ConstraintContext* ctx);
-
-  Any visitFunctionCall(Parser::FunctionCallContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(SparqlAutomaticParser::FunctionCallContext* ctx);
-
-  Any visitArgList(Parser::ArgListContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  vector<ExpressionPtr> visitTypesafe(Parser::ArgListContext* ctx);
-
-  Any visitExpressionList(Parser::ExpressionListContext* ctx) override {
-    return visitChildren(ctx);
-  }
-
-  Any visitConstructTemplate(Parser::ConstructTemplateContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::optional<parsedQuery::ConstructClause> visitTypesafe(
+  std::optional<parsedQuery::ConstructClause> visit(
       Parser::ConstructTemplateContext* ctx);
 
-  Any visitConstructTriples(Parser::ConstructTriplesContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  Triples visit(Parser::ConstructTriplesContext* ctx);
 
-  Triples visitTypesafe(Parser::ConstructTriplesContext* ctx);
+  Triples visit(Parser::TriplesSameSubjectContext* ctx);
 
-  Any visitTriplesSameSubject(Parser::TriplesSameSubjectContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PropertyList visit(Parser::PropertyListContext* ctx);
 
-  Triples visitTypesafe(Parser::TriplesSameSubjectContext* ctx);
+  PropertyList visit(Parser::PropertyListNotEmptyContext* ctx);
 
-  Any visitPropertyList(Parser::PropertyListContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  VarOrTerm visit(Parser::VerbContext* ctx);
 
-  PropertyList visitTypesafe(Parser::PropertyListContext* ctx);
+  ObjectList visit(Parser::ObjectListContext* ctx);
 
-  Any visitPropertyListNotEmpty(
-      Parser::PropertyListNotEmptyContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  Node visit(Parser::ObjectRContext* ctx);
 
-  PropertyList visitTypesafe(Parser::PropertyListNotEmptyContext* ctx);
-
-  Any visitVerb(Parser::VerbContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  VarOrTerm visitTypesafe(Parser::VerbContext* ctx);
-
-  Any visitObjectList(Parser::ObjectListContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ObjectList visitTypesafe(Parser::ObjectListContext* ctx);
-
-  Any visitObjectR(Parser::ObjectRContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  Node visitTypesafe(Parser::ObjectRContext* ctx);
-
-  Any visitTriplesSameSubjectPath(
-      Parser::TriplesSameSubjectPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  vector<TripleWithPropertyPath> visitTypesafe(
+  vector<TripleWithPropertyPath> visit(
       Parser::TriplesSameSubjectPathContext* ctx);
 
-  Any visitTupleWithoutPath(Parser::TupleWithoutPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PathTuples visit(Parser::TupleWithoutPathContext* ctx);
 
-  PathTuples visitTypesafe(Parser::TupleWithoutPathContext* ctx);
-
-  Any visitTupleWithPath(Parser::TupleWithPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  PathTuples visitTypesafe(Parser::TupleWithPathContext* ctx);
+  PathTuples visit(Parser::TupleWithPathContext* ctx);
 
   [[noreturn]] void throwCollectionsAndBlankNodePathsNotSupported(auto* ctx) {
     reportError(
         ctx, "( ... ) and [ ... ] in triples are not yet supported by QLever.");
   }
 
-  Any visitPropertyListPath(Parser::PropertyListPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::optional<PathTuples> visitTypesafe(
+  std::optional<PathTuples> visit(
       SparqlAutomaticParser::PropertyListPathContext* ctx);
 
-  Any visitPropertyListPathNotEmpty(
-      Parser::PropertyListPathNotEmptyContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PathTuples visit(Parser::PropertyListPathNotEmptyContext* ctx);
 
-  PathTuples visitTypesafe(Parser::PropertyListPathNotEmptyContext* ctx);
+  PropertyPath visit(Parser::VerbPathContext* ctx);
 
-  Any visitVerbPath(Parser::VerbPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  Variable visit(Parser::VerbSimpleContext* ctx);
 
-  PropertyPath visitTypesafe(Parser::VerbPathContext* ctx);
-
-  Any visitVerbSimple(Parser::VerbSimpleContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  Variable visitTypesafe(Parser::VerbSimpleContext* ctx);
-
-  Any visitVerbPathOrSimple(Parser::VerbPathOrSimpleContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ad_utility::sparql_types::VarOrPath visitTypesafe(
+  ad_utility::sparql_types::VarOrPath visit(
       Parser::VerbPathOrSimpleContext* ctx);
 
-  Any visitObjectListPath(Parser::ObjectListPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ObjectList visit(Parser::ObjectListPathContext* ctx);
 
-  ObjectList visitTypesafe(Parser::ObjectListPathContext* ctx);
+  VarOrTerm visit(Parser::ObjectPathContext* ctx);
 
-  Any visitObjectPath(Parser::ObjectPathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PropertyPath visit(Parser::PathContext* ctx);
 
-  VarOrTerm visitTypesafe(Parser::ObjectPathContext* ctx);
+  PropertyPath visit(Parser::PathAlternativeContext* ctx);
 
-  Any visitPath(Parser::PathContext* ctx) override {
-    // returns PropertyPath
-    return visitTypesafe(ctx);
-  }
+  PropertyPath visit(Parser::PathSequenceContext* ctx);
 
-  PropertyPath visitTypesafe(Parser::PathContext* ctx);
+  PropertyPath visit(Parser::PathEltContext* ctx);
 
-  Any visitPathAlternative(Parser::PathAlternativeContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PropertyPath visit(Parser::PathEltOrInverseContext* ctx);
 
-  PropertyPath visitTypesafe(Parser::PathAlternativeContext* ctx);
+  [[noreturn]] void visit(Parser::PathModContext* ctx);
 
-  Any visitPathSequence(Parser::PathSequenceContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  PropertyPath visit(Parser::PathPrimaryContext* ctx);
 
-  PropertyPath visitTypesafe(Parser::PathSequenceContext* ctx);
+  PropertyPath visit(Parser::PathNegatedPropertySetContext*);
 
-  Any visitPathElt(Parser::PathEltContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  PropertyPath visitTypesafe(Parser::PathEltContext* ctx);
-
-  Any visitPathEltOrInverse(Parser::PathEltOrInverseContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  PropertyPath visitTypesafe(Parser::PathEltOrInverseContext* ctx);
-
-  Any visitPathMod(Parser::PathModContext*) override {
-    // PathMod should be handled by upper clauses. It should not be visited.
-    AD_FAIL();
-  }
-
-  Any visitPathPrimary(Parser::PathPrimaryContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  PropertyPath visitTypesafe(Parser::PathPrimaryContext* ctx);
-
-  Any visitPathNegatedPropertySet(
-      Parser::PathNegatedPropertySetContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  PropertyPath visitTypesafe(Parser::PathNegatedPropertySetContext*);
-
-  Any visitPathOneInPropertySet(
-      Parser::PathOneInPropertySetContext* ctx) override {
-    reportError(
-        ctx,
-        R"("!" and "^" inside a property path is not supported by QLever.)");
-  }
+  [[noreturn]] void visit(Parser::PathOneInPropertySetContext* ctx);
 
   /// Note that in the SPARQL grammar the INTEGER rule refers to positive
   /// integers without an explicit sign.
-  Any visitInteger(Parser::IntegerContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  unsigned long long int visit(Parser::IntegerContext* ctx);
 
-  unsigned long long int visitTypesafe(Parser::IntegerContext* ctx);
+  Node visit(Parser::TriplesNodeContext* ctx);
 
-  Any visitTriplesNode(Parser::TriplesNodeContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  Node visit(Parser::BlankNodePropertyListContext* ctx);
 
-  Node visitTypesafe(Parser::TriplesNodeContext* ctx);
+  [[noreturn]] void visit(Parser::TriplesNodePathContext* ctx);
 
-  Any visitBlankNodePropertyList(
-      Parser::BlankNodePropertyListContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::BlankNodePropertyListPathContext* ctx);
 
-  Node visitTypesafe(Parser::BlankNodePropertyListContext* ctx);
+  Node visit(Parser::CollectionContext* ctx);
 
-  Any visitTriplesNodePath(Parser::TriplesNodePathContext* ctx) override {
-    // TODO<qup42> use visitAlternative when NotSupported Exceptions and return
-    // types are implemented.
-    return visitChildren(ctx);
-  }
+  [[noreturn]] void visit(Parser::CollectionPathContext* ctx);
 
-  Any visitBlankNodePropertyListPath(
-      Parser::BlankNodePropertyListPathContext* ctx) override {
-    throwCollectionsAndBlankNodePathsNotSupported(ctx);
-    AD_FAIL()  // Should be unreachable.
-  }
+  Node visit(Parser::GraphNodeContext* ctx);
 
-  Any visitCollection(Parser::CollectionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  VarOrTerm visit(Parser::GraphNodePathContext* ctx);
 
-  Node visitTypesafe(Parser::CollectionContext* ctx);
+  VarOrTerm visit(Parser::VarOrTermContext* ctx);
 
-  Any visitCollectionPath(Parser::CollectionPathContext* ctx) override {
-    throwCollectionsAndBlankNodePathsNotSupported(ctx);
-    AD_FAIL()  // Should be unreachable.
-  }
+  VarOrTerm visit(Parser::VarOrIriContext* ctx);
 
-  Any visitGraphNode(Parser::GraphNodeContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  Variable visit(Parser::VarContext* ctx);
 
-  Node visitTypesafe(Parser::GraphNodeContext* ctx);
+  GraphTerm visit(Parser::GraphTermContext* ctx);
 
-  Any visitGraphNodePath(Parser::GraphNodePathContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  VarOrTerm visitTypesafe(Parser::GraphNodePathContext* ctx);
-
-  Any visitVarOrTerm(Parser::VarOrTermContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  VarOrTerm visitTypesafe(Parser::VarOrTermContext* ctx);
-
-  Any visitVarOrIri(Parser::VarOrIriContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  VarOrTerm visitTypesafe(Parser::VarOrIriContext* ctx);
-
-  Any visitVar(Parser::VarContext* ctx) override { return visitTypesafe(ctx); }
-
-  Variable visitTypesafe(Parser::VarContext* ctx);
-
-  Any visitGraphTerm(Parser::GraphTermContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  GraphTerm visitTypesafe(Parser::GraphTermContext* ctx);
-
-  Any visitExpression(Parser::ExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::ExpressionContext* ctx);
+  ExpressionPtr visit(Parser::ExpressionContext* ctx);
 
   std::vector<std::string> visitOperationTags(
       const std::vector<antlr4::tree::ParseTree*>& childContexts,
@@ -716,38 +327,15 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
     return operations;
   }
 
-  Any visitConditionalOrExpression(
-      Parser::ConditionalOrExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ExpressionPtr visit(Parser::ConditionalOrExpressionContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::ConditionalOrExpressionContext* ctx);
+  ExpressionPtr visit(Parser::ConditionalAndExpressionContext* ctx);
 
-  Any visitConditionalAndExpression(
-      Parser::ConditionalAndExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ExpressionPtr visit(Parser::ValueLogicalContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::ConditionalAndExpressionContext* ctx);
+  ExpressionPtr visit(Parser::RelationalExpressionContext* ctx);
 
-  Any visitValueLogical(Parser::ValueLogicalContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::ValueLogicalContext* ctx);
-
-  Any visitRelationalExpression(
-      Parser::RelationalExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::RelationalExpressionContext* ctx);
-
-  Any visitNumericExpression(Parser::NumericExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::NumericExpressionContext* ctx);
+  ExpressionPtr visit(Parser::NumericExpressionContext* ctx);
 
   template <typename Expr>
   ExpressionPtr createExpression(auto... children) {
@@ -755,174 +343,69 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
         std::array<ExpressionPtr, sizeof...(children)>{std::move(children)...});
   }
 
-  Any visitAdditiveExpression(Parser::AdditiveExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ExpressionPtr visit(Parser::AdditiveExpressionContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::AdditiveExpressionContext* ctx);
+  [[noreturn]] void visit(
+      Parser::StrangeMultiplicativeSubexprOfAdditiveContext* ctx);
 
-  Any visitStrangeMultiplicativeSubexprOfAdditive(
-      Parser::StrangeMultiplicativeSubexprOfAdditiveContext* ctx) override {
-    reportError(
-        ctx,
-        "StrangeMultiplicativeSubexprOfAdditiveContext must not be visited.");
-  }
+  ExpressionPtr visit(Parser::MultiplicativeExpressionContext* ctx);
 
-  Any visitMultiplicativeExpression(
-      Parser::MultiplicativeExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ExpressionPtr visit(Parser::UnaryExpressionContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::MultiplicativeExpressionContext* ctx);
+  ExpressionPtr visit(Parser::PrimaryExpressionContext* ctx);
 
-  Any visitUnaryExpression(Parser::UnaryExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  ExpressionPtr visit(Parser::BrackettedExpressionContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::UnaryExpressionContext* ctx);
+  ExpressionPtr visit(Parser::BuiltInCallContext* ctx);
 
-  Any visitPrimaryExpression(Parser::PrimaryExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::RegexExpressionContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::PrimaryExpressionContext* ctx);
+  [[noreturn]] void visit(Parser::SubstringExpressionContext* ctx);
 
-  Any visitBrackettedExpression(
-      Parser::BrackettedExpressionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::StrReplaceExpressionContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::BrackettedExpressionContext* ctx);
+  [[noreturn]] void visit(Parser::ExistsFuncContext* ctx);
 
-  Any visitBuiltInCall(
-      [[maybe_unused]] Parser::BuiltInCallContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  [[noreturn]] void visit(Parser::NotExistsFuncContext* ctx);
 
-  ExpressionPtr visitTypesafe(Parser::BuiltInCallContext* ctx);
+  ExpressionPtr visit(Parser::AggregateContext* ctx);
 
-  Any visitRegexExpression(Parser::RegexExpressionContext* context) override {
-    return visitChildren(context);
-  }
+  ExpressionPtr visit(Parser::IriOrFunctionContext* ctx);
 
-  Any visitSubstringExpression(
-      Parser::SubstringExpressionContext* context) override {
-    return visitChildren(context);
-  }
+  std::string visit(Parser::RdfLiteralContext* ctx);
 
-  Any visitStrReplaceExpression(
-      Parser::StrReplaceExpressionContext* context) override {
-    return visitChildren(context);
-  }
+  std::variant<int64_t, double> visit(Parser::NumericLiteralContext* ctx);
 
-  Any visitExistsFunc(Parser::ExistsFuncContext* ctx) override {
-    return visitChildren(ctx);
-  }
-
-  Any visitNotExistsFunc(Parser::NotExistsFuncContext* ctx) override {
-    return visitChildren(ctx);
-  }
-
-  Any visitAggregate(Parser::AggregateContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::AggregateContext* ctx);
-
-  Any visitIriOrFunction(Parser::IriOrFunctionContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  ExpressionPtr visitTypesafe(Parser::IriOrFunctionContext* ctx);
-
-  Any visitRdfLiteral(Parser::RdfLiteralContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::string visitTypesafe(Parser::RdfLiteralContext* ctx);
-
-  Any visitNumericLiteral(Parser::NumericLiteralContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::variant<int64_t, double> visitTypesafe(
-      Parser::NumericLiteralContext* ctx);
-
-  Any visitNumericLiteralUnsigned(
-      Parser::NumericLiteralUnsignedContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::variant<int64_t, double> visitTypesafe(
+  std::variant<int64_t, double> visit(
       Parser::NumericLiteralUnsignedContext* ctx);
 
-  Any visitNumericLiteralPositive(
-      Parser::NumericLiteralPositiveContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::variant<int64_t, double> visitTypesafe(
+  std::variant<int64_t, double> visit(
       Parser::NumericLiteralPositiveContext* ctx);
 
-  Any visitNumericLiteralNegative(
-      Parser::NumericLiteralNegativeContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  std::variant<int64_t, double> visitTypesafe(
+  std::variant<int64_t, double> visit(
       Parser::NumericLiteralNegativeContext* ctx);
 
-  Any visitBooleanLiteral(Parser::BooleanLiteralContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  bool visit(Parser::BooleanLiteralContext* ctx);
 
-  bool visitTypesafe(Parser::BooleanLiteralContext* ctx);
+  string visit(Parser::StringContext* ctx);
 
-  Any visitString(Parser::StringContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  string visit(Parser::IriContext* ctx);
 
-  string visitTypesafe(Parser::StringContext* ctx);
+  string visit(Parser::IrirefContext* ctx);
 
-  Any visitIri(Parser::IriContext* ctx) override { return visitTypesafe(ctx); }
+  string visit(Parser::PrefixedNameContext* ctx);
 
-  string visitTypesafe(Parser::IriContext* ctx);
+  BlankNode visit(Parser::BlankNodeContext* ctx);
 
-  Any visitIriref(Parser::IrirefContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
+  string visit(Parser::PnameLnContext* ctx);
 
-  string visitTypesafe(Parser::IrirefContext* ctx);
-
-  Any visitPrefixedName(Parser::PrefixedNameContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  string visitTypesafe(Parser::PrefixedNameContext* ctx);
-
-  Any visitBlankNode(Parser::BlankNodeContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  BlankNode visitTypesafe(Parser::BlankNodeContext* ctx);
-
-  Any visitPnameLn(Parser::PnameLnContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  string visitTypesafe(Parser::PnameLnContext* ctx);
-
-  Any visitPnameNs(Parser::PnameNsContext* ctx) override {
-    return visitTypesafe(ctx);
-  }
-
-  string visitTypesafe(Parser::PnameNsContext* ctx);
+  string visit(Parser::PnameNsContext* ctx);
 
   // Visit a vector of Contexts and return the corresponding results as a
-  // vector. Only Contexts that have a matching `visitTypesafe` are supported.
+  // vector. Only Contexts that have a matching `visit` are supported.
   template <typename Ctx>
   auto visitVector(const std::vector<Ctx*>& childContexts)
-      -> std::vector<decltype(visitTypesafe(childContexts[0]))>;
+      -> std::vector<decltype(visit(childContexts[0]))>;
 
   // Check that exactly one of the `ctxs` is not `null`, visit that context,
   // cast the result to `Out` and return it. Requires that for all of the
@@ -931,9 +414,9 @@ class SparqlQleverVisitor : public SparqlAutomaticVisitor {
   Out visitAlternative(Contexts*... ctxs);
 
   // Returns `std::nullopt` if the pointer is the `nullptr`. Otherwise return
-  // `visitTypesafe(ctx)`.
+  // `visit(ctx)`.
   template <typename Ctx>
-  auto visitOptional(Ctx* ctx) -> std::optional<decltype(visitTypesafe(ctx))>;
+  auto visitOptional(Ctx* ctx) -> std::optional<decltype(visit(ctx))>;
 
   /// If `ctx` is not `nullptr`, visit it, convert the result to `Intermediate`
   /// and assign it to `*target`. The case where `Intermediate!=Target` is

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -138,7 +138,7 @@ TEST(SparqlParser, Prefix) {
     ParserAndVisitor p{"PREFIX wd: <www.wikidata.org/>"};
     auto defaultPrefixes = p.visitor_.prefixMap();
     ASSERT_EQ(defaultPrefixes.size(), 0);
-    p.visitor_.visitTypesafe(p.parser_.prefixDecl());
+    p.visitor_.visit(p.parser_.prefixDecl());
     auto prefixes = p.visitor_.prefixMap();
     ASSERT_EQ(prefixes.size(), 1);
     ASSERT_EQ(prefixes.at("wd"), "<www.wikidata.org/>");


### PR DESCRIPTION
Implement typesafe visitor functions for all Contexts. This removes the need to inherit from the ANTLR generated `SparqlAutomaticVisitor` in the Visitor. Also rename `visitTypesafe` to `visit`.

TODO:
- [ ] better error messages for unsupported Rules
- [ ] helper for throwing in an unsupported Rule.