### PR TITLE
One block cache per permutation

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -17,7 +17,7 @@ using namespace std::chrono_literals;
 void CompressedRelationReader::scan(
     const CompressedRelationMetadata& metadata,
     const vector<CompressedBlockMetadata>& blockMetadata,
-    const std::string& permutationName, ad_utility::File& file, IdTable* result,
+    ad_utility::File& file, IdTable* result,
     ad_utility::SharedConcurrentTimeoutTimer timer) const {
   AD_CONTRACT_CHECK(result->numColumns() == NumColumns);
 
@@ -77,10 +77,8 @@ void CompressedRelationReader::scan(
   // Set up a lambda, that reads this block and decompresses it to
   // the result.
   auto readIncompleteBlock = [&](const auto& block) {
-    auto cacheKey =
-        permutationName +
-        std::to_string(block._offsetsAndCompressedSize.at(0)._offsetInFile);
-
+    // A block is uniquely identified by its start position in the file.
+    auto cacheKey = block._offsetsAndCompressedSize.at(0)._offsetInFile;
     auto uncompressedBuffer = blockCache_
                                   .computeOnce(cacheKey,
                                                [&]() {

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -12,6 +12,8 @@
 #include "global/Id.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "util/BufferedVector.h"
+#include "util/Cache.h"
+#include "util/ConcurrentCache.h"
 #include "util/File.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 #include "util/Serializer/SerializeVector.h"
@@ -21,6 +23,11 @@
 
 // Forward declaration of the `IdTable` class.
 class IdTable;
+
+inline bool& globalBlockCacheIsEnabled() {
+  static bool isEnabled = false;
+  return isEnabled;
+}
 
 // Currently our indexes have two columns (the first column of a triple
 // is stored in the respective metadata). This might change in the future when
@@ -117,89 +124,6 @@ struct CompressedRelationMetadata {
 
   // Two of these are equal if all members are equal.
   bool operator==(const CompressedRelationMetadata&) const = default;
-
-  /**
-   * @brief For a permutation XYZ, retrieve all YZ for a given X.
-   *
-   * @param metadata The metadata of the given X.
-   * @param blockMetadata The metadata of the on-disk blocks for the given
-   * permutation.
-   * @param permutationName A human readable name that identifies the
-   *          permutation. It is used to uniquely identify a cache for recently
-   *          decompressed blocks.
-   * @param file The file in which the permutation is stored.
-   * @param result The ID table to which we write the result. It must have
-   * exactly two columns.
-   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
-   *          if the timer runs out during the exeuction of this function.
-   *
-   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
-   * The same `CompressedRelationWriter` (see below).
-   */
-  static void scan(const CompressedRelationMetadata& metadata,
-                   const vector<CompressedBlockMetadata>& blockMetadata,
-                   const std::string& permutationName, ad_utility::File& file,
-                   IdTable* result,
-                   ad_utility::SharedConcurrentTimeoutTimer timer);
-
-  /**
-   * @brief For a permutation XYZ, retrieve all Z for given X and Y.
-   *
-   * @param metaData The metadata of the given X.
-   * @param col1Id The ID for Y.
-   * @param blocks The metadata of the on-disk blocks for the given permutation.
-   * @param file The file in which the permutation is stored.
-   * @param result The ID table to which we write the result. It must have
-   * exactly one column.
-   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
-   *              if the timer runs out during the exeuction of this function.
-   *
-   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
-   * The same `CompressedRelationWriter` (see below).
-   */
-  static void scan(const CompressedRelationMetadata& metaData, Id col1Id,
-                   const vector<CompressedBlockMetadata>& blocks,
-                   ad_utility::File& file, IdTable* result,
-                   ad_utility::SharedConcurrentTimeoutTimer timer = nullptr);
-
- private:
-  // Read the block that is identified by the `blockMetaData` from the `file`.
-  // If `columnIndices` is `nullopt`, then all columns of the block are read,
-  // else only the specified columns are read.
-  static CompressedBlock readCompressedBlockFromFile(
-      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
-      std::optional<std::vector<size_t>> columnIndices);
-
-  // Decompress the `compressedBlock`. The number of rows that the block will
-  // have after decompression must be passed in via the `numRowsToRead`
-  // argument. It is typically obtained from the corresponding
-  // `CompressedBlockMetaData`.
-  static DecompressedBlock decompressBlock(
-      const CompressedBlock& compressedBlock, size_t numRowsToRead);
-
-  // Similar to `decompressBlock`, but the block is directly decompressed into
-  // the `table`, starting at the `offsetInTable`-th row. The `table` and the
-  // `compressedBlock` must have the same number of columns, and the `table`
-  // must have at least `numRowsToRead + offsetInTable` rows.
-  static void decompressBlockToExistingIdTable(
-      const CompressedBlock& compressedBlock, size_t numRowsToRead,
-      IdTable& table, size_t offsetInTable);
-
-  // Helper function used by `decompressBlock` and
-  // `decompressBlockToExistingIdTable`. Decompress the `compressedColumn` and
-  // store the result at the `iterator`. For the `numRowsToRead` argument, see
-  // the documentation of `decompressBlock`.
-  template <typename Iterator>
-  static void decompressColumn(const std::vector<char>& compressedColumn,
-                               size_t numRowsToRead, Iterator iterator);
-
-  // Read the block that is identified by the `blockMetaData` from the `file`,
-  // decompress and return it.
-  // If `columnIndices` is `nullopt`, then all columns of the block are read,
-  // else only the specified columns are read.
-  static DecompressedBlock readAndDecompressBlock(
-      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
-      std::optional<std::vector<size_t>> columnIndices);
 };
 
 // Serialization of the compressed "relation" meta data.
@@ -297,6 +221,105 @@ class CompressedRelationWriter {
   // size of the compressed column in the `_outfile`.
   CompressedBlockMetadata::OffsetAndCompressedSize compressAndWriteColumn(
       std::span<const Id> column);
+};
+
+/// Manage the reading of relations from disk that have been previously written
+/// using the `CompressedRelationWriter`.
+class CompressedRelationReader {
+ private:
+  // This cache stores a small number of decompressed blocks. Its current
+  // purpose is to make the e2e-tests run fast. They contain many SPARL queries
+  // with ?s ?p ?o triples in the body.
+  // Note: The cache is thread-safe and using it does not change the semantics
+  // of this class, so it is safe to mark it as `mutable` to make the `scan`
+  // functions below `const`.
+  mutable ad_utility::ConcurrentCache<
+      ad_utility::HeapBasedLRUCache<std::string, DecompressedBlock>>
+      blockCache_{20ul};
+
+ public:
+  /**
+   * @brief For a permutation XYZ, retrieve all YZ for a given X.
+   *
+   * @param metadata The metadata of the given X.
+   * @param blockMetadata The metadata of the on-disk blocks for the given
+   * permutation.
+   * @param permutationName A human readable name that identifies the
+   *          permutation. It is used to uniquely identify a cache for recently
+   *          decompressed blocks.
+   * @param file The file in which the permutation is stored.
+   * @param result The ID table to which we write the result. It must have
+   * exactly two columns.
+   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
+   *          if the timer runs out during the exeuction of this function.
+   *
+   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The same `CompressedRelationWriter` (see below).
+   */
+  void scan(const CompressedRelationMetadata& metadata,
+            const vector<CompressedBlockMetadata>& blockMetadata,
+            const std::string& permutationName, ad_utility::File& file,
+            IdTable* result,
+            ad_utility::SharedConcurrentTimeoutTimer timer) const;
+
+  /**
+   * @brief For a permutation XYZ, retrieve all Z for given X and Y.
+   *
+   * @param metaData The metadata of the given X.
+   * @param col1Id The ID for Y.
+   * @param blocks The metadata of the on-disk blocks for the given permutation.
+   * @param file The file in which the permutation is stored.
+   * @param result The ID table to which we write the result. It must have
+   * exactly one column.
+   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
+   *              if the timer runs out during the exeuction of this function.
+   *
+   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The same `CompressedRelationWriter` (see below).
+   */
+  void scan(const CompressedRelationMetadata& metaData, Id col1Id,
+            const vector<CompressedBlockMetadata>& blocks,
+            ad_utility::File& file, IdTable* result,
+            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+ private:
+  // Read the block that is identified by the `blockMetaData` from the `file`.
+  // If `columnIndices` is `nullopt`, then all columns of the block are read,
+  // else only the specified columns are read.
+  static CompressedBlock readCompressedBlockFromFile(
+      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
+      std::optional<std::vector<size_t>> columnIndices);
+
+  // Decompress the `compressedBlock`. The number of rows that the block will
+  // have after decompression must be passed in via the `numRowsToRead`
+  // argument. It is typically obtained from the corresponding
+  // `CompressedBlockMetaData`.
+  static DecompressedBlock decompressBlock(
+      const CompressedBlock& compressedBlock, size_t numRowsToRead);
+
+  // Similar to `decompressBlock`, but the block is directly decompressed into
+  // the `table`, starting at the `offsetInTable`-th row. The `table` and the
+  // `compressedBlock` must have the same number of columns, and the `table`
+  // must have at least `numRowsToRead + offsetInTable` rows.
+  static void decompressBlockToExistingIdTable(
+      const CompressedBlock& compressedBlock, size_t numRowsToRead,
+      IdTable& table, size_t offsetInTable);
+
+  // Helper function used by `decompressBlock` and
+  // `decompressBlockToExistingIdTable`. Decompress the `compressedColumn` and
+  // store the result at the `iterator`. For the `numRowsToRead` argument, see
+  // the documentation of `decompressBlock`.
+  template <typename Iterator>
+  static void decompressColumn(const std::vector<char>& compressedColumn,
+                               size_t numRowsToRead, Iterator iterator);
+
+  // Read the block that is identified by the `blockMetaData` from the `file`,
+  // decompress and return it.
+  // If `columnIndices` is `nullopt`, then all columns of the block are read,
+  // else only the specified columns are read.
+  static DecompressedBlock readAndDecompressBlock(
+      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
+      std::optional<std::vector<size_t>> columnIndices);
 };
 
 #endif  // QLEVER_COMPRESSEDRELATION_H

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -234,7 +234,7 @@ class CompressedRelationReader {
   // of this class, so it is safe to mark it as `mutable` to make the `scan`
   // functions below `const`.
   mutable ad_utility::ConcurrentCache<
-      ad_utility::HeapBasedLRUCache<std::string, DecompressedBlock>>
+      ad_utility::HeapBasedLRUCache<off_t, DecompressedBlock>>
       blockCache_{20ul};
 
  public:
@@ -244,9 +244,6 @@ class CompressedRelationReader {
    * @param metadata The metadata of the given X.
    * @param blockMetadata The metadata of the on-disk blocks for the given
    * permutation.
-   * @param permutationName A human readable name that identifies the
-   *          permutation. It is used to uniquely identify a cache for recently
-   *          decompressed blocks.
    * @param file The file in which the permutation is stored.
    * @param result The ID table to which we write the result. It must have
    * exactly two columns.
@@ -258,8 +255,7 @@ class CompressedRelationReader {
    */
   void scan(const CompressedRelationMetadata& metadata,
             const vector<CompressedBlockMetadata>& blockMetadata,
-            const std::string& permutationName, ad_utility::File& file,
-            IdTable* result,
+            ad_utility::File& file, IdTable* result,
             ad_utility::SharedConcurrentTimeoutTimer timer) const;
 
   /**

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -64,8 +64,8 @@ class PermutationImpl {
       return;
     }
     const auto& metaData = _meta.getMetaData(col0Id);
-    return _reader.scan(metaData, _meta.blockData(), _readableName, _file,
-                        result, std::move(timer));
+    return _reader.scan(metaData, _meta.blockData(), _file, result,
+                        std::move(timer));
   }
   /// For given IDs for the first and second column, retrieve all IDs of the
   /// third column, and store them in `result`. This is just a thin wrapper

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -64,9 +64,8 @@ class PermutationImpl {
       return;
     }
     const auto& metaData = _meta.getMetaData(col0Id);
-    return CompressedRelationMetadata::scan(metaData, _meta.blockData(),
-                                            _readableName, _file, result,
-                                            std::move(timer));
+    return _reader.scan(metaData, _meta.blockData(), _readableName, _file,
+                        result, std::move(timer));
   }
   /// For given IDs for the first and second column, retrieve all IDs of the
   /// third column, and store them in `result`. This is just a thin wrapper
@@ -79,8 +78,8 @@ class PermutationImpl {
     }
     const auto& metaData = _meta.getMetaData(col0Id);
 
-    return CompressedRelationMetadata::scan(metaData, col1Id, _meta.blockData(),
-                                            _file, result, timer);
+    return _reader.scan(metaData, col1Id, _meta.blockData(), _file, result,
+                        timer);
   }
 
   // _______________________________________________________
@@ -101,6 +100,8 @@ class PermutationImpl {
   MetaData _meta;
 
   mutable ad_utility::File _file;
+
+  CompressedRelationReader _reader;
 
   bool _isLoaded = false;
 };

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -97,6 +97,8 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
   auto timer = std::make_shared<ad_utility::ConcurrentTimeoutTimer>(
       ad_utility::TimeoutTimer::unlimited());
   // Check the contents of the metadata.
+
+  CompressedRelationReader reader;
   for (size_t i = 0; i < metaData.size(); ++i) {
     const auto& m = metaData[i];
     ASSERT_EQ(V(inputs[i].col0_), m._col0Id);
@@ -107,9 +109,8 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
                     m._multiplicityCol1);
     // Scan for all distinct `col0` and check that we get the expected result.
     IdTable table{2, ad_utility::testing::makeAllocator()};
-    CompressedRelationMetadata::scan(metaData[i], blocks,
-                                     testCaseName + std::to_string(blocksize),
-                                     file, &table, timer);
+    reader.scan(metaData[i], blocks, testCaseName + std::to_string(blocksize),
+                file, &table, timer);
     const auto& col1And2 = inputs[i].col1And2_;
     checkThatTablesAreEqual(col1And2, table);
 
@@ -121,8 +122,8 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
 
     auto scanAndCheck = [&]() {
       IdTable tableWidthOne{1, ad_utility::testing::makeAllocator()};
-      CompressedRelationMetadata::scan(metaData[i], V(lastCol1Id), blocks, file,
-                                       &tableWidthOne, timer);
+      reader.scan(metaData[i], V(lastCol1Id), blocks, file, &tableWidthOne,
+                  timer);
       checkThatTablesAreEqual(col3, tableWidthOne);
     };
     for (size_t j = 0; j < col1And2.size(); ++j) {

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -109,8 +109,7 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
                     m._multiplicityCol1);
     // Scan for all distinct `col0` and check that we get the expected result.
     IdTable table{2, ad_utility::testing::makeAllocator()};
-    reader.scan(metaData[i], blocks, testCaseName + std::to_string(blocksize),
-                file, &table, timer);
+    reader.scan(metaData[i], blocks, file, &table, timer);
     const auto& col1And2 = inputs[i].col1And2_;
     checkThatTablesAreEqual(col1And2, table);
 


### PR DESCRIPTION
Previously there was one small global (singleton!) cache for blocks of triples that were cached after reading them from disk and decompressing them. This caache is used to speed up the E2E tests which often read the same blocks and then only use a small portion of that block for a single query. There is now one such cache for each permutation in each index. This makes the design much cleaner and prevents strange bugs in unit tests, where different indexes accessed the same global cache.