### PR TITLE
Improve handling of `Values` and `LocalVocab`

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -87,7 +87,7 @@ void Bind::computeResult(ResultTable* result) {
 
   result->_idTable.setNumColumns(getResultWidth());
   result->_resultTypes = subRes->_resultTypes;
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
   int inwidth = subRes->_idTable.numColumns();
   int outwidth = getResultWidth();
 
@@ -115,7 +115,7 @@ void Bind::computeExpressionBind(
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), *inputResultTable._localVocab);
+      getExecutionContext()->getAllocator(), *inputResultTable.getLocalVocab());
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);
@@ -165,7 +165,7 @@ void Bind::computeExpressionBind(
         if (it != resultGenerator.end()) {
           Id constantId =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(*it), *(outputResultTable->_localVocab));
+                  std::move(*it), *(outputResultTable->getLocalVocab()));
           for (size_t i = 0; i < inSize; ++i) {
             output(i, inCols) = constantId;
           }
@@ -175,7 +175,8 @@ void Bind::computeExpressionBind(
         for (auto&& resultValue : resultGenerator) {
           output(i, inCols) =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(resultValue), *(outputResultTable->_localVocab));
+                  std::move(resultValue),
+                  *(outputResultTable->getLocalVocab()));
           i++;
         }
       }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -88,7 +88,7 @@ void Bind::computeResult(ResultTable* result) {
   result->_idTable.setNumColumns(getResultWidth());
   result->_resultTypes = subRes->_resultTypes;
 
-  // Make a deep copy of the local vocab from `subresult` and then add to it (in
+  // Make a deep copy of the local vocab from `subRes` and then add to it (in
   // case BIND adds a new word or words).
   //
   // TODO: In most BIND operations, nothing is added to the local vocabulary, so

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -87,7 +87,7 @@ void Bind::computeResult(ResultTable* result) {
 
   result->_idTable.setNumColumns(getResultWidth());
   result->_resultTypes = subRes->_resultTypes;
-  result->setLocalVocab(subRes->getLocalVocab());
+  result->shareLocalVocabFrom(*subRes);
   int inwidth = subRes->_idTable.numColumns();
   int outwidth = getResultWidth();
 
@@ -115,7 +115,7 @@ void Bind::computeExpressionBind(
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), *inputResultTable.getLocalVocab());
+      getExecutionContext()->getAllocator(), inputResultTable.getLocalVocab());
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);
@@ -165,7 +165,7 @@ void Bind::computeExpressionBind(
         if (it != resultGenerator.end()) {
           Id constantId =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(*it), *(outputResultTable->getLocalVocab()));
+                  std::move(*it), outputResultTable->getLocalVocabNonConst());
           for (size_t i = 0; i < inSize; ++i) {
             output(i, inCols) = constantId;
           }
@@ -176,7 +176,7 @@ void Bind::computeExpressionBind(
           output(i, inCols) =
               sparqlExpression::detail::constantExpressionResultToId(
                   std::move(resultValue),
-                  *(outputResultTable->getLocalVocab()));
+                  outputResultTable->getLocalVocabNonConst());
           i++;
         }
       }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -124,7 +124,7 @@ void Bind::computeExpressionBind(
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), inputResultTable.getLocalVocab());
+      getExecutionContext()->getAllocator(), inputResultTable.localVocab());
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);
@@ -174,7 +174,7 @@ void Bind::computeExpressionBind(
         if (it != resultGenerator.end()) {
           Id constantId =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(*it), outputResultTable->getLocalVocabNonConst());
+                  std::move(*it), outputResultTable->localVocabNonConst());
           for (size_t i = 0; i < inSize; ++i) {
             output(i, inCols) = constantId;
           }
@@ -185,7 +185,7 @@ void Bind::computeExpressionBind(
           output(i, inCols) =
               sparqlExpression::detail::constantExpressionResultToId(
                   std::move(resultValue),
-                  outputResultTable->getLocalVocabNonConst());
+                  outputResultTable->localVocabNonConst());
           i++;
         }
       }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -87,7 +87,16 @@ void Bind::computeResult(ResultTable* result) {
 
   result->_idTable.setNumColumns(getResultWidth());
   result->_resultTypes = subRes->_resultTypes;
-  result->shareLocalVocabFrom(*subRes);
+
+  // Make a deep copy of the local vocab from `subresult` and then add to it (in
+  // case BIND adds a new word or words).
+  //
+  // TODO: In most BIND operations, nothing is added to the local vocabulary, so
+  // it would be more efficient to first share the pointer here (like with
+  // `shareLocalVocabFrom`) and only copy it when a new word is about to be
+  // added. Same for GROUP BY.
+  result->getCopyOfLocalVocabFrom(*subRes);
+
   int inwidth = subRes->_idTable.numColumns();
   int outwidth = getResultWidth();
 

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -136,7 +136,7 @@ void CountAvailablePredicates::computeResult(ResultTable* result) {
         &result->_idTable, hasPattern, hasPredicate, patterns);
   } else {
     std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-    result->_localVocab = subresult->_localVocab;
+    result->setLocalVocab(subresult->getLocalVocab());
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
 

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -136,7 +136,7 @@ void CountAvailablePredicates::computeResult(ResultTable* result) {
         &result->_idTable, hasPattern, hasPredicate, patterns);
   } else {
     std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-    result->setLocalVocab(subresult->getLocalVocab());
+    result->shareLocalVocabFrom(*subresult);
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -48,7 +48,7 @@ void Distinct::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->setLocalVocab(subRes->getLocalVocab());
+  result->shareLocalVocabFrom(*subRes);
   int width = subRes->_idTable.numColumns();
   CALL_FIXED_SIZE(width, &Engine::distinct, subRes->_idTable, _keepIndices,
                   &result->_idTable);

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -48,7 +48,7 @@ void Distinct::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
   int width = subRes->_idTable.numColumns();
   CALL_FIXED_SIZE(width, &Engine::distinct, subRes->_idTable, _keepIndices,
                   &result->_idTable);

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -108,7 +108,7 @@ nlohmann::json ExportQueryExecutionTrees::idTableToQLeverJSONArray(
       }
       const auto& currentId = data(rowIndex, opt->_columnIndex);
       const auto& optionalStringAndXsdType = idToStringAndType(
-          qet.getQec()->getIndex(), currentId, *resultTable->_localVocab);
+          qet.getQec()->getIndex(), currentId, *resultTable->getLocalVocab());
       if (!optionalStringAndXsdType.has_value()) {
         row.emplace_back(nullptr);
         continue;
@@ -272,7 +272,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultToSparqlJSON(
     for (const auto& column : columns) {
       const auto& currentId = idTable(rowIndex, column->_columnIndex);
       const auto& optionalValue = idToStringAndType(
-          qet.getQec()->getIndex(), currentId, *resultTable->_localVocab);
+          qet.getQec()->getIndex(), currentId, *resultTable->getLocalVocab());
       if (!optionalValue.has_value()) {
         continue;
       }
@@ -381,7 +381,7 @@ ExportQueryExecutionTrees::selectQueryResultToCsvTsvOrBinary(
         Id id = idTable(i, val._columnIndex);
         auto optionalStringAndType =
             idToStringAndType(qet.getQec()->getIndex(), id,
-                              *resultTable->_localVocab, escapeFunction);
+                              *resultTable->getLocalVocab(), escapeFunction);
         if (optionalStringAndType.has_value()) [[likely]] {
           co_yield optionalStringAndType.value().first;
         }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -108,7 +108,7 @@ nlohmann::json ExportQueryExecutionTrees::idTableToQLeverJSONArray(
       }
       const auto& currentId = data(rowIndex, opt->_columnIndex);
       const auto& optionalStringAndXsdType = idToStringAndType(
-          qet.getQec()->getIndex(), currentId, resultTable->getLocalVocab());
+          qet.getQec()->getIndex(), currentId, resultTable->localVocab());
       if (!optionalStringAndXsdType.has_value()) {
         row.emplace_back(nullptr);
         continue;
@@ -272,7 +272,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultToSparqlJSON(
     for (const auto& column : columns) {
       const auto& currentId = idTable(rowIndex, column->_columnIndex);
       const auto& optionalValue = idToStringAndType(
-          qet.getQec()->getIndex(), currentId, resultTable->getLocalVocab());
+          qet.getQec()->getIndex(), currentId, resultTable->localVocab());
       if (!optionalValue.has_value()) {
         continue;
       }
@@ -381,7 +381,7 @@ ExportQueryExecutionTrees::selectQueryResultToCsvTsvOrBinary(
         Id id = idTable(i, val._columnIndex);
         auto optionalStringAndType =
             idToStringAndType(qet.getQec()->getIndex(), id,
-                              resultTable->getLocalVocab(), escapeFunction);
+                              resultTable->localVocab(), escapeFunction);
         if (optionalStringAndType.has_value()) [[likely]] {
           co_yield optionalStringAndType.value().first;
         }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -108,7 +108,7 @@ nlohmann::json ExportQueryExecutionTrees::idTableToQLeverJSONArray(
       }
       const auto& currentId = data(rowIndex, opt->_columnIndex);
       const auto& optionalStringAndXsdType = idToStringAndType(
-          qet.getQec()->getIndex(), currentId, *resultTable->getLocalVocab());
+          qet.getQec()->getIndex(), currentId, resultTable->getLocalVocab());
       if (!optionalStringAndXsdType.has_value()) {
         row.emplace_back(nullptr);
         continue;
@@ -272,7 +272,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultToSparqlJSON(
     for (const auto& column : columns) {
       const auto& currentId = idTable(rowIndex, column->_columnIndex);
       const auto& optionalValue = idToStringAndType(
-          qet.getQec()->getIndex(), currentId, *resultTable->getLocalVocab());
+          qet.getQec()->getIndex(), currentId, resultTable->getLocalVocab());
       if (!optionalValue.has_value()) {
         continue;
       }
@@ -381,7 +381,7 @@ ExportQueryExecutionTrees::selectQueryResultToCsvTsvOrBinary(
         Id id = idTable(i, val._columnIndex);
         auto optionalStringAndType =
             idToStringAndType(qet.getQec()->getIndex(), id,
-                              *resultTable->getLocalVocab(), escapeFunction);
+                              resultTable->getLocalVocab(), escapeFunction);
         if (optionalStringAndType.has_value()) [[likely]] {
           co_yield optionalStringAndType.value().first;
         }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -74,7 +74,7 @@ void Filter::computeFilterImpl(ResultTable* outputResultTable,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), inputResultTable.getLocalVocab());
+      getExecutionContext()->getAllocator(), inputResultTable.localVocab());
 
   // TODO<joka921> This should be a mandatory argument to the EvaluationContext
   // constructor.

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -53,7 +53,7 @@ void Filter::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->setLocalVocab(subRes->getLocalVocab());
+  result->shareLocalVocabFrom(*subRes);
 
   int width = result->_idTable.numColumns();
   CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this, result, *subRes);
@@ -74,7 +74,7 @@ void Filter::computeFilterImpl(ResultTable* outputResultTable,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), *inputResultTable.getLocalVocab());
+      getExecutionContext()->getAllocator(), inputResultTable.getLocalVocab());
 
   // TODO<joka921> This should be a mandatory argument to the EvaluationContext
   // constructor.

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -53,7 +53,7 @@ void Filter::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
 
   int width = result->_idTable.numColumns();
   CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this, result, *subRes);
@@ -74,7 +74,7 @@ void Filter::computeFilterImpl(ResultTable* outputResultTable,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), *inputResultTable._localVocab);
+      getExecutionContext()->getAllocator(), *inputResultTable.getLocalVocab());
 
   // TODO<joka921> This should be a mandatory argument to the EvaluationContext
   // constructor.

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -177,7 +177,7 @@ void GroupBy::processGroup(
       *resultType =
           sparqlExpression::detail::expressionResultTypeToQleverResultType<T>();
       resultEntry = sparqlExpression::detail::constantExpressionResultToId(
-          singleResult, outTable->getLocalVocabNonConst());
+          singleResult, outTable->localVocabNonConst());
     } else {
       // This should never happen since aggregates always return constants.
       AD_FAIL();
@@ -225,7 +225,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inTable->_idTable,
-      getExecutionContext()->getAllocator(), outTable->getLocalVocabNonConst());
+      getExecutionContext()->getAllocator(), outTable->localVocabNonConst());
 
   auto processNextBlock = [&](size_t blockStart, size_t blockEnd) {
     result.emplace_back();

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -286,7 +286,12 @@ void GroupBy::computeResult(ResultTable* result) {
   LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
 
   // Make a deep copy of the local vocab from `subresult` and then add to it (in
-  // case GROUP_CONCAT adds something).
+  // case GROUP_CONCAT adds a new word or words).
+  //
+  // TODO: In most GROUP BY operations, nothing is added to the local
+  // vocabulary, so it would be more efficient to first share the pointer here
+  // (like with `shareLocalVocabFrom`) and only copy it when a new word is about
+  // to be added. Same for BIND.
   result->getCopyOfLocalVocabFrom(*subresult);
 
   std::vector<size_t> groupByColumns;

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -177,7 +177,7 @@ void GroupBy::processGroup(
       *resultType =
           sparqlExpression::detail::expressionResultTypeToQleverResultType<T>();
       resultEntry = sparqlExpression::detail::constantExpressionResultToId(
-          singleResult, *(outTable->_localVocab));
+          singleResult, *(outTable->getLocalVocab()));
     } else {
       // This should never happen since aggregates always return constants.
       AD_FAIL();
@@ -225,7 +225,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inTable->_idTable,
-      getExecutionContext()->getAllocator(), *outTable->_localVocab);
+      getExecutionContext()->getAllocator(), *outTable->getLocalVocab());
 
   auto processNextBlock = [&](size_t blockStart, size_t blockEnd) {
     result.emplace_back();
@@ -285,15 +285,15 @@ void GroupBy::computeResult(ResultTable* result) {
   std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
   LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
 
-  // Make a copy of the local vocab from the sub-result and then add to it (in
+  // Make a deep copy of the local vocab from `subresult` and then add to it (in
   // case GROUP_CONCAT adds something).
   //
-  // NOTE: If we did `result->_localVocab = subresult->_localVocab` here, only a
+  // NOTE: With `result->setLocalVocab(subresult->getLocalVocab())`, only a
   // shared pointer would be copied. The the additions made in this operation
-  // would also affect the `subresult`, which leads to all kinds of unexpected
+  // would also affect `subresult`, which leads to all kinds of unexpected
   // behavior.
-  result->_localVocab =
-      std::make_shared<LocalVocab>(subresult->_localVocab->clone());
+  result->setLocalVocab(
+      std::make_shared<LocalVocab>(subresult->getLocalVocab()->clone()));
 
   std::vector<size_t> groupByColumns;
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -243,7 +243,7 @@ void HasPredicateScan::computeResult(ResultTable* result) {
     case ScanType::SUBQUERY_S:
 
       std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-      result->_localVocab = subresult->_localVocab;
+      result->setLocalVocab(subresult->getLocalVocab());
       result->_resultTypes.insert(result->_resultTypes.begin(),
                                   subresult->_resultTypes.begin(),
                                   subresult->_resultTypes.end());

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -243,7 +243,7 @@ void HasPredicateScan::computeResult(ResultTable* result) {
     case ScanType::SUBQUERY_S:
 
       std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-      result->setLocalVocab(subresult->getLocalVocab());
+      result->shareLocalVocabFrom(*subresult);
       result->_resultTypes.insert(result->_resultTypes.begin(),
                                   subresult->_resultTypes.begin(),
                                   subresult->_resultTypes.end());

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -149,9 +149,9 @@ void Join::computeResult(ResultTable* result) {
                   leftRes->_idTable, _leftJoinCol, rightRes->_idTable,
                   _rightJoinCol, &result->_idTable);
 
-  // If only one of the two operands has a local vocab, pass it on.
-  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftRes->getLocalVocab(), rightRes->getLocalVocab()));
+  // If only one of the two operands has a non-empty local vocabulary, share
+  // with that one (otherwise, throws an exception).
+  result->shareLocalVocabFromNonEmptyOf(*leftRes, *rightRes);
 
   LOG(DEBUG) << "Join result computation done" << endl;
 }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -150,8 +150,8 @@ void Join::computeResult(ResultTable* result) {
                   _rightJoinCol, &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftRes->_localVocab, rightRes->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftRes->getLocalVocab(), rightRes->getLocalVocab()));
 
   LOG(DEBUG) << "Join result computation done" << endl;
 }

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -57,6 +57,7 @@ LocalVocabIndex LocalVocab::getIndexAndAddIfNotContainedImpl(WordT&& word) {
       wordsToIndexesMap_.insert({std::forward<WordT>(word), nextFreeIndex_});
   const auto& [wordInMap, index] = *wordInMapAndIndex;
   if (isNewWord) {
+    AD_CONTRACT_CHECK(!readOnly_);
     indexesToWordsMap_.push_back(&wordInMap);
     nextFreeIndex_ = LocalVocabIndex::make(indexesToWordsMap_.size());
   }
@@ -83,20 +84,4 @@ const std::string& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
         indexesToWordsMap_.size(), ", please contact the developers"));
   }
   return *(indexesToWordsMap_.at(localVocabIndex.get()));
-}
-
-// _____________________________________________________________________________
-std::shared_ptr<LocalVocab> LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-    const std::shared_ptr<LocalVocab>& localVocab1,
-    const std::shared_ptr<LocalVocab>& localVocab2) {
-  AD_CONTRACT_CHECK(localVocab1 != nullptr);
-  AD_CONTRACT_CHECK(localVocab2 != nullptr);
-  bool isLocalVocab1Empty = localVocab1->empty();
-  bool isLocalVocab2Empty = localVocab2->empty();
-  if (!isLocalVocab1Empty && !isLocalVocab2Empty) {
-    throw std::runtime_error(
-        "Merging of two non-empty local vocabularies is currently not "
-        "supported, please contact the developers");
-  }
-  return !isLocalVocab1Empty ? localVocab1 : localVocab2;
 }

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -37,6 +37,11 @@ class LocalVocab {
   // word).
   LocalVocabIndex nextFreeIndex_ = LocalVocabIndex::make(0);
 
+  // Indicator that the local vocabulary is read only. This will be set once the
+  // local vocabulary is shared between more than one result; see the respective
+  // methods in `ResultTable`.
+  bool readOnly_ = false;
+
  public:
   // Create a new, empty local vocabulary.
   LocalVocab() = default;
@@ -53,6 +58,9 @@ class LocalVocab {
   LocalVocab(LocalVocab&&) = default;
   LocalVocab& operator=(LocalVocab&&) = default;
 
+  // Make the local vocabulary read only.
+  void makeReadOnly() { readOnly_ = true; }
+
   // Get the index of a word in the local vocabulary. If the word was already
   // contained, return the already existing index. If the word was not yet
   // contained, add it, and return the new index.
@@ -67,16 +75,6 @@ class LocalVocab {
 
   // Return a const reference to the word.
   const std::string& getWord(LocalVocabIndex localVocabIndex) const;
-
-  // Merge two local vocabularies if at least one of them is empty. If both are
-  // non-empty, throws an exception. Assumes that both vocabularies exist.
-  //
-  // TODO: Eventually, we want to have one local vocab for the whole query to
-  // which each operation writes (one after the other). Then we don't need a
-  // merge function anymore.
-  static std::shared_ptr<LocalVocab> mergeLocalVocabsIfOneIsEmpty(
-      const std::shared_ptr<LocalVocab>& localVocab1,
-      const std::shared_ptr<LocalVocab>& localVocab2);
 
  private:
   // Common implementation for the two variants of

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -54,7 +54,7 @@ void Minus::computeResult(ResultTable* result) {
   const auto leftResult = _left->getResult();
   const auto rightResult = _right->getResult();
 
-  LOG(DEBUG) << "Minus subresult computation done." << std::endl;
+  LOG(DEBUG) << "Minus subresult computation done" << std::endl;
 
   // We have the same output columns as the left input, so we also
   // have the same output column types.
@@ -69,11 +69,11 @@ void Minus::computeResult(ResultTable* result) {
                   this, leftResult->_idTable, rightResult->_idTable,
                   _matchedColumns, &result->_idTable);
 
-  // If only one of the two operands has a local vocab, pass it on.
-  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
+  // If only one of the two operands has a non-empty local vocabulary, share
+  // with that one (otherwise, throws an exception).
+  result->shareLocalVocabFromNonEmptyOf(*leftResult, *rightResult);
 
-  LOG(DEBUG) << "Minus result computation done." << endl;
+  LOG(DEBUG) << "Minus result computation done" << endl;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -70,8 +70,8 @@ void Minus::computeResult(ResultTable* result) {
                   _matchedColumns, &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->_localVocab, rightResult->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
 
   LOG(DEBUG) << "Minus result computation done." << endl;
 }

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -114,11 +114,11 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
                   leftResult->_idTable, rightResult->_idTable, _joinColumns,
                   &result->_idTable);
 
-  // If only one of the two operands has a local vocab, pass it on.
-  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
+  // If only one of the two operands has a non-empty local vocabulary, share
+  // with that one (otherwise, throws an exception).
+  result->shareLocalVocabFromNonEmptyOf(*leftResult, *rightResult);
 
-  LOG(DEBUG) << "MultiColumnJoin result computation done." << endl;
+  LOG(DEBUG) << "MultiColumnJoin result computation done" << endl;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -115,8 +115,8 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
                   &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->_localVocab, rightResult->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
 
   LOG(DEBUG) << "MultiColumnJoin result computation done." << endl;
 }

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -120,9 +120,9 @@ void OptionalJoin::computeResult(ResultTable* result) {
                   rightResult->_idTable, _leftOptional, _rightOptional,
                   _joinColumns, &result->_idTable);
 
-  // If only one of the two operands has a local vocab, pass it on.
-  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
+  // If only one of the two operands has a non-empty local vocabulary, share
+  // with that one (otherwise, throws an exception).
+  result->shareLocalVocabFromNonEmptyOf(*leftResult, *rightResult);
 
   LOG(DEBUG) << "Join result computation done" << endl;
   LOG(DEBUG) << "OptionalJoin result computation done." << endl;

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -121,8 +121,8 @@ void OptionalJoin::computeResult(ResultTable* result) {
                   _joinColumns, &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->_localVocab, rightResult->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
 
   LOG(DEBUG) << "Join result computation done" << endl;
   LOG(DEBUG) << "OptionalJoin result computation done." << endl;

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -89,7 +89,7 @@ void OrderBy::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->setLocalVocab(subRes->getLocalVocab());
+  result->shareLocalVocabFrom(*subRes);
   result->_idTable = subRes->_idTable.clone();
 
   int width = result->_idTable.numColumns();

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -89,8 +89,7 @@ void OrderBy::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
-
+  result->setLocalVocab(subRes->getLocalVocab());
   result->_idTable = subRes->_idTable.clone();
 
   int width = result->_idTable.numColumns();

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -1,6 +1,8 @@
-// Copyright 2015 -2022, University of Freiburg
+// Copyright 2015 - 2023, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include "engine/ResultTable.h"
 
@@ -19,4 +21,31 @@ string ResultTable::asDebugString() const {
     os << '\n';
   }
   return std::move(os).str();
+}
+
+// _____________________________________________________________________________
+void ResultTable::shareLocalVocabFrom(const ResultTable& resultTable) {
+  // This copies a shared pointer, so both results share the same local
+  // vocabulary.
+  localVocab_ = resultTable.localVocab_;
+  localVocab_->makeReadOnly();
+}
+
+// _____________________________________________________________________________
+void ResultTable::shareLocalVocabFromNonEmptyOf(
+    const ResultTable& resultTable1, const ResultTable& resultTable2) {
+  const auto& localVocab1 = resultTable1.localVocab_;
+  const auto& localVocab2 = resultTable2.localVocab_;
+  if (!localVocab1->empty() && !localVocab2->empty()) {
+    throw std::runtime_error(
+        "Merging of two non-empty local vocabularies is currently not "
+        "supported, please contact the developers");
+  }
+  localVocab_ = localVocab2->empty() ? localVocab1 : localVocab2;
+  localVocab_->makeReadOnly();
+}
+
+// _____________________________________________________________________________
+void ResultTable::getCopyOfLocalVocabFrom(const ResultTable& resultTable) {
+  localVocab_ = std::make_shared<LocalVocab>(resultTable.localVocab_->clone());
 }

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -1,31 +1,12 @@
 // Copyright 2015 -2022, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include "engine/ResultTable.h"
 
 #include <cassert>
 
 #include "engine/LocalVocab.h"
-
-// _____________________________________________________________________________
-ResultTable::ResultTable(ad_utility::AllocatorWithLimit<Id> allocator)
-    : _sortedBy(),
-      _idTable(std::move(allocator)),
-      _resultTypes(),
-      // TODO: Why initialize with a pointer to an empty local vocabulary
-      // instead of with nullptr?
-      _localVocab(std::make_shared<LocalVocab>()) {}
-
-// _____________________________________________________________________________
-void ResultTable::clear() {
-  _localVocab = nullptr;
-  _idTable.clear();
-}
-
-// _____________________________________________________________________________
-ResultTable::~ResultTable() { clear(); }
 
 // _____________________________________________________________________________
 string ResultTable::asDebugString() const {
@@ -39,6 +20,3 @@ string ResultTable::asDebugString() const {
   }
   return std::move(os).str();
 }
-
-// _____________________________________________________________________________
-size_t ResultTable::size() const { return _idTable.size(); }

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -1,4 +1,4 @@
-// Copyright 2015 - 2022, University of Freiburg
+// Copyright 2015 - 2023, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
@@ -90,15 +90,57 @@ class ResultTable {
   // Get the number of columns of this result.
   size_t width() const { return _idTable.numColumns(); }
 
-  // Set local vocabulary. This only copies a shared pointer. In order to make a
-  // deep copy, use LocalVocab::clone(); see `GroupBy.cpp` for an example.
-  void setLocalVocab(const std::shared_ptr<LocalVocab>& localVocab) {
-    localVocab_ = localVocab;
-  }
+  // Share the local vocabulary with the given other result. After this is
+  // called, the (shared) local vocabulary is set to read only (because adding
+  // to it further would affect earlier results, which might be cached, which
+  // can give all sort of unexpected behavior or even wrong results).
+  //
+  // NOTE: In order to make a deep copy, use LocalVocab::clone(); see
+  // `GroupBy.cpp` for an example.
+  void shareLocalVocabFrom(const ResultTable& resultTable);
 
-  // Get the local vocabulary of this result (not `const` because we may want to
-  // augment it while constructing the result).
-  std::shared_ptr<LocalVocab> getLocalVocab() const { return localVocab_; }
+  // Like `shareLocalVocabFrom`, but takes *two* results and assumes that one of
+  // their local vocabularies is empty and shares the the result with the
+  // non-empty one (if both are empty, arbitrarily share with the first one).
+  //
+  // TODO: Eventually, we want to be able to merge two non-empty local
+  // vocabularies, but that requires more work since we have to rewrite IDs then
+  // (from the previous separate local vocabularies to the new merged one).
+  void shareLocalVocabFromNonEmptyOf(const ResultTable& resultTable1,
+                                     const ResultTable& resultTable2);
+
+  // Get a (deep) copy of the local vocabulary from the given result. Use this
+  // when you want to (potentially) add further words to the local vocabulary
+  // (which is not possible with `shareLocalVocabFrom`).
+  void getCopyOfLocalVocabFrom(const ResultTable& resultTable);
+
+  // Get the local vocabulary of this result, used for lookup only.
+  //
+  // NOTE: This is currently used in the following methods (in parentheses
+  // the name of the function called with the local vocab as argument):
+  //
+  // ExportQueryExecutionTrees::idTableToQLeverJSONArray (idToStringAndType)
+  // ExportQueryExecutionTrees::selectQueryResultToSparqlJSON (dito)
+  // ExportQueryExecutionTrees::selectQueryResultToCsvTsvOrBinary (dito)
+  // Filter::computeFilterImpl (evaluationContext)
+  // Variable::evaluate (idToStringAndType)
+  //
+  const LocalVocab& getLocalVocab() const { return *localVocab_; }
+
+  // The non-const version of the above.
+  //
+  // NOTE: This is currently used in the following methods:
+  //
+  // Values::writeValues (toValueId)
+  // Bind::computeExpressionBind (evaluationContext)
+  // Bind::computeExpressionBind (constantExpressionResultToId)
+  // GroupBy::processGroup (constantExpressionResultToId)
+  // GroupBy::doGroupBy (evaluationContext)
+  // GroupByTest::doGroupBy [that could be done differently there]
+  //
+  // TODO: I added the `NonConst` to the name to emphasize that this is not the
+  // ideal interface. But good enough for now.
+  LocalVocab& getLocalVocabNonConst() { return *localVocab_; }
 
   // Log the size of this result. We call this at several places in
   // `Server::processQuery`. Ideally, this should only be called in one

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -1,6 +1,7 @@
 // Copyright 2015 - 2022, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #pragma once
@@ -27,59 +28,92 @@ using std::mutex;
 using std::unique_lock;
 using std::vector;
 
+// The result of an `Operation`. This is the class QLever uses for all
+// intermediate or final results when processing a SPARQL query. The actual data
+// is always a table and contained in the member `_idTable`.
+//
+// TODO: I would find it more appropriate to simply call this class `Result`.
+// Otherwise, it's not clear from the names what the difference between a
+// `ResultTable` and an `IdTable` is.
 class ResultTable {
  public:
+  // The status of the result.
   enum Status { IN_PROGRESS = 0, FINISHED = 1, ABORTED = 2 };
-  using ResultType = qlever::ResultType;
 
-  /**
-   * @brief This vector contains a list of column indices by which the result
-   *        is sorted. This vector may be empty if the result is not sorted
-   *        on any column. The primary sort column is _sortedBy[0]
-   *        (if it exists).
-   */
-  vector<size_t> _sortedBy;
+ public:
+  // TODO: I think that none of these member variables should be public. They
+  // probably are for historical reasons. I already added a `getLocalVocab`
+  // method.
 
+  // The actual entries.
   IdTable _idTable;
 
+  // The entries in `_resultTypes` used to be significant in an old version of
+  // the QLever code, but they longer are (because reality is more complicated
+  // than "one type per column). It is still important for the correctness of
+  // the code, however, that this vector has the same size as the number of
+  // columns of the table.
+  //
+  // TODO: Properly keep track of result types again. In particular, efficiency
+  // should benefit in the common use case where all entries in a column have a
+  // certain type or types.
+  using ResultType = qlever::ResultType;
   vector<ResultType> _resultTypes;
 
-  std::shared_ptr<LocalVocab> _localVocab;
+  // The column indices by which the result is sorted (primary sort key first).
+  // Empty if the result is not sorted on any column.
+  vector<size_t> _sortedBy;
 
-  explicit ResultTable(ad_utility::AllocatorWithLimit<Id> allocator);
+ private:
+  // The local vocabulary of the result.
+  std::shared_ptr<LocalVocab> localVocab_ = std::make_shared<LocalVocab>();
 
+ public:
+  // Construct with given allocator.
+  explicit ResultTable(ad_utility::AllocatorWithLimit<Id> allocator)
+      : _idTable(std::move(allocator)) {}
+
+  // Prevent accidental copying of a result table.
   ResultTable(const ResultTable& other) = delete;
-
-  ResultTable(ResultTable&& other) = default;
-
   ResultTable& operator=(const ResultTable& other) = delete;
 
+  // Moving of a result table is OK.
+  ResultTable(ResultTable&& other) = default;
   ResultTable& operator=(ResultTable&& other) = default;
 
-  virtual ~ResultTable();
+  // Default destructor.
+  virtual ~ResultTable() = default;
 
-  size_t size() const;
+  // Get the number of rows of this result.
+  size_t size() const { return _idTable.size(); }
+
+  // Get the number of columns of this result.
   size_t width() const { return _idTable.numColumns(); }
 
-  // Log to INFO the size of this result.
-  //
-  // NOTE: Due to the current sub-optimal design of `Server::processQuery`, we
-  // need the same message in multiple places and so instead of duplicating the
-  // message, we should have a method for it.
+  // Set local vocabulary. This only copies a shared pointer. In order to make a
+  // deep copy, use LocalVocab::clone(); see `GroupBy.cpp` for an example.
+  void setLocalVocab(const std::shared_ptr<LocalVocab>& localVocab) {
+    localVocab_ = localVocab;
+  }
+
+  // Get the local vocabulary of this result (not `const` because we may want to
+  // augment it while constructing the result).
+  std::shared_ptr<LocalVocab> getLocalVocab() const { return localVocab_; }
+
+  // Log the size of this result. We call this at several places in
+  // `Server::processQuery`. Ideally, this should only be called in one
+  // place, but for now, this method at least makes sure that these log
+  // messages look all the same.
   void logResultSize() const {
     LOG(INFO) << "Result has size " << size() << " x " << width() << std::endl;
   }
 
-  void clear();
-
+  // The first rows of the result and its total size (for debugging).
   string asDebugString() const;
 
+  // Get the result type for the given column if provided (default:
+  // ResultType::KB).
   ResultType getResultType(size_t col) const {
-    if (col < _resultTypes.size()) {
-      return _resultTypes[col];
-    }
-    return ResultType::KB;
+    return col < _resultTypes.size() ? _resultTypes[col] : ResultType::KB;
   }
-
- private:
 };

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -42,7 +42,7 @@ class ResultTable {
 
  public:
   // TODO: I think that none of these member variables should be public. They
-  // probably are for historical reasons. I already added a `getLocalVocab`
+  // probably are for historical reasons. I already added a `localVocab`
   // method.
 
   // The actual entries.
@@ -122,7 +122,7 @@ class ResultTable {
   // Filter::computeFilterImpl (evaluationContext)
   // Variable::evaluate (idToStringAndType)
   //
-  const LocalVocab& getLocalVocab() const { return *localVocab_; }
+  const LocalVocab& localVocab() const { return *localVocab_; }
 
   // The non-const version of the above.
   //
@@ -137,7 +137,7 @@ class ResultTable {
   //
   // TODO: I added the `NonConst` to the name to emphasize that this is not the
   // ideal interface. But good enough for now.
-  LocalVocab& getLocalVocabNonConst() { return *localVocab_; }
+  LocalVocab& localVocabNonConst() { return *localVocab_; }
 
   // Log the size of this result. We call this at several places in
   // `Server::processQuery`. Ideally, this should only be called in one

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -48,15 +48,12 @@ class ResultTable {
   // The actual entries.
   IdTable _idTable;
 
-  // The entries in `_resultTypes` used to be significant in an old version of
-  // the QLever code, but they longer are (because reality is more complicated
-  // than "one type per column). It is still important for the correctness of
-  // the code, however, that this vector has the same size as the number of
-  // columns of the table.
+  // The semantics of `_resultTypes` is not not used anymore in the QLever code,
+  // see the comment in `ResultType.h`. We still need the declaration though
+  // because it is checked, at various places, that this vector has the same
+  // size as the number of columns of the table.
   //
-  // TODO: Properly keep track of result types again. In particular, efficiency
-  // should benefit in the common use case where all entries in a column have a
-  // certain type or types.
+  // TODO: Refactor this code according to the comment in `ResultType.h`.
   using ResultType = qlever::ResultType;
   vector<ResultType> _resultTypes;
 

--- a/src/engine/ResultType.h
+++ b/src/engine/ResultType.h
@@ -1,27 +1,26 @@
-//
-// Created by johannes on 09.05.21.
-//
+// Copyright 2021 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
-#ifndef QLEVER_RESULTTYPE_H
-#define QLEVER_RESULTTYPE_H
+#pragma once
 
 namespace qlever {
-/**
- * @brief Describes the type of a columns data
- */
+
+// Enumerate the types of entries we can have in a `ResultTable`.
 enum class ResultType {
-  // An entry in the knowledgebase
+  // An entry that is contained in the vocabulary of the indexed data.
   KB,
-  // An unsigned integer (size_t)
+  // An unsigned integer. TODO: Briefly describe why this is still needed. It is
+  // used in `GroupBy`, `CountAvailablePredicates`, `TextOperationWithFilter`,
+  // `TextOperationWithoutFilter`.
   VERBATIM,
-  // A byte offset in the text index
+  // An entry from the text index (a byte offset in the text index).
   TEXT,
-  // A 32 bit float, stored in the first 4 bytes of the entry. The last four
-  // bytes have to be zero.
+  // A floating point number. TODO: Is this still used somwehere? It doesn't
+  // look like it is, now that we have values "folded into" IDs.
   FLOAT,
-  // An entry in the ResultTable's _localVocab
+  // An entry in the `LocalVocab` of a `ResultTable`. TODO: Is this still used
+  // somewhere? It doesn't look like it is.
   LOCAL_VOCAB
 };
 }  // namespace qlever
-
-#endif  // QLEVER_RESULTTYPE_H

--- a/src/engine/ResultType.h
+++ b/src/engine/ResultType.h
@@ -7,20 +7,27 @@
 namespace qlever {
 
 // Enumerate the types of entries we can have in a `ResultTable`.
+//
+// NOTE: This was used in an old version of the QLever code, but no longer is
+// (because reality is more complicated than "one type per column"). The class
+// is still needed for the correctness of the code, see `ResultTable.h`.
+//
+// TODO: Properly keep track of result types again. In particular, efficiency
+// should benefit in the common use case where all entries in a column have a
+// certain type or types.
 enum class ResultType {
   // An entry that is contained in the vocabulary of the indexed data.
   KB,
-  // An unsigned integer. TODO: Briefly describe why this is still needed. It is
-  // used in `GroupBy`, `CountAvailablePredicates`, `TextOperationWithFilter`,
-  // `TextOperationWithoutFilter`.
+  // An unsigned integer.
+  //
+  // NOTE: This is currently used in `GroupBy`, `CountAvailablePredicates`,
+  // `TextOperationWithFilter`, `TextOperationWithoutFilter`.
   VERBATIM,
   // An entry from the text index (a byte offset in the text index).
   TEXT,
-  // A floating point number. TODO: Is this still used somwehere? It doesn't
-  // look like it is, now that we have values "folded into" IDs.
+  // A floating point number. NOTE: This isn't used anywhere anymore.
   FLOAT,
-  // An entry in the `LocalVocab` of a `ResultTable`. TODO: Is this still used
-  // somewhere? It doesn't look like it is.
+  // An entry in the `LocalVocab`. NOTE: This isn't used anywhere anymore.
   LOCAL_VOCAB
 };
 }  // namespace qlever

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -132,7 +132,7 @@ void Sort::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
   result->_idTable = subRes->_idTable.clone();
   result->_sortedBy = resultSortedOn();
   sortImpl(result->_idTable, sortColumnIndices_);

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -132,7 +132,7 @@ void Sort::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->setLocalVocab(subRes->getLocalVocab());
+  result->shareLocalVocabFrom(*subRes);
   result->_idTable = subRes->_idTable.clone();
   result->_sortedBy = resultSortedOn();
   sortImpl(result->_idTable, sortColumnIndices_);

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -84,7 +84,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) {
   AD_CONTRACT_CHECK(getNofVars() >= 1);
   result->_idTable.setNumColumns(getResultWidth());
   shared_ptr<const ResultTable> filterResult = _filterResult->getResult();
-  result->setLocalVocab(filterResult->getLocalVocab());
+  result->shareLocalVocabFrom(*filterResult);
 
   result->_resultTypes.reserve(result->_idTable.numColumns());
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -84,7 +84,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) {
   AD_CONTRACT_CHECK(getNofVars() >= 1);
   result->_idTable.setNumColumns(getResultWidth());
   shared_ptr<const ResultTable> filterResult = _filterResult->getResult();
-  result->_localVocab = filterResult->_localVocab;
+  result->setLocalVocab(filterResult->getLocalVocab());
 
   result->_resultTypes.reserve(result->_idTable.numColumns());
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -673,7 +673,7 @@ void TransitivePath::computeResult(ResultTable* result) {
   // an index scan (which has an empty local vocabulary by default) is the
   // `LocalVocabTest`. But it doesn't harm to propagate the local vocab here
   // either.
-  result->setLocalVocab(subRes->getLocalVocab());
+  result->shareLocalVocabFrom(*subRes);
 
   result->_sortedBy = resultSortedOn();
   if (_leftIsVar || _leftSideTree != nullptr) {

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -670,10 +670,10 @@ void TransitivePath::computeResult(ResultTable* result) {
   LOG(DEBUG) << "TransitivePath subresult computation done." << std::endl;
 
   // NOTE: The only place, where the input to a transitive path operation is not
-  // an index scan (which have empty local vocabularies by default) is the
-  // `LocalVocabTest`. But it doesn't harm to propagate `_localVocab` here
+  // an index scan (which has an empty local vocabulary by default) is the
+  // `LocalVocabTest`. But it doesn't harm to propagate the local vocab here
   // either.
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
 
   result->_sortedBy = resultSortedOn();
   if (_leftIsVar || _leftSideTree != nullptr) {

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -167,8 +167,8 @@ void Union::computeResult(ResultTable* result) {
                   subRes1->_idTable, subRes2->_idTable, _columnOrigins);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      subRes1->_localVocab, subRes2->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      subRes1->getLocalVocab(), subRes2->getLocalVocab()));
 
   LOG(DEBUG) << "Union result computation done." << std::endl;
 }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -166,11 +166,11 @@ void Union::computeResult(ResultTable* result) {
                   &Union::computeUnion, this, &result->_idTable,
                   subRes1->_idTable, subRes2->_idTable, _columnOrigins);
 
-  // If only one of the two operands has a local vocab, pass it on.
-  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      subRes1->getLocalVocab(), subRes2->getLocalVocab()));
+  // If only one of the two operands has a non-empty local vocabulary, share
+  // with that one (otherwise, throws an exception).
+  result->shareLocalVocabFromNonEmptyOf(*subRes1, *subRes2);
 
-  LOG(DEBUG) << "Union result computation done." << std::endl;
+  LOG(DEBUG) << "Union result computation done" << std::endl;
 }
 
 template <int LEFT_WIDTH, int RIGHT_WIDTH, int OUT_WIDTH>

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -118,7 +118,7 @@ void Values::writeValues(ResultTable* result) {
     for (size_t colIdx = 0; colIdx < idTable.numColumns(); colIdx++) {
       TripleComponent& tc = row[colIdx];
       Id id = std::move(tc).toValueId(getIndex().getVocab(),
-                                      *result->getLocalVocab());
+                                      result->getLocalVocabNonConst());
       idTable(rowIdx, colIdx) = id;
       if (id.getDatatype() == Datatype::LocalVocabIndex) {
         ++numLocalVocabPerColumn[colIdx];

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -16,8 +16,7 @@
 
 // ____________________________________________________________________________
 Values::Values(QueryExecutionContext* qec, SparqlValues parsedValues)
-    : Operation(qec) {
-  parsedValues_ = std::move(parsedValues);
+    : Operation(qec), parsedValues_(std::move(parsedValues)) {
   AD_CONTRACT_CHECK(
       std::ranges::all_of(parsedValues_._values, [&](const auto& row) {
         return row.size() == parsedValues_._variables.size();

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -117,7 +117,7 @@ void Values::writeValues(ResultTable* result) {
     for (size_t colIdx = 0; colIdx < idTable.numColumns(); colIdx++) {
       TripleComponent& tc = row[colIdx];
       Id id = std::move(tc).toValueId(getIndex().getVocab(),
-                                      result->getLocalVocabNonConst());
+                                      result->localVocabNonConst());
       idTable(rowIdx, colIdx) = id;
       if (id.getDatatype() == Datatype::LocalVocabIndex) {
         ++numLocalVocabPerColumn[colIdx];

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -15,25 +15,28 @@
 #include "util/HashSet.h"
 
 // ____________________________________________________________________________
-Values::Values(QueryExecutionContext* qec, SparqlValues values)
+Values::Values(QueryExecutionContext* qec, SparqlValues parsedValues)
     : Operation(qec) {
-  _values = sanitizeValues(std::move(values));
+  parsedValues_ = sanitizeValues(std::move(parsedValues));
 }
 
 // ____________________________________________________________________________
 string Values::asStringImpl(size_t indent) const {
   return absl::StrCat(std::string(indent, ' '), "VALUES (",
-                      _values.variablesToString(), ") { ",
-                      _values.valuesToString(), " }");
+                      parsedValues_.variablesToString(), ") { ",
+                      parsedValues_.valuesToString(), " }");
 }
 
 // ____________________________________________________________________________
 string Values::getDescriptor() const {
-  return absl::StrCat("Values with variables ", _values.variablesToString());
+  return absl::StrCat("Values with variables ",
+                      parsedValues_.variablesToString());
 }
 
 // ____________________________________________________________________________
-size_t Values::getResultWidth() const { return _values._variables.size(); }
+size_t Values::getResultWidth() const {
+  return parsedValues_._variables.size();
+}
 
 // ____________________________________________________________________________
 vector<size_t> Values::resultSortedOn() const { return {}; }
@@ -41,70 +44,59 @@ vector<size_t> Values::resultSortedOn() const { return {}; }
 // ____________________________________________________________________________
 VariableToColumnMap Values::computeVariableToColumnMap() const {
   VariableToColumnMap map;
-  for (size_t i = 0; i < _values._variables.size(); i++) {
+  for (size_t i = 0; i < parsedValues_._variables.size(); i++) {
     // TODO<joka921> Make the `_variables` also `Variable`s
-    map[Variable{_values._variables[i]}] = i;
+    map[Variable{parsedValues_._variables[i]}] = i;
   }
   return map;
 }
 
 // ____________________________________________________________________________
 float Values::getMultiplicity(size_t col) {
-  if (_multiplicities.empty()) {
+  if (multiplicities_.empty()) {
     computeMultiplicities();
   }
-  if (col < _multiplicities.size()) {
-    return _multiplicities[col];
+  if (col < multiplicities_.size()) {
+    return multiplicities_[col];
   }
   return 1;
 }
 
 // ____________________________________________________________________________
-size_t Values::getSizeEstimate() { return _values._values.size(); }
+size_t Values::getSizeEstimate() { return parsedValues_._values.size(); }
 
 // ____________________________________________________________________________
-size_t Values::getCostEstimate() { return _values._values.size(); }
+size_t Values::getCostEstimate() { return parsedValues_._values.size(); }
 
 // ____________________________________________________________________________
 void Values::computeMultiplicities() {
-  if (_values._variables.empty()) {
+  if (parsedValues_._variables.empty()) {
     // If the result is empty we still add a column to the multiplicities to
     // mark them as computed.
-    _multiplicities.resize(1, 1);
+    multiplicities_.resize(1, 1);
     return;
   }
-  _multiplicities.resize(_values._variables.size());
+  multiplicities_.resize(parsedValues_._variables.size());
   ad_utility::HashSet<TripleComponent> distinctValues;
-  size_t numValues = _values._values.size();
-  for (size_t col = 0; col < _values._variables.size(); col++) {
+  size_t numValues = parsedValues_._values.size();
+  for (size_t col = 0; col < parsedValues_._variables.size(); col++) {
     distinctValues.clear();
-    for (const auto& valuesTuple : _values._values) {
+    for (const auto& valuesTuple : parsedValues_._values) {
       distinctValues.insert(valuesTuple[col]);
     }
     size_t numDistinctValues = distinctValues.size();
-    _multiplicities[col] = float(numValues) / float(numDistinctValues);
+    multiplicities_[col] = float(numValues) / float(numDistinctValues);
   }
-}
-
-// ____________________________________________________________________________
-void Values::computeResult(ResultTable* result) {
-  const Index& index = getIndex();
-
-  result->_sortedBy = resultSortedOn();
-  result->_idTable.setNumColumns(getResultWidth());
-  result->_resultTypes.resize(_values._variables.size(),
-                              ResultTable::ResultType::KB);
-
-  size_t resWidth = getResultWidth();
-  CALL_FIXED_SIZE(resWidth, &Values::writeValues, this, &result->_idTable,
-                  index, _values, result->_localVocab);
 }
 
 // ____________________________________________________________________________
 auto Values::sanitizeValues(SparqlValues&& values) -> SparqlValues {
+  // Find all UNDEF values and remember tuples (rows) where all values are
+  // UNDEF as well as for each variable when it had a value that was not UNDEF
+  // at least once.
   std::vector<std::pair<std::size_t, std::size_t>> variableBound;
   for (size_t i = 0; i < values._variables.size(); ++i) {
-    variableBound.emplace_back(i, 0);  // variable i is unbound so far;
+    variableBound.emplace_back(i, 0);
   }
   std::vector<std::size_t> emptyValues;
   for (std::size_t i = 0; i < values._values.size(); ++i) {
@@ -120,63 +112,72 @@ auto Values::sanitizeValues(SparqlValues&& values) -> SparqlValues {
       }
     }
   }
-  // erase all the values where every variable is "UNDEF"
+
+  // Remove all value tuples where every value is "UNDEF".
   for (auto it = emptyValues.rbegin(); it != emptyValues.rend(); ++it) {
-    getWarnings().push_back(
-        "Found a value line, where no variable is bound, ignoring it");
+    getWarnings().push_back("Removing VALUES tuple where all values are UNDEF");
     values._values.erase(values._values.begin() + *it);
   }
 
-  // completely erase all the variables which are never bound.
+  // Remove all variables that are not bound in a single value tuple.
   for (auto it = variableBound.rbegin(); it != variableBound.rend(); ++it) {
     if (it->second) {
       continue;
     }
     getWarnings().push_back(
-        "Found a VALUES variable , which is never bound in the value clause "
-        ",ignoring it");
+        "Removing VALUES variable for which all values were UNDEF");
     values._variables.erase(values._variables.begin() + it->first);
     for (auto& val : values._values) {
       val.erase(val.begin() + it->first);
     }
   }
+
+  // If no variables or tuples remain, throw an exception.
   if (values._values.empty() || values._variables.empty()) {
     AD_THROW(
-        "After removing undefined values and variables, a VALUES clause was "
-        "found to be empty. This"
-        "(the neutral element for JOIN) is currently not supported by QLever");
+        "After removing all UNDEF values and variables, a VALUES clause was "
+        "found to be empty. Such an operation result (the neutral element for "
+        "JOIN) is currently not supported by QLever");
   }
+
   return std::move(values);
 }
 
 // ____________________________________________________________________________
+void Values::computeResult(ResultTable* result) {
+  // Set basic properties of the result table.
+  result->_sortedBy = resultSortedOn();
+  result->_idTable.setNumColumns(getResultWidth());
+  result->_resultTypes.resize(parsedValues_._variables.size(),
+                              ResultTable::ResultType::KB);
+
+  // Fill the result table using the `writeValues` method below.
+  size_t resWidth = getResultWidth();
+  CALL_FIXED_SIZE(resWidth, &Values::writeValues, this, result);
+}
+
+// ____________________________________________________________________________
 template <size_t I>
-void Values::writeValues(IdTable* res, const Index& index,
-                         const SparqlValues& values,
-                         std::shared_ptr<LocalVocab> localVocab) {
-  IdTableStatic<I> result = std::move(*res).toStatic<I>();
-  result.resize(values._values.size());
-  size_t numTuples = 0;
-  std::vector<size_t> numLocalVocabPerColumn(result.numColumns());
-  for (const auto& row : values._values) {
-    for (size_t colIdx = 0; colIdx < result.numColumns(); colIdx++) {
-      const TripleComponent& tc = row[colIdx];
-      std::optional<Id> id = tc.toValueId(index.getVocab());
-      if (!id) {
-        AD_CONTRACT_CHECK(tc.isString());
-        auto& newWord = tc.getString();
+void Values::writeValues(ResultTable* result) {
+  IdTableStatic<I> idTable = std::move(result->_idTable).toStatic<I>();
+  idTable.resize(parsedValues_._values.size());
+  size_t rowIdx = 0;
+  std::vector<size_t> numLocalVocabPerColumn(idTable.numColumns());
+  for (auto& row : parsedValues_._values) {
+    for (size_t colIdx = 0; colIdx < idTable.numColumns(); colIdx++) {
+      TripleComponent& tc = row[colIdx];
+      Id id = std::move(tc).toValueId(getIndex().getVocab(),
+                                      *result->getLocalVocab());
+      idTable(rowIdx, colIdx) = id;
+      if (id.getDatatype() == Datatype::LocalVocabIndex) {
         ++numLocalVocabPerColumn[colIdx];
-        id = Id::makeFromLocalVocabIndex(
-            localVocab->getIndexAndAddIfNotContained(std::move(newWord)));
       }
-      result(numTuples, colIdx) = id.value();
     }
-    numTuples++;
+    rowIdx++;
   }
-  AD_CONTRACT_CHECK(numTuples == values._values.size());
-  LOG(INFO) << "Number of tuples in VALUES clause: " << numTuples << std::endl;
-  LOG(DEBUG) << "Number of entries in local vocabulary per column: "
-             << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
-  result.resize(numTuples);
-  *res = std::move(result).toDynamic();
+  AD_CORRECTNESS_CHECK(rowIdx == parsedValues_._values.size());
+  LOG(INFO) << "Number of tuples in VALUES clause: " << rowIdx << std::endl;
+  LOG(INFO) << "Number of entries in local vocabulary per column: "
+            << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
+  result->_idTable = std::move(idTable).toDynamic();
 }

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -18,6 +18,11 @@
 Values::Values(QueryExecutionContext* qec, SparqlValues parsedValues)
     : Operation(qec) {
   parsedValues_ = sanitizeValues(std::move(parsedValues));
+
+  AD_CONTRACT_CHECK(
+      std::ranges::all_of(parsedValues_._values, [&](const auto& row) {
+        return row.size() == parsedValues_._variables.size();
+      }));
 }
 
 // ____________________________________________________________________________
@@ -85,7 +90,8 @@ void Values::computeMultiplicities() {
       distinctValues.insert(valuesTuple[col]);
     }
     size_t numDistinctValues = distinctValues.size();
-    multiplicities_[col] = float(numValues) / float(numDistinctValues);
+    multiplicities_[col] =
+        static_cast<float>(numValues) / static_cast<float>(numDistinctValues);
   }
 }
 

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -53,11 +53,6 @@ class Values : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
  private:
-  // Remove all UNDEF values and with it all tuples with only UNDEF values as
-  // well as variables with only UNDEF values. Throws an exception if nothing
-  // remains.
-  SparqlValues sanitizeValues(SparqlValues&& values);
-
   // Compute the per-column multiplicity of the parsed values.
   void computeMultiplicities();
 

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -13,14 +13,14 @@ class Values : public Operation {
   using SparqlValues = parsedQuery::SparqlValues;
 
  private:
-  std::vector<size_t> _multiplicities;
+  std::vector<size_t> multiplicities_;
 
-  SparqlValues _values;
+  SparqlValues parsedValues_;
 
  public:
-  /// constructor sanitizes the input by removing completely undefined variables
-  /// and values.
-  Values(QueryExecutionContext* qec, SparqlValues values);
+  // Create operation from parsed values. This calls `sanitizeValues`.
+  // and values.
+  Values(QueryExecutionContext* qec, SparqlValues parsedValues);
 
  protected:
   virtual string asStringImpl(size_t indent = 0) const override;
@@ -35,7 +35,7 @@ class Values : public Operation {
   virtual void setTextLimit(size_t limit) override { (void)limit; }
 
   virtual bool knownEmptyResult() override {
-    return _values._variables.empty() || _values._values.empty();
+    return parsedValues_._variables.empty() || parsedValues_._values.empty();
   }
 
   virtual float getMultiplicity(size_t col) override;
@@ -53,13 +53,18 @@ class Values : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
  private:
-  template <size_t I>
-  void writeValues(IdTable* res, const Index& index, const SparqlValues& values,
-                   std::shared_ptr<LocalVocab> localVocab);
-
-  /// remove all completely undefined values and variables
-  /// throw if nothing remains
+  // Remove all UNDEF values and with it all tuples with only UNDEF values as
+  // well as variables with only UNDEF values. Throws an exception if nothing
+  // remains.
   SparqlValues sanitizeValues(SparqlValues&& values);
 
+  // Compute the per-column multiplicity of the parsed values.
   void computeMultiplicities();
+
+  // Write `parsedValues_` to the given result object.
+  //
+  // NOTE: this moves the values out of `parsedValues_` (to save a string copy
+  // for those values that end up in the local vocabulary).
+  template <size_t I>
+  void writeValues(ResultTable* result);
 };

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -13,7 +13,7 @@ class Values : public Operation {
   using SparqlValues = parsedQuery::SparqlValues;
 
  private:
-  std::vector<size_t> multiplicities_;
+  std::vector<float> multiplicities_;
 
   SparqlValues parsedValues_;
 
@@ -23,7 +23,7 @@ class Values : public Operation {
   Values(QueryExecutionContext* qec, SparqlValues parsedValues);
 
  protected:
-  virtual string asStringImpl(size_t indent = 0) const override;
+  virtual string asStringImpl(size_t indent) const override;
 
  public:
   virtual string getDescriptor() const override;

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -14,10 +14,7 @@ namespace parsedQuery {
 
 // _____________________________________________________________________________
 std::string SparqlValues::variablesToString() const {
-  return absl::StrJoin(_variables, " ",
-                       [](std::string* out, const Variable& variable) {
-                         out->append(variable.name());
-                       });
+  return absl::StrJoin(_variables, "\t", Variable::AbslFormatter);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -11,6 +11,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/GraphPattern.h"
 #include "parser/TripleComponent.h"
+#include "parser/data/VarOrTerm.h"
 #include "parser/data/Variable.h"
 #include "util/Algorithm.h"
 #include "util/VisitMixin.h"
@@ -35,7 +36,7 @@ struct SparqlValues {
   std::vector<Variable> _variables;
   // A table storing the values in their string form
   std::vector<std::vector<TripleComponent>> _values;
-  // The `_variable` as a string, in the format like so: "?x ?y ?z".
+  // The `_variables` as a string, in the format like so: "?x ?y ?z".
   std::string variablesToString() const;
   // The `_values` as a string, in the format like so: "(<v12> <v12> <v13>)
   // (<v21> <v22> <v23>)".

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -56,13 +56,15 @@ void SelectClause::setSelected(std::vector<Variable> variables) {
   setSelected(v);
 }
 
-// ____________________________________________________________________
+// ____________________________________________________________________________
 [[nodiscard]] const std::vector<Variable>& SelectClause::getSelectedVariables()
     const {
   return isAsterisk()
              ? visibleVariables_
              : std::get<VarsAndAliases>(varsAndAliasesOrAsterisk_).vars_;
 }
+
+// ____________________________________________________________________________
 [[nodiscard]] std::vector<std::string>
 SelectClause::getSelectedVariablesAsStrings() const {
   std::vector<std::string> result;

--- a/src/parser/SelectClause.h
+++ b/src/parser/SelectClause.h
@@ -51,7 +51,7 @@ struct SelectClause : ClauseBase {
   [[nodiscard]] bool isAsterisk() const;
 
   // Set the selector to '*', which means that all variables for which
-  // `addVariableForAsterisk()` is called are implicitly selected.
+  // `addVisibleVariable()` is called are implicitly selected.
   void setAsterisk();
 
   // Set the (manually) selected variables and aliases. All variables

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -10,9 +10,13 @@ using AntlrParser = SparqlAutomaticParser;
 
 // _____________________________________________________________________________
 ParsedQuery SparqlParser::parseQuery(std::string query) {
+  // The second argument is the `PrefixMap` for QLever's internal IRIs.
   sparqlParserHelpers::ParserAndVisitor p{
       std::move(query),
       {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+  // Note: `AntlrParser::query` is a method of `AntlrParser` (which is an alias
+  // for `SparqlAutomaticParser`) that returns the `QueryContext*` for the whole
+  // query.
   auto resultOfParseAndRemainingText = p.parseTypesafe(&AntlrParser::query);
   // The query rule ends with <EOF> so the parse always has to consume the whole
   // input. If this is not the case a ParseException should have been thrown at

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -10,7 +10,7 @@ namespace sparqlParserHelpers {
 using std::string;
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string input)
+ParserAndVisitor::ParserAndVisitor(std::string input)
     : input_{std::move(input)}, visitor_{} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
@@ -22,7 +22,7 @@ ParserAndVisitor::ParserAndVisitor(string input)
 }
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string input,
+ParserAndVisitor::ParserAndVisitor(std::string input,
                                    SparqlQleverVisitor::PrefixMap prefixes)
     : ParserAndVisitor{std::move(input)} {
   visitor_.setPrefixMapManually(std::move(prefixes));

--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -13,6 +13,8 @@ std::ostream& operator<<(std::ostream& stream, const TripleComponent& obj) {
       [&stream]<typename T>(const T& value) -> void {
         if constexpr (std::is_same_v<T, Variable>) {
           stream << value.name();
+        } else if constexpr (std::is_same_v<T, TripleComponent::UNDEF>) {
+          stream << "UNDEF";
         } else {
           stream << value;
         }

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -29,9 +29,6 @@ class TripleComponent {
     bool operator==(const UNDEF&) const = default;
     // Hash to arbitrary (fixed) value. For example, needed in
     // `Values::computeMultiplicities`.
-    //
-    // TODO: Without this, the code seg faults when creating a `VALUES` caluse
-    // containing an `UNDEF` value. Report this to the `absl` people.
     template <typename H>
     friend H AbslHashValue(H h, [[maybe_unused]] const UNDEF& undef) {
       return H::combine(std::move(h), 42);
@@ -106,8 +103,12 @@ class TripleComponent {
   bool operator==(const TripleComponent&) const = default;
 
   /// Hash value for `TripleComponent` object.
+  /// Note: It is important to use `std::same_as` because otherwise this
+  /// overload would also be eligible for the contained types that are
+  /// implicitly convertible to `TripleComponent` which would lead to strange
+  /// bugs.
   template <typename H>
-  friend H AbslHashValue(H h, const TripleComponent& tc) {
+  friend H AbslHashValue(H h, const std::same_as<TripleComponent> auto& tc) {
     return H::combine(std::move(h), tc._variant);
   }
 

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -33,7 +33,7 @@ class TripleComponent {
     // TODO: Without this, the code seg faults when creating a `VALUES` caluse
     // containing an `UNDEF` value. Report this to the `absl` people.
     template <typename H>
-    friend H AbslHashValue(H h, const UNDEF& undef) {
+    friend H AbslHashValue(H h, [[maybe_unused]] const UNDEF& undef) {
       return H::combine(std::move(h), 42);
     }
   };

--- a/src/parser/data/VarOrTerm.h
+++ b/src/parser/data/VarOrTerm.h
@@ -7,14 +7,15 @@
 #include <string>
 #include <variant>
 
-#include "../../engine/ResultTable.h"
-#include "../../index/Index.h"
-#include "../../util/VisitMixin.h"
-#include "./GraphTerm.h"
-#include "./Variable.h"
+#include "engine/ResultTable.h"
+#include "index/Index.h"
+#include "parser/data/GraphTerm.h"
+#include "parser/data/Variable.h"
+#include "util/VisitMixin.h"
 
 using VarOrTermBase = std::variant<Variable, GraphTerm>;
 
+// TODO: This class should have some documentation.
 class VarOrTerm : public VarOrTermBase,
                   public VisitMixin<VarOrTerm, VarOrTermBase> {
  public:

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -35,7 +35,7 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
     size_t index = variableColumns.at(*this);
     auto id = idTable(row, index);
     auto optionalStringAndType = ExportQueryExecutionTrees::idToStringAndType(
-        qecIndex, id, *res._localVocab);
+        qecIndex, id, *res.getLocalVocab());
     if (!optionalStringAndType.has_value()) {
       return std::nullopt;
     }

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -35,7 +35,7 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
     size_t index = variableColumns.at(*this);
     auto id = idTable(row, index);
     auto optionalStringAndType = ExportQueryExecutionTrees::idToStringAndType(
-        qecIndex, id, *res.getLocalVocab());
+        qecIndex, id, res.getLocalVocab());
     if (!optionalStringAndType.has_value()) {
       return std::nullopt;
     }

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -35,7 +35,7 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
     size_t index = variableColumns.at(*this);
     auto id = idTable(row, index);
     auto optionalStringAndType = ExportQueryExecutionTrees::idToStringAndType(
-        qecIndex, id, res.getLocalVocab());
+        qecIndex, id, res.localVocab());
     if (!optionalStringAndType.has_value()) {
       return std::nullopt;
     }

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -47,4 +47,9 @@ class Variable {
   friend H AbslHashValue(H h, const Variable& v) {
     return H::combine(std::move(h), v._name);
   }
+
+  // Formatter for use in `absl::StrJoin` (we need this in several places).
+  static void AbslFormatter(std::string* out, const Variable& variable) {
+    out->append(variable.name());
+  }
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -695,10 +695,6 @@ uint64_t Visitor::visit(Parser::TextLimitClauseContext* ctx) {
 SparqlValues Visitor::visit(Parser::InlineDataOneVarContext* ctx) {
   SparqlValues values;
   values._variables.push_back(visit(ctx->var()));
-  if (ctx->dataBlockValue().empty())
-    reportError(ctx,
-                "No values were specified in Values "
-                "clause. This is not supported by QLever.");
   for (auto& dataBlockValue : ctx->dataBlockValue()) {
     values._values.push_back({visit(dataBlockValue)});
   }
@@ -708,14 +704,6 @@ SparqlValues Visitor::visit(Parser::InlineDataOneVarContext* ctx) {
 // ____________________________________________________________________________________
 SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
   SparqlValues values;
-  if (ctx->dataBlockSingle().empty())
-    reportError(ctx,
-                "No values were specified in Values "
-                "clause. This is not supported by QLever.");
-  if (ctx->NIL())
-    reportError(ctx,
-                "No variables were specified in Values "
-                "clause. This is not supported by QLever.");
   values._variables = visitVector(ctx->var());
   values._values = visitVector(ctx->dataBlockSingle());
   if (std::any_of(values._values.begin(), values._values.end(),
@@ -732,7 +720,7 @@ SparqlValues Visitor::visit(Parser::InlineDataFullContext* ctx) {
 // ____________________________________________________________________________________
 vector<TripleComponent> Visitor::visit(Parser::DataBlockSingleContext* ctx) {
   if (ctx->NIL()) {
-    reportNotSupported(ctx, "Empty VALUES clauses are");
+    return {};
   }
   return visitVector(ctx->dataBlockValue());
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -749,13 +749,12 @@ TripleComponent Visitor::visit(Parser::DataBlockValueContext* ctx) {
     return std::visit(
         [](auto intOrDouble) { return TripleComponent{intOrDouble}; },
         visit(ctx->numericLiteral()));
-  } else if (ctx->booleanLiteral()) {
-    // TODO implement
-    reportError(ctx, "Booleans in values clauses are not supported.");
+  } else if (ctx->UNDEF()) {
+    return TripleComponent::UNDEF{};
   } else {
-    AD_CORRECTNESS_CHECK(ctx->UNDEF());
-    // TODO implement
-    reportError(ctx, "UNDEF in values clauses is not supported.");
+    // TODO implement.
+    AD_CORRECTNESS_CHECK(ctx->booleanLiteral());
+    reportError(ctx, "Booleans in VALUES clauses are not supported");
   }
 }
 

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -1,16 +1,19 @@
-// Copyright 2022, University of Freiburg,
+// Copyright 2022 - 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+// Authors: Julian Mundhahs <mundhahj@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #ifndef QLEVER_ALGORITHM_H
 #define QLEVER_ALGORITHM_H
 
+#include <algorithm>
 #include <numeric>
 #include <string>
 #include <string_view>
 #include <utility>
 
 #include "util/Forward.h"
+#include "util/HashSet.h"
 #include "util/Iterators.h"
 #include "util/TypeTraits.h"
 
@@ -84,7 +87,8 @@ auto transform(Range&& input, F unaryOp) {
 template <typename T>
 std::vector<T> flatten(std::vector<std::vector<T>>&& input) {
   std::vector<T> out;
-  // Reserve the total required space. It is the sum of all the vectors lengths.
+  // Reserve the total required space. It is the sum of all the vectors
+  // lengths.
   out.reserve(std::accumulate(
       input.begin(), input.end(), 0,
       [](size_t i, const std::vector<T>& elem) { return i + elem.size(); }));
@@ -93,6 +97,27 @@ std::vector<T> flatten(std::vector<std::vector<T>>&& input) {
     appendVector(out, std::move(sub));
   }
   return out;
+}
+
+// Remove duplicates in the given vector without changing the order. For
+// example: 4, 6, 6, 2, 2, 4, 2 becomes 4, 6, 2.
+//
+// NOTE: This makes two copies of the first element in `input` with a
+// particular value. One copy for the result, and one copy for the hash set
+// used to keep track of which values we have already seen. One of these
+// copies could be avoided, but our current uses of this function are
+// currently not at all performance-critical (small `input` and small `T`).
+template <typename T>
+std::vector<T> removeDuplicates(const std::vector<T>& input) {
+  std::vector<T> result;
+  ad_utility::HashSet<T> distinctElements;
+  for (const T& element : input) {
+    if (!distinctElements.contains(element)) {
+      result.emplace_back(element);
+      distinctElements.insert(element);
+    }
+  }
+  return result;
 }
 
 }  // namespace ad_utility

--- a/src/util/GeoSparqlHelpers.cpp
+++ b/src/util/GeoSparqlHelpers.cpp
@@ -4,9 +4,6 @@
 
 #include "./GeoSparqlHelpers.h"
 
-#include <absl/strings/charconv.h>
-#include <ctre/ctre.h>
-
 #include <cmath>
 #include <limits>
 #include <numbers>
@@ -15,6 +12,8 @@
 #include <string_view>
 
 #include "./Exception.h"
+#include "absl/strings/charconv.h"
+#include "ctre/ctre.h"
 
 namespace ad_utility {
 

--- a/test/AlgorithmTest.cpp
+++ b/test/AlgorithmTest.cpp
@@ -1,6 +1,7 @@
-//  Copyright 2023, University of Freiburg,
-//                  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2023, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include <gtest/gtest.h>
 
@@ -10,6 +11,7 @@
 
 using namespace ad_utility;
 
+// _____________________________________________________________________________
 TEST(Algorithm, Contains) {
   std::vector v{1, 42, 5, 3};
   ASSERT_TRUE(
@@ -54,6 +56,7 @@ TEST(Algorithm, Contains) {
   testStringLike.template operator()<std::string_view>();
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, ContainsIF) {
   std::vector v{1, 3, 42};
   ASSERT_TRUE(contains_if(v, [](const auto& el) { return el > 5; }));
@@ -63,6 +66,7 @@ TEST(Algorithm, ContainsIF) {
   ASSERT_FALSE(contains_if(v, [](const auto& el) { return el < 0; }));
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, AppendVector) {
   using V = std::vector<std::string>;
   V v{"1", "2", "7"};
@@ -82,6 +86,7 @@ TEST(Algorithm, AppendVector) {
   ASSERT_TRUE(v3[1].empty());
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, Transform) {
   std::vector<std::string> v{"hi", "bye", "why"};
   auto vCopy = v;
@@ -99,6 +104,7 @@ TEST(Algorithm, Transform) {
   ASSERT_TRUE(std::ranges::all_of(v, &std::string::empty));
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, Flatten) {
   std::vector<std::vector<std::string>> v{{"hi"}, {"bye", "why"}, {"me"}};
   auto v3 = flatten(std::move(v));
@@ -109,3 +115,20 @@ TEST(Algorithm, Flatten) {
     return std::ranges::all_of(inner, &std::string::empty);
   }));
 }
+
+// _____________________________________________________________________________
+TEST(AlgorithmTest, removeDuplicates) {
+  // Test with ints.
+  ASSERT_EQ(ad_utility::removeDuplicates(std::vector<int>{4, 6, 6, 2, 2, 4, 2}),
+            (std::vector<int>{4, 6, 2}));
+  // Test with strings.
+  std::string s1 = "four";
+  std::string s2 = "six";
+  std::string s3 = "abcdefghijklmnopqrstuvwxzy";
+  ASSERT_EQ(ad_utility::removeDuplicates(
+                std::vector<std::string>{s1, s2, s1, s1, s3, s1, s3}),
+            (std::vector<std::string>{s1, s2, s3}));
+  // Test with empty input.
+  ASSERT_EQ(ad_utility::removeDuplicates(std::vector<int>{}),
+            (std::vector<int>{}));
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -288,10 +288,6 @@ addLinkAndDiscoverTest(CompressedRelationsTest index)
 
 addLinkAndDiscoverTest(ExceptionTest)
 
-addLinkAndDiscoverTest(CompressedRelationsTest index)
-
-addLinkAndDiscoverTest(ExceptionTest)
-
 addLinkAndDiscoverTestSerial(RandomExpressionTest absl::flat_hash_map index)
 
 addLinkAndDiscoverTestSerial(SortTest engine)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -270,6 +270,8 @@ addLinkAndDiscoverTestSerial(RegexExpressionTest parser sparqlExpressions index 
 
 addLinkAndDiscoverTestSerial(LocalVocabTest engine)
 
+addLinkAndDiscoverTest(ValuesTest engine)
+
 addLinkAndDiscoverTest(HttpTest boost_iostreams http)
 
 addLinkAndDiscoverTest(CallFixedSizeTest)
@@ -280,7 +282,11 @@ addLinkAndDiscoverTest(ResetWhenMovedTest)
 
 addLinkAndDiscoverTest(TimerTest absl::strings)
 
-addLinkAndDiscoverTest(AlgorithmTest)
+addLinkAndDiscoverTest(AlgorithmTest absl::flat_hash_set)
+
+addLinkAndDiscoverTest(CompressedRelationsTest index)
+
+addLinkAndDiscoverTest(ExceptionTest)
 
 addLinkAndDiscoverTest(CompressedRelationsTest index)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -270,7 +270,7 @@ addLinkAndDiscoverTestSerial(RegexExpressionTest parser sparqlExpressions index 
 
 addLinkAndDiscoverTestSerial(LocalVocabTest engine)
 
-addLinkAndDiscoverTest(ValuesTest engine)
+addLinkAndDiscoverTestSerial(ValuesTest engine)
 
 addLinkAndDiscoverTest(HttpTest boost_iostreams http)
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -87,7 +87,7 @@ TEST_F(GroupByTest, doGroupBy) {
     floatBuffers[i] = Id::makeFromDouble(floatValues[i]);
   }
 
-  // add some words to the index's vocabulary
+  // Add some words to the index's vocabulary.
   auto& vocab = const_cast<RdfsVocabulary&>(_index.getVocab());
   ad_utility::HashSet<std::string> s;
   s.insert("<entity1>");
@@ -98,15 +98,14 @@ TEST_F(GroupByTest, doGroupBy) {
   s.insert(ad_utility::convertFloatStringToIndexWord("17"));
   vocab.createFromSet(s);
 
-  // create an input result table with a local vocabulary
+  // Create an input result table with a local vocabulary.
   ResultTable inTable{makeAllocator()};
-  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local1>");
-  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local2>");
-  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local3>");
+  inTable.getLocalVocabNonConst().getIndexAndAddIfNotContained("<local1>");
+  inTable.getLocalVocabNonConst().getIndexAndAddIfNotContained("<local2>");
+  inTable.getLocalVocabNonConst().getIndexAndAddIfNotContained("<local3>");
 
   IdTable inputData(6, makeAllocator());
-  // The input data types are
-  //                   KB, KB, VERBATIM, TEXT, FLOAT,           STRING
+  // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.
   inputData.push_back({I(1), I(4), I(123), I(0), floatBuffers[0], I(0)});
   inputData.push_back({I(1), I(5), I(0), I(1), floatBuffers[1], I(1)});
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -100,9 +100,9 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // Create an input result table with a local vocabulary.
   ResultTable inTable{makeAllocator()};
-  inTable.getLocalVocabNonConst().getIndexAndAddIfNotContained("<local1>");
-  inTable.getLocalVocabNonConst().getIndexAndAddIfNotContained("<local2>");
-  inTable.getLocalVocabNonConst().getIndexAndAddIfNotContained("<local3>");
+  inTable.localVocabNonConst().getIndexAndAddIfNotContained("<local1>");
+  inTable.localVocabNonConst().getIndexAndAddIfNotContained("<local2>");
+  inTable.localVocabNonConst().getIndexAndAddIfNotContained("<local3>");
 
   IdTable inputData(6, makeAllocator());
   // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -100,9 +100,9 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // create an input result table with a local vocabulary
   ResultTable inTable{makeAllocator()};
-  inTable._localVocab->getIndexAndAddIfNotContained("<local1>");
-  inTable._localVocab->getIndexAndAddIfNotContained("<local2>");
-  inTable._localVocab->getIndexAndAddIfNotContained("<local3>");
+  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local1>");
+  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local2>");
+  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local3>");
 
   IdTable inputData(6, makeAllocator());
   // The input data types are

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -119,11 +119,9 @@ TEST(LocalVocab, clone) {
 
 // _____________________________________________________________________________
 TEST(LocalVocab, propagation) {
-  // Query execution context (with small test index) and allocator for testing,
-  // see `IndexTestHelpers.h`.
+  // Query execution context (with small test index), see `IndexTestHelpers.h`.
   using ad_utility::AllocatorWithLimit;
   QueryExecutionContext* testQec = ad_utility::testing::getQec();
-  AllocatorWithLimit<Id> testAllocator = ad_utility::testing::makeAllocator();
 
   // Lambda that checks the contents of the local vocabulary after the specified
   // operation.
@@ -136,9 +134,9 @@ TEST(LocalVocab, propagation) {
     ASSERT_TRUE(resultTable)
         << "Operation: " << operation.getDescriptor() << std::endl;
     std::vector<std::string> localVocabWords;
-    for (size_t i = 0; i < resultTable->_localVocab->size(); ++i) {
+    for (size_t i = 0; i < resultTable->getLocalVocab()->size(); ++i) {
       localVocabWords.emplace_back(
-          resultTable->_localVocab->getWord(LocalVocabIndex::make(i)));
+          resultTable->getLocalVocab()->getWord(LocalVocabIndex::make(i)));
     }
     ASSERT_EQ(localVocabWords, expectedWords)
         << "Operation: " << operation.getDescriptor() << std::endl;
@@ -159,20 +157,27 @@ TEST(LocalVocab, propagation) {
 
   // VALUES operation with two variables and two rows. Adds four new literals.
   //
-  // Note: For literals, the quotes are part of the name, so if we wanted the
+  // Note 1: It is important to pass a copy of `values1` (and `values2` below)
+  // to `checkLocalVocab` because when the operation is executed, the parsed
+  // values are moved out by `Values::writeValues` and would then no longer be
+  // there in the subsequent uses of `values1` and `values2` if it were not
+  // copied.
+  //
+  // Note 2: For literals, the quotes are part of the name, so if we wanted the
   // literal "x", we would have to write TripleComponent{"\"x\""}. For the
   // purposes of this test, we just want something that's not yet in the index,
   // so "x" etc. is just fine (and also different from the "<x>" below).
-  //
   Values values1(testQec, {{Variable{"?x"}, Variable{"?y"}},
                            {{TripleComponent{"x"}, TripleComponent{"y1"}},
                             {TripleComponent{"x"}, TripleComponent{"y2"}}}});
-  checkLocalVocab(values1, std::vector<std::string>{"x", "y1", "y2"});
+  Values values1copy = values1;
+  checkLocalVocab(values1copy, std::vector<std::string>{"x", "y1", "y2"});
 
   // VALUES operation that uses an existing literal (from the test index).
   Values values2(testQec, {{Variable{"?x"}, Variable{"?y"}},
                            {{TripleComponent{"<x>"}, TripleComponent{"<y>"}}}});
-  checkLocalVocab(values2, std::vector<std::string>{});
+  Values values2copy = values2;
+  checkLocalVocab(values2copy, std::vector<std::string>{});
 
   // JOIN operation with exactly one non-empty local vocab and with two
   // non-empty local vocabs (the last two arguments are the two join columns).

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -134,9 +134,9 @@ TEST(LocalVocab, propagation) {
     ASSERT_TRUE(resultTable)
         << "Operation: " << operation.getDescriptor() << std::endl;
     std::vector<std::string> localVocabWords;
-    for (size_t i = 0; i < resultTable->getLocalVocab().size(); ++i) {
+    for (size_t i = 0; i < resultTable->localVocab().size(); ++i) {
       localVocabWords.emplace_back(
-          resultTable->getLocalVocab().getWord(LocalVocabIndex::make(i)));
+          resultTable->localVocab().getWord(LocalVocabIndex::make(i)));
     }
     ASSERT_EQ(localVocabWords, expectedWords)
         << "Operation: " << operation.getDescriptor() << std::endl;

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -134,9 +134,9 @@ TEST(LocalVocab, propagation) {
     ASSERT_TRUE(resultTable)
         << "Operation: " << operation.getDescriptor() << std::endl;
     std::vector<std::string> localVocabWords;
-    for (size_t i = 0; i < resultTable->getLocalVocab()->size(); ++i) {
+    for (size_t i = 0; i < resultTable->getLocalVocab().size(); ++i) {
       localVocabWords.emplace_back(
-          resultTable->getLocalVocab()->getWord(LocalVocabIndex::make(i)));
+          resultTable->getLocalVocab().getWord(LocalVocabIndex::make(i)));
     }
     ASSERT_EQ(localVocabWords, expectedWords)
         << "Operation: " << operation.getDescriptor() << std::endl;

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -566,11 +566,12 @@ TEST(SparqlParser, DataBlock) {
   expectDataBlock("?test { \"foo\" }",
                   m::Values({Var{"?test"}}, {{"\"foo\""}}));
   expectDataBlock("?test { 10.0 }", m::Values({Var{"?test"}}, {{10.0}}));
-  // Booleans and UNDEF are not yet parsed as `dataBlockValue`.
+  expectDataBlock("?test { UNDEF }",
+                  m::Values({Var{"?test"}}, {{TripleComponent::UNDEF{}}}));
+  // Booleans are not yet parsed as `dataBlockValue`.
   // (numericLiteral/booleanLiteral)
   // TODO<joka921/qup42> implement.
   expectDataBlockFails("?test { true }");
-  expectDataBlockFails("?test { UNDEF }");
   expectDataBlock(R"(?foo { "baz" "bar" })",
                   m::Values({Var{"?foo"}}, {{"\"baz\""}, {"\"bar\""}}));
   // TODO<joka921/qup42> implement.

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -574,7 +574,10 @@ TEST(SparqlParser, DataBlock) {
   expectDataBlockFails("?test { true }");
   expectDataBlock(R"(?foo { "baz" "bar" })",
                   m::Values({Var{"?foo"}}, {{"\"baz\""}, {"\"bar\""}}));
+  // TODO: Is this semantics correct?
+  expectDataBlock(R"(( ) { ( ) })", m::Values({}, {{}}));
   expectDataBlock(R"(( ) { })", m::Values({}, {}));
+  expectDataBlockFails("?test { ( ) }");
   expectDataBlock(R"(?foo { })", m::Values({Var{"?foo"}}, {}));
   expectDataBlock(R"(( ?foo ) { })", m::Values({Var{"?foo"}}, {}));
   expectDataBlockFails(R"(( ?foo ?bar ) { (<foo>) (<bar>) })");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -574,10 +574,9 @@ TEST(SparqlParser, DataBlock) {
   expectDataBlockFails("?test { true }");
   expectDataBlock(R"(?foo { "baz" "bar" })",
                   m::Values({Var{"?foo"}}, {{"\"baz\""}, {"\"bar\""}}));
-  // TODO<joka921/qup42> implement.
-  expectDataBlockFails(R"(( ) { })");
-  expectDataBlockFails(R"(?foo { })");
-  expectDataBlockFails(R"(( ?foo ) { })");
+  expectDataBlock(R"(( ) { })", m::Values({}, {}));
+  expectDataBlock(R"(?foo { })", m::Values({Var{"?foo"}}, {}));
+  expectDataBlock(R"(( ?foo ) { })", m::Values({Var{"?foo"}}, {}));
   expectDataBlockFails(R"(( ?foo ?bar ) { (<foo>) (<bar>) })");
   expectDataBlock(R"(( ?foo ?bar ) { (<foo> <bar>) })",
                   m::Values({Var{"?foo"}, Var{"?bar"}}, {{"<foo>", "<bar>"}}));

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -48,10 +48,6 @@ TEST(Values, basicMethods) {
 }
 
 // Check some corner cases for an empty VALUES clause.
-//
-// TODO: An empty VALUES clause currently produces a parse error ("No values
-// were specified in Values clause") in `SparqlQleverVisitor.cpp`. Shouldn't we
-// just allow it?
 TEST(Values, emptyValuesClause) {
   auto testQec = ad_utility::testing::getQec();
   Values emptyValuesOp(testQec, {});

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -120,10 +120,12 @@ TEST(Values, BasicMethods) {
     // function which will be removed soon anyway. Then we can reinstate this
     // code. But maybe we want to disallow empty VALUES clauses altogether and
     // remove that code.
+    /*
     Values emptyValuesOp(testQec, {});
     EXPECT_TRUE(emptyValuesOp.knownEmptyResult());
     // The current implementation always returns `1.0` for nonexisting columns.
     EXPECT_FLOAT_EQ(emptyValuesOp.getMultiplicity(32), 1.0);
+     */
   }
 }
 

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -93,6 +93,7 @@ TEST(Values, BasicMethods) {
                           {TC{7}, TC{42}, TC{3}}};
   Values valuesOp(testQec,
                   {{Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, values});
+  EXPECT_FALSE(valuesOp.knownEmptyResult());
   EXPECT_EQ(valuesOp.getSizeEstimate(), 4u);
   EXPECT_EQ(valuesOp.getCostEstimate(), 4u);
   EXPECT_EQ(valuesOp.getDescriptor(), "Values with variables ?x\t?y\t?z");
@@ -112,6 +113,18 @@ TEST(Values, BasicMethods) {
   ASSERT_EQ(varToCol.at(Variable{"?x"}), 0);
   ASSERT_EQ(varToCol.at(Variable{"?y"}), 1);
   ASSERT_EQ(varToCol.at(Variable{"?z"}), 2);
+
+  {
+    // Test some corner cases for an empty VALUES clause
+    // TODO<joka921> This case is currently disallowed by the `sanitizeValues`
+    // function which will be removed soon anyway. Then we can reinstate this
+    // code. But maybe we want to disallow empty VALUES clauses altogether and
+    // remove that code.
+    Values emptyValuesOp(testQec, {});
+    EXPECT_TRUE(emptyValuesOp.knownEmptyResult());
+    // The current implementation always returns `1.0` for nonexisting columns.
+    EXPECT_FLOAT_EQ(emptyValuesOp.getMultiplicity(32), 1.0);
+  }
 }
 
 TEST(Values, computeResult) {

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -1,0 +1,83 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "./IndexTestHelpers.h"
+#include "engine/ResultTable.h"
+#include "engine/Values.h"
+#include "engine/idTable/IdTable.h"
+
+using TC = TripleComponent;
+using ValuesComponents = std::vector<std::vector<TripleComponent>>;
+
+// ____________________________________________________________________________
+TEST(Values, sanitizeValues) {
+  // Query execution context (with small test index), see `IndexTestHelpers.h`.
+  using ad_utility::AllocatorWithLimit;
+  QueryExecutionContext* testQec = ad_utility::testing::getQec();
+  AllocatorWithLimit<Id> testAllocator = ad_utility::testing::makeAllocator();
+
+  // Make sure that the `UNDEF` value gets assigned `LocalVocabIndex:0`.
+  Id undefId = Id::makeFromLocalVocabIndex(LocalVocabIndex::make(0));
+
+  // Lambda for checking that the given `ResultTable` contains the given
+  // `IdTable`.
+  auto checkResult = [&](const ResultTable& result,
+                         const ValuesComponents values) -> void {
+    ASSERT_EQ(result.size(), values.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      ASSERT_EQ(result.width(), values[i].size()) << "row " << i;
+      for (size_t j = 0; j < result.width(); ++j) {
+        std::optional<Id> idOrNullIfUndef = result._idTable[i][j];
+        if (idOrNullIfUndef.value() == undefId) {
+          idOrNullIfUndef = std::nullopt;
+        }
+        ASSERT_EQ(idOrNullIfUndef,
+                  values[i][j].toValueId(testQec->getIndex().getVocab()))
+            << "row " << i << ", column " << j;
+      }
+    }
+  };
+
+  // No UNDEF values, nothing filtered out.
+  {
+    ValuesComponents values{{TC{"<x>"}, TC{"<y>"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), values);
+  }
+
+  // Some UNDEF values, but no row or columns with only UNDEF values, so nothing
+  // filtered out (but the "UNDEF" are added to the local vocabulary, which is
+  // weird, but that's how it currently is).
+  {
+    ValuesComponents values{{TC{"UNDEF"}, TC{"<y>"}}, {TC{"<x>"}, TC{"UNDEF"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), values);
+  }
+
+  // A row full of UNDEF values (which then gets removed).
+  {
+    ValuesComponents values{{TC{"<x>"}, TC{"<y>"}}, {TC{"UNDEF"}, TC{"UNDEF"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), {{TC{"<x>"}, TC{"<y>"}}});
+  }
+
+  // A column full of UNDEF values (which then gets removed).
+  {
+    ValuesComponents values{{TC{"UNDEF"}, TC{"<x>"}}, {TC{"UNDEF"}, TC{"<y>"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), {{TC{"<x>"}}, {{TC{"<y>"}}}});
+  }
+
+  // A row and a column full of UNDEF values (which both get removed).
+  {
+    ValuesComponents values{{TC{"UNDEF"}, TC{"UNDEF"}},
+                            {TC{"UNDEF"}, TC{"<y>"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), {{{TC{"<y>"}}}});
+  }
+}

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -16,76 +16,8 @@
 using TC = TripleComponent;
 using ValuesComponents = std::vector<std::vector<TripleComponent>>;
 
-// ____________________________________________________________________________
-TEST(Values, sanitizeValues) {
-  // Query execution context (with small test index), see `IndexTestHelpers.h`.
-  using ad_utility::AllocatorWithLimit;
-  QueryExecutionContext* testQec = ad_utility::testing::getQec();
-  AllocatorWithLimit<Id> testAllocator = ad_utility::testing::makeAllocator();
-
-  // Make sure that the `UNDEF` value gets assigned `LocalVocabIndex:0`.
-  Id undefId = Id::makeFromLocalVocabIndex(LocalVocabIndex::make(0));
-
-  // Lambda for checking that the given `ResultTable` contains the given
-  // `IdTable`.
-  auto checkResult = [&](const ResultTable& result,
-                         const ValuesComponents values) -> void {
-    ASSERT_EQ(result.size(), values.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      ASSERT_EQ(result.width(), values[i].size()) << "row " << i;
-      for (size_t j = 0; j < result.width(); ++j) {
-        std::optional<Id> idOrNullIfUndef = result._idTable[i][j];
-        if (idOrNullIfUndef.value() == undefId) {
-          idOrNullIfUndef = std::nullopt;
-        }
-        ASSERT_EQ(idOrNullIfUndef,
-                  values[i][j].toValueId(testQec->getIndex().getVocab()))
-            << "row " << i << ", column " << j;
-      }
-    }
-  };
-
-  // No UNDEF values, nothing filtered out.
-  {
-    ValuesComponents values{{TC{"<x>"}, TC{"<y>"}}};
-    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
-    checkResult(*valuesOperation.getResult(), values);
-  }
-
-  // Some UNDEF values, but no row or columns with only UNDEF values, so nothing
-  // filtered out (but the "UNDEF" are added to the local vocabulary, which is
-  // weird, but that's how it currently is).
-  {
-    ValuesComponents values{{TC{"UNDEF"}, TC{"<y>"}}, {TC{"<x>"}, TC{"UNDEF"}}};
-    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
-    checkResult(*valuesOperation.getResult(), values);
-  }
-
-  // A row full of UNDEF values (which then gets removed).
-  {
-    ValuesComponents values{{TC{"<x>"}, TC{"<y>"}}, {TC{"UNDEF"}, TC{"UNDEF"}}};
-    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
-    checkResult(*valuesOperation.getResult(), {{TC{"<x>"}, TC{"<y>"}}});
-  }
-
-  // A column full of UNDEF values (which then gets removed).
-  {
-    ValuesComponents values{{TC{"UNDEF"}, TC{"<x>"}}, {TC{"UNDEF"}, TC{"<y>"}}};
-    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
-    checkResult(*valuesOperation.getResult(), {{TC{"<x>"}}, {{TC{"<y>"}}}});
-  }
-
-  // A row and a column full of UNDEF values (which both get removed).
-  {
-    ValuesComponents values{{TC{"UNDEF"}, TC{"UNDEF"}},
-                            {TC{"UNDEF"}, TC{"<y>"}}};
-    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
-    checkResult(*valuesOperation.getResult(), {{{TC{"<y>"}}}});
-  }
-}
-
-// ________________________________________________________________
-TEST(Values, BasicMethods) {
+// Check the basic methods of the `Values` clause.
+TEST(Values, basicMethods) {
   QueryExecutionContext* testQec = ad_utility::testing::getQec();
   ValuesComponents values{{TC{1}, TC{2}, TC{3}},
                           {TC{5}, TC{2}, TC{3}},
@@ -113,30 +45,31 @@ TEST(Values, BasicMethods) {
   ASSERT_EQ(varToCol.at(Variable{"?x"}), 0);
   ASSERT_EQ(varToCol.at(Variable{"?y"}), 1);
   ASSERT_EQ(varToCol.at(Variable{"?z"}), 2);
-
-  {
-    // Test some corner cases for an empty VALUES clause
-    // TODO<joka921> This case is currently disallowed by the `sanitizeValues`
-    // function which will be removed soon anyway. Then we can reinstate this
-    // code. But maybe we want to disallow empty VALUES clauses altogether and
-    // remove that code.
-    /*
-    Values emptyValuesOp(testQec, {});
-    EXPECT_TRUE(emptyValuesOp.knownEmptyResult());
-    // The current implementation always returns `1.0` for nonexisting columns.
-    EXPECT_FLOAT_EQ(emptyValuesOp.getMultiplicity(32), 1.0);
-     */
-  }
 }
 
+// Check some corner cases for an empty VALUES clause.
+//
+// TODO: An empty VALUES clause currently produces a parse error ("No values
+// were specified in Values clause") in `SparqlQleverVisitor.cpp`. Shouldn't we
+// just allow it?
+TEST(Values, emptyValuesClause) {
+  auto testQec = ad_utility::testing::getQec();
+  Values emptyValuesOp(testQec, {});
+  EXPECT_TRUE(emptyValuesOp.knownEmptyResult());
+  // The current implementation always returns `1.0` for nonexisting columns.
+  EXPECT_FLOAT_EQ(emptyValuesOp.getMultiplicity(32), 1.0);
+}
+
+// Check that `computeResult`, given a parsed VALUES clause, computes the
+// correct result table.
 TEST(Values, computeResult) {
-  auto qec = ad_utility::testing::getQec("<x> <x> <x> .");
+  auto testQec = ad_utility::testing::getQec("<x> <x> <x> .");
   ValuesComponents values{{TC{12}, TC{"<x>"}}, {TC::UNDEF{}, TC{"<y>"}}};
-  Values valuesOperation(qec, {{Variable{"?x"}, Variable{"?y"}}, values});
+  Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
   auto result = valuesOperation.getResult();
   const auto& table = result->_idTable;
   Id x;
-  bool success = qec->getIndex().getId("<x>", &x);
+  bool success = testQec->getIndex().getId("<x>", &x);
   AD_CORRECTNESS_CHECK(success);
   auto I = ad_utility::testing::IntId;
   auto L = ad_utility::testing::LocalVocabId;
@@ -144,6 +77,8 @@ TEST(Values, computeResult) {
   ASSERT_EQ(table, makeIdTableFromIdVector({{I(12), x}, {U, L(0)}}));
 }
 
+// Check that if the number of variables and the number of values in each row
+// are not all equal, an exception is thrown.
 TEST(Values, illegalInput) {
   auto qec = ad_utility::testing::getQec();
   ValuesComponents values{{TC{12}, TC{"<x>"}}, {TC::UNDEF{}}};

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -7,6 +7,8 @@
 #include <vector>
 
 #include "./IndexTestHelpers.h"
+#include "./util/IdTableHelpers.h"
+#include "./util/IdTestHelpers.h"
 #include "engine/ResultTable.h"
 #include "engine/Values.h"
 #include "engine/idTable/IdTable.h"
@@ -80,4 +82,55 @@ TEST(Values, sanitizeValues) {
     Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
     checkResult(*valuesOperation.getResult(), {{{TC{"<y>"}}}});
   }
+}
+
+// ________________________________________________________________
+TEST(Values, BasicMethods) {
+  QueryExecutionContext* testQec = ad_utility::testing::getQec();
+  ValuesComponents values{{TC{1}, TC{2}, TC{3}},
+                          {TC{5}, TC{2}, TC{3}},
+                          {TC{7}, TC{42}, TC{3}},
+                          {TC{7}, TC{42}, TC{3}}};
+  Values valuesOp(testQec,
+                  {{Variable{"?x"}, Variable{"?y"}, Variable{"?z"}}, values});
+  EXPECT_EQ(valuesOp.getSizeEstimate(), 4u);
+  EXPECT_EQ(valuesOp.getCostEstimate(), 4u);
+  EXPECT_EQ(valuesOp.getDescriptor(), "Values with variables ?x\t?y\t?z");
+  EXPECT_TRUE(valuesOp.resultSortedOn().empty());
+  EXPECT_EQ(valuesOp.getResultWidth(), 3u);
+  // Col 0: 1, 5, 42, 42
+  EXPECT_FLOAT_EQ(valuesOp.getMultiplicity(0), 4.0 / 3.0);
+  // Col 2: 2, 2, 3, 3
+  EXPECT_FLOAT_EQ(valuesOp.getMultiplicity(1), 2.0f);
+  // Col 3: always `3`.
+  EXPECT_FLOAT_EQ(valuesOp.getMultiplicity(2), 4.0f);
+  // Out-of-bounds columns always return 1.
+  EXPECT_FLOAT_EQ(valuesOp.getMultiplicity(4), 1.0f);
+
+  auto varToCol = valuesOp.getExternallyVisibleVariableColumns();
+  ASSERT_EQ(varToCol.size(), 3u);
+  ASSERT_EQ(varToCol.at(Variable{"?x"}), 0);
+  ASSERT_EQ(varToCol.at(Variable{"?y"}), 1);
+  ASSERT_EQ(varToCol.at(Variable{"?z"}), 2);
+}
+
+TEST(Values, computeResult) {
+  auto qec = ad_utility::testing::getQec("<x> <x> <x> .");
+  ValuesComponents values{{TC{12}, TC{"<x>"}}, {TC::UNDEF{}, TC{"<y>"}}};
+  Values valuesOperation(qec, {{Variable{"?x"}, Variable{"?y"}}, values});
+  auto result = valuesOperation.getResult();
+  const auto& table = result->_idTable;
+  Id x;
+  bool success = qec->getIndex().getId("<x>", &x);
+  AD_CORRECTNESS_CHECK(success);
+  auto I = ad_utility::testing::IntId;
+  auto L = ad_utility::testing::LocalVocabId;
+  auto U = Id::makeUndefined();
+  ASSERT_EQ(table, makeIdTableFromIdVector({{I(12), x}, {U, L(0)}}));
+}
+
+TEST(Values, illegalInput) {
+  auto qec = ad_utility::testing::getQec();
+  ValuesComponents values{{TC{12}, TC{"<x>"}}, {TC::UNDEF{}}};
+  ASSERT_ANY_THROW(Values(qec, {{Variable{"?x"}, Variable{"?y"}}, values}));
 }

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -17,6 +17,10 @@ inline auto VocabId = [](const auto& v) {
   return Id::makeFromVocabIndex(VocabIndex::make(v));
 };
 
+inline auto LocalVocabId = [](const auto& v) {
+  return Id::makeFromLocalVocabIndex(LocalVocabIndex::make(v));
+};
+
 inline auto TextRecordId = [](const auto& t) {
   return Id::makeFromTextRecordIndex(TextRecordIndex ::make(t));
 };


### PR DESCRIPTION
Improve Values and ResultTable classes and related code

Clean up and improve the `Values` class. Most notably: in `writeValues`,
move the values out of `parsedValues_` to avoid unncessary copies.
This necessitates a change in `test/LocalVocabTest`.

In the `ResultTable` class, make `localVocab_` private and provide a
public getter and setter and use them everywhere. Also improve
the documentation of the class.

Add an algorithm for removing the duplicates in a given `std::vector`
without changing the order of the elements.

Several associated improvements in the code and also some minor
unrelated stuff I stumbled upon.