### PR TITLE
Make the interface to the IdTable class more STL conform

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -219,6 +219,7 @@ class IdTable {
   // `std::vector<someRowType>`.
   size_t numRows() const { return numRows_; }
   size_t size() const { return numRows(); }
+  bool empty() const { return numRows() == 0; }
 
   // Return the number of columns.
   size_t numColumns() const {
@@ -253,6 +254,15 @@ class IdTable {
   const_row_reference_restricted operator[](size_t index) const {
     return *(begin() + index);
   }
+
+  // The usual `front` and `back` functions to make the interface similar to
+  // `std::vector` aand other containers.
+  // TODO<C++23, joka921> Remove the duplicates via explicit object parameters
+  // ("deducing this").
+  row_reference_restricted front() { return (*this)[0]; }
+  const_row_reference_restricted front() const { return (*this)[0]; }
+  row_reference_restricted back() { return (*this)[numRows() - 1]; }
+  const_row_reference_restricted back() const { return (*this)[numRows() - 1]; }
 
   // Resize the `IdTable` to exactly `numRows`. If `numRows < size()`, then the
   // last `size() - numRows` rows of the table will be deleted. If

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -143,12 +143,14 @@ class IteratorForAccessOperator {
   }
 
   decltype(auto) operator*() const { return _accessor(*_vector, _index); }
-  decltype(auto) operator*() { return _accessor(*_vector, _index); }
+  decltype(auto) operator*() requires(!isConst) {
+    return _accessor(*_vector, _index);
+  }
 
   // Only allowed, if `RandomAccessContainer` yields references and not values
   template <typename A = Accessor, typename P = RandomAccessContainerPtr>
   requires requires(A a, P p, uint64_t i) { {&a(*p, i)}; }
-  auto operator->() { return &(*(*this)); }
+  auto operator->() requires(!isConst) { return &(*(*this)); }
   template <typename A = Accessor, typename P = RandomAccessContainerPtr>
   requires requires(A a, P p, uint64_t i) { {&a(*p, i)}; }
   auto operator->() const { return &(*(*this)); }

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -134,6 +134,78 @@ TEST(IdTableTest, DocumentationOfIteratorUsage) {
   }
 }
 
+// The following test demonstrates the iterator functionality of a single
+// row.
+TEST(IdTableTest, rowIterators) {
+  using IntTable = columnBasedIdTable::IdTable<int, 0>;
+  auto testRow = [](auto row) {
+    row[0] = 0;
+    row[1] = 1;
+    row[2] = 2;
+    ASSERT_TRUE(std::is_sorted(row.begin(), row.end()));
+    ASSERT_TRUE(std::is_sorted(row.cbegin(), row.cend()));
+    ASSERT_TRUE(
+        std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
+
+    row[0] = 3;
+    ASSERT_FALSE(std::is_sorted(row.begin(), row.end()));
+    ASSERT_FALSE(std::is_sorted(row.cbegin(), row.cend()));
+    ASSERT_FALSE(
+        std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
+    row[0] = 0;
+    row[2] = -1;
+    ASSERT_FALSE(std::is_sorted(row.begin(), row.end()));
+    ASSERT_FALSE(std::is_sorted(row.cbegin(), row.cend()));
+    ASSERT_FALSE(
+        std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
+
+    std::ranges::sort(row.begin(), row.end());
+    ASSERT_EQ(-1, row[0]);
+    ASSERT_EQ(0, row[1]);
+    ASSERT_EQ(1, row[2]);
+  };
+  using IntTable = columnBasedIdTable::IdTable<int, 0>;
+  testRow(IntTable::row_type{3});
+
+  IntTable table{3};
+  table.emplace_back();
+  testRow(IntTable::row_reference{table[0]});
+  // This shouldn't work
+  {
+    auto row = table[0];
+    table[0][0] = 0;
+    table[0][1] = 1;
+    table[0][2] = 2;
+    ASSERT_TRUE(std::is_sorted(row.begin(), row.end()));
+    ASSERT_TRUE(std::is_sorted(row.cbegin(), row.cend()));
+    ASSERT_TRUE(
+        std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
+
+    table[0][0] = 3;
+    ASSERT_FALSE(std::is_sorted(row.begin(), row.end()));
+    ASSERT_FALSE(std::is_sorted(row.cbegin(), row.cend()));
+    ASSERT_FALSE(
+        std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
+    table[0][0] = 0;
+    table[0][2] = -1;
+    ASSERT_FALSE(std::is_sorted(row.begin(), row.end()));
+    ASSERT_FALSE(std::is_sorted(row.cbegin(), row.cend()));
+    ASSERT_FALSE(
+        std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
+
+    // TODO<joka921> Sorting of the proxy type `row_reference_restricted` can
+    // only be performed via `std::sort` as follows:
+    std::sort(std::move(row).begin(), std::move(row).end());
+    // The following calls all would not compile:
+    // std::sort(row.begin(), row.end());
+    // std::ranges::sort(row);
+    // std::ranges::sort(std::move(row));
+    ASSERT_EQ(-1, row[0]);
+    ASSERT_EQ(0, row[1]);
+    ASSERT_EQ(1, row[2]);
+  }
+}
+
 // Run a test case for the following different instantiations of the `IdTable`
 // template:
 // - The default `IdTable` (stores `Id`s in a `vector<Id, AllocatorWithLimit>`.
@@ -446,8 +518,8 @@ TEST(IdTableTest, sortTest) {
 
   // Now try the actual sort
   test = orig.clone();
-  std::sort(test.begin(), test.end(),
-            [](const auto& v1, const auto& v2) { return v1[0] < v2[0]; });
+  std::ranges::sort(test, std::less<>{},
+                    [](const auto& row) { return row[0]; });
 
   // The sorted order of the orig tables should be:
   // 3, 2, 0, 4, 5, 1
@@ -740,9 +812,31 @@ TEST(IdTableTest, conversion) {
   }
 }
 
+TEST(IdTableTest, empty) {
+  using IntTable = columnBasedIdTable::IdTable<int, 0>;
+  IntTable t{3};
+  ASSERT_TRUE(t.empty());
+  t.emplace_back();
+  ASSERT_FALSE(t.empty());
+}
+
+TEST(IdTableTest, fronAndBack) {
+  using IntTable = columnBasedIdTable::IdTable<int, 0>;
+  IntTable t{1};
+  t.resize(3);
+  t(0, 0) = 42;
+  t(2, 0) = 43;
+  ASSERT_EQ(42, t.front()[0]);
+  ASSERT_EQ(42, std::as_const(t).front()[0]);
+  ASSERT_EQ(43, t.back()[0]);
+  ASSERT_EQ(43, std::as_const(t).back()[0]);
+}
+
 TEST(IdTableTest, staticAsserts) {
   static_assert(std::is_trivially_copyable_v<IdTableStatic<1>::iterator>);
   static_assert(std::is_trivially_copyable_v<IdTableStatic<1>::const_iterator>);
+  static_assert(std::ranges::random_access_range<IdTable>);
+  static_assert(std::ranges::random_access_range<IdTableStatic<1>>);
 }
 
 // Check that we can completely instantiate `IdTable`s with a different value

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -193,7 +193,7 @@ TEST(IdTableTest, rowIterators) {
     ASSERT_FALSE(
         std::is_sorted(std::as_const(row).begin(), std::as_const(row).end()));
 
-    // TODO<joka921> Sorting of the proxy type `row_reference_restricted` can
+    // Sorting the proxy type `row_reference_restricted` can
     // only be performed via `std::sort` as follows:
     std::sort(std::move(row).begin(), std::move(row).end());
     // The following calls all would not compile:
@@ -820,7 +820,7 @@ TEST(IdTableTest, empty) {
   ASSERT_FALSE(t.empty());
 }
 
-TEST(IdTableTest, fronAndBack) {
+TEST(IdTableTest, frontAndBack) {
   using IntTable = columnBasedIdTable::IdTable<int, 0>;
   IntTable t{1};
   t.resize(3);


### PR DESCRIPTION
Add the functions `empty()` `front()` and `back()` to the `IdTable` class for an interface more similar to `std::vector`.

Improve the iterators of `IdTable` s.t. it becomes a proper `random_access_range` that can e.g. be used with `std::ranges::sort`.

Add random access iterators for the various `Row` and `RowReference` types to also improve their interface. These are mostly useful for simpler testing.