### PR TITLE
Fix the installation of Clang 15

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -74,7 +74,15 @@ jobs:
       run : sudo apt install clang-14
       if :  matrix.compiler == 'clang' && matrix.compiler-version == 14
     - name: Install clang 15
-      run:  wget https://apt.llvm.org/llvm.sh && sudo chmod +x llvm.sh && sudo ./llvm.sh 15 all # && sudo apt install clang-15
+      # The sed command fixes a bug in `llvm.sh` in combination with the latest version of
+      # `apt-key`. Without it the GPG key for the llvm repository is downloaded but deleted
+      # immediately after.
+      run:  | 
+        wget https://apt.llvm.org/llvm.sh
+        sudo chmod +x llvm.sh
+        sed   '/apt-key del/d' llvm.sh -iy
+        sudo ./llvm.sh 15 all
+        sudo apt install clang-15
       if :  matrix.compiler == 'clang' && matrix.compiler-version == 15
 
     - name: Python dependencies


### PR DESCRIPTION
There currently is a small bug in the download script for LLVM that prevents
the installation on the latest ubuntu versions. We slighly modify this script to
work around this bug.