### PR TITLE
Make the timeout check a little bit more efficient.

### DIFF
--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -203,8 +203,8 @@ class Operation {
             this](size_t countIncrease = 1) mutable {
       i += countIncrease;
       if (i >= numOperationsBetweenTimeoutChecks) {
-        _timeoutTimer->wlock()->checkTimeoutAndThrow("Timeout in " +
-                                                     getDescriptor());
+        _timeoutTimer->wlock()->checkTimeoutAndThrow(
+            [this]() { return "Timeout in " + getDescriptor(); });
         i = 0;
       }
     };

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -150,7 +150,7 @@ class TimeoutTimer : public Timer {
 
   // Check if this timer has timed out. If the timer has timed out, throws a
   // TimeoutException. Else, nothing happens.
-  void checkTimeoutAndThrow(std::string additionalMessage = {}) {
+  void checkTimeoutAndThrow(std::string_view additionalMessage = {}) {
     if (hasTimedOut()) {
       double seconds =
           static_cast<double>(_timeLimitInMicroseconds) / (1000 * 1000);
@@ -158,9 +158,20 @@ class TimeoutTimer : public Timer {
       // Seconds with three digits after the decimal point.
       // TODO<C++20> : Use std::format for formatting, it is much more readable.
       numberStream << std::setprecision(3) << std::fixed << seconds;
-      throw TimeoutException(additionalMessage +
-                             "A Timeout occured. The time limit was "s +
-                             std::move(numberStream).str() + "seconds"s);
+      throw TimeoutException{absl::StrCat(
+          additionalMessage, "A Timeout occured. The time limit was "s,
+          std::move(numberStream).str(), "seconds"s)};
+    }
+  }
+
+  // Overload that does not take an error message directly, but a callable that
+  // creates the error message lazily when the timeout occurs. This can be used
+  // to make calling this function cheaper in the typical "no timeout" case.
+  template <typename F>
+  requires std::is_invocable_r_v<std::string_view, F>
+  void checkTimeoutAndThrow(F&& f) {
+    if (hasTimedOut()) {
+      checkTimeoutAndThrow(f());
     }
   }
 


### PR DESCRIPTION
The error message (That is only needed if a timeout occurs) can now be passed as a lambda that lazily creates the error message to the `checkTimeoutAndThrow` function. This makes calling this function cheaper when no timeout occurs and the message as to be constructed in a non-trivial way.

This also allows to call the timeout checks inside an `Operation` on invalid operations that don't have valid children as long as the actual timeout never occurs. This can be useful during unit testing and benchmarking.