### PR TITLE
Column-based storage of the indices on disk

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -567,6 +567,12 @@ class IdTable {
     return {data().data() + i * capacityRows_, numRows_};
   }
 
+  // Return all the columns as a `std::vector` (if `isDynamic`) or as a
+  // `std::array` (else). The elements of the vector/array are `std::span<T>`
+  // or `std::span<const T>`, depending on whether `this` is const.
+  auto getColumns() { return getColumnsImpl(*this); }
+  auto getColumns() const { return getColumnsImpl(*this); }
+
  private:
   // Get direct access to the underlying data() as a reference.
   Storage& data() requires(!isView) { return data_; }
@@ -673,12 +679,6 @@ class IdTable {
       return columns;
     }
   }
-
-  // Return all the columns as a `std::vector` (if `isDynamic`) or as a
-  // `std::array` (else). The elements of the vector/array are `std::span<T>`
-  // or `std::span<const T>`, depending on whether `this` is const.
-  auto getColumns() { return getColumnsImpl(*this); }
-  auto getColumns() const { return getColumnsImpl(*this); }
 };
 
 }  // namespace columnBasedIdTable

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -5,11 +5,11 @@
 #include "CompressedRelation.h"
 
 #include "engine/idTable/IdTable.h"
-#include "index/ConstantsIndexBuilding.h"
 #include "index/Permutations.h"
 #include "util/Cache.h"
 #include "util/CompressionUsingZstd/ZstdWrapper.h"
 #include "util/ConcurrentCache.h"
+#include "util/Generator.h"
 #include "util/TypeTraits.h"
 
 using namespace std::chrono_literals;
@@ -20,43 +20,37 @@ using namespace std::chrono_literals;
 // TODO<joka921> Improve the performance of these triples also for large
 // knowledge bases.
 auto& globalBlockCache() {
-  static ad_utility::ConcurrentCache<ad_utility::HeapBasedLRUCache<
-      std::string, std::vector<std::array<Id, 2>>>>
+  static ad_utility::ConcurrentCache<
+      ad_utility::HeapBasedLRUCache<std::string, DecompressedBlock>>
       globalCache(20ul);
   return globalCache;
 }
 
 // ____________________________________________________________________________
-template <class Permutation, typename IdTableImpl>
 void CompressedRelationMetaData::scan(
-    Id col0Id, IdTableImpl* result, const Permutation& permutation,
+    const CompressedRelationMetaData& metaData,
+    const std::vector<CompressedBlockMetaData> blocks,
+    const std::string& permutationName, ad_utility::File& file, IdTable* result,
     ad_utility::SharedConcurrentTimeoutTimer timer) {
-  if (!permutation._isLoaded) {
-    throw std::runtime_error("This query requires the permutation " +
-                             permutation._readableName +
-                             ", which was not loaded");
-  }
-  if constexpr (!ad_utility::isVector<IdTableImpl>) {
-    AD_CHECK(result->numColumns() == 2);
-  }
-  if (!permutation._meta.col0IdExists(col0Id)) {
-    return;
-  }
-  const auto& metaData = permutation._meta.getMetaData(col0Id);
+  AD_CHECK(result->numColumns() == 2);
 
   // get all the blocks where _col0FirstId <= col0Id <= _col0LastId
   struct KeyLhs {
     Id _col0FirstId;
     Id _col0LastId;
   };
+  Id col0Id = metaData._col0Id;
   // TODO<joka921, Clang16> Use a structured binding. Structured bindings are
   // currently not supported by clang when using OpenMP because clang internally
   // transforms the `#pragma`s into lambdas, and capturing structured bindings
   // is only supported in clang >= 16.
-  decltype(permutation._meta.blockData().begin()) beginBlock, endBlock;
+  decltype(blocks.begin()) beginBlock, endBlock;
   std::tie(beginBlock, endBlock) = std::equal_range(
-      permutation._meta.blockData().begin(),
-      permutation._meta.blockData().end(), KeyLhs{col0Id, col0Id},
+      // TODO<joka921> For some reason we can't use `std::ranges::equal_range`,
+      // find out why. Note: possibly it has something to do with the limited
+      // support of ranges in clang with versions < 16. Revisit this when
+      // we use clang 16.
+      blocks.begin(), blocks.end(), KeyLhs{col0Id, col0Id},
       [](const auto& a, const auto& b) {
         return a._col0FirstId < b._col0FirstId && a._col0LastId < b._col0LastId;
       });
@@ -64,12 +58,11 @@ void CompressedRelationMetaData::scan(
   // The total size of the result is now known.
   result->resize(metaData.getNofElements());
 
-  // The position in the result, to which the next block is being
+  // The position in the result to which the next block is being
   // decompressed.
-  size_t currentIndex = 0;
-  // auto* position = reinterpret_cast<std::array<Id, 2>*>(result->data());
+  size_t rowIndexOfNextBlock = 0;
 
-  // The number of Id Pairs for which we still have space
+  // The number of rows for which we still have space
   // in the result (only needed for checking of invariants).
   size_t spaceLeft = result->size();
 
@@ -92,38 +85,33 @@ void CompressedRelationMetaData::scan(
     AD_CHECK(metaData._offsetInBlock != std::numeric_limits<uint64_t>::max());
   }
 
-  auto get = [result](size_t row, size_t col) -> Id& {
-    if constexpr (requires { (*result)(0, 0); }) {
-      return (*result)(row, col);
-    } else {
-      return (*result)[row][col];
-    }
-  };
-
   // We have at most one block that is incomplete and thus requires trimming.
   // Set up a lambda, that reads this block and decompresses it to
   // the result.
   auto readIncompleteBlock = [&](const auto& block) {
     auto cacheKey =
-        permutation._readableName + std::to_string(block._offsetInFile);
+        permutationName +
+        std::to_string(block._offsetsAndCompressedSize.at(0)._offsetInFile);
 
-    auto uncompressedBuffer =
-        globalBlockCache()
-            .computeOnce(
-                cacheKey,
-                [&]() { return readAndDecompressBlock(block, permutation); })
-            ._resultPointer;
+    auto uncompressedBuffer = globalBlockCache()
+                                  .computeOnce(cacheKey,
+                                               [&]() {
+                                                 return readAndDecompressBlock(
+                                                     block, file, std::nullopt);
+                                               })
+                                  ._resultPointer;
 
     // Extract the part of the block that actually belongs to the relation
-    auto begin = uncompressedBuffer->begin() + metaData._offsetInBlock;
-    auto end = begin + metaData._numRows;
-    auto numElements = static_cast<size_t>(end - begin);
-    AD_CHECK(numElements <= spaceLeft);
-    for (size_t i = 0; i < numElements; ++i) {
-      get(currentIndex + i, 0) = (*(begin + i))[0];
-      get(currentIndex + i, 1) = (*(begin + i))[1];
+    auto numElements = metaData._numRows;
+    AD_CHECK(uncompressedBuffer->numColumns() == numColumns());
+    for (size_t i = 0; i < uncompressedBuffer->numColumns(); ++i) {
+      const auto& inputCol = uncompressedBuffer->getColumn(i);
+      auto begin = inputCol.begin() + metaData._offsetInBlock;
+      auto resultColumn = result->getColumn(i);
+      AD_CHECK(numElements <= spaceLeft);
+      std::copy(begin, begin + numElements, resultColumn.begin());
     }
-    currentIndex += numElements;
+    rowIndexOfNextBlock += numElements;
     spaceLeft -= numElements;
   };
 
@@ -145,22 +133,18 @@ void CompressedRelationMetaData::scan(
         const auto& block = *beginBlock;
         // Read a block from disk (serially).
 
-        std::vector<char> compressedBuffer =
-            readCompressedBlockFromFile(block, permutation);
+        CompressedBlock compressedBuffer =
+            readCompressedBlockFromFile(block, file, std::nullopt);
 
         // This lambda decompresses the block that was just read to the
         // correct position in the result.
-        auto decompressLambda = [&get, currentIndex, &block,
+        auto decompressLambda = [&result, rowIndexOfNextBlock, &block,
                                  compressedBuffer =
                                      std::move(compressedBuffer)]() {
           ad_utility::TimeBlockAndLog("Decompressing a block");
-          std::vector<std::array<Id, 2>> buffer;
-          buffer.resize(block._numRows);
-          decompressBlock(compressedBuffer, block._numRows, buffer.data());
-          for (size_t i = 0; i < block._numRows; ++i) {
-            get(currentIndex + i, 0) = buffer[i][0];
-            get(currentIndex + i, 1) = buffer[i][1];
-          }
+
+          decompressBlockToExistingIdTable(compressedBuffer, block._numRows,
+                                           *result, rowIndexOfNextBlock);
         };
 
         // The `decompressLambda` can now run in parallel
@@ -174,86 +158,19 @@ void CompressedRelationMetaData::scan(
         // this is again serial code, set up the correct pointers
         // for the next block;
         spaceLeft -= block._numRows;
-        currentIndex += block._numRows;
+        rowIndexOfNextBlock += block._numRows;
       }
       AD_CHECK(spaceLeft == 0);
     }  // End of omp parallel region, all the decompression was handled now.
   }
 }
 
-// Explicit instantiations for all six permutations
-template void CompressedRelationMetaData::scan<Permutation::POS_T, IdTable>(
-    Id key, IdTable* result, const Permutation::POS_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::PSO_T, IdTable>(
-    Id key, IdTable* result, const Permutation::PSO_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::SPO_T, IdTable>(
-    Id key, IdTable* result, const Permutation::SPO_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::SOP_T, IdTable>(
-    Id key, IdTable* result, const Permutation::SOP_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::OPS_T, IdTable>(
-    Id key, IdTable* result, const Permutation::OPS_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::OSP_T, IdTable>(
-    Id key, IdTable* result, const Permutation::OSP_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-
-using V = std::vector<std::array<Id, 2>,
-                      ad_utility::AllocatorWithLimit<std::array<Id, 2>>>;
-template void CompressedRelationMetaData::scan<Permutation::POS_T, V>(
-    Id key, V* result, const Permutation::POS_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::PSO_T, V>(
-    Id key, V* result, const Permutation::PSO_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::SPO_T, V>(
-    Id key, V* result, const Permutation::SPO_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::SOP_T, V>(
-    Id key, V* result, const Permutation::SOP_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::OPS_T, V>(
-    Id key, V* result, const Permutation::OPS_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::OSP_T, V>(
-    Id key, V* result, const Permutation::OSP_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-
-using V2 = std::vector<std::array<Id, 2>>;
-template void CompressedRelationMetaData::scan<Permutation::POS_T, V2>(
-    Id key, V2* result, const Permutation::POS_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::PSO_T, V2>(
-    Id key, V2* result, const Permutation::PSO_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::SPO_T, V2>(
-    Id key, V2* result, const Permutation::SPO_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::SOP_T, V2>(
-    Id key, V2* result, const Permutation::SOP_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::OPS_T, V2>(
-    Id key, V2* result, const Permutation::OPS_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-template void CompressedRelationMetaData::scan<Permutation::OSP_T, V2>(
-    Id key, V2* result, const Permutation::OSP_T& p,
-    ad_utility::SharedConcurrentTimeoutTimer timer);
-
 // _____________________________________________________________________________
-template <class Permutation, typename IdTableImpl>
 void CompressedRelationMetaData::scan(
-    const Id col0Id, const Id& col1Id, IdTableImpl* result,
-    const Permutation& permutation,
-    ad_utility::SharedConcurrentTimeoutTimer timer) {
+    const CompressedRelationMetaData& metaData, Id col1Id,
+    const std::vector<CompressedBlockMetaData> blocks, ad_utility::File& file,
+    IdTable* result, ad_utility::SharedConcurrentTimeoutTimer timer) {
   AD_CHECK(result->numColumns() == 1);
-
-  if (!permutation._meta.col0IdExists(col0Id)) {
-    return;
-  }
-  const auto& metaData = permutation._meta.getMetaData(col0Id);
 
   // Get all the blocks  that possibly might contain our pair of col0Id and
   // col1Id
@@ -271,12 +188,13 @@ void CompressedRelationMetaData::scan(
     return endBeforeBegin;
   };
 
+  Id col0Id = metaData._col0Id;
+
   // Note: See the comment in the other overload for `scan` above for the
   // reason why we (currently) can't use a structured binding here.
-  decltype(permutation._meta.blockData().begin()) beginBlock, endBlock;
+  decltype(blocks.begin()) beginBlock, endBlock;
   std::tie(beginBlock, endBlock) =
-      std::equal_range(permutation._meta.blockData().begin(),
-                       permutation._meta.blockData().end(),
+      std::equal_range(blocks.begin(), blocks.end(),
                        KeyLhs{col0Id, col0Id, col1Id, col1Id}, comp);
 
   // Invariant: The col0Id is completely stored in a single block, or it is
@@ -288,38 +206,41 @@ void CompressedRelationMetaData::scan(
     AD_CHECK(endBlock - beginBlock <= 1);
   }
 
-  // The first and the last block might possibly be incomplete (that is, only
+  // The first and the last block might be incomplete (that is, only
   // a part of these blocks is actually part of the result,
   // set up a lambda which allows us to read these blocks, and returns
   // the result as a vector.
   auto readPossiblyIncompleteBlock = [&](const auto& block) {
-    std::vector<std::array<Id, 2>> uncompressedBuffer =
-        readAndDecompressBlock(block, permutation);
+    DecompressedBlock uncompressedBuffer =
+        readAndDecompressBlock(block, file, std::nullopt);
+    AD_CHECK(uncompressedBuffer.numColumns() == 2);
+    const auto& col1Column = uncompressedBuffer.getColumn(0);
+    const auto& col2Column = uncompressedBuffer.getColumn(1);
 
     // Find the range in the block, that belongs to the same relation `col0Id`
     bool containedInOnlyOneBlock =
         metaData._offsetInBlock != std::numeric_limits<uint64_t>::max();
-    auto begin = uncompressedBuffer.begin();
+    auto begin = col1Column.begin();
     if (containedInOnlyOneBlock) {
       begin += metaData._offsetInBlock;
     }
-    auto end = containedInOnlyOneBlock ? begin + metaData._numRows
-                                       : uncompressedBuffer.end();
+    auto end =
+        containedInOnlyOneBlock ? begin + metaData._numRows : col1Column.end();
 
     // Find the range in the block, where also the col1Id matches (the second
     // ID in the `std::array` does not matter).
-    std::tie(begin, end) = std::equal_range(
-        begin, end, std::array<Id, 2>{col1Id, Id{}},
-        [](const auto& a, const auto& b) { return a[0] < b[0]; });
+    std::tie(begin, end) = std::equal_range(begin, end, col1Id);
 
-    // Extract the one column result from the two column block.
-    std::vector<Id> result;
-    result.reserve(end - begin);
-    std::for_each(begin, end, [&](const auto& p) { result.push_back(p[1]); });
+    size_t beginIndex = begin - col1Column.begin();
+    size_t endIndex = end - col1Column.begin();
+
+    // Only extract the relevant portion of the second column.
+    std::vector<Id> result(col2Column.begin() + beginIndex,
+                           col2Column.begin() + endIndex);
     return result;
   };
 
-  // The first and the last block might possibly be incomplete, compute
+  // The first and the last block might be incomplete, compute
   // and store the partial results from them.
   std::vector<Id> firstBlockResult, lastBlockResult;
   if (beginBlock < endBlock) {
@@ -347,14 +268,11 @@ void CompressedRelationMetaData::scan(
   totalResultSize += firstBlockResult.size() + lastBlockResult.size();
 
   result->resize(totalResultSize);
-  // Only one column, so there is only one Vector
-  Id* position = &(*result)(0, 0);
-  size_t spaceLeft = result->size();
 
   // Insert the first block into the result;
-  position =
-      std::copy(firstBlockResult.begin(), firstBlockResult.end(), position);
-  spaceLeft -= firstBlockResult.size();
+  std::copy(firstBlockResult.begin(), firstBlockResult.end(),
+            result->getColumn(0).data());
+  size_t rowIndexOfNextBlockStart = firstBlockResult.size();
 
   // Insert the complete blocks from the middle in parallel
   if (beginBlock < endBlock) {
@@ -363,22 +281,20 @@ void CompressedRelationMetaData::scan(
     for (; beginBlock < endBlock; ++beginBlock) {
       const auto& block = *beginBlock;
 
-      // Read the block serially
-      std::vector<char> compressedBuffer =
-          readCompressedBlockFromFile(block, permutation);
+      // Read the block serially, only read the second column
+      AD_CHECK(block._offsetsAndCompressedSize.size() == 2);
+      CompressedBlock compressedBuffer =
+          readCompressedBlockFromFile(block, file, std::vector{1ul});
 
       // A lambda that owns the compressed block decompresses it to the
       // correct position in the result. It may safely be run in parallel
-      auto decompressLambda = [position, &block,
+      auto decompressLambda = [rowIndexOfNextBlockStart, &block, result,
                                compressedBuffer =
                                    std::move(compressedBuffer)]() mutable {
         ad_utility::TimeBlockAndLog("Decompression a block");
-        std::vector<std::array<Id, 2>> uncompressedBuffer =
-            decompressBlock(compressedBuffer, block._numRows);
 
-        // Extract the single result column from the two column block;
-        std::for_each(uncompressedBuffer.begin(), uncompressedBuffer.end(),
-                      [&](const auto& p) { *position++ = p[1]; });
+        decompressBlockToExistingIdTable(compressedBuffer, block._numRows,
+                                         *result, rowIndexOfNextBlockStart);
       };
 
       // Register an OpenMP task that performs the decompression of this
@@ -391,163 +307,211 @@ void CompressedRelationMetaData::scan(
       }
 
       // update the pointers
-      spaceLeft -= block._numRows;
-      position += block._numRows;
+      rowIndexOfNextBlockStart += block._numRows;
     }  // end of parallel region
   }
   // Add the last block.
-  std::copy(lastBlockResult.begin(), lastBlockResult.end(), position);
-  spaceLeft -= lastBlockResult.size();
-  AD_CHECK(spaceLeft == 0);
+  std::copy(lastBlockResult.begin(), lastBlockResult.end(),
+            result->getColumn(0).data() + rowIndexOfNextBlockStart);
+  AD_CHECK(rowIndexOfNextBlockStart + lastBlockResult.size() == result->size());
 }
 
-// Explicit instantiations for all six permutations
-template void CompressedRelationMetaData::scan<Permutation::POS_T, IdTable>(
-    const Id, const Id&, IdTable*, const Permutation::POS_T&,
-    ad_utility::SharedConcurrentTimeoutTimer);
-template void CompressedRelationMetaData::scan<Permutation::PSO_T, IdTable>(
-    const Id, const Id&, IdTable*, const Permutation::PSO_T&,
-    ad_utility::SharedConcurrentTimeoutTimer);
-template void CompressedRelationMetaData::scan<Permutation::SOP_T, IdTable>(
-    const Id, const Id&, IdTable*, const Permutation::SOP_T&,
-    ad_utility::SharedConcurrentTimeoutTimer);
-template void CompressedRelationMetaData::scan<Permutation::SPO_T, IdTable>(
-    const Id, const Id&, IdTable*, const Permutation::SPO_T&,
-    ad_utility::SharedConcurrentTimeoutTimer);
-template void CompressedRelationMetaData::scan<Permutation::OPS_T, IdTable>(
-    const Id, const Id&, IdTable*, const Permutation::OPS_T&,
-    ad_utility::SharedConcurrentTimeoutTimer);
-template void CompressedRelationMetaData::scan<Permutation::OSP_T, IdTable>(
-    const Id, const Id&, IdTable*, const Permutation::OSP_T&,
-    ad_utility::SharedConcurrentTimeoutTimer);
+// _____________________________________________________________________________
+float CompressedRelationWriter::computeMultiplicity(
+    size_t numElements, size_t numDistinctElements) {
+  bool functional = numElements == numDistinctElements;
+  float multiplicity =
+      functional ? 1.0 : numElements / float(numDistinctElements);
+  // Ensure that the multiplicity is only exactly 1.0 if the relation is indeed
+  // functional to prevent numerical instabilities;
+  if (!functional && multiplicity == 1.0) [[unlikely]] {
+    multiplicity = std::nextafter(1.0f, 2.0f);
+  }
+  return multiplicity;
+}
 
 // ___________________________________________________________________________
-void CompressedRelationWriter::addRelation(
-    Id col0Id, const ad_utility::BufferedVector<std::array<Id, 2>>& data,
-    size_t numDistinctCol1, bool functional) {
-  LOG(TRACE) << "Writing a relation ...\n";
-  AD_CHECK_GT(data.size(), 0);
-  LOG(TRACE) << "Calculating multiplicities ...\n";
-  float multC1 = functional ? 1.0 : data.size() / float(numDistinctCol1);
+void CompressedRelationWriter::addRelation(Id col0Id,
+                                           const BufferedIdTable& col1And2Ids,
+                                           size_t numDistinctCol1) {
+  AD_CHECK(!col1And2Ids.empty());
+  float multC1 = computeMultiplicity(col1And2Ids.numRows(), numDistinctCol1);
   // Dummy value that will be overwritten later
   float multC2 = 42.42;
-  LOG(TRACE) << "Done calculating multiplicities.\n";
   // This sets everything except the _offsetInBlock, which will be set
   // explicitly below.
-  CompressedRelationMetaData metaData{col0Id, data.size(), multC1, multC2};
-  auto sizeOfRelation = data.size() * 2 * sizeof(Id);
+  CompressedRelationMetaData metaData{col0Id, col1And2Ids.numRows(), multC1,
+                                      multC2};
+  auto sizeOfRelation =
+      col1And2Ids.numRows() * col1And2Ids.numColumns() * sizeof(Id);
 
   // If this is a large relation, or the currrently buffered relations +
   // this relation are too large, we will write the buffered relations to file
   // and start a new block.
-  if (sizeOfRelation > BLOCKSIZE_COMPRESSED_METADATA * 8 / 10 ||
-      sizeOfRelation + _buffer.data().size() >
-          1.5 * BLOCKSIZE_COMPRESSED_METADATA) {
+  if (sizeOfRelation > _numBytesPerBlock * 8 / 10 ||
+      sizeOfRelation + _buffer.numRows() > 1.5 * _numBytesPerBlock) {
     writeBufferedRelationsToSingleBlock();
   }
 
-  if (sizeOfRelation > BLOCKSIZE_COMPRESSED_METADATA * 8 / 10) {
+  if (sizeOfRelation > _numBytesPerBlock * 8 / 10) {
     // The relation is large, immediately write the relation to a set of
     // exclusive blocks.
-    writeRelationToExclusiveBlocks(col0Id, data);
+    writeRelationToExclusiveBlocks(col0Id, col1And2Ids);
     metaData._offsetInBlock = std::numeric_limits<uint64_t>::max();
   } else {
     // Append to the current buffered block.
-    metaData._offsetInBlock = _buffer.data().size() / (2 * sizeof(Id));
-    static_assert(sizeof(data[0]) == 2 * sizeof(Id));
-    if (_buffer.data().empty()) {
+    metaData._offsetInBlock = _buffer.numRows();
+    static_assert(sizeof(col1And2Ids[0][0]) == sizeof(Id));
+    if (_buffer.numRows() == 0) {
       _currentBlockData._col0FirstId = col0Id;
-      _currentBlockData._col1FirstId = data.front()[0];
+      _currentBlockData._col1FirstId = col1And2Ids(0, 0);
     }
     _currentBlockData._col0LastId = col0Id;
-    _currentBlockData._col1LastId = data.back()[0];
-    _buffer.serializeBytes(reinterpret_cast<const char*>(data.data()),
-                           data.size() * 2 * sizeof(Id));
+    _currentBlockData._col1LastId = col1And2Ids(col1And2Ids.numRows() - 1, 0);
+    AD_CHECK(_buffer.numColumns() == col1And2Ids.numColumns());
+    auto bufferOldSize = _buffer.numRows();
+    _buffer.resize(_buffer.numRows() + col1And2Ids.numRows());
+    for (size_t i = 0; i < col1And2Ids.numColumns(); ++i) {
+      const auto& column = col1And2Ids.getColumn(i);
+      std::ranges::copy(column, _buffer.getColumn(i).begin() + bufferOldSize);
+    }
   }
   _metaDataBuffer.push_back(metaData);
 }
 
 // _____________________________________________________________________________
 void CompressedRelationWriter::writeRelationToExclusiveBlocks(
-    Id col0Id, const ad_utility::BufferedVector<std::array<Id, 2>>& data) {
-  constexpr size_t NUM_ROWS_PER_BLOCK =
-      BLOCKSIZE_COMPRESSED_METADATA / (2 * sizeof(Id));
-  for (size_t i = 0; i < data.size(); i += NUM_ROWS_PER_BLOCK) {
-    size_t actualNumRowsPerBlock =
-        std::min(NUM_ROWS_PER_BLOCK, size_t(data.size() - i));
+    Id col0Id, const BufferedIdTable& data) {
+  const size_t numRowsPerBlock = _numBytesPerBlock / (2 * sizeof(Id));
+  AD_CHECK(numRowsPerBlock > 0);
+  AD_CHECK(data.numColumns() == 2);
+  const auto totalSize = data.numRows();
+  for (size_t i = 0; i < totalSize; i += numRowsPerBlock) {
+    size_t actualNumRowsPerBlock = std::min(numRowsPerBlock, totalSize - i);
 
-    std::vector<char> compressedBlock = ZstdWrapper::compress(
-        (void*)(data.data() + i), actualNumRowsPerBlock * 2 * sizeof(Id));
+    std::vector<CompressedBlockMetaData::OffsetAndCompressedSize> offsets;
+    for (const auto& column : data.getColumns()) {
+      offsets.push_back(compressAndWriteColumn(
+          {column.begin() + i, column.begin() + i + actualNumRowsPerBlock}));
+    }
+
     _blockBuffer.push_back(CompressedBlockMetaData{
-        _outfile.tell(), compressedBlock.size(), actualNumRowsPerBlock, col0Id,
-        col0Id, data[i][0], data[i + actualNumRowsPerBlock - 1][0]});
-    _outfile.write(compressedBlock.data(), compressedBlock.size());
+        std::move(offsets), actualNumRowsPerBlock, col0Id, col0Id, data[i][0],
+        data[i + actualNumRowsPerBlock - 1][0]});
   }
-  LOG(TRACE) << "Done writing relation.\n";
 }
 
 // ___________________________________________________________________________
 void CompressedRelationWriter::writeBufferedRelationsToSingleBlock() {
-  if (_buffer.data().empty()) {
+  if (_buffer.empty()) {
     return;
   }
 
-  auto bytesFromBuffer = std::move(_buffer).data();
-  _buffer.clear();
+  AD_CHECK(_buffer.numColumns() == 2);
+  // Convert from bytes to number of ID pairs.
+  size_t numRows = _buffer.numRows();
 
-  // Convert from bytes to number of Id pairs.
-  size_t numRows = bytesFromBuffer.size() / (2 * sizeof(Id));
+  // TODO<joka921, C++23> This is
+  // `ranges::to<vector>(ranges::transform_view(_buffer.getColumns(),
+  // compressAndWriteColumn))`;
+  std::ranges::for_each(_buffer.getColumns(),
+                        [this](const auto& column) mutable {
+                          _currentBlockData._offsetsAndCompressedSize.push_back(
+                              compressAndWriteColumn(column));
+                        });
 
-  std::vector<char> compressedBlock = ZstdWrapper::compress(
-      (void*)(bytesFromBuffer.data()), bytesFromBuffer.size());
-  _currentBlockData._offsetInFile = _outfile.tell();
-  _currentBlockData._compressedSize = compressedBlock.size();
   _currentBlockData._numRows = numRows;
   // The `firstId` and `lastId` of `_currentBlockData` were already set
   // correctly by `addRelation()`.
   _blockBuffer.push_back(_currentBlockData);
-  _outfile.write(compressedBlock.data(), compressedBlock.size());
-  LOG(TRACE) << "Done writing relation.\n";
+  // Reset the data of the current block.
+  _currentBlockData = CompressedBlockMetaData{};
+  _buffer.clear();
 }
 
 // _____________________________________________________________________________
-template <class Permutation>
-std::vector<char> CompressedRelationMetaData::readCompressedBlockFromFile(
-    const CompressedBlockMetaData& block, const Permutation& permutation) {
-  std::vector<char> compressedBuffer;
-  compressedBuffer.resize(block._compressedSize);
-  permutation._file.read(compressedBuffer.data(), block._compressedSize,
-                         block._offsetInFile);
+CompressedBlock CompressedRelationMetaData::readCompressedBlockFromFile(
+    const CompressedBlockMetaData& blockMetaData, ad_utility::File& file,
+    std::optional<std::vector<size_t>> columnIndices) {
+  // If we have no column indices specified, we read all the columns.
+  // TODO<joka921> This should be some kind of `smallVector` for performance
+  // reasons.
+  if (!columnIndices.has_value()) {
+    columnIndices.emplace();
+    // TODO<joka921, C++23> this is ranges::to<vector>(std::iota).
+    columnIndices->reserve(NumColumns);
+    for (size_t i = 0; i < NumColumns; ++i) {
+      columnIndices->push_back(i);
+    }
+  }
+  CompressedBlock compressedBuffer;
+  compressedBuffer.resize(columnIndices->size());
+  // TODO<C++23> Use `std::views::zip`
+  for (size_t i = 0; i < compressedBuffer.size(); ++i) {
+    const auto& offset =
+        blockMetaData._offsetsAndCompressedSize.at(columnIndices->at(i));
+    auto& currentCol = compressedBuffer[i];
+    currentCol.resize(offset._compressedSize);
+    file.read(currentCol.data(), offset._compressedSize, offset._offsetInFile);
+  }
   return compressedBuffer;
 }
 
 // ____________________________________________________________________________
-std::vector<std::array<Id, 2>> CompressedRelationMetaData::decompressBlock(
-    const std::vector<char>& compressedBlock, size_t numRowsToRead) {
-  std::vector<std::array<Id, 2>> uncompressedBuffer;
-  uncompressedBuffer.resize(numRowsToRead);
-  decompressBlock(compressedBlock, numRowsToRead, uncompressedBuffer.data());
-  return uncompressedBuffer;
+DecompressedBlock CompressedRelationMetaData::decompressBlock(
+    const CompressedBlock& compressedBlock, size_t numRowsToRead) {
+  DecompressedBlock decompressedBlock{compressedBlock.size()};
+  decompressedBlock.resize(numRowsToRead);
+  for (size_t i = 0; i < compressedBlock.size(); ++i) {
+    auto col = decompressedBlock.getColumn(i);
+    decompressColumn(compressedBlock[i], numRowsToRead, col.data());
+  }
+  return decompressedBlock;
+}
+
+// ____________________________________________________________________________
+void CompressedRelationMetaData::decompressBlockToExistingIdTable(
+    const CompressedBlock& compressedBlock, size_t numRowsToRead,
+    IdTable& table, size_t offsetInTable) {
+  AD_CHECK(table.numRows() >= offsetInTable + numRowsToRead);
+  // TODO<joka921, C++23> use zip_view.
+  AD_CHECK(compressedBlock.size() == table.numColumns());
+  for (size_t i = 0; i < compressedBlock.size(); ++i) {
+    auto col = table.getColumn(i);
+    decompressColumn(compressedBlock[i], numRowsToRead,
+                     col.data() + offsetInTable);
+  }
 }
 
 // ____________________________________________________________________________
 template <typename Iterator>
-void CompressedRelationMetaData::decompressBlock(
+void CompressedRelationMetaData::decompressColumn(
     const std::vector<char>& compressedBlock, size_t numRowsToRead,
     Iterator iterator) {
   auto numBytesActuallyRead = ZstdWrapper::decompressToBuffer(
       compressedBlock.data(), compressedBlock.size(), iterator,
       numRowsToRead * sizeof(*iterator));
-  static_assert(2 * sizeof(Id) == sizeof(*iterator));
-  AD_CHECK(numRowsToRead * 2 * sizeof(Id) == numBytesActuallyRead);
+  static_assert(sizeof(Id) == sizeof(*iterator));
+  AD_CHECK(numRowsToRead * sizeof(Id) == numBytesActuallyRead);
 }
 
 // _____________________________________________________________________________
-template <class Permutation>
-std::vector<std::array<Id, 2>>
-CompressedRelationMetaData::readAndDecompressBlock(
-    const CompressedBlockMetaData& block, const Permutation& permutation) {
-  auto compressed = readCompressedBlockFromFile(block, permutation);
-  auto numRowsToRead = block._numRows;
-  return decompressBlock(compressed, numRowsToRead);
+DecompressedBlock CompressedRelationMetaData::readAndDecompressBlock(
+    const CompressedBlockMetaData& blockMetaData, ad_utility::File& file,
+    std::optional<std::vector<size_t>> columnIndices) {
+  CompressedBlock compressedColumns = readCompressedBlockFromFile(
+      blockMetaData, file, std::move(columnIndices));
+  const auto numRowsToRead = blockMetaData._numRows;
+  return decompressBlock(compressedColumns, numRowsToRead);
 }
+
+// _____________________________________________________________________________
+CompressedBlockMetaData::OffsetAndCompressedSize
+CompressedRelationWriter::compressAndWriteColumn(std::span<const Id> column) {
+  std::vector<char> compressedBlock = ZstdWrapper::compress(
+      (void*)(column.data()), column.size() * sizeof(column[0]));
+  auto offsetInFile = _outfile.tell();
+  auto compressedSize = compressedBlock.size();
+  _outfile.write(compressedBlock.data(), compressedBlock.size());
+  return {offsetInFile, compressedSize};
+};

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -8,19 +8,52 @@
 #include <algorithm>
 #include <vector>
 
-#include "../global/Id.h"
-#include "../util/BufferedVector.h"
-#include "../util/File.h"
-#include "../util/Serializer/ByteBufferSerializer.h"
-#include "../util/Serializer/SerializeVector.h"
-#include "../util/Serializer/Serializer.h"
-#include "../util/Timer.h"
-#include "../util/TypeTraits.h"
+#include "engine/idTable/IdTable.h"
+#include "global/Id.h"
+#include "index/ConstantsIndexBuilding.h"
+#include "util/BufferedVector.h"
+#include "util/File.h"
+#include "util/Serializer/ByteBufferSerializer.h"
+#include "util/Serializer/SerializeVector.h"
+#include "util/Serializer/Serializer.h"
+#include "util/Timer.h"
+#include "util/TypeTraits.h"
 
-// The meta data of a compressed block of ID triples in an index permutation.
+// Forward declaration of the `IdTable` class.
+class IdTable;
+
+// Currently our indexes have two columns (the first column of a triple
+// is stored in the respective metadata). This might change in the future when
+// we add a column for patterns or functional relations like rdf:type.
+static constexpr int NumColumns = 2;
+// Two columns of IDs that are buffered in a file if they become too large.
+// This is the format in which the raw two-column data for a single relation is
+// passed around during the index building.
+using BufferedIdTable =
+    columnBasedIdTable::IdTable<Id, NumColumns, ad_utility::BufferedVector<Id>>;
+
+// This type is used to buffer small relations that will be stored in the same
+// block.
+using SmallRelationsBuffer = columnBasedIdTable::IdTable<Id, NumColumns>;
+
+// Sometimes we do not read/decompress  all the columns, so we store in a
+// dynamic `IdTable`.
+using DecompressedBlock = columnBasedIdTable::IdTable<Id, 0>;
+
+// After compression the columns have different sizes, so we cannot use an
+// `IdTable`.
+using CompressedBlock = std::vector<std::vector<char>>;
+
+// The metadata of a compressed block of ID triples in an index permutation.
 struct CompressedBlockMetaData {
-  off_t _offsetInFile;
-  size_t _compressedSize;  // In bytes.
+  // Since we have column-based indices, the two columns of each block are
+  // stored separately (but adjacently).
+  struct OffsetAndCompressedSize {
+    off_t _offsetInFile;
+    size_t _compressedSize;
+    bool operator==(const OffsetAndCompressedSize&) const = default;
+  };
+  std::vector<OffsetAndCompressedSize> _offsetsAndCompressedSize;
   size_t _numRows;
   // For example, in the PSO permutation, col0 is the P and col1 is the S. The
   // col0 ID is not stored in the block. First and last are meant inclusively,
@@ -34,10 +67,15 @@ struct CompressedBlockMetaData {
   bool operator==(const CompressedBlockMetaData&) const = default;
 };
 
-// Serialization of the block meta data.
-AD_SERIALIZE_FUNCTION(CompressedBlockMetaData) {
+// Serialization of the `OffsetAndcompressedSize` subclass.
+AD_SERIALIZE_FUNCTION(CompressedBlockMetaData::OffsetAndCompressedSize) {
   serializer | arg._offsetInFile;
   serializer | arg._compressedSize;
+}
+
+// Serialization of the block metadata.
+AD_SERIALIZE_FUNCTION(CompressedBlockMetaData) {
+  serializer | arg._offsetsAndCompressedSize;
   serializer | arg._numRows;
   serializer | arg._col0FirstId;
   serializer | arg._col0LastId;
@@ -45,7 +83,7 @@ AD_SERIALIZE_FUNCTION(CompressedBlockMetaData) {
   serializer | arg._col1LastId;
 }
 
-// The meta data of a whole compressed "relation", where relation refers to a
+// The metadata of a whole compressed "relation", where relation refers to a
 // maximal sequence of triples with equal first component (e.g., P for the PSO
 // permutation).
 struct CompressedRelationMetaData {
@@ -63,6 +101,12 @@ struct CompressedRelationMetaData {
 
   size_t getNofElements() const { return _numRows; }
 
+  // We currently always store two columns (the second and third column of a
+  // triple). This might change in the future when we might also store
+  // patterns and functional relations. Factor out this magic constant already
+  // now to make the code more readable.
+  static constexpr size_t numColumns() { return 2; }
+
   // Setters and getters for the multiplicities.
   float getCol1Multiplicity() const { return _multiplicityCol1; }
   float getCol2Multiplicity() const { return _multiplicityCol2; }
@@ -71,75 +115,90 @@ struct CompressedRelationMetaData {
 
   bool isFunctional() const { return _multiplicityCol1 == 1.0; }
 
-  // A special value for an "empty" or "nonexisting" meta data. This is needed
-  // for the mmap-based meta data.
-  // TODO<joka921> Can we throw this out?
-  static CompressedRelationMetaData emptyMetaData() {
-    auto id = ID_NO_VALUE;
-    size_t m = size_t(-1);
-    return CompressedRelationMetaData{id, m, 0, 0, m};
-  }
-
   // Two of these are equal if all members are equal.
   bool operator==(const CompressedRelationMetaData&) const = default;
 
   /**
    * @brief For a permutation XYZ, retrieve all YZ for a given X.
    *
-   * @tparam Permutation The permutations Index::POS()... have different types
-   *
-   * @param col0Id The ID of the "relation". That is, for permutation XYZ, the
-   * ID of an X.
-   *
-   * @param result The ID table to which we write the result, which must have
+   * @param metaData The metadata of the given X.
+   * @param blocks The metadata of the on-disk blocks for the given permutation.
+   * @param permutationName A human readable name that identifies the
+   *          permutation. It is used to uniquely identify a cache for recently
+   *          decompressed blocks.
+   * @param file The file in which the permutation is stored.
+   * @param result The ID table to which we write the result. It must have
    * exactly two columns.
+   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
+   *          if the timer runs out during the exeuction of this function.
    *
-   * @param permutation The permutation from which to scan, which is one of:
-   * PSO, POS, SPO, SOP, OSO, OPS.
+   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The same `CompressedRelationWriter` (see below).
    */
-  // The IdTable is a rather expensive type, so we don't include it here.
-  // but we can also not forward declare it because it is actually an alias.
-  template <class Permutation, typename IdTableImpl>
-  static void scan(Id col0Id, IdTableImpl* result,
-                   const Permutation& permutation,
-                   ad_utility::SharedConcurrentTimeoutTimer timer = nullptr);
+  static void scan(const CompressedRelationMetaData& metaData,
+                   const std::vector<CompressedBlockMetaData> blocks,
+                   const std::string& permutationName, ad_utility::File& file,
+                   IdTable* result,
+                   ad_utility::SharedConcurrentTimeoutTimer timer);
 
   /**
    * @brief For a permutation XYZ, retrieve all Z for given X and Y.
    *
-   * @tparam Permutation The permutations Index::POS()... have different types
-   *
-   * @param col0Id The ID for X.
-   *
+   * @param metaData The metadata of the given X.
    * @param col1Id The ID for Y.
+   * @param blocks The metadata of the on-disk blocks for the given permutation.
+   * @param file The file in which the permutation is stored.
+   * @param result The ID table to which we write the result. It must have
+   * exactly one column.
+   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
+   *              if the timer runs out during the exeuction of this function.
    *
-   * @param result The ID table to which we write the result.
-   *
-   * @param permutation The permutation from which to scan, which is one of:
-   * PSO, POS, SPO, SOP, OSO, OPS.
+   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The same `CompressedRelationWriter` (see below).
    */
-  template <class PermutationInfo, typename IdTableImpl>
-  static void scan(const Id count, const Id& col1Id, IdTableImpl* result,
-                   const PermutationInfo& permutation,
+  static void scan(const CompressedRelationMetaData& metaData, Id col1Id,
+                   const std::vector<CompressedBlockMetaData> blocks,
+                   ad_utility::File& file, IdTable* result,
                    ad_utility::SharedConcurrentTimeoutTimer timer = nullptr);
 
  private:
-  // Some helper functions for reading and decompressing blocks.
+  // Read the block that is identified by the `blockMetaData` from the `file`.
+  // If `columnIndices` is `nullopt`, then all columns of the block are read,
+  // else only the specified columns are read.
+  static CompressedBlock readCompressedBlockFromFile(
+      const CompressedBlockMetaData& blockMetaData, ad_utility::File& file,
+      std::optional<std::vector<size_t>> columnIndices);
 
-  template <class Permutation>
-  static std::vector<char> readCompressedBlockFromFile(
-      const CompressedBlockMetaData& block, const Permutation& permutation);
+  // Decompress the `compressedBlock`. The number of rows that the block will
+  // have after decompression must be passed in via the `numRowsToRead`
+  // argument. It is typically obtained from the corresponding
+  // `CompressedBlockMetaData`.
+  static DecompressedBlock decompressBlock(
+      const CompressedBlock& compressedBlock, size_t numRowsToRead);
 
-  static std::vector<std::array<Id, 2>> decompressBlock(
-      const std::vector<char>& compressedBlock, size_t numRowsToRead);
+  // Similar to `decompressBlock`, but the block is directly decompressed into
+  // the `table`, starting at the `offsetInTable`-th row. The `table` and the
+  // `compressedBlock` must have the same number of columns, and the `table`
+  // must have at least `numRowsToRead + offsetInTable` rows.
+  static void decompressBlockToExistingIdTable(
+      const CompressedBlock& compressedBlock, size_t numRowsToRead,
+      IdTable& table, size_t offsetInTable);
 
+  // Helper function used by `decompressBlock` and
+  // `decompressBlockToExistingIdTable`. Decompress the `compressedColumn` and
+  // store the result at the `iterator`. For the `numRowsToRead` argument, see
+  // the documentation of `decompressBlock`.
   template <typename Iterator>
-  static void decompressBlock(const std::vector<char>& compressedBlock,
-                              size_t numRowsToRead, Iterator iterator);
+  static void decompressColumn(const std::vector<char>& compressedColumn,
+                               size_t numRowsToRead, Iterator iterator);
 
-  template <class Permutation>
-  static std::vector<std::array<Id, 2>> readAndDecompressBlock(
-      const CompressedBlockMetaData& block, const Permutation& permutation);
+  // Read the block that is identified by the `blockMetaData` from the `file`,
+  // decompress and return it.
+  // If `columnIndices` is `nullopt`, then all columns of the block are read,
+  // else only the specified columns are read.
+  static DecompressedBlock readAndDecompressBlock(
+      const CompressedBlockMetaData& blockMetaData, ad_utility::File& file,
+      std::optional<std::vector<size_t>> columnIndices);
 };
 
 // Serialization of the compressed "relation" meta data.
@@ -159,11 +218,15 @@ class CompressedRelationWriter {
   std::vector<CompressedRelationMetaData> _metaDataBuffer;
   std::vector<CompressedBlockMetaData> _blockBuffer;
   CompressedBlockMetaData _currentBlockData;
-  ad_utility::serialization::ByteBufferWriteSerializer _buffer;
+  SmallRelationsBuffer _buffer;
+  size_t _numBytesPerBlock;
 
  public:
   /// Create using a filename, to which the relation data will be written.
-  CompressedRelationWriter(ad_utility::File f) : _outfile{std::move(f)} {}
+  CompressedRelationWriter(
+      ad_utility::File f,
+      size_t numBytesPerBlock = BLOCKSIZE_COMPRESSED_METADATA)
+      : _outfile{std::move(f)}, _numBytesPerBlock{numBytesPerBlock} {}
 
   /**
    * Add a complete (single) relation.
@@ -171,31 +234,32 @@ class CompressedRelationWriter {
    * \param col0Id The ID of the relation, that is, the value of X for a
    * permutation XYZ.
    *
-   * \param data The sorted data of the relation, that is, the sequence of all
-   * pairs of Y and Z for the given X.
+   * \param col1And2Ids The sorted data of the relation, that is, the sequence
+   * of all pairs of Y and Z for the given X.
    *
    * \param numDistinctCol1 The number of distinct values for X (from which we
-   * can also calculate the average multiplicity, so we don't need to store that
+   * can also calculate the average multiplicity and whether the relation is
+   * functional, so we don't need to store that
    * explicitly).
-   *
-   * \param functional Whether each value of Y occurs at most once (so that we
-   * have a function from the occurring Ys to the Zs).
    */
-  void addRelation(Id col0Id,
-                   const ad_utility::BufferedVector<std::array<Id, 2>>& data,
-                   size_t numDistinctCol1, bool functional);
+  void addRelation(Id col0Id, const BufferedIdTable& col1And2Ids,
+                   size_t numDistinctCol1);
 
   /// Finish writing all relations which have previously been added, but might
   /// still be in some internal buffer.
-  void finish() { writeBufferedRelationsToSingleBlock(); }
+  void finish() {
+    writeBufferedRelationsToSingleBlock();
+    _outfile.close();
+  }
 
   /// Get the complete CompressedRelationMetaData created by the calls to
   /// addRelation. This meta data is then deleted from the
   /// CompressedRelationWriter. The typical workflow is: add all relations,
   /// then call `finish()` and then call this method.
   auto getFinishedMetaData() {
-    return std::move(_metaDataBuffer);
+    auto result = std::move(_metaDataBuffer);
     _metaDataBuffer.clear();
+    return result;
   }
 
   /// Get all the CompressedBlockMetaData that were created by the calls to
@@ -203,9 +267,19 @@ class CompressedRelationWriter {
   /// CompressedRelationWriter. The typical workflow is: add all relations,
   /// then call `finish()` and then call this method.
   auto getFinishedBlocks() {
-    return std::move(_blockBuffer);
+    auto result = std::move(_blockBuffer);
     _blockBuffer.clear();
+    return result;
   }
+
+  // Compute the multiplicity of given the number of elements and the number of
+  // distinct elements. It is basically `numElements / numDistinctElements` with
+  // the following addition: the result will only be exactly `1.0` if
+  // `numElements == numDistinctElements`, s.t. `1.0` is equivalent to
+  // `functional`. Note that this is not automatically ensured by the division
+  // because of the numeric properties of `float`.
+  static float computeMultiplicity(size_t numElements,
+                                   size_t numDistinctElements);
 
  private:
   // Compress the contents of `_buffer` into a single block and write it to
@@ -215,9 +289,13 @@ class CompressedRelationWriter {
 
   // Compress the relation from `data` into one or more blocks, depending on
   // its size. Write the blocks to `_outfile` and append all the created
-  // block meta data to `_blockBuffer`.
-  void writeRelationToExclusiveBlocks(
-      Id col0Id, const ad_utility::BufferedVector<std::array<Id, 2>>& data);
+  // block metadata to `_blockBuffer`.
+  void writeRelationToExclusiveBlocks(Id col0Id, const BufferedIdTable& data);
+
+  // Compress the `column` and write it to the `_outfile`. Return the offset and
+  // size of the compressed column in the `_outfile`.
+  CompressedBlockMetaData::OffsetAndCompressedSize compressAndWriteColumn(
+      std::span<const Id> column);
 };
 
 #endif  // QLEVER_COMPRESSEDRELATION_H

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -509,7 +509,7 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
   size_t from = 0;
   std::optional<Id> currentRel;
   BufferedIdTable buffer{ad_utility::BufferedVector<Id>{
-      THRESHOLD_RELATION_CREATION, "fileName1.tmp.mmap-buffer"}};
+      THRESHOLD_RELATION_CREATION, fileName1 + ".tmp.mmap-buffer"}};
   size_t distinctCol1 = 0;
   Id lastLhs = ID_NO_VALUE;
   uint64_t totalNumTriples = 0;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -508,9 +508,8 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
   LOG(INFO) << "Creating a pair of index permutations ... " << std::endl;
   size_t from = 0;
   std::optional<Id> currentRel;
-  ad_utility::BufferedVector<array<Id, 2>> buffer(
-      THRESHOLD_RELATION_CREATION, fileName1 + ".tmp.mmap-buffer");
-  bool functional = true;
+  BufferedIdTable buffer{ad_utility::BufferedVector<Id>{
+      THRESHOLD_RELATION_CREATION, "fileName1.tmp.mmap-buffer"}};
   size_t distinctCol1 = 0;
   Id lastLhs = ID_NO_VALUE;
   uint64_t totalNumTriples = 0;
@@ -522,7 +521,7 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
     (..., perTripleCallbacks(triple));
     ++totalNumTriples;
     if (triple[c0] != currentRel) {
-      writer1.addRelation(currentRel.value(), buffer, distinctCol1, functional);
+      writer1.addRelation(currentRel.value(), buffer, distinctCol1);
       writeSwitchedRel(&writer2, currentRel.value(), &buffer);
       for (auto& md : writer1.getFinishedMetaData()) {
         metaData1.add(md);
@@ -533,19 +532,14 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
       buffer.clear();
       distinctCol1 = 1;
       currentRel = triple[c0];
-      functional = true;
     } else {
-      if (triple[c1] == lastLhs) {
-        functional = false;
-      } else {
-        distinctCol1++;
-      }
+      distinctCol1 += triple[c1] != lastLhs;
     }
-    buffer.push_back({triple[c1], triple[c2]});
+    buffer.push_back(std::array{triple[c1], triple[c2]});
     lastLhs = triple[c1];
   }
   if (from < totalNumTriples) {
-    writer1.addRelation(currentRel.value(), buffer, distinctCol1, functional);
+    writer1.addRelation(currentRel.value(), buffer, distinctCol1);
     writeSwitchedRel(&writer2, currentRel.value(), &buffer);
   }
 
@@ -564,33 +558,29 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
 }
 
 // __________________________________________________________________________
-void IndexImpl::writeSwitchedRel(
-    CompressedRelationWriter* out, Id currentRel,
-    ad_utility::BufferedVector<array<Id, 2>>* bufPtr) {
-  // sort according to the "switched" relation.
+void IndexImpl::writeSwitchedRel(CompressedRelationWriter* out, Id currentRel,
+                                 BufferedIdTable* bufPtr) {
+  // Sort according to the "switched" relation.
+  // TODO<joka921> The swapping is rather inefficient, as we have to iterate
+  // over the whole file. Maybe the `CompressedRelationWriter` should take
+  // the switched relations directly.
   auto& buffer = *bufPtr;
 
-  for (auto& el : buffer) {
-    std::swap(el[0], el[1]);
+  AD_CHECK(buffer.numColumns() == 2);
+  for (BufferedIdTable::row_reference row : buffer) {
+    std::swap(row[0], row[1]);
   }
-  std::sort(buffer.begin(), buffer.end(), [](const auto& a, const auto& b) {
-    return a[0] == b[0] ? a[1] < b[1] : a[0] < b[0];
+  std::ranges::sort(buffer, [](const auto& a, const auto& b) {
+    return std::ranges::lexicographical_compare(a, b);
   });
-
   Id lastLhs = std::numeric_limits<Id>::max();
 
-  bool functional = true;
   size_t distinctC1 = 0;
-  for (const auto& el : buffer) {
-    if (el[0] == lastLhs) {
-      functional = false;
-    } else {
-      distinctC1++;
-    }
-    lastLhs = el[0];
+  for (const auto& el : buffer.getColumn(0)) {
+    distinctC1 += el != lastLhs;
+    lastLhs = el;
   }
-
-  out->addRelation(currentRel, buffer, distinctC1, functional);
+  out->addRelation(currentRel, buffer, distinctC1);
 }
 
 // ________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -534,7 +534,7 @@ class IndexImpl {
   template <class Permutation>
   void scan(Id key, IdTable* result, const Permutation& p,
             ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const {
-    CompressedRelationMetaData::scan(key, result, p, std::move(timer));
+    p.scan(key, result, std::move(timer));
   }
 
   /**
@@ -594,8 +594,7 @@ class IndexImpl {
                << col0String << " with fixed subject: " << col1String
                << "...\n";
 
-    CompressedRelationMetaData::scan(col0Id.value(), col1Id.value(), result, p,
-                                     timer);
+    p.scan(col0Id.value(), col1Id.value(), result, timer);
   }
 
   // Internal implementation for `applyToPermutation` (see below).
@@ -698,7 +697,7 @@ class IndexImpl {
                             size_t c2, auto&&... perTripleCallbacks);
 
   void writeSwitchedRel(CompressedRelationWriter* out, Id currentRel,
-                        ad_utility::BufferedVector<array<Id, 2>>* bufPtr);
+                        BufferedIdTable* bufPtr);
 
   // _______________________________________________________________________
   // Create a pair of permutations. Only works for valid pairs (PSO-POS,

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -71,9 +71,9 @@ class IndexMetaData {
  public:
   typedef M MapType;
   using value_type = typename MapType::value_type;
-  using AddType = CompressedRelationMetaData;
-  using GetType = const CompressedRelationMetaData&;
-  using BlocksType = std::vector<CompressedBlockMetaData>;
+  using AddType = CompressedRelationMetadata;
+  using GetType = const CompressedRelationMetadata&;
+  using BlocksType = std::vector<CompressedBlockMetadata>;
 
   // Private member variables.
  private:
@@ -124,9 +124,9 @@ class IndexMetaData {
   // from RAM-based (e.g. hashMap based sparse) ones at compile time, this is
   // done in the following block.
   using MetaWrapperMmap =
-      MetaDataWrapperDense<ad_utility::MmapVector<CompressedRelationMetaData>>;
+      MetaDataWrapperDense<ad_utility::MmapVector<CompressedRelationMetadata>>;
   using MetaWrapperMmapView = MetaDataWrapperDense<
-      ad_utility::MmapVectorView<CompressedRelationMetaData>>;
+      ad_utility::MmapVectorView<CompressedRelationMetadata>>;
   template <typename T>
   struct IsMmapBased {
     static const bool value = std::is_same<MetaWrapperMmap, T>::value ||
@@ -225,11 +225,11 @@ ad_utility::File& operator<<(ad_utility::File& f,
 
 // aliases for easier use in Index class
 using MetaWrapperMmap =
-    MetaDataWrapperDense<ad_utility::MmapVector<CompressedRelationMetaData>>;
+    MetaDataWrapperDense<ad_utility::MmapVector<CompressedRelationMetadata>>;
 using MetaWrapperMmapView = MetaDataWrapperDense<
-    ad_utility::MmapVectorView<CompressedRelationMetaData>>;
+    ad_utility::MmapVectorView<CompressedRelationMetadata>>;
 using MetaWrapperHashMap =
-    MetaDataWrapperHashMap<ad_utility::HashMap<Id, CompressedRelationMetaData>>;
+    MetaDataWrapperHashMap<ad_utility::HashMap<Id, CompressedRelationMetadata>>;
 using IndexMetaDataHmap = IndexMetaData<MetaWrapperHashMap>;
 using IndexMetaDataMmap = IndexMetaData<MetaWrapperMmap>;
 using IndexMetaDataMmapView = IndexMetaData<MetaWrapperMmapView>;

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -57,7 +57,17 @@ class PermutationImpl {
   template <typename IdTableImpl>
   void scan(Id col0Id, IdTableImpl* result,
             ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const {
-    return CompressedRelationMetaData::scan(col0Id, result, *this, timer);
+    if (!_isLoaded) {
+      throw std::runtime_error("This query requires the permutation " +
+                               _readableName + ", which was not loaded");
+    }
+    if (!_meta.col0IdExists(col0Id)) {
+      return;
+    }
+    const auto& metaData = _meta.getMetaData(col0Id);
+    return CompressedRelationMetaData::scan(metaData, _meta.blockData(),
+                                            _readableName, _file, result,
+                                            std::move(timer));
   }
   /// For given IDs for the first and second column, retrieve all IDs of the
   /// third column, and store them in `result`. This is just a thin wrapper
@@ -65,8 +75,13 @@ class PermutationImpl {
   template <typename IdTableImpl>
   void scan(Id col0Id, Id col1Id, IdTableImpl* result,
             ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const {
-    return CompressedRelationMetaData::scan(col0Id, col1Id, result, *this,
-                                            timer);
+    if (!_meta.col0IdExists(col0Id)) {
+      return;
+    }
+    const auto& metaData = _meta.getMetaData(col0Id);
+
+    return CompressedRelationMetaData::scan(metaData, col1Id, _meta.blockData(),
+                                            _file, result, timer);
   }
 
   // _______________________________________________________

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -65,7 +65,7 @@ class PermutationImpl {
       return;
     }
     const auto& metaData = _meta.getMetaData(col0Id);
-    return CompressedRelationMetaData::scan(metaData, _meta.blockData(),
+    return CompressedRelationMetadata::scan(metaData, _meta.blockData(),
                                             _readableName, _file, result,
                                             std::move(timer));
   }
@@ -80,7 +80,7 @@ class PermutationImpl {
     }
     const auto& metaData = _meta.getMetaData(col0Id);
 
-    return CompressedRelationMetaData::scan(metaData, col1Id, _meta.blockData(),
+    return CompressedRelationMetadata::scan(metaData, col1Id, _meta.blockData(),
                                             _file, result, timer);
   }
 

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -73,14 +73,14 @@ cppcoro::generator<std::array<Id, 3>> TriplesView(
   // blocks, making the limit here unnecessary.
   using Tuple = std::array<Id, 2>;
   auto tupleAllocator = allocator.as<Tuple>();
-  IdTable col2And3{2, allocator};
+  IdTable col1And2{2, allocator};
   for (auto& [begin, end] : allowedRanges) {
     for (auto it = begin; it != end; ++it) {
-      col2And3.clear();
+      col1And2.clear();
       Id id = it.getId();
       // TODO<joka921> We could also pass a timeout pointer here.
-      permutation.scan(id, &col2And3);
-      for (const auto& row : col2And3) {
+      permutation.scan(id, &col1And2);
+      for (const auto& row : col1And2) {
         std::array<Id, 3> triple{id, row[0], row[1]};
         if (isTripleIgnored(triple)) [[unlikely]] {
           continue;

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -3,11 +3,12 @@
 #include <utility>
 #include <vector>
 
-#include "../global/Id.h"
-#include "../util/AllocatorWithLimit.h"
-#include "../util/File.h"
-#include "../util/Generator.h"
 #include "CompressedRelation.h"
+#include "engine/idTable/IdTable.h"
+#include "global/Id.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/File.h"
+#include "util/Generator.h"
 
 namespace detail {
 using IgnoredRelations = std::vector<std::pair<Id, Id>>;
@@ -72,16 +73,15 @@ cppcoro::generator<std::array<Id, 3>> TriplesView(
   // blocks, making the limit here unnecessary.
   using Tuple = std::array<Id, 2>;
   auto tupleAllocator = allocator.as<Tuple>();
-  std::vector<Tuple, ad_utility::AllocatorWithLimit<Tuple>> col2And3{
-      tupleAllocator};
+  IdTable col2And3{2, allocator};
   for (auto& [begin, end] : allowedRanges) {
     for (auto it = begin; it != end; ++it) {
       col2And3.clear();
       Id id = it.getId();
       // TODO<joka921> We could also pass a timeout pointer here.
       permutation.scan(id, &col2And3);
-      for (const auto& [col2, col3] : col2And3) {
-        std::array<Id, 3> triple{id, col2, col3};
+      for (const auto& row : col2And3) {
+        std::array<Id, 3> triple{id, row[0], row[1]};
         if (isTripleIgnored(triple)) [[unlikely]] {
           continue;
         }

--- a/src/util/BufferedVector.h
+++ b/src/util/BufferedVector.h
@@ -76,12 +76,12 @@ class BufferedVector {
   const T& back() const { return at(size() - 1); }
 
   // no copy construction/assignment since the MmapVector does not support this
-  BufferedVector(const BufferedVector<T>&) = delete;
-  BufferedVector& operator=(const BufferedVector<T>&) = delete;
+  BufferedVector(const BufferedVector&) = delete;
+  BufferedVector& operator=(const BufferedVector&) = delete;
 
   // move construction and assignment
-  BufferedVector(BufferedVector<T>&& other) = default;
-  BufferedVector& operator=(BufferedVector<T>&& other) = default;
+  BufferedVector& operator=(BufferedVector&& other) = default;
+  BufferedVector(BufferedVector&& other) = default;
 
   // _________________________________________________________________________
   void clear() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,7 +141,7 @@ addLinkAndDiscoverTest(MinusTest engine)
 addAndLinkTest(SortPerformanceEstimatorTest SortPerformanceEstimator)
 #addLinkAndDiscoverTest(SortPerformanceEstimatorTest SortPerformanceEstimator)
 
-addLinkAndDiscoverTest(SparqlAntlrParserTest parser sparqlExpressions engine)
+addLinkAndDiscoverTestSerial(SparqlAntlrParserTest parser sparqlExpressions engine)
 
 # The SerializerTest uses temporary files. The tests fail when multiple test
 # cases are run in parallel. This should be fixed by using distinct filenames
@@ -242,7 +242,7 @@ addLinkAndDiscoverTest(CheckUsePatternTrickTest parser engine)
 
 addLinkAndDiscoverTestSerial(RegexExpressionTest sparqlExpressions index engine)
 
-addLinkAndDiscoverTest(LocalVocabTest engine)
+addLinkAndDiscoverTestSerial(LocalVocabTest engine)
 
 addLinkAndDiscoverTest(HttpTest boost_iostreams http)
 
@@ -251,3 +251,7 @@ addLinkAndDiscoverTest(CallFixedSizeTest)
 addLinkAndDiscoverTest(ConstexprUtilsTest)
 
 addLinkAndDiscoverTest(ResetWhenMovedTest)
+
+addLinkAndDiscoverTest(ResetWhenMovedTest)
+
+addLinkAndDiscoverTest(CompressedRelationsTest index)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -252,6 +252,4 @@ addLinkAndDiscoverTest(ConstexprUtilsTest)
 
 addLinkAndDiscoverTest(ResetWhenMovedTest)
 
-addLinkAndDiscoverTest(ResetWhenMovedTest)
-
 addLinkAndDiscoverTest(CompressedRelationsTest index)

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -106,7 +106,7 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
                     m._multiplicityCol1);
     // Scan for all distinct `col0` and check that we get the expected result.
     IdTable table{2, ad_utility::testing::makeAllocator()};
-    CompressedRelationMetaData::scan(metaData[i], blocks,
+    CompressedRelationMetadata::scan(metaData[i], blocks,
                                      testCaseName + std::to_string(blocksize),
                                      file, &table, timer);
     const auto& col1And2 = inputs[i].col1And2_;
@@ -120,7 +120,7 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
 
     auto scanAndCheck = [&]() {
       IdTable tableWidthOne{1, ad_utility::testing::makeAllocator()};
-      CompressedRelationMetaData::scan(metaData[i], V(lastCol1Id), blocks, file,
+      CompressedRelationMetadata::scan(metaData[i], V(lastCol1Id), blocks, file,
                                        &tableWidthOne, timer);
       checkThatTablesAreEqual(col3, tableWidthOne);
     };
@@ -235,8 +235,8 @@ TEST(CompressedRelationWriter, MultiplicityCornerCases) {
             CompressedRelationWriter::computeMultiplicity(plusOne, veryLarge));
 }
 
-TEST(CompressedRelationMetaData, GettersAndSetters) {
-  CompressedRelationMetaData m;
+TEST(CompressedRelationMetadata, GettersAndSetters) {
+  CompressedRelationMetadata m;
   m.setCol1Multiplicity(2.0f);
   ASSERT_FLOAT_EQ(2.0f, m.getCol1Multiplicity());
   ASSERT_FLOAT_EQ(2.0f, m._multiplicityCol1);

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1,0 +1,251 @@
+//  Copyright 2023, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include "./IndexTestHelpers.h"
+#include "index/CompressedRelation.h"
+#include "index/Permutations.h"
+#include "util/Serializer/ByteBufferSerializer.h"
+
+// Return an `ID` of type `VocabIndex` from `index`. Assert that `index`
+// is `>= 0`.
+Id V(int64_t index) {
+  AD_CHECK(index >= 0);
+  return Id::makeFromVocabIndex(VocabIndex::make(index));
+}
+
+// A representation of a relation, consisting of the constant `col0_` element
+// as well as the 2D-vector for the other two columns. `col1And2_` must be
+// sorted.
+struct RelationInput {
+  int col0_;
+  std::vector<std::array<int, 2>> col1And2_;
+};
+
+// Check that `expected` and `actual` have the same contents. The `int`s in
+// expected are converted to `Id`s of type `VocabIndex` using the `V`-function
+// before the comparison.
+template <size_t NumColumns>
+void checkThatTablesAreEqual(
+    const std::vector<std::array<int, NumColumns>> expected,
+    const IdTable& actual) {
+  ASSERT_EQ(NumColumns, actual.numColumns());
+  for (size_t i = 0; i < actual.numRows(); ++i) {
+    for (size_t j = 0; j < actual.numColumns(); ++j) {
+      ASSERT_EQ(V(expected[i][j]), actual(i, j));
+    }
+  }
+}
+
+// Run a set of tests on a permutation that is defined by the `inputs`. The
+// `inputs` must be ordered wrt the `col0_`. `testCaseName` is used to create
+// a unique name for the required temporary files and for the implicit cache
+// of the `CompressedRelationMetaData`. `blocksize` is the size of the blocks
+// in which the permutation will be compressed and stored on disk.
+void testCompressedRelations(const std::vector<RelationInput>& inputs,
+                             std::string testCaseName, size_t blocksize) {
+  // First check the invariants of the `inputs`. They must be sorted by the
+  // `col0_` and for each of the `inputs` the `col1And2_` must also be sorted.
+  AD_CHECK(std::ranges::is_sorted(
+      inputs, {}, [](const RelationInput& r) { return r.col0_; }));
+  AD_CHECK(std::ranges::all_of(inputs, [](const RelationInput& r) {
+    return std::ranges::is_sorted(
+        r.col1And2_, [](const auto& a, const auto& b) {
+          return std::ranges::lexicographical_compare(a, b);
+        });
+  }));
+
+  std::string filename = testCaseName + ".dat";
+
+  // First create the on-disk permutation.
+  CompressedRelationWriter writer{ad_utility::File{filename, "w"}, blocksize};
+  {
+    size_t i = 0;
+    for (const auto& input : inputs) {
+      std::string bufferFilename =
+          testCaseName + ".buffers." + std::to_string(i) + ".dat";
+      BufferedIdTable buffer{
+          ad_utility::BufferedVector<Id>{30, bufferFilename}};
+      for (const auto& arr : input.col1And2_) {
+        buffer.push_back({V(arr[0]), V(arr[1])});
+      }
+      // The last argument is the number of distinctC1. We store a dummy value
+      // here that we can check later.
+      writer.addRelation(V(input.col0_), buffer, i + 1);
+      ++i;
+    }
+  }
+  writer.finish();
+  auto metaData = writer.getFinishedMetaData();
+  auto blocks = writer.getFinishedBlocks();
+  // Test the serialization of the blocks and the metaData.
+  ad_utility::serialization::ByteBufferWriteSerializer w;
+  w << metaData;
+  w << blocks;
+  metaData.clear();
+  blocks.clear();
+  ad_utility::serialization::ByteBufferReadSerializer r{std::move(w).data()};
+  r >> metaData;
+  r >> blocks;
+
+  ASSERT_EQ(metaData.size(), inputs.size());
+
+  ad_utility::File file{filename, "r"};
+  auto timer = std::make_shared<ad_utility::ConcurrentTimeoutTimer>(
+      ad_utility::TimeoutTimer::unlimited());
+  // Check the contents of the metadata.
+  for (size_t i = 0; i < metaData.size(); ++i) {
+    const auto& m = metaData[i];
+    ASSERT_EQ(V(inputs[i].col0_), m._col0Id);
+    ASSERT_EQ(inputs[i].col1And2_.size(), m._numRows);
+    // The number of distinctC1 was passed in as `i + 1` for testing purposes,
+    // so this is the expected multiplicity.
+    ASSERT_FLOAT_EQ(m._numRows / static_cast<float>(i + 1),
+                    m._multiplicityCol1);
+    // Scan for all distinct `col0` and check that we get the expected result.
+    IdTable table{2, ad_utility::testing::makeAllocator()};
+    CompressedRelationMetaData::scan(metaData[i], blocks,
+                                     testCaseName + std::to_string(blocksize),
+                                     file, &table, timer);
+    const auto& col1And2 = inputs[i].col1And2_;
+    checkThatTablesAreEqual(col1And2, table);
+
+    // Check for all distinct combinations of `(col0, col1)` and check that
+    // we get the expected result.
+    // TODO<joka921, C++23 use views::chunk_by
+    int lastCol1Id = col1And2[0][0];
+    std::vector<std::array<int, 1>> col3;
+
+    auto scanAndCheck = [&]() {
+      IdTable tableWidthOne{1, ad_utility::testing::makeAllocator()};
+      CompressedRelationMetaData::scan(metaData[i], V(lastCol1Id), blocks, file,
+                                       &tableWidthOne, timer);
+      checkThatTablesAreEqual(col3, tableWidthOne);
+    };
+    for (size_t j = 0; j < col1And2.size(); ++j) {
+      if (col1And2[j][0] == lastCol1Id) {
+        col3.push_back({col1And2[j][1]});
+        continue;
+      }
+      scanAndCheck();
+      lastCol1Id = col1And2[j][0];
+      col3.clear();
+      col3.push_back({col1And2[j][1]});
+    }
+    // Don't forget the last block.
+    scanAndCheck();
+  }
+  file.close();
+  ad_utility::deleteFile(filename);
+}
+
+// Run `testCompressedRelations` (see above) for the given `inputs` and
+// `testCaseName`, but with a set of different `blocksizes` (small and medium
+// size, powers of two and odd), to find subtle rounding bugs when creating the
+// blocks.
+void testWithDifferentBlockSizes(const std::vector<RelationInput>& inputs,
+                                 std::string testCaseName) {
+  testCompressedRelations(inputs, testCaseName, 37);
+  testCompressedRelations(inputs, testCaseName, 237);
+  testCompressedRelations(inputs, testCaseName, 4096);
+}
+
+// Test for very small relations many of which are stored in the same block.
+TEST(CompressedRelationWriter, SmallRelations) {
+  std::vector<RelationInput> inputs;
+  for (int i = 1; i < 200; ++i) {
+    inputs.push_back(
+        RelationInput{i, {{i - 1, i + 1}, {i - 1, i + 2}, {i, i - 1}}});
+  }
+  testWithDifferentBlockSizes(inputs, "smallRelations");
+}
+
+// Test for larger relations that span over several blocks. There are no
+// duplicates in the `col1`, so a combination of `(col0, col1)` will be stored
+// in a single block.
+TEST(CompressedRelationWriter, LargeRelationsDistinctCol1) {
+  std::vector<RelationInput> inputs;
+  for (int i = 1; i < 6; ++i) {
+    std::vector<std::array<int, 2>> col1And2;
+    for (int j = 0; j < 200; ++j) {
+      col1And2.push_back(std::array{i * j, i * j + 3});
+    }
+    inputs.push_back(RelationInput{i * 17, std::move(col1And2)});
+  }
+  testWithDifferentBlockSizes(inputs, "largeRelationsDistinctCol1");
+}
+
+// Test for larger relations that span over several blocks. There are many
+// duplicates in the `col1`, so a combination of `(col0, col1)` will also be
+// stored in several blocks.
+TEST(CompressedRelationWriter, LargeRelationsDuplicatesCol1) {
+  std::vector<RelationInput> inputs;
+  for (int i = 1; i < 6; ++i) {
+    std::vector<std::array<int, 2>> col1And2;
+    for (int j = 0; j < 200; ++j) {
+      col1And2.push_back(std::array{i * 12, i * j + 3});
+    }
+    inputs.push_back(RelationInput{i * 17, std::move(col1And2)});
+  }
+  testWithDifferentBlockSizes(inputs, "largeRelationsDuplicatesCol1");
+}
+
+// Test a permutation that consists of relations of different sizes and
+// characteristics by combining the characteristics of the three test cases
+// above.
+TEST(CompressedRelationWriter, MixedSizes) {
+  std::vector<RelationInput> inputs;
+  for (int y = 0; y < 3; ++y) {
+    // First some large relations with many duplicates in `col1`.
+    for (int i = 1; i < 6; ++i) {
+      std::vector<std::array<int, 2>> col1And2;
+      for (int j = 0; j < 50; ++j) {
+        col1And2.push_back(std::array{i * 12, i * j + 3});
+      }
+      inputs.push_back(RelationInput{i + (y * 300), std::move(col1And2)});
+    }
+
+    // Then some small relations
+    for (int i = 9; i < 50; ++i) {
+      inputs.push_back(RelationInput{
+          i + (y * 300), {{i - 1, i + 1}, {i - 1, i + 2}, {i, i - 1}}});
+    }
+
+    // Finally some large relations with few duplicates in `col1`.
+    for (int i = 205; i < 221; ++i) {
+      std::vector<std::array<int, 2>> col1And2;
+      for (int j = 0; j < 80; ++j) {
+        col1And2.push_back(std::array{i * j + y, i * j + 3});
+      }
+      inputs.push_back(RelationInput{i + (y * 300), std::move(col1And2)});
+    }
+  }
+  testWithDifferentBlockSizes(inputs, "mixedSizes");
+}
+
+TEST(CompressedRelationWriter, MultiplicityCornerCases) {
+  ASSERT_EQ(1.0f, CompressedRelationWriter::computeMultiplicity(12, 12));
+
+  constexpr static size_t veryLarge = 1111111111111111;
+  constexpr static size_t plusOne = veryLarge + 1;
+  ASSERT_EQ(1.0f, static_cast<float>(plusOne) / static_cast<float>(veryLarge));
+  ASSERT_NE(1.0f,
+            CompressedRelationWriter::computeMultiplicity(plusOne, veryLarge));
+}
+
+TEST(CompressedRelationMetaData, GettersAndSetters) {
+  CompressedRelationMetaData m;
+  m.setCol1Multiplicity(2.0f);
+  ASSERT_FLOAT_EQ(2.0f, m.getCol1Multiplicity());
+  ASSERT_FLOAT_EQ(2.0f, m._multiplicityCol1);
+  m.setCol2Multiplicity(1.0f);
+  ASSERT_FLOAT_EQ(1.0f, m._multiplicityCol2);
+  ASSERT_FLOAT_EQ(1.0f, m.getCol2Multiplicity());
+  ASSERT_FALSE(m.isFunctional());
+  m.setCol1Multiplicity(1.0f);
+  ASSERT_TRUE(m.isFunctional());
+  m._numRows = 43;
+  ASSERT_EQ(43, m._numRows);
+}

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -16,9 +16,9 @@ auto I = [](const auto& id) {
 
 TEST(RelationMetaDataTest, writeReadTest) {
   try {
-    CompressedBlockMetaData rmdB{
+    CompressedBlockMetadata rmdB{
         {{12, 34}, {46, 11}}, 5, I(0), I(2), I(13), I(24)};
-    CompressedRelationMetaData rmdF{I(1), 3, 2.0, 42.0, 16};
+    CompressedRelationMetadata rmdF{I(1), 3, 2.0, 42.0, 16};
 
     ad_utility::serialization::FileWriteSerializer f("_testtmp.rmd");
     f << rmdF;
@@ -26,8 +26,8 @@ TEST(RelationMetaDataTest, writeReadTest) {
     f.close();
 
     ad_utility::serialization::FileReadSerializer in("_testtmp.rmd");
-    CompressedRelationMetaData rmdF2;
-    CompressedBlockMetaData rmdB2;
+    CompressedRelationMetadata rmdF2;
+    CompressedBlockMetadata rmdB2;
     in >> rmdF2;
     in >> rmdB2;
 
@@ -46,13 +46,13 @@ TEST(RelationMetaDataTest, writeReadTest) {
 
 TEST(IndexMetaDataTest, writeReadTest2Hmap) {
   try {
-    vector<CompressedBlockMetaData> bs;
-    bs.push_back(CompressedBlockMetaData{
+    vector<CompressedBlockMetadata> bs;
+    bs.push_back(CompressedBlockMetadata{
         {{12, 34}, {42, 5}}, 5, I(0), I(2), I(13), I(24)});
-    bs.push_back(CompressedBlockMetaData{
+    bs.push_back(CompressedBlockMetadata{
         {{16, 34}, {165, 3}}, 5, I(0), I(2), I(13), I(24)});
-    CompressedRelationMetaData rmdF{I(1), 3, 2.0, 42.0, 16};
-    CompressedRelationMetaData rmdF2{I(2), 5, 3.0, 43.0, 10};
+    CompressedRelationMetadata rmdF{I(1), 3, 2.0, 42.0, 16};
+    CompressedRelationMetadata rmdF2{I(2), 5, 3.0, 43.0, 10};
     IndexMetaDataHmap imd;
     imd.add(rmdF);
     imd.add(rmdF2);
@@ -86,13 +86,13 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
   std::string imdFilename = "_testtmp.imd";
   std::string mmapFilename = imdFilename + ".mmap";
   try {
-    vector<CompressedBlockMetaData> bs;
-    bs.push_back(CompressedBlockMetaData{
+    vector<CompressedBlockMetadata> bs;
+    bs.push_back(CompressedBlockMetadata{
         {{12, 34}, {42, 17}}, 5, I(0), I(2), I(13), I(24)});
-    bs.push_back(CompressedBlockMetaData{
+    bs.push_back(CompressedBlockMetadata{
         {{12, 34}, {16, 12}}, 5, I(0), I(2), I(13), I(24)});
-    CompressedRelationMetaData rmdF{I(1), 3, 2.0, 42.0, 16};
-    CompressedRelationMetaData rmdF2{I(2), 5, 3.0, 43.0, 10};
+    CompressedRelationMetadata rmdF{I(1), 3, 2.0, 42.0, 16};
+    CompressedRelationMetadata rmdF2{I(2), 5, 3.0, 43.0, 10};
     // The index MetaData does not have an explicit clear, so we
     // force destruction to close and reopen the mmap-File
     {

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -16,7 +16,8 @@ auto I = [](const auto& id) {
 
 TEST(RelationMetaDataTest, writeReadTest) {
   try {
-    CompressedBlockMetaData rmdB{12, 34, 5, I(0), I(2), I(13), I(24)};
+    CompressedBlockMetaData rmdB{
+        {{12, 34}, {46, 11}}, 5, I(0), I(2), I(13), I(24)};
     CompressedRelationMetaData rmdF{I(1), 3, 2.0, 42.0, 16};
 
     ad_utility::serialization::FileWriteSerializer f("_testtmp.rmd");
@@ -46,8 +47,10 @@ TEST(RelationMetaDataTest, writeReadTest) {
 TEST(IndexMetaDataTest, writeReadTest2Hmap) {
   try {
     vector<CompressedBlockMetaData> bs;
-    bs.push_back(CompressedBlockMetaData{12, 34, 5, I(0), I(2), I(13), I(24)});
-    bs.push_back(CompressedBlockMetaData{12, 34, 5, I(0), I(2), I(13), I(24)});
+    bs.push_back(CompressedBlockMetaData{
+        {{12, 34}, {42, 5}}, 5, I(0), I(2), I(13), I(24)});
+    bs.push_back(CompressedBlockMetaData{
+        {{16, 34}, {165, 3}}, 5, I(0), I(2), I(13), I(24)});
     CompressedRelationMetaData rmdF{I(1), 3, 2.0, 42.0, 16};
     CompressedRelationMetaData rmdF2{I(2), 5, 3.0, 43.0, 10};
     IndexMetaDataHmap imd;
@@ -84,8 +87,10 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
   std::string mmapFilename = imdFilename + ".mmap";
   try {
     vector<CompressedBlockMetaData> bs;
-    bs.push_back(CompressedBlockMetaData{12, 34, 5, I(0), I(2), I(13), I(24)});
-    bs.push_back(CompressedBlockMetaData{12, 34, 5, I(0), I(2), I(13), I(24)});
+    bs.push_back(CompressedBlockMetaData{
+        {{12, 34}, {42, 17}}, 5, I(0), I(2), I(13), I(24)});
+    bs.push_back(CompressedBlockMetaData{
+        {{12, 34}, {16, 12}}, 5, I(0), I(2), I(13), I(24)});
     CompressedRelationMetaData rmdF{I(1), 3, 2.0, 42.0, 16};
     CompressedRelationMetaData rmdF2{I(2), 5, 3.0, 43.0, 10};
     // The index MetaData does not have an explicit clear, so we

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -95,8 +95,10 @@ TEST(IndexTest, createFromTurtleTest) {
 
     // Relation b
     // Pair index
-    std::vector<std::array<Id, 2>> buffer;
-    CompressedRelationMetaData::scan(I(2), &buffer, index.PSO());
+    IdTable buffer{2, makeAllocator()};
+    // TODO<joka921> All these tests should only work on vocabulary entries,
+    // and not on hardcoded IDs to make them robust against internal changes.
+    index.PSO().scan(I(2), &buffer);
     ASSERT_EQ(2ul, buffer.size());
     ASSERT_EQ(I(0), buffer[0][0]);
     ASSERT_EQ(I(4), buffer[0][1]);
@@ -104,7 +106,7 @@ TEST(IndexTest, createFromTurtleTest) {
     ASSERT_EQ(I(5u), buffer[1][1]);
 
     // Relation b2
-    CompressedRelationMetaData::scan(I(3), &buffer, index.PSO());
+    index.PSO().scan(I(3), &buffer);
     ASSERT_EQ(2ul, buffer.size());
     ASSERT_EQ(I(0), buffer[0][0]);
     ASSERT_EQ(I(4u), buffer[0][1]);
@@ -174,9 +176,9 @@ TEST(IndexTest, createFromTurtleTest) {
     ASSERT_TRUE(index.POS().metaData().col0IdExists(I(7)));
     ASSERT_FALSE(index.POS().metaData().getMetaData(I(7)).isFunctional());
 
-    std::vector<std::array<Id, 2>> buffer;
+    IdTable buffer{2, makeAllocator()};
     // is-a
-    CompressedRelationMetaData::scan(I(7), &buffer, index.PSO());
+    index.PSO().scan(I(7), &buffer);
     ASSERT_EQ(7ul, buffer.size());
     // Pair index
     ASSERT_EQ(I(4u), buffer[0][0]);
@@ -195,7 +197,7 @@ TEST(IndexTest, createFromTurtleTest) {
     ASSERT_EQ(I(2u), buffer[6][1]);
 
     // is-a for POS
-    CompressedRelationMetaData::scan(I(7), &buffer, index.POS());
+    index.POS().scan(I(7), &buffer);
     ASSERT_EQ(7ul, buffer.size());
     // Pair index
     ASSERT_EQ(I(0u), buffer[0][0]);


### PR DESCRIPTION
So far QLever uses a column-based IdTable but stores its Indices still in a row-based manner.
This  PR now switches the Index structure also to a column-based layout.