### PR TITLE
Enable IdTable with arbitrary value type and underlying storage

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -586,7 +586,7 @@ class IdTable {
       data() = std::move(newData);
     } else {
       // If it is complicated to create a`Storage` object (e.g. for file-based
-      // data structures like `BufferedVector`, we resize the current `Storage`
+      // data structures like `BufferedVector`), we resize the current `Storage`
       // object and move the contents in place. For file-based storage types the
       // `resize` operation is cheap as only new blocks are appended to the file
       // without copying any data.

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -391,9 +391,8 @@ class IdTable {
     }
     AD_CHECK(numColumns() == NewNumColumns || NewNumColumns == 0);
     auto result = IdTable<T, NewNumColumns, Storage>{
-        std::move(data()), numColumns(), size(), capacityRows_};
-    numRows_ = 0;
-    capacityRows_ = 0;
+        std::move(data()), numColumns(), std::move(numRows_),
+        std::move(capacityRows_)};
     return result;
   }
 
@@ -401,10 +400,9 @@ class IdTable {
   // function may only be called on rvalues, because the table will be moved
   // from.
   IdTable<T, 0, Storage> toDynamic() && requires(!isView) {
-    auto result = IdTable<T, 0, Storage>{std::move(data()), numColumns_, size(),
-                                         capacityRows_};
-    numRows_ = 0;
-    capacityRows_ = 0;
+    auto result =
+        IdTable<T, 0, Storage>{std::move(data()), numColumns_,
+                               std::move(numRows_), std::move(capacityRows_)};
     return result;
   }
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -373,6 +373,18 @@ class IdTable {
         data(), numColumns_, numRows_, capacityRows_};
   }
 
+  // Overload of `clone` for `Storage` types that are not copy constructible.
+  // It requires a preconstructed but empty argument of type `Storage` that
+  // is then resized and filled with the appropriate contents.
+  IdTable<T, NumColumns, Storage, IsView::False> clone(Storage storage) const
+      requires(!std::is_copy_constructible_v<Storage>) {
+    AD_CHECK(storage.empty());
+    storage.resize(data().size());
+    std::copy(data().begin(), data().end(), storage.begin());
+    return IdTable<T, NumColumns, Storage, IsView::False>{
+        std::move(storage), numColumns_, numRows_, capacityRows_};
+  }
+
   // From a dynamic (`NumColumns == 0`) IdTable, create a static (`NumColumns !=
   // 0`) IdTable with `NumColumns == NewNumColumns`. The number of columns
   // actually stored in the dynamic table must be equal to `NewNumColumns`, or

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -10,8 +10,9 @@
 #include <variant>
 #include <vector>
 
-#include "global/Id.h"
 #include "util/Enums.h"
+#include "util/Exception.h"
+#include "util/TypeTraits.h"
 #include "util/UninitializedAllocator.h"
 
 namespace columnBasedIdTable {
@@ -21,14 +22,14 @@ namespace columnBasedIdTable {
 // below).
 enum struct IsView { True, False };
 
-// A row of a table of IDs. It stores the IDs as a `std::array` or `std::vector`
+// A row of a table of `T`s. It stores the IDs as a `std::array` or `std::vector`
 // depending on whether `NumColumns` is 0 (which means that the number of
 // columns is specified at runtime). This class is used as the `value_type` of
 // the columns-ordered `IdTable` and must be used whenever a row (not a
 // reference to a row) has to be stored outside the IdTable. The implementation
-// is a rather thin wrapper around `std::vector<Id>` or `std::array<Id,
+// is a rather thin wrapper around `std::vector<T>` or `std::array<T,
 // NumColumns>`, respectively (see above).
-template <int NumColumns = 0>
+template <typename T, int NumColumns = 0>
 class Row {
  public:
   // Returns true iff the number of columns is only known at runtime and we
@@ -41,9 +42,9 @@ class Row {
   // `isDynamic()` case.
   using Data = std::conditional_t<
       isDynamic(),
-      std::vector<Id,
-                  ad_utility::default_init_allocator<Id, std::allocator<Id>>>,
-      std::array<Id, NumColumns>>;
+      std::vector<T,
+                  ad_utility::default_init_allocator<T, std::allocator<T>>>,
+      std::array<T, NumColumns>>;
 
  private:
   Data data_;
@@ -62,8 +63,8 @@ class Row {
       : Row() {}
 
   // Access the i-th element.
-  Id& operator[](size_t i) { return data_[i]; }
-  const Id& operator[](size_t i) const { return data_[i]; }
+  T& operator[](size_t i) { return data_[i]; }
+  const T& operator[](size_t i) const { return data_[i]; }
 
   size_t numColumns() const { return data_.size(); }
 
@@ -92,7 +93,7 @@ class RowReferenceImpl {
   template <typename Table, ad_utility::IsConst isConst>
   friend class RowReference;
 
-  template <int NumCols, typename Allocator, IsView isView>
+  template <typename T, int NumCols, typename Allocator, IsView isView>
   friend class IdTable;
 
   // The actual implementation of a reference to a row that allows mutable
@@ -105,10 +106,11 @@ class RowReferenceImpl {
    public:
     static constexpr bool isConst = isConstTag == ad_utility::IsConst::True;
     using TablePtr = std::conditional_t<isConst, const Table*, Table*>;
+    using T = typename Table::value_type;
     static constexpr int numStaticColumns = Table::numStaticColumns;
 
     // Grant the `IdTable` class access to the internal details.
-    template <int NumCols, typename Allocator, IsView isView>
+    template <typename T, int NumCols, typename Allocator, IsView isView>
     friend class IdTable;
 
    private:
@@ -143,9 +145,9 @@ class RowReferenceImpl {
    public:
     // Access to the `i`-th columns of this row. Only allowed for const values
     // and for rvalues.
-    Id& operator[](size_t i) && requires(!isConst) { return getImpl(*this, i); }
-    const Id& operator[](size_t i) const& { return getImpl(*this, i); }
-    const Id& operator[](size_t i) const&& { return getImpl(*this, i); }
+    T& operator[](size_t i) && requires(!isConst) { return getImpl(*this, i); }
+    const T& operator[](size_t i) const& { return getImpl(*this, i); }
+    const T& operator[](size_t i) const&& { return getImpl(*this, i); }
 
     // The number of columns that this row contains.
     size_t numColumns() const { return table_->numColumns(); }
@@ -168,9 +170,9 @@ class RowReferenceImpl {
 
     // Equality comparison. Works between two `RowReference`s, but also between
     // a `RowReference` and a `Row` if the number of columns match.
-    template <typename T>
-    bool operator==(const T& other) const
-        requires(numStaticColumns == T::numStaticColumns) {
+    template <typename U>
+    bool operator==(const U& other) const
+        requires(numStaticColumns == U::numStaticColumns) {
       if constexpr (numStaticColumns == 0) {
         if (numColumns() != other.numColumns()) {
           return false;
@@ -185,9 +187,9 @@ class RowReferenceImpl {
     }
 
     // Convert from a `RowReference` to a `Row`.
-    operator Row<numStaticColumns>() const {
+    operator Row<T, numStaticColumns>() const {
       auto numCols = (std::move(*this)).numColumns();
-      Row<numStaticColumns> result{numCols};
+      Row<T, numStaticColumns> result{numCols};
       for (size_t i = 0; i < numCols; ++i) {
         result[i] = std::move(*this)[i];
       }
@@ -209,7 +211,7 @@ class RowReferenceImpl {
 
    public:
     // Assignment from a `Row` with the same number of columns.
-    This& operator=(const Row<numStaticColumns>& other) && {
+    This& operator=(const Row<T, numStaticColumns>& other) && {
       return assignmentImpl(*this, other);
     }
 
@@ -247,6 +249,7 @@ class RowReference
       RowReferenceImpl::RowReferenceWithRestrictedAccess<Table, isConstTag>;
   using Base::numStaticColumns;
   using TablePtr = typename Base::TablePtr;
+  using T = typename Base::T;
   static constexpr bool isConst = isConstTag == ad_utility::IsConst::True;
 
   // Efficient access to the base class subobject to invoke its functions.
@@ -260,10 +263,10 @@ class RowReference
   RowReference(Base b) : Base{std::move(b)} {}
 
   // Access to the `i`-th column of this row.
-  Id& operator[](size_t i) requires(!isConst) {
+  T& operator[](size_t i) requires(!isConst) {
     return Base::getImpl(base(), i);
   }
-  const Id& operator[](size_t i) const { return Base::getImpl(base(), i); }
+  const T& operator[](size_t i) const { return Base::getImpl(base(), i); }
 
   // __________________________________________________________________________
   template <ad_utility::SimilarTo<RowReference> R>
@@ -281,7 +284,7 @@ class RowReference
 
  public:
   // Assignment from a `Row` with the same number of columns.
-  RowReference& operator=(const Row<numStaticColumns>& other) {
+  RowReference& operator=(const Row<T, numStaticColumns>& other) {
     return this->assignmentImpl(base(), other);
   }
 

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -22,13 +22,13 @@ namespace columnBasedIdTable {
 // below).
 enum struct IsView { True, False };
 
-// A row of a table of `T`s. It stores the IDs as a `std::array` or `std::vector`
-// depending on whether `NumColumns` is 0 (which means that the number of
-// columns is specified at runtime). This class is used as the `value_type` of
-// the columns-ordered `IdTable` and must be used whenever a row (not a
-// reference to a row) has to be stored outside the IdTable. The implementation
-// is a rather thin wrapper around `std::vector<T>` or `std::array<T,
-// NumColumns>`, respectively (see above).
+// A row of a table of `T`s. It stores the IDs as a `std::array` or
+// `std::vector` depending on whether `NumColumns` is 0 (which means that the
+// number of columns is specified at runtime). This class is used as the
+// `value_type` of the columns-ordered `IdTable` and must be used whenever a row
+// (not a reference to a row) has to be stored outside the IdTable. The
+// implementation is a rather thin wrapper around `std::vector<T>` or
+// `std::array<T, NumColumns>`, respectively (see above).
 template <typename T, int NumColumns = 0>
 class Row {
  public:
@@ -42,8 +42,7 @@ class Row {
   // `isDynamic()` case.
   using Data = std::conditional_t<
       isDynamic(),
-      std::vector<T,
-                  ad_utility::default_init_allocator<T, std::allocator<T>>>,
+      std::vector<T, ad_utility::default_init_allocator<T, std::allocator<T>>>,
       std::array<T, NumColumns>>;
 
  private:

--- a/src/util/BufferedVector.h
+++ b/src/util/BufferedVector.h
@@ -120,7 +120,7 @@ class BufferedVector {
       _extVec.resize(newSize);
     } else if (_isInternal && newSize < _threshold) {
       _vec.resize(newSize);
-    } else if (_isInternal && newSize > _threshold) {
+    } else if (_isInternal && newSize >= _threshold) {
       _extVec.resize(newSize);
       AD_CHECK(newSize > oldSize);
       std::copy(_vec.begin(), _vec.end(), _extVec.begin());
@@ -131,6 +131,7 @@ class BufferedVector {
       AD_CHECK(newSize < oldSize);
       _vec.resize(newSize);
       std::copy(_extVec.begin(), _extVec.begin() + newSize, _vec.begin());
+      _isInternal = true;
     }
   }
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(http)
 add_library(util GeoSparqlHelpers.h GeoSparqlHelpers.cpp VisitMixin.h
-        antlr/ANTLRErrorHandling.cpp antlr/ANTLRErrorHandling.h Conversions.cpp)
+        antlr/ANTLRErrorHandling.cpp antlr/ANTLRErrorHandling.h Conversions.cpp ResetWhenMoved.h)
 target_link_libraries(util absl::strings)

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -9,9 +9,10 @@
 #include <sstream>
 #include <string>
 
-#include "../util/Exception.h"
-#include "../util/Iterators.h"
-#include "File.h"
+#include "util/Exception.h"
+#include "util/File.h"
+#include "util/Iterators.h"
+#include "util/ResetWhenMoved.h"
 
 using std::string;
 
@@ -49,7 +50,7 @@ class TruncateException : public std::exception {
   std::string _filename;
   size_t _bytesize;
   int _errno;
-  mutable std::string _msg;
+  std::string _msg;
 };
 
 // ________________________________________________________________
@@ -270,10 +271,10 @@ class MmapVector {
   // advise the kernel to use a certain access pattern
   void advise(AccessPattern pattern);
 
-  T* _ptr = nullptr;
-  size_t _size = 0;
-  size_t _capacity = 0;
-  size_t _bytesize = 0;
+  ResetWhenMoved<T*, nullptr> _ptr;
+  ResetWhenMoved<size_t, 0> _size;
+  ResetWhenMoved<size_t, 0> _capacity;
+  ResetWhenMoved<size_t, 0> _bytesize;
   std::string _filename = "";
   AccessPattern _pattern = AccessPattern::None;
   static constexpr float ResizeFactor = 1.5;

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -360,7 +360,7 @@ class MmapVectorTmp : public MmapVector<T> {
   }
 
   MmapVectorTmp<T>& operator=(MmapVectorTmp<T>&& rhs) noexcept {
-    MmapVector<T>::operator=(rhs);
+    MmapVector<T>::operator=(std::move(rhs));
     return *this;
   }
 

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -164,7 +164,9 @@ void MmapVector<T>::adaptCapacity(size_t newCapacity) {
 template <class T>
 void MmapVector<T>::resize(size_t newSize) {
   _size = newSize;
-  adaptCapacity(newSize);
+  if (newSize > capacity()) {
+    adaptCapacity(newSize);
+  }
 }
 
 // _________________________________________________________________

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -141,6 +141,7 @@ VecInfo MmapVector<T>::convertArraySizeToFileSize(size_t targetSize) const {
 // _________________________________________________________________
 template <class T>
 void MmapVector<T>::adaptCapacity(size_t newCapacity) {
+  throwIfUninitialized();
   auto oldBytesize = _bytesize;
   auto realSize = convertArraySizeToFileSize(newCapacity);
   _capacity = realSize._capacity;
@@ -276,17 +277,7 @@ void MmapVector<T>::unmap() {
 
 // ________________________________________________________________
 template <class T>
-MmapVector<T>::MmapVector(MmapVector<T>&& other) noexcept
-    : _ptr(other._ptr),
-      _size(other._size),
-      _capacity(other._capacity),
-      _bytesize(other._bytesize),
-      _filename(other._filename),
-      _pattern(other._pattern) {
-  // we take exclusive ownership of the arguments mapping, setting
-  other._ptr = nullptr;
-  other._filename = "";
-}
+MmapVector<T>::MmapVector(MmapVector<T>&& other) noexcept = default;
 
 // ________________________________________________________________
 template <class T>
@@ -296,15 +287,12 @@ MmapVector<T>& MmapVector<T>::operator=(MmapVector<T>&& other) noexcept {
   }
   // if this vector already has a mapping, close it correctly
   close();
-  _ptr = other._ptr;
-  _size = other._size;
-  _capacity = other._capacity;
-  _bytesize = other._bytesize;
-  _filename = other._filename;
-  _pattern = other._pattern;
-  // we take exclusive ownership of the arguments mapping, setting
-  other._ptr = nullptr;
-  other._filename = "";
+  _ptr = std::move(other._ptr);
+  _size = std::move(other._size);
+  _capacity = std::move(other._capacity);
+  _bytesize = std::move(other._bytesize);
+  _filename = std::move(other._filename);
+  _pattern = std::move(other._pattern);
   return *this;
 }
 
@@ -329,17 +317,7 @@ void MmapVector<T>::advise(AccessPattern pattern) {
 // MmapVector. But since we have chosen the "greedy" template constructors,
 // this is necessary.
 template <class T>
-MmapVectorView<T>::MmapVectorView(MmapVectorView<T>&& other) noexcept {
-  this->_ptr = std::move(other._ptr);
-  this->_size = std::move(other._size);
-  this->_capacity = std::move(other._capacity);
-  this->_bytesize = std::move(other._bytesize);
-  this->_filename = std::move(other._filename);
-  this->_pattern = std::move(other._pattern);
-  // we take exclusive ownership of the arguments mapping, setting
-  other._ptr = nullptr;
-  other._filename = "";
-}
+MmapVectorView<T>::MmapVectorView(MmapVectorView<T>&& other) noexcept = default;
 
 // ________________________________________________________________
 template <class T>
@@ -353,9 +331,6 @@ MmapVectorView<T>& MmapVectorView<T>::operator=(
   this->_bytesize = std::move(other._bytesize);
   this->_filename = std::move(other._filename);
   this->_pattern = std::move(other._pattern);
-  // we take exclusive ownership of the arguments mapping, setting
-  other._ptr = nullptr;
-  other._filename = "";
   return *this;
 }
 

--- a/src/util/ResetWhenMoved.h
+++ b/src/util/ResetWhenMoved.h
@@ -6,20 +6,35 @@
 #include <utility>
 
 namespace ad_utility {
+// This class stores a single value of type `T` ( and is implicitly convertible
+// to and from `T`. Each time an object of type `ResetWhenMoved<T>` is moved
+// into another `ResetWhenMoved<T>` or into a plain `T`, its value changes back
+// to the `DefaultValue`. This class can be used as a simplification to
+// implement data structures that store raw integers or pointers that have to be
+// reset when the data structure is moved. When using `ResetWhenMoved` for such
+// members, then often the defaulted move constructors and move assignment
+// operators will have the correct semantics. For example usages see
+// `MmapVector.h` and `IdTable.h`.
 template <typename T, T DefaultValue>
 struct ResetWhenMoved {
   T value_ = DefaultValue;
   ResetWhenMoved() = default;
-  operator T() const { return value_; }
-  operator T&() { return value_; }
-  ResetWhenMoved(T t) : value_{std::move(t)} {}
 
+  // Implicit conversion to and from `T`.
+  ResetWhenMoved(T t) : value_{std::move(t)} {}
+  operator T() const& { return value_; }
+  operator T&() & { return value_; }
+  // When moving into a `T`, the `value_` is reset to the `DefaultValue`.
+  operator T() && { return std::exchange(value_, DefaultValue); }
+
+  // The copy constructor and copy assignment both just copy the value.
   ResetWhenMoved(const ResetWhenMoved&) = default;
   ResetWhenMoved& operator=(const ResetWhenMoved&) = default;
 
   constexpr static bool isNoexcept = std::is_nothrow_move_constructible_v<T> &&
                                      std::is_nothrow_move_assignable_v<T>;
 
+  // The move constructor and move assignment operators reset the `value_`
   ResetWhenMoved(ResetWhenMoved&& other) noexcept(isNoexcept)
       : value_{std::exchange(other.value_, DefaultValue)} {}
   ResetWhenMoved& operator=(ResetWhenMoved&& other) noexcept(isNoexcept) {

--- a/src/util/ResetWhenMoved.h
+++ b/src/util/ResetWhenMoved.h
@@ -1,0 +1,30 @@
+//  Copyright 2022, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#pragma once
+#include <utility>
+
+namespace ad_utility {
+template <typename T, T DefaultValue>
+struct ResetWhenMoved {
+  T value_ = DefaultValue;
+  ResetWhenMoved() = default;
+  operator T() const { return value_; }
+  operator T&() { return value_; }
+  ResetWhenMoved(T t) : value_{std::move(t)} {}
+
+  ResetWhenMoved(const ResetWhenMoved&) = default;
+  ResetWhenMoved& operator=(const ResetWhenMoved&) = default;
+
+  constexpr static bool isNoexcept = std::is_nothrow_move_constructible_v<T> &&
+                                     std::is_nothrow_move_assignable_v<T>;
+
+  ResetWhenMoved(ResetWhenMoved&& other) noexcept(isNoexcept)
+      : value_{std::exchange(other.value_, DefaultValue)} {}
+  ResetWhenMoved& operator=(ResetWhenMoved&& other) noexcept(isNoexcept) {
+    value_ = std::exchange(other.value_, DefaultValue);
+    return *this;
+  }
+};
+}  // namespace ad_utility

--- a/test/BufferedVectorTest.cpp
+++ b/test/BufferedVectorTest.cpp
@@ -12,7 +12,7 @@ using ad_utility::BufferedVector;
 
 // ______________________________________________________
 TEST(BufferedVectorTest, Constructor) {
-  BufferedVector<int> b(15, "_testBuf.dat");
+  BufferedVector<int> b(15, "_testBufConstructor.dat");
   ASSERT_EQ(b.threshold(), 15u);
   ASSERT_TRUE(b.isInternal());
   ASSERT_EQ(b.size(), 0u);
@@ -20,7 +20,7 @@ TEST(BufferedVectorTest, Constructor) {
 
 // ______________________________________________________
 TEST(BufferedVectorTest, PushBackSmall) {
-  BufferedVector<int> b(15, "_testBuf.dat");
+  BufferedVector<int> b(15, "_testBufPushBackSmall.dat");
   for (int i = 0; i < 13; ++i) {
     b.push_back(i);
   }
@@ -47,7 +47,7 @@ TEST(BufferedVectorTest, PushBackSmall) {
 
 // ______________________________________________________
 TEST(BufferedVectorTest, PushBackBig) {
-  BufferedVector<int> b(15, "_testBuf.dat");
+  BufferedVector<int> b(15, "_testBufPushBackBig.dat");
   for (int i = 0; i < 25; ++i) {
     b.push_back(i);
   }
@@ -74,7 +74,7 @@ TEST(BufferedVectorTest, PushBackBig) {
 
 // ______________________________________________________
 TEST(BufferedVectorTest, Clear) {
-  BufferedVector<int> b(15, "_testBuf.dat");
+  BufferedVector<int> b(15, "_testBufClear.dat");
   for (int i = 0; i < 25; ++i) {
     b.push_back(i);
   }
@@ -110,5 +110,45 @@ TEST(BufferedVectorTest, Clear) {
     ASSERT_EQ(el++, idx + 42);
     ASSERT_EQ(idx + 1 + 42, b[idx]);
     ++idx;
+  }
+}
+
+TEST(BufferedVectorTest, Resize) {
+  BufferedVector<int> b{5, "_testBufResize.dat"};
+  b.push_back(0);
+  b.push_back(1);
+  b.resize(4);
+  ASSERT_EQ(4, b.size());
+  ASSERT_TRUE(b.isInternal());
+  ASSERT_EQ(0, b[0]);
+  ASSERT_EQ(1, b[1]);
+  b.resize(5);
+  ASSERT_FALSE(b.isInternal());
+  ASSERT_EQ(5, b.size());
+  ASSERT_EQ(0, b[0]);
+  ASSERT_EQ(1, b[1]);
+  b[2] = 2;
+  b[3] = 3;
+  b[4] = 4;
+  b.resize(3000);
+  ASSERT_FALSE(b.isInternal());
+  ASSERT_EQ(3000, b.size());
+  for (size_t i = 0; i < 5; ++i) {
+    ASSERT_EQ(i, b[i]);
+  }
+  b[5] = 5;
+  b[6] = 6;
+  b.resize(7);
+  ASSERT_FALSE(b.isInternal());
+  ASSERT_EQ(7, b.size());
+  for (size_t i = 0; i < 7; ++i) {
+    ASSERT_EQ(i, b[i]);
+  }
+  // Resizing back from the external to the internal vector
+  b.resize(4);
+  ASSERT_TRUE(b.isInternal());
+  ASSERT_EQ(4, b.size());
+  for (size_t i = 0; i < 4; ++i) {
+    ASSERT_EQ(i, b[i]);
   }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -247,3 +247,5 @@ addLinkAndDiscoverTest(HttpTest boost_iostreams http)
 addLinkAndDiscoverTest(CallFixedSizeTest)
 
 addLinkAndDiscoverTest(ConstexprUtilsTest)
+
+addLinkAndDiscoverTest(ResetWhenMovedTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,7 +115,7 @@ addLinkAndDiscoverTest(TurtleParserTest parser absl::flat_hash_map re2)
 
 addLinkAndDiscoverTest(MultiColumnJoinTest engine)
 
-addLinkAndDiscoverTest(IdTableTest)
+addLinkAndDiscoverTest(IdTableTest absl::strings)
 
 addLinkAndDiscoverTest(TransitivePathTest engine)
 

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -10,6 +10,7 @@
 
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
+#include "util/BufferedVector.h"
 
 ad_utility::AllocatorWithLimit<Id>& allocator() {
   static ad_utility::AllocatorWithLimit<Id> a{
@@ -663,3 +664,8 @@ TEST(IdTableTest, staticAsserts) {
   static_assert(std::is_trivially_copyable_v<IdTableStatic<1>::iterator>);
   static_assert(std::is_trivially_copyable_v<IdTableStatic<1>::const_iterator>);
 }
+
+template class columnBasedIdTable::IdTable<char, 0>;
+static_assert(!std::is_copy_constructible_v<ad_utility::BufferedVector<char>>);
+template class columnBasedIdTable::IdTable<char, 0,
+                                           ad_utility::BufferedVector<char>>;

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -134,7 +134,56 @@ TEST(IdTableTest, DocumentationOfIteratorUsage) {
   }
 }
 
+// Run a test case for the following different instantiations of the `IdTable`
+// template:
+// - The default IdTable (stores `Id`s in a `vector<Id, AllocatorWithLimit>`.
+// - An IdTable that stores plain `int`s in plain `std::vector`.
+// - An `IdTable` that stores `Id`s in a `BufferedVector`.
+// Arguments:
+// `NumIdTables` - the number of distinct `IdTable` objects that are used inside
+//                 the test case
+// `test case` -   A lambda that is templated on a specific `IdTable`
+// instantiation, and takes one or two arguments. The first argument is a
+// function that converts a `size_t` to the `value_type` of the `IdTable`, and
+// the second one (if present) is a `std::vector` with `NumIdTables` entries
+// that represent the additional arguments that are needed to instantiate an
+// `IdTable` (e.g. an allocator or a `BufferedVector`).
+template <size_t NumIdTables>
+void runTestForDifferentTypes(auto testCase, std::string testCaseName) {
+  using Buffer = ad_utility::BufferedVector<Id>;
+  using BufferedTable = columnBasedIdTable::IdTable<Id, 0, Buffer>;
+  using intTable = columnBasedIdTable::IdTable<int, 0>;
+  // Prepare the vectors of `allocators` and distinct `BufferedVector`s needed
+  // for the respective `IdTable` types.
+  std::vector<std::decay_t<decltype(allocator())>> allocators;
+  std::vector<Buffer> buffers;
+  for (size_t i = 0; i < NumIdTables; ++i) {
+    buffers.emplace_back(3, testCaseName + std::to_string(i) + ".dat");
+    allocators.emplace_back(allocator());
+  }
+  testCase.template operator()<IdTable>(I, std::move(allocators));
+  testCase.template operator()<BufferedTable>(I, std::move(buffers));
+  auto makeInt = [](auto el) { return static_cast<int>(el); };
+  testCase.template operator()<intTable>(makeInt);
+}
+
+// This helper function has to be used inside the `testCase` lambdas for the
+// `runTestForDifferenTypes` function above whenever a copy of an `IdTable` has
+// to be made. It is necessary because for some `IdTable` instantiations
+// (for example when the data is stored in a `BufferedVector`) the `clone`
+// member function needs additional arguments. For an example usage see the
+// test cases below.
+auto clone(const auto& table, auto... args) {
+  if constexpr (requires { table.clone(); }) {
+    return table.clone();
+  } else {
+    return table.clone(std::move(args)...);
+  }
+}
+
 TEST(IdTableTest, push_back_and_assign) {
+  // A lambda that is used as the `testCase` argument to the
+  // `runtTestForDifferenTypes` function (see above for details).
   auto runTestForIdTable = []<typename Table>(auto make,
                                               auto... additionalArgs) {
     constexpr size_t NUM_ROWS = 30;
@@ -166,122 +215,140 @@ TEST(IdTableTest, push_back_and_assign) {
                 t1(i / NUM_COLS, i % NUM_COLS));
     }
   };
-  using Buffer = ad_utility::BufferedVector<Id>;
-  using BufferedTable = columnBasedIdTable::IdTable<Id, 0, Buffer>;
-  using intTable = columnBasedIdTable::IdTable<int, 0>;
-  auto makeInt = [](auto el) { return static_cast<int>(el); };
-  runTestForIdTable.operator()<IdTable>(I, std::array{allocator()});
-  runTestForIdTable.operator()<BufferedTable>(
-      I, std::array{Buffer{3, "_idTableTest.pushBackAssign.dat"}});
-  runTestForIdTable.operator()<intTable>(makeInt);
+  runTestForDifferentTypes<1>(runTestForIdTable, "idTableTest.pushBackAssign");
 }
 
 TEST(IdTableTest, insertAtEnd) {
-  IdTable t1{4, allocator()};
-  t1.push_back({I(7), I(2), I(4), I(1)});
-  t1.push_back({I(0), I(22), I(1), I(4)});
+  // A lambda that is used as the `testCase` argument to the
+  // `runtTestForDifferenTypes` function (see above for details).
+  auto runTestForIdTable = []<typename Table>(auto make,
+                                              auto... additionalArgs) {
+    Table t1{4, std::move(additionalArgs.at(0))...};
+    t1.push_back({make(7), make(2), make(4), make(1)});
+    t1.push_back({make(0), make(22), make(1), make(4)});
 
-  IdTable init(4, allocator());
-  init.push_back({I(1), I(0), I(6), I(3)});
-  init.push_back({I(3), I(1), I(8), I(2)});
-  init.push_back({I(0), I(6), I(8), I(5)});
-  init.push_back({I(9), I(2), I(6), I(8)});
+    Table init{4, std::move(additionalArgs.at(1))...};
+    init.push_back({make(1), make(0), make(6), make(3)});
+    init.push_back({make(3), make(1), make(8), make(2)});
+    init.push_back({make(0), make(6), make(8), make(5)});
+    init.push_back({make(9), make(2), make(6), make(8)});
 
-  IdTable t2 = init.clone();
-
-  // Test inserting at the end
-  t2.insertAtEnd(t1.begin(), t1.end());
-  for (size_t i = 0; i < init.size(); i++) {
-    ASSERT_EQ(init[i], t2[i]) << i;
-  }
-  for (size_t i = 0; i < t1.size(); i++) {
-    ASSERT_EQ(t1[i], t2[i + init.size()]);
-  }
+    Table t2 = clone(init, std::move(additionalArgs.at(2))...);
+    // Test inserting at the end
+    t2.insertAtEnd(t1.begin(), t1.end());
+    for (size_t i = 0; i < init.size(); i++) {
+      ASSERT_EQ(init[i], t2[i]) << i;
+    }
+    for (size_t i = 0; i < t1.size(); i++) {
+      ASSERT_EQ(t1[i], t2[i + init.size()]);
+    }
+  };
+  runTestForDifferentTypes<3>(runTestForIdTable, "idTableTest.insertAtEnd");
 }
 
 TEST(IdTableTest, reserve_and_resize) {
-  constexpr size_t NUM_ROWS = 34;
-  constexpr size_t NUM_COLS = 20;
+  // A lambda that is used as the `testCase` argument to the
+  // `runtTestForDifferenTypes` function (see above for details).
+  auto runTestForIdTable = []<typename Table>(auto make,
+                                              auto... additionalArgs) {
+    constexpr size_t NUM_ROWS = 34;
+    constexpr size_t NUM_COLS = 20;
 
-  // Test a reserve call before insertions
-  IdTable t1(NUM_COLS, allocator());
-  t1.reserve(NUM_ROWS);
+    // Test a reserve call before insertions
+    Table t1(NUM_COLS, std::move(additionalArgs.at(0))...);
+    t1.reserve(NUM_ROWS);
 
-  // Fill the rows with numbers counting up from 1
-  for (size_t i = 0; i < NUM_ROWS; i++) {
-    t1.emplace_back();
-    for (size_t j = 0; j < NUM_COLS; j++) {
-      t1(i, j) = I(i * NUM_COLS + 1 + j);
+    // Fill the rows with numbers counting up from 1
+    for (size_t i = 0; i < NUM_ROWS; i++) {
+      t1.emplace_back();
+      for (size_t j = 0; j < NUM_COLS; j++) {
+        t1(i, j) = make(i * NUM_COLS + 1 + j);
+      }
     }
-  }
 
-  ASSERT_EQ(NUM_ROWS, t1.size());
-  ASSERT_EQ(NUM_ROWS, t1.numRows());
-  ASSERT_EQ(NUM_COLS, t1.numColumns());
-  // check the entries
-  for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
-    ASSERT_EQ(I(i + 1), t1(i / NUM_COLS, i % NUM_COLS));
-  }
+    ASSERT_EQ(NUM_ROWS, t1.size());
+    ASSERT_EQ(NUM_ROWS, t1.numRows());
+    ASSERT_EQ(NUM_COLS, t1.numColumns());
+    // check the entries
+    for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
+      ASSERT_EQ(make(i + 1), t1(i / NUM_COLS, i % NUM_COLS));
+    }
 
-  // Test a resize call instead of insertions
-  IdTable t2(NUM_COLS, allocator());
-  t2.resize(NUM_ROWS);
+    // Test a resize call instead of insertions
+    Table t2(NUM_COLS, std::move(additionalArgs.at(1))...);
+    t2.resize(NUM_ROWS);
 
-  // Fill the rows with numbers counting up from 1
-  for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
-    t2(i / NUM_COLS, i % NUM_COLS) = I(i + 1);
-  }
+    // Fill the rows with numbers counting up from 1
+    for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
+      t2(i / NUM_COLS, i % NUM_COLS) = make(i + 1);
+    }
 
-  ASSERT_EQ(NUM_ROWS, t2.size());
-  ASSERT_EQ(NUM_ROWS, t2.numRows());
-  ASSERT_EQ(NUM_COLS, t2.numColumns());
-  // check the entries
-  for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
-    ASSERT_EQ(I(i + 1), t2(i / NUM_COLS, i % NUM_COLS));
-  }
+    ASSERT_EQ(NUM_ROWS, t2.size());
+    ASSERT_EQ(NUM_ROWS, t2.numRows());
+    ASSERT_EQ(NUM_COLS, t2.numColumns());
+    // check the entries
+    for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
+      ASSERT_EQ(make(i + 1), t2(i / NUM_COLS, i % NUM_COLS));
+    }
+  };
+  runTestForDifferentTypes<2>(runTestForIdTable,
+                              "idTableTest.reserveAndResize");
 }
 
 TEST(IdTableTest, copyAndMove) {
-  constexpr size_t NUM_ROWS = 100;
-  constexpr size_t NUM_COLS = 4;
+  // A lambda that is used as the `testCase` argument to the
+  // `runtTestForDifferenTypes` function (see above for details).
+  auto runTestForIdTable = []<typename Table>(auto make,
+                                              auto... additionalArgs) {
+    constexpr size_t NUM_ROWS = 100;
+    constexpr size_t NUM_COLS = 4;
 
-  IdTable t1(NUM_COLS, allocator());
-  // Fill the rows with numbers counting up from 1
-  for (size_t i = 0; i < NUM_ROWS; i++) {
-    t1.push_back({I(i * NUM_COLS + 1), I(i * NUM_COLS + 2), I(i * NUM_COLS + 3),
-                  I(i * NUM_COLS + 4)});
-  }
+    Table t1(NUM_COLS, std::move(additionalArgs.at(0))...);
+    // Fill the rows with numbers counting up from 1
+    for (size_t i = 0; i < NUM_ROWS; i++) {
+      t1.push_back({make(i * NUM_COLS + 1), make(i * NUM_COLS + 2),
+                    make(i * NUM_COLS + 3), make(i * NUM_COLS + 4)});
+    }
 
-  // Test all copy and move constructors and assignment operators
-  IdTable t2 = t1.clone();
-  IdTable t3 = t1.clone();
-  IdTable tmp = t1.clone();
-  IdTable t4(std::move(t1));
-  IdTable t5 = std::move(tmp);
+    // Test all copy and move constructors and assignment operators
+    Table t2 = clone(t1, std::move(additionalArgs.at(1))...);
+    Table t3{NUM_COLS, std::move(additionalArgs.at(2))...};
+    t3 = clone(t1, std::move(additionalArgs.at(3))...);
+    Table tmp = clone(t1, std::move(additionalArgs.at(4))...);
+    Table t4(std::move(t1));
+    Table t5{NUM_COLS, std::move(additionalArgs.at(5))...};
+    t5 = std::move(tmp);
 
-  ASSERT_EQ(NUM_ROWS, t2.size());
-  ASSERT_EQ(NUM_ROWS, t2.numRows());
-  ASSERT_EQ(NUM_COLS, t2.numColumns());
+    // t1 and tmp have been moved from
+    ASSERT_EQ(0, t1.numRows());
+    ASSERT_EQ(0, tmp.numRows());
 
-  ASSERT_EQ(NUM_ROWS, t3.size());
-  ASSERT_EQ(NUM_ROWS, t3.numRows());
-  ASSERT_EQ(NUM_COLS, t3.numColumns());
+    ASSERT_EQ(NUM_ROWS, t2.size());
+    ASSERT_EQ(NUM_ROWS, t2.numRows());
+    ASSERT_EQ(NUM_COLS, t2.numColumns());
 
-  ASSERT_EQ(NUM_ROWS, t4.size());
-  ASSERT_EQ(NUM_ROWS, t4.numRows());
-  ASSERT_EQ(NUM_COLS, t4.numColumns());
+    ASSERT_EQ(NUM_ROWS, t3.size());
+    ASSERT_EQ(NUM_ROWS, t3.numRows());
+    ASSERT_EQ(NUM_COLS, t3.numColumns());
 
-  ASSERT_EQ(NUM_ROWS, t5.size());
-  ASSERT_EQ(NUM_ROWS, t5.numRows());
-  ASSERT_EQ(NUM_COLS, t5.numColumns());
+    ASSERT_EQ(NUM_ROWS, t4.size());
+    ASSERT_EQ(NUM_ROWS, t4.numRows());
+    ASSERT_EQ(NUM_COLS, t4.numColumns());
 
-  // check the entries
-  for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
-    ASSERT_EQ(I(i + 1), t2(i / NUM_COLS, i % NUM_COLS));
-    ASSERT_EQ(I(i + 1), t3(i / NUM_COLS, i % NUM_COLS));
-    ASSERT_EQ(I(i + 1), t4(i / NUM_COLS, i % NUM_COLS));
-    ASSERT_EQ(I(i + 1), t5(i / NUM_COLS, i % NUM_COLS));
-  }
+    ASSERT_EQ(NUM_ROWS, t5.size());
+    ASSERT_EQ(NUM_ROWS, t5.numRows());
+    ASSERT_EQ(NUM_COLS, t5.numColumns());
+
+    // check the entries
+    for (size_t i = 0; i < NUM_ROWS * NUM_COLS; i++) {
+      ASSERT_EQ(make(i + 1), t2(i / NUM_COLS, i % NUM_COLS));
+      ASSERT_EQ(make(i + 1), t3(i / NUM_COLS, i % NUM_COLS));
+      ASSERT_EQ(make(i + 1), t4(i / NUM_COLS, i % NUM_COLS));
+      ASSERT_EQ(make(i + 1), t5(i / NUM_COLS, i % NUM_COLS));
+    }
+  };
+
+  runTestForDifferentTypes<6>(runTestForIdTable, "idTableTest.copyAndMove");
 }
 
 TEST(IdTableTest, erase) {
@@ -677,6 +744,8 @@ TEST(IdTableTest, staticAsserts) {
   static_assert(std::is_trivially_copyable_v<IdTableStatic<1>::const_iterator>);
 }
 
+// Check that we can completely instantiate `IdTable`s with a different value
+// type and a different underlying storage.
 template class columnBasedIdTable::IdTable<char, 0>;
 static_assert(!std::is_copy_constructible_v<ad_utility::BufferedVector<char>>);
 template class columnBasedIdTable::IdTable<char, 0,

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -746,7 +746,16 @@ TEST(IdTableTest, staticAsserts) {
 
 // Check that we can completely instantiate `IdTable`s with a different value
 // type and a different underlying storage.
+
+// Note: Clang 13 and 14 don't handle the `requires` clauses in the `clone`
+// member function correctly, so we have to disable these checks for those
+// compiler versions.
+// TODO<joka921> throw these checks out as soon as we don't support these
+// compiler versions anymore.
+
+#if not(defined(__clang__)) || (__clang_major__ != 13 && __clang_major__ != 14)
 template class columnBasedIdTable::IdTable<char, 0>;
 static_assert(!std::is_copy_constructible_v<ad_utility::BufferedVector<char>>);
 template class columnBasedIdTable::IdTable<char, 0,
                                            ad_utility::BufferedVector<char>>;
+#endif

--- a/test/MmapVectorTest.cpp
+++ b/test/MmapVectorTest.cpp
@@ -295,7 +295,7 @@ TEST(MmapVectorTest, Reuse) {
 
 // ____________________________________________________________________
 TEST(MmapVectorTest, MoveConstructor) {
-  // make sure that we get a unsignned 5000 to prevent compiler warnings
+  // make sure that we get a unsigned 5000 to prevent compiler warnings
 
   size_t s = 5000;
   {

--- a/test/MmapVectorTest.cpp
+++ b/test/MmapVectorTest.cpp
@@ -166,6 +166,45 @@ TEST(MmapVectorTest, PushBackLvalue) {
   }
 }
 
+// ___________________________________________________________________
+TEST(MmapVectorTest, ReserveAndResize) {
+  {
+    MmapVector<int> v(0, "_testResize.mmap");
+    ASSERT_EQ(size_t(0), v.size());
+    for (int i = 0; i < 5000; i++) {
+      int tmp = 5000 - i;
+      v.push_back(tmp);
+    }
+    size_t s = 5000;
+    ASSERT_EQ(s, v.size());
+    ASSERT_LE(s, v.capacity());
+    v.reserve(12000);
+    ASSERT_EQ(s, v.size());
+    ASSERT_LE(12000, v.capacity());
+    for (int i = 0; i < 5000; i++) {
+      ASSERT_EQ(v.at(i), 5000 - i);
+    }
+    auto ptr = v.data();
+    v.resize(12000);
+    ASSERT_LE(12000, v.capacity());
+    ASSERT_EQ(12000, v.size());
+    // There was enough capacity for the resize, so the underlying data hasn't
+    // changed.
+    ASSERT_EQ(ptr, v.data());
+
+    v.resize(14000);
+    ASSERT_EQ(14000, v.size());
+    ASSERT_LE(14000, v.capacity());
+
+    v.resize(500);
+    ASSERT_EQ(500, v.size());
+    ASSERT_LE(14000, v.capacity());
+    for (int i = 0; i < 500; i++) {
+      ASSERT_EQ(v.at(i), 5000 - i);
+    }
+  }
+}
+
 // ____________________________________________________________________
 TEST(MmapVectorTest, constIterators) {
   // make sure that we get a unsignned 5000 to prevent compiler warnings
@@ -311,6 +350,10 @@ TEST(MmapVectorTest, MoveConstructor) {
 
     MmapVector<int> v2(std::move(v));
     ASSERT_EQ(nullptr, v.data());
+    ASSERT_EQ(0, v.size());
+    ASSERT_EQ(0, v.capacity());
+    ASSERT_ANY_THROW(v.push_back(42));
+    ASSERT_ANY_THROW(v.resize(42));
 
     ASSERT_EQ(s, v2.size());
     ASSERT_LE(s, v2.capacity());
@@ -330,6 +373,8 @@ TEST(MmapVectorTest, MoveConstructor) {
 
   MmapVectorView<int> v2(std::move(v));
   ASSERT_EQ(nullptr, v.data());
+  ASSERT_EQ(nullptr, v.data());
+  ASSERT_EQ(0, v.size());
 
   ASSERT_EQ(s, v2.size());
   ASSERT_NE(nullptr, v2.data());
@@ -354,8 +399,19 @@ TEST(MmapVectorTest, MoveAssignment) {
       v[i] = i;
     }
 
-    MmapVector<int> v2 = std::move(v);
+    MmapVector<int> v2;
+    ASSERT_EQ(nullptr, v2.data());
+    ASSERT_EQ(0, v2.size());
+    ASSERT_EQ(0, v2.capacity());
+    ASSERT_ANY_THROW(v2.push_back(42));
+    ASSERT_ANY_THROW(v2.resize(42));
+    v2 = std::move(v);
+
     ASSERT_EQ(nullptr, v.data());
+    ASSERT_EQ(0, v.size());
+    ASSERT_EQ(0, v.capacity());
+    ASSERT_ANY_THROW(v.push_back(42));
+    ASSERT_ANY_THROW(v.resize(42));
 
     ASSERT_EQ(s, v2.size());
     ASSERT_LE(s, v2.capacity());
@@ -372,9 +428,12 @@ TEST(MmapVectorTest, MoveAssignment) {
   for (int i = 0; i < 5000; ++i) {
     ASSERT_EQ(v[i], i);
   }
-
-  MmapVectorView<int> v2 = std::move(v);
+  MmapVectorView<int> v2;
+  ASSERT_EQ(nullptr, v2.data());
+  ASSERT_EQ(0, v2.size());
+  v2 = std::move(v);
   ASSERT_EQ(nullptr, v.data());
+  ASSERT_EQ(0, v.size());
 
   ASSERT_EQ(s, v2.size());
   ASSERT_NE(nullptr, v2.data());

--- a/test/ResetWhenMovedTest.cpp
+++ b/test/ResetWhenMovedTest.cpp
@@ -5,7 +5,7 @@
 #include "gtest/gtest.h"
 #include "util/ResetWhenMoved.h"
 
-TEST(ResetWhenMoved, integer) {
+TEST(ResetWhenMoved, IntegerZero) {
   using R = ad_utility::ResetWhenMoved<int, 0>;
   R r;
   ASSERT_EQ(r, 0);
@@ -31,4 +31,32 @@ TEST(ResetWhenMoved, integer) {
   x = std::move(r2);
   ASSERT_EQ(r2, 0);
   ASSERT_EQ(x, 42);
+}
+
+TEST(ResetWhenMoved, IntegerFortyTwo) {
+  using R = ad_utility::ResetWhenMoved<int, 42>;
+  R r;
+  ASSERT_EQ(r, 42);
+  r = 24;
+  ASSERT_EQ(r, 24);
+
+  R r2 = r;
+  ASSERT_EQ(r, 24);
+  ASSERT_EQ(r2, 24);
+
+  R r3{std::move(r)};
+  ASSERT_EQ(r, 42);
+  ASSERT_EQ(r3, 24);
+
+  r2 = std::move(r3);
+  ASSERT_EQ(r3, 42);
+  ASSERT_EQ(r2, 24);
+
+  int x = r2;
+  ASSERT_EQ(x, 24);
+  ASSERT_EQ(r2, 24);
+  r2 = 43;
+  x = std::move(r2);
+  ASSERT_EQ(r2, 42);
+  ASSERT_EQ(x, 43);
 }

--- a/test/ResetWhenMovedTest.cpp
+++ b/test/ResetWhenMovedTest.cpp
@@ -1,0 +1,34 @@
+//  Copyright 2022, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include "gtest/gtest.h"
+#include "util/ResetWhenMoved.h"
+
+TEST(ResetWhenMoved, integer) {
+  using R = ad_utility::ResetWhenMoved<int, 0>;
+  R r;
+  ASSERT_EQ(r, 0);
+  r = 24;
+  ASSERT_EQ(r, 24);
+
+  R r2 = r;
+  ASSERT_EQ(r, 24);
+  ASSERT_EQ(r2, 24);
+
+  R r3{std::move(r)};
+  ASSERT_EQ(r, 0);
+  ASSERT_EQ(r3, 24);
+
+  r2 = std::move(r3);
+  ASSERT_EQ(r3, 0);
+  ASSERT_EQ(r2, 24);
+
+  int x = r2;
+  ASSERT_EQ(x, 24);
+  ASSERT_EQ(r2, 24);
+  r2 = 42;
+  x = std::move(r2);
+  ASSERT_EQ(r2, 0);
+  ASSERT_EQ(x, 42);
+}


### PR DESCRIPTION
This allows to change the stored value type via a template parameter to something other than `Id`. 
It also allows to change the chosen storage model to something other than `std::vector<T>` (e.g. `ad_utility::BufferedVector`, or `someBlockwiseStorageType`.

TODO<joka921>
It still needs several comments and tests.