### PR TITLE
Efficient COUNT for certain types of queries involving index scans

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -362,12 +362,9 @@ bool GroupBy::computeOptimizedAggregatesOnIndexScanChild(ResultTable* result,
   return false;
 }
 
-// TODO<joka921> Get a good name.
-// Check whether `fst` is valid as the <Arbitrary other result> from
-// the example and that `snd` is a valid triple with three variables.
-// Note: this is in a lambda because the two children of the join might be
-// switched and we need to check both ways.
-std::optional<Index::Permutation> isThreeVariableTripleThatContainsVariable(
+// _____________________________________________________________________________
+std::optional<Index::Permutation>
+GroupBy::isThreeVariableTripleThatContainsVariable(
     const QueryExecutionTree* tree, const Variable& countedVariable) {
   // TODO<joka921> Factor this out as a function
   //  `isThreeVariableIndexScanThatContainsVariable`

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -346,7 +346,7 @@ void GroupBy::computeResult(ResultTable* result) {
 }
 
 bool GroupBy::computeOptimizedAggregatesOnIndexScanChild(ResultTable* result,
-                                                         IndexScan* ptr) {
+                                                         const IndexScan* ptr) {
   if (ptr->getResultWidth() > 1 && _groupByVariables.empty() &&
       _aliases.size() == 1) {
     auto optVariableAndDistinctness =
@@ -411,8 +411,8 @@ GroupBy::checkIfOptimizedAggregateOnJoinChildIsPossible(const Join* joinPtr) {
   // triple with three variables that fulfills the condition.
   auto* fst = static_cast<const Operation*>(joinPtr)->getChildren().at(0);
   auto* snd = static_cast<const Operation*>(joinPtr)->getChildren().at(1);
-  // TODO<joka921, C++23> Use `optional::or_else`
 
+  // TODO<joka921, C++23> Use `optional::or_else`
   auto scanAndPermutation =
       isThreeVariableTripleThatContainsVariable(fst, countedVar);
   if (!scanAndPermutation.has_value()) {
@@ -484,7 +484,8 @@ bool GroupBy::computeOptimizedAggregatesOnJoinChild(ResultTable* result,
 
 // _____________________________________________________________________________
 bool GroupBy::computeOptimizedAggregatesIfPossible(ResultTable* result) {
-  if (auto ptr = dynamic_cast<IndexScan*>(_subtree->getRootOperation().get())) {
+  if (auto ptr =
+          dynamic_cast<const IndexScan*>(_subtree->getRootOperation().get())) {
     return computeOptimizedAggregatesOnIndexScanChild(result, ptr);
   } else if (auto joinPtr = dynamic_cast<const Join*>(
                  _subtree->getRootOperation().get())) {

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -126,8 +126,18 @@ float GroupBy::getMultiplicity(size_t col) {
 }
 
 size_t GroupBy::getSizeEstimate() {
-  // TODO: stub implementation of getSizeEstimate()
-  return _subtree->getSizeEstimate();
+  if (_groupByVariables.empty()) {
+    return 1;
+  }
+  // Assume that the number of groups in total is the input size divided
+  // by the minimal multiplicity of one of the grouped variables.
+  std::vector<float> multiplicities;
+  for (const auto& var : _groupByVariables) {
+    multiplicities.push_back(
+        _subtree->getMultiplicity(_subtree->getVariableColumn(var)));
+  }
+  return _subtree->getSizeEstimate() /
+         *std::ranges::min_element(multiplicities);
 }
 
 size_t GroupBy::getCostEstimate() {

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -116,10 +116,8 @@ class GroupBy : public Operation {
   bool computeOptimizedAggregatesIfPossible(ResultTable* result);
   // TODO<joka921> Comment
 
-  // TODO<joka921> The argument `ptr` might be const as soon as the
-  // `getSizeEstimate` method is const (which it should be).
   bool computeOptimizedAggregatesOnIndexScanChild(ResultTable* result,
-                                                  IndexScan* ptr);
+                                                  const IndexScan* ptr);
   struct JoinChildAggregateData {
     const QueryExecutionTree& otherSubtree_;
     Index::Permutation permutation_;

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -120,6 +120,13 @@ class GroupBy : public Operation {
   // `getSizeEstimate` method is const (which it should be).
   bool computeOptimizedAggregatesOnIndexScanChild(ResultTable* result,
                                                   IndexScan* ptr);
+  struct JoinChildAggregateData {
+    const QueryExecutionTree& otherSubtree_;
+    Index::Permutation permutation_;
+    size_t subtreeColumnIndex_;
+  };
+  std::optional<JoinChildAggregateData>
+  checkIfOptimizedAggregateOnJoinChildIsPossible(const Join* joinPtr);
   bool computeOptimizedAggregatesOnJoinChild(ResultTable* result,
                                              const Join* ptr);
 };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -135,7 +135,8 @@ class GroupBy : public Operation {
                                              const Join* ptr);
 
   static std::optional<Index::Permutation> getPermutationForThreeVariableTriple(
-      const QueryExecutionTree* tree, const Variable& variableByWhichToSort);
+      const QueryExecutionTree* tree, const Variable& variableByWhichToSort,
+      const Variable& variableThatMustBeContained);
 
   // TODO<joka921> check and resolve Hannah's engine crashes when using the
   // optimized aggregates
@@ -147,7 +148,4 @@ class GroupBy : public Operation {
 
   // TODO<joka921> Also inform the query planner (via the cost estimate)
   // that the optimization can be done.
-
-  // TODO<joka921> Throw out `subjectCardinality` etc. functions in
-  // `Index(Impl)`, they are only used in one place.
 };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -131,4 +131,12 @@ class GroupBy : public Operation {
   checkIfOptimizedAggregateOnJoinChildIsPossible(const Join* joinPtr);
   bool computeOptimizedAggregatesOnJoinChild(ResultTable* result,
                                              const Join* ptr);
+  // TODO<joka921> Get a good name.
+  // Check whether `fst` is valid as the <Arbitrary other result> from
+  // the example and that `snd` is a valid triple with three variables.
+  // Note: this is in a lambda because the two children of the join might be
+  // switched and we need to check both ways.
+  static std::optional<Index::Permutation>
+  isThreeVariableTripleThatContainsVariable(const QueryExecutionTree* tree,
+                                            const Variable& countedVariable);
 };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -22,6 +22,10 @@
 using std::string;
 using std::vector;
 
+// Forward declarations for internal member function
+class IndexScan;
+class Join;
+
 class GroupBy : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
@@ -110,4 +114,12 @@ class GroupBy : public Operation {
   // applies, `false` is returned and the `result` is untouched. Precondition:
   // The `result` must be empty.
   bool computeOptimizedAggregatesIfPossible(ResultTable* result);
+  // TODO<joka921> Comment
+
+  // TODO<joka921> The argument `ptr` might be const as soon as the
+  // `getSizeEstimate` method is const (which it should be).
+  bool computeOptimizedAggregatesOnIndexScanChild(ResultTable* result,
+                                                  IndexScan* ptr);
+  bool computeOptimizedAggregatesOnJoinChild(ResultTable* result,
+                                             const Join* ptr);
 };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -97,4 +97,17 @@ class GroupBy : public Operation {
                  ResultTable* outTable) const;
 
   FRIEND_TEST(GroupByTest, doGroupBy);
+
+  // For certain combinations of `_groupByColumns`, `_aliases` and `_subtree`,
+  // it is not necessary to fully materialize the `_subtree`'s result to compute
+  // the GROUP BY, but the result can simply be read from the index meta data.
+  // An example for such a combination is the query
+  //  SELECT ((COUNT ?x) as ?cnt) WHERE {
+  //  ?x <somePredicate> ?y
+  //  }
+  // This function checks, if such a case applies. In this case the result is
+  // computed and stored in `result` and `true` is returned. If no such case
+  // applies, `false` is returned and the `result` is untouched. Precondition:
+  // The `result` must be empty.
+  bool computeOptimizedAggregatesIfPossible(ResultTable* result);
 };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -111,32 +111,43 @@ class GroupBy : public Operation {
   // the GROUP BY, but the result can simply be read from the index meta data.
   // An example for such a combination is the query
   //  SELECT ((COUNT ?x) as ?cnt) WHERE {
-  //  ?x <somePredicate> ?y
+  //    ?x <somePredicate> ?y
   //  }
-  // This function checks, if such a case applies. In this case the result is
-  // computed and stored in `result` and `true` is returned. If no such case
+  // This function checks whether such a case applies. In this case the result
+  // is computed and stored in `result` and `true` is returned. If no such case
   // applies, `false` is returned and the `result` is untouched. Precondition:
   // The `result` must be empty.
+  // TODO<joka921> Check whether we can simply return
+  // `std::optional<ResultTable>` (Also for all the other functions).
   bool computeOptimizedAggregatesIfPossible(ResultTable* result);
-  // TODO<joka921> Comment
+  // TODO<joka921> Comment all the other functions.
 
   bool computeOptimizedAggregatesOnIndexScanChild(ResultTable* result,
-                                                  const IndexScan* ptr);
-  struct JoinChildAggregateData {
+                                                  const IndexScan* indexScan);
+  struct OptimizedAggregateData {
     const QueryExecutionTree& otherSubtree_;
     Index::Permutation permutation_;
     size_t subtreeColumnIndex_;
   };
-  std::optional<JoinChildAggregateData>
-  checkIfOptimizedAggregateOnJoinChildIsPossible(const Join* joinPtr);
+  std::optional<OptimizedAggregateData>
+  checkIfOptimizedAggregateOnJoinChildIsPossible(const Join* join);
   bool computeOptimizedAggregatesOnJoinChild(ResultTable* result,
                                              const Join* ptr);
-  // TODO<joka921> Get a good name.
-  // Check whether `fst` is valid as the <Arbitrary other result> from
-  // the example and that `snd` is a valid triple with three variables.
-  // Note: this is in a lambda because the two children of the join might be
-  // switched and we need to check both ways.
-  static std::optional<Index::Permutation>
-  isThreeVariableTripleThatContainsVariable(const QueryExecutionTree* tree,
-                                            const Variable& countedVariable);
+
+  static std::optional<Index::Permutation> getPermutationForThreeVariableTriple(
+      const QueryExecutionTree* tree, const Variable& variableByWhichToSort);
+
+  // TODO<joka921> check and resolve Hannah's engine crashes when using the
+  // optimized aggregates
+
+  // TODO<joka921> implement optimization when *additional* Variables are
+  // grouped.
+  // TODO<joka921> implement optimization when there are additional aggregates
+  // that work on the variables that are NOT part of the three-variable-triple.
+
+  // TODO<joka921> Also inform the query planner (via the cost estimate)
+  // that the optimization can be done.
+
+  // TODO<joka921> Throw out `subjectCardinality` etc. functions in
+  // `Index(Impl)`, they are only used in one place.
 };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -118,44 +118,44 @@ class GroupBy : public Operation {
   // applies, `false` is returned and the `result` is untouched. Precondition:
   // The `result` must be empty.
   // TODO<joka921> Check whether we can simply return
-  // `std::optional<ResultTable>` (Also for all the other functions).
-  bool computeOptimizedAggregatesIfPossible(ResultTable* result);
+  // `std::optional<ResultTable>` (also for all the other functions).
+  bool computeOptimizedGroupByIfPossible(ResultTable* result);
 
   // First, check if the query represented by this GROUP BY is of the following
   // form:
-  //  SELECT ((COUNT ?x) as ?cnt) WHERE {
+  //  SELECT (COUNT (?x) as ?cnt) WHERE {
   //    ?x <somePredicate> ?y
   //  }
-  // (The single triple must contain two or three variables, and the fixed value
+  // The single triple must contain two or three variables, and the fixed value
   // in the two variable case might also be the subject or object of the triple.
   // The COUNT may be computed on any of the variables in the triple. If the
   // query has that form, the result of the query (which consists of one line)
   // is computed and stored in the `result` and `true` is returned. If not, the
   // `result` is left untouched, and `false` is returned.
-  bool computeOptimizedAggregatesOnIndexScanChild(ResultTable* result);
+  bool computeGroupByForSingleIndexScan(ResultTable* result);
 
   // First, check if the query represented by this GROUP BY is of the following
   // form:
-  //  SELECT ?x ((COUNT ?x) as ?cnt) WHERE {
-  //    %arbitrary subresult that contains `?x`, but neither `?y`, nor `?z`.
+  //  SELECT ?x (COUNT (?x) as ?cnt) WHERE {
+  //    %arbitrary graph pattern that contains `?x`, but neither `?y`, nor `?z`.
   //    ?x ?y ?z
   //  } GROUP BY ?x
   // Note that `?x` can also be the predicate or object of the three variable
   // triple, and that the COUNT may be by any of the variables `?x`, `?y`, or
   // `?z`.
-  bool computeOptimizedAggregatesOnJoinChild(ResultTable* result);
+  bool computeGroupByForJoinWithFullScan(ResultTable* result);
 
   // The check whether the optimization just described can be applied and its
   // actual computation are split up in two functions. This struct contains
   // information that has to be passed between the check and the computation.
-  struct OptimizedAggregateData {
+  struct OptimizedGroupByData {
     // The subtree of the `JOIN` operation that is *not* the three variable
     // triple.
     const QueryExecutionTree& otherSubtree_;
     // The permutation in which the three variable triple has to be sorted for
     // the JOIN, etc. `SPO` if the variable that joins the three variable triple
     // and the rest of the query body is the subject of the three variable
-    // triple, or `PSO` if it is the predicate.
+    // triple, `PSO` if it is the predicate, `OSP` if it is the object.
     Index::Permutation permutation_;
     // The column index wrt the `otherSubtree_` of the variable that joins the
     // three variable triple and the rest of the query body.
@@ -165,8 +165,7 @@ class GroupBy : public Operation {
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Join*`.
-  std::optional<OptimizedAggregateData>
-  checkIfOptimizedAggregateOnJoinChildIsPossible(const Join* join);
+  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(const Join* join);
 
   // Check if the following is true: the `tree` represents a three variable
   // triple, that contains both `variableByWhichToSort` and
@@ -178,13 +177,14 @@ class GroupBy : public Operation {
       const QueryExecutionTree* tree, const Variable& variableByWhichToSort,
       const Variable& variableThatMustBeContained);
 
+  // If this GROUP BY has exactly one alias, and that alias is a non-distinct
+  // count of a single variable, return that variable. Else return
+  // `std::nullopt`.
   std::optional<Variable> getVariableForNonDistinctCountOfSingleAlias() const;
-
-  // TODO<joka921> check and resolve Hannah's engine crashes when using the
-  // optimized aggregates
 
   // TODO<joka921> implement optimization when *additional* Variables are
   // grouped.
+
   // TODO<joka921> implement optimization when there are additional aggregates
   // that work on the variables that are NOT part of the three-variable-triple.
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -102,6 +102,10 @@ class GroupBy : public Operation {
 
   FRIEND_TEST(GroupByTest, doGroupBy);
 
+ public:
+  // TODO<joka921> use `FRIEND_TEST` here once we have converged on the set
+  // of tests to write.
+
   // For certain combinations of `_groupByColumns`, `_aliases` and `_subtree`,
   // it is not necessary to fully materialize the `_subtree`'s result to compute
   // the GROUP BY, but the result can simply be read from the index meta data.

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -323,11 +323,11 @@ size_t IndexScan::computeSizeEstimate() {
     // TODO<joka921> Should be a oneliner
     // getIndex().cardinality(getPermutation(), getFirstKey());
     if (_type == SPO_FREE_P || _type == SOP_FREE_O) {
-      return getIndex().subjectCardinality(_subject);
+      return getIndex().getCardinality(_subject, Index::Permutation::SPO);
     } else if (_type == POS_FREE_O || _type == PSO_FREE_S) {
-      return getIndex().relationCardinality(_predicate);
+      return getIndex().getCardinality(_predicate, Index::Permutation::PSO);
     } else if (_type == OPS_FREE_P || _type == OSP_FREE_S) {
-      return getIndex().objectCardinality(_object);
+      return getIndex().getCardinality(_object, Index::Permutation::OSP);
     }
     // The triple consists of three variables.
     return getIndex().getNofTriples();

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -348,6 +348,11 @@ size_t IndexScan::getCostEstimate() {
   if (getResultWidth() != 3) {
     return getSizeEstimate();
   } else {
+    // This is to make unit tests pass that have no explicit execution context.
+    // TODO<joka921> get rid of these unit tests!
+    if (!_executionContext) {
+      return getSizeEstimate();
+    }
     // The computation of the `full scan` estimate must be consistent with the
     // full scan dummy joins in `Join.cpp` for correct query planning.
     // TODO<joka921> Factor out the common code to keep it in sync.

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -357,7 +357,14 @@ size_t IndexScan::getCostEstimate() {
             : 200000;
     auto numScans = getSizeEstimate() / getMultiplicity(0);
     auto averageScanSize = getMultiplicity(0);
-    return numScans * (diskRandomAccessCost + averageScanSize);
+
+    // We need to make the full scan's estimate super expensive, s.t. the
+    // optimized JOIN operation where one child is a full scan is always cheaper
+    // than a full scan + a possible sort.
+
+    static constexpr size_t fullScanPenalty = 1'000'000'000;
+    return fullScanPenalty * numScans *
+           (diskRandomAccessCost + averageScanSize);
   }
 }
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -357,24 +357,27 @@ size_t IndexScan::getCostEstimate() {
     // The computation of the `full scan` estimate must be consistent with the
     // full scan dummy joins in `Join.cpp` for correct query planning.
     // TODO<joka921> Factor out the common code to keep it in sync.
-    float diskRandomAccessCost =
+    size_t diskRandomAccessCost =
         _executionContext
             ? _executionContext->getCostFactor("DISK_RANDOM_ACCESS_COST")
             : 200000;
-    LOG(WARN) << "Disk random Access  Cost" << diskRandomAccessCost << std::endl;
+    LOG(WARN) << "Disk random Access  Cost" << diskRandomAccessCost
+              << std::endl;
     LOG(WARN) << "Size estimate" << getSizeEstimate() << std::endl;
     LOG(WARN) << "Multiplicity column 0 " << getMultiplicity(0) << std::endl;
 
-    auto numScans = getSizeEstimate() / getMultiplicity(0);
-    auto averageScanSize = getMultiplicity(0);
+    size_t numScans = getSizeEstimate() / getMultiplicity(0);
+    size_t averageScanSize = getMultiplicity(0);
 
     // We need to make the full scan's estimate super expensive, s.t. the
     // optimized JOIN operation where one child is a full scan is always cheaper
     // than a full scan + a possible sort.
 
     static constexpr size_t fullScanPenalty = 1'000'000'000;
-    return fullScanPenalty * numScans *
+    auto totalCost = fullScanPenalty * numScans *
            (diskRandomAccessCost + averageScanSize);
+    LOG(WARN) << "Total cost is" << totalCost << std::endl;
+    return totalCost;
   }
 }
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -348,6 +348,7 @@ size_t IndexScan::getCostEstimate() {
   if (getResultWidth() != 3) {
     return getSizeEstimate();
   } else {
+    LOG(WARN) << "Computing cost estimate for 3VarTriple" << std::endl;
     // This is to make unit tests pass that have no explicit execution context.
     // TODO<joka921> get rid of these unit tests!
     if (!_executionContext) {
@@ -360,6 +361,10 @@ size_t IndexScan::getCostEstimate() {
         _executionContext
             ? _executionContext->getCostFactor("DISK_RANDOM_ACCESS_COST")
             : 200000;
+    LOG(WARN) << "Disk random Access  Cost" << diskRandomAccessCost << std::endl;
+    LOG(WARN) << "Size estimate" << getSizeEstimate() << std::endl;
+    LOG(WARN) << "Multiplicity column 0 " << getMultiplicity(0) << std::endl;
+
     auto numScans = getSizeEstimate() / getMultiplicity(0);
     auto averageScanSize = getMultiplicity(0);
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -374,8 +374,8 @@ size_t IndexScan::getCostEstimate() {
     // than a full scan + a possible sort.
 
     static constexpr size_t fullScanPenalty = 10'000;
-    auto totalCost = fullScanPenalty * numScans *
-           (diskRandomAccessCost + averageScanSize);
+    auto totalCost =
+        fullScanPenalty * numScans * (diskRandomAccessCost + averageScanSize);
     LOG(WARN) << "Total cost is" << totalCost << std::endl;
     return totalCost;
   }

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -373,7 +373,7 @@ size_t IndexScan::getCostEstimate() {
     // optimized JOIN operation where one child is a full scan is always cheaper
     // than a full scan + a possible sort.
 
-    static constexpr size_t fullScanPenalty = 1'000'000'000;
+    static constexpr size_t fullScanPenalty = 10'000;
     auto totalCost = fullScanPenalty * numScans *
            (diskRandomAccessCost + averageScanSize);
     LOG(WARN) << "Total cost is" << totalCost << std::endl;

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -368,18 +368,16 @@ size_t IndexScan::getCostEstimate() {
     // Note that we cannot set the cost to `infinity` or `max`, because this
     // might lead to overflows in upstream operations when the cost estimate is
     // an integer (this currently is the case). When implementing them as
-    // floating point numbers, `infinity` would lead to saturating. This would
+    // floating point numbers, a cost estimate of `infinity` would
     // remove the ability to distinguish the costs of plans that perform full
-    // scans but still have different overall costs.0
+    // scans but still have different overall costs.
     // TODO<joka921> The conceptually right way to do this is to make the cost
-    // estimate a tuple of
-    // `(numFullIndexScans, costEstimateForRemainder)`. Implement this
-    // functionality.
+    // estimate a tuple `(numFullIndexScans, costEstimateForRemainder)`.
+    // Implement this functionality.
     size_t diskRandomAccessCost =
         _executionContext->getCostFactor("DISK_RANDOM_ACCESS_COST");
     size_t numScans = getSizeEstimate() / getMultiplicity(0);
     size_t averageScanSize = getMultiplicity(0);
-
     static constexpr size_t fullScanPenalty = 1'000;
     auto totalCost =
         fullScanPenalty * numScans * (diskRandomAccessCost + averageScanSize);

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -66,7 +66,7 @@ class IndexScan : public Operation {
     return _sizeEstimate;
   }
 
-  virtual size_t getCostEstimate() override { return getSizeEstimate(); }
+  virtual size_t getCostEstimate() override;
 
   void determineMultiplicities();
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -59,11 +59,15 @@ class IndexScan : public Operation {
     // Do nothing.
   }
 
-  virtual size_t getSizeEstimate() override {
-    if (_sizeEstimate == std::numeric_limits<size_t>::max()) {
-      _sizeEstimate = computeSizeEstimate();
-    }
+  size_t getSizeEstimate() const {
+    AD_CHECK(_sizeEstimate != std::numeric_limits<size_t>::max());
     return _sizeEstimate;
+  }
+
+  // TODO<joka921> Make the `getSizeEstimate()` function `const` for ALL the
+  // `Operations`.
+  size_t getSizeEstimate() override {
+    return const_cast<const IndexScan*>(this)->getSizeEstimate();
   }
 
   virtual size_t getCostEstimate() override;

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -241,14 +241,14 @@ size_t Join::getCostEstimate() {
     costJoin = _left->getSizeEstimate() + _right->getSizeEstimate();
   }
 
-  if (!isFullScanDummy(_left)) {
-    costJoin += _left->getCostEstimate();
-  }
-  if (!isFullScanDummy(_right)) {
-    costJoin += _right->getCostEstimate();
-  }
-  auto sizeEstimate = getSizeEstimate();
-  return sizeEstimate + costJoin;
+  // TODO<joka921> once the `getCostEstimate` functions are `const`,
+  // the argument can also be `const auto`
+  auto costIfNotFullScan = [](auto& subtree) {
+    return isFullScanDummy(subtree) ? size_t{0} : subtree->getCostEstimate();
+  };
+
+  return getSizeEstimate() + costJoin + costIfNotFullScan(_left) +
+         costIfNotFullScan(_right);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -240,8 +240,15 @@ size_t Join::getCostEstimate() {
     // Normal case:
     costJoin = _left->getSizeEstimate() + _right->getSizeEstimate();
   }
-  return getSizeEstimate() + _left->getCostEstimate() +
-         _right->getCostEstimate() + costJoin;
+
+  if (!isFullScanDummy(_left)) {
+    costJoin += _left->getCostEstimate();
+  }
+  if (!isFullScanDummy(_right)) {
+    costJoin += _right->getCostEstimate();
+  }
+  auto sizeEstimate = getSizeEstimate();
+  return sizeEstimate + costJoin;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -130,7 +130,7 @@ class Operation {
   }
 
   // If the result of this `Operation` is sorted (either because this
-  // `Operation` enforces this sorting, or because it preserve the sorting of
+  // `Operation` enforces this sorting, or because it preserves the sorting of
   // its children), return the variable that is the primary sort key. Else
   // return nullopt.
   virtual std::optional<Variable> getPrimarySortKeyVariable() const final;

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -219,6 +219,14 @@ class QueryExecutionTree {
       std::shared_ptr<QueryExecutionTree> qet,
       const vector<size_t>& sortColumns);
 
+  // If the result of this `Operation` is sorted (either because this
+  // `Operation` enforces this sorting, or because it preserves the sorting of
+  // its children), return the variable that is the primary sort key. Else
+  // return nullopt.
+  std::optional<Variable> getPrimarySortKeyVariable() const {
+    return getRootOperation()->getPrimarySortKeyVariable();
+  }
+
  private:
   QueryExecutionContext* _qec;  // No ownership
   std::shared_ptr<Operation>

--- a/src/engine/QueryPlanningCostFactors.cpp
+++ b/src/engine/QueryPlanningCostFactors.cpp
@@ -21,6 +21,9 @@ QueryPlanningCostFactors::QueryPlanningCostFactors() : _factors() {
   _factors["HASH_MAP_OPERATION_COST"] = 50.0;
   _factors["JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 0.7;
   _factors["DUMMY_JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 0.7;
+
+  // Assume that a random disk seek is 100 times more expensive than an
+  // average `O(1)` access to a single ID.
   _factors["DISK_RANDOM_ACCESS_COST"] = 100;
 }
 

--- a/src/engine/QueryPlanningCostFactors.cpp
+++ b/src/engine/QueryPlanningCostFactors.cpp
@@ -21,7 +21,7 @@ QueryPlanningCostFactors::QueryPlanningCostFactors() : _factors() {
   _factors["HASH_MAP_OPERATION_COST"] = 50.0;
   _factors["JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 0.7;
   _factors["DUMMY_JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 0.7;
-  _factors["DISK_RANDOM_ACCESS_COST"] = 1000;
+  _factors["DISK_RANDOM_ACCESS_COST"] = 100;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanningCostFactors.cpp
+++ b/src/engine/QueryPlanningCostFactors.cpp
@@ -20,7 +20,7 @@ QueryPlanningCostFactors::QueryPlanningCostFactors() : _factors() {
   _factors["FILTER_SELECTIVITY"] = 0.1;
   _factors["HASH_MAP_OPERATION_COST"] = 50.0;
   _factors["JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 0.7;
-  _factors["DUMMY_JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 1000.0;
+  _factors["DUMMY_JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"] = 0.7;
   _factors["DISK_RANDOM_ACCESS_COST"] = 1000;
 }
 

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -26,6 +26,9 @@ class Values : public Operation {
   virtual string asStringImpl(size_t indent = 0) const override;
 
  public:
+  // Return the contents of the VALUES clause
+  const SparqlValues& values() const { return _values; }
+
   virtual string getDescriptor() const override;
 
   virtual size_t getResultWidth() const override;

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -26,9 +26,6 @@ class Values : public Operation {
   virtual string asStringImpl(size_t indent = 0) const override;
 
  public:
-  // Return the contents of the VALUES clause
-  const SparqlValues& values() const { return _values; }
-
   virtual string getDescriptor() const override;
 
   virtual size_t getResultWidth() const override;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -82,6 +82,21 @@ size_t Index::objectCardinality(const TripleComponent& obj) const {
   return pimpl_->objectCardinality(obj);
 }
 
+// _____________________________________________________________________________
+size_t Index::getCardinality(const TripleComponent& comp,
+                             Index::Permutation p) const {
+  return pimpl_->applyToPermutation(p, [&](const auto& permutation) {
+    return pimpl_->getCardinality(comp, permutation);
+  });
+}
+
+// _____________________________________________________________________________
+size_t Index::getCardinality(Id id, Index::Permutation p) const {
+  return pimpl_->applyToPermutation(p, [&](const auto& permutation) {
+    return pimpl_->getCardinality(id, permutation);
+  });
+}
+
 // _______________________________________________
 std::optional<std::string> Index::idToOptionalString(Id id) const {
   return pimpl_->idToOptionalString(id);

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -67,21 +67,6 @@ auto Index::getTextVocab() const -> const TextVocab& {
   return pimpl_->getTextVocab();
 }
 
-// __________________________________________________
-size_t Index::relationCardinality(const std::string& relationName) const {
-  return pimpl_->relationCardinality(relationName);
-}
-
-// _________________________________________________
-size_t Index::subjectCardinality(const TripleComponent& sub) const {
-  return pimpl_->subjectCardinality(sub);
-}
-
-// ________________________________________________
-size_t Index::objectCardinality(const TripleComponent& obj) const {
-  return pimpl_->objectCardinality(obj);
-}
-
 // _____________________________________________________________________________
 size_t Index::getCardinality(const TripleComponent& comp,
                              Index::Permutation p) const {

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -101,6 +101,10 @@ class Index {
 
   [[nodiscard]] size_t objectCardinality(const TripleComponent& obj) const;
 
+  [[nodiscard]] size_t getCardinality(const TripleComponent& comp,
+                                      Permutation permutation) const;
+  [[nodiscard]] size_t getCardinality(Id id, Permutation permutation) const;
+
   // TODO<joka921> Once we have an overview over the folding this logic should
   // probably not be in the index class.
   [[nodiscard]] std::optional<std::string> idToOptionalString(Id id) const;

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -94,13 +94,6 @@ class Index {
   // --------------------------------------------------------------------------
   // RDF RETRIEVAL
   // --------------------------------------------------------------------------
-  [[nodiscard]] size_t relationCardinality(
-      const std::string& relationName) const;
-
-  [[nodiscard]] size_t subjectCardinality(const TripleComponent& sub) const;
-
-  [[nodiscard]] size_t objectCardinality(const TripleComponent& obj) const;
-
   [[nodiscard]] size_t getCardinality(const TripleComponent& comp,
                                       Permutation permutation) const;
   [[nodiscard]] size_t getCardinality(Id id, Permutation permutation) const;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -745,37 +745,19 @@ size_t IndexImpl::relationCardinality(const string& relationName) const {
   if (relationName == INTERNAL_TEXT_MATCH_PREDICATE) {
     return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
   }
-  Id relId;
-  if (getId(relationName, &relId)) {
-    if (this->_PSO.metaData().col0IdExists(relId)) {
-      return this->_PSO.metaData().getMetaData(relId).getNofElements();
-    }
-  }
-  return 0;
+  return getCardinality(relationName, _PSO);
 }
 
 // TODO<joka921> There is a lot of duplication in the three cardinality
 // functions, remove it.
 // _____________________________________________________________________________
 size_t IndexImpl::subjectCardinality(const TripleComponent& sub) const {
-  std::optional<Id> relId = sub.toValueId(getVocab());
-  if (relId.has_value()) {
-    if (this->_SPO.metaData().col0IdExists(relId.value())) {
-      return this->_SPO.metaData().getMetaData(relId.value()).getNofElements();
-    }
-  }
-  return 0;
+  return getCardinality(sub, _SPO);
 }
 
 // _____________________________________________________________________________
 size_t IndexImpl::objectCardinality(const TripleComponent& obj) const {
-  std::optional<Id> relId = obj.toValueId(getVocab());
-  if (relId.has_value()) {
-    if (this->_OSP.metaData().col0IdExists(relId.value())) {
-      return this->_OSP.metaData().getMetaData(relId.value()).getNofElements();
-    }
-  }
-  return 0;
+  return getCardinality(obj, _OSP);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -741,26 +741,6 @@ size_t IndexImpl::getNumDistinctSubjectPredicatePairs() const {
 }
 
 // _____________________________________________________________________________
-size_t IndexImpl::relationCardinality(const string& relationName) const {
-  if (relationName == INTERNAL_TEXT_MATCH_PREDICATE) {
-    return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
-  }
-  return getCardinality(relationName, _PSO);
-}
-
-// TODO<joka921> There is a lot of duplication in the three cardinality
-// functions, remove it.
-// _____________________________________________________________________________
-size_t IndexImpl::subjectCardinality(const TripleComponent& sub) const {
-  return getCardinality(sub, _SPO);
-}
-
-// _____________________________________________________________________________
-size_t IndexImpl::objectCardinality(const TripleComponent& obj) const {
-  return getCardinality(obj, _OSP);
-}
-
-// _____________________________________________________________________________
 template <class T>
 void IndexImpl::writeAsciiListFile(const string& filename, const T& ids) const {
   std::ofstream f(filename);

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -202,6 +202,8 @@ class IndexImpl {
     // TODO<joka921> This special case is only relevant for the `PSO` and `POS`
     // permutations, but this internal predicate should never appear in subjects
     // or objects anyway.
+    // TODO<joka921> Find out what the effect of this special case is for the
+    // query planning.
     if (comp == INTERNAL_TEXT_MATCH_PREDICATE) {
       return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
     }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -187,12 +187,6 @@ class IndexImpl {
   // --------------------------------------------------------------------------
   // RDF RETRIEVAL
   // --------------------------------------------------------------------------
-  size_t relationCardinality(const string& relationName) const;
-
-  size_t subjectCardinality(const TripleComponent& sub) const;
-
-  size_t objectCardinality(const TripleComponent& obj) const;
-
   template <typename Permutation>
   size_t getCardinality(Id id, const Permutation& permutation) const {
     if (permutation.metaData().col0IdExists(id)) {
@@ -205,6 +199,12 @@ class IndexImpl {
   template <typename Permutation>
   size_t getCardinality(const TripleComponent& comp,
                         const Permutation& permutation) const {
+    // TODO<joka921> This special case is only relevant for the `PSO` and `POS`
+    // permutations, but this internal predicate should never appear in subjects
+    // or objects anyway.
+    if (comp == INTERNAL_TEXT_MATCH_PREDICATE) {
+      return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
+    }
     std::optional<Id> relId = comp.toValueId(getVocab());
     if (relId.has_value()) {
       return getCardinality(relId.value(), permutation);

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -193,6 +193,25 @@ class IndexImpl {
 
   size_t objectCardinality(const TripleComponent& obj) const;
 
+  template <typename Permutation>
+  size_t getCardinality(Id id, const Permutation& permutation) const {
+    if (permutation.metaData().col0IdExists(id)) {
+      return permutation.metaData().getMetaData(id).getNofElements();
+    }
+    return 0;
+  }
+
+  // ___________________________________________________________________________
+  template <typename Permutation>
+  size_t getCardinality(const TripleComponent& comp,
+                        const Permutation& permutation) const {
+    std::optional<Id> relId = comp.toValueId(getVocab());
+    if (relId.has_value()) {
+      return getCardinality(relId.value(), permutation);
+    }
+    return 0;
+  }
+
   // TODO<joka921> Once we have an overview over the folding this logic should
   // probably not be in the index class.
   std::optional<string> idToOptionalString(Id id) const {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,7 +95,7 @@ addLinkAndDiscoverTest(HashMapTest absl::flat_hash_map)
 
 addLinkAndDiscoverTest(HashSetTest absl::flat_hash_set)
 
-addLinkAndDiscoverTest(GroupByTest engine)
+addLinkAndDiscoverTestSerial(GroupByTest engine)
 
 addLinkAndDiscoverTest(VocabularyGeneratorTest index)
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -475,10 +475,9 @@ TEST_F(GroupBySpecialCount, computeOptimizedAggregatesOnJoinChild) {
     // No optimization was applied, so the result is untouched.
     AD_CHECK(result._idTable.size() == 0);
 
-    // The child of the GROUP BY is not an index scan, so this is also
+    // The child of the GROUP BY is not a join, so this is also
     // invalid.
-    GroupBy invalidGroupBy2{qec, variablesOnlyX, emptyAliases,
-                            validJoinWhenGroupingByX};
+    GroupBy invalidGroupBy2{qec, variablesOnlyX, emptyAliases, xScan};
     ASSERT_FALSE(
         invalidGroupBy2.computeOptimizedAggregatesOnJoinChild(&result));
     AD_CHECK(result._idTable.size() == 0);

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -485,7 +485,7 @@ TEST_F(GroupBySpecialCount, computeGroupByForJoinWithFullScan) {
   }
 
   // `chooseInterface == true` means "use the dedicated
-  // `computeGroupByForJoinWithFullScan` method", `chooseInterface == true`
+  // `computeGroupByForJoinWithFullScan` method", `chooseInterface == false`
   // means use the general `computeOptimizedGroupByIfPossible` function.
   auto testWithBothInterfaces = [&](bool chooseInterface) {
     // Set up a `VALUES` clause with three values for `?x`, two of which (`<x>`
@@ -562,7 +562,7 @@ TEST_F(GroupBySpecialCount, computeGroupByForSingleIndexScan) {
   testFailure(emptyVariables, aliasesXAsV, xyzScanSortedByX);
 
   // `chooseInterface == true` means "use the dedicated
-  // `computeGroupByForJoinWithFullScan` method", `chooseInterface == true`
+  // `computeGroupByForJoinWithFullScan` method", `chooseInterface == false`
   // means use the general `computeOptimizedGroupByIfPossible` function.
   auto testWithBothInterfaces = [&](bool chooseInterface) {
     ResultTable result{qec->getAllocator()};

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -387,17 +387,18 @@ struct GroupBySpecialCount : ::testing::Test {
   }
 };
 
-TEST_F(GroupBySpecialCount, isThreeVariableTripleThatContainsVariable) {
+// TODO<joka921> Comment the tests, clean up, and complete them.
+TEST_F(GroupBySpecialCount, getPermutationForThreeVariableTriple) {
   using enum Index::Permutation;
-  ASSERT_EQ(SPO, GroupBy::isThreeVariableTripleThatContainsVariable(
-                     xyzScan.get(), Variable{"?x"}));
-  ASSERT_EQ(POS, GroupBy::isThreeVariableTripleThatContainsVariable(
-                     xyzScan.get(), Variable{"?y"}));
-  ASSERT_EQ(OSP, GroupBy::isThreeVariableTripleThatContainsVariable(
-                     xyzScan.get(), Variable{"?z"}));
-  ASSERT_EQ(std::nullopt, GroupBy::isThreeVariableTripleThatContainsVariable(
+  ASSERT_EQ(SPO, GroupBy::getPermutationForThreeVariableTriple(xyzScan.get(),
+                                                               Variable{"?x"}));
+  ASSERT_EQ(POS, GroupBy::getPermutationForThreeVariableTriple(xyzScan.get(),
+                                                               Variable{"?y"}));
+  ASSERT_EQ(OSP, GroupBy::getPermutationForThreeVariableTriple(xyzScan.get(),
+                                                               Variable{"?z"}));
+  ASSERT_EQ(std::nullopt, GroupBy::getPermutationForThreeVariableTriple(
                               xyzScan.get(), Variable{"?a"}));
-  ASSERT_EQ(std::nullopt, GroupBy::isThreeVariableTripleThatContainsVariable(
+  ASSERT_EQ(std::nullopt, GroupBy::getPermutationForThreeVariableTriple(
                               xScan.get(), Variable{"?x"}));
 }
 TEST_F(GroupBySpecialCount, checkIfOptimizedAggregateOnJoinChildIsPossible) {
@@ -433,11 +434,21 @@ TEST_F(GroupBySpecialCount, computeOptimizedAggregatesOnJoinChild) {
 
   auto join = makeExecutionTree<Join>(qec, values, xyzScanSortedByY, 0, 0);
 
-  GroupBy validForOptimization{qec, validVariables, validAliases, join};
+  // TODO<joka921> we found out, that the AD_CHECK is not correct inside the
+  // computeOptimized... function. It has to be a simple `if`.
+  GroupBy validForOptimization{qec, std::vector<Variable>{varY}, validAliases,
+                               join};
   ASSERT_TRUE(validForOptimization.computeOptimizedAggregatesOnJoinChild(
       &result, getJoinPtr(join)));
 
   // TODO<joka921> Check the contents of `result`
+
+  // The following is also invalid, because the JOIN before the GROUP BY is
+  // on the wrong variable
+  GroupBy invalidForOptimization2{qec, std::vector<Variable>{varX},
+                                  validAliases, join};
+  ASSERT_FALSE(invalidForOptimization2.computeOptimizedAggregatesOnJoinChild(
+      &result, getJoinPtr(join)));
 }
 
 }  // namespace

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -9,6 +9,7 @@
 #include "engine/GroupBy.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
+#include "engine/Values.h"
 #include "engine/sparqlExpressions/AggregateExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "gtest/gtest.h"
@@ -334,6 +335,7 @@ std::shared_ptr<QueryExecutionTree> makeExecutionTree(
       qec, std::make_shared<Operation>(qec, AD_FWD(args)...));
 }
 
+using namespace sparqlExpression;
 struct GroupBySpecialCount : ::testing::Test {
   using Tree = std::shared_ptr<QueryExecutionTree>;
   Variable varX{"?x"};
@@ -343,9 +345,40 @@ struct GroupBySpecialCount : ::testing::Test {
   SparqlTriple xyzTriple{Variable{"?x"}, "?y", Variable{"?z"}};
   Tree xyzScan = makeExecutionTree<IndexScan>(
       qec, IndexScan::FULL_INDEX_SCAN_SOP, xyzTriple);
+  Tree xyzScanSortedByY = makeExecutionTree<IndexScan>(
+      qec, IndexScan::FULL_INDEX_SCAN_POS, xyzTriple);
   Tree xScan = makeExecutionTree<IndexScan>(
       qec, IndexScan::PSO_BOUND_S,
       SparqlTriple{{"<x>"}, {"<label"}, Variable{"?x"}});
+
+  Tree invalidJoin = makeExecutionTree<Join>(qec, xScan, xScan, 0, 0);
+
+  Tree validJoin = makeExecutionTree<Join>(qec, xScan, xyzScan, 0, 0);
+
+  std::vector<Variable> emptyVariables{};
+  std::vector<Variable> validVariables{varX};
+
+  std::vector<Alias> emptyAliases{};
+
+  SparqlExpression::Ptr varXExpression =
+      std::make_unique<DummyExpression>(varX);
+  SparqlExpressionPimpl varxExpressionPimpl =
+      SparqlExpressionPimpl{std::move(varXExpression), "?x"};
+  SparqlExpression::Ptr varXExpression2 =
+      std::make_unique<VariableExpression>(varX);
+  SparqlExpressionPimpl countXPimpl = SparqlExpressionPimpl{
+      std::make_unique<CountExpression>(false, std::move(varXExpression2)),
+      "COUNT(?x)"};
+  SparqlExpression::Ptr varXExpression3 =
+      std::make_unique<VariableExpression>(varX);
+  SparqlExpressionPimpl countDistinctXPimpl = SparqlExpressionPimpl{
+      std::make_unique<CountExpression>(true, std::move(varXExpression3)),
+      "COUNT(?x)"};
+  std::vector<Alias> invalidAliases{
+      Alias{varxExpressionPimpl, Variable{"?count"}}};
+  std::vector<Alias> invalidAliases2{
+      Alias{countDistinctXPimpl, Variable{"?count"}}};
+  std::vector<Alias> validAliases{Alias{countXPimpl, Variable{"?count"}}};
 
   const Join* getJoinPtr(const Tree& tree) {
     auto joinPtr = dynamic_cast<const Join*>(tree->getRootOperation().get());
@@ -368,37 +401,8 @@ TEST_F(GroupBySpecialCount, isThreeVariableTripleThatContainsVariable) {
                               xScan.get(), Variable{"?x"}));
 }
 TEST_F(GroupBySpecialCount, checkIfOptimizedAggregateOnJoinChildIsPossible) {
-  using namespace sparqlExpression;
-  auto qec = sparqlExpression::getQec();
-
-  auto invalidJoin = makeExecutionTree<Join>(qec, xScan, xScan, 0, 0);
-
-  auto validJoin = makeExecutionTree<Join>(qec, xScan, xyzScan, 0, 0);
-
-  std::vector<Variable> emptyVariables{};
-  std::vector<Variable> validVariables{varX};
-
-  std::vector<Alias> emptyAliases{};
-
-  auto varXExpression = std::make_unique<DummyExpression>(varX);
-  auto varxExpressionPimpl =
-      SparqlExpressionPimpl{std::move(varXExpression), "?x"};
-  auto varXExpression2 = std::make_unique<VariableExpression>(varX);
-  auto countXPimpl = SparqlExpressionPimpl{
-      std::make_unique<CountExpression>(false, std::move(varXExpression2)),
-      "COUNT(?x)"};
-  auto varXExpression3 = std::make_unique<VariableExpression>(varX);
-  auto countDistinctXPimpl = SparqlExpressionPimpl{
-      std::make_unique<CountExpression>(true, std::move(varXExpression3)),
-      "COUNT(?x)"};
-  std::vector<Alias> invalidAliases{
-      Alias{varxExpressionPimpl, Variable{"?count"}}};
-  std::vector<Alias> invalidAliases2{
-      Alias{countDistinctXPimpl, Variable{"?count"}}};
-  std::vector<Alias> validAliases{Alias{countXPimpl, Variable{"?count"}}};
-
-  auto testFailure = [this, &qec](const auto& groupByVariables,
-                                  const auto& aliases, const auto& join) {
+  auto testFailure = [this](const auto& groupByVariables, const auto& aliases,
+                            const auto& join) {
     auto groupBy = GroupBy{qec, groupByVariables, aliases, join};
     ASSERT_FALSE(groupBy.checkIfOptimizedAggregateOnJoinChildIsPossible(
         getJoinPtr(join)));
@@ -414,4 +418,26 @@ TEST_F(GroupBySpecialCount, checkIfOptimizedAggregateOnJoinChildIsPossible) {
   ASSERT_TRUE(groupBy.checkIfOptimizedAggregateOnJoinChildIsPossible(
       getJoinPtr(validJoin)));
 }
+
+TEST_F(GroupBySpecialCount, computeOptimizedAggregatesOnJoinChild) {
+  GroupBy invalidForOptimization{qec, emptyVariables, validAliases, validJoin};
+  ResultTable result{qec->getAllocator()};
+  ASSERT_FALSE(invalidForOptimization.computeOptimizedAggregatesOnJoinChild(
+      &result, getJoinPtr(validJoin)));
+
+  parsedQuery::SparqlValues sparqlValues;
+  sparqlValues._variables.push_back(varY);
+  sparqlValues._values.emplace_back(std::vector{TripleComponent{"<x>"}});
+
+  auto values = makeExecutionTree<Values>(qec, sparqlValues);
+
+  auto join = makeExecutionTree<Join>(qec, values, xyzScanSortedByY, 0, 0);
+
+  GroupBy validForOptimization{qec, validVariables, validAliases, join};
+  ASSERT_TRUE(validForOptimization.computeOptimizedAggregatesOnJoinChild(
+      &result, getJoinPtr(join)));
+
+  // TODO<joka921> Check the contents of `result`
+}
+
 }  // namespace

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -46,7 +46,7 @@ Index makeTestIndex() {
   std::string filename = "relationalExpressionTestIndex.ttl";
   std::string dummyKb =
       "<x> <label> \"alpha\" . <x> <label> \"älpha\" . <x> <label> \"A\" . <x> "
-      "<label> \"Beta\".";
+      "<label> \"Beta\". <x> <is-a> <y>. <y> <is-a> <x>. ";
 
   FILE_BUFFER_SIZE() = 1000;
   std::fstream f(filename, std::ios_base::out);


### PR DESCRIPTION
Currently optimized are:

```
SELECT (COUNT(?x) as ?cnt) WHERE {
 ?x <somePred> ?y
}
```
(also for fixed subject/object and for a triple with three variables).

and
```
SELECT p (COUNT(?p) as ?cnt) WHERE {
  VALUES ?x {<p1> <p2> <p3>}
  ?s ?x ?o
} GROUP BY ?p
```

Also for the case where the `VALUES` variable is the subject or object of the triple.