### PR TITLE
Fix parser error messages that contain multibyte UTF-8 characters

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -811,12 +811,18 @@ boost::asio::awaitable<void> Server::processQuery(
   //  optional<errorMsg> and optional<metadata> and does this logic
   if (exceptionErrorMsg) {
     LOG(ERROR) << exceptionErrorMsg.value() << std::endl;
-    if (metadata.has_value()) {
-     // The `coloredError()` message might fail because of the different Unicode handling of QLever and ANTLR. Make sure to detect this case so that we can fix it if it happens.
+    if (metadata) {
+      // The `coloredError()` message might fail because of the different
+      // Unicode handling of QLever and ANTLR. Make sure to detect this case so
+      // that we can fix it if it happens.
       try {
         LOG(ERROR) << metadata.value().coloredError() << std::endl;
-      } catch (const std::exception&) {
-        LOG(ERROR) << "Failed to highlight error in query " << std::endl;
+      } catch (const std::exception& e) {
+        exceptionErrorMsg.value().append(absl::StrCat(
+            " Highlighting an error for the command line log failed: ",
+            e.what()));
+        LOG(ERROR) << "Failed to highlight error in query. " << e.what()
+                   << std::endl;
         LOG(ERROR) << metadata.value().query_ << std::endl;
       }
     }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -811,11 +811,16 @@ boost::asio::awaitable<void> Server::processQuery(
   //  optional<errorMsg> and optional<metadata> and does this logic
   if (exceptionErrorMsg) {
     LOG(ERROR) << exceptionErrorMsg.value() << std::endl;
+    if (metadata.has_value()) {
+      try {
+        LOG(ERROR) << metadata.value().coloredError() << std::endl;
+      } catch (const std::exception&) {
+        LOG(ERROR) << "Failed to highlight error in query " << std::endl;
+        LOG(ERROR) << metadata.value().query_ << std::endl;
+      }
+    }
     auto errorResponseJson = composeErrorResponseJson(
         query, exceptionErrorMsg.value(), requestTimer, metadata);
-    if (metadata.has_value()) {
-      LOG(ERROR) << metadata.value().coloredError() << std::endl;
-    }
     if (queryExecutionTree) {
       errorResponseJson["runtimeInformation"] = nlohmann::ordered_json(
           queryExecutionTree->getRootOperation()->getRuntimeInfo());

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -812,6 +812,7 @@ boost::asio::awaitable<void> Server::processQuery(
   if (exceptionErrorMsg) {
     LOG(ERROR) << exceptionErrorMsg.value() << std::endl;
     if (metadata.has_value()) {
+     // The `coloredError()` message might fail because of the different Unicode handling of QLever and ANTLR. Make sure to detect this case so that we can fix it if it happens.
       try {
         LOG(ERROR) << metadata.value().coloredError() << std::endl;
       } catch (const std::exception&) {

--- a/src/parser/ParseException.cpp
+++ b/src/parser/ParseException.cpp
@@ -7,10 +7,12 @@
 #include <util/Exception.h>
 
 std::string ExceptionMetadata::coloredError() const {
-  // stopIndex_ == startIndex_ - 1 might happen if the offending string is empty.
+  // stopIndex_ == startIndex_ - 1 might happen if the offending string is
+  // empty.
   AD_CHECK(stopIndex_ + 1 >= startIndex_);
   std::string_view query = query_;
-  // The `startIndex_` and `stopIndex_` are wrt Unicode codepoints, but the `query_` is UTF-8 encoded. 
+  // The `startIndex_` and `stopIndex_` are wrt Unicode codepoints, but the
+  // `query_` is UTF-8 encoded.
   auto first = ad_utility::getUTF8Substring(query, 0, startIndex_);
   auto middle = ad_utility::getUTF8Substring(query, startIndex_,
                                              stopIndex_ + 1 - startIndex_);

--- a/src/parser/ParseException.cpp
+++ b/src/parser/ParseException.cpp
@@ -7,13 +7,12 @@
 #include <util/Exception.h>
 
 std::string ExceptionMetadata::coloredError() const {
-  AD_CHECK(startIndex_ < query_.size());
-  AD_CHECK(stopIndex_ < query_.size());
-  AD_CHECK(startIndex_ <= stopIndex_);
+  AD_CHECK(stopIndex_ + 1 >= startIndex_);
   std::string_view query = query_;
-  auto first = query.substr(0, startIndex_);
-  auto middle = query.substr(startIndex_, stopIndex_ - startIndex_ + 1);
-  auto end = query.substr(stopIndex_ + 1);
+  auto first = ad_utility::getUTF8Substring(query, 0, startIndex_);
+  auto middle = ad_utility::getUTF8Substring(query, startIndex_,
+                                             stopIndex_ + 1 - startIndex_);
+  auto end = ad_utility::getUTF8Substring(query, stopIndex_ + 1);
 
   return absl::StrCat(first, "\x1b[1m\x1b[4m\x1b[31m", middle, "\x1b[0m", end);
 }

--- a/src/parser/ParseException.cpp
+++ b/src/parser/ParseException.cpp
@@ -7,8 +7,10 @@
 #include <util/Exception.h>
 
 std::string ExceptionMetadata::coloredError() const {
+  // stopIndex_ == startIndex_ - 1 might happen if the offending string is empty.
   AD_CHECK(stopIndex_ + 1 >= startIndex_);
   std::string_view query = query_;
+  // The `startIndex_` and `stopIndex_` are wrt Unicode codepoints, but the `query_` is UTF-8 encoded. 
   auto first = ad_utility::getUTF8Substring(query, 0, startIndex_);
   auto middle = ad_utility::getUTF8Substring(query, startIndex_,
                                              stopIndex_ + 1 - startIndex_);

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -44,6 +44,7 @@ struct ParserAndVisitor {
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {
     auto resultOfParse = visitor_.visit(std::invoke(F, parser_));
 
+   // The `startIndex()` denotes the index of a Unicode codepoint, but `input_` is UTF-8 encoded.
     auto remainingString = ad_utility::getUTF8Substring(
         input_, parser_.getCurrentToken()->getStartIndex());
     return ResultOfParseAndRemainingText{std::move(resultOfParse),

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -44,11 +44,8 @@ struct ParserAndVisitor {
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {
     auto resultOfParse = visitor_.visit(std::invoke(F, parser_));
 
-    // Use `ANTLRInputStream.getText` because queries may contain multibyte
-    // characters. ANTLR uses UTF-32 internally so this problem can be
-    // circumvented by using this method.
-    auto remainingString = stream_.getText(antlr4::misc::Interval(
-        parser_.getCurrentToken()->getStartIndex(), stream_.size()));
+    auto remainingString = ad_utility::getUTF8Substring(
+        input_, parser_.getCurrentToken()->getStartIndex());
     return ResultOfParseAndRemainingText{std::move(resultOfParse),
                                          std::string{remainingString}};
   }

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -44,8 +44,11 @@ struct ParserAndVisitor {
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {
     auto resultOfParse = visitor_.visit(std::invoke(F, parser_));
 
-    auto remainingString =
-        input_.substr(parser_.getCurrentToken()->getStartIndex());
+    // Use `ANTLRInputStream.getText` because queries may contain multibyte
+    // characters. ANTLR uses UTF-32 internally so this problem can be
+    // circumvented by using this method.
+    auto remainingString = stream_.getText(antlr4::misc::Interval(
+        parser_.getCurrentToken()->getStartIndex(), stream_.size()));
     return ResultOfParseAndRemainingText{std::move(resultOfParse),
                                          std::string{remainingString}};
   }

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -44,7 +44,8 @@ struct ParserAndVisitor {
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {
     auto resultOfParse = visitor_.visit(std::invoke(F, parser_));
 
-   // The `startIndex()` denotes the index of a Unicode codepoint, but `input_` is UTF-8 encoded.
+    // The `startIndex()` denotes the index of a Unicode codepoint, but `input_`
+    // is UTF-8 encoded.
     auto remainingString = ad_utility::getUTF8Substring(
         input_, parser_.getCurrentToken()->getStartIndex());
     return ResultOfParseAndRemainingText{std::move(resultOfParse),

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -30,8 +30,8 @@ inline string getUppercase(const string& orig);
 
 inline string getLowercaseUtf8(std::string_view s);
 
-inline std::pair<size_t, std::string> getUTF8Prefix(std::string_view s,
-                                                    size_t prefixLength);
+inline std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view s,
+                                                         size_t prefixLength);
 
 //! Gets the last part of a string that is somehow split by the given separator.
 inline string getLastPartOfString(const string& text, const char separator);
@@ -116,8 +116,8 @@ std::string getLowercaseUtf8(std::string_view s) {
  * @return the first max(prefixLength, numCodepointsInArgSP) Unicode
  * codepoints of sv, encoded as UTF-8
  */
-std::pair<size_t, std::string> getUTF8Prefix(std::string_view sv,
-                                             size_t prefixLength) {
+std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view sv,
+                                                  size_t prefixLength) {
   const char* s = sv.data();
   int32_t length = sv.length();
   size_t numCodepoints = 0;
@@ -132,7 +132,17 @@ std::pair<size_t, std::string> getUTF8Prefix(std::string_view sv,
           "Illegal UTF sequence in ad_utility::getUTF8Prefix");
     }
   }
-  return {numCodepoints, std::string(sv.data(), i)};
+  return {numCodepoints, sv.substr(0, i)};
+}
+
+inline string_view getUTF8Substring(const std::string_view str, size_t start,
+                                    size_t size) {
+  auto [numCodepoints, upToEnd] = getUTF8Prefix(str, start + size);
+  auto [numCodepoints2, prefix] = getUTF8Prefix(upToEnd, start);
+  return upToEnd.substr(prefix.size());
+}
+inline string_view getUTF8Substring(const std::string_view str, size_t start) {
+  return getUTF8Substring(str, start, str.size());
 }
 
 // ____________________________________________________________________________

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -141,7 +141,9 @@ inline string_view getUTF8Substring(const std::string_view str, size_t start,
   auto [numCodepoints2, prefix] = getUTF8Prefix(upToEnd, start);
   return upToEnd.substr(prefix.size());
 }
+// Overload for the above function that creates the substring from the `start`-th codepoint to the end of the string.
 inline string_view getUTF8Substring(const std::string_view str, size_t start) {
+  // `str.size()` is >= the number of codepoints because each codepoint has at least one byte in UTF-8
   return getUTF8Substring(str, start, str.size());
 }
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -135,15 +135,25 @@ std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view sv,
   return {numCodepoints, sv.substr(0, i)};
 }
 
+/**
+ * Get the substring from the UTF8-encoded str that starts at the start-th
+ * codepoint as has a length of size codepoints. If start >= the number of
+ * codepoints in str, std::out_of_range is thrown. If start + size >= the number
+ * of codepoints in str then the substring will reach until the end of str. This
+ * behavior is consistent with std::string::substr, but working on UTF-8
+ * characters that might have multiple bytes.
+ */
 inline string_view getUTF8Substring(const std::string_view str, size_t start,
                                     size_t size) {
   auto [numCodepoints, upToEnd] = getUTF8Prefix(str, start + size);
   auto [numCodepoints2, prefix] = getUTF8Prefix(upToEnd, start);
   return upToEnd.substr(prefix.size());
 }
-// Overload for the above function that creates the substring from the `start`-th codepoint to the end of the string.
+// Overload for the above function that creates the substring from the
+// `start`-th codepoint to the end of the string.
 inline string_view getUTF8Substring(const std::string_view str, size_t start) {
-  // `str.size()` is >= the number of codepoints because each codepoint has at least one byte in UTF-8
+  // `str.size()` is >= the number of codepoints because each codepoint has at
+  // least one byte in UTF-8
   return getUTF8Substring(str, start, str.size());
 }
 

--- a/src/util/antlr/ANTLRErrorHandling.cpp
+++ b/src/util/antlr/ANTLRErrorHandling.cpp
@@ -61,7 +61,8 @@ std::string generateExceptionMessage(antlr4::Token* offendingSymbol,
     return msg;
   } else if (offendingSymbol->getStartIndex() ==
              offendingSymbol->getStopIndex() + 1) {
-    // This can only happen at the end of the query when a token is expected, but none is found. The offending token is then empty.
+    // This can only happen at the end of the query when a token is expected,
+    // but none is found. The offending token is then empty.
     return absl::StrCat("Unexpected end of Query: ", msg);
   } else {
     return absl::StrCat("Token \"", offendingSymbol->getText(), "\": ", msg);

--- a/src/util/antlr/ANTLRErrorHandling.cpp
+++ b/src/util/antlr/ANTLRErrorHandling.cpp
@@ -57,9 +57,14 @@ ExceptionMetadata generateMetadata(antlr4::ParserRuleContext* ctx) {
 
 std::string generateExceptionMessage(antlr4::Token* offendingSymbol,
                                      const std::string& msg) {
-  return (offendingSymbol)
-             ? absl::StrCat("Token \"", offendingSymbol->getText(), "\": ", msg)
-             : msg;
+  if (!offendingSymbol) {
+    return msg;
+  } else if (offendingSymbol->getStartIndex() ==
+             offendingSymbol->getStopIndex() + 1) {
+    return absl::StrCat("Unexpected end of Query: ", msg);
+  } else {
+    return absl::StrCat("Token \"", offendingSymbol->getText(), "\": ", msg);
+  }
 }
 
 // _____________________________________________________________________________

--- a/src/util/antlr/ANTLRErrorHandling.cpp
+++ b/src/util/antlr/ANTLRErrorHandling.cpp
@@ -61,6 +61,7 @@ std::string generateExceptionMessage(antlr4::Token* offendingSymbol,
     return msg;
   } else if (offendingSymbol->getStartIndex() ==
              offendingSymbol->getStopIndex() + 1) {
+    // This can only happen at the end of the query when a token is expected, but none is found. The offending token is then empty.
     return absl::StrCat("Unexpected end of Query: ", msg);
   } else {
     return absl::StrCat("Token \"", offendingSymbol->getText(), "\": ", msg);

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -7,6 +7,7 @@
 #include "util/StringUtils.h"
 
 using ad_utility::getLowercaseUtf8;
+using ad_utility::getUTF8Substring;
 
 TEST(StringUtilsTest, getLowercaseUtf8) {
   setlocale(LC_CTYPE, "");
@@ -17,30 +18,32 @@ TEST(StringUtilsTest, getLowercaseUtf8) {
 
 TEST(StringUtilsTest, getUTF8Substring) {
   // Works normally for strings with only single byte characters.
-  ASSERT_EQ("fel", ad_utility::getUTF8Substring("Apfelsaft", 2, 3));
-  ASSERT_EQ("saft", ad_utility::getUTF8Substring("Apfelsaft", 5, 4));
+  ASSERT_EQ("fel", getUTF8Substring("Apfelsaft", 2, 3));
+  ASSERT_EQ("saft", getUTF8Substring("Apfelsaft", 5, 4));
   // start+size > number of codepoints
-  ASSERT_EQ("saft", ad_utility::getUTF8Substring("Apfelsaft", 5, 5));
-  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 9));
+  ASSERT_EQ("saft", getUTF8Substring("Apfelsaft", 5, 5));
+  ASSERT_EQ("Apfelsaft", getUTF8Substring("Apfelsaft", 0, 9));
   // start+size > number of codepoints
-  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 100));
+  ASSERT_EQ("Apfelsaft", getUTF8Substring("Apfelsaft", 0, 100));
   // start > number of codepoints
-  ASSERT_EQ("", ad_utility::getUTF8Substring("Apfelsaft", 12, 13));
-  ASSERT_EQ("saft", ad_utility::getUTF8Substring("Apfelsaft", 5));
-  ASSERT_EQ("t", ad_utility::getUTF8Substring("Apfelsaft", 8));
+  ASSERT_EQ("", getUTF8Substring("Apfelsaft", 12, 13));
+  ASSERT_EQ("saft", getUTF8Substring("Apfelsaft", 5));
+  ASSERT_EQ("t", getUTF8Substring("Apfelsaft", 8));
   // String with multibyte UTF-16 characters.
-  ASSERT_EQ("Fl", ad_utility::getUTF8Substring("Flöhe", 0, 2));
-  ASSERT_EQ("he", ad_utility::getUTF8Substring("Flöhe", 3, 2));
+  ASSERT_EQ("Fl", getUTF8Substring("Flöhe", 0, 2));
+  ASSERT_EQ("he", getUTF8Substring("Flöhe", 3, 2));
   // start+size > number of codepoints
-  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 100));
-  ASSERT_EQ("he", ad_utility::getUTF8Substring("Flöhe", 3, 4));
-  ASSERT_EQ("löh", ad_utility::getUTF8Substring("Flöhe", 1, 3));
+  ASSERT_EQ("Apfelsaft", getUTF8Substring("Apfelsaft", 0, 100));
+  ASSERT_EQ("he", getUTF8Substring("Flöhe", 3, 4));
+  ASSERT_EQ("löh", getUTF8Substring("Flöhe", 1, 3));
   // UTF-32 and UTF-16 Characters.
-  ASSERT_EQ("\u2702", ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 0, 1));
+  ASSERT_EQ("\u2702", getUTF8Substring("\u2702\U0001F605\u231A\u00A9", 0, 1));
+  ASSERT_EQ("\U0001F605\u231A",
+            getUTF8Substring("\u2702\U0001F605\u231A\u00A9", 1, 2));
   ASSERT_EQ("\u231A\u00A9",
-            ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 1, 2));
-  ASSERT_EQ("\u00A9", ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 2, 1));
+            getUTF8Substring("\u2702\U0001F605\u231A\u00A9", 2, 2));
+  ASSERT_EQ("\u00A9", getUTF8Substring("\u2702\U0001F605\u231A\u00A9", 3, 1));
   // start+size > number of codepoints
-  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 100));
-  ASSERT_EQ("\u00A9", ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 2, 2));
+  ASSERT_EQ("Apfelsaft", getUTF8Substring("Apfelsaft", 0, 100));
+  ASSERT_EQ("\u00A9", getUTF8Substring("\u2702\u231A\u00A9", 2, 2));
 }

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -4,7 +4,7 @@
 
 #include <gtest/gtest.h>
 
-#include "../src/util/StringUtils.h"
+#include "util/StringUtils.h"
 
 using ad_utility::getLowercaseUtf8;
 
@@ -13,4 +13,34 @@ TEST(StringUtilsTest, getLowercaseUtf8) {
   ASSERT_EQ("schindler's list", getLowercaseUtf8("Schindler's List"));
   ASSERT_EQ("#+-_foo__bar++", getLowercaseUtf8("#+-_foo__Bar++"));
   ASSERT_EQ("fôéßaéé", getLowercaseUtf8("FÔÉßaéÉ"));
+}
+
+TEST(StringUtilsTest, getUTF8Substring) {
+  // Works normally for strings with only single byte characters.
+  ASSERT_EQ("fel", ad_utility::getUTF8Substring("Apfelsaft", 2, 3));
+  ASSERT_EQ("saft", ad_utility::getUTF8Substring("Apfelsaft", 5, 4));
+  // start+size > number of codepoints
+  ASSERT_EQ("saft", ad_utility::getUTF8Substring("Apfelsaft", 5, 5));
+  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 9));
+  // start+size > number of codepoints
+  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 100));
+  // start > number of codepoints
+  ASSERT_EQ("", ad_utility::getUTF8Substring("Apfelsaft", 12, 13));
+  ASSERT_EQ("saft", ad_utility::getUTF8Substring("Apfelsaft", 5));
+  ASSERT_EQ("t", ad_utility::getUTF8Substring("Apfelsaft", 8));
+  // String with multibyte UTF-16 characters.
+  ASSERT_EQ("Fl", ad_utility::getUTF8Substring("Flöhe", 0, 2));
+  ASSERT_EQ("he", ad_utility::getUTF8Substring("Flöhe", 3, 2));
+  // start+size > number of codepoints
+  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 100));
+  ASSERT_EQ("he", ad_utility::getUTF8Substring("Flöhe", 3, 4));
+  ASSERT_EQ("löh", ad_utility::getUTF8Substring("Flöhe", 1, 3));
+  // UTF-32 and UTF-16 Characters.
+  ASSERT_EQ("\u2702", ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 0, 1));
+  ASSERT_EQ("\u231A\u00A9",
+            ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 1, 2));
+  ASSERT_EQ("\u00A9", ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 2, 1));
+  // start+size > number of codepoints
+  ASSERT_EQ("Apfelsaft", ad_utility::getUTF8Substring("Apfelsaft", 0, 100));
+  ASSERT_EQ("\u00A9", ad_utility::getUTF8Substring("\u2702\u231A\u00A9", 2, 2));
 }


### PR DESCRIPTION
- [x] Docstrings
- [x] Tests