### PR TITLE
Use local vocabulary for VALUES clause

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -846,18 +846,21 @@ queries:
       - selected: ["?a", "?b", "?c"]
 
 
+  # In the following query, <Zwulm> and <Albert_Zweistein> don't occur in the
+  # input data and are hence added to the local vocabulary when processing the
+  # query.
   - query: new-values
     type: no-text
     sparql: |
       SELECT ?x ?y ?z WHERE {
-        VALUES (?x ?y ?z) { (<Albert_Einstein> <Ulm> 1879) (<Albert_Zweistein> <Zwulm> 2001) }
+        VALUES (?x ?y ?z) { (<Albert_Einstein> <Zwulm> 1879) (<Albert_Zweistein> <Ulm> 2001) }
         VALUES ?x { <Albert_Einstein> }
       }
     checks:
       - num_cols: 3
       - num_rows: 1
       - selected: ["?x", "?y", "?z"]
-      - contains_row: ["<Albert_Einstein>", "<Ulm>", 1879]
+      - contains_row: ["<Albert_Einstein>", "<Zwulm>", 1879]
 
 
   - query: values-empty-join

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -846,18 +846,18 @@ queries:
       - selected: ["?a", "?b", "?c"]
 
 
-  - query: nonexisting-values
+  - query: new-values
     type: no-text
     sparql: |
-      SELECT ?a WHERE {
-        VALUES ?a {"obscure Literal"@xf <Albert_Einstein> <Non_Exisiting_Scientist>}
+      SELECT ?x ?y ?z WHERE {
+        VALUES (?x ?y ?z) { (<Albert_Einstein> <Ulm> 1879) (<Albert_Zweistein> <Zwulm> 2001) }
+        VALUES ?x { <Albert_Einstein> }
       }
     checks:
-      - num_cols: 1
+      - num_cols: 3
       - num_rows: 1
-      - selected: ["?a"]
-      - contains_row: ["<Albert_Einstein>"]
-      - contains_warning: ["The word \"obscure Literal\"@xf", "The word <Non_Exisiting", "Ignored 2 rows"]
+      - selected: ["?x", "?y", "?z"]
+      - contains_row: ["<Albert_Einstein>", "<Ulm>", 1879]
 
 
   - query: values-empty-join

--- a/src/engine/CheckUsePatternTrick.cpp
+++ b/src/engine/CheckUsePatternTrick.cpp
@@ -64,8 +64,7 @@ bool isVariableContainedInGraphPatternOperation(
                     triple._o == variable);
           });
     } else if constexpr (std::is_same_v<T, p::Values>) {
-      return ad_utility::contains(arg._inlineValues._variables,
-                                  variable.name());
+      return ad_utility::contains(arg._inlineValues._variables, variable);
     } else {
       static_assert(std::is_same_v<T, p::TransPath>);
       // The `TransPath` is set up later in the query planning, when this

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -1,85 +1,44 @@
 // Copyright 2019 - 2022, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Florian Kramer <kramerf@cs.uni-freiburg.de>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include "Values.h"
 
-#include <absl/strings/str_join.h>
-
 #include <sstream>
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "engine/CallFixedSize.h"
 #include "util/Exception.h"
 #include "util/HashSet.h"
 
+// ____________________________________________________________________________
 Values::Values(QueryExecutionContext* qec, SparqlValues values)
     : Operation(qec) {
   _values = sanitizeValues(std::move(values));
 }
 
+// ____________________________________________________________________________
 string Values::asStringImpl(size_t indent) const {
-  std::ostringstream os;
-  for (size_t i = 0; i < indent; ++i) {
-    os << " ";
-  }
-  os << "VALUES (";
-  for (size_t i = 0; i < _values._variables.size(); i++) {
-    os << _values._variables[i];
-    if (i + 1 < _values._variables.size()) {
-      os << " ";
-    }
-  }
-  os << ") {";
-  for (size_t i = 0; i < _values._values.size(); i++) {
-    const vector<TripleComponent>& v = _values._values[i];
-    os << "(";
-    for (size_t j = 0; j < v.size(); j++) {
-      os << v[j];
-      if (j + 1 < v.size()) {
-        os << " ";
-      }
-    }
-    os << ")";
-    if (i + 1 < _values._variables.size()) {
-      os << " ";
-    }
-  }
-  os << "}";
-  return std::move(os).str();
+  return absl::StrCat(std::string(indent, ' '), "VALUES (",
+                      _values.variablesToString(), ") { ",
+                      _values.valuesToString(), " }");
 }
 
+// ____________________________________________________________________________
 string Values::getDescriptor() const {
-  std::ostringstream os;
-  os << "Values with variables ";
-  for (size_t i = 0; i < _values._variables.size(); i++) {
-    os << _values._variables[i];
-    if (i + 1 < _values._variables.size()) {
-      os << " ";
-    }
-  }
-  os << " and values ";
-  for (size_t i = 0; i < _values._values.size(); i++) {
-    const vector<TripleComponent>& v = _values._values[i];
-    os << "(";
-    for (size_t j = 0; j < v.size(); j++) {
-      os << v[j];
-      if (j + 1 < v.size()) {
-        os << " ";
-      }
-    }
-    os << ")";
-    if (i + 1 < _values._variables.size()) {
-      os << " ";
-    }
-  }
-  return std::move(os).str();
+  return absl::StrCat("Values with variables ", _values.variablesToString());
 }
 
+// ____________________________________________________________________________
 size_t Values::getResultWidth() const { return _values._variables.size(); }
 
+// ____________________________________________________________________________
 vector<size_t> Values::resultSortedOn() const { return {}; }
 
+// ____________________________________________________________________________
 VariableToColumnMap Values::computeVariableToColumnMap() const {
   VariableToColumnMap map;
   for (size_t i = 0; i < _values._variables.size(); i++) {
@@ -89,6 +48,7 @@ VariableToColumnMap Values::computeVariableToColumnMap() const {
   return map;
 }
 
+// ____________________________________________________________________________
 float Values::getMultiplicity(size_t col) {
   if (_multiplicities.empty()) {
     computeMultiplicities();
@@ -99,10 +59,13 @@ float Values::getMultiplicity(size_t col) {
   return 1;
 }
 
+// ____________________________________________________________________________
 size_t Values::getSizeEstimate() { return _values._values.size(); }
 
+// ____________________________________________________________________________
 size_t Values::getCostEstimate() { return _values._values.size(); }
 
+// ____________________________________________________________________________
 void Values::computeMultiplicities() {
   if (_values._variables.empty()) {
     // If the result is empty we still add a column to the multiplicities to
@@ -111,23 +74,19 @@ void Values::computeMultiplicities() {
     return;
   }
   _multiplicities.resize(_values._variables.size());
-  ad_utility::HashSet<TripleComponent> values;
+  ad_utility::HashSet<TripleComponent> distinctValues;
+  size_t numValues = _values._values.size();
   for (size_t col = 0; col < _values._variables.size(); col++) {
-    values.clear();
-    size_t count = 0;
-    size_t distinct = 0;
-    for (size_t j = 0; j < _values._values.size(); j++) {
-      const TripleComponent& v = _values._values[j][col];
-      count++;
-      if (values.count(v) == 0) {
-        distinct++;
-        values.insert(v);
-      }
+    distinctValues.clear();
+    for (const auto& valuesTuple : _values._values) {
+      distinctValues.insert(valuesTuple[col]);
     }
-    _multiplicities[col] = double(count) / distinct;
+    size_t numDistinctValues = distinctValues.size();
+    _multiplicities[col] = float(numValues) / float(numDistinctValues);
   }
 }
 
+// ____________________________________________________________________________
 void Values::computeResult(ResultTable* result) {
   const Index& index = getIndex();
 
@@ -141,6 +100,7 @@ void Values::computeResult(ResultTable* result) {
                     result->_localVocab);
 }
 
+// ____________________________________________________________________________
 auto Values::sanitizeValues(SparqlValues&& values) -> SparqlValues {
   std::vector<std::pair<std::size_t, std::size_t>> variableBound;
   for (size_t i = 0; i < values._variables.size(); ++i) {
@@ -190,13 +150,14 @@ auto Values::sanitizeValues(SparqlValues&& values) -> SparqlValues {
   return std::move(values);
 }
 
+// ____________________________________________________________________________
 template <size_t I>
 void Values::writeValues(IdTable* res, const Index& index,
                          const SparqlValues& values,
                          std::shared_ptr<LocalVocab> localVocab) {
   IdTableStatic<I> result = res->moveToStatic<I>();
   result.resize(values._values.size());
-  size_t numRows = 0;
+  size_t numTuples = 0;
   std::vector<size_t> numLocalVocabPerColumn(result.cols());
   for (const auto& row : values._values) {
     for (size_t colIdx = 0; colIdx < result.cols(); colIdx++) {
@@ -209,15 +170,14 @@ void Values::writeValues(IdTable* res, const Index& index,
         id = Id::makeFromLocalVocabIndex(
             localVocab->getIndexAndAddIfNotContained(std::move(newWord)));
       }
-      result(numRows, colIdx) = id.value();
+      result(numTuples, colIdx) = id.value();
     }
-    numRows++;
+    numTuples++;
   }
-  AD_CHECK(numRows == values._values.size());
-  LOG(INFO) << "Total number of rows in VALUES clause: " << numRows
-            << std::endl;
+  AD_CHECK(numTuples == values._values.size());
+  LOG(INFO) << "Number of tuples in VALUES clause: " << numTuples << std::endl;
   LOG(DEBUG) << "Number of entries in local vocabulary per column: "
              << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
-  result.resize(numRows);
+  result.resize(numTuples);
   *res = result.moveToDynamic();
 }

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -44,14 +44,16 @@ class Values : public Operation {
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 
- private:
+ public:
+  // These two are also used by class `Service`, hence public.
   virtual void computeResult(ResultTable* result) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
+ private:
   template <size_t I>
-  void writeValues(IdTable* res, const Index& index,
-                   const SparqlValues& values);
+  void writeValues(IdTable* res, const Index& index, const SparqlValues& values,
+                   std::shared_ptr<LocalVocab> localVocab);
 
   /// remove all completely undefined values and variables
   /// throw if nothing remains

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -1,6 +1,8 @@
-// Copyright 2019, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Florian Kramer (florian.kramer@netpun.uni-freiburg.de)
+// Copyright 2019 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Florian Kramer <kramerf@cs.uni-freiburg.de>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #pragma once
 

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(parser
         TokenizerCtre.h TurtleTokenId.h
         ParallelBuffer.cpp
         SparqlParserHelpers.h SparqlParserHelpers.cpp
-        TripleComponent.h
+        TripleComponent.h TripleComponent.cpp
         GraphPatternOperation.cpp
         PropertyPath.h PropertyPath.cpp Alias.h data/SolutionModifiers.h
         data/LimitOffsetClause.h data/SparqlFilter.h data/SparqlFilter.cpp

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -1,11 +1,43 @@
-//  Copyright 2022, University of Freiburg, Chair of Algorithms and Data
-//  Structures. Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include "parser/GraphPatternOperation.h"
 
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
 #include "parser/ParsedQuery.h"
 #include "util/Forward.h"
+
 namespace parsedQuery {
+
+// _____________________________________________________________________________
+std::string SparqlValues::variablesToString() const {
+  return absl::StrJoin(_variables, " ",
+                       [](std::string* out, const Variable& variable) {
+                         out->append(variable.name());
+                       });
+}
+
+// _____________________________________________________________________________
+std::string SparqlValues::valuesToString() const {
+  auto tripleComponentVectorAsValueTuple =
+      [](const std::vector<TripleComponent>& v) -> std::string {
+    return absl::StrCat(
+        "(",
+        absl::StrJoin(v, " ",
+                      [](std::string* out, const TripleComponent& tc) {
+                        out->append(tc.toString());
+                      }),
+        ")");
+  };
+  return absl::StrJoin(
+      _values, " ",
+      [&](std::string* out, const std::vector<TripleComponent>& v) {
+        out->append(tripleComponentVectorAsValueTuple(v));
+      });
+}
 
 // Small anonymous helper function that is used in the definition of the member
 // functions of the `Subquery` class.
@@ -59,19 +91,11 @@ void GraphPatternOperation::toString(std::ostringstream& os,
       // TODO<joka921> make the subquery a value-semantics type.
       os << arg.get().asString();
     } else if constexpr (std::is_same_v<T, Values>) {
-      os << "VALUES (";
-      for (const auto& v : arg._inlineValues._variables) {
-        os << v << ' ';
-      }
-      os << ") ";
-
-      for (const auto& v : arg._inlineValues._values) {
-        os << "(";
-        for (const auto& val : v) {
-          os << val << ' ';
-        }
-        os << ')';
-      }
+      // TODO: Why is there indentation in some of these strings, but not in
+      // others? And why do we have three different places that convert a SPARQL
+      // operation to a string?
+      os << "VALUES (" << arg._inlineValues.variablesToString() << ") "
+         << arg._inlineValues.valuesToString();
     } else if constexpr (std::is_same_v<T, BasicGraphPattern>) {
       for (size_t i = 0; i + 1 < arg._triples.size(); ++i) {
         os << "\n";

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -91,9 +91,6 @@ void GraphPatternOperation::toString(std::ostringstream& os,
       // TODO<joka921> make the subquery a value-semantics type.
       os << arg.get().asString();
     } else if constexpr (std::is_same_v<T, Values>) {
-      // TODO: Why is there indentation in some of these strings, but not in
-      // others? And why do we have three different places that convert a SPARQL
-      // operation to a string?
       os << "VALUES (" << arg._inlineValues.variablesToString() << ") "
          << arg._inlineValues.valuesToString();
     } else if constexpr (std::is_same_v<T, BasicGraphPattern>) {

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -1,5 +1,7 @@
-//  Copyright 2022, University of Freiburg, Chair of Algorithms and Data
-//  Structures. Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #pragma once
 
@@ -9,6 +11,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/GraphPattern.h"
 #include "parser/TripleComponent.h"
+#include "parser/data/Variable.h"
 #include "util/Algorithm.h"
 #include "util/VisitMixin.h"
 
@@ -29,9 +32,14 @@ class GraphPattern;
 class SparqlValues {
  public:
   // The variables to which the values will be bound
-  std::vector<std::string> _variables;
+  std::vector<Variable> _variables;
   // A table storing the values in their string form
   std::vector<std::vector<TripleComponent>> _values;
+  // The `_variable` as a string, in the format like so: "?x ?y ?z".
+  std::string variablesToString() const;
+  // The `_values` as a string, in the format like so: "(<v12> <v12> <v13>)
+  // (<v21> <v22> <v23>)".
+  std::string valuesToString() const;
 };
 
 /// A `BasicGraphPattern` represents a consecutive block of triples.

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -160,6 +160,12 @@ struct GraphPatternOperation
     return std::get<BasicGraphPattern>(*this);
   }
 
+  // A string representation of the operation.
+  //
+  // TODO: The implementation of this method duplicates code found in the
+  // implementations of `asStringImpl` for the individual operations in
+  // `src/engine`. This function is therefore probably redundant (but currently
+  // used in some of our unit tests).
   void toString(std::ostringstream& os, int indentation = 0) const;
 };
 }  // namespace parsedQuery

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -31,7 +31,7 @@ class SparqlValues {
   // The variables to which the values will be bound
   std::vector<std::string> _variables;
   // A table storing the values in their string form
-  std::vector<std::vector<std::string>> _values;
+  std::vector<std::vector<TripleComponent>> _values;
 };
 
 /// A `BasicGraphPattern` represents a consecutive block of triples.

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -1,0 +1,29 @@
+// Copyright 2018 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include "parser/TripleComponent.h"
+
+#include "absl/strings/str_cat.h"
+
+// ____________________________________________________________________________
+std::ostream& operator<<(std::ostream& stream, const TripleComponent& obj) {
+  std::visit(
+      [&stream]<typename T>(const T& value) -> void {
+        if constexpr (std::is_same_v<T, Variable>) {
+          stream << value.name();
+        } else {
+          stream << value;
+        }
+      },
+      obj._variant);
+  return stream;
+}
+
+// ____________________________________________________________________________
+[[nodiscard]] std::string TripleComponent::toString() const {
+  std::stringstream stream;
+  stream << *this;
+  return std::move(stream).str();
+}

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -84,6 +84,12 @@ class TripleComponent {
   /// Equality comparison between two `TripleComponent`s.
   bool operator==(const TripleComponent&) const = default;
 
+  /// Hash value for `TripleComponent` object.
+  template <typename H>
+  friend H AbslHashValue(H h, const TripleComponent& tc) {
+    return H::combine(std::move(h), tc._variant);
+  }
+
   /// Check which type the underlying variants hold.
   [[nodiscard]] bool isString() const {
     return std::holds_alternative<std::string>(_variant);

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -1,11 +1,9 @@
-// Copyright 2018, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach(joka921) <johannes.kalmbach@gmail.com>
+// Copyright 2018 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
-#ifndef QLEVER_TRIPLECOMPONENT_H
-#define QLEVER_TRIPLECOMPONENT_H
-
-#include <absl/strings/str_cat.h>
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -112,6 +110,7 @@ class TripleComponent {
   [[nodiscard]] const std::string& getString() const {
     return std::get<std::string>(_variant);
   }
+
   // Non-const overload. TODO<C++23> Deducing this.
   std::string& getString() { return std::get<std::string>(_variant); }
 
@@ -183,24 +182,8 @@ class TripleComponent {
   /// Human readable output. Is used for debugging, testing, and for the
   /// creation of descriptors and cache keys.
   friend std::ostream& operator<<(std::ostream& stream,
-                                  const TripleComponent& obj) {
-    std::visit(
-        [&stream]<typename T>(const T& value) -> void {
-          if constexpr (std::is_same_v<T, Variable>) {
-            stream << value.name();
-          } else {
-            stream << value;
-          }
-        },
-        obj._variant);
-    return stream;
-  }
+                                  const TripleComponent& obj);
 
-  [[nodiscard]] std::string toString() const {
-    std::stringstream stream;
-    stream << *this;
-    return std::move(stream).str();
-  }
+  // Return as string.
+  [[nodiscard]] std::string toString() const;
 };
-
-#endif  // QLEVER_TRIPLECOMPONENT_H

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -679,8 +679,7 @@ uint64_t Visitor::visit(Parser::TextLimitClauseContext* ctx) {
 // ____________________________________________________________________________________
 SparqlValues Visitor::visit(Parser::InlineDataOneVarContext* ctx) {
   SparqlValues values;
-  auto var = visit(ctx->var());
-  values._variables.push_back(Variable{var.name()});
+  values._variables.push_back(visit(ctx->var()));
   if (ctx->dataBlockValue().empty())
     reportError(ctx,
                 "No values were specified in Values "
@@ -702,9 +701,7 @@ SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
     reportError(ctx,
                 "No variables were specified in Values "
                 "clause. This is not supported by QLever.");
-  for (auto& var : ctx->var()) {
-    values._variables.push_back(Variable{visit(var).name()});
-  }
+  values._variables = visitVector(ctx->var());
   values._values = visitVector(ctx->dataBlockSingle());
   if (std::any_of(values._values.begin(), values._values.end(),
                   [numVars = values._variables.size()](const auto& inner) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -204,9 +204,10 @@ class SparqlQleverVisitor {
   [[nodiscard]] parsedQuery::SparqlValues visit(
       Parser::InlineDataFullContext* ctx);
 
-  [[nodiscard]] vector<std::string> visit(Parser::DataBlockSingleContext* ctx);
+  [[nodiscard]] vector<TripleComponent> visit(
+      Parser::DataBlockSingleContext* ctx);
 
-  [[nodiscard]] std::string visit(Parser::DataBlockValueContext* ctx);
+  [[nodiscard]] TripleComponent visit(Parser::DataBlockValueContext* ctx);
 
   [[nodiscard]] GraphPatternOperation visit(
       Parser::MinusGraphPatternContext* ctx);

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -1,14 +1,15 @@
-// Copyright 2011, University of Freiburg, Chair of Algorithms and Data
-// Structures.
-// Author: Björn Buchhold <buchholb>
+// Copyright 2011 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Björn Buchhold <b.buchholb@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #pragma once
 
-#include <absl/container/flat_hash_set.h>
-
 #include <string>
 
-#include "./AllocatorWithLimit.h"
+#include "absl/container/flat_hash_set.h"
+#include "util/AllocatorWithLimit.h"
 
 using std::string;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -220,7 +220,7 @@ addLinkAndDiscoverTest(GeoSparqlHelpersTest util)
 
 addLinkAndDiscoverTest(DateTest)
 
-addLinkAndDiscoverTest(TripleObjectTest absl::strings)
+addLinkAndDiscoverTest(TripleObjectTest absl::strings parser)
 
 addLinkAndDiscoverTest(ValueIdTest absl::flat_hash_set)
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -550,18 +550,16 @@ TEST(SparqlParser, SolutionModifier) {
 TEST(SparqlParser, DataBlock) {
   auto expectDataBlock = ExpectCompleteParse<&Parser::dataBlock>{};
   auto expectDataBlockFails = ExpectParseFails<&Parser::dataBlock>();
-  expectDataBlock(
-      "?test { \"foo\" }",
-      m::Values(vector<string>{"?test"}, vector<vector<string>>{{"\"foo\""}}));
-  // These are not implemented yet in dataBlockValue
+  expectDataBlock("?test { \"foo\" }", m::Values({"?test"}, {{"\"foo\""}}));
+  expectDataBlock("?test { 10.0 }", m::Values({"?test"}, {{10.0}}));
+  // Booleans and UNDEF are not yet parsed as `dataBlockValue`.
   // (numericLiteral/booleanLiteral)
-  // TODO<joka921/qup42> implement
+  // TODO<joka921/qup42> implement.
   expectDataBlockFails("?test { true }");
-  expectDataBlockFails("?test { 10.0 }");
   expectDataBlockFails("?test { UNDEF }");
   expectDataBlock(R"(?foo { "baz" "bar" })",
                   m::Values({"?foo"}, {{"\"baz\""}, {"\"bar\""}}));
-  // TODO<joka921/qup42> implement
+  // TODO<joka921/qup42> implement.
   expectDataBlockFails(R"(( ) { })");
   expectDataBlockFails(R"(?foo { })");
   expectDataBlockFails(R"(( ?foo ) { })");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -550,28 +550,29 @@ TEST(SparqlParser, SolutionModifier) {
 TEST(SparqlParser, DataBlock) {
   auto expectDataBlock = ExpectCompleteParse<&Parser::dataBlock>{};
   auto expectDataBlockFails = ExpectParseFails<&Parser::dataBlock>();
-  expectDataBlock("?test { \"foo\" }", m::Values({"?test"}, {{"\"foo\""}}));
-  expectDataBlock("?test { 10.0 }", m::Values({"?test"}, {{10.0}}));
+  expectDataBlock("?test { \"foo\" }",
+                  m::Values({Var{"?test"}}, {{"\"foo\""}}));
+  expectDataBlock("?test { 10.0 }", m::Values({Var{"?test"}}, {{10.0}}));
   // Booleans and UNDEF are not yet parsed as `dataBlockValue`.
   // (numericLiteral/booleanLiteral)
   // TODO<joka921/qup42> implement.
   expectDataBlockFails("?test { true }");
   expectDataBlockFails("?test { UNDEF }");
   expectDataBlock(R"(?foo { "baz" "bar" })",
-                  m::Values({"?foo"}, {{"\"baz\""}, {"\"bar\""}}));
+                  m::Values({Var{"?foo"}}, {{"\"baz\""}, {"\"bar\""}}));
   // TODO<joka921/qup42> implement.
   expectDataBlockFails(R"(( ) { })");
   expectDataBlockFails(R"(?foo { })");
   expectDataBlockFails(R"(( ?foo ) { })");
   expectDataBlockFails(R"(( ?foo ?bar ) { (<foo>) (<bar>) })");
   expectDataBlock(R"(( ?foo ?bar ) { (<foo> <bar>) })",
-                  m::Values({"?foo", "?bar"}, {{"<foo>", "<bar>"}}));
-  expectDataBlock(
-      R"(( ?foo ?bar ) { (<foo> "m") ("1" <bar>) })",
-      m::Values({"?foo", "?bar"}, {{"<foo>", "\"m\""}, {"\"1\"", "<bar>"}}));
+                  m::Values({Var{"?foo"}, Var{"?bar"}}, {{"<foo>", "<bar>"}}));
+  expectDataBlock(R"(( ?foo ?bar ) { (<foo> "m") ("1" <bar>) })",
+                  m::Values({Var{"?foo"}, Var{"?bar"}},
+                            {{"<foo>", "\"m\""}, {"\"1\"", "<bar>"}}));
   expectDataBlock(
       R"(( ?foo ?bar ) { (<foo> "m") (<bar> <e>) ("1" "f") })",
-      m::Values({"?foo", "?bar"},
+      m::Values({Var{"?foo"}, Var{"?bar"}},
                 {{"<foo>", "\"m\""}, {"<bar>", "<e>"}, {"\"1\"", "\"f\""}}));
   // TODO<joka921/qup42> implement
   expectDataBlockFails(R"(( ) { (<foo>) })");
@@ -581,7 +582,7 @@ TEST(SparqlParser, InlineData) {
   auto expectInlineData = ExpectCompleteParse<&Parser::inlineData>{};
   auto expectInlineDataFails = ExpectParseFails<&Parser::inlineData>();
   expectInlineData("VALUES ?test { \"foo\" }",
-                   m::InlineData({"?test"}, {{"\"foo\""}}));
+                   m::InlineData({Var{"?test"}}, {{"\"foo\""}}));
   // There must always be a block present for InlineData
   expectInlineDataFails("");
 }
@@ -783,9 +784,10 @@ TEST(SparqlParser, GroupGraphPattern) {
                      m::GraphPattern(false, {"(?a=10)"}, DummyTriplesMatcher));
   expectGraphPattern("{ BIND (?f - ?b as ?c) }",
                      m::GraphPattern(m::Bind(Var{"?c"}, "?f-?b")));
-  expectGraphPattern("{ VALUES (?a ?b) { (<foo> <bar>) (<a> <b>) } }",
-                     m::GraphPattern(m::InlineData(
-                         {"?a", "?b"}, {{"<foo>", "<bar>"}, {"<a>", "<b>"}})));
+  expectGraphPattern(
+      "{ VALUES (?a ?b) { (<foo> <bar>) (<a> <b>) } }",
+      m::GraphPattern(m::InlineData({Var{"?a"}, Var{"?b"}},
+                                    {{"<foo>", "<bar>"}, {"<a>", "<b>"}})));
   expectGraphPattern("{ ?x ?y ?z }", m::GraphPattern(DummyTriplesMatcher));
   expectGraphPattern(
       "{ SELECT *  WHERE { ?x ?y ?z } }",
@@ -831,7 +833,7 @@ TEST(SparqlParser, GroupGraphPattern) {
       "{ SELECT *  WHERE { ?x ?y ?z } VALUES ?a { <a> <b> } }",
       m::GraphPattern(m::SubSelect(m::AsteriskSelect(false, false),
                                    m::GraphPattern(DummyTriplesMatcher)),
-                      m::InlineData({"?a"}, {{"<a>"}, {"<b>"}})));
+                      m::InlineData({Var{"?a"}}, {{"<a>"}, {"<b>"}})));
   // graphGraphPattern and serviceGraphPattern are not supported.
   expectGroupGraphPatternFails("{ GRAPH ?a { } }");
   expectGroupGraphPatternFails("{ GRAPH <foo> { } }");

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -12,6 +12,7 @@
 #include "parser/Alias.h"
 #include "parser/ParsedQuery.h"
 #include "parser/SparqlParserHelpers.h"
+#include "parser/TripleComponent.h"
 #include "parser/data/OrderKey.h"
 #include "parser/data/VarOrTerm.h"
 #include "util/GTestHelpers.h"
@@ -423,9 +424,9 @@ auto GroupByVariables =
                   testing::UnorderedElementsAreArray(vars));
 };
 
-auto Values =
-    [](const vector<string>& vars,
-       const vector<vector<string>>& values) -> Matcher<const p::Values&> {
+auto Values = [](const vector<string>& vars,
+                 const vector<vector<TripleComponent>>& values)
+    -> Matcher<const p::Values&> {
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this
   //  becomes a trivial Eq matcher.
   using SparqlValues = p::SparqlValues;
@@ -436,7 +437,7 @@ auto Values =
 };
 
 auto InlineData = [](const vector<string>& vars,
-                     const vector<vector<string>>& values)
+                     const vector<vector<TripleComponent>>& values)
     -> Matcher<const p::GraphPatternOperation&> {
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this
   //  becomes a trivial Eq matcher.

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -8,6 +8,10 @@
 
 #include <gmock/gmock.h>
 
+#include <iostream>
+#include <string>
+#include <vector>
+
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/Alias.h"
 #include "parser/ParsedQuery.h"
@@ -15,6 +19,7 @@
 #include "parser/TripleComponent.h"
 #include "parser/data/OrderKey.h"
 #include "parser/data/VarOrTerm.h"
+#include "parser/data/Variable.h"
 #include "util/GTestHelpers.h"
 #include "util/SourceLocation.h"
 #include "util/TypeTraits.h"
@@ -424,8 +429,8 @@ auto GroupByVariables =
                   testing::UnorderedElementsAreArray(vars));
 };
 
-auto Values = [](const vector<string>& vars,
-                 const vector<vector<TripleComponent>>& values)
+auto Values = [](const std::vector<::Variable>& vars,
+                 const std::vector<vector<TripleComponent>>& values)
     -> Matcher<const p::Values&> {
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this
   //  becomes a trivial Eq matcher.
@@ -436,7 +441,7 @@ auto Values = [](const vector<string>& vars,
                      AD_FIELD(SparqlValues, _values, testing::Eq(values)))));
 };
 
-auto InlineData = [](const vector<string>& vars,
+auto InlineData = [](const std::vector<::Variable>& vars,
                      const vector<vector<TripleComponent>>& values)
     -> Matcher<const p::GraphPatternOperation&> {
   // TODO Refactor GraphPatternOperation::Values / SparqlValues s.t. this

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -248,7 +248,7 @@ TEST(ParserTest, testParse) {
 
       vector<string> vvars = {"?a"};
       ASSERT_EQ(vvars, values1._variables);
-      vector<vector<string>> vvals = {{"<1>"}, {"\"2\""}};
+      vector<vector<TripleComponent>> vvals = {{"<1>"}, {"\"2\""}};
       ASSERT_EQ(vvals, values1._values);
 
       vvars = {"?b", "?c"};
@@ -273,7 +273,7 @@ TEST(ParserTest, testParse) {
 
       vector<string> vvars = {"?a"};
       ASSERT_EQ(vvars, values1._variables);
-      vector<vector<string>> vvals = {{"<Albert_Einstein>"}};
+      vector<vector<TripleComponent>> vvals = {{"<Albert_Einstein>"}};
       ASSERT_EQ(vvals, values1._values);
 
       vvars = {"?b", "?c"};
@@ -306,7 +306,7 @@ TEST(ParserTest, testParse) {
       const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
       vector<string> vvars = {"?citytype"};
       ASSERT_EQ(vvars, values1._variables);
-      vector<vector<string>> vvals = {
+      vector<vector<TripleComponent>> vvals = {
           {"<http://www.wikidata.org/entity/Q515>"},
           {"<http://www.wikidata.org/entity/Q262166>"}};
       ASSERT_EQ(vvals, values1._values);

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -1,6 +1,8 @@
-// Copyright 2014, University of Freiburg, Chair of Algorithms and Data
-// Structures.
-// Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+// Copyright 2014 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures.
+// Authors: Björn Buchhold <b.buchhold@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include <gtest/gtest.h>
 
@@ -246,12 +248,12 @@ TEST(ParserTest, testParse) {
       const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
       const auto& values2 = std::get<p::Values>(pq.children()[1])._inlineValues;
 
-      vector<string> vvars = {"?a"};
+      vector<Variable> vvars = {Var{"?a"}};
       ASSERT_EQ(vvars, values1._variables);
       vector<vector<TripleComponent>> vvals = {{"<1>"}, {"\"2\""}};
       ASSERT_EQ(vvals, values1._values);
 
-      vvars = {"?b", "?c"};
+      vvars = {Var{"?b"}, Var{"?c"}};
       ASSERT_EQ(vvars, values2._variables);
       vvals = {{"<1>", "<2>"}, {"\"1\"", "\"2\""}};
       ASSERT_EQ(vvals, values2._values);
@@ -271,12 +273,12 @@ TEST(ParserTest, testParse) {
       const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
       const auto& values2 = std::get<p::Values>(pq.children()[1])._inlineValues;
 
-      vector<string> vvars = {"?a"};
+      vector<Variable> vvars = {Var{"?a"}};
       ASSERT_EQ(vvars, values1._variables);
       vector<vector<TripleComponent>> vvals = {{"<Albert_Einstein>"}};
       ASSERT_EQ(vvals, values1._values);
 
-      vvars = {"?b", "?c"};
+      vvars = {Var{"?b"}, Var{"?c"}};
       ASSERT_EQ(vvars, values2._variables);
       vvals = {{"<Marie_Curie>", "<Joseph_Jacobson>"},
                {"<Freiherr>", "<Lord_of_the_Isles>"}};
@@ -304,7 +306,7 @@ TEST(ParserTest, testParse) {
       ASSERT_EQ(c._triples[0]._o, Var{"?citytype"});
 
       const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
-      vector<string> vvars = {"?citytype"};
+      vector<Variable> vvars = {Var{"?citytype"}};
       ASSERT_EQ(vvars, values1._variables);
       vector<vector<TripleComponent>> vvals = {
           {"<http://www.wikidata.org/entity/Q515>"},


### PR DESCRIPTION
So far, a row of a VALUES clause was ignored when one of the values did not occur in the normal vocabulary and could not be folded into an ID (like an integer or a double). Now all rows are considered and such OOV values are added to the local vocabulary.

On the side, the SPARQL parser for the VALUES clause is modified so that it does not produce a `std::string` for each value like it did so far, but a `TripleComponent`.