### PR TITLE
Fix the Turtle export

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -520,15 +520,13 @@ ad_utility::streams::stream_generator QueryExecutionTree::writeRdfGraphTurtle(
     co_yield ' ';
     co_yield triple._predicate;
     co_yield ' ';
-    // NOTE: It's tempting to co_yield an expression using a ternary operator
-    // here, but that's wrong because function argument is a std::string_view,
-    // which depends on the std::string `triple._object`, which might have
-    // changed when the function is executed.
-    //
+    // NOTE: It's tempting to co_yield an expression using a ternary operator:
     // co_yield triple._object.starts_with('"')
     //     ? RdfEscaping::validRDFLiteralFromNormalized(triple._object)
     //     : triple._object;
-    //
+    // but this leads to 1. segfaults in GCC (probably a compiler bug) and 2.
+    // to unnecessary copies of `triple._object` in the `else` case because
+    // the ternary always has to create a new prvalue.
     if (triple._object.starts_with('"')) {
       std::string objectAsValidRdfLiteral =
           RdfEscaping::validRDFLiteralFromNormalized(triple._object);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -520,7 +520,9 @@ ad_utility::streams::stream_generator QueryExecutionTree::writeRdfGraphTurtle(
     co_yield ' ';
     co_yield triple._predicate;
     co_yield ' ';
-    co_yield triple._object;
+    co_yield triple._object.starts_with('"')
+        ? RdfEscaping::validRDFLiteralFromNormalized(triple._object)
+        : triple._object;
     co_yield " .\n";
   }
 }

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -520,9 +520,22 @@ ad_utility::streams::stream_generator QueryExecutionTree::writeRdfGraphTurtle(
     co_yield ' ';
     co_yield triple._predicate;
     co_yield ' ';
-    co_yield triple._object.starts_with('"')
-        ? RdfEscaping::validRDFLiteralFromNormalized(triple._object)
-        : triple._object;
+    // NOTE: It's tempting to co_yield an expression using a ternary operator
+    // here, but that's wrong because function argument is a std::string_view,
+    // which depends on the std::string `triple._object`, which might have
+    // changed when the function is executed.
+    //
+    // co_yield triple._object.starts_with('"')
+    //     ? RdfEscaping::validRDFLiteralFromNormalized(triple._object)
+    //     : triple._object;
+    //
+    if (triple._object.starts_with('"')) {
+      std::string objectAsValidRdfLiteral =
+          RdfEscaping::validRDFLiteralFromNormalized(triple._object);
+      co_yield objectAsValidRdfLiteral;
+    } else {
+      co_yield triple._object;
+    }
     co_yield " .\n";
   }
 }

--- a/src/parser/RdfEscaping.cpp
+++ b/src/parser/RdfEscaping.cpp
@@ -223,14 +223,17 @@ std::string validRDFLiteralFromNormalized(std::string_view normLiteral) {
   size_t posLastQuote = normLiteral.rfind('"');
   // If there are onyl two quotes (the first and the last, which every
   // normalized literal has), there is nothing to do.
-  if (posSecondQuote == posLastQuote) {
+  if (posSecondQuote == posLastQuote &&
+      normLiteral.find('\\') == std::string::npos) {
     return std::string{normLiteral};
   }
-  // Otherwise escape all quotes in the part between the first and the last
-  // quote and leave the rest unchanged.
+  // Otherwise escape first all backlashes then all quotes (the order is
+  // important) in the part between the first and the last quote and leave the
+  // rest unchanged.
   std::string content = std::string(normLiteral.substr(1, posLastQuote - 1));
-  return absl::StrCat("\"", detail::replaceAll(content, "\"", "\\\""),
-                      normLiteral.substr(posLastQuote));
+  content = detail::replaceAll(content, "\\", "\\\\");
+  content = detail::replaceAll(content, "\"", "\\\"");
+  return absl::StrCat("\"", content, normLiteral.substr(posLastQuote));
 }
 
 /**

--- a/src/parser/RdfEscaping.cpp
+++ b/src/parser/RdfEscaping.cpp
@@ -2,16 +2,17 @@
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
 
+#include <absl/strings/str_cat.h>
+#include <ctre/ctre.h>
 #include <unicode/ustream.h>
 
 #include <sstream>
 #include <string>
 
-#include "../util/Exception.h"
-#include "../util/HashSet.h"
-#include "../util/Log.h"
-#include "../util/StringUtils.h"
-#include "ctre/ctre.h"
+#include "util/Exception.h"
+#include "util/HashSet.h"
+#include "util/Log.h"
+#include "util/StringUtils.h"
 
 namespace RdfEscaping {
 using namespace std::string_literals;
@@ -143,6 +144,16 @@ void unescapeStringAndNumericEscapes(InputIterator beginIterator,
     beginIterator = nextBackslashIterator + numCharactersFromInput;
   }
 }
+
+std::string replaceAll(std::string str, const std::string_view from,
+                       const std::string_view to) {
+  size_t start_pos = 0;
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+    start_pos += to.length();
+  }
+  return str;
+}
 }  // namespace detail
 
 // _____________________________________________________________________________
@@ -204,6 +215,24 @@ std::string normalizeRDFLiteral(const std::string_view origLiteral) {
   return res;
 }
 
+// ____________________________________________________________________________
+std::string validRDFLiteralFromNormalized(std::string_view normLiteral) {
+  AD_CHECK(normLiteral.starts_with('"'));
+  size_t posSecondQuote = normLiteral.find('"', 1);
+  AD_CHECK(posSecondQuote != std::string::npos);
+  size_t posLastQuote = normLiteral.rfind('"');
+  // If there are onyl two quotes (the first and the last, which every
+  // normalized literal has), there is nothing to do.
+  if (posSecondQuote == posLastQuote) {
+    return std::string{normLiteral};
+  }
+  // Otherwise escape all quotes in the part between the first and the last
+  // quote and leave the rest unchanged.
+  std::string content = std::string(normLiteral.substr(1, posLastQuote - 1));
+  return absl::StrCat("\"", detail::replaceAll(content, "\"", "\\\""),
+                      normLiteral.substr(posLastQuote));
+}
+
 /**
  * In an Iriref, the only allowed escapes are \uXXXX and '\UXXXXXXXX' ,where X
  * is hexadecimal ([0-9a-fA-F]). This function replaces these escapes by the
@@ -252,28 +281,18 @@ std::string unescapePrefixedIri(std::string_view literal) {
   return res;
 }
 
-std::string replaceAll(std::string str, const std::string_view from,
-                       const std::string_view to) {
-  size_t start_pos = 0;
-  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-    str.replace(start_pos, from.length(), to);
-    start_pos += to.length();
-  }
-  return str;
-}
-
 std::string escapeForCsv(std::string input) {
   if (!ctre::search<"[\r\n\",]">(input)) [[likely]] {
     return input;
   }
-  return '"' + replaceAll(std::move(input), "\"", "\"\"") + '"';
+  return '"' + detail::replaceAll(std::move(input), "\"", "\"\"") + '"';
 }
 
 std::string escapeForTsv(std::string input) {
   if (!ctre::search<"[\n\t]">(input)) [[likely]] {
     return input;
   }
-  auto stage1 = replaceAll(std::move(input), "\t", " ");
-  return replaceAll(std::move(stage1), "\n", "\\n");
+  auto stage1 = detail::replaceAll(std::move(input), "\t", " ");
+  return detail::replaceAll(std::move(stage1), "\n", "\\n");
 }
 }  // namespace RdfEscaping

--- a/src/parser/RdfEscaping.cpp
+++ b/src/parser/RdfEscaping.cpp
@@ -145,6 +145,7 @@ void unescapeStringAndNumericEscapes(InputIterator beginIterator,
   }
 }
 
+// _____________________________________________________________________________
 std::string replaceAll(std::string str, const std::string_view from,
                        const std::string_view to) {
   size_t start_pos = 0;
@@ -224,15 +225,17 @@ std::string validRDFLiteralFromNormalized(std::string_view normLiteral) {
   // If there are onyl two quotes (the first and the last, which every
   // normalized literal has), there is nothing to do.
   if (posSecondQuote == posLastQuote &&
-      normLiteral.find('\\') == std::string::npos) {
+      normLiteral.find_first_of("\\\n\r") == std::string::npos) {
     return std::string{normLiteral};
   }
   // Otherwise escape first all backlashes then all quotes (the order is
   // important) in the part between the first and the last quote and leave the
   // rest unchanged.
   std::string content = std::string(normLiteral.substr(1, posLastQuote - 1));
-  content = detail::replaceAll(content, "\\", "\\\\");
-  content = detail::replaceAll(content, "\"", "\\\"");
+  content = detail::replaceAll(std::move(content), "\\", "\\\\");
+  content = detail::replaceAll(std::move(content), "\n", "\\n");
+  content = detail::replaceAll(std::move(content), "\r", "\\r");
+  content = detail::replaceAll(std::move(content), "\"", "\\\"");
   return absl::StrCat("\"", content, normLiteral.substr(posLastQuote));
 }
 

--- a/src/parser/RdfEscaping.h
+++ b/src/parser/RdfEscaping.h
@@ -33,7 +33,7 @@ std::string unescapeNewlinesAndBackslashes(std::string_view literal);
  * RDFLiterals in Turtle or Sparql can have several forms: They may either
  * be surrounded with one (" or ') quotation mark and contain all special
  * characters in escaped form, like "\\\t". Alternatively literals may be
- * surroounded by three (""" or ''') quotation marks. Then escapes are still
+ * surrounded by three (""" or ''') quotation marks. Then escapes are still
  * allowed, but several special characters (e.g. '\n' or '\t' may be contained
  * directly in the string (For details, see the Turtle or Sparql standard).
  *
@@ -45,6 +45,18 @@ std::string unescapeNewlinesAndBackslashes(std::string_view literal);
  * inside QLever.
  */
 std::string normalizeRDFLiteral(std::string_view origLiteral);
+
+/**
+ * Convert a literal in the form produced by `normalizeRDFLiteral` into a form
+ * that is a valid literal in Turtle. For example, "al"pah" becomes "al\"pha"
+ * and "be"ta"@en becomes "be\"ta"@en.
+ *
+ * If the `normLiteral` is not a literal, an AD_CHECK will fail.
+ *
+ * TODO: This function currently only handles the escaping of " inside the
+ * literal, no other characters. Is that enough?
+ */
+std::string validRDFLiteralFromNormalized(std::string_view normLiteral);
 
 /**
  * In an Iriref, the only allowed escapes are \uXXXX and '\UXXXXXXXX' ,where X

--- a/test/RdfEscapingTest.cpp
+++ b/test/RdfEscapingTest.cpp
@@ -1,20 +1,30 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Author: Robin Textor-Falconi (textorr@informatik.uni-freiburg.de)
+// Authors: Robin Textor-Falconi (textorr@informatik.uni-freiburg.de)
+//          Hannah bast <bast@cs.uni-freiburg.de>
 
 #include <gtest/gtest.h>
 
-#include "../src/parser/RdfEscaping.h"
+#include "parser/RdfEscaping.h"
 
+namespace RdfEscaping {
 TEST(RdfEscapingTest, testEscapeForCsv) {
-  ASSERT_EQ(RdfEscaping::escapeForCsv("abc"), "abc");
-  ASSERT_EQ(RdfEscaping::escapeForCsv("a\nb\rc,d"), "\"a\nb\rc,d\"");
-  ASSERT_EQ(RdfEscaping::escapeForCsv("\""), "\"\"\"\"");
-  ASSERT_EQ(RdfEscaping::escapeForCsv("a\"b"), "\"a\"\"b\"");
-  ASSERT_EQ(RdfEscaping::escapeForCsv("a\"\"c"), "\"a\"\"\"\"c\"");
+  ASSERT_EQ(escapeForCsv("abc"), "abc");
+  ASSERT_EQ(escapeForCsv("a\nb\rc,d"), "\"a\nb\rc,d\"");
+  ASSERT_EQ(escapeForCsv("\""), "\"\"\"\"");
+  ASSERT_EQ(escapeForCsv("a\"b"), "\"a\"\"b\"");
+  ASSERT_EQ(escapeForCsv("a\"\"c"), "\"a\"\"\"\"c\"");
 }
 
 TEST(RdfEscapingTest, testEscapeForTsv) {
-  ASSERT_EQ(RdfEscaping::escapeForTsv("abc"), "abc");
-  ASSERT_EQ(RdfEscaping::escapeForTsv("a\nb\tc"), "a\\nb c");
+  ASSERT_EQ(escapeForTsv("abc"), "abc");
+  ASSERT_EQ(escapeForTsv("a\nb\tc"), "a\\nb c");
 }
+
+TEST(RdfEscapingTest, testValidRDFLiteralFromNormalized) {
+  ASSERT_EQ(validRDFLiteralFromNormalized(R"(""alpha")"), R"("\"alpha")");
+  ASSERT_EQ(validRDFLiteralFromNormalized(R"("be"ta"@en)"), R"("be\"ta"@en)");
+  ASSERT_EQ(validRDFLiteralFromNormalized(R"("gamma""^^<string>)"),
+            R"("gamma\""^^<string>)");
+}
+}  // namespace RdfEscaping

--- a/test/RdfEscapingTest.cpp
+++ b/test/RdfEscapingTest.cpp
@@ -22,9 +22,8 @@ TEST(RdfEscapingTest, testEscapeForTsv) {
 }
 
 TEST(RdfEscapingTest, testValidRDFLiteralFromNormalized) {
-  ASSERT_EQ(validRDFLiteralFromNormalized(R"(""alpha")"), R"("\"alpha")");
-  ASSERT_EQ(validRDFLiteralFromNormalized(R"("be"ta"@en)"), R"("be\"ta"@en)");
-  ASSERT_EQ(validRDFLiteralFromNormalized(R"("gamma""^^<string>)"),
-            R"("gamma\""^^<string>)");
+  ASSERT_EQ(validRDFLiteralFromNormalized(R"(""\a\"")"), R"("\"\\a\\\"")");
+  ASSERT_EQ(validRDFLiteralFromNormalized(R"("\b\"@en)"), R"("\\b\\"@en)");
+  ASSERT_EQ(validRDFLiteralFromNormalized(R"("\c""^^<s>)"), R"("\\c\""^^<s>)");
 }
 }  // namespace RdfEscaping

--- a/test/RdfEscapingTest.cpp
+++ b/test/RdfEscapingTest.cpp
@@ -25,5 +25,6 @@ TEST(RdfEscapingTest, testValidRDFLiteralFromNormalized) {
   ASSERT_EQ(validRDFLiteralFromNormalized(R"(""\a\"")"), R"("\"\\a\\\"")");
   ASSERT_EQ(validRDFLiteralFromNormalized(R"("\b\"@en)"), R"("\\b\\"@en)");
   ASSERT_EQ(validRDFLiteralFromNormalized(R"("\c""^^<s>)"), R"("\\c\""^^<s>)");
+  ASSERT_EQ(validRDFLiteralFromNormalized("\"\nhi\r\\\""), R"("\nhi\r\\")");
 }
 }  // namespace RdfEscaping


### PR DESCRIPTION
So far, the Turtle export (for CONSTRUCT queries) writes literals in QLever's internal representation, where, in particular, quotes are not escaped. This is fixed now.