### PR TITLE
Refactor the `Timer` class (improve interface and use std::chrono)

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -60,8 +60,7 @@ void Operation::recursivelySetTimeoutTimer(
 // Get the result for the subtree rooted at this element. Use existing results
 // if they are already available, otherwise trigger computation.
 shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
-  ad_utility::Timer timer;
-  timer.start();
+  ad_utility::Timer timer{ad_utility::Timer::Started};
 
   if (isRoot) {
     // Start with an estimated runtime info which will be updated as we go.
@@ -99,7 +98,6 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
     // exception handler is called.
     ad_utility::OnDestruction onDestruction{[&]() {
       if (std::uncaught_exceptions()) {
-        timer.stop();
         updateRuntimeInformationOnFailure(timer.msecs());
       }
     }};
@@ -122,11 +120,9 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
       // correct runtimeInfo. The children of the runtime info are already set
       // correctly because the result was computed, so we can pass `nullopt` as
       // the last argument.
-      timer.stop();
       updateRuntimeInformationOnSuccess(*val._resultTable,
                                         ad_utility::CacheStatus::computed,
                                         timer.msecs(), std::nullopt);
-      timer.cont();
       val._runtimeInfo = getRuntimeInfo();
       return val;
     };
@@ -144,7 +140,6 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
     auto result = (pinResult) ? cache.computeOncePinned(cacheKey, computeLambda)
                               : cache.computeOnce(cacheKey, computeLambda);
 
-    timer.stop();
     updateRuntimeInformationOnSuccess(result, timer.msecs());
     auto resultNumRows = result._resultPointer->_resultTable->size();
     auto resultNumCols = result._resultPointer->_resultTable->width();

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -78,15 +78,12 @@ void OrderBy::computeResult(ResultTable* result) {
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
-  double remainingSecs =
-      static_cast<double>(_timeoutTimer->wlock()->remainingMicroseconds()) /
-      1'000'000;
+  auto remainingTime = _timeoutTimer->wlock()->remainingTime();
   auto sortEstimateCancellationFactor =
       RuntimeParameters().get<"sort-estimate-cancellation-factor">();
-  if (getExecutionContext()
-          ->getSortPerformanceEstimator()
-          .estimatedSortTimeInSeconds(subRes->size(), subRes->width()) >
-      remainingSecs * sortEstimateCancellationFactor) {
+  if (getExecutionContext()->getSortPerformanceEstimator().estimatedSortTime(
+          subRes->size(), subRes->width()) >
+      remainingTime * sortEstimateCancellationFactor) {
     // The estimated time for this sort is much larger than the actually
     // remaining time, cancel this operation
     throw ad_utility::TimeoutException(

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -55,15 +55,12 @@ void Sort::computeResult(ResultTable* result) {
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
-  double remainingSecs =
-      static_cast<double>(_timeoutTimer->wlock()->remainingMicroseconds()) /
-      1'000'000;
+  auto remainingTime = _timeoutTimer->wlock()->remainingTime();
   auto sortEstimateCancellationFactor =
       RuntimeParameters().get<"sort-estimate-cancellation-factor">();
-  if (getExecutionContext()
-          ->getSortPerformanceEstimator()
-          .estimatedSortTimeInSeconds(subRes->size(), subRes->width()) >
-      remainingSecs * sortEstimateCancellationFactor) {
+  if (getExecutionContext()->getSortPerformanceEstimator().estimatedSortTime(
+          subRes->size(), subRes->width()) >
+      remainingTime * sortEstimateCancellationFactor) {
     // The estimated time for this sort is much larger than the actually
     // remaining time, cancel this operation
     throw ad_utility::TimeoutException(

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -1,5 +1,5 @@
 // Copyright 2021, University of Freiburg,
-// Chair of Algorithms and Data Structures.
+//                 Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
 
 #include "engine/SortPerformanceEstimator.h"

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -156,14 +156,16 @@ void SortPerformanceEstimator::computeEstimatesExpensively(
                    << std::endl;
         LOG(TRACE) << "Creating an estimate from a smaller result" << std::endl;
         if (i > 0) {
-          // Assume that sorting time grows linearly in the number of rows
+          // Assume that sorting time grows linearly in the number of rows. For
+          // details on the usage of `toDuration()` see its first usage above.
           float ratio = static_cast<float>(sampleValuesRows[i]) /
                         static_cast<float>(sampleValuesRows[i - 1]);
           _samples[i][j] = Timer::toDuration(_samples[i - 1][j] * ratio);
         } else if (j > 0) {
           // Assume that sorting time grows with the square root in the number
           // of columns. The square root is just a heuristic: a simple function
-          // between linear and constant.
+          // between linear and constant. For details on the usage of
+          // `toDuration()` see its first usage above.
           float ratio = static_cast<float>(sampleValuesCols[j]) /
                         static_cast<float>(sampleValuesCols[j - 1]);
           _samples[i][j] =

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -101,7 +101,11 @@ auto SortPerformanceEstimator::estimatedSortTime(size_t numRows,
   auto numColumnsInSample = static_cast<double>(sampleValuesCols[columnIndex]);
   double columnRatio = static_cast<double>(numCols) / numColumnsInSample;
   // Scale linearly with the number of rows. Scale the number of columns with
-  // the square root
+  // the square root. The cast `toDuration` is necessary because the
+  // multiplication with a float (`rowRation`) propagates from the integer-
+  // based `Duration` to a float-based `std::chrono::duration`. The cast is
+  // semantically valid as the `result` is typically much larger than the
+  // timer resolution specified via the `Duration` (currently microseconds).
   result = Timer::toDuration(result * rowRatio * std::sqrt(columnRatio));
 
   return result;

--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -1,5 +1,5 @@
 // Copyright 2021, University of Freiburg,
-// Chair of Algorithms and Data Structures.
+//                 Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
 
 #ifndef QLEVER_SORTPERFORMANCEESTIMATOR_H

--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -7,12 +7,15 @@
 
 #include <array>
 
-#include "../global/Id.h"
-#include "../util/AllocatorWithLimit.h"
+#include "global/Id.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/Timer.h"
 
 /// Estimates the time it takes to sort an IdTable with a given number of rows
 /// and columns;
 class SortPerformanceEstimator {
+  using Timer = ad_utility::Timer;
+
  public:
   // Create a SortPerformanceEstimator. This involves sorting large results to
   // get good estimates. The call might take several minutes, depending on the
@@ -20,14 +23,14 @@ class SortPerformanceEstimator {
   // explicit factory function.
 
   // Create a random IdTable with the specified number of rows and columns. Sort
-  // this table and return the time in seconds that this sorting took.
-  static double measureSortingTimeInSeconds(
+  // this table and return the time that this sorting took.
+  static Timer::Duration measureSortingTime(
       size_t numRows, size_t numColumns,
       const ad_utility::AllocatorWithLimit<Id>& allocator);
 
   // Compute and return an Estimate for how long sorting an IdTable with the
   // specified number of rows and columns takes.
-  double estimatedSortTimeInSeconds(size_t numRows,
+  Timer::Duration estimatedSortTime(size_t numRows,
                                     size_t numCols) const noexcept;
 
   // Create an uninitialized SortPerformanceEstimator, which is cheap. Before
@@ -62,7 +65,8 @@ class SortPerformanceEstimator {
   // _samples[i][j] is the measured time it takes to sort an IdTable with
   // sampleValuesRows[i] rows and sampleValuesCols[j] columns.
   // The values are default-initialized to 0.
-  std::array<std::array<double, NUM_SAMPLES_COLS>, NUM_SAMPLES_ROWS> _samples{};
+  std::array<std::array<Timer::Duration, NUM_SAMPLES_COLS>, NUM_SAMPLES_ROWS>
+      _samples{};
 
   bool _estimatesWereCalculated = false;
 };

--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -1,6 +1,6 @@
-//
-// Created by johannes on 21.04.21.
-//
+// Copyright 2021, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
 
 #ifndef QLEVER_SORTPERFORMANCEESTIMATOR_H
 #define QLEVER_SORTPERFORMANCEESTIMATOR_H

--- a/src/engine/sparqlExpressions/RelationalExpressions.cpp
+++ b/src/engine/sparqlExpressions/RelationalExpressions.cpp
@@ -27,8 +27,7 @@ namespace detail {
 // doesn't compile with G++11. Find out, why.
 template <typename T>
 constexpr auto getObjectOfValueTypeHelper(T&& t) {
-  if constexpr (ad_utility::similarToInstantiation<VectorWithMemoryLimit,
-                                                   std::decay_t<T>>) {
+  if constexpr (ad_utility::similarToInstantiation<T, VectorWithMemoryLimit>) {
     return std::move(t[0]);
   } else {
     return std::move(t);

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -345,12 +345,13 @@ std::optional<ExpressionResult> evaluateOnSpecializedFunctionsIfPossible(
 /// multiple `ValueGetters` (a parameter pack, that has to appear at the end of
 /// the template declaration) and the default parameter for the
 /// `FunctionForSetOfIntervals` (which also has to appear at the end).
-template <size_t NumOperands, typename FunctionAndValueGettersT,
-          typename... SpecializedFunctions>
-requires ad_utility::isInstantiation<FunctionAndValueGetters,
-                                     FunctionAndValueGettersT> &&
-    (...&& ad_utility::isInstantiation<SpecializedFunction,
-                                       SpecializedFunctions>)struct Operation {
+template <
+    size_t NumOperands,
+    ad_utility::isInstantiation<FunctionAndValueGetters>
+        FunctionAndValueGettersT,
+    ad_utility::isInstantiation<SpecializedFunction>... SpecializedFunctions>
+
+struct Operation {
  private:
   using OriginalValueGetters = typename FunctionAndValueGettersT::ValueGetters;
   static constexpr size_t NV = std::tuple_size_v<OriginalValueGetters>;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -311,7 +311,8 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
       }
       LOG(TIMING) << "WaitTimes for Pipeline in msecs\n";
       for (const auto& t : p.getWaitingTime()) {
-        LOG(TIMING) << t << " msecs" << std::endl;
+        LOG(TIMING) << ad_utility::Timer::toMilliseconds(t) << " msecs"
+                    << std::endl;
       }
 
       if constexpr (requires(Parser p) { p.printAndResetQueueStatistics(); }) {
@@ -324,12 +325,10 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
     // to control the number of threads and the amount of memory used at the
     // same time. typically sorting is finished before we reach again here so
     // it is not a bottleneck.
-    ad_utility::Timer sortFutureTimer;
-    sortFutureTimer.start();
+    ad_utility::Timer sortFutureTimer{ad_utility::Timer::Started};
     if (writePartialVocabularyFuture[0].valid()) {
       writePartialVocabularyFuture[0].get();
     }
-    sortFutureTimer.stop();
     LOG(TIMING)
         << "Time spent waiting for the writing of a previous vocabulary: "
         << sortFutureTimer.msecs() << "ms." << std::endl;

--- a/src/util/Serializer/SerializeHashMap.h
+++ b/src/util/Serializer/SerializeHashMap.h
@@ -13,7 +13,7 @@
 namespace ad_utility::serialization {
 
 AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
-    (ad_utility::similarToInstantiation<ad_utility::HashMap, T>)) {
+    (ad_utility::similarToInstantiation<T, ad_utility::HashMap>)) {
   using K = typename std::decay_t<T>::key_type;
   using M = typename std::decay_t<T>::mapped_type;
   if constexpr (WriteSerializer<S>) {

--- a/src/util/Serializer/SerializePair.h
+++ b/src/util/Serializer/SerializePair.h
@@ -11,7 +11,7 @@
 
 namespace ad_utility::serialization {
 AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
-    (ad_utility::similarToInstantiation<std::pair, T>)) {
+    (ad_utility::similarToInstantiation<T, std::pair>)) {
   serializer | arg.first;
   serializer | arg.second;
 }

--- a/src/util/Serializer/SerializeVector.h
+++ b/src/util/Serializer/SerializeVector.h
@@ -14,8 +14,8 @@
 
 namespace ad_utility::serialization {
 AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT(
-    (ad_utility::similarToInstantiation<std::vector, T> ||
-     ad_utility::similarToInstantiation<std::basic_string, T>)) {
+    (ad_utility::similarToInstantiation<T, std::vector> ||
+     ad_utility::similarToInstantiation<T, std::basic_string>)) {
   using V = typename std::decay_t<T>::value_type;
   auto size = arg.size();  // The value is ignored for `ReadSerializer`s.
   serializer | size;

--- a/src/util/TaskQueue.h
+++ b/src/util/TaskQueue.h
@@ -132,13 +132,10 @@ class TaskQueue {
   decltype(auto) executeAndUpdateTimer(F&& f, std::atomic<size_t>& duration) {
     if constexpr (TrackTimes) {
       struct T {
-        ad_utility::Timer _t;
+        ad_utility::Timer _t{ad_utility::Timer::Started};
         std::atomic<size_t>& _target;
-        T(std::atomic<size_t>& target) : _target(target) { _t.start(); }
-        ~T() {
-          _t.stop();
-          _target += _t.msecs();
-        }
+        T(std::atomic<size_t>& target) : _target(target) {}
+        ~T() { _target += _t.msecs(); }
       };
       T timeHandler{duration};
       return f();

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -171,7 +171,7 @@ class TimeoutTimer : public Timer {
       numberStream << std::setprecision(3) << std::fixed << seconds;
       throw TimeoutException{absl::StrCat(
           additionalMessage, "A Timeout occured. The time limit was "s,
-          std::move(numberStream).str(), "seconds"s)};
+          std::move(numberStream).str(), " seconds"s)};
     }
   }
 
@@ -206,13 +206,14 @@ class TimeoutTimer : public Timer {
 // The callback can be used to change the logging mechanism. It must be
 // callable with a `size_t` (the number of milliseconds) and `message`.
 #if LOGLEVEL >= TIMING
-struct [[nodiscard]] TimeBlockAndLockCallbackDummy{};
+struct [[nodiscard]] TimeBlockAndLockCallbackDummy {};
 template <typename Callback = TimeBlockAndLockCallbackDummy>
 struct TimeBlockAndLog {
   Timer t_{Timer::Started};
   std::string message_;
   Callback callback_;
-  TimeBlockAndLog(std::string message, Callback callback = {}) : message_{std::move(message)}, callback_{std::move(callback)} {
+  TimeBlockAndLog(std::string message, Callback callback = {})
+      : message_{std::move(message)}, callback_{std::move(callback)} {
     t_.start();
   }
   ~TimeBlockAndLog() {

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -46,8 +46,8 @@ class Timer {
   // TODO<joka921, GCC 12.3> This could be `using enum InitialStatus`,
   // but that leads to an internal compiler error in GCC. I suspect that it is
   // this bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103081
-  static const InitialStatus Started = InitialStatus::Started;
-  static const InitialStatus Stopped = InitialStatus::Stopped;
+  static constexpr InitialStatus Started = InitialStatus::Started;
+  static constexpr InitialStatus Stopped = InitialStatus::Stopped;
 
   // Convert any `std::chrono::duration` to the underlying `Duration` type
   // of the `Timer` class.

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -201,11 +201,11 @@ class TimeoutTimer : public Timer {
   TimeoutTimer(UnlimitedTag) : Timer{Timer::Started}, _isUnlimited{true} {}
 };
 
+namespace detail {
 // A helper struct that measures the time from its creation until its
 // destruction and logs the time together with a specified message
 // The callback can be used to change the logging mechanism. It must be
 // callable with a `size_t` (the number of milliseconds) and `message`.
-#if LOGLEVEL >= TIMING
 struct [[nodiscard]] TimeBlockAndLockCallbackDummy {};
 template <typename Callback = TimeBlockAndLockCallbackDummy>
 struct TimeBlockAndLog {
@@ -225,6 +225,10 @@ struct TimeBlockAndLog {
     }
   }
 };
+}  // namespace detail
+
+#if LOGLEVEL >= TIMING
+using detail::TimeBlockAndLog;
 #else
 struct TimeBlockAndLog {
   TimeBlockAndLog(const std::string&) {}

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -42,7 +42,12 @@ class Timer {
   // A simple enum used in the constructor to decide whether the timer is
   // immediately started or not.
   enum class InitialStatus { Started, Stopped };
-  using enum InitialStatus;
+  // Allow the usage of `Timer::Started` and `Timer::Stopped`.
+  // TODO<joka921, GCC 12.3> This could be `using enum InitialStatus`,
+  // but that leads to an internal compiler error in GCC. I suspect that it is
+  // this bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103081
+  static const InitialStatus Started = InitialStatus::Started;
+  static const InitialStatus Stopped = InitialStatus::Stopped;
 
   // Convert any `std::chrono::duration` to the underlying `Duration` type
   // of the `Timer` class.

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -211,8 +211,8 @@ namespace detail {
 // destruction and logs the time together with a specified message
 // The callback can be used to change the logging mechanism. It must be
 // callable with a `size_t` (the number of milliseconds) and `message`.
-[[maybe_unused]] auto defaultLogger = [](size_t msecs,
-                                         std::string_view message) {
+[[maybe_unused]] inline auto defaultLogger = [](size_t msecs,
+                                                std::string_view message) {
   LOG(TIMING) << message << " took " << msecs << "ms" << std::endl;
 };
 template <typename Callback = decltype(defaultLogger)>

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -72,7 +72,7 @@ struct FirstWrapper : public std::type_identity<T> {};
 ///
 /// isInstantiation<std::vector, std::vector<int>> == true;
 /// isInstantiation<std::vector, const std::vector<int>&> == false;
-template <template <typename...> typename TemplatedType, typename T>
+template <typename T, template <typename...> typename TemplatedType>
 concept isInstantiation =
     detail::IsInstantiationOf<TemplatedType>::template Instantiation<T>::value;
 
@@ -81,21 +81,21 @@ concept isInstantiation =
 ///
 /// similarToInstantiation<std::vector, std::vector<int>> == true;
 /// similarToInstantiation<std::vector, const std::vector<int>&> == true;
-template <template <typename...> typename TemplatedType, typename T>
+template <typename T, template <typename...> typename TemplatedType>
 concept similarToInstantiation =
-    isInstantiation<TemplatedType, std::decay_t<T>>;
+    isInstantiation<std::decay_t<T>, TemplatedType>;
 
 /// isVector<T> is true if and only if T is an instantiation of std::vector
 template <typename T>
-constexpr static bool isVector = isInstantiation<std::vector, T>;
+constexpr static bool isVector = isInstantiation<T, std::vector>;
 
 /// isTuple<T> is true if and only if T is an instantiation of std::tuple
 template <typename T>
-constexpr static bool isTuple = isInstantiation<std::tuple, T>;
+constexpr static bool isTuple = isInstantiation<T, std::tuple>;
 
 /// isVariant<T> is true if and only if T is an instantiation of std::variant
 template <typename T>
-constexpr static bool isVariant = isInstantiation<std::variant, T>;
+constexpr static bool isVariant = isInstantiation<T, std::variant>;
 
 /// Two types are similar, if they are the same when we remove all cv (const or
 /// volatile) qualifiers and all references

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -251,3 +251,5 @@ addLinkAndDiscoverTest(CallFixedSizeTest)
 addLinkAndDiscoverTest(ConstexprUtilsTest)
 
 addLinkAndDiscoverTest(ResetWhenMovedTest)
+
+addLinkAndDiscoverTest(TimerTest absl::strings)

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -80,12 +80,10 @@ using SimpleConcurrentLruCache =
 
 TEST(ConcurrentCache, sequentialComputation) {
   SimpleConcurrentLruCache a{3ul};
-  ad_utility::Timer t;
-  t.start();
+  ad_utility::Timer t{ad_utility::Timer::Started};
   // Fake computation that takes 5ms and returns value "3", which is then
   // stored under key 3.
   auto result = a.computeOnce(3, waiting_function("3"s, 5));
-  t.stop();
   ASSERT_EQ("3"s, *result._resultPointer);
   ASSERT_EQ(result._cacheStatus, ad_utility::CacheStatus::computed);
   ASSERT_GE(t.msecs(), 5);
@@ -98,7 +96,6 @@ TEST(ConcurrentCache, sequentialComputation) {
   t.start();
   // takes 0 msecs to compute, as the request is served from the cache.
   auto result2 = a.computeOnce(3, waiting_function("3"s, 5));
-  t.stop();
   // computing result again: still yields "3", was cached and takes 0
   // milliseconds (result is read from cache)
   ASSERT_EQ("3"s, *result2._resultPointer);
@@ -112,12 +109,10 @@ TEST(ConcurrentCache, sequentialComputation) {
 
 TEST(ConcurrentCache, sequentialPinnedComputation) {
   SimpleConcurrentLruCache a{3ul};
-  ad_utility::Timer t;
-  t.start();
+  ad_utility::Timer t{ad_utility::Timer::Started};
   // Fake computation that takes 5ms and returns value "3", which is then
   // stored under key 3.
   auto result = a.computeOncePinned(3, waiting_function("3"s, 5));
-  t.stop();
   ASSERT_EQ("3"s, *result._resultPointer);
   ASSERT_EQ(result._cacheStatus, ad_utility::CacheStatus::computed);
   ASSERT_GE(t.msecs(), 5);
@@ -131,7 +126,6 @@ TEST(ConcurrentCache, sequentialPinnedComputation) {
   // takes 0 msecs to compute, as the request is served from the cache.
   // we don't request a pin, but the original computation was pinned
   auto result2 = a.computeOnce(3, waiting_function("3"s, 5));
-  t.stop();
   // computing result again: still yields "3", was cached and takes 0
   // milliseconds (result is read from cache)
   ASSERT_EQ("3"s, *result2._resultPointer);
@@ -145,12 +139,10 @@ TEST(ConcurrentCache, sequentialPinnedComputation) {
 
 TEST(ConcurrentCache, sequentialPinnedUpgradeComputation) {
   SimpleConcurrentLruCache a{3ul};
-  ad_utility::Timer t;
-  t.start();
+  ad_utility::Timer t{ad_utility::Timer::Started};
   // Fake computation that takes 5ms and returns value "3", which is then
   // stored under key 3.
   auto result = a.computeOnce(3, waiting_function("3"s, 5));
-  t.stop();
   ASSERT_EQ("3"s, *result._resultPointer);
   ASSERT_EQ(result._cacheStatus, ad_utility::CacheStatus::computed);
   ASSERT_GE(t.msecs(), 5);
@@ -165,7 +157,6 @@ TEST(ConcurrentCache, sequentialPinnedUpgradeComputation) {
   // request a pin, the result should be read from the cache and upgraded
   // to a pinned result.
   auto result2 = a.computeOncePinned(3, waiting_function("3"s, 5));
-  t.stop();
   // computing result again: still yields "3", was cached and takes 0
   // milliseconds (result is read from cache)
   ASSERT_EQ("3"s, *result2._resultPointer);

--- a/test/SortPerformanceEstimatorTest.cpp
+++ b/test/SortPerformanceEstimatorTest.cpp
@@ -1,15 +1,15 @@
-//
-// Created by johannes on 21.04.21.
-//
+//  Copyright 2021, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #include <gtest/gtest.h>
 
 #include <chrono>
 #include <thread>
 
-#include "../../src/engine/SortPerformanceEstimator.h"
-#include "../../src/util/Log.h"
-#include "../../src/util/Random.h"
+#include "engine/SortPerformanceEstimator.h"
+#include "util/Log.h"
+#include "util/Random.h"
 
 TEST(SortPerformanceEstimator, TestManyEstimates) {
   // only allow the test to use 1 Gig of RAM
@@ -30,14 +30,15 @@ TEST(SortPerformanceEstimator, TestManyEstimates) {
         continue;
       }
       try {
-        double measurement =
-            SortPerformanceEstimator::measureSortingTimeInSeconds(i, numColumns,
-                                                                  allocator);
-        double estimate = t.estimatedSortTimeInSeconds(i, numColumns);
+        using ad_utility::Timer;
+        Timer::Duration measurement =
+            SortPerformanceEstimator::measureSortingTime(i, numColumns,
+                                                         allocator);
+        Timer::Duration estimate = t.estimatedSortTime(i, numColumns);
         LOG(INFO) << std::fixed << std::setprecision(3) << "input of size " << i
-                  << "with " << numColumns << " columns took " << measurement
-                  << " seconds, estimate was " << estimate << " seconds"
-                  << std::endl;
+                  << "with " << numColumns << " columns took "
+                  << Timer::toSeconds(measurement) << " seconds, estimate was "
+                  << Timer::toSeconds(estimate) << " seconds" << std::endl;
         ASSERT_GE(2 * measurement, estimate);
         if (!isFirst) {
           EXPECT_LE(0.5 * measurement, estimate);

--- a/test/TimerTest.cpp
+++ b/test/TimerTest.cpp
@@ -4,9 +4,6 @@
 
 #include <gtest/gtest.h>
 
-// This redefinition is used to enable the `TimeBlockAndLog` struct for testing.
-#undef LOGLEVEL
-#define LOGLEVEL 10
 #include "util/Timer.h"
 
 using ad_utility::TimeoutTimer;
@@ -100,7 +97,9 @@ TEST(TimeoutTimer, Unlimited) {
     std::this_thread::sleep_for(1ms);
     ASSERT_FALSE(timer.hasTimedOut());
     ASSERT_NO_THROW(timer.checkTimeoutAndThrow("error1"));
-    ASSERT_NO_THROW(timer.checkTimeoutAndThrow([]() { return "error2"; }));
+    // When no timeout occurs, the lambda is not executed.
+    ASSERT_NO_THROW(
+        timer.checkTimeoutAndThrow([]() -> std::string { throw 42; }));
   }
 }
 

--- a/test/TimerTest.cpp
+++ b/test/TimerTest.cpp
@@ -1,0 +1,135 @@
+//  Copyright 2023, University of Freiburg,
+//                  Chair of Algorithms and Data Structures.
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+// This redefinition is used to enable the `TimeBlockAndLog` struct for testing.
+#define LOGLEVEL 10
+#include "util/Timer.h"
+
+using ad_utility::Timer;
+using ad_utility::TimeoutTimer;
+using namespace std::chrono_literals;
+
+void testTime(Timer::Duration duration, size_t msecs, std::chrono::milliseconds expected) {
+  ASSERT_GE(duration, 0.9 * expected );
+  ASSERT_LE(duration, 1.1 * (expected + 1ms));
+
+  ASSERT_GE(msecs, 0.9 * expected.count());
+  ASSERT_LE(msecs, 1.1 * (expected.count() + 1));
+
+  ASSERT_GE(Timer::toSeconds(duration), 0.0009 * expected.count());
+  ASSERT_LE(Timer::toSeconds(duration), 0.0011 * (expected.count() + 1));
+
+}
+
+void testTime(const ad_utility::Timer& timer, std::chrono::milliseconds expected) {
+  testTime(timer.value(), timer.msecs(), expected);
+}
+
+TEST(Timer, BasicWorkflow) {
+  Timer t{Timer::Started};
+  ASSERT_TRUE(t.isRunning());
+  std::this_thread::sleep_for(10ms);
+  testTime(t, 10ms);
+
+  // After stopping the timer, the value remains unchanged.
+  t.stop();
+  ASSERT_FALSE(t.isRunning());
+  auto v = t.value();
+  auto m = t.msecs();
+  std::this_thread::sleep_for(10ms);
+  ASSERT_EQ(v, t.value());
+  ASSERT_EQ(m, t.msecs());
+
+  // Stopping an already stopped timer also is a noop.
+  t.stop();
+  std::this_thread::sleep_for(5ms);
+  ASSERT_FALSE(t.isRunning());
+  ASSERT_EQ(v, t.value());
+  ASSERT_EQ(m, t.msecs());
+
+  // Continue the timer.
+  t.cont();
+  ASSERT_TRUE(t.isRunning());
+  std::this_thread::sleep_for(15ms);
+  // Continuing a running timer is a noop;
+  t.cont();
+  ASSERT_TRUE(t.isRunning());
+  std::this_thread::sleep_for(5ms);
+  testTime(t, 30ms);
+
+  // Measure the time after stopping the timer
+  t.stop();
+  testTime(t, 30ms);
+
+  t.cont();
+  // Reset leads to a stopped timer.
+  t.reset();
+  ASSERT_FALSE(t.isRunning());
+  ASSERT_EQ(t.value(), Timer::Duration::zero());
+  ASSERT_EQ(t.msecs(), 0u);
+  std::this_thread::sleep_for(5ms);
+
+  // Start leads to a running timer
+  t.start();
+  ASSERT_TRUE(t.isRunning());
+  testTime(t, 0ms);
+}
+
+TEST(Timer, InitiallyStopped) {
+  Timer t{Timer::Stopped};
+  ASSERT_FALSE(t.isRunning());
+  ASSERT_EQ(t.value(), Timer::Duration::zero());
+  ASSERT_EQ(t.msecs(), 0u);
+  std::this_thread::sleep_for(15ms);
+  ASSERT_EQ(t.value(), Timer::Duration::zero());
+  ASSERT_EQ(t.msecs(), 0u);
+
+  t.cont();
+  std::this_thread::sleep_for(15ms);
+  testTime(t, 15ms);
+}
+
+TEST(TimeoutTimer, Unlimited) {
+  auto timer = TimeoutTimer::unlimited();
+  for (size_t i = 0; i < 10; ++i) {
+    std::this_thread::sleep_for(1ms);
+    ASSERT_FALSE(timer.hasTimedOut());
+    ASSERT_NO_THROW(timer.checkTimeoutAndThrow("error1"));
+    ASSERT_NO_THROW(timer.checkTimeoutAndThrow([](){return "error2";}));
+  }
+}
+
+TEST(TimeoutTimer, Limited) {
+  auto timer = TimeoutTimer{10ms, Timer::Started};
+  std::this_thread::sleep_for(5ms);
+  ASSERT_FALSE(timer.hasTimedOut());
+  ASSERT_NO_THROW(timer.checkTimeoutAndThrow("error1"));
+  ASSERT_NO_THROW(timer.checkTimeoutAndThrow([](){return "error2";}));
+  std::this_thread::sleep_for(7ms);
+
+  ASSERT_TRUE(timer.hasTimedOut());
+  ASSERT_THROW(timer.checkTimeoutAndThrow("hi"), ad_utility::TimeoutException);
+  try {
+    timer.checkTimeoutAndThrow([](){return "test error";});
+    FAIL() << "Expected a timeout exception, but no exception was thrown";
+  }
+  catch (const ad_utility::TimeoutException& ex) {
+    ASSERT_EQ(ex.what(), "Some message");
+  }
+}
+
+TEST(TimeBlockAndLock, TimeBlockAndLock) {
+  std::string s;
+  {
+    auto callback = [&s](size_t msecs, std::string_view message) {
+      s = absl::StrCat(message, ": ", msecs);
+    };
+    ad_utility::TimeBlockAndLog t {"message", callback};
+    std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_EQ("some Message", s);
+
+}

--- a/test/TimerTest.cpp
+++ b/test/TimerTest.cpp
@@ -71,7 +71,7 @@ TEST(Timer, BasicWorkflow) {
   ASSERT_EQ(t.msecs(), 0u);
   std::this_thread::sleep_for(5ms);
 
-  // Start leads to a running timer
+  // Start leads to a running timer.
   t.start();
   ASSERT_TRUE(t.isRunning());
   testTime(t, 0ms);


### PR DESCRIPTION
It internally uses `std::chrono` now instead of legacy C-APIs. 
Also use `std::chrono::duration` in many more parts of QLever instead of plain `double` or `int`.

The time value of a timer can now also be obtained while the timer is running, previously this call was only valid while the timer was stopped.

TODO: Write unit tests for the Timer, we have None so far.