### PR TITLE
When resizing `IdTable`, ensure minimum growth of factor 1.5

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -276,7 +276,7 @@ class IdTable {
     if (numRows > capacityRows_) {
       // Increase by at least the `growthFactor` to enforce the amortized O(1)
       // complexity also for patterns like `resize(numRows() + 1)`.
-      growWithMinimalGrowth(numRows);
+      reserveWithMinimalGrowth(numRows);
     }
     numRows_ = numRows;
   }
@@ -582,7 +582,7 @@ class IdTable {
   // by at least the `growthFactor`. This helper function is used inside
   // `growIfFull` and `resize` to enforce the amortized O(1) guarantee for
   // chains of operations.
-  void growWithMinimalGrowth(size_t newCapacity) {
+  void reserveWithMinimalGrowth(size_t newCapacity) {
     setCapacity(std::max(newCapacity,
                          static_cast<size_t>(capacityRows_ * growthFactor)));
   }
@@ -591,7 +591,7 @@ class IdTable {
   // full. Otherwise, do nothing.
   void growIfFull() {
     if (numRows_ == capacityRows_) {
-      growWithMinimalGrowth(capacityRows_ + 1);
+      reserveWithMinimalGrowth(capacityRows_ + 1);
     }
   }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -276,8 +276,7 @@ class IdTable {
     if (numRows > capacityRows_) {
       // Increase by at least the `growthFactor` to enforce the amortized O(1)
       // complexity also for patterns like `resize(numRows() + 1)`.
-      size_t minimalGrowth = static_cast<size_t>(capacityRows_ * growthFactor);
-      setCapacity(std::max(numRows, minimalGrowth));
+      growWithMinimalGrowth(numRows);
     }
     numRows_ = numRows;
   }
@@ -579,12 +578,20 @@ class IdTable {
     data() = std::move(newData);
   }
 
+  // Change the capacity s.t. it is at least `newCapacity` but also increases
+  // by at least the `growthFactor`. This helper function is used inside
+  // `growIfFull` and `resize` to enforce the amortized O(1) guarantee for
+  // chains of operations.
+  void growWithMinimalGrowth(size_t newCapacity) {
+    setCapacity(std::max(newCapacity,
+                         static_cast<size_t>(capacityRows_ * growthFactor)));
+  }
+
   // Increase the capacity by the `growthFactor` if the table is completely
   // full. Otherwise, do nothing.
   void growIfFull() {
     if (numRows_ == capacityRows_) {
-      setCapacity(std::max(capacityRows_ + 1,
-                           static_cast<size_t>(capacityRows_ * growthFactor)));
+      growWithMinimalGrowth(capacityRows_ + 1);
     }
   }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -143,7 +143,7 @@ class IdTable {
   size_t numColumns_ = NumColumns;
   size_t numRows_ = 0;
   size_t capacityRows_ = 0;
-  static constexpr size_t growthFactor = 2;
+  static constexpr double growthFactor = 1.5;
 
  public:
   // Construct from the number of columns and an allocator. If `NumColumns != 0`
@@ -274,7 +274,10 @@ class IdTable {
   // To set the capacity, use the `reserve` function.
   void resize(size_t numRows) requires(!isView) {
     if (numRows > capacityRows_) {
-      setCapacity(numRows);
+      // Increase by at least the `growthFactor` to enforce the amortized O(1)
+      // complexity also for patterns like `resize(numRows() + 1)`.
+      size_t minimalGrowth = static_cast<size_t>(capacityRows_ * growthFactor);
+      setCapacity(std::max(numRows, minimalGrowth);
     }
     numRows_ = numRows;
   }
@@ -580,7 +583,8 @@ class IdTable {
   // full. Otherwise, do nothing.
   void growIfFull() {
     if (numRows_ == capacityRows_) {
-      setCapacity(std::max(1ul, capacityRows_ * growthFactor));
+      setCapacity(
+          std::max(1ul, static_cast<size_t>(capacityRows_ * growthFactor)));
     }
   }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -583,8 +583,8 @@ class IdTable {
   // full. Otherwise, do nothing.
   void growIfFull() {
     if (numRows_ == capacityRows_) {
-      setCapacity(
-          std::max(1ul, static_cast<size_t>(capacityRows_ * growthFactor)));
+      setCapacity(std::max(capacityRows_ + 1,
+                           static_cast<size_t>(capacityRows_ * growthFactor)));
     }
   }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -277,7 +277,7 @@ class IdTable {
       // Increase by at least the `growthFactor` to enforce the amortized O(1)
       // complexity also for patterns like `resize(numRows() + 1)`.
       size_t minimalGrowth = static_cast<size_t>(capacityRows_ * growthFactor);
-      setCapacity(std::max(numRows, minimalGrowth);
+      setCapacity(std::max(numRows, minimalGrowth));
     }
     numRows_ = numRows;
   }


### PR DESCRIPTION
Change the `IdTables` growthFactor to 1.5 and also amortize the costs… of repeated `resize` calls.

A growth factor of 1.5 was also present in the old row-based `IdTable` and is considered to be better than a factor of 2 also by many industry experts (see for example `folly::fbvector`.

A `resize` operation now increases the capacity by at least the growth factor. This also amortizes the costs of a chain of "small" `resize` operations.