### PR TITLE
Add a Github action that uploads a given code coverage file

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -1,0 +1,28 @@
+name: Upload code coverage
+
+on:
+  workflow_run:
+    workflows: ["Measure code coverage"]
+    types:
+      -completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download code coverage'
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-report
+      - name: 'View files'
+        run: ls -al
+      - name: "Upload coverage report"
+        uses: codecov/codecov-action@v3
+        with:
+          file: coverage.lcov
+          # Note: technically, a `token` is not required for codecov.io when
+          # uploading from a public repository, but specifying it avoids the
+          # nasty spurious failures due to Github's rate limit for codecov's
+          # public default token.
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
As is this file has no effects, but it has to be in the `master` branch to be active.
For details see
[here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)