### PR TITLE
Refactor the code handling the local vocabulary

### DIFF
--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -102,7 +102,7 @@ if [ ${REBUILD_THE_INDEX} == "YES" ] || ! [ -f "${INDEX}.vocabulary" ]; then
 	rm -f "$INDEX.*"
 	pushd "$BINARY_DIR"
 	echo "Building index $INDEX"
-	./IndexBuilderMain -l -i "$INDEX" \
+	./IndexBuilderMain -i "$INDEX" \
 	    -F ttl \
 	    -f "$INPUT.nt" \
 	    -s "$PROJECT_DIR/e2e/e2e-build-settings.json" \

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -165,7 +165,7 @@ void Bind::computeExpressionBind(
         if (it != resultGenerator.end()) {
           Id constantId =
               sparqlExpression::detail::constantExpressionResultToId(
-                  *it, *(outputResultTable->_localVocab));
+                  std::move(*it), *(outputResultTable->_localVocab));
           for (size_t i = 0; i < inSize; ++i) {
             output(i, inCols) = constantId;
           }
@@ -175,7 +175,7 @@ void Bind::computeExpressionBind(
         for (auto&& resultValue : resultGenerator) {
           output(i, inCols) =
               sparqlExpression::detail::constantExpressionResultToId(
-                  resultValue, *(outputResultTable->_localVocab));
+                  std::move(resultValue), *(outputResultTable->_localVocab));
           i++;
         }
       }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -171,7 +171,9 @@ void Bind::computeExpressionBind(
     }
   };
 
+  outputResultTable->_localVocab->startConstructionPhase();
   std::visit(visitor, std::move(expressionResult));
+  outputResultTable->_localVocab->endConstructionPhase();
 
   outputResultTable->_idTable = output.moveToDynamic();
 }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -160,20 +160,31 @@ void Bind::computeExpressionBind(
       *resultType =
           sparqlExpression::detail::expressionResultTypeToQleverResultType<T>();
 
-      size_t i = 0;
-      for (auto&& resultValue : resultGenerator) {
-        output(i, inCols) =
-            sparqlExpression::detail::constantExpressionResultToId(
-                resultValue, *(outputResultTable->_localVocab),
-                isConstant && i > 0);
-        i++;
+      if (isConstant) {
+        auto it = resultGenerator.begin();
+        if (it != resultGenerator.end()) {
+          Id constantId =
+              sparqlExpression::detail::constantExpressionResultToId(
+                  *it, *(outputResultTable->_localVocab));
+          for (size_t i = 0; i < inSize; ++i) {
+            output(i, inCols) = constantId;
+          }
+        }
+      } else {
+        size_t i = 0;
+        for (auto&& resultValue : resultGenerator) {
+          output(i, inCols) =
+              sparqlExpression::detail::constantExpressionResultToId(
+                  resultValue, *(outputResultTable->_localVocab));
+          i++;
+        }
       }
     }
   };
 
-  outputResultTable->_localVocab->startConstructionPhase();
+  // outputResultTable->_localVocab->startConstructionPhase();
   std::visit(visitor, std::move(expressionResult));
-  outputResultTable->_localVocab->endConstructionPhase();
+  // outputResultTable->_localVocab->endConstructionPhase();
 
   outputResultTable->_idTable = output.moveToDynamic();
 }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -182,9 +182,7 @@ void Bind::computeExpressionBind(
     }
   };
 
-  // outputResultTable->_localVocab->startConstructionPhase();
   std::visit(visitor, std::move(expressionResult));
-  // outputResultTable->_localVocab->endConstructionPhase();
 
   outputResultTable->_idTable = output.moveToDynamic();
 }

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(engine
         ../util/Socket.h
         Comparators.h
         ResultTable.h ResultTable.cpp
+        LocalVocab.h LocalVocab.cpp
         QueryExecutionContext.h
         IndexScan.h IndexScan.cpp
         Join.h Join.cpp

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -171,7 +171,7 @@ void GroupBy::processGroup(
       *resultType =
           sparqlExpression::detail::expressionResultTypeToQleverResultType<T>();
       resultEntry = sparqlExpression::detail::constantExpressionResultToId(
-          singleResult, *(outTable->_localVocab), false);
+          singleResult, *(outTable->_localVocab));
     } else {
       // This should never happen since aggregates always return constants.
       AD_FAIL()
@@ -235,9 +235,9 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
 
   if (groupByCols.empty()) {
     // The entire input is a single group
-    outTable->_localVocab->startConstructionPhase();
+    // outTable->_localVocab->startConstructionPhase();
     processNextBlock(0, input.size());
-    outTable->_localVocab->endConstructionPhase();
+    // outTable->_localVocab->endConstructionPhase();
     *dynResult = result.moveToDynamic();
     return;
   }
@@ -251,7 +251,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   size_t blockStart = 0;
   auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory(32000);
 
-  outTable->_localVocab->startConstructionPhase();
+  // outTable->_localVocab->startConstructionPhase();
   for (size_t pos = 1; pos < input.size(); pos++) {
     checkTimeoutAfterNCalls(currentGroupBlock.size());
     bool rowMatchesCurrentBlock =
@@ -269,7 +269,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
     }
   }
   processNextBlock(blockStart, input.size());
-  outTable->_localVocab->endConstructionPhase();
+  // outTable->_localVocab->endConstructionPhase();
   *dynResult = result.moveToDynamic();
 }
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -235,9 +235,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
 
   if (groupByCols.empty()) {
     // The entire input is a single group
-    // outTable->_localVocab->startConstructionPhase();
     processNextBlock(0, input.size());
-    // outTable->_localVocab->endConstructionPhase();
     *dynResult = result.moveToDynamic();
     return;
   }
@@ -251,7 +249,6 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   size_t blockStart = 0;
   auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory(32000);
 
-  // outTable->_localVocab->startConstructionPhase();
   for (size_t pos = 1; pos < input.size(); pos++) {
     checkTimeoutAfterNCalls(currentGroupBlock.size());
     bool rowMatchesCurrentBlock =
@@ -269,7 +266,6 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
     }
   }
   processNextBlock(blockStart, input.size());
-  // outTable->_localVocab->endConstructionPhase();
   *dynResult = result.moveToDynamic();
 }
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -235,7 +235,9 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
 
   if (groupByCols.empty()) {
     // The entire input is a single group
+    outTable->_localVocab->startConstructionPhase();
     processNextBlock(0, input.size());
+    outTable->_localVocab->endConstructionPhase();
     *dynResult = result.moveToDynamic();
     return;
   }
@@ -249,6 +251,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   size_t blockStart = 0;
   auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory(32000);
 
+  outTable->_localVocab->startConstructionPhase();
   for (size_t pos = 1; pos < input.size(); pos++) {
     checkTimeoutAfterNCalls(currentGroupBlock.size());
     bool rowMatchesCurrentBlock =
@@ -266,6 +269,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
     }
   }
   processNextBlock(blockStart, input.size());
+  outTable->_localVocab->endConstructionPhase();
   *dynResult = result.moveToDynamic();
 }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -144,6 +144,21 @@ void Join::computeResult(ResultTable* result) {
                     _leftJoinCol, rightRes->_idTable, _rightJoinCol,
                     &result->_idTable);
 
+  // If only one of the two operands has a local vocab, pass it on.
+  bool leftLocalVocabEmpty = leftRes->_localVocab->empty();
+  bool rightLocalVocabEmpty = rightRes->_localVocab->empty();
+  if (!leftLocalVocabEmpty || !rightLocalVocabEmpty) {
+    if (!leftLocalVocabEmpty && rightLocalVocabEmpty) {
+      result->_localVocab = std::move(leftRes->_localVocab);
+    } else if (leftLocalVocabEmpty && !rightLocalVocabEmpty) {
+      result->_localVocab = std::move(rightRes->_localVocab);
+    } else {
+      throw std::runtime_error(
+          "JOIN of two results, where both have a non-empty vocabulary, is "
+          "currently not supported");
+    }
+  }
+
   LOG(DEBUG) << "Join result computation done." << endl;
 }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -145,21 +145,10 @@ void Join::computeResult(ResultTable* result) {
                     &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  bool leftLocalVocabEmpty = leftRes->_localVocab->empty();
-  bool rightLocalVocabEmpty = rightRes->_localVocab->empty();
-  if (!leftLocalVocabEmpty || !rightLocalVocabEmpty) {
-    if (!leftLocalVocabEmpty && rightLocalVocabEmpty) {
-      result->_localVocab = std::move(leftRes->_localVocab);
-    } else if (leftLocalVocabEmpty && !rightLocalVocabEmpty) {
-      result->_localVocab = std::move(rightRes->_localVocab);
-    } else {
-      throw std::runtime_error(
-          "JOIN of two results, where both have a non-empty vocabulary, is "
-          "currently not supported");
-    }
-  }
+  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftRes->_localVocab, rightRes->_localVocab);
 
-  LOG(DEBUG) << "Join result computation done." << endl;
+  LOG(DEBUG) << "Join result computation done" << endl;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -33,10 +33,13 @@ LocalVocabIndex LocalVocab::getIndexAndAddIfNotContainedImpl(WordT&& word) {
   return index;
 }
 
+// _____________________________________________________________________________
 LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(
     const std::string& word) {
   return getIndexAndAddIfNotContainedImpl(word);
 }
+
+// _____________________________________________________________________________
 LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(std::string&& word) {
   return getIndexAndAddIfNotContainedImpl(std::move(word));
 }

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -9,20 +9,22 @@
 #include "global/ValueId.h"
 
 // _____________________________________________________________________________
-Id LocalVocab::getIdAndAddIfNotContained(const std::string& word) {
+LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(
+    const std::string& word) {
   // The following code avoids computing the hash for `word` twice in case we
   // see it for the first time (note that hashing a string is not cheap). The
   // return value of the `insert` operation is a pair, where `result.first` is
   // an iterator to the (already existing or newly inserted) key-value pair, and
   // `result.second` is a `bool`, which is `true` if and only if the value was
   // newly inserted.
-  auto [keyValuePair, isNewWord] = wordsToIdsMap_.insert({word, nextFreeId_});
+  auto [wordInMapAndIndex, isNewWord] =
+      wordsToIdsMap_.insert({word, nextFreeIndex_});
+  const auto& [wordInMap, index] = *wordInMapAndIndex;
   if (isNewWord) {
-    idsToWordsMap_.push_back(&(keyValuePair->first));
-    nextFreeId_ = Id::makeFromLocalVocabIndex(
-        LocalVocabIndex::make(idsToWordsMap_.size()));
+    idsToWordsMap_.push_back(&wordInMap);
+    nextFreeIndex_ = LocalVocabIndex::make(idsToWordsMap_.size());
   }
-  return keyValuePair->second;
+  return index;
 }
 
 // _____________________________________________________________________________
@@ -38,8 +40,10 @@ const std::string& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
 
 // _____________________________________________________________________________
 std::shared_ptr<LocalVocab> LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-    std::shared_ptr<LocalVocab> localVocab1,
-    std::shared_ptr<LocalVocab> localVocab2) {
+    const std::shared_ptr<LocalVocab>& localVocab1,
+    const std::shared_ptr<LocalVocab>& localVocab2) {
+  AD_CHECK(localVocab1 != nullptr);
+  AD_CHECK(localVocab2 != nullptr);
   bool isLocalVocab1Empty = localVocab1->empty();
   bool isLocalVocab2Empty = localVocab2->empty();
   if (!isLocalVocab1Empty && !isLocalVocab2Empty) {

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -1,0 +1,51 @@
+// Copyright 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include "engine/LocalVocab.h"
+
+#include "absl/strings/str_cat.h"
+#include "global/Id.h"
+#include "global/ValueId.h"
+
+// _____________________________________________________________________________
+Id LocalVocab::getIdAndAddIfNotContained(const std::string& word) {
+  // The following code avoids computing the hash for `word` twice in case we
+  // see it for the first time (note that hashing a string is not cheap). The
+  // return value of the `insert` operation is a pair, where `result.first` is
+  // an iterator to the (already existing or newly inserted) key-value pair, and
+  // `result.second` is a `bool`, which is `true` if and only if the value was
+  // newly inserted.
+  auto [keyValuePair, isNewWord] = wordsToIdsMap_.insert({word, nextFreeId_});
+  if (isNewWord) {
+    idsToWordsMap_.push_back(&(keyValuePair->first));
+    nextFreeId_ = Id::makeFromLocalVocabIndex(
+        LocalVocabIndex::make(idsToWordsMap_.size()));
+  }
+  return keyValuePair->second;
+}
+
+// _____________________________________________________________________________
+const std::string& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
+  if (localVocabIndex.get() > idsToWordsMap_.size()) {
+    throw std::runtime_error(absl::StrCat(
+        "LocalVocab error: request for word with local vocab index ",
+        localVocabIndex.get(), ", but size of local vocab is only ",
+        idsToWordsMap_.size(), ", please contact the developers"));
+  }
+  return *(idsToWordsMap_[localVocabIndex.get()]);
+}
+
+// _____________________________________________________________________________
+std::shared_ptr<LocalVocab> LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+    std::shared_ptr<LocalVocab> localVocab1,
+    std::shared_ptr<LocalVocab> localVocab2) {
+  bool isLocalVocab1Empty = localVocab1->empty();
+  bool isLocalVocab2Empty = localVocab2->empty();
+  if (!isLocalVocab1Empty && !isLocalVocab2Empty) {
+    throw std::runtime_error(
+        "Merging of two non-empty local vocabularies is currently not "
+        "supported, please contact the developers");
+  }
+  return !isLocalVocab1Empty ? localVocab1 : localVocab2;
+}

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -20,16 +20,15 @@ class LocalVocab {
 
   // Prevent accidental copying of a local vocabulary (it can be quite large),
   // but moving it is OK.
-  //
-  // TODO: does the default move do the "right" thing, that is, move the hash
-  // map instead of copying it?
   LocalVocab(const LocalVocab&) = delete;
+  LocalVocab& operator=(const LocalVocab&) = delete;
   LocalVocab(LocalVocab&&) = default;
+  LocalVocab& operator=(LocalVocab&&) = default;
 
-  // Get ID of a word in the local vocabulary. If the word was already
-  // contained, return the already existing ID. If the word was not yet
-  // contained, add it, and return the new ID.
-  Id getIdAndAddIfNotContained(const std::string& word);
+  // Get the index of a word in the local vocabulary. If the word was already
+  // contained, return the already existing index. If the word was not yet
+  // contained, add it, and return the new index.
+  LocalVocabIndex getIndexAndAddIfNotContained(const std::string& word);
 
   // The number of words in the vocabulary.
   size_t size() const { return idsToWordsMap_.size(); }
@@ -41,21 +40,21 @@ class LocalVocab {
   const std::string& getWord(LocalVocabIndex localVocabIndex) const;
 
   // Merge two local vocabularies if at least one of them is empty. If both are
-  // non-empty, throws an exception.
+  // non-empty, throws an exception. Assumes that both vocabularies exist.
   //
   // TODO: Eventually, we want to have one local vocab for the whole query to
   // which each operation writes (one after the other). Then we don't need a
   // merge function anymore.
   static std::shared_ptr<LocalVocab> mergeLocalVocabsIfOneIsEmpty(
-      std::shared_ptr<LocalVocab> localVocab1,
-      std::shared_ptr<LocalVocab> localVocab2);
+      const std::shared_ptr<LocalVocab>& localVocab1,
+      const std::shared_ptr<LocalVocab>& localVocab2);
 
  private:
   // A map of the words in the local vocabulary to their local IDs. This is a
   // node hash map because we need the addresses of the words (which are of type
   // `std::string`) to remain stable over their lifetime in the hash map because
   // we refer to them in `wordsToIdsMap_` below.
-  absl::node_hash_map<std::string, Id> wordsToIdsMap_;
+  absl::node_hash_map<std::string, LocalVocabIndex> wordsToIdsMap_;
 
   // A map of the local IDs to the words. Since the IDs are contiguous, we can
   // use a `std::vector`. We store pointers to the actual words in
@@ -65,5 +64,5 @@ class LocalVocab {
 
   // The next free local ID (will be incremented by one each time we add a new
   // word).
-  Id nextFreeId_ = Id::makeFromLocalVocabIndex(LocalVocabIndex::make(0));
+  LocalVocabIndex nextFreeIndex_ = LocalVocabIndex::make(0);
 };

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -1,0 +1,69 @@
+// Copyright 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#pragma once
+
+#include "absl/container/node_hash_map.h"
+
+// A class for maintaing a local vocabulary with contiguous (local) IDs. This is
+// meant for words that are not part of the normal vocabulary (constructed from
+// the input data at indexing time).
+//
+// TODO: This is a first version of this class with basic functionality. Note
+// that the local vocabulary used to be a simple `std::vector<std::string>`
+// defined inside of the `ResultTable` class. You gotta start somewhere.
+class LocalVocab {
+ public:
+  // Create a new, empty local vocabulary.
+  LocalVocab() = default;
+
+  // Prevent accidental copying of a local vocabulary (it can be quite large),
+  // but moving it is OK.
+  //
+  // TODO: does the default move do the "right" thing, that is, move the hash
+  // map instead of copying it?
+  LocalVocab(const LocalVocab&) = delete;
+  LocalVocab(LocalVocab&&) = default;
+
+  // Get ID of a word in the local vocabulary. If the word was already
+  // contained, return the already existing ID. If the word was not yet
+  // contained, add it, and return the new ID.
+  Id getIdAndAddIfNotContained(const std::string& word);
+
+  // The number of words in the vocabulary.
+  size_t size() const { return idsToWordsMap_.size(); }
+
+  // Return true if and only if the local vocabulary is empty.
+  bool empty() const { return idsToWordsMap_.empty(); }
+
+  // Return a const reference to the word.
+  const std::string& getWord(LocalVocabIndex localVocabIndex) const;
+
+  // Merge two local vocabularies if at least one of them is empty. If both are
+  // non-empty, throws an exception.
+  //
+  // TODO: Eventually, we want to have one local vocab for the whole query to
+  // which each operation writes (one after the other). Then we don't need a
+  // merge function anymore.
+  static std::shared_ptr<LocalVocab> mergeLocalVocabsIfOneIsEmpty(
+      std::shared_ptr<LocalVocab> localVocab1,
+      std::shared_ptr<LocalVocab> localVocab2);
+
+ private:
+  // A map of the words in the local vocabulary to their local IDs. This is a
+  // node hash map because we need the addresses of the words (which are of type
+  // `std::string`) to remain stable over their lifetime in the hash map because
+  // we refer to them in `wordsToIdsMap_` below.
+  absl::node_hash_map<std::string, Id> wordsToIdsMap_;
+
+  // A map of the local IDs to the words. Since the IDs are contiguous, we can
+  // use a `std::vector`. We store pointers to the actual words in
+  // `wordsToIdsMap_` to avoid storing every word twice. This saves space, but
+  // costs us an indirection when looking up a word by its ID.
+  std::vector<const std::string*> idsToWordsMap_;
+
+  // The next free local ID (will be incremented by one each time we add a new
+  // word).
+  Id nextFreeId_ = Id::makeFromLocalVocabIndex(LocalVocabIndex::make(0));
+};

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -14,6 +14,23 @@
 // that the local vocabulary used to be a simple `std::vector<std::string>`
 // defined inside of the `ResultTable` class. You gotta start somewhere.
 class LocalVocab {
+ private:
+  // A map of the words in the local vocabulary to their local IDs. This is a
+  // node hash map because we need the addresses of the words (which are of type
+  // `std::string`) to remain stable over their lifetime in the hash map because
+  // we refer to them in `wordsToIdsMap_` below.
+  absl::node_hash_map<std::string, LocalVocabIndex> wordsToIdsMap_;
+
+  // A map of the local IDs to the words. Since the IDs are contiguous, we can
+  // use a `std::vector`. We store pointers to the actual words in
+  // `wordsToIdsMap_` to avoid storing every word twice. This saves space, but
+  // costs us an indirection when looking up a word by its ID.
+  std::vector<const std::string*> idsToWordsMap_;
+
+  // The next free local ID (will be incremented by one each time we add a new
+  // word).
+  LocalVocabIndex nextFreeIndex_ = LocalVocabIndex::make(0);
+
  public:
   // Create a new, empty local vocabulary.
   LocalVocab() = default;
@@ -29,6 +46,7 @@ class LocalVocab {
   // contained, return the already existing index. If the word was not yet
   // contained, add it, and return the new index.
   LocalVocabIndex getIndexAndAddIfNotContained(const std::string& word);
+  LocalVocabIndex getIndexAndAddIfNotContained(std::string&& word);
 
   // The number of words in the vocabulary.
   size_t size() const { return idsToWordsMap_.size(); }
@@ -50,19 +68,8 @@ class LocalVocab {
       const std::shared_ptr<LocalVocab>& localVocab2);
 
  private:
-  // A map of the words in the local vocabulary to their local IDs. This is a
-  // node hash map because we need the addresses of the words (which are of type
-  // `std::string`) to remain stable over their lifetime in the hash map because
-  // we refer to them in `wordsToIdsMap_` below.
-  absl::node_hash_map<std::string, LocalVocabIndex> wordsToIdsMap_;
-
-  // A map of the local IDs to the words. Since the IDs are contiguous, we can
-  // use a `std::vector`. We store pointers to the actual words in
-  // `wordsToIdsMap_` to avoid storing every word twice. This saves space, but
-  // costs us an indirection when looking up a word by its ID.
-  std::vector<const std::string*> idsToWordsMap_;
-
-  // The next free local ID (will be incremented by one each time we add a new
-  // word).
-  LocalVocabIndex nextFreeIndex_ = LocalVocabIndex::make(0);
+  // Common implementation for the two variants of
+  // `getIndexAndAddIfNotContainedImpl` above.
+  template <typename WordT>
+  LocalVocabIndex getIndexAndAddIfNotContainedImpl(WordT&& word);
 };

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -333,12 +333,8 @@ QueryExecutionTree::idToStringAndType(Id id,
       return std::pair{std::move(entity.value()), nullptr};
     }
     case Datatype::LocalVocabIndex: {
-      auto optionalString =
-          resultTable.indexToOptionalString(id.getLocalVocabIndex());
-      if (!optionalString.has_value()) {
-        return std::nullopt;
-      }
-      return std::pair{optionalString.value(), nullptr};
+      return std::pair{
+          resultTable._localVocab->getWord(id.getLocalVocabIndex()), nullptr};
     }
     case Datatype::TextRecordIndex:
       return std::pair{_qec->getIndex().getTextExcerpt(id.getTextRecordIndex()),
@@ -453,8 +449,7 @@ ad_utility::streams::stream_generator QueryExecutionTree::generateResults(
             break;
           case Datatype::LocalVocabIndex:
             co_yield escapeFunction(
-                resultTable->indexToOptionalString(id.getLocalVocabIndex())
-                    .value_or(""));
+                resultTable->_localVocab->getWord(id.getLocalVocabIndex()));
             break;
           case Datatype::TextRecordIndex:
             co_yield escapeFunction(

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -7,46 +7,7 @@
 
 #include <cassert>
 
-#include "global/Id.h"
-#include "global/ValueId.h"
-
-// _____________________________________________________________________________
-Id LocalVocab::getIdAndAddIfNotContained(const std::string& word) {
-  if (constructionHasFinished_) {
-    throw std::runtime_error(
-        "Invalid use of `LocalVocab`: You must not call "
-        "`getIdAndAddIfNotContained` after `endConstructionPhase` has been "
-        "called");
-  }
-  // The following code avoids computing the hash for `word` twice in case we
-  // see it for the first time (note that hashing a string is not cheap). The
-  // return value of the `insert` operation is a pair, where `result.first` is
-  // an iterator to the (already existing or newly inserted) key-value pair, and
-  // `result.second` is a `bool`, which is `true` if and only if the value was
-  // newly inserted.
-  auto result = wordsToIdsMap_.insert(
-      {word,
-       Id::makeFromLocalVocabIndex(LocalVocabIndex::make(words_.size()))});
-  if (result.second) {
-    words_.push_back(word);
-  }
-  return result.first->second;
-}
-
-// _____________________________________________________________________________
-void LocalVocab::startConstructionPhase() {
-  if (!words_.empty()) {
-    throw std::runtime_error(
-        "Invalid use of `LocalVocab`: `startConstructionPhase` must currently "
-        "only be called when the vocabulary is still empty");
-  }
-}
-
-// _____________________________________________________________________________
-void LocalVocab::endConstructionPhase() {
-  wordsToIdsMap_.clear();
-  constructionHasFinished_ = true;
-}
+#include "engine/LocalVocab.h"
 
 // _____________________________________________________________________________
 ResultTable::ResultTable(ad_utility::AllocatorWithLimit<Id> allocator)

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -1,6 +1,8 @@
-// Copyright 2015, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+// Copyright 2015 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Björn Buchhold <b.buchhold@gmail.com>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
+
 #pragma once
 
 #include <array>
@@ -9,10 +11,12 @@
 #include <optional>
 #include <vector>
 
-#include "../global/Id.h"
-#include "../util/Exception.h"
-#include "IdTable.h"
-#include "ResultType.h"
+#include "engine/IdTable.h"
+#include "engine/ResultType.h"
+#include "global/Id.h"
+#include "global/ValueId.h"
+#include "util/Exception.h"
+#include "util/HashMap.h"
 
 using std::array;
 using std::condition_variable;
@@ -20,6 +24,59 @@ using std::lock_guard;
 using std::mutex;
 using std::unique_lock;
 using std::vector;
+
+// The local vocabulary for a particular result table. It maps the IDs that are
+// not part of the normal vocabulary
+//
+//
+// It contains a map from
+// (local vocab) ids
+class LocalVocab {
+ public:
+  // Create a new, empty local vocabulary.
+  LocalVocab() {}
+
+  // Prevent accidental copying of a local vocabulary.
+  // TODO: Needed in SparqlExpressionTestHelpers.h:91.
+  // LocalVocab(const LocalVocab&) = delete;
+
+  // Get ID of a word in the local vocabulary. If the word was already
+  // contained, return the already existing ID. If the word was not yet
+  // contained, add it, and return the new ID.
+  [[maybe_unused]] Id getIdAndAddIfNotContained(const std::string& word);
+
+  // Start the construction of a local vocabulary. This is currently allowed
+  // only once, when the vocabulary is still empty.
+  void startConstructionPhase();
+
+  // Signal that the construction of the local vocabulary is done. This call
+  // will clear the `wordsToIdsMap_` (to save space) and afterwards,
+  // `getIdAndAddIfNotContained` can no longer be called.
+  void endConstructionPhase();
+
+  // The number of words in the vocabulary.
+  size_t size() const { return words_.size(); }
+
+  // Return true if and only if the local vocabulary is empty.
+  bool empty() const { return words_.empty(); }
+
+  // Return a const reference to the i-th word.
+  const std::string& operator[](size_t i) const { return words_[i]; }
+
+ private:
+  // The words of the local vocabulary. The index of a word in the `std::vector`
+  // corresponds to its ID in the local vocabulary.
+  std::vector<string> words_;
+
+  // Remember which words are already in the vocabulary and with which ID. This
+  // map is only used during the construction of a local vocabulary and can (and
+  // should) be cleared when the construction is done (to save space).
+  ad_utility::HashMap<std::string, Id> wordsToIdsMap_;
+
+  // Indicator whether the vocabulary is still under construction (only then can
+  // `getIdAndAddIfNotContained` be called) or done.
+  bool constructionHasFinished_ = false;
+};
 
 class ResultTable {
  public:
@@ -38,18 +95,6 @@ class ResultTable {
 
   vector<ResultType> _resultTypes;
 
-  // This vector is used to store generated strings (such as the GROUP_CONCAT
-  // results) which are used in the output with the ResultType::STRING type.
-  // A std::shared_ptr is used to allow for quickly passing the vocabulary
-  // from one result to the next, as any operation that occurs after one
-  // having added entries to the _localVocab needs to ensure its ResultTable
-  // has the same _localVocab. As currently entries in the _localVocab are not
-  // being moved or deleted having a single copy used by several operations
-  // should not lead to any references to the _localVocab being invalidated
-  // due to later use.
-  // WARNING: Currently only operations that can run after a GroupBy copy
-  //          the _localVocab of a subresult.
-  using LocalVocab = vector<string>;
   std::shared_ptr<LocalVocab> _localVocab;
 
   explicit ResultTable(ad_utility::AllocatorWithLimit<Id> allocator);

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -77,7 +77,6 @@ void Sort::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  // TODO: Shouldn't we use std::move here?
   result->_localVocab = subRes->_localVocab;
   result->_idTable.insert(result->_idTable.end(), subRes->_idTable.begin(),
                           subRes->_idTable.end());

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -77,6 +77,7 @@ void Sort::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
+  // TODO: Shouldn't we use std::move here?
   result->_localVocab = subRes->_localVocab;
   result->_idTable.insert(result->_idTable.end(), subRes->_idTable.begin(),
                           subRes->_idTable.end());

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -241,7 +241,8 @@ template <SingleExpressionResult T, typename LocalVocabT>
 Id constantExpressionResultToId(T&& result, LocalVocabT& localVocab) {
   static_assert(isConstantResult<T>);
   if constexpr (ad_utility::isSimilar<T, string>) {
-    return localVocab.getIdAndAddIfNotContained(std::forward<T>(result));
+    return Id::makeFromLocalVocabIndex(
+        localVocab.getIndexAndAddIfNotContained(std::forward<T>(result)));
   } else if constexpr (ad_utility::isSimilar<double, T>) {
     return Id::makeFromDouble(result);
   } else if constexpr (ad_utility::isSimilar<T, Id>) {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -238,19 +238,10 @@ constexpr static qlever::ResultType expressionResultTypeToQleverResultType() {
 
 /// Get Id of constant result of type T.
 template <SingleExpressionResult T, typename LocalVocabT>
-Id constantExpressionResultToId(T&& result, LocalVocabT& localVocab,
-                                [[maybe_unused]] bool isRepetitionOfConstant) {
+Id constantExpressionResultToId(T&& result, LocalVocabT& localVocab) {
   static_assert(isConstantResult<T>);
   if constexpr (ad_utility::isSimilar<T, string>) {
-    // TODO: Should we make this more efficient by profiting from the
-    // knowledge in `isRepetitionOfConstant`? The previous code did this (out of
-    // neccessity because it just appended words to the local vocab vector).
     return localVocab.getIdAndAddIfNotContained(std::forward<T>(result));
-    // if (!isRepetitionOfConstant) {
-    //   localVocab.addWordNoMatterWhat(std::forward<T>(result));
-    // }
-    // return Id::makeFromLocalVocabIndex(
-    //     LocalVocabIndex::make(localVocab.size() - 1));
   } else if constexpr (ad_utility::isSimilar<double, T>) {
     return Id::makeFromDouble(result);
   } else if constexpr (ad_utility::isSimilar<T, Id>) {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -122,7 +122,7 @@ struct EvaluationContext {
   ad_utility::AllocatorWithLimit<Id> _allocator;
 
   /// The local vocabulary of the input.
-  const ResultTable::LocalVocab& _localVocab;
+  const LocalVocab& _localVocab;
 
   /// Constructor for evaluating an expression on the complete input.
   EvaluationContext(
@@ -130,7 +130,7 @@ struct EvaluationContext {
       const VariableToColumnAndResultTypeMap& variableToColumnAndResultTypeMap,
       const IdTable& inputTable,
       const ad_utility::AllocatorWithLimit<Id>& allocator,
-      const ResultTable::LocalVocab& localVocab)
+      const LocalVocab& localVocab)
       : _qec{qec},
         _variableToColumnAndResultTypeMap{variableToColumnAndResultTypeMap},
         _inputTable{inputTable},
@@ -144,7 +144,7 @@ struct EvaluationContext {
                     const IdTable& inputTable, size_t beginIndex,
                     size_t endIndex,
                     const ad_utility::AllocatorWithLimit<Id>& allocator,
-                    const ResultTable::LocalVocab& localVocab)
+                    const LocalVocab& localVocab)
       : _qec{qec},
         _variableToColumnAndResultTypeMap{map},
         _inputTable{inputTable},
@@ -237,17 +237,20 @@ constexpr static qlever::ResultType expressionResultTypeToQleverResultType() {
 }
 
 /// Get Id of constant result of type T.
-template <SingleExpressionResult T, typename LocalVocab>
-Id constantExpressionResultToId(T&& result, LocalVocab& localVocab,
-                                bool isRepetitionOfConstant) {
+template <SingleExpressionResult T, typename LocalVocabT>
+Id constantExpressionResultToId(T&& result, LocalVocabT& localVocab,
+                                [[maybe_unused]] bool isRepetitionOfConstant) {
   static_assert(isConstantResult<T>);
   if constexpr (ad_utility::isSimilar<T, string>) {
-    // Return the index in the local vocabulary.
-    if (!isRepetitionOfConstant) {
-      localVocab.push_back(std::forward<T>(result));
-    }
-    return Id::makeFromLocalVocabIndex(
-        LocalVocabIndex::make(localVocab.size() - 1));
+    // TODO: Should we make this more efficient by profiting from the
+    // knowledge in `isRepetitionOfConstant`? The previous code did this (out of
+    // neccessity because it just appended words to the local vocab vector).
+    return localVocab.getIdAndAddIfNotContained(std::forward<T>(result));
+    // if (!isRepetitionOfConstant) {
+    //   localVocab.addWordNoMatterWhat(std::forward<T>(result));
+    // }
+    // return Id::makeFromLocalVocabIndex(
+    //     LocalVocabIndex::make(localVocab.size() - 1));
   } else if constexpr (ad_utility::isSimilar<double, T>) {
     return Id::makeFromDouble(result);
   } else if constexpr (ad_utility::isSimilar<T, Id>) {

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -50,9 +50,7 @@ bool EffectiveBooleanValueGetter::operator()(ValueId id,
                   .empty();
     }
     case Datatype::LocalVocabIndex: {
-      auto index = id.getLocalVocabIndex();
-      AD_CHECK(index.get() < context->_localVocab.size());
-      return !(context->_localVocab[index.get()].empty());
+      return !(context->_localVocab.getWord(id.getLocalVocabIndex()).empty());
     }
     case Datatype::TextRecordIndex:
       return true;
@@ -75,9 +73,7 @@ string StringValueGetter::operator()(Id id, EvaluationContext* context) const {
           .indexToOptionalString(id.getVocabIndex())
           .value_or("");
     case Datatype::LocalVocabIndex: {
-      auto index = id.getLocalVocabIndex().get();
-      AD_CHECK(index < context->_localVocab.size());
-      return context->_localVocab[index];
+      return context->_localVocab.getWord(id.getLocalVocabIndex());
     }
     case Datatype::TextRecordIndex:
       return context->_qec.getIndex().getTextExcerpt(id.getTextRecordIndex());

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -24,5 +24,5 @@ add_library(parser
         SelectClause.h GraphPatternOperation.cpp GraphPatternOperation.h
         # The `Variable.cpp` from the subdirectory is linked here because otherwise we get linking errors.
         GraphPattern.cpp GraphPattern.h ConstructClause.h data/Variable.cpp)
-target_link_libraries(parser sparqlParser parserData sparqlExpressions rdfEscaping re2 absl::flat_hash_map util)
+target_link_libraries(parser sparqlParser parserData sparqlExpressions rdfEscaping re2 absl::flat_hash_map util engine)
 

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -45,7 +45,7 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
       case Datatype::VocabIndex:
         return qecIndex.idToOptionalString(id).value_or("");
       case Datatype::LocalVocabIndex:
-        return res.indexToOptionalString(id.getLocalVocabIndex()).value_or("");
+        return res._localVocab->getWord(id.getLocalVocabIndex());
       case Datatype::TextRecordIndex:
         return qecIndex.getTextExcerpt(id.getTextRecordIndex());
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,7 +61,7 @@ endfunction()
 
 addLinkAndDiscoverTest(ValueIdComparatorsTest)
 
-addLinkAndDiscoverTest(SparqlParserTest parser sparqlExpressions ${ICU_LIBRARIES})
+addLinkAndDiscoverTest(SparqlParserTest parser engine sparqlExpressions ${ICU_LIBRARIES})
 
 addLinkAndDiscoverTest(StringUtilsTest ${ICU_LIBRARIES})
 
@@ -139,7 +139,7 @@ addLinkAndDiscoverTest(MinusTest engine)
 addAndLinkTest(SortPerformanceEstimatorTest SortPerformanceEstimator)
 #addLinkAndDiscoverTest(SortPerformanceEstimatorTest SortPerformanceEstimator)
 
-addLinkAndDiscoverTest(SparqlAntlrParserTest parser sparqlExpressions)
+addLinkAndDiscoverTest(SparqlAntlrParserTest parser sparqlExpressions engine)
 
 # The SerializerTest uses temporary files. The tests fail when multiple test
 # cases are run in parallel. This should be fixed by using distinct filenames
@@ -157,7 +157,7 @@ addLinkAndDiscoverTest(SetOfIntervalsTest sparqlExpressions)
 
 addLinkAndDiscoverTest(TypeTraitsTest)
 
-addLinkAndDiscoverTest(SparqlExpressionTest sparqlExpressions index)
+addLinkAndDiscoverTest(SparqlExpressionTest sparqlExpressions index engine)
 
 addLinkAndDiscoverTest(StreamableBodyTest)
 
@@ -226,11 +226,11 @@ addLinkAndDiscoverTest(ValueIdTest absl::flat_hash_set)
 
 addLinkAndDiscoverTest(LambdaHelpersTest)
 
-addLinkAndDiscoverTest(ParseExceptionTest parser)
+addLinkAndDiscoverTest(ParseExceptionTest parser engine)
 
 addLinkAndDiscoverTest(TransparentFunctorsTest)
 
-addLinkAndDiscoverTest(SelectClauseTest parser)
+addLinkAndDiscoverTest(SelectClauseTest parser engine)
 
 addLinkAndDiscoverTestSerial(RelationalExpressionTest sparqlExpressions index engine)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -237,3 +237,5 @@ addLinkAndDiscoverTestSerial(RelationalExpressionTest sparqlExpressions index en
 addLinkAndDiscoverTest(CheckUsePatternTrickTest parser engine)
 
 addLinkAndDiscoverTestSerial(RegexExpressionTest sparqlExpressions index engine)
+
+addLinkAndDiscoverTest(LocalVocabTest engine)

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -104,11 +104,9 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // create an input result table with a local vocabulary
   ResultTable inTable{allocator()};
-  inTable._localVocab->startConstructionPhase();
   inTable._localVocab->getIdAndAddIfNotContained("<local1>");
   inTable._localVocab->getIdAndAddIfNotContained("<local2>");
   inTable._localVocab->getIdAndAddIfNotContained("<local3>");
-  inTable._localVocab->endConstructionPhase();
 
   IdTable inputData(6, allocator());
   // The input data types are

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -104,9 +104,9 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // create an input result table with a local vocabulary
   ResultTable inTable{allocator()};
-  inTable._localVocab->getIdAndAddIfNotContained("<local1>");
-  inTable._localVocab->getIdAndAddIfNotContained("<local2>");
-  inTable._localVocab->getIdAndAddIfNotContained("<local3>");
+  inTable._localVocab->getIndexAndAddIfNotContained("<local1>");
+  inTable._localVocab->getIndexAndAddIfNotContained("<local2>");
+  inTable._localVocab->getIndexAndAddIfNotContained("<local3>");
 
   IdTable inputData(6, allocator());
   // The input data types are

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -104,9 +104,11 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // create an input result table with a local vocabulary
   ResultTable inTable{allocator()};
-  inTable._localVocab->push_back("<local1>");
-  inTable._localVocab->push_back("<local2>");
-  inTable._localVocab->push_back("<local3>");
+  inTable._localVocab->startConstructionPhase();
+  inTable._localVocab->getIdAndAddIfNotContained("<local1>");
+  inTable._localVocab->getIdAndAddIfNotContained("<local2>");
+  inTable._localVocab->getIdAndAddIfNotContained("<local3>");
+  inTable._localVocab->endConstructionPhase();
 
   IdTable inputData(6, allocator());
   // The input data types are

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -4,19 +4,39 @@
 
 #include <gtest/gtest.h>
 
+#include <sstream>
+#include <string>
+
 #include "engine/ResultTable.h"
 #include "global/Id.h"
 
 TEST(LocalVocab, construction) {
-  auto makeIndex = [](size_t i) { return LocalVocabIndex::make(i); };
+  // Generate a test collection of words. For the tests below to work, these
+  // must all be different.
+  std::vector<std::string> testVocab(10'000);
+  for (size_t i = 0; i < testVocab.size(); ++i) {
+    testVocab[i] = std::to_string(i * 7635475567ULL);
+  }
+  // Create empty local vocabulary.
   LocalVocab localVocab;
   ASSERT_TRUE(localVocab.empty());
-  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("bla"), makeIndex(0));
-  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("blu"), makeIndex(1));
-  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("bli"), makeIndex(2));
-  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("bla"), makeIndex(0));
-  ASSERT_EQ(localVocab.size(), 3);
-  ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(0)), "bla");
-  ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(1)), "blu");
-  ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(2)), "bli");
+  // Add the words from our test vocabulary and check that they get the expected
+  // local IDs.
+  for (size_t i = 0; i < testVocab.size(); ++i) {
+    ASSERT_EQ(localVocab.getIndexAndAddIfNotContained(testVocab[i]),
+              LocalVocabIndex::make(i));
+  }
+  ASSERT_EQ(localVocab.size(), testVocab.size());
+  // Check that we get the same IDs if we do this again, but that no new words
+  // will be added.
+  for (size_t i = 0; i < testVocab.size(); ++i) {
+    ASSERT_EQ(localVocab.getIndexAndAddIfNotContained(testVocab[i]),
+              LocalVocabIndex::make(i));
+  }
+  ASSERT_EQ(localVocab.size(), testVocab.size());
+  // Check that the lookup by ID gives the correct words.
+  for (size_t i = 0; i < testVocab.size(); ++i) {
+    ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(i)), testVocab[i]);
+  }
+  ASSERT_EQ(localVocab.size(), testVocab.size());
 }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -8,15 +8,13 @@
 #include "global/Id.h"
 
 TEST(LocalVocab, construction) {
-  auto checkId = [](Id id, size_t i) {
-    ASSERT_EQ(id, Id::makeFromLocalVocabIndex(LocalVocabIndex::make(i)));
-  };
+  auto makeIndex = [](size_t i) { return LocalVocabIndex::make(i); };
   LocalVocab localVocab;
   ASSERT_TRUE(localVocab.empty());
-  checkId(localVocab.getIdAndAddIfNotContained("bla"), 0);
-  checkId(localVocab.getIdAndAddIfNotContained("blu"), 1);
-  checkId(localVocab.getIdAndAddIfNotContained("bli"), 2);
-  checkId(localVocab.getIdAndAddIfNotContained("bla"), 0);
+  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("bla"), makeIndex(0));
+  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("blu"), makeIndex(1));
+  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("bli"), makeIndex(2));
+  ASSERT_EQ(localVocab.getIndexAndAddIfNotContained("bla"), makeIndex(0));
   ASSERT_EQ(localVocab.size(), 3);
   ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(0)), "bla");
   ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(1)), "blu");

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -1,0 +1,28 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include "engine/ResultTable.h"
+#include "global/Id.h"
+
+TEST(LocalVocab, construction) {
+  auto checkId = [](Id id, size_t i) {
+    ASSERT_EQ(id, Id::makeFromLocalVocabIndex(LocalVocabIndex::make(i)));
+  };
+  LocalVocab localVocab;
+  ASSERT_TRUE(localVocab.empty());
+  localVocab.startConstructionPhase();
+  checkId(localVocab.getIdAndAddIfNotContained("bla"), 0);
+  checkId(localVocab.getIdAndAddIfNotContained("blu"), 1);
+  checkId(localVocab.getIdAndAddIfNotContained("bli"), 2);
+  checkId(localVocab.getIdAndAddIfNotContained("bla"), 0);
+  localVocab.endConstructionPhase();
+  ASSERT_EQ(localVocab.size(), 3);
+  ASSERT_EQ(localVocab[0], "bla");
+  ASSERT_EQ(localVocab[1], "blu");
+  ASSERT_EQ(localVocab[2], "bli");
+  ASSERT_THROW(localVocab.getIdAndAddIfNotContained("one more"),
+               std::runtime_error);
+}

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -13,16 +13,12 @@ TEST(LocalVocab, construction) {
   };
   LocalVocab localVocab;
   ASSERT_TRUE(localVocab.empty());
-  localVocab.startConstructionPhase();
   checkId(localVocab.getIdAndAddIfNotContained("bla"), 0);
   checkId(localVocab.getIdAndAddIfNotContained("blu"), 1);
   checkId(localVocab.getIdAndAddIfNotContained("bli"), 2);
   checkId(localVocab.getIdAndAddIfNotContained("bla"), 0);
-  localVocab.endConstructionPhase();
   ASSERT_EQ(localVocab.size(), 3);
-  ASSERT_EQ(localVocab[0], "bla");
-  ASSERT_EQ(localVocab[1], "blu");
-  ASSERT_EQ(localVocab[2], "bli");
-  ASSERT_THROW(localVocab.getIdAndAddIfNotContained("one more"),
-               std::runtime_error);
+  ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(0)), "bla");
+  ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(1)), "blu");
+  ASSERT_EQ(localVocab.getWord(LocalVocabIndex::make(2)), "bli");
 }

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -402,7 +402,7 @@ auto testNotComparableHelper(T leftValue, U rightValue,
   ad_utility::AllocatorWithLimit<Id> alloc{
       ad_utility::makeAllocationMemoryLeftThreadsafeObject(1000)};
   sparqlExpression::VariableToColumnAndResultTypeMap map;
-  ResultTable::LocalVocab localVocab;
+  LocalVocab localVocab;
   IdTable table{alloc};
   sparqlExpression::EvaluationContext context{*getQec(), map, table, alloc,
                                               localVocab};

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -179,7 +179,7 @@ TEST(SparqlExpressionParser, First) {
   ad_utility::AllocatorWithLimit<Id> alloc{
       ad_utility::makeAllocationMemoryLeftThreadsafeObject(1000)};
   IdTable table{alloc};
-  ResultTable::LocalVocab localVocab;
+  LocalVocab localVocab;
   sparqlExpression::EvaluationContext input{*qec, map, table, alloc,
                                             localVocab};
   auto result = resultAsExpression->evaluate(&input);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -41,7 +41,7 @@ auto testNaryExpression = [](const auto& expected, auto&&... operands) {
   ad_utility::AllocatorWithLimit<Id> alloc{
       ad_utility::makeAllocationMemoryLeftThreadsafeObject(1000)};
   sparqlExpression::VariableToColumnAndResultTypeMap map;
-  ResultTable::LocalVocab localVocab;
+  LocalVocab localVocab;
   IdTable table{alloc};
 
   auto getResultSize = []<typename T>(const T& operand) -> size_t {

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -91,7 +91,7 @@ static QueryExecutionContext* getQec() {
 struct TestContext {
   QueryExecutionContext* qec = getQec();
   sparqlExpression::VariableToColumnAndResultTypeMap varToColMap;
-  ResultTable::LocalVocab localVocab;
+  LocalVocab localVocab;
   IdTable table{qec->getAllocator()};
   sparqlExpression::EvaluationContext context{*getQec(), varToColMap, table,
                                               qec->getAllocator(), localVocab};


### PR DESCRIPTION
The LocalVocab used to be an alias for std::vector<std::string> (defined inside of the ResultTable class). New words were pushed to this vector without checking whether they were already in the vocabulary (exception: when a sequence of identical new words were encountered in a SPARQL expression result, the words was only added once per sequence).

The basic data is still a std::vector<std::string>, but there is now a phase, started by LocalVocab::startConstructionPhase() and ended by LocalVocab::endConstrutionPhase(), where new words can be added and a words-to-ID map records which words have already been added. After that phase, the map is deleted and the local vocabulary is read-only. Check test/LocalVocabTest for how it works in prinicple.

This is also used by the Values class in PR #793 (and I tested it already quite extensively and it works).