### PR TITLE
Fix visibility bug for BIND

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1347,6 +1347,6 @@ queries:
       }
     checks:
       - num_cols: 1
-      - num_rows : 149
+      - num_rows : 150
       - selected: [ "?x" ]
       - contains_row: [ "<Max_Planck_Medal>" ]

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1334,3 +1334,19 @@ queries:
       - num_rows : 1031
       - selected: [ "?cls", "?cnt" ]
       - contains_row: [ "<Academic>", 4909 ]
+
+  # The query checks the bugfix of issue #804.  The variable `?y` is not visible outside the subquery,
+  # but it is visible inside the subquery for the (completely pointless) BIND.
+  - query: scoping-of-subqueries-only-externally
+    type: no-text
+    sparql: |
+      SELECT ?x WHERE {
+        SELECT ?x WHERE {
+          <Albert_Einstein> ?y ?x . 
+          BIND (?y AS ?z)}
+      }
+    checks:
+      - num_cols: 1
+      - num_rows : 149
+      - selected: [ "?x" ]
+      - contains_row: [ "<Max_Planck_Medal>" ]

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -58,7 +58,7 @@ string Bind::asStringImpl(size_t indent) const {
   }
 
   os << "BIND ";
-  os << _bind._expression.getCacheKey(getVariableColumns());
+  os << _bind._expression.getCacheKey(_subtree->getVariableColumns());
   os << "\n" << _subtree->asString(indent);
   return std::move(os).str();
 }
@@ -108,7 +108,7 @@ void Bind::computeExpressionBind(
     const ResultTable& inputResultTable,
     sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::VariableToColumnAndResultTypeMap columnMap;
-  for (const auto& [variable, columnIndex] : getVariableColumns()) {
+  for (const auto& [variable, columnIndex] : _subtree->getVariableColumns()) {
     // Ignore the added (bound) variable.
     if (columnIndex < inputResultTable.width()) {
       columnMap[variable] =
@@ -143,7 +143,7 @@ void Bind::computeExpressionBind(
     constexpr static bool isVariable = std::is_same_v<T, ::Variable>;
     constexpr static bool isStrongId = std::is_same_v<T, Id>;
     if constexpr (isVariable) {
-      auto column = getVariableColumns().at(singleResult.name());
+      auto column = _subtree->getVariableColumns().at(singleResult.name());
       for (size_t i = 0; i < inSize; ++i) {
         output(i, inCols) = output(i, column);
       }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -109,8 +109,8 @@ void Bind::computeExpressionBind(
     sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::VariableToColumnAndResultTypeMap columnMap;
   for (const auto& [variable, columnIndex] : _subtree->getVariableColumns()) {
-      columnMap[variable] =
-          std::pair(columnIndex, inputResultTable.getResultType(columnIndex));
+    columnMap[variable] =
+        std::pair(columnIndex, inputResultTable.getResultType(columnIndex));
   }
 
   sparqlExpression::EvaluationContext evaluationContext(

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -109,11 +109,8 @@ void Bind::computeExpressionBind(
     sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::VariableToColumnAndResultTypeMap columnMap;
   for (const auto& [variable, columnIndex] : _subtree->getVariableColumns()) {
-    // Ignore the added (bound) variable.
-    if (columnIndex < inputResultTable.width()) {
       columnMap[variable] =
           std::pair(columnIndex, inputResultTable.getResultType(columnIndex));
-    }
   }
 
   sparqlExpression::EvaluationContext evaluationContext(
@@ -143,7 +140,8 @@ void Bind::computeExpressionBind(
     constexpr static bool isVariable = std::is_same_v<T, ::Variable>;
     constexpr static bool isStrongId = std::is_same_v<T, Id>;
     if constexpr (isVariable) {
-      auto column = _subtree->getVariableColumns().at(singleResult.name());
+      auto column =
+          getInternallyVisibleVariableColumns().at(singleResult.name());
       for (size_t i = 0; i < inSize; ++i) {
         output(i, inCols) = output(i, column);
       }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -35,7 +35,7 @@ GroupBy::GroupBy(QueryExecutionContext* qec, vector<Variable> groupByVariables,
 }
 
 string GroupBy::asStringImpl(size_t indent) const {
-  const auto varMap = getVariableColumns();
+  const auto varMap = getInternallyVisibleVariableColumns();
   const auto varMapInput = _subtree->getVariableColumns();
   std::ostringstream os;
   for (size_t i = 0; i < indent; ++i) {
@@ -58,10 +58,10 @@ string GroupBy::getDescriptor() const {
   return "GroupBy on " + absl::StrJoin(_groupByVariables, " ");
 }
 
-size_t GroupBy::getResultWidth() const { return getVariableColumns().size(); }
+size_t GroupBy::getResultWidth() const { return getInternallyVisibleVariableColumns().size(); }
 
 vector<size_t> GroupBy::resultSortedOn() const {
-  auto varCols = getVariableColumns();
+  auto varCols = getInternallyVisibleVariableColumns();
   vector<size_t> sortedOn;
   sortedOn.reserve(_groupByVariables.size());
   for (const std::string& var : _groupByVariables) {
@@ -295,7 +295,7 @@ void GroupBy::computeResult(ResultTable* result) {
   }
 
   // parse the aggregate aliases
-  const auto& varColMap = getVariableColumns();
+  const auto& varColMap = getInternallyVisibleVariableColumns();
   for (const Alias& alias : _aliases) {
     aggregates.push_back(
         Aggregate{alias._expression, varColMap.at(alias._target.name())});

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -58,7 +58,9 @@ string GroupBy::getDescriptor() const {
   return "GroupBy on " + absl::StrJoin(_groupByVariables, " ");
 }
 
-size_t GroupBy::getResultWidth() const { return getInternallyVisibleVariableColumns().size(); }
+size_t GroupBy::getResultWidth() const {
+  return getInternallyVisibleVariableColumns().size();
+}
 
 vector<size_t> GroupBy::resultSortedOn() const {
   auto varCols = getInternallyVisibleVariableColumns();

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -237,7 +237,7 @@ void Operation::updateRuntimeInformationOnFailure(size_t timeInMilliseconds) {
 void Operation::createRuntimeInfoFromEstimates() {
   // reset
   _runtimeInfo = RuntimeInformation{};
-  _runtimeInfo.setColumnNames(getVariableColumns());
+  _runtimeInfo.setColumnNames(getInternallyVisibleVariableColumns());
   const auto numCols = getResultWidth();
   _runtimeInfo.numCols_ = numCols;
   _runtimeInfo.descriptor_ = getDescriptor();
@@ -272,7 +272,7 @@ void Operation::createRuntimeInfoFromEstimates() {
 }
 
 // ___________________________________________________________________________
-const Operation::VariableToColumnMap& Operation::getVariableColumns() const {
+const Operation::VariableToColumnMap& Operation::getInternallyVisibleVariableColumns() const {
   // TODO<joka921> Once the operation class is based on a variant rather than
   // on inheritance, we can get rid of the locking here, as we can enforce,
   // that `computeVariableToColumnMap` is always called in the constructor of
@@ -285,8 +285,22 @@ const Operation::VariableToColumnMap& Operation::getVariableColumns() const {
 }
 
 // ___________________________________________________________________________
-Operation::VariableToColumnMap& Operation::getVariableColumnsNotConst() {
+const Operation::VariableToColumnMap& Operation::getExternallyVisibleVariableColumns() const {
+  // TODO<joka921> Once the operation class is based on a variant rather than
+  // on inheritance, we can get rid of the locking here, as we can enforce,
+  // that `computeVariableToColumnMap` is always called in the constructor of
+  // each `Operation`.
+  std::lock_guard l{variableToColumnMapMutex_};
+  if (!externallyVisibleVariableToColumnMap_.has_value()) {
+    externallyVisibleVariableToColumnMap_ = computeVariableToColumnMap();
+  }
+  return externallyVisibleVariableToColumnMap_.value();
+}
+
+// ___________________________________________________________________________
+Operation::VariableToColumnMap& Operation::getExternallyVisibleVariableColumnsNotConst() {
   // This is a safe const-cast because the actual access is to the non-const
   // `*this` object.
-  return const_cast<VariableToColumnMap&>(getVariableColumns());
+  return const_cast<VariableToColumnMap&>(
+      getInternallyVisibleVariableColumns());
 }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -305,5 +305,5 @@ Operation::getExternallyVisibleVariableColumnsNotConst() {
   // This is a safe const-cast because the actual access is to the non-const
   // `*this` object.
   return const_cast<VariableToColumnMap&>(
-      getInternallyVisibleVariableColumns());
+      getExternallyVisibleVariableColumns());
 }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -272,7 +272,8 @@ void Operation::createRuntimeInfoFromEstimates() {
 }
 
 // ___________________________________________________________________________
-const Operation::VariableToColumnMap& Operation::getInternallyVisibleVariableColumns() const {
+const Operation::VariableToColumnMap&
+Operation::getInternallyVisibleVariableColumns() const {
   // TODO<joka921> Once the operation class is based on a variant rather than
   // on inheritance, we can get rid of the locking here, as we can enforce,
   // that `computeVariableToColumnMap` is always called in the constructor of
@@ -285,7 +286,8 @@ const Operation::VariableToColumnMap& Operation::getInternallyVisibleVariableCol
 }
 
 // ___________________________________________________________________________
-const Operation::VariableToColumnMap& Operation::getExternallyVisibleVariableColumns() const {
+const Operation::VariableToColumnMap&
+Operation::getExternallyVisibleVariableColumns() const {
   // TODO<joka921> Once the operation class is based on a variant rather than
   // on inheritance, we can get rid of the locking here, as we can enforce,
   // that `computeVariableToColumnMap` is always called in the constructor of
@@ -298,7 +300,8 @@ const Operation::VariableToColumnMap& Operation::getExternallyVisibleVariableCol
 }
 
 // ___________________________________________________________________________
-Operation::VariableToColumnMap& Operation::getExternallyVisibleVariableColumnsNotConst() {
+Operation::VariableToColumnMap&
+Operation::getExternallyVisibleVariableColumnsNotConst() {
   // This is a safe const-cast because the actual access is to the non-const
   // `*this` object.
   return const_cast<VariableToColumnMap&>(

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -303,10 +303,8 @@ Operation::getExternallyVisibleVariableColumns() const {
 void Operation::setSelectedVariablesForSubquery(
     const std::vector<Variable>& selectedVariables) {
   const auto& internalVariables = getInternallyVisibleVariableColumns();
-  // This `const_cast` is safe.
-  auto& externalVariables =
-      const_cast<VariableToColumnMap&>(getExternallyVisibleVariableColumns());
-  externalVariables.clear();
+  externallyVisibleVariableToColumnMap_.emplace();
+  auto& externalVariables = externallyVisibleVariableToColumnMap_.value();
   for (const Variable& variable : selectedVariables) {
     if (internalVariables.contains(variable.name())) {
       externalVariables[variable.name()] =

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -99,9 +99,13 @@ class Operation {
   virtual float getMultiplicity(size_t col) = 0;
   virtual bool knownEmptyResult() = 0;
 
-  // Get the mapping from variables to columns but without the variables that are not visible to the outside because they were not selected by a subquery.
-  virtual const VariableToColumnMap& getExternallyVisibleVariableColumns() const final;
-  virtual VariableToColumnMap& getExternallyVisibleVariableColumnsNotConst() final;
+  // Get the mapping from variables to columns but without the variables that
+  // are not visible to the outside because they were not selected by a
+  // subquery.
+  virtual const VariableToColumnMap& getExternallyVisibleVariableColumns()
+      const final;
+  virtual VariableToColumnMap& getExternallyVisibleVariableColumnsNotConst()
+      final;
 
   RuntimeInformation& getRuntimeInfo() { return _runtimeInfo; }
 
@@ -191,8 +195,11 @@ class Operation {
     };
   }
 
-  // Get the mapping from variables to column indices. This mapping may only be used internally, because the actually visible variables might be different in case of a subquery.
-  virtual const VariableToColumnMap& getInternallyVisibleVariableColumns() const final;
+  // Get the mapping from variables to column indices. This mapping may only be
+  // used internally, because the actually visible variables might be different
+  // in case of a subquery.
+  virtual const VariableToColumnMap& getInternallyVisibleVariableColumns()
+      const final;
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
@@ -221,7 +228,6 @@ class Operation {
   // `getInternallyVisibleVariableColumns`.
   virtual VariableToColumnMap computeVariableToColumnMap() const = 0;
 
-
   // Recursively call a function on all children.
   template <typename F>
   void forAllDescendants(F f);
@@ -244,8 +250,8 @@ class Operation {
 
   // A mutex that can be "copied". The semantics are, that copying will create
   // a new mutex. This is sufficient for applications like in
-  // `getInternallyVisibleVariableColumns()` where we just want to make a `const` member function
-  // that modifies a `mutable` member threadsafe.
+  // `getInternallyVisibleVariableColumns()` where we just want to make a
+  // `const` member function that modifies a `mutable` member threadsafe.
   struct CopyableMutex : std::mutex {
     using std::mutex::mutex;
     CopyableMutex(const CopyableMutex&) {}
@@ -255,10 +261,13 @@ class Operation {
   mutable CopyableMutex variableToColumnMapMutex_;
   // Store the mapping from variables to column indices. `nullopt` means that
   // this map has not yet been computed. This computation is typically performed
-  // in the const member function `getInternallyVisibleVariableColumns`, so we have to make it
-  // threadsafe.
+  // in the const member function `getInternallyVisibleVariableColumns`, so we
+  // have to make it threadsafe.
   mutable std::optional<VariableToColumnMap> variableToColumnMap_;
 
-  // Store the mapping from variables to column indices that is externally visible. This might be different from the `variableToColumnMap_` in case of a subquery that doesn't select all variables.
-  mutable std::optional<VariableToColumnMap> externallyVisibleVariableToColumnMap_;
+  // Store the mapping from variables to column indices that is externally
+  // visible. This might be different from the `variableToColumnMap_` in case of
+  // a subquery that doesn't select all variables.
+  mutable std::optional<VariableToColumnMap>
+      externallyVisibleVariableToColumnMap_;
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -18,6 +18,8 @@
 #include <memory>
 #include <utility>
 
+#include "parser/data/Variable.h"
+
 using std::endl;
 using std::pair;
 using std::shared_ptr;
@@ -104,8 +106,8 @@ class Operation {
   // subquery.
   virtual const VariableToColumnMap& getExternallyVisibleVariableColumns()
       const final;
-  virtual VariableToColumnMap& getExternallyVisibleVariableColumnsNotConst()
-      final;
+  virtual void setSelectedVariablesForSubquery(
+      const std::vector<Variable>& selectedVariables) final;
 
   RuntimeInformation& getRuntimeInfo() { return _runtimeInfo; }
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -99,8 +99,9 @@ class Operation {
   virtual float getMultiplicity(size_t col) = 0;
   virtual bool knownEmptyResult() = 0;
 
-  virtual const VariableToColumnMap& getVariableColumns() const final;
-  virtual VariableToColumnMap& getVariableColumnsNotConst() final;
+  // Get the mapping from variables to columns but without the variables that are not visible to the outside because they were not selected by a subquery.
+  virtual const VariableToColumnMap& getExternallyVisibleVariableColumns() const final;
+  virtual VariableToColumnMap& getExternallyVisibleVariableColumnsNotConst() final;
 
   RuntimeInformation& getRuntimeInfo() { return _runtimeInfo; }
 
@@ -190,6 +191,9 @@ class Operation {
     };
   }
 
+  // Get the mapping from variables to column indices. This mapping may only be used internally, because the actually visible variables might be different in case of a subquery.
+  virtual const VariableToColumnMap& getInternallyVisibleVariableColumns() const final;
+
  private:
   //! Compute the result of the query-subtree rooted at this element..
   //! Computes both, an EntityList and a HitList.
@@ -214,8 +218,9 @@ class Operation {
   void updateRuntimeInformationOnFailure(size_t timeInMilliseconds);
 
   // Compute the variable to column index mapping. Is used internally by
-  // `getVariableColumns`.
+  // `getInternallyVisibleVariableColumns`.
   virtual VariableToColumnMap computeVariableToColumnMap() const = 0;
+
 
   // Recursively call a function on all children.
   template <typename F>
@@ -239,7 +244,7 @@ class Operation {
 
   // A mutex that can be "copied". The semantics are, that copying will create
   // a new mutex. This is sufficient for applications like in
-  // `getVariableColumns()` where we just want to make a `const` member function
+  // `getInternallyVisibleVariableColumns()` where we just want to make a `const` member function
   // that modifies a `mutable` member threadsafe.
   struct CopyableMutex : std::mutex {
     using std::mutex::mutex;
@@ -250,7 +255,10 @@ class Operation {
   mutable CopyableMutex variableToColumnMapMutex_;
   // Store the mapping from variables to column indices. `nullopt` means that
   // this map has not yet been computed. This computation is typically performed
-  // in the const member function `getVariableColumns`, so we have to make it
+  // in the const member function `getInternallyVisibleVariableColumns`, so we have to make it
   // threadsafe.
   mutable std::optional<VariableToColumnMap> variableToColumnMap_;
+
+  // Store the mapping from variables to column indices that is externally visible. This might be different from the `variableToColumnMap_` in case of a subquery that doesn't select all variables.
+  mutable std::optional<VariableToColumnMap> externallyVisibleVariableToColumnMap_;
 };

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -79,8 +79,7 @@ void QueryExecutionTree::setOperation(QueryExecutionTree::OperationType type,
 // _____________________________________________________________________________
 size_t QueryExecutionTree::getVariableColumn(const string& variable) const {
   AD_CHECK(_rootOperation);
-  // TODO<joka921> unnecessary copies here...
-  const auto& varCols = _rootOperation->getVariableColumns();
+  const auto& varCols = getVariableColumns();
   if (!varCols.contains(variable)) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
              "Variable could not be mapped to result column. Var: " + variable);
@@ -288,7 +287,7 @@ bool QueryExecutionTree::knownEmptyResult() {
 // _____________________________________________________________________________
 bool QueryExecutionTree::varCovered(string var) const {
   AD_CHECK(_rootOperation);
-  return _rootOperation->getVariableColumns().contains(var);
+  return getVariableColumns().contains(var);
 }
 
 // _______________________________________________________________________

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -69,8 +69,7 @@ class QueryExecutionTree {
 
   const QueryExecutionContext* getQec() const { return _qec; }
 
-  // TODO<joka921> make this a const&
-  ad_utility::HashMap<string, size_t> getVariableColumns() const {
+  const Operation::VariableToColumnMap& getVariableColumns() const {
     AD_CHECK(_rootOperation);
     return _rootOperation->getVariableColumns();
   }

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -71,7 +71,7 @@ class QueryExecutionTree {
 
   const Operation::VariableToColumnMap& getVariableColumns() const {
     AD_CHECK(_rootOperation);
-    return _rootOperation->getVariableColumns();
+    return _rootOperation->getExternallyVisibleVariableColumns();
   }
 
   std::shared_ptr<Operation> getRootOperation() const { return _rootOperation; }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -386,7 +386,8 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         auto removeNotSelectedVariables = [&](SubtreePlan& plan) {
           Operation::VariableToColumnMap visibleVariables;
           auto& variablesFromSubquery =
-              plan._qet->getRootOperation()->getVariableColumnsNotConst();
+              plan._qet->getRootOperation()
+                  ->getExternallyVisibleVariableColumnsNotConst();
           for (const std::string& variable :
                arg.get().selectClause().getSelectedVariablesAsStrings()) {
             if (variablesFromSubquery.contains(variable)) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -383,12 +383,11 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         auto candidatesForSubquery = createExecutionTrees(arg.get());
         // Make sure that variables that are not selected by the subquery are
         // not visible.
-        auto removeNotSelectedVariables = [&](SubtreePlan& plan) {
+        auto setSelectedVariables = [&](SubtreePlan& plan) {
           plan._qet->getRootOperation()->setSelectedVariablesForSubquery(
               arg.get().selectClause().getSelectedVariables());
         };
-        std::ranges::for_each(candidatesForSubquery,
-                              removeNotSelectedVariables);
+        std::ranges::for_each(candidatesForSubquery, setSelectedVariables);
         joinCandidates(std::move(candidatesForSubquery));
       } else if constexpr (std::is_same_v<T, p::TransPath>) {
         // TODO<kramerfl> This is obviously how you set up transitive paths.

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -384,17 +384,8 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
         // Make sure that variables that are not selected by the subquery are
         // not visible.
         auto removeNotSelectedVariables = [&](SubtreePlan& plan) {
-          Operation::VariableToColumnMap visibleVariables;
-          auto& variablesFromSubquery =
-              plan._qet->getRootOperation()
-                  ->getExternallyVisibleVariableColumnsNotConst();
-          for (const std::string& variable :
-               arg.get().selectClause().getSelectedVariablesAsStrings()) {
-            if (variablesFromSubquery.contains(variable)) {
-              visibleVariables[variable] = variablesFromSubquery.at(variable);
-            }
-          }
-          variablesFromSubquery = std::move(visibleVariables);
+          plan._qet->getRootOperation()->setSelectedVariablesForSubquery(
+              arg.get().selectClause().getSelectedVariables());
         };
         std::ranges::for_each(candidatesForSubquery,
                               removeNotSelectedVariables);

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -16,7 +16,8 @@ Union::Union(QueryExecutionContext* qec,
   _subtrees[1] = t2;
 
   // compute the column origins
-  ad_utility::HashMap<string, size_t> variableColumns = getVariableColumns();
+  ad_utility::HashMap<string, size_t> variableColumns =
+      getInternallyVisibleVariableColumns();
   _columnOrigins.resize(variableColumns.size(), {NO_COLUMN, NO_COLUMN});
   const auto& t1VarCols = t1->getVariableColumns();
   const auto& t2VarCols = t2->getVariableColumns();


### PR DESCRIPTION
This might happen if the BIND is the last Operation in a Subquery, and some of its used or exported variables are not selected by that subquery.
TODO

- [ ] Add an e2e test
- [ ] Systematically evaluate, if other operations are vulnerable to this behavior.
- [ ] Refactor the subquery mechanism: There is the "internal" variable column map, and the "external/exported variable column map". Only the access to the latter one is not private.