### PR TITLE
Improve Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@ ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 FROM base as builder
-RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git
-RUN apt install -y libjemalloc-dev ninja-build libzstd-dev libssl-dev
-RUN apt install -y libboost1.74-dev libboost-program-options1.74-dev libboost-iostreams1.74-dev
+RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.74-dev libboost-program-options1.74-dev libboost-iostreams1.74-dev
 
 COPY . /app/
 
@@ -22,9 +20,7 @@ RUN make test
 FROM base as runtime
 WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1 uuid-runtime make
-RUN apt install -y lbzip2 libjemalloc-dev libzstd-dev libssl-dev
-RUN apt install -y libboost1.74-dev libboost-program-options1.74-dev libboost-iostreams1.74-dev
+RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1 uuid-runtime make lbzip2 libjemalloc-dev libzstd-dev libssl-dev libboost1.74-dev libboost-program-options1.74-dev libboost-iostreams1.74-dev
 
 ARG UID=1000
 RUN groupadd -r qlever && useradd --no-log-init -r -u $UID -g qlever qlever && chown qlever:qlever /app

--- a/Dockerfiles/Dockerfile.Ubuntu18.04
+++ b/Dockerfiles/Dockerfile.Ubuntu18.04
@@ -15,12 +15,7 @@ FROM base as builder
 RUN apt install -y gpg wget
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 RUN echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
-RUN apt-get update
-
-RUN apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git
-RUN apt install -y gcc-11 g++-11
-RUN apt install -y libjemalloc-dev ninja-build libzstd-dev libssl-dev
-RUN apt install -y libboost1.74-dev
+RUN apt-get update && build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git gcc-11 g++-11 libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.74-dev
 
 COPY . /app/
 
@@ -34,8 +29,7 @@ RUN make test
 FROM base as runtime
 WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1 uuid-runtime
-RUN apt install -y lbzip2 libjemalloc-dev libzstd-dev libssl-dev
+RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1 uuid-runtime lbzip2 libjemalloc-dev libzstd-dev libssl-dev
 
 ARG UID=1000
 RUN groupadd -r qlever && useradd --no-log-init -r -u $UID -g qlever qlever && chown qlever:qlever /app

--- a/Dockerfiles/Dockerfile.Ubuntu20.04
+++ b/Dockerfiles/Dockerfile.Ubuntu20.04
@@ -11,10 +11,7 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
 RUN apt-get update
 
 FROM base as builder
-RUN apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git
-RUN apt install -y gcc-11 g++-11
-RUN apt install -y libjemalloc-dev ninja-build libzstd-dev libssl-dev
-RUN apt install -y libboost1.74-dev
+RUN apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git gcc-11 g++-11 libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.74-dev
 
 COPY . /app/
 
@@ -28,8 +25,7 @@ RUN make test
 FROM base as runtime
 WORKDIR /app
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1 uuid-runtime
-RUN apt install -y lbzip2 libjemalloc-dev libzstd-dev libssl-dev
+RUN apt-get update && apt-get install -y wget python3-yaml unzip curl bzip2 pkg-config libicu-dev python3-icu libgomp1 uuid-runtime lbzip2 libjemalloc-dev libzstd-dev libssl-dev
 
 ARG UID=1000
 RUN groupadd -r qlever && useradd --no-log-init -r -u $UID -g qlever qlever && chown qlever:qlever /app


### PR DESCRIPTION
Have all package installations in a single RUN command, preceded by an "apt update". This avoids problems with docker caching when adding packages to the list.