### PR TITLE
Use the strong `Variable` type for the `VariableToColumnMap`

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -67,7 +67,7 @@ string Bind::asStringImpl(size_t indent) const {
 Operation::VariableToColumnMap Bind::computeVariableToColumnMap() const {
   auto res = _subtree->getVariableColumns();
   // The new variable is always appended at the end.
-  res[_bind._target.name()] = getResultWidth() - 1;
+  res[_bind._target] = getResultWidth() - 1;
   return res;
 }
 
@@ -140,14 +140,13 @@ void Bind::computeExpressionBind(
     constexpr static bool isVariable = std::is_same_v<T, ::Variable>;
     constexpr static bool isStrongId = std::is_same_v<T, Id>;
     if constexpr (isVariable) {
-      auto column =
-          getInternallyVisibleVariableColumns().at(singleResult.name());
+      auto column = getInternallyVisibleVariableColumns().at(singleResult);
       for (size_t i = 0; i < inSize; ++i) {
         output(i, inCols) = output(i, column);
       }
-      *resultType = evaluationContext._variableToColumnAndResultTypeMap
-                        .at(singleResult.name())
-                        .second;
+      *resultType =
+          evaluationContext._variableToColumnAndResultTypeMap.at(singleResult)
+              .second;
     } else if constexpr (isStrongId) {
       for (size_t i = 0; i < inSize; ++i) {
         output(i, inCols) = singleResult;

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -64,7 +64,7 @@ string Bind::asStringImpl(size_t indent) const {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap Bind::computeVariableToColumnMap() const {
+VariableToColumnMap Bind::computeVariableToColumnMap() const {
   auto res = _subtree->getVariableColumns();
   // The new variable is always appended at the end.
   res[_bind._target] = getResultWidth() - 1;

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library(engine
         ../util/Random.h
         Minus.h Minus.cpp
         ResultType.h
-        ../util/Parameters.h RuntimeInformation.cpp CheckUsePatternTrick.cpp CheckUsePatternTrick.h)
+        ../util/Parameters.h RuntimeInformation.cpp CheckUsePatternTrick.cpp CheckUsePatternTrick.h
+        VariableToColumnMap.cpp)
 
 
 target_link_libraries(engine index parser sparqlExpressions httpServer SortPerformanceEstimator absl::flat_hash_set ${ICU_LIBRARIES} boost_iostreams)

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -61,8 +61,8 @@ vector<size_t> CountAvailablePredicates::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap
-CountAvailablePredicates::computeVariableToColumnMap() const {
+VariableToColumnMap CountAvailablePredicates::computeVariableToColumnMap()
+    const {
   VariableToColumnMap varCols;
   varCols[_predicateVariable] = 0;
   varCols[_countVariable] = 1;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -13,8 +13,8 @@ CountAvailablePredicates::CountAvailablePredicates(QueryExecutionContext* qec,
     : Operation(qec),
       _subtree(nullptr),
       _subjectColumnIndex(0),
-      _predicateVarName(std::move(predicateVariable)),
-      _countVarName(std::move(countVariable)) {}
+      _predicateVariable(std::move(predicateVariable)),
+      _countVariable(std::move(countVariable)) {}
 
 // _____________________________________________________________________________
 CountAvailablePredicates::CountAvailablePredicates(
@@ -25,8 +25,8 @@ CountAvailablePredicates::CountAvailablePredicates(
       _subtree(QueryExecutionTree::createSortedTree(std::move(subtree),
                                                     {subjectColumnIndex})),
       _subjectColumnIndex(subjectColumnIndex),
-      _predicateVarName(std::move(predicateVariable)),
-      _countVarName(std::move(countVariable)) {}
+      _predicateVariable(std::move(predicateVariable)),
+      _countVariable(std::move(countVariable)) {}
 
 // _____________________________________________________________________________
 string CountAvailablePredicates::asStringImpl(size_t indent) const {
@@ -63,9 +63,9 @@ vector<size_t> CountAvailablePredicates::resultSortedOn() const {
 // _____________________________________________________________________________
 Operation::VariableToColumnMap
 CountAvailablePredicates::computeVariableToColumnMap() const {
-  ad_utility::HashMap<string, size_t> varCols;
-  varCols[_predicateVarName.name()] = 0;
-  varCols[_countVarName.name()] = 1;
+  VariableToColumnMap varCols;
+  varCols[_predicateVariable] = 0;
+  varCols[_countVariable] = 1;
   return varCols;
 }
 

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -28,8 +28,8 @@ class CountAvailablePredicates : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   size_t _subjectColumnIndex;
-  Variable _predicateVarName;
-  Variable _countVarName;
+  Variable _predicateVariable;
+  Variable _countVariable;
 
  public:
   /**

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -34,7 +34,7 @@ string Distinct::asStringImpl(size_t indent) const {
 string Distinct::getDescriptor() const { return "Distinct"; }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap Distinct::computeVariableToColumnMap() const {
+VariableToColumnMap Distinct::computeVariableToColumnMap() const {
   return _subtree->getVariableColumns();
 }
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -95,7 +95,7 @@ vector<size_t> GroupBy::computeSortColumns(const QueryExecutionTree* subtree) {
   return cols;
 }
 
-Operation::VariableToColumnMap GroupBy::computeVariableToColumnMap() const {
+VariableToColumnMap GroupBy::computeVariableToColumnMap() const {
   VariableToColumnMap result;
   // The returned columns are all groupByVariables followed by aggregrates.
   size_t colIndex = 0;

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -40,7 +40,6 @@ string GroupBy::asStringImpl(size_t indent) const {
     os << " ";
   }
   os << "GROUP_BY ";
-  // TODO<joka921> The `_groupByVariables` should have type `Variable`
   for (const auto& var : _groupByVariables) {
     os << varMap.at(var) << ", ";
   }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -25,7 +25,7 @@ using std::vector;
 class GroupBy : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
-  vector<string> _groupByVariables;
+  vector<Variable> _groupByVariables;
   std::vector<Alias> _aliases;
 
  public:

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -110,21 +110,23 @@ vector<size_t> HasPredicateScan::resultSortedOn() const {
 
 Operation::VariableToColumnMap HasPredicateScan::computeVariableToColumnMap()
     const {
-  ad_utility::HashMap<string, size_t> varCols;
+  VariableToColumnMap varCols;
+  using V = Variable;
   switch (_type) {
     case ScanType::FREE_S:
-      varCols.insert(std::make_pair(_subject, 0));
+      // TODO<joka921> Better types for `_subject` and `_object`.
+      varCols.insert(std::make_pair(V{_subject}, 0));
       break;
     case ScanType::FREE_O:
-      varCols.insert(std::make_pair(_object, 0));
+      varCols.insert(std::make_pair(V{_object}, 0));
       break;
     case ScanType::FULL_SCAN:
-      varCols.insert(std::make_pair(_subject, 0));
-      varCols.insert(std::make_pair(_object, 1));
+      varCols.insert(std::make_pair(V{_subject}, 0));
+      varCols.insert(std::make_pair(V{_object}, 1));
       break;
     case ScanType::SUBQUERY_S:
       varCols = _subtree->getVariableColumns();
-      varCols.insert(std::make_pair(_object, getResultWidth() - 1));
+      varCols.insert(std::make_pair(V{_object}, getResultWidth() - 1));
       break;
   }
   return varCols;

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -108,8 +108,7 @@ vector<size_t> HasPredicateScan::resultSortedOn() const {
   return {};
 }
 
-Operation::VariableToColumnMap HasPredicateScan::computeVariableToColumnMap()
-    const {
+VariableToColumnMap HasPredicateScan::computeVariableToColumnMap() const {
   VariableToColumnMap varCols;
   using V = Variable;
   switch (_type) {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -142,23 +142,25 @@ vector<size_t> IndexScan::resultSortedOn() const {
 
 // _____________________________________________________________________________
 Operation::VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
-  ad_utility::HashMap<string, size_t> res;
+  VariableToColumnMap res;
   size_t col = 0;
 
   // Helper lambdas that add the respective triple component as the next column.
   auto addSubject = [&]() {
     if (_subject.isVariable()) {
-      res[_subject.getVariable().name()] = col++;
+      res[_subject.getVariable()] = col++;
     }
   };
+  // TODO<joka921> Refactor the `PropertyPath` class s.t. it also has
+  //`isVariable` and `getVariable`, then those three lambdas can become one.
   auto addPredicate = [&]() {
     if (_predicate[0] == '?') {
-      res[_predicate] = col++;
+      res[Variable{_predicate}] = col++;
     }
   };
   auto addObject = [&]() {
     if (_object.isVariable()) {
-      res[_object.getVariable().name()] = col++;
+      res[_object.getVariable()] = col++;
     }
   };
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -141,7 +141,7 @@ vector<size_t> IndexScan::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
+VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
   VariableToColumnMap res;
   size_t col = 0;
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -60,7 +60,6 @@ string Join::asStringImpl(size_t indent) const {
 // _____________________________________________________________________________
 string Join::getDescriptor() const {
   std::string joinVar = "";
-  // TODO<joka921> This can be some kind of `ranges::find_if`.
   for (auto p : _left->getVariableColumns()) {
     if (p.second == _leftJoinCol) {
       joinVar = p.first.name();

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -149,7 +149,7 @@ void Join::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap Join::computeVariableToColumnMap() const {
+VariableToColumnMap Join::computeVariableToColumnMap() const {
   VariableToColumnMap retVal;
   if (!isFullScanDummy(_left) && !isFullScanDummy(_right)) {
     retVal = _left->getVariableColumns();

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -60,9 +60,10 @@ string Join::asStringImpl(size_t indent) const {
 // _____________________________________________________________________________
 string Join::getDescriptor() const {
   std::string joinVar = "";
+  // TODO<joka921> This can be some kind of `ranges::find_if`.
   for (auto p : _left->getVariableColumns()) {
     if (p.second == _leftJoinCol) {
-      joinVar = p.first;
+      joinVar = p.first.name();
       break;
     }
   }
@@ -149,7 +150,7 @@ void Join::computeResult(ResultTable* result) {
 
 // _____________________________________________________________________________
 Operation::VariableToColumnMap Join::computeVariableToColumnMap() const {
-  ad_utility::HashMap<string, size_t> retVal;
+  VariableToColumnMap retVal;
   if (!isFullScanDummy(_left) && !isFullScanDummy(_right)) {
     retVal = _left->getVariableColumns();
     size_t leftSize = _left->getResultWidth();

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -71,7 +71,7 @@ void Minus::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap Minus::computeVariableToColumnMap() const {
+VariableToColumnMap Minus::computeVariableToColumnMap() const {
   return _left->getVariableColumns();
 }
 

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -119,14 +119,8 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
 VariableToColumnMap MultiColumnJoin::computeVariableToColumnMap() const {
   VariableToColumnMap retVal(_left->getVariableColumns());
   size_t columnIndex = retVal.size();
-  const auto variableColumnsRightSorted = [&] {
-    const auto& r = _right->getVariableColumns();
-    using P = std::pair<Variable, size_t>;
-    std::vector<P> v(r.begin(), r.end());
-    std::sort(v.begin(), v.end(),
-              [](const auto& a, const auto& b) { return a.second < b.second; });
-    return v;
-  }();
+  const auto variableColumnsRightSorted =
+      sortedByColumnIndex(_right->getVariableColumns());
   for (const auto& it : variableColumnsRightSorted) {
     bool isJoinColumn = false;
     for (const std::array<ColumnIndex, 2>& a : _joinColumns) {

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -120,7 +120,7 @@ VariableToColumnMap MultiColumnJoin::computeVariableToColumnMap() const {
   VariableToColumnMap retVal(_left->getVariableColumns());
   size_t columnIndex = retVal.size();
   const auto variableColumnsRightSorted =
-      sortedByColumnIndex(_right->getVariableColumns());
+      copySortedByColumnIndex(_right->getVariableColumns());
   for (const auto& it : variableColumnsRightSorted) {
     bool isJoinColumn = false;
     for (const std::array<ColumnIndex, 2>& a : _joinColumns) {

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -63,7 +63,7 @@ string MultiColumnJoin::getDescriptor() const {
       // If the left join column matches the index of a variable in the left
       // subresult.
       if (jc[0] == p.second) {
-        joinVars += p.first + " ";
+        joinVars += p.first.name() + " ";
       }
     }
   }
@@ -118,11 +118,11 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
 // _____________________________________________________________________________
 Operation::VariableToColumnMap MultiColumnJoin::computeVariableToColumnMap()
     const {
-  ad_utility::HashMap<string, size_t> retVal(_left->getVariableColumns());
+  VariableToColumnMap retVal(_left->getVariableColumns());
   size_t columnIndex = retVal.size();
   const auto variableColumnsRightSorted = [&] {
     const auto& r = _right->getVariableColumns();
-    using P = std::pair<string, size_t>;
+    using P = std::pair<Variable, size_t>;
     std::vector<P> v(r.begin(), r.end());
     std::sort(v.begin(), v.end(),
               [](const auto& a, const auto& b) { return a.second < b.second; });

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -116,8 +116,7 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap MultiColumnJoin::computeVariableToColumnMap()
-    const {
+VariableToColumnMap MultiColumnJoin::computeVariableToColumnMap() const {
   VariableToColumnMap retVal(_left->getVariableColumns());
   size_t columnIndex = retVal.size();
   const auto variableColumnsRightSorted = [&] {

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -274,8 +274,8 @@ void Operation::createRuntimeInfoFromEstimates() {
 }
 
 // ___________________________________________________________________________
-const Operation::VariableToColumnMap&
-Operation::getInternallyVisibleVariableColumns() const {
+const VariableToColumnMap& Operation::getInternallyVisibleVariableColumns()
+    const {
   // TODO<joka921> Once the operation class is based on a variant rather than
   // on inheritance, we can get rid of the locking here because we can enforce
   // that `computeVariableToColumnMap` is always called in the constructor of
@@ -288,8 +288,8 @@ Operation::getInternallyVisibleVariableColumns() const {
 }
 
 // ___________________________________________________________________________
-const Operation::VariableToColumnMap&
-Operation::getExternallyVisibleVariableColumns() const {
+const VariableToColumnMap& Operation::getExternallyVisibleVariableColumns()
+    const {
   // TODO<joka921> Once the operation class is based on a variant rather than
   // on inheritance, we can get rid of the locking here because we can enforce
   // that `computeVariableToColumnMap` is always called in the constructor of

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -308,9 +308,8 @@ void Operation::setSelectedVariablesForSubquery(
   externallyVisibleVariableToColumnMap_.emplace();
   auto& externalVariables = externallyVisibleVariableToColumnMap_.value();
   for (const Variable& variable : selectedVariables) {
-    if (internalVariables.contains(variable.name())) {
-      externalVariables[variable.name()] =
-          internalVariables.at(variable.name());
+    if (internalVariables.contains(variable)) {
+      externalVariables[variable] = internalVariables.at(variable);
     }
   }
 }

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -24,7 +24,7 @@ class QueryExecutionTree;
 
 class Operation {
  public:
-  using VariableToColumnMap = ad_utility::HashMap<std::string, size_t>;
+  using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
   // Default Constructor.
   Operation() : _executionContext(nullptr) {}
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -14,6 +14,7 @@
 #include "engine/QueryExecutionContext.h"
 #include "engine/ResultTable.h"
 #include "engine/RuntimeInformation.h"
+#include "engine/VariableToColumnMap.h"
 #include "parser/data/Variable.h"
 #include "util/Exception.h"
 #include "util/Log.h"
@@ -24,7 +25,6 @@ class QueryExecutionTree;
 
 class Operation {
  public:
-  using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
   // Default Constructor.
   Operation() : _executionContext(nullptr) {}
 

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -122,8 +122,7 @@ void OptionalJoin::computeResult(ResultTable* result) {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap OptionalJoin::computeVariableToColumnMap()
-    const {
+VariableToColumnMap OptionalJoin::computeVariableToColumnMap() const {
   VariableToColumnMap retVal(_left->getVariableColumns());
   size_t leftSize = _left->getResultWidth();
   for (const auto& [variable, columnIndexRight] :

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -67,7 +67,7 @@ string OptionalJoin::getDescriptor() const {
       // If the left join column matches the index of a variable in the left
       // subresult.
       if (jc[0] == p.second) {
-        joinVars += p.first + " ";
+        joinVars += p.first.name() + " ";
       }
     }
   }
@@ -124,7 +124,7 @@ void OptionalJoin::computeResult(ResultTable* result) {
 // _____________________________________________________________________________
 Operation::VariableToColumnMap OptionalJoin::computeVariableToColumnMap()
     const {
-  ad_utility::HashMap<string, size_t> retVal(_left->getVariableColumns());
+  VariableToColumnMap retVal(_left->getVariableColumns());
   size_t leftSize = _left->getResultWidth();
   for (const auto& [variable, columnIndexRight] :
        _right->getVariableColumns()) {

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -102,5 +102,5 @@ class OptionalJoin : public Operation {
 
   virtual void computeResult(ResultTable* result) override;
 
-  Operation::VariableToColumnMap computeVariableToColumnMap() const override;
+  VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -48,9 +48,9 @@ string OrderBy::getDescriptor() const {
     for (auto oc : _sortIndices) {
       if (oc.first == p.second) {
         if (oc.second) {
-          orderByVars += "DESC(" + p.first + ") ";
+          orderByVars += "DESC(" + p.first.name() + ") ";
         } else {
-          orderByVars += "ASC(" + p.first + ") ";
+          orderByVars += "ASC(" + p.first.name() + ") ";
         }
       }
     }

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -286,7 +286,6 @@ bool QueryExecutionTree::knownEmptyResult() {
 }
 
 // _____________________________________________________________________________
-// TODO<joka921> This should take a `Variable` as an argument.
 bool QueryExecutionTree::isVariableCovered(Variable variable) const {
   AD_CHECK(_rootOperation);
   return getVariableColumns().contains(variable);

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -77,14 +77,16 @@ void QueryExecutionTree::setOperation(QueryExecutionTree::OperationType type,
 }
 
 // _____________________________________________________________________________
+// TODO<joka921> Refactor this to take a `Variable`
 size_t QueryExecutionTree::getVariableColumn(const string& variable) const {
   AD_CHECK(_rootOperation);
+  auto var = Variable{variable};
   const auto& varCols = getVariableColumns();
-  if (!varCols.contains(variable)) {
+  if (!varCols.contains(var)) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
              "Variable could not be mapped to result column. Var: " + variable);
   }
-  return varCols.find(variable)->second;
+  return varCols.at(var);
 }
 
 // ___________________________________________________________________________
@@ -96,8 +98,8 @@ QueryExecutionTree::selectedVariablesToColumnIndices(
 
   for (const auto& var : selectClause.getSelectedVariables()) {
     std::string varString = var.name();
-    if (getVariableColumns().contains(varString)) {
-      auto columnIndex = getVariableColumns().at(varString);
+    if (getVariableColumns().contains(var)) {
+      auto columnIndex = getVariableColumns().at(var);
       // Remove the question mark from the variable name if requested.
       if (!includeQuestionMark && varString.starts_with('?')) {
         varString = varString.substr(1);
@@ -285,9 +287,10 @@ bool QueryExecutionTree::knownEmptyResult() {
 }
 
 // _____________________________________________________________________________
+// TODO<joka921> This should take a `Variable` as an argument.
 bool QueryExecutionTree::varCovered(string var) const {
   AD_CHECK(_rootOperation);
-  return getVariableColumns().contains(var);
+  return getVariableColumns().contains(Variable{var});
 }
 
 // _______________________________________________________________________

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -77,16 +77,15 @@ void QueryExecutionTree::setOperation(QueryExecutionTree::OperationType type,
 }
 
 // _____________________________________________________________________________
-// TODO<joka921> Refactor this to take a `Variable`
-size_t QueryExecutionTree::getVariableColumn(const string& variable) const {
+size_t QueryExecutionTree::getVariableColumn(const Variable& variable) const {
   AD_CHECK(_rootOperation);
-  auto var = Variable{variable};
   const auto& varCols = getVariableColumns();
-  if (!varCols.contains(var)) {
+  if (!varCols.contains(variable)) {
     AD_THROW(ad_semsearch::Exception::CHECK_FAILED,
-             "Variable could not be mapped to result column. Var: " + variable);
+             "Variable could not be mapped to result column. Var: " +
+                 variable.name());
   }
-  return varCols.at(var);
+  return varCols.at(variable);
 }
 
 // ___________________________________________________________________________
@@ -288,9 +287,9 @@ bool QueryExecutionTree::knownEmptyResult() {
 
 // _____________________________________________________________________________
 // TODO<joka921> This should take a `Variable` as an argument.
-bool QueryExecutionTree::varCovered(string var) const {
+bool QueryExecutionTree::isVariableCovered(Variable variable) const {
   AD_CHECK(_rootOperation);
-  return getVariableColumns().contains(Variable{var});
+  return getVariableColumns().contains(variable);
 }
 
 // _______________________________________________________________________

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -86,7 +86,7 @@ class QueryExecutionTree {
     return _type == OperationType::UNDEFINED || !_rootOperation;
   }
 
-  size_t getVariableColumn(const string& var) const;
+  size_t getVariableColumn(const Variable& variable) const;
 
   size_t getResultWidth() const { return _rootOperation->getResultWidth(); }
 
@@ -164,7 +164,7 @@ class QueryExecutionTree {
                                _rootOperation->getMultiplicity(col));
   }
 
-  bool varCovered(string var) const;
+  bool isVariableCovered(Variable variable) const;
 
   bool knownEmptyResult();
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -69,7 +69,7 @@ class QueryExecutionTree {
 
   const QueryExecutionContext* getQec() const { return _qec; }
 
-  const Operation::VariableToColumnMap& getVariableColumns() const {
+  const VariableToColumnMap& getVariableColumns() const {
     AD_CHECK(_rootOperation);
     return _rootOperation->getExternallyVisibleVariableColumns();
   }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -518,7 +518,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
     vector<size_t> keepIndices;
     ad_utility::HashSet<size_t> indDone;
     const auto& colMap = parent._qet->getVariableColumns();
-    for (const auto& var : selectClause.getSelectedVariablesAsStrings()) {
+    for (const auto& var : selectClause.getSelectedVariables()) {
       // There used to be a special treatment for `?ql_textscore_` variables
       // which was considered a bug.
       if (auto it = colMap.find(var); it != colMap.end()) {
@@ -1523,9 +1523,9 @@ string QueryPlanner::getPruningKey(
   std::ostringstream os;
   const auto& varCols = plan._qet->getVariableColumns();
   for (size_t orderedOnCol : orderedOnColumns) {
-    for (const auto& varCol : varCols) {
-      if (varCol.second == orderedOnCol) {
-        os << varCol.first << ", ";
+    for (const auto& [variable, columnIndex] : varCols) {
+      if (columnIndex == orderedOnCol) {
+        os << variable.name() << ", ";
         break;
       }
     }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -407,14 +407,12 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           bool leftVar, rightVar;
           if (isVariable(arg._left)) {
             leftVar = true;
-            leftCol = sub._qet->getVariableColumn(
-                arg._innerLeft.getVariable().name());
+            leftCol = sub._qet->getVariableColumn(arg._innerLeft.getVariable());
             leftColName = Variable{arg._left.getVariable()};
           } else {
             leftVar = false;
             leftColName = generateUniqueVarName();
-            leftCol = sub._qet->getVariableColumn(
-                arg._innerLeft.getVariable().name());
+            leftCol = sub._qet->getVariableColumn(arg._innerLeft.getVariable());
             if (auto opt = arg._left.toValueId(_qec->getIndex().getVocab());
                 opt.has_value()) {
               leftValue = opt.value();
@@ -426,13 +424,13 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           // TODO<joka921> This is really much code duplication, get rid of it!
           if (isVariable(arg._right)) {
             rightVar = true;
-            rightCol = sub._qet->getVariableColumn(
-                arg._innerRight.getVariable().name());
+            rightCol =
+                sub._qet->getVariableColumn(arg._innerRight.getVariable());
             rightColName = Variable{arg._right.getVariable()};
           } else {
             rightVar = false;
-            rightCol = sub._qet->getVariableColumn(
-                arg._innerRight.getVariable().name());
+            rightCol =
+                sub._qet->getVariableColumn(arg._innerRight.getVariable());
             rightColName = generateUniqueVarName();
             if (auto opt = arg._right.toValueId(_qec->getIndex().getVocab());
                 opt.has_value()) {
@@ -581,7 +579,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getPatternTrickRow(
       // Determine the column containing the subjects for which we are
       // interested in their predicates.
       auto subjectColumn =
-          parent._qet->getVariableColumn(patternTrickTuple.subject_.name());
+          parent._qet->getVariableColumn(patternTrickTuple.subject_);
       auto patternTrickPlan = makeSubtreePlan<CountAvailablePredicates>(
           _qec, parent._qet, subjectColumn, predicateVariable, countVariable);
       added.push_back(std::move(patternTrickPlan));
@@ -650,8 +648,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     plan._idsOfIncludedNodes = parent._idsOfIncludedNodes;
     plan._idsOfIncludedFilters = parent._idsOfIncludedFilters;
     if (pq._orderBy.size() == 1 && !pq._orderBy[0].isDescending_) {
-      size_t col =
-          parent._qet->getVariableColumn(pq._orderBy[0].variable_.name());
+      size_t col = parent._qet->getVariableColumn(pq._orderBy[0].variable_);
       const std::vector<size_t>& previousSortedOn =
           parent._qet->resultSortedOn();
       if (!previousSortedOn.empty() && col == previousSortedOn[0]) {
@@ -664,9 +661,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     } else {
       vector<pair<size_t, bool>> sortIndices;
       for (auto& ord : pq._orderBy) {
-        sortIndices.emplace_back(
-            parent._qet->getVariableColumn(ord.variable_.name()),
-            ord.isDescending_);
+        sortIndices.emplace_back(parent._qet->getVariableColumn(ord.variable_),
+                                 ord.isDescending_);
       }
       const std::vector<size_t>& previousSortedOn =
           parent._qet->resultSortedOn();
@@ -1579,7 +1575,7 @@ void QueryPlanner::applyFiltersIfPossible(
 
       if (std::ranges::all_of(filters[i].expression_.containedVariables(),
                               [&plan](const auto& variable) {
-                                return plan._qet->varCovered(variable->name());
+                                return plan._qet->isVariableCovered(*variable);
                               })) {
         // Apply this filter.
         SubtreePlan newPlan =

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -83,7 +83,7 @@ void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
 
 // ________________________________________________________________________________________________________________
 void RuntimeInformation::setColumnNames(
-    const ad_utility::HashMap<std::string, size_t>& columnMap) {
+    const ad_utility::HashMap<Variable, size_t>& columnMap) {
   if (columnMap.empty()) {
     return;
   }
@@ -95,7 +95,7 @@ void RuntimeInformation::setColumnNames(
   // Now copy the (variable, index) pairs to the vector.
   for (const auto& [variable, columnIndex] : columnMap) {
     AD_CHECK(columnIndex < columnNames_.size());
-    columnNames_[columnIndex] = variable;
+    columnNames_[columnIndex] = variable.name();
   }
 }
 

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -82,8 +82,7 @@ void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
 }
 
 // ________________________________________________________________________________________________________________
-void RuntimeInformation::setColumnNames(
-    const ad_utility::HashMap<Variable, size_t>& columnMap) {
+void RuntimeInformation::setColumnNames(const VariableToColumnMap& columnMap) {
   if (columnMap.empty()) {
     return;
   }

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
-#include <absl/strings/str_join.h>
-#include <util/HashMap.h>
-#include <util/json.h>
-
 #include <iostream>
 #include <string>
 #include <vector>
+
+#include "absl/strings/str_join.h"
+#include "parser/data/Variable.h"
+#include "util/HashMap.h"
+#include "util/json.h"
 
 /// A class to store information about the status of an operation (result size,
 /// time to compute, status, etc.). Also contains the functionality to print
@@ -80,8 +81,7 @@ class RuntimeInformation {
 
   /// Set the names of the columns from the HashMap format that is used in the
   /// rest of the Qlever code.
-  void setColumnNames(
-      const ad_utility::HashMap<std::string, size_t>& columnMap);
+  void setColumnNames(const ad_utility::HashMap<Variable, size_t>& columnMap);
 
   /// Get the time spent computing the operation. This is the total time minus
   /// the time spent computing the children.

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "absl/strings/str_join.h"
+#include "engine/VariableToColumnMap.h"
 #include "parser/data/Variable.h"
 #include "util/HashMap.h"
 #include "util/json.h"
@@ -81,7 +82,7 @@ class RuntimeInformation {
 
   /// Set the names of the columns from the HashMap format that is used in the
   /// rest of the Qlever code.
-  void setColumnNames(const ad_utility::HashMap<Variable, size_t>& columnMap);
+  void setColumnNames(const VariableToColumnMap& columnMap);
 
   /// Get the time spent computing the operation. This is the total time minus
   /// the time spent computing the children.

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -41,7 +41,7 @@ string Sort::getDescriptor() const {
   std::string orderByVars;
   for (const auto& p : _subtree->getVariableColumns()) {
     if (p.second == _sortCol) {
-      orderByVars = "ASC(" + p.first + ") ";
+      orderByVars = "ASC(" + p.first.name() + ") ";
       break;
     }
   }

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -33,19 +33,23 @@ TextOperationWithFilter::TextOperationWithFilter(
 // _____________________________________________________________________________
 Operation::VariableToColumnMap
 TextOperationWithFilter::computeVariableToColumnMap() const {
-  ad_utility::HashMap<string, size_t> vcmap;
+  VariableToColumnMap vcmap;
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.
-  vcmap[_cvar.name()] = 0;
-  vcmap[absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, _cvar.name().substr(1))] = 1;
+  vcmap[_cvar] = 0;
+  // TODO<joka921> Make this a function.
+  vcmap[Variable{
+      absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, _cvar.name().substr(1))}] = 1;
   size_t colN = 2;
   const auto& filterColumns = _filterResult.get()->getVariableColumns();
+  // TODO<joka921> The order of the `_variables` is not deterministic,
+  // check whether this is correct (especially in the presence of caching).
   for (const auto& var : _variables) {
     if (var == _cvar) {
       continue;
     }
-    if (filterColumns.count(var.name()) == 0) {
-      vcmap[var.name()] = colN++;
+    if (!filterColumns.contains(var)) {
+      vcmap[var] = colN++;
     }
   }
   for (const auto& varcol : filterColumns) {

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -37,7 +37,7 @@ VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.
   vcmap[_cvar] = 0;
-  vcmap[_cvar.getTextscoreVariable()] = 1;
+  vcmap[_cvar.getTextScoreVariable()] = 1;
   size_t colN = 2;
   const auto& filterColumns = _filterResult.get()->getVariableColumns();
   // TODO<joka921> The order of the `_variables` is not deterministic,

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -38,8 +38,7 @@ VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
   // is provided by the filter table and still has the same place there.
   vcmap[_cvar] = 0;
   // TODO<joka921> Make this a function.
-  vcmap[Variable{
-      absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, _cvar.name().substr(1))}] = 1;
+  vcmap[_cvar.getTextscoreVariable()] = 1;
   size_t colN = 2;
   const auto& filterColumns = _filterResult.get()->getVariableColumns();
   // TODO<joka921> The order of the `_variables` is not deterministic,

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -37,7 +37,6 @@ VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.
   vcmap[_cvar] = 0;
-  // TODO<joka921> Make this a function.
   vcmap[_cvar.getTextscoreVariable()] = 1;
   size_t colN = 2;
   const auto& filterColumns = _filterResult.get()->getVariableColumns();

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -31,8 +31,8 @@ TextOperationWithFilter::TextOperationWithFilter(
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap
-TextOperationWithFilter::computeVariableToColumnMap() const {
+VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
+    const {
   VariableToColumnMap vcmap;
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -33,9 +33,7 @@ VariableToColumnMap TextOperationWithoutFilter::computeVariableToColumnMap()
   VariableToColumnMap vcmap;
   size_t index = 0;
   vcmap[_cvar] = index++;
-  // TODO<joka921> make this a function, probably in the `Variable` header.
-  vcmap[Variable{absl::StrCat(TEXTSCORE_VARIABLE_PREFIX,
-                              _cvar.name().substr(1))}] = index++;
+  vcmap[_cvar.getTextscoreVariable()] = index++;
   // TODO<joka921> The order of the variables is not deterministic, check
   // whether this is correct.
   for (const auto& var : _variables) {

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -30,14 +30,17 @@ TextOperationWithoutFilter::TextOperationWithoutFilter(
 // _____________________________________________________________________________
 Operation::VariableToColumnMap
 TextOperationWithoutFilter::computeVariableToColumnMap() const {
-  ad_utility::HashMap<string, size_t> vcmap;
+  VariableToColumnMap vcmap;
   size_t index = 0;
-  vcmap[_cvar.name()] = index++;
-  vcmap[absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, _cvar.name().substr(1))] =
-      index++;
+  vcmap[_cvar] = index++;
+  // TODO<joka921> make this a function, probably in the `Variable` header.
+  vcmap[Variable{absl::StrCat(TEXTSCORE_VARIABLE_PREFIX,
+                              _cvar.name().substr(1))}] = index++;
+  // TODO<joka921> The order of the variables is not deterministic, check
+  // whether this is correct.
   for (const auto& var : _variables) {
     if (var != _cvar) {
-      vcmap[var.name()] = index++;
+      vcmap[var] = index++;
     }
   }
   return vcmap;

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -28,8 +28,8 @@ TextOperationWithoutFilter::TextOperationWithoutFilter(
       _sizeEstimate(std::numeric_limits<size_t>::max()) {}
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap
-TextOperationWithoutFilter::computeVariableToColumnMap() const {
+VariableToColumnMap TextOperationWithoutFilter::computeVariableToColumnMap()
+    const {
   VariableToColumnMap vcmap;
   size_t index = 0;
   vcmap[_cvar] = index++;

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -33,7 +33,7 @@ VariableToColumnMap TextOperationWithoutFilter::computeVariableToColumnMap()
   VariableToColumnMap vcmap;
   size_t index = 0;
   vcmap[_cvar] = index++;
-  vcmap[_cvar.getTextscoreVariable()] = index++;
+  vcmap[_cvar.getTextScoreVariable()] = index++;
   // TODO<joka921> The order of the variables is not deterministic, check
   // whether this is correct.
   for (const auto& var : _variables) {

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -34,8 +34,8 @@ TransitivePath::TransitivePath(
       _rightColName(rightColName.name()),
       _minDist(minDist),
       _maxDist(maxDist) {
-  _variableColumns[_leftColName] = 0;
-  _variableColumns[_rightColName] = 1;
+  _variableColumns[leftColName] = 0;
+  _variableColumns[rightColName] = 1;
 }
 
 // _____________________________________________________________________________
@@ -729,7 +729,7 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftSide(
   std::shared_ptr<TransitivePath> p = std::make_shared<TransitivePath>(*this);
   p->_leftSideTree = leftop;
   p->_leftSideCol = inputCol;
-  const ad_utility::HashMap<string, size_t>& var = leftop->getVariableColumns();
+  const auto& var = leftop->getVariableColumns();
   for (auto col : var) {
     if (col.second != inputCol) {
       if (col.second > inputCol) {
@@ -753,8 +753,8 @@ std::shared_ptr<TransitivePath> TransitivePath::bindRightSide(
   std::shared_ptr<TransitivePath> p = std::make_shared<TransitivePath>(*this);
   p->_rightSideTree = rightop;
   p->_rightSideCol = inputCol;
-  const ad_utility::HashMap<string, size_t>& var =
-      rightop->getVariableColumns();
+  const auto& var = rightop->getVariableColumns();
+  // TODO<joka921> Use structured binding to make this more readable.
   for (auto col : var) {
     if (col.second != inputCol) {
       if (col.second > inputCol) {

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -133,8 +133,7 @@ vector<size_t> TransitivePath::resultSortedOn() const {
 }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap TransitivePath::computeVariableToColumnMap()
-    const {
+VariableToColumnMap TransitivePath::computeVariableToColumnMap() const {
   return _variableColumns;
 }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -729,12 +729,12 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftSide(
   p->_leftSideTree = leftop;
   p->_leftSideCol = inputCol;
   const auto& var = leftop->getVariableColumns();
-  for (auto col : var) {
-    if (col.second != inputCol) {
-      if (col.second > inputCol) {
-        p->_variableColumns[col.first] = col.second + 1;
+  for (const auto& [variable, columnIndex] : var) {
+    if (columnIndex != inputCol) {
+      if (columnIndex > inputCol) {
+        p->_variableColumns[variable] = columnIndex + 1;
       } else {
-        p->_variableColumns[col.first] = col.second + 2;
+        p->_variableColumns[variable] = columnIndex + 2;
       }
       p->_resultWidth++;
     }
@@ -745,6 +745,9 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftSide(
 // _____________________________________________________________________________
 std::shared_ptr<TransitivePath> TransitivePath::bindRightSide(
     std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const {
+  // TODO<joka921> `bindRightSide` and `bindLeftSide` are almost the same,
+  // could and should this be made generic? It probably requires refactoring
+  // quite a lot of this class though.
   // Enforce required sorting of `rightop`.
   rightop =
       QueryExecutionTree::createSortedTree(std::move(rightop), {inputCol});
@@ -753,13 +756,12 @@ std::shared_ptr<TransitivePath> TransitivePath::bindRightSide(
   p->_rightSideTree = rightop;
   p->_rightSideCol = inputCol;
   const auto& var = rightop->getVariableColumns();
-  // TODO<joka921> Use structured binding to make this more readable.
-  for (auto col : var) {
-    if (col.second != inputCol) {
-      if (col.second > inputCol) {
-        p->_variableColumns[col.first] = col.second + 1;
+  for (const auto& [variable, columnIndex] : var) {
+    if (columnIndex != inputCol) {
+      if (columnIndex > inputCol) {
+        p->_variableColumns[variable] = columnIndex + 1;
       } else {
-        p->_variableColumns[col.first] = col.second + 2;
+        p->_variableColumns[variable] = columnIndex + 2;
       }
       p->_resultWidth++;
     }

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -23,7 +23,7 @@ class TransitivePath : public Operation {
   size_t _rightSideCol;
 
   size_t _resultWidth;
-  ad_utility::HashMap<std::string, size_t> _variableColumns;
+  VariableToColumnMap _variableColumns;
 
   std::shared_ptr<QueryExecutionTree> _subtree;
   bool _leftIsVar;

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -138,5 +138,5 @@ class TransitivePath : public Operation {
  private:
   virtual void computeResult(ResultTable* result) override;
 
-  Operation::VariableToColumnMap computeVariableToColumnMap() const override;
+  VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -65,7 +65,7 @@ size_t Union::getResultWidth() const {
 vector<size_t> Union::resultSortedOn() const { return {}; }
 
 // _____________________________________________________________________________
-Operation::VariableToColumnMap Union::computeVariableToColumnMap() const {
+VariableToColumnMap Union::computeVariableToColumnMap() const {
   using VarAndIndex = std::pair<Variable, size_t>;
 
   // TODO<joka921> The "sorting by index" or "sorting by keys" should

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -68,16 +68,6 @@ vector<size_t> Union::resultSortedOn() const { return {}; }
 VariableToColumnMap Union::computeVariableToColumnMap() const {
   using VarAndIndex = std::pair<Variable, size_t>;
 
-  // TODO<joka921> The "sorting by index" or "sorting by keys" should
-  // be a separate function, it is duplicated at least in the MultiColumnJoin.
-  auto getVarsSortedByIndex = [](const auto& subtree) {
-    const auto& subtreeVariableColumns = subtree->getVariableColumns();
-    std::vector<VarAndIndex> varsAsPairs(subtreeVariableColumns.begin(),
-                                         subtreeVariableColumns.end());
-    std::ranges::sort(varsAsPairs, {}, ad_utility::second);
-    return varsAsPairs;
-  };
-
   VariableToColumnMap variableColumns;
   size_t column = 0;
 
@@ -89,12 +79,11 @@ VariableToColumnMap Union::computeVariableToColumnMap() const {
         }
       };
 
-  auto addVariablesForSubtree =
-      [&getVarsSortedByIndex,
-       &addVariableColumnIfNotExists](const auto& subtree) {
-        std::ranges::for_each(getVarsSortedByIndex(subtree),
-                              addVariableColumnIfNotExists);
-      };
+  auto addVariablesForSubtree = [&addVariableColumnIfNotExists](
+                                    const auto& subtree) {
+    std::ranges::for_each(sortedByColumnIndex(subtree->getVariableColumns()),
+                          addVariableColumnIfNotExists);
+  };
 
   std::ranges::for_each(_subtrees, addVariablesForSubtree);
   return variableColumns;

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -79,11 +79,12 @@ VariableToColumnMap Union::computeVariableToColumnMap() const {
         }
       };
 
-  auto addVariablesForSubtree = [&addVariableColumnIfNotExists](
-                                    const auto& subtree) {
-    std::ranges::for_each(sortedByColumnIndex(subtree->getVariableColumns()),
-                          addVariableColumnIfNotExists);
-  };
+  auto addVariablesForSubtree =
+      [&addVariableColumnIfNotExists](const auto& subtree) {
+        std::ranges::for_each(
+            copySortedByColumnIndex(subtree->getVariableColumns()),
+            addVariableColumnIfNotExists);
+      };
 
   std::ranges::for_each(_subtrees, addVariablesForSubtree);
   return variableColumns;

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -19,8 +19,7 @@ Union::Union(QueryExecutionContext* qec,
   _subtrees[1] = t2;
 
   // compute the column origins
-  ad_utility::HashMap<string, size_t> variableColumns =
-      getInternallyVisibleVariableColumns();
+  VariableToColumnMap variableColumns = getInternallyVisibleVariableColumns();
   _columnOrigins.resize(variableColumns.size(), {NO_COLUMN, NO_COLUMN});
   const auto& t1VarCols = t1->getVariableColumns();
   const auto& t2VarCols = t2->getVariableColumns();
@@ -67,8 +66,10 @@ vector<size_t> Union::resultSortedOn() const { return {}; }
 
 // _____________________________________________________________________________
 Operation::VariableToColumnMap Union::computeVariableToColumnMap() const {
-  using VarAndIndex = std::pair<std::string, size_t>;
+  using VarAndIndex = std::pair<Variable, size_t>;
 
+  // TODO<joka921> The "sorting by index" or "sorting by keys" should
+  // be a separate function, it is duplicated at least in the MultiColumnJoin.
   auto getVarsSortedByIndex = [](const auto& subtree) {
     const auto& subtreeVariableColumns = subtree->getVariableColumns();
     std::vector<VarAndIndex> varsAsPairs(subtreeVariableColumns.begin(),

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -78,9 +78,10 @@ size_t Values::getResultWidth() const { return _values._variables.size(); }
 vector<size_t> Values::resultSortedOn() const { return {}; }
 
 Operation::VariableToColumnMap Values::computeVariableToColumnMap() const {
-  ad_utility::HashMap<string, size_t> map;
+  VariableToColumnMap map;
   for (size_t i = 0; i < _values._variables.size(); i++) {
-    map[_values._variables[i]] = i;
+    // TODO<joka921> Make the `_variables` also `Variable`s
+    map[Variable{_values._variables[i]}] = i;
   }
   return map;
 }

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -77,7 +77,7 @@ size_t Values::getResultWidth() const { return _values._variables.size(); }
 
 vector<size_t> Values::resultSortedOn() const { return {}; }
 
-Operation::VariableToColumnMap Values::computeVariableToColumnMap() const {
+VariableToColumnMap Values::computeVariableToColumnMap() const {
   VariableToColumnMap map;
   for (size_t i = 0; i < _values._variables.size(); i++) {
     // TODO<joka921> Make the `_variables` also `Variable`s

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -47,7 +47,7 @@ class Values : public Operation {
  private:
   virtual void computeResult(ResultTable* result) override;
 
-  Operation::VariableToColumnMap computeVariableToColumnMap() const override;
+  VariableToColumnMap computeVariableToColumnMap() const override;
 
   template <size_t I>
   void writeValues(IdTable* res, const Index& index,

--- a/src/engine/VariableToColumnMap.cpp
+++ b/src/engine/VariableToColumnMap.cpp
@@ -4,10 +4,11 @@
 
 #include "./VariableToColumnMap.h"
 
-std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
+// _____________________________________________________________________________
+std::vector<std::pair<Variable, size_t>> copySortedByColumnIndex(
     VariableToColumnMap map) {
   std::vector<std::pair<Variable, size_t>> result{
       std::make_move_iterator(map.begin()), std::make_move_iterator(map.end())};
-  std::ranges::sort(result, {}, ad_utility::second);
+  std::ranges::sort(result, std::less<>{}, ad_utility::second);
   return result;
 }

--- a/src/engine/VariableToColumnMap.cpp
+++ b/src/engine/VariableToColumnMap.cpp
@@ -1,0 +1,13 @@
+//  Copyright 2022, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include "./VariableToColumnMap.h"
+
+std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
+    VariableToColumnMap map) {
+  std::vector<std::pair<Variable, size_t>> result{
+      std::make_move_iterator(map.begin()), std::make_move_iterator(map.end())};
+  std::ranges::sort(result, {}, ad_utility::second);
+  return result;
+}

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -10,10 +10,10 @@
 
 // A hash map from variables to the column index of that variable in a table,
 // used in several places (e.g. the `Operation` class, the `SparqlExpression`
-// module, etc.
+// module, etc.).
 using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
 
 // Return a vector that contains the contents of the `VariableToColumnMap` in
 // ascending order of the column indices.
-std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
+std::vector<std::pair<Variable, size_t>> copySortedByColumnIndex(
     VariableToColumnMap map);

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -1,0 +1,13 @@
+//  Copyright 2022, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#pragma once
+
+#include "parser/data/Variable.h"
+#include "util/HashMap.h"
+
+// A hash map from variables to the column index of that variable in a table,
+// used in several places (e.g. the `Operation` class, the `SparqlExpression`
+// module, etc.
+using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -13,11 +13,6 @@
 // module, etc.
 using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
 
-// TODO<joka921> Comment and move to .cpp file.
-inline std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
-    VariableToColumnMap map) {
-  std::vector<std::pair<Variable, size_t>> result{
-      std::make_move_iterator(map.begin()), std::make_move_iterator(map.end())};
-  std::ranges::sort(result, {}, ad_utility::second);
-  return result;
-}
+// Return a vector that contains the contents of the `VariableToColumnMap` in ascending order of the column indices.
+std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
+    VariableToColumnMap map);

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -6,8 +6,18 @@
 
 #include "parser/data/Variable.h"
 #include "util/HashMap.h"
+#include "util/TransparentFunctors.h"
 
 // A hash map from variables to the column index of that variable in a table,
 // used in several places (e.g. the `Operation` class, the `SparqlExpression`
 // module, etc.
 using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
+
+// TODO<joka921> Comment and move to .cpp file.
+inline std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
+    VariableToColumnMap map) {
+  std::vector<std::pair<Variable, size_t>> result{
+      std::make_move_iterator(map.begin()), std::make_move_iterator(map.end())};
+  std::ranges::sort(result, {}, ad_utility::second);
+  return result;
+}

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -13,6 +13,7 @@
 // module, etc.
 using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
 
-// Return a vector that contains the contents of the `VariableToColumnMap` in ascending order of the column indices.
+// Return a vector that contains the contents of the `VariableToColumnMap` in
+// ascending order of the column indices.
 std::vector<std::pair<Variable, size_t>> sortedByColumnIndex(
     VariableToColumnMap map);

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -66,7 +66,7 @@ class LiteralExpression : public SparqlExpression {
   // ______________________________________________________________________
   string getCacheKey(const VariableToColumnMap& varColMap) const override {
     if constexpr (std::is_same_v<T, ::Variable>) {
-      return {"#column_" + std::to_string(varColMap.at(_value.name())) + "#"};
+      return {"#column_" + std::to_string(varColMap.at(_value)) + "#"};
     } else if constexpr (std::is_same_v<T, string>) {
       return _value;
     } else if constexpr (std::is_same_v<T, ValueId>) {

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -145,7 +145,7 @@ RegexExpression::RegexExpression(
 
 // ___________________________________________________________________________
 string RegexExpression::getCacheKey(
-    const sparqlExpression::VariableToColumnMap& varColMap) const {
+    const VariableToColumnMap& varColMap) const {
   return "REGEX expression " + child_->getCacheKey(varColMap) + " with " +
          regexAsString_;
 }

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -25,14 +25,14 @@ void getIdsFromVariableImpl(VectorWithMemoryLimit<ValueId>& result,
   const size_t beginIndex = context->_beginIndex;
   const size_t endIndex = context->_endIndex;
 
-  if (!context->_variableToColumnAndResultTypeMap.contains(variable.name())) {
+  if (!context->_variableToColumnAndResultTypeMap.contains(variable)) {
     throw std::runtime_error(
         "Variable " + variable.name() +
         " could not be mapped to context column of expression evaluation");
   }
 
   const size_t columnIndex =
-      context->_variableToColumnAndResultTypeMap.at(variable.name()).first;
+      context->_variableToColumnAndResultTypeMap.at(variable).first;
 
   result.reserve(endIndex - endIndex);
   for (size_t i = beginIndex; i < endIndex; ++i) {

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -52,8 +52,8 @@ std::optional<::Variable> SparqlExpressionPimpl::getVariableOrNullopt() const {
 
 // ___________________________________________________________________________
 std::string SparqlExpressionPimpl::getCacheKey(
-    const VariableColumnMap& variableColumnMap) const {
-  return _pimpl->getCacheKey(variableColumnMap);
+    const VariableToColumnMap& variableToColumnMap) const {
+  return _pimpl->getCacheKey(variableToColumnMap);
 }
 
 // ____________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -8,13 +8,12 @@
 #include <optional>
 #include <vector>
 
+#include "engine/VariableToColumnMap.h"
 #include "parser/data/Variable.h"
 #include "util/HashMap.h"
 #include "util/HashSet.h"
 
 namespace sparqlExpression {
-
-using VariableColumnMap = ad_utility::HashMap<Variable, size_t>;
 
 class SparqlExpression;
 struct EvaluationContext;
@@ -67,7 +66,7 @@ class SparqlExpressionPimpl {
   // has to be in the .cpp file because `SparqlExpression` is only forward
   // declared.
   [[nodiscard]] std::string getCacheKey(
-      const VariableColumnMap& variableColumnMap) const;
+      const VariableToColumnMap& variableToColumnMap) const;
   SparqlExpressionPimpl(std::shared_ptr<SparqlExpression>&& pimpl,
                         std::string descriptor);
   ~SparqlExpressionPimpl();

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -14,7 +14,7 @@
 
 namespace sparqlExpression {
 
-using VariableColumnMap = ad_utility::HashMap<std::string, size_t>;
+using VariableColumnMap = ad_utility::HashMap<Variable, size_t>;
 
 class SparqlExpression;
 struct EvaluationContext;

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -94,13 +94,14 @@ using StrongIdsWithResultType = VectorWithMemoryLimit<ValueId>;
 
 /// Typedef for a map from variable names to the corresponding column in the
 /// input of a SparqlExpression.
-using VariableToColumnMap = ad_utility::HashMap<std::string, size_t>;
+/// TODO<joka921> extract the currently `three` definitions of
+/// `VariableToColumnMap` to a separate header.
+using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
 
 /// Typedef for a map from variables names to (input column, type of input
 /// column.
 using VariableToColumnAndResultTypeMap =
-    ad_utility::HashMap<std::string,
-                        std::pair<size_t, ResultTable::ResultType>>;
+    ad_utility::HashMap<Variable, std::pair<size_t, ResultTable::ResultType>>;
 
 /// All the additional information which is needed to evaluate a Sparql
 /// expression.
@@ -162,7 +163,7 @@ struct EvaluationContext {
     if (_columnsByWhichResultIsSorted.empty()) {
       return false;
     }
-    if (!_variableToColumnAndResultTypeMap.contains(variable.name())) {
+    if (!_variableToColumnAndResultTypeMap.contains(variable)) {
       return false;
     }
 
@@ -175,11 +176,11 @@ struct EvaluationContext {
   // ____________________________________________________________________________
   [[nodiscard]] size_t getColumnIndexForVariable(const Variable& var) const {
     const auto& map = _variableToColumnAndResultTypeMap;
-    if (!map.contains(var._name)) {
+    if (!map.contains(var)) {
       throw std::runtime_error(absl::StrCat(
-          "Variable ", var._name, " was not found in input to expression."));
+          "Variable ", var.name(), " was not found in input to expression."));
     }
-    return map.at(var._name).first;
+    return map.at(var).first;
   }
 };
 

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -92,12 +92,6 @@ namespace sparqlExpression {
 /// A list of StrongIds that all have the same datatype.
 using StrongIdsWithResultType = VectorWithMemoryLimit<ValueId>;
 
-/// Typedef for a map from variable names to the corresponding column in the
-/// input of a SparqlExpression.
-/// TODO<joka921> extract the currently `three` definitions of
-/// `VariableToColumnMap` to a separate header.
-using VariableToColumnMap = ad_utility::HashMap<Variable, size_t>;
-
 /// Typedef for a map from variables names to (input column, type of input
 /// column.
 using VariableToColumnAndResultTypeMap =

--- a/src/parser/data/Context.h
+++ b/src/parser/data/Context.h
@@ -4,18 +4,21 @@
 
 #pragma once
 
-#include <engine/ResultTable.h>
-#include <util/HashMap.h>
-
 #include <string>
+
+#include "engine/ResultTable.h"
+#include "parser/data/Variable.h"
+#include "util/HashMap.h"
 
 // Forward declarations to avoid cyclic dependencies
 class Index;
-enum ContextRole { SUBJECT, PREDICATE, OBJECT };
+enum ContextRole : int { SUBJECT, PREDICATE, OBJECT };
 
 struct Context {
   const size_t _row;
   const ResultTable& _res;
-  const ad_utility::HashMap<std::string, size_t>& _variableColumns;
+  // TODO<joka921> Should be `VariableToColumnMap` once this is in a separate
+  // header.
+  const ad_utility::HashMap<Variable, size_t>& _variableColumns;
   const Index& _qecIndex;
 };

--- a/src/parser/data/Context.h
+++ b/src/parser/data/Context.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "engine/ResultTable.h"
+#include "engine/VariableToColumnMap.h"
 #include "parser/data/Variable.h"
 #include "util/HashMap.h"
 
@@ -17,8 +18,6 @@ enum ContextRole : int { SUBJECT, PREDICATE, OBJECT };
 struct Context {
   const size_t _row;
   const ResultTable& _res;
-  // TODO<joka921> Should be `VariableToColumnMap` once this is in a separate
-  // header.
-  const ad_utility::HashMap<Variable, size_t>& _variableColumns;
+  const VariableToColumnMap& _variableColumns;
   const Index& _qecIndex;
 };

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -6,6 +6,7 @@
 
 #include "ctre/ctre.h"
 #include "index/Index.h"
+#include "parser/data/Context.h"
 
 // ___________________________________________________________________________
 Variable::Variable(std::string name) : _name{std::move(name)} {
@@ -22,12 +23,11 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
     const Context& context, [[maybe_unused]] ContextRole role) const {
   size_t row = context._row;
   const ResultTable& res = context._res;
-  const ad_utility::HashMap<string, size_t>& variableColumns =
-      context._variableColumns;
+  const auto& variableColumns = context._variableColumns;
   const Index& qecIndex = context._qecIndex;
   const auto& idTable = res._idTable;
-  if (variableColumns.contains(_name)) {
-    size_t index = variableColumns.at(_name);
+  if (variableColumns.contains(*this)) {
+    size_t index = variableColumns.at(*this);
     auto id = idTable(row, index);
     switch (id.getDatatype()) {
       case Datatype::Undefined:

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -54,3 +54,8 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
   }
   return std::nullopt;
 }
+
+// _____________________________________________________________________________
+Variable Variable::getTextscoreVariable() const {
+  return Variable{absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, name().substr(1))};
+}

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -56,6 +56,6 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
 }
 
 // _____________________________________________________________________________
-Variable Variable::getTextscoreVariable() const {
+Variable Variable::getTextScoreVariable() const {
   return Variable{absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, name().substr(1))};
 }

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -36,7 +36,7 @@ class Variable {
   [[nodiscard]] const std::string& targetVariable() const { return _name; }
 
   // Convert `?someVariable` into `?ql_textscore_someVariable`
-  Variable getTextscoreVariable() const;
+  Variable getTextScoreVariable() const;
 
   bool operator==(const Variable&) const = default;
 

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -35,6 +35,9 @@ class Variable {
   // Needed for consistency with the `Alias` class.
   [[nodiscard]] const std::string& targetVariable() const { return _name; }
 
+  // Convert `?someVariable` into `?ql_textscore_someVariable`
+  Variable getTextscoreVariable() const;
+
   bool operator==(const Variable&) const = default;
 
   // Make the type hashable for absl, see

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 
-#include "Context.h"
+// Forward declaration because of cyclic dependencies
+// TODO<joka921> The coupling of the `Variable` with its `evaluate` methods
+// is not very clean and should be refactored.
+struct Context;
+enum ContextRole : int;
 
 class Variable {
  public:
@@ -17,9 +22,6 @@ class Variable {
 
   // TODO<joka921> There are several similar variants of this function across
   // the codebase. Unify them!
-  // TODO<joka921> This function can also be in the .cpp file, but we first
-  // have to figure out the link order.
-
   // ___________________________________________________________________________
   [[nodiscard]] std::optional<std::string> evaluate(
       const Context& context, [[maybe_unused]] ContextRole role) const;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -947,7 +947,7 @@ vector<TripleWithPropertyPath> Visitor::visit(
       if (auto* propertyPath = std::get_if<PropertyPath>(&predicate)) {
         if (propertyPath->asString() == CONTAINS_ENTITY_PREDICATE ||
             propertyPath->asString() == CONTAINS_WORD_PREDICATE) {
-          addVisibleVariable(var->getTextscoreVariable());
+          addVisibleVariable(var->getTextScoreVariable());
         }
       }
     }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -441,7 +441,11 @@ parsedQuery::GraphPatternOperation Visitor::visit(
 // ____________________________________________________________________________________
 parsedQuery::GraphPatternOperation Visitor::visit(
     Parser::ServiceGraphPatternContext* ctx) {
-  reportNotSupported(ctx, "Federated queries (SERVICE) are");
+  auto beg = ctx->groupGraphPattern()->getStart()->getStartIndex();
+  auto s = ctx->groupGraphPattern()->getStop()->getStopIndex();
+  auto s = ctx->getStart()->getInputStream()->getText()
+
+               reportNotSupported(ctx, "Federated queries (SERVICE) are");
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -441,11 +441,7 @@ parsedQuery::GraphPatternOperation Visitor::visit(
 // ____________________________________________________________________________________
 parsedQuery::GraphPatternOperation Visitor::visit(
     Parser::ServiceGraphPatternContext* ctx) {
-  auto beg = ctx->groupGraphPattern()->getStart()->getStartIndex();
-  auto s = ctx->groupGraphPattern()->getStop()->getStopIndex();
-  auto s = ctx->getStart()->getInputStream()->getText()
-
-               reportNotSupported(ctx, "Federated queries (SERVICE) are");
+  reportNotSupported(ctx, "Federated queries (SERVICE) are");
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -947,8 +947,7 @@ vector<TripleWithPropertyPath> Visitor::visit(
       if (auto* propertyPath = std::get_if<PropertyPath>(&predicate)) {
         if (propertyPath->asString() == CONTAINS_ENTITY_PREDICATE ||
             propertyPath->asString() == CONTAINS_WORD_PREDICATE) {
-          addVisibleVariable(
-              absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, var->name().substr(1)));
+          addVisibleVariable(var->getTextscoreVariable());
         }
       }
     }

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -65,9 +65,10 @@ class DummyOperation : public Operation {
 
  private:
   virtual VariableToColumnMap computeVariableToColumnMap() const override {
-    ad_utility::HashMap<string, size_t> m;
-    m["?a"] = 0;
-    m["?b"] = 1;
+    VariableToColumnMap m;
+    using V = Variable;
+    m[V{"?a"}] = 0;
+    m[V{"?b"}] = 1;
     return m;
   }
 };

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -66,9 +66,8 @@ class DummyOperation : public Operation {
  private:
   virtual VariableToColumnMap computeVariableToColumnMap() const override {
     VariableToColumnMap m;
-    using V = Variable;
-    m[V{"?a"}] = 0;
-    m[V{"?b"}] = 1;
+    m[Variable{"?a"}] = 0;
+    m[Variable{"?b"}] = 1;
     return m;
   }
 };

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -946,7 +946,7 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
         qet.asString());
     auto c = Variable{"?c"};
     ASSERT_EQ(0u, qet.getVariableColumn(c));
-    ASSERT_EQ(1u, qet.getVariableColumn(c.getTextscoreVariable()));
+    ASSERT_EQ(1u, qet.getVariableColumn(c.getTextScoreVariable()));
     ASSERT_EQ(2u, qet.getVariableColumn(Variable{"?y"}));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -944,10 +944,10 @@ TEST(QueryExecutionTreeTest, testBornInEuropeOwCocaine) {
         "      qet-width: 2 \n    } join-column: [0]\n    qet-width: 2 \n"
         "  }\n   filtered on column 1\n  qet-width: 4 \n}",
         qet.asString());
-    ASSERT_EQ(0u, qet.getVariableColumn("?c"));
-    ASSERT_EQ(1u, qet.getVariableColumn(
-                      absl::StrCat(TEXTSCORE_VARIABLE_PREFIX, "c")));
-    ASSERT_EQ(2u, qet.getVariableColumn("?y"));
+    auto c = Variable{"?c"};
+    ASSERT_EQ(0u, qet.getVariableColumn(c));
+    ASSERT_EQ(1u, qet.getVariableColumn(c.getTextscoreVariable()));
+    ASSERT_EQ(2u, qet.getVariableColumn(Variable{"?y"}));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();
@@ -1160,8 +1160,8 @@ TEST(QueryExecutionTreeTest, testFormerSegfaultTriFilter) {
         "} LIMIT 300");
     QueryPlanner qp(nullptr);
     QueryExecutionTree qet = qp.createExecutionTree(pq);
-    ASSERT_TRUE(qet.varCovered("?1"));
-    ASSERT_TRUE(qet.varCovered("?0"));
+    ASSERT_TRUE(qet.isVariableCovered(Variable{"?1"}));
+    ASSERT_TRUE(qet.isVariableCovered(Variable{"?0"}));
   } catch (const ad_semsearch::Exception& e) {
     std::cout << "Caught: " << e.getFullErrorMessage() << std::endl;
     FAIL() << e.getFullErrorMessage();

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -192,8 +192,8 @@ TEST(RegexExpression, getCacheKey) {
   auto exp2 = makeRegexExpression("?first", "alp");
 
   VariableToColumnMap map;
-  map["?first"] = 0;
-  map["?second"] = 1;
+  map[Variable{"?first"}] = 0;
+  map[Variable{"?second"}] = 1;
   ASSERT_EQ(exp1.getCacheKey(map), exp2.getCacheKey(map));
 
   // Different regex, different cache key.
@@ -211,7 +211,7 @@ TEST(RegexExpression, getCacheKey) {
   // Different variable name, but the variable is stored in the same column ->
   // same cache key.
   auto map2 = map;
-  map2["?otherFirst"] = 0;
+  map2[Variable{"?otherFirst"}] = 0;
   auto exp6 = makeRegexExpression("?otherFirst", "alp");
   ASSERT_EQ(exp1.getCacheKey(map), exp6.getCacheKey(map2));
 }

--- a/test/SparqlDataTypesTest.cpp
+++ b/test/SparqlDataTypesTest.cpp
@@ -19,7 +19,8 @@ ad_utility::AllocatorWithLimit<Id>& allocator() {
 struct ContextWrapper {
   Index _index{};
   ResultTable _resultTable{allocator()};
-  ad_utility::HashMap<std::string, size_t> _hashMap{};
+  // TODO<joka921> `VariableToColumnMap`
+  ad_utility::HashMap<Variable, size_t> _hashMap{};
 
   Context createContextForRow(size_t row) const {
     return {row, _resultTable, _hashMap, _index};
@@ -205,7 +206,7 @@ TEST(SparqlDataTypesTest, VariableInvalidNamesThrowException) {
 TEST(SparqlDataTypesTest, VariableEvaluatesCorrectlyBasedOnContext) {
   auto wrapper = prepareContext();
 
-  wrapper._hashMap["?var"] = 0;
+  wrapper._hashMap[Variable{"?var"}] = 0;
   wrapper._resultTable._resultTypes.push_back(qlever::ResultType::VERBATIM);
   wrapper._resultTable._idTable.setCols(1);
   Id value1 = Id::makeFromInt(69);
@@ -247,7 +248,7 @@ TEST(SparqlDataTypesTest, VariableEvaluatesNothingForUnusedName) {
 TEST(SparqlDataTypesTest, VariableEvaluateIsPropagatedCorrectly) {
   auto wrapper = prepareContext();
 
-  wrapper._hashMap["?var"] = 0;
+  wrapper._hashMap[Variable{"?var"}] = 0;
   wrapper._resultTable._resultTypes.push_back(qlever::ResultType::VERBATIM);
   wrapper._resultTable._idTable.setCols(1);
   Id value = Id::makeFromInt(69);

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -126,18 +126,19 @@ struct TestContext {
     context._beginIndex = 0;
     context._endIndex = table.size();
     // Define the mapping from variable names to column indices.
-    varToColMap["?ints"] = {0, qlever::ResultType::KB};
-    varToColMap["?doubles"] = {1, qlever::ResultType::KB};
-    varToColMap["?numeric"] = {2, qlever::ResultType::KB};
-    varToColMap["?vocab"] = {3, qlever::ResultType::KB};
-    varToColMap["?mixed"] = {4, qlever::ResultType::KB};
+    using V = Variable;
+    varToColMap[V{"?ints"}] = {0, qlever::ResultType::KB};
+    varToColMap[V{"?doubles"}] = {1, qlever::ResultType::KB};
+    varToColMap[V{"?numeric"}] = {2, qlever::ResultType::KB};
+    varToColMap[V{"?vocab"}] = {3, qlever::ResultType::KB};
+    varToColMap[V{"?mixed"}] = {4, qlever::ResultType::KB};
   }
 
   // Get a test context where the rows are the same as by default, but sorted by
   // `variable`
   static TestContext sortedBy(const Variable& variable) {
     TestContext result;
-    auto columnIndex = result.varToColMap.at(variable.name()).first;
+    auto columnIndex = result.varToColMap.at(variable).first;
     std::sort(result.table.begin(), result.table.end(),
               [columnIndex](const auto& a, const auto& b) {
                 return valueIdComparators::compareByBits(a[columnIndex],


### PR DESCRIPTION
This is now `HashMap<Variable, size_t>` instead of `HashMap<string, size_t>`
TODO:
- Adress several todos (create one central definition for the type,
move some member variables to the `Variable` type, etc.