### PR TITLE
(*TestForRebase*)Improve Values and ResultTable classes and related code(

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -1,19 +1,7 @@
-# This workflow runs as soon as the workflow from `code-coverage.yml` has
-# successfully finished. It downloads the created artifact and runs the
-# Codecov uploader. This workflow uses the `workflow_run` trigger. This
-# means that it will always be run from the master branch, meaning that
-# the contents of this file will always be taken from the master branch,
-# even if a PR changes it. Since this approach disallows several attacks
-# from malicious PR authors, such workflows have access to the secrets
-# stored on GitHub. For details on the `workflow_run` trigger and this
-# security measures, see
-# https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 name: Upload code coverage
 
 on:
   workflow_run:
-    # This has to be the `name:` of the workflow in `code_coverage.yml`.
-    # Start when this  workflow has finished successfully.
     workflows: [measure-code-coverage]
     types:
       - completed
@@ -21,17 +9,16 @@ on:
 jobs:
   upload:
     runs-on: ubuntu-latest
-    # Only run on successful pull requests. Merge commits to master upload
-    # their coverage reports directly inside `code-coverage.yml`
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: print info
+        env: 
+          GITHUB_CONTEXT: ${{toJson(github.event.workflow_run)}}
+        run: echo "$GITHUB_CONTEXT"
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0
-        # The following script is taken from the link stated at the
-        # beginning of this file. It manually downloads an artifact
-        # from another workflow.
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -51,27 +38,10 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/coverage-report.zip', Buffer.from(download.data));
       - run: unzip coverage-report.zip
-      # Read the metadata into environment variables.
+      - name: 'View files'
+        run: ls -al
       - name: "Read PR number"
         run: echo "pr_number=`cat pr`" >> $GITHUB_ENV
-      - name: "Read Github Ref"
-        run: echo "original_github_ref=`cat github_ref`" >> $GITHUB_ENV;
-      - name: "Read Github Repository"
-        run: echo "original_github_repository=`cat github_repository`" >> $GITHUB_ENV;
-        # We have to check out the source code from the PR, otherwise Codecov
-        # won't process the upload properly. We first check it out into a
-        # subdirectory `qlever-source`, otherwise the coverage report will
-        # be overwritten. We then move all the files back into the working
-        # directory such that Codecov will pick them up properly.
-      - name: "Checkout"
-        uses: actions/checkout@v3
-        with:
-          repository: ${{env.original_github_repository}}
-          submodules: "recursive"
-          ref: ${{env.original_github_ref}}
-          path: qlever-source
-      - name: "Move qlever sources up"
-        run: mv qlever-source/* .
       - name: "Upload coverage report"
         uses: codecov/codecov-action@v3
         with:
@@ -82,10 +52,10 @@ jobs:
           # public default token.
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
-          # Since this workflow runs on the master branch and not in a PR
-          # we have to specify the following settings manually to make Codecov
-          # aware of the "actual" origin of the coverage report.
           override_branch: ${{github.event.workflow_run.head_branch}}
+          # Do we need the following line to work?
           override_build: ${{github.event.workflow_run.workflow_id}}
           override_commit: ${{github.event.workflow_run.head_commit.id}}
           override_pr: ${{env.pr_number}}
+          
+         

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -87,7 +87,7 @@ void Bind::computeResult(ResultTable* result) {
 
   result->_idTable.setNumColumns(getResultWidth());
   result->_resultTypes = subRes->_resultTypes;
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
   int inwidth = subRes->_idTable.numColumns();
   int outwidth = getResultWidth();
 
@@ -115,7 +115,7 @@ void Bind::computeExpressionBind(
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), *inputResultTable._localVocab);
+      getExecutionContext()->getAllocator(), *inputResultTable.getLocalVocab());
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);
@@ -165,7 +165,7 @@ void Bind::computeExpressionBind(
         if (it != resultGenerator.end()) {
           Id constantId =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(*it), *(outputResultTable->_localVocab));
+                  std::move(*it), *(outputResultTable->getLocalVocab()));
           for (size_t i = 0; i < inSize; ++i) {
             output(i, inCols) = constantId;
           }
@@ -175,7 +175,8 @@ void Bind::computeExpressionBind(
         for (auto&& resultValue : resultGenerator) {
           output(i, inCols) =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(resultValue), *(outputResultTable->_localVocab));
+                  std::move(resultValue),
+                  *(outputResultTable->getLocalVocab()));
           i++;
         }
       }

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -136,7 +136,7 @@ void CountAvailablePredicates::computeResult(ResultTable* result) {
         &result->_idTable, hasPattern, hasPredicate, patterns);
   } else {
     std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-    result->_localVocab = subresult->_localVocab;
+    result->setLocalVocab(subresult->getLocalVocab());
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -48,7 +48,7 @@ void Distinct::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
   int width = subRes->_idTable.numColumns();
   CALL_FIXED_SIZE(width, &Engine::distinct, subRes->_idTable, _keepIndices,
                   &result->_idTable);

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -53,7 +53,7 @@ void Filter::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
 
   int width = result->_idTable.numColumns();
   CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this, result, *subRes);
@@ -74,7 +74,7 @@ void Filter::computeFilterImpl(ResultTable* outputResultTable,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inputResultTable._idTable,
-      getExecutionContext()->getAllocator(), *inputResultTable._localVocab);
+      getExecutionContext()->getAllocator(), *inputResultTable.getLocalVocab());
 
   // TODO<joka921> This should be a mandatory argument to the EvaluationContext
   // constructor.

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -177,7 +177,7 @@ void GroupBy::processGroup(
       *resultType =
           sparqlExpression::detail::expressionResultTypeToQleverResultType<T>();
       resultEntry = sparqlExpression::detail::constantExpressionResultToId(
-          singleResult, *(outTable->_localVocab));
+          singleResult, *(outTable->getLocalVocab()));
     } else {
       // This should never happen since aggregates always return constants.
       AD_FAIL();
@@ -225,7 +225,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
 
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), columnMap, inTable->_idTable,
-      getExecutionContext()->getAllocator(), *outTable->_localVocab);
+      getExecutionContext()->getAllocator(), *outTable->getLocalVocab());
 
   auto processNextBlock = [&](size_t blockStart, size_t blockEnd) {
     result.emplace_back();
@@ -285,15 +285,15 @@ void GroupBy::computeResult(ResultTable* result) {
   std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
   LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
 
-  // Make a copy of the local vocab from the sub-result and then add to it (in
+  // Make a deep copy of the local vocab from `subresult` and then add to it (in
   // case GROUP_CONCAT adds something).
   //
-  // NOTE: If we did `result->_localVocab = subresult->_localVocab` here, only a
+  // NOTE: With `result->setLocalVocab(subresult->getLocalVocab())`, only a
   // shared pointer would be copied. The the additions made in this operation
-  // would also affect the `subresult`, which leads to all kinds of unexpected
+  // would also affect `subresult`, which leads to all kinds of unexpected
   // behavior.
-  result->_localVocab =
-      std::make_shared<LocalVocab>(subresult->_localVocab->clone());
+  result->setLocalVocab(
+      std::make_shared<LocalVocab>(subresult->getLocalVocab()->clone()));
 
   std::vector<size_t> groupByColumns;
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -243,7 +243,7 @@ void HasPredicateScan::computeResult(ResultTable* result) {
     case ScanType::SUBQUERY_S:
 
       std::shared_ptr<const ResultTable> subresult = _subtree->getResult();
-      result->_localVocab = subresult->_localVocab;
+      result->setLocalVocab(subresult->getLocalVocab());
       result->_resultTypes.insert(result->_resultTypes.begin(),
                                   subresult->_resultTypes.begin(),
                                   subresult->_resultTypes.end());

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -150,8 +150,8 @@ void Join::computeResult(ResultTable* result) {
                   _rightJoinCol, &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftRes->_localVocab, rightRes->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftRes->getLocalVocab(), rightRes->getLocalVocab()));
 
   LOG(DEBUG) << "Join result computation done" << endl;
 }

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -70,8 +70,8 @@ void Minus::computeResult(ResultTable* result) {
                   _matchedColumns, &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->_localVocab, rightResult->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
 
   LOG(DEBUG) << "Minus result computation done." << endl;
 }

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -115,8 +115,8 @@ void MultiColumnJoin::computeResult(ResultTable* result) {
                   &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->_localVocab, rightResult->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
 
   LOG(DEBUG) << "MultiColumnJoin result computation done." << endl;
 }

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -121,8 +121,8 @@ void OptionalJoin::computeResult(ResultTable* result) {
                   _joinColumns, &result->_idTable);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      leftResult->_localVocab, rightResult->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      leftResult->getLocalVocab(), rightResult->getLocalVocab()));
 
   LOG(DEBUG) << "Join result computation done" << endl;
   LOG(DEBUG) << "OptionalJoin result computation done." << endl;

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -1,35 +1,27 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Author: 2015 - 2017 Björn Buchhold (buchhold@cs.uni-freiburg.de)
-// Author: 2023 -      Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
+// Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 
-#include "engine/OrderBy.h"
+#include "OrderBy.h"
 
 #include <sstream>
 
-#include "engine/CallFixedSize.h"
-#include "engine/Comparators.h"
-#include "engine/QueryExecutionTree.h"
-#include "global/ValueIdComparators.h"
+#include "CallFixedSize.h"
+#include "Comparators.h"
+#include "QueryExecutionTree.h"
 
 using std::string;
 
 // _____________________________________________________________________________
-size_t OrderBy::getResultWidth() const { return subtree_->getResultWidth(); }
+size_t OrderBy::getResultWidth() const { return _subtree->getResultWidth(); }
 
 // _____________________________________________________________________________
 OrderBy::OrderBy(QueryExecutionContext* qec,
                  std::shared_ptr<QueryExecutionTree> subtree,
                  vector<pair<size_t, bool>> sortIndices)
-    : Operation{qec},
-      subtree_{std::move(subtree)},
-      sortIndices_{std::move(sortIndices)} {
-  AD_CONTRACT_CHECK(!sortIndices_.empty());
-  AD_CONTRACT_CHECK(std::ranges::all_of(
-      sortIndices_,
-      [this](ColumnIndex index) { return index < getResultWidth(); },
-      ad_utility::first));
-}
+    : Operation(qec),
+      _subtree(std::move(subtree)),
+      _sortIndices(std::move(sortIndices)) {}
 
 // _____________________________________________________________________________
 string OrderBy::asStringImpl(size_t indent) const {
@@ -37,38 +29,53 @@ string OrderBy::asStringImpl(size_t indent) const {
   for (size_t i = 0; i < indent; ++i) {
     os << " ";
   }
-  os << "ORDER BY on columns:";
+  os << "SORT / ORDER BY on columns:";
 
   // TODO<joka921> This produces exactly the same format as SORT operations
   // which is crucial for caching. Please refactor those classes to one class
   // (this is only an optimization for sorts on a single column)
-  for (auto ind : sortIndices_) {
+  for (auto ind : _sortIndices) {
     os << (ind.second ? "desc(" : "asc(") << ind.first << ") ";
   }
-  os << "\n" << subtree_->asString(indent);
+  os << "\n" << _subtree->asString(indent);
   return std::move(os).str();
 }
 
 // _____________________________________________________________________________
 string OrderBy::getDescriptor() const {
   std::string orderByVars;
-  const auto& varCols = subtree_->getVariableColumns();
-  for (auto [sortIndex, isDescending] : sortIndices_) {
-    for (const auto& [var, varIndex] : varCols) {
-      if (sortIndex == varIndex) {
-        using namespace std::string_literals;
-        std::string s = isDescending ? " DESC("s : " ASC("s;
-        orderByVars += s + var.name() + ")";
+  for (const auto& p : _subtree->getVariableColumns()) {
+    for (auto oc : _sortIndices) {
+      if (oc.first == p.second) {
+        if (oc.second) {
+          orderByVars += "DESC(" + p.first.name() + ") ";
+        } else {
+          orderByVars += "ASC(" + p.first.name() + ") ";
+        }
       }
     }
   }
-  return "OrderBy on" + orderByVars;
+  return "OrderBy (Sort) on " + orderByVars;
+}
+
+// _____________________________________________________________________________
+vector<size_t> OrderBy::resultSortedOn() const {
+  std::vector<size_t> sortedOn;
+  sortedOn.reserve(_sortIndices.size());
+  for (const pair<size_t, bool>& p : _sortIndices) {
+    if (!p.second) {
+      // Only ascending columns count as sorted.
+      sortedOn.push_back(p.first);
+    }
+  }
+  return sortedOn;
 }
 
 // _____________________________________________________________________________
 void OrderBy::computeResult(ResultTable* result) {
-  LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
-  shared_ptr<const ResultTable> subRes = subtree_->getResult();
+  LOG(DEBUG) << "Gettign sub-result for OrderBy result computation..." << endl;
+  AD_CONTRACT_CHECK(!_sortIndices.empty());
+  shared_ptr<const ResultTable> subRes = _subtree->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
   auto remainingTime = _timeoutTimer->wlock()->remainingTime();
@@ -89,45 +96,27 @@ void OrderBy::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
-
+  result->setLocalVocab(subRes->getLocalVocab());
   result->_idTable = subRes->_idTable.clone();
+  /*
+  result->_idTable.setNumColumns(subRes->_idTable.numColumns());
+  result->_idTable.insert(result->_idTable.end(), subRes->_idTable.begin(),
+                          subRes->_idTable.end());
+                          */
 
   int width = result->_idTable.numColumns();
 
-  // TODO<joka921> Measure (as soon as we have the benchmark merged)
-  // whether it is beneficial to manually instantiate the comparison when
-  // sorting by only one or two columns.
-
-  // TODO<joka921> In the case of a single variable, it might be more efficient
-  // to first sort by the ID values and then "repair" the resulting range by
-  // some O(n) algorithms, or even by returning lazy generators that yield
-  // the repaired order.
-
-  // TODO<joka921> For proper sorting of the local vocab we also need to
-  // add some logic for the proper sorting.
-
-  // TODO<joka921> Undefined values should always be at the end, no matter
-  // if the ordering is ascending or descending.
-
-  // TODO<joka921> If we know, that all the sort columns contain only datatypes
-  // for which the `internal` order is also the `semantic` order, or if a column
-  // only contains a single datatype, then we can use more efficient
-  // implementations here.
-
-  // Return true iff `rowA` comes before `rowB` in the sort order specified by
-  // `sortIndices_`.
-  auto comparison = [this](const auto& row1, const auto& row2) -> bool {
-    for (auto& [column, isDescending] : sortIndices_) {
-      if (row1[column] == row2[column]) {
-        continue;
+  // TODO(florian): Check if the lambda is a performance problem
+  auto comparison = [this](const auto& a, const auto& b) {
+    for (auto& entry : _sortIndices) {
+      if (a[entry.first] < b[entry.first]) {
+        return !entry.second;
       }
-      bool isLessThan = valueIdComparators::compareIds<
-          valueIdComparators::ComparisonForIncompatibleTypes::CompareByType>(
-          row1[column], row2[column], valueIdComparators::Comparison::LT);
-      return isLessThan != isDescending;
+      if (a[entry.first] > b[entry.first]) {
+        return entry.second;
+      }
     }
-    return false;
+    return a[0] < b[0];
   };
 
   // We cannot use the `CALL_FIXED_SIZE` macro here because the `sort` function

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -15,23 +15,18 @@
 #include "engine/Bind.h"
 #include "engine/CountAvailablePredicates.h"
 #include "engine/Distinct.h"
-#include "engine/ExportQueryExecutionTrees.h"
 #include "engine/Filter.h"
 #include "engine/GroupBy.h"
 #include "engine/HasPredicateScan.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
-#include "engine/Minus.h"
-#include "engine/MultiColumnJoin.h"
 #include "engine/NeutralElementOperation.h"
-#include "engine/OptionalJoin.h"
 #include "engine/OrderBy.h"
 #include "engine/Sort.h"
 #include "engine/TextOperationWithFilter.h"
 #include "engine/TransitivePath.h"
 #include "engine/Union.h"
 #include "engine/Values.h"
-#include "engine/ValuesForTesting.h"
 #include "parser/RdfEscaping.h"
 
 using std::string;
@@ -122,6 +117,138 @@ QueryExecutionTree::selectedVariablesToColumnIndices(
 }
 
 // _____________________________________________________________________________
+nlohmann::json QueryExecutionTree::writeResultAsQLeverJson(
+    const SelectClause& selectClause, size_t limit, size_t offset,
+    shared_ptr<const ResultTable> resultTable) const {
+  // They may trigger computation (but does not have to).
+  if (!resultTable) {
+    resultTable = getResult();
+  }
+  LOG(DEBUG) << "Resolving strings for finished binary result...\n";
+  ColumnIndicesAndTypes validIndices =
+      selectedVariablesToColumnIndices(selectClause, *resultTable, true);
+  if (validIndices.empty()) {
+    return {std::vector<std::string>()};
+  }
+
+  return writeQLeverJsonTable(offset, limit, validIndices,
+                              std::move(resultTable));
+}
+
+// _____________________________________________________________________________
+nlohmann::json QueryExecutionTree::writeResultAsSparqlJson(
+    const SelectClause& selectClause, size_t limit, size_t offset,
+    shared_ptr<const ResultTable> resultTable) const {
+  using nlohmann::json;
+
+  // This might trigger the actual query processing.
+  if (!resultTable) {
+    resultTable = getResult();
+  }
+  LOG(DEBUG) << "Finished computing the query result in the ID space. "
+                "Resolving strings in result...\n";
+
+  // Don't include the question mark in the variable names.
+  ColumnIndicesAndTypes columns =
+      selectedVariablesToColumnIndices(selectClause, *resultTable, false);
+
+  std::erase(columns, std::nullopt);
+
+  if (columns.empty()) {
+    return {std::vector<std::string>()};
+  }
+
+  const IdTable& idTable = resultTable->_idTable;
+
+  json result;
+  std::vector<std::string> selectedVars =
+      selectClause.getSelectedVariablesAsStrings();
+  // Strip the leading '?' from the variables, it is not part of the SPARQL JSON
+  // output format.
+  for (auto& var : selectedVars) {
+    if (std::string_view{var}.starts_with('?')) {
+      var = var.substr(1);
+    }
+  }
+  result["head"]["vars"] = selectedVars;
+
+  json bindings = json::array();
+
+  const auto upperBound = std::min(idTable.size(), limit + offset);
+
+  // Take a string from the vocabulary, deduce the type and
+  // return a json dict that describes the binding
+  auto stringToBinding = [](std::string_view entitystr) -> nlohmann::json {
+    nlohmann::ordered_json b;
+    // The string is an IRI or literal.
+    if (entitystr.starts_with('<')) {
+      // Strip the <> surrounding the iri.
+      b["value"] = entitystr.substr(1, entitystr.size() - 2);
+      // Even if they are technically IRIs, the format needs the type to be
+      // "uri".
+      b["type"] = "uri";
+    } else if (entitystr.starts_with("_:")) {
+      b["value"] = entitystr.substr(2);
+      b["type"] = "bnode";
+    } else {
+      size_t quote_pos = entitystr.rfind('"');
+      if (quote_pos == std::string::npos) {
+        // TEXT entries are currently not surrounded by quotes
+        b["value"] = entitystr;
+        b["type"] = "literal";
+      } else {
+        b["value"] = entitystr.substr(1, quote_pos - 1);
+        b["type"] = "literal";
+        // Look for a language tag or type.
+        if (quote_pos < entitystr.size() - 1 &&
+            entitystr[quote_pos + 1] == '@') {
+          b["xml:lang"] = entitystr.substr(quote_pos + 2);
+        } else if (quote_pos < entitystr.size() - 2 &&
+                   entitystr[quote_pos + 1] == '^') {
+          AD_CONTRACT_CHECK(entitystr[quote_pos + 2] == '^');
+          std::string_view datatype{entitystr};
+          // remove the < angledBrackets> around the datatype IRI
+          AD_CONTRACT_CHECK(datatype.size() >= quote_pos + 5);
+          datatype.remove_prefix(quote_pos + 4);
+          datatype.remove_suffix(1);
+          b["datatype"] = datatype;
+          ;
+        }
+      }
+    }
+    return b;
+  };
+
+  for (size_t rowIndex = offset; rowIndex < upperBound; ++rowIndex) {
+    // TODO: ordered_json` entries are ordered alphabetically, but insertion
+    // order would be preferable.
+    nlohmann::ordered_json binding;
+    for (const auto& column : columns) {
+      const auto& currentId = idTable(rowIndex, column->_columnIndex);
+      const auto& optionalValue = idToStringAndType(currentId, *resultTable);
+      if (!optionalValue.has_value()) {
+        continue;
+      }
+      const auto& [stringValue, xsdType] = optionalValue.value();
+      nlohmann::ordered_json b;
+      if (!xsdType) {
+        // no xsdType, this means that `stringValue` is a plain string literal
+        // or entity
+        b = stringToBinding(stringValue);
+      } else {
+        b["value"] = stringValue;
+        b["type"] = "literal";
+        b["datatype"] = xsdType;
+      }
+      binding[column->_variable] = std::move(b);
+    }
+    bindings.emplace_back(std::move(binding));
+  }
+  result["results"]["bindings"] = std::move(bindings);
+  return result;
+}
+
+// _____________________________________________________________________________
 size_t QueryExecutionTree::getCostEstimate() {
   if (_cachedResult) {
     // result is pinned in cache. Nothing to compute
@@ -175,6 +302,299 @@ void QueryExecutionTree::readFromCache() {
   }
 }
 
+// ___________________________________________________________________________
+std::optional<std::pair<std::string, const char*>>
+QueryExecutionTree::idToStringAndType(Id id,
+                                      const ResultTable& resultTable) const {
+  // TODO<joka921> This is one of the central methods which we have to rewrite
+  switch (id.getDatatype()) {
+    case Datatype::Undefined:
+      return std::nullopt;
+    case Datatype::Double: {
+      // Format as integer if fractional part is zero, let C++ decide otherwise.
+      std::stringstream ss;
+      double d = id.getDouble();
+      double dIntPart;
+      if (std::modf(d, &dIntPart) == 0.0) {
+        ss << std::fixed << std::setprecision(0) << id.getDouble();
+      } else {
+        ss << d;
+      }
+      return std::pair{std::move(ss).str(), XSD_DECIMAL_TYPE};
+    }
+    case Datatype::Int:
+      return std::pair{std::to_string(id.getInt()), XSD_INT_TYPE};
+    case Datatype::VocabIndex: {
+      std::optional<string> entity = _qec->getIndex().idToOptionalString(id);
+      if (!entity.has_value()) {
+        return std::nullopt;
+      }
+      return std::pair{std::move(entity.value()), nullptr};
+    }
+    case Datatype::LocalVocabIndex: {
+      return std::pair{
+          resultTable.getLocalVocab()->getWord(id.getLocalVocabIndex()),
+          nullptr};
+    }
+    case Datatype::TextRecordIndex:
+      return std::pair{_qec->getIndex().getTextExcerpt(id.getTextRecordIndex()),
+                       nullptr};
+  }
+  AD_FAIL();
+}
+
+// __________________________________________________________________________________________________________
+nlohmann::json QueryExecutionTree::writeQLeverJsonTable(
+    size_t from, size_t limit, const ColumnIndicesAndTypes& columns,
+    shared_ptr<const ResultTable> resultTable) const {
+  if (!resultTable) {
+    resultTable = getResult();
+  }
+  const IdTable& data = resultTable->_idTable;
+  nlohmann::json json = nlohmann::json::array();
+
+  const auto upperBound = std::min(data.size(), limit + from);
+
+  for (size_t rowIndex = from; rowIndex < upperBound; ++rowIndex) {
+    json.emplace_back();
+    auto& row = json.back();
+    for (const auto& opt : columns) {
+      if (!opt) {
+        row.emplace_back(nullptr);
+        continue;
+      }
+      const auto& currentId = data(rowIndex, opt->_columnIndex);
+      const auto& optionalStringAndXsdType =
+          idToStringAndType(currentId, *resultTable);
+      if (!optionalStringAndXsdType.has_value()) {
+        row.emplace_back(nullptr);
+        continue;
+      }
+      const auto& [stringValue, xsdType] = optionalStringAndXsdType.value();
+      if (xsdType) {
+        row.emplace_back('"' + stringValue + "\"^^<" + xsdType + '>');
+      } else {
+        row.emplace_back(stringValue);
+      }
+    }
+  }
+  return json;
+}
+
+// _____________________________________________________________________________
+template <QueryExecutionTree::ExportSubFormat format>
+ad_utility::streams::stream_generator QueryExecutionTree::generateResults(
+    const SelectClause& selectClause, size_t limit, size_t offset) const {
+  static_assert(format == ExportSubFormat::BINARY ||
+                format == ExportSubFormat::CSV ||
+                format == ExportSubFormat::TSV);
+
+  // This call triggers the possibly expensive computation of the query result
+  // unless the result is already cached.
+  shared_ptr<const ResultTable> resultTable = getResult();
+  resultTable->logResultSize();
+  LOG(DEBUG) << "Converting result IDs to their corresponding strings ..."
+             << std::endl;
+  auto selectedColumnIndices =
+      selectedVariablesToColumnIndices(selectClause, *resultTable, true);
+
+  const auto& idTable = resultTable->_idTable;
+  size_t upperBound = std::min<size_t>(offset + limit, idTable.size());
+
+  // special case : binary export of IdTable
+  if constexpr (format == ExportSubFormat::BINARY) {
+    for (size_t i = offset; i < upperBound; ++i) {
+      for (const auto& columnIndex : selectedColumnIndices) {
+        if (columnIndex.has_value()) {
+          co_yield std::string_view{reinterpret_cast<const char*>(&idTable(
+                                        i, columnIndex.value()._columnIndex)),
+                                    sizeof(Id)};
+        }
+      }
+    }
+    co_return;
+  }
+
+  static constexpr char sep = format == ExportSubFormat::TSV ? '\t' : ',';
+  constexpr std::string_view sepView{&sep, 1};
+  // Print header line
+  const auto& variables = selectClause.getSelectedVariablesAsStrings();
+  co_yield absl::StrJoin(variables, sepView);
+  co_yield '\n';
+
+  constexpr auto& escapeFunction = format == ExportSubFormat::TSV
+                                       ? RdfEscaping::escapeForTsv
+                                       : RdfEscaping::escapeForCsv;
+
+  for (size_t i = offset; i < upperBound; ++i) {
+    for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
+      if (selectedColumnIndices[j].has_value()) {
+        const auto& val = selectedColumnIndices[j].value();
+        Id id = idTable(i, val._columnIndex);
+        switch (id.getDatatype()) {
+          case Datatype::Undefined:
+            break;
+          case Datatype::Double:
+            co_yield id.getDouble();
+            break;
+          case Datatype::Int:
+            co_yield id.getInt();
+            break;
+          case Datatype::VocabIndex:
+            co_yield escapeFunction(
+                _qec->getIndex()
+                    .getVocab()
+                    .indexToOptionalString(id.getVocabIndex())
+                    .value_or(""));
+            break;
+          case Datatype::LocalVocabIndex:
+            co_yield escapeFunction(
+                resultTable->getLocalVocab()->getWord(id.getLocalVocabIndex()));
+            break;
+          case Datatype::TextRecordIndex:
+            co_yield escapeFunction(
+                _qec->getIndex().getTextExcerpt(id.getTextRecordIndex()));
+            break;
+          default:
+            AD_THROW("Cannot deduce output type.");
+        }
+      }
+      co_yield j + 1 < selectedColumnIndices.size() ? sep : '\n';
+    }
+  }
+  LOG(DEBUG) << "Done creating readable result.\n";
+}
+
+// Instantiate template function for all enum types
+
+template ad_utility::streams::stream_generator
+QueryExecutionTree::generateResults<QueryExecutionTree::ExportSubFormat::CSV>(
+    const SelectClause& selectClause, size_t limit, size_t offset) const;
+
+template ad_utility::streams::stream_generator
+QueryExecutionTree::generateResults<QueryExecutionTree::ExportSubFormat::TSV>(
+    const SelectClause& selectClause, size_t limit, size_t offset) const;
+
+template ad_utility::streams::stream_generator QueryExecutionTree::
+    generateResults<QueryExecutionTree::ExportSubFormat::BINARY>(
+        const SelectClause& selectClause, size_t limit, size_t offset) const;
+
+// _____________________________________________________________________________
+
+cppcoro::generator<QueryExecutionTree::StringTriple>
+QueryExecutionTree::generateRdfGraph(
+    const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+    size_t offset, std::shared_ptr<const ResultTable> res) const {
+  size_t upperBound = std::min<size_t>(offset + limit, res->_idTable.size());
+  auto variableColumns = getVariableColumns();
+  for (size_t i = offset; i < upperBound; i++) {
+    Context context{i, *res, variableColumns, _qec->getIndex()};
+    for (const auto& triple : constructTriples) {
+      auto subject = triple[0].evaluate(context, SUBJECT);
+      auto predicate = triple[1].evaluate(context, PREDICATE);
+      auto object = triple[2].evaluate(context, OBJECT);
+      if (!subject.has_value() || !predicate.has_value() ||
+          !object.has_value()) {
+        continue;
+      }
+      co_yield {std::move(subject.value()), std::move(predicate.value()),
+                std::move(object.value())};
+    }
+  }
+}
+
+// _____________________________________________________________________________
+ad_utility::streams::stream_generator QueryExecutionTree::writeRdfGraphTurtle(
+    const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+    size_t offset, std::shared_ptr<const ResultTable> resultTable) const {
+  resultTable->logResultSize();
+  auto generator =
+      generateRdfGraph(constructTriples, limit, offset, resultTable);
+  for (const auto& triple : generator) {
+    co_yield triple._subject;
+    co_yield ' ';
+    co_yield triple._predicate;
+    co_yield ' ';
+    // NOTE: It's tempting to co_yield an expression using a ternary operator:
+    // co_yield triple._object.starts_with('"')
+    //     ? RdfEscaping::validRDFLiteralFromNormalized(triple._object)
+    //     : triple._object;
+    // but this leads to 1. segfaults in GCC (probably a compiler bug) and 2.
+    // to unnecessary copies of `triple._object` in the `else` case because
+    // the ternary always has to create a new prvalue.
+    if (triple._object.starts_with('"')) {
+      std::string objectAsValidRdfLiteral =
+          RdfEscaping::validRDFLiteralFromNormalized(triple._object);
+      co_yield objectAsValidRdfLiteral;
+    } else {
+      co_yield triple._object;
+    }
+    co_yield " .\n";
+  }
+}
+
+// _____________________________________________________________________________
+template <QueryExecutionTree::ExportSubFormat format>
+ad_utility::streams::stream_generator
+QueryExecutionTree::writeRdfGraphSeparatedValues(
+    const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+    size_t offset, std::shared_ptr<const ResultTable> resultTable) const {
+  static_assert(format == ExportSubFormat::BINARY ||
+                format == ExportSubFormat::CSV ||
+                format == ExportSubFormat::TSV);
+  if constexpr (format == ExportSubFormat::BINARY) {
+    throw std::runtime_error{
+        "Binary export is not supported for CONSTRUCT queries"};
+  }
+  resultTable->logResultSize();
+  constexpr auto& escapeFunction = format == ExportSubFormat::TSV
+                                       ? RdfEscaping::escapeForTsv
+                                       : RdfEscaping::escapeForCsv;
+  constexpr char sep = format == ExportSubFormat::TSV ? '\t' : ',';
+  auto generator =
+      generateRdfGraph(constructTriples, limit, offset, resultTable);
+  for (auto& triple : generator) {
+    co_yield escapeFunction(std::move(triple._subject));
+    co_yield sep;
+    co_yield escapeFunction(std::move(triple._predicate));
+    co_yield sep;
+    co_yield escapeFunction(std::move(triple._object));
+    co_yield "\n";
+  }
+}
+
+// Instantiate template function for all enum types
+
+template ad_utility::streams::stream_generator QueryExecutionTree::
+    writeRdfGraphSeparatedValues<QueryExecutionTree::ExportSubFormat::CSV>(
+        const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+        size_t offset, std::shared_ptr<const ResultTable> res) const;
+
+template ad_utility::streams::stream_generator QueryExecutionTree::
+    writeRdfGraphSeparatedValues<QueryExecutionTree::ExportSubFormat::TSV>(
+        const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+        size_t offset, std::shared_ptr<const ResultTable> res) const;
+
+template ad_utility::streams::stream_generator QueryExecutionTree::
+    writeRdfGraphSeparatedValues<QueryExecutionTree::ExportSubFormat::BINARY>(
+        const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+        size_t offset, std::shared_ptr<const ResultTable> res) const;
+
+// _____________________________________________________________________________
+nlohmann::json QueryExecutionTree::writeRdfGraphJson(
+    const ad_utility::sparql_types::Triples& constructTriples, size_t limit,
+    size_t offset, std::shared_ptr<const ResultTable> res) const {
+  auto generator =
+      generateRdfGraph(constructTriples, limit, offset, std::move(res));
+  std::vector<std::array<std::string, 3>> jsonArray;
+  for (auto& triple : generator) {
+    jsonArray.push_back({std::move(triple._subject),
+                         std::move(triple._predicate),
+                         std::move(triple._object)});
+  }
+  return jsonArray;
+}
+
 bool QueryExecutionTree::isIndexScan() const { return _type == SCAN; }
 
 template <typename Op>
@@ -209,14 +629,6 @@ void QueryExecutionTree::setOperation(std::shared_ptr<Op> operation) {
     _type = TEXT_WITH_FILTER;
   } else if constexpr (std::is_same_v<Op, CountAvailablePredicates>) {
     _type = COUNT_AVAILABLE_PREDICATES;
-  } else if constexpr (std::is_same_v<Op, Minus>) {
-    _type = MINUS;
-  } else if constexpr (std::is_same_v<Op, OptionalJoin>) {
-    _type = OPTIONAL_JOIN;
-  } else if constexpr (std::is_same_v<Op, MultiColumnJoin>) {
-    _type = MULTICOLUMN_JOIN;
-  } else if constexpr (std::is_same_v<Op, ValuesForTesting>) {
-    _type = DUMMY;
   } else {
     static_assert(ad_utility::alwaysFalse<Op>,
                   "New type of operation that was not yet registered");
@@ -243,12 +655,6 @@ template void QueryExecutionTree::setOperation(
     std::shared_ptr<TextOperationWithFilter>);
 template void QueryExecutionTree::setOperation(
     std::shared_ptr<CountAvailablePredicates>);
-template void QueryExecutionTree::setOperation(std::shared_ptr<Minus>);
-template void QueryExecutionTree::setOperation(std::shared_ptr<OptionalJoin>);
-template void QueryExecutionTree::setOperation(
-    std::shared_ptr<MultiColumnJoin>);
-template void QueryExecutionTree::setOperation(
-    std::shared_ptr<ValuesForTesting>);
 
 // ________________________________________________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
@@ -264,22 +670,18 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
   }
 
   QueryExecutionContext* qec = qet->getRootOperation()->getExecutionContext();
-  auto sort = std::make_shared<Sort>(qec, std::move(qet), sortColumns);
-  return std::make_shared<QueryExecutionTree>(qec, std::move(sort));
-}
-
-// ________________________________________________________________________________________________________________
-std::array<std::shared_ptr<QueryExecutionTree>, 2>
-QueryExecutionTree::createSortedTrees(
-    std::shared_ptr<QueryExecutionTree> qetA,
-    std::shared_ptr<QueryExecutionTree> qetB,
-    const vector<std::array<size_t, 2>>& sortColumns) {
-  std::vector<size_t> sortColumnsA, sortColumnsB;
-  for (auto [sortColumnA, sortColumnB] : sortColumns) {
-    sortColumnsA.push_back(sortColumnA);
-    sortColumnsB.push_back(sortColumnB);
+  if (sortColumns.size() == 1) {
+    auto sort = std::make_shared<Sort>(qec, std::move(qet), sortColumns[0]);
+    return std::make_shared<QueryExecutionTree>(qec, std::move(sort));
+  } else {
+    std::vector<std::pair<size_t, bool>> sortColsForOrderBy;
+    for (auto i : sortColumns) {
+      // The second argument set to `false` means sort in ascending order.
+      // TODO<joka921> fix this.
+      sortColsForOrderBy.emplace_back(i, false);
+    }
+    auto sort = std::make_shared<OrderBy>(qec, std::move(qet),
+                                          std::move(sortColsForOrderBy));
+    return std::make_shared<QueryExecutionTree>(qec, std::move(sort));
   }
-
-  return {createSortedTree(std::move(qetA), sortColumnsA),
-          createSortedTree(std::move(qetB), sortColumnsB)};
 }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -33,8 +33,14 @@
 
 namespace p = parsedQuery;
 namespace {
-
-using ad_utility::makeExecutionTree;
+// All the operations take a `QueryExecutionContext` as a first argument.
+// Todo: Continue the comment.
+template <typename Operation>
+std::shared_ptr<QueryExecutionTree> makeExecutionTree(
+    QueryExecutionContext* qec, auto&&... args) {
+  return std::make_shared<QueryExecutionTree>(
+      qec, std::make_shared<Operation>(qec, AD_FWD(args)...));
+}
 
 template <typename Operation>
 QueryPlanner::SubtreePlan makeSubtreePlan(QueryExecutionContext* qec,
@@ -531,8 +537,19 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
       distinctPlan._qet =
           makeExecutionTree<Distinct>(_qec, parent._qet, keepIndices);
     } else {
-      auto tree = makeExecutionTree<Sort>(_qec, parent._qet, keepIndices);
-      distinctPlan._qet = makeExecutionTree<Distinct>(_qec, tree, keepIndices);
+      if (keepIndices.size() == 1) {
+        auto tree = makeExecutionTree<Sort>(_qec, parent._qet, keepIndices[0]);
+        distinctPlan._qet =
+            makeExecutionTree<Distinct>(_qec, tree, keepIndices);
+      } else {
+        vector<pair<size_t, bool>> obCols;
+        for (auto& i : keepIndices) {
+          obCols.emplace_back(std::make_pair(i, false));
+        }
+        auto tree = makeExecutionTree<OrderBy>(_qec, parent._qet, obCols);
+        distinctPlan._qet =
+            makeExecutionTree<Distinct>(_qec, tree, keepIndices);
+      }
     }
     added.push_back(distinctPlan);
   }
@@ -628,27 +645,38 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     auto& tree = plan._qet;
     plan._idsOfIncludedNodes = parent._idsOfIncludedNodes;
     plan._idsOfIncludedFilters = parent._idsOfIncludedFilters;
-    vector<pair<size_t, bool>> sortIndices;
-    for (auto& ord : pq._orderBy) {
-      sortIndices.emplace_back(parent._qet->getVariableColumn(ord.variable_),
-                               ord.isDescending_);
-    }
-
-    if (pq._isInternalSort == IsInternalSort::True) {
-      std::vector<size_t> sortColumns;
-      for (auto& [index, isDescending] : sortIndices) {
-        AD_CONTRACT_CHECK(!isDescending);
-        sortColumns.push_back(index);
+    if (pq._orderBy.size() == 1 && !pq._orderBy[0].isDescending_) {
+      size_t col = parent._qet->getVariableColumn(pq._orderBy[0].variable_);
+      const std::vector<size_t>& previousSortedOn =
+          parent._qet->resultSortedOn();
+      if (!previousSortedOn.empty() && col == previousSortedOn[0]) {
+        // Already sorted perfectly
+        added.push_back(parent);
+      } else {
+        tree = makeExecutionTree<Sort>(_qec, parent._qet, col);
+        added.push_back(plan);
       }
-      tree = QueryExecutionTree::createSortedTree(parent._qet, sortColumns);
     } else {
-      AD_CONTRACT_CHECK(pq._isInternalSort == IsInternalSort::False);
-      // Note: As the internal ordering is different from the semantic ordering
-      // needed by `OrderBy`, we always have to instantiate the `OrderBy`
-      // operation.
-      tree = makeExecutionTree<OrderBy>(_qec, parent._qet, sortIndices);
+      vector<pair<size_t, bool>> sortIndices;
+      for (auto& ord : pq._orderBy) {
+        sortIndices.emplace_back(parent._qet->getVariableColumn(ord.variable_),
+                                 ord.isDescending_);
+      }
+      const std::vector<size_t>& previousSortedOn =
+          parent._qet->resultSortedOn();
+      bool alreadySorted = previousSortedOn.size() >= sortIndices.size();
+      for (size_t j = 0; alreadySorted && j < sortIndices.size(); j++) {
+        alreadySorted = alreadySorted && !sortIndices[j].second &&
+                        sortIndices[j].first == previousSortedOn[j];
+      }
+      if (alreadySorted) {
+        // Already sorted perfectly
+        added.push_back(parent);
+      } else {
+        tree = makeExecutionTree<OrderBy>(_qec, parent._qet, sortIndices);
+        added.push_back(plan);
+      }
     }
-    added.push_back(plan);
   }
   return added;
 }
@@ -1230,13 +1258,53 @@ QueryPlanner::SubtreePlan QueryPlanner::optionalJoin(
   // TODO<joka921/kramerfl> : actually the second one must be the optional
   AD_CONTRACT_CHECK(a.type != SubtreePlan::OPTIONAL ||
                     b.type != SubtreePlan::OPTIONAL);
+  SubtreePlan plan(_qec);
 
-  auto jcs = getJoinColumns(a, b);
-  auto [qetA, qetB] =
-      QueryExecutionTree::createSortedTrees(a._qet, b._qet, jcs);
-  return makeSubtreePlan<OptionalJoin>(_qec, qetA,
-                                       a.type == SubtreePlan::OPTIONAL, qetB,
-                                       b.type == SubtreePlan::OPTIONAL, jcs);
+  std::vector<std::array<ColumnIndex, 2>> jcs = getJoinColumns(a, b);
+
+  const vector<size_t>& aSortedOn = a._qet->resultSortedOn();
+  const vector<size_t>& bSortedOn = b._qet->resultSortedOn();
+
+  bool aSorted = aSortedOn.size() >= jcs.size();
+  // TODO: We could probably also accept permutations of the join columns
+  // as the order of a here and then permute the join columns to match the
+  // sorted columns of a or b (whichever is larger).
+  for (size_t i = 0; aSorted && i < jcs.size(); i++) {
+    aSorted = aSorted && jcs[i][0] == aSortedOn[i];
+  }
+  bool bSorted = bSortedOn.size() >= jcs.size();
+  for (size_t i = 0; bSorted && i < jcs.size(); i++) {
+    bSorted = bSorted && jcs[i][1] == bSortedOn[i];
+  }
+
+  // a and b need to be ordered properly first
+  vector<pair<size_t, bool>> sortIndicesA;
+  vector<pair<size_t, bool>> sortIndicesB;
+  for (array<ColumnIndex, 2>& jc : jcs) {
+    sortIndicesA.push_back(std::make_pair(jc[0], false));
+    sortIndicesB.push_back(std::make_pair(jc[1], false));
+  }
+
+  SubtreePlan orderByPlanA(_qec), orderByPlanB(_qec);
+  auto orderByA = std::make_shared<OrderBy>(_qec, a._qet, sortIndicesA);
+  auto orderByB = std::make_shared<OrderBy>(_qec, b._qet, sortIndicesB);
+
+  if (!aSorted) {
+    orderByPlanA._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByA);
+  }
+  if (!bSorted) {
+    orderByPlanB._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByB);
+  }
+
+  auto join = std::make_shared<OptionalJoin>(
+      _qec, aSorted ? a._qet : orderByPlanA._qet,
+      a.type == SubtreePlan::OPTIONAL, bSorted ? b._qet : orderByPlanB._qet,
+      b.type == SubtreePlan::OPTIONAL, jcs);
+  QueryExecutionTree& tree = *plan._qet;
+  tree.setOperation(QueryExecutionTree::OPTIONAL_JOIN, join);
+
+  plan.type = SubtreePlan::BASIC;
+  return plan;
 }
 
 // _____________________________________________________________________________
@@ -1246,30 +1314,106 @@ QueryPlanner::SubtreePlan QueryPlanner::minus(const SubtreePlan& a,
                     b.type == SubtreePlan::MINUS);
   std::vector<std::array<ColumnIndex, 2>> jcs = getJoinColumns(a, b);
 
+  const vector<size_t>& aSortedOn = a._qet->resultSortedOn();
+  const vector<size_t>& bSortedOn = b._qet->resultSortedOn();
+
+  bool aSorted = aSortedOn.size() >= jcs.size();
   // TODO: We could probably also accept permutations of the join columns
   // as the order of a here and then permute the join columns to match the
   // sorted columns of a or b (whichever is larger).
-  auto [qetA, qetB] =
-      QueryExecutionTree::createSortedTrees(a._qet, b._qet, jcs);
-  return makeSubtreePlan<Minus>(_qec, qetA, qetB, jcs);
+  for (size_t i = 0; aSorted && i < jcs.size(); i++) {
+    aSorted = aSorted && jcs[i][0] == aSortedOn[i];
+  }
+  bool bSorted = bSortedOn.size() >= jcs.size();
+  for (size_t i = 0; bSorted && i < jcs.size(); i++) {
+    bSorted = bSorted && jcs[i][1] == bSortedOn[i];
+  }
+
+  // a and b need to be ordered properly first
+  vector<pair<size_t, bool>> sortIndicesA;
+  vector<pair<size_t, bool>> sortIndicesB;
+  for (const auto& [joinColumnA, joinColumnB] : jcs) {
+    sortIndicesA.push_back(std::make_pair(joinColumnA, false));
+    sortIndicesB.push_back(std::make_pair(joinColumnB, false));
+  }
+
+  SubtreePlan orderByPlanA(_qec), orderByPlanB(_qec);
+  auto orderByA = std::make_shared<OrderBy>(_qec, a._qet, sortIndicesA);
+  auto orderByB = std::make_shared<OrderBy>(_qec, b._qet, sortIndicesB);
+
+  if (!aSorted) {
+    orderByPlanA._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByA);
+  }
+  if (!bSorted) {
+    orderByPlanB._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByB);
+  }
+
+  SubtreePlan plan(_qec);
+
+  auto join =
+      std::make_shared<Minus>(_qec, aSorted ? a._qet : orderByPlanA._qet,
+                              bSorted ? b._qet : orderByPlanB._qet, jcs);
+  QueryExecutionTree& tree = *plan._qet;
+  tree.setOperation(QueryExecutionTree::MINUS, join);
+
+  plan.type = SubtreePlan::BASIC;
+  return plan;
 }
 
 // _____________________________________________________________________________
 QueryPlanner::SubtreePlan QueryPlanner::multiColumnJoin(
     const SubtreePlan& a, const SubtreePlan& b) const {
+  SubtreePlan plan(_qec);
+
+  std::vector<std::array<ColumnIndex, 2>> jcs = getJoinColumns(a, b);
+
+  const vector<size_t>& aSortedOn = a._qet->resultSortedOn();
+  const vector<size_t>& bSortedOn = b._qet->resultSortedOn();
+
+  bool aSorted = aSortedOn.size() >= jcs.size();
+  // TODO: We could probably also accept permutations of the join columns
+  // as the order of a here and then permute the join columns to match the
+  // sorted columns of a or b (whichever is larger).
+  for (size_t i = 0; aSorted && i < jcs.size(); i++) {
+    aSorted = aSorted && jcs[i][0] == aSortedOn[i];
+  }
+  bool bSorted = bSortedOn.size() >= jcs.size();
+  for (size_t i = 0; bSorted && i < jcs.size(); i++) {
+    bSorted = bSorted && jcs[i][1] == bSortedOn[i];
+  }
+
+  // a and b need to be ordered properly first
+  vector<pair<size_t, bool>> sortIndicesA;
+  vector<pair<size_t, bool>> sortIndicesB;
+  for (const auto& [joinColumnA, joinColumnB] : jcs) {
+    sortIndicesA.push_back(std::make_pair(joinColumnA, false));
+    sortIndicesB.push_back(std::make_pair(joinColumnB, false));
+  }
+
+  SubtreePlan orderByPlanA(_qec), orderByPlanB(_qec);
+  auto orderByA = std::make_shared<OrderBy>(_qec, a._qet, sortIndicesA);
+  auto orderByB = std::make_shared<OrderBy>(_qec, b._qet, sortIndicesB);
+
+  if (!aSorted) {
+    orderByPlanA._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByA);
+  }
+  if (!bSorted) {
+    orderByPlanB._qet->setOperation(QueryExecutionTree::ORDER_BY, orderByB);
+  }
+
+  const auto& actualA = aSorted ? a._qet : orderByPlanA._qet;
+  const auto& actualB = bSorted ? b._qet : orderByPlanB._qet;
   if (Join::isFullScanDummy(a._qet) || Join::isFullScanDummy(b._qet)) {
     throw std::runtime_error(
         "Trying a JOIN between two full scan dummys, this"
         "will be handled by the calling code automatically");
   }
 
-  // TODO: We could probably also accept permutations of the join columns
-  // as the order of a here and then permute the join columns to match the
-  // sorted columns of a or b (whichever is larger).
-  std::vector<std::array<ColumnIndex, 2>> jcs = getJoinColumns(a, b);
-  auto [qetA, qetB] =
-      QueryExecutionTree::createSortedTrees(a._qet, b._qet, jcs);
-  return makeSubtreePlan<MultiColumnJoin>(_qec, qetA, qetB, jcs);
+  auto join = std::make_shared<MultiColumnJoin>(_qec, actualA, actualB, jcs);
+  QueryExecutionTree& tree = *plan._qet;
+  tree.setOperation(QueryExecutionTree::MULTICOLUMN_JOIN, join);
+
+  return plan;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -1,31 +1,12 @@
 // Copyright 2015 -2022, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
-//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include "engine/ResultTable.h"
 
 #include <cassert>
 
 #include "engine/LocalVocab.h"
-
-// _____________________________________________________________________________
-ResultTable::ResultTable(ad_utility::AllocatorWithLimit<Id> allocator)
-    : _sortedBy(),
-      _idTable(std::move(allocator)),
-      _resultTypes(),
-      // TODO: Why initialize with a pointer to an empty local vocabulary
-      // instead of with nullptr?
-      _localVocab(std::make_shared<LocalVocab>()) {}
-
-// _____________________________________________________________________________
-void ResultTable::clear() {
-  _localVocab = nullptr;
-  _idTable.clear();
-}
-
-// _____________________________________________________________________________
-ResultTable::~ResultTable() { clear(); }
 
 // _____________________________________________________________________________
 string ResultTable::asDebugString() const {
@@ -39,6 +20,3 @@ string ResultTable::asDebugString() const {
   }
   return std::move(os).str();
 }
-
-// _____________________________________________________________________________
-size_t ResultTable::size() const { return _idTable.size(); }

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -1,6 +1,7 @@
 // Copyright 2015 - 2022, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <b.buchhold@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #pragma once
@@ -27,59 +28,92 @@ using std::mutex;
 using std::unique_lock;
 using std::vector;
 
+// The result of an `Operation`. This is the class QLever uses for all
+// intermediate or final results when processing a SPARQL query. The actual data
+// is always a table and contained in the member `_idTable`.
+//
+// TODO: I would find it more appropriate to simply call this class `Result`.
+// Otherwise, it's not clear from the names what the difference between a
+// `ResultTable` and an `IdTable` is.
 class ResultTable {
  public:
+  // The status of the result.
   enum Status { IN_PROGRESS = 0, FINISHED = 1, ABORTED = 2 };
-  using ResultType = qlever::ResultType;
 
-  /**
-   * @brief This vector contains a list of column indices by which the result
-   *        is sorted. This vector may be empty if the result is not sorted
-   *        on any column. The primary sort column is _sortedBy[0]
-   *        (if it exists).
-   */
-  vector<size_t> _sortedBy;
+ public:
+  // TODO: I think that none of these member variables should be public. They
+  // probably are for historical reasons. I already added a `getLocalVocab`
+  // method.
 
+  // The actual entries.
   IdTable _idTable;
 
+  // The entries in `_resultTypes` used to be significant in an old version of
+  // the QLever code, but they longer are (because reality is more complicated
+  // than "one type per column). It is still important for the correctness of
+  // the code, however, that this vector has the same size as the number of
+  // columns of the table.
+  //
+  // TODO: Properly keep track of result types again. In particular, efficiency
+  // should benefit in the common use case where all entries in a column have a
+  // certain type or types.
+  using ResultType = qlever::ResultType;
   vector<ResultType> _resultTypes;
 
-  std::shared_ptr<LocalVocab> _localVocab;
+  // The column indices by which the result is sorted (primary sort key first).
+  // Empty if the result is not sorted on any column.
+  vector<size_t> _sortedBy;
 
-  explicit ResultTable(ad_utility::AllocatorWithLimit<Id> allocator);
+ private:
+  // The local vocabulary of the result.
+  std::shared_ptr<LocalVocab> localVocab_ = std::make_shared<LocalVocab>();
 
+ public:
+  // Construct with given allocator.
+  explicit ResultTable(ad_utility::AllocatorWithLimit<Id> allocator)
+      : _idTable(std::move(allocator)) {}
+
+  // Prevent accidental copying of a result table.
   ResultTable(const ResultTable& other) = delete;
-
-  ResultTable(ResultTable&& other) = default;
-
   ResultTable& operator=(const ResultTable& other) = delete;
 
+  // Moving of a result table is OK.
+  ResultTable(ResultTable&& other) = default;
   ResultTable& operator=(ResultTable&& other) = default;
 
-  virtual ~ResultTable();
+  // Default destructor.
+  virtual ~ResultTable() = default;
 
-  size_t size() const;
+  // Get the number of rows of this result.
+  size_t size() const { return _idTable.size(); }
+
+  // Get the number of columns of this result.
   size_t width() const { return _idTable.numColumns(); }
 
-  // Log to INFO the size of this result.
-  //
-  // NOTE: Due to the current sub-optimal design of `Server::processQuery`, we
-  // need the same message in multiple places and so instead of duplicating the
-  // message, we should have a method for it.
+  // Set local vocabulary. This only copies a shared pointer. In order to make a
+  // deep copy, use LocalVocab::clone(); see `GroupBy.cpp` for an example.
+  void setLocalVocab(const std::shared_ptr<LocalVocab>& localVocab) {
+    localVocab_ = localVocab;
+  }
+
+  // Get the local vocabulary of this result (not `const` because we may want to
+  // augment it while constructing the result).
+  std::shared_ptr<LocalVocab> getLocalVocab() const { return localVocab_; }
+
+  // Log the size of this result. We call this at several places in
+  // `Server::processQuery`. Ideally, this should only be called in one
+  // place, but for now, this method at least makes sure that these log
+  // messages look all the same.
   void logResultSize() const {
     LOG(INFO) << "Result has size " << size() << " x " << width() << std::endl;
   }
 
-  void clear();
-
+  // The first rows of the result and its total size (for debugging).
   string asDebugString() const;
 
+  // Get the result type for the given column if provided (default:
+  // ResultType::KB).
   ResultType getResultType(size_t col) const {
-    if (col < _resultTypes.size()) {
-      return _resultTypes[col];
-    }
-    return ResultType::KB;
+    return col < _resultTypes.size() ? _resultTypes[col] : ResultType::KB;
   }
-
- private:
 };

--- a/src/engine/ResultType.h
+++ b/src/engine/ResultType.h
@@ -1,27 +1,26 @@
-//
-// Created by johannes on 09.05.21.
-//
+// Copyright 2021 - 2022, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
-#ifndef QLEVER_RESULTTYPE_H
-#define QLEVER_RESULTTYPE_H
+#pragma once
 
 namespace qlever {
-/**
- * @brief Describes the type of a columns data
- */
+
+// Enumerate the types of entries we can have in a `ResultTable`.
 enum class ResultType {
-  // An entry in the knowledgebase
+  // An entry that is contained in the vocabulary of the indexed data.
   KB,
-  // An unsigned integer (size_t)
+  // An unsigned integer. TODO: Briefly describe why this is still needed. It is
+  // used in `GroupBy`, `CountAvailablePredicates`, `TextOperationWithFilter`,
+  // `TextOperationWithoutFilter`.
   VERBATIM,
-  // A byte offset in the text index
+  // An entry from the text index (a byte offset in the text index).
   TEXT,
-  // A 32 bit float, stored in the first 4 bytes of the entry. The last four
-  // bytes have to be zero.
+  // A floating point number. TODO: Is this still used somwehere? It doesn't
+  // look like it is, now that we have values "folded into" IDs.
   FLOAT,
-  // An entry in the ResultTable's _localVocab
+  // An entry in the `LocalVocab` of a `ResultTable`. TODO: Is this still used
+  // somewhere? It doesn't look like it is.
   LOCAL_VOCAB
 };
 }  // namespace qlever
-
-#endif  // QLEVER_RESULTTYPE_H

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -132,7 +132,7 @@ void Sort::computeResult(ResultTable* result) {
   result->_resultTypes.insert(result->_resultTypes.end(),
                               subRes->_resultTypes.begin(),
                               subRes->_resultTypes.end());
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
   result->_idTable = subRes->_idTable.clone();
   result->_sortedBy = resultSortedOn();
   sortImpl(result->_idTable, sortColumnIndices_);

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -84,7 +84,7 @@ void TextOperationWithFilter::computeResult(ResultTable* result) {
   AD_CONTRACT_CHECK(getNofVars() >= 1);
   result->_idTable.setNumColumns(getResultWidth());
   shared_ptr<const ResultTable> filterResult = _filterResult->getResult();
-  result->_localVocab = filterResult->_localVocab;
+  result->setLocalVocab(filterResult->getLocalVocab());
 
   result->_resultTypes.reserve(result->_idTable.numColumns());
   result->_resultTypes.push_back(ResultTable::ResultType::TEXT);

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -670,10 +670,10 @@ void TransitivePath::computeResult(ResultTable* result) {
   LOG(DEBUG) << "TransitivePath subresult computation done." << std::endl;
 
   // NOTE: The only place, where the input to a transitive path operation is not
-  // an index scan (which have empty local vocabularies by default) is the
-  // `LocalVocabTest`. But it doesn't harm to propagate `_localVocab` here
+  // an index scan (which has an empty local vocabulary by default) is the
+  // `LocalVocabTest`. But it doesn't harm to propagate the local vocab here
   // either.
-  result->_localVocab = subRes->_localVocab;
+  result->setLocalVocab(subRes->getLocalVocab());
 
   result->_sortedBy = resultSortedOn();
   if (_leftIsVar || _leftSideTree != nullptr) {

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -167,8 +167,8 @@ void Union::computeResult(ResultTable* result) {
                   subRes1->_idTable, subRes2->_idTable, _columnOrigins);
 
   // If only one of the two operands has a local vocab, pass it on.
-  result->_localVocab = LocalVocab::mergeLocalVocabsIfOneIsEmpty(
-      subRes1->_localVocab, subRes2->_localVocab);
+  result->setLocalVocab(LocalVocab::mergeLocalVocabsIfOneIsEmpty(
+      subRes1->getLocalVocab(), subRes2->getLocalVocab()));
 
   LOG(DEBUG) << "Union result computation done." << std::endl;
 }

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -15,25 +15,28 @@
 #include "util/HashSet.h"
 
 // ____________________________________________________________________________
-Values::Values(QueryExecutionContext* qec, SparqlValues values)
+Values::Values(QueryExecutionContext* qec, SparqlValues parsedValues)
     : Operation(qec) {
-  _values = sanitizeValues(std::move(values));
+  parsedValues_ = sanitizeValues(std::move(parsedValues));
 }
 
 // ____________________________________________________________________________
 string Values::asStringImpl(size_t indent) const {
   return absl::StrCat(std::string(indent, ' '), "VALUES (",
-                      _values.variablesToString(), ") { ",
-                      _values.valuesToString(), " }");
+                      parsedValues_.variablesToString(), ") { ",
+                      parsedValues_.valuesToString(), " }");
 }
 
 // ____________________________________________________________________________
 string Values::getDescriptor() const {
-  return absl::StrCat("Values with variables ", _values.variablesToString());
+  return absl::StrCat("Values with variables ",
+                      parsedValues_.variablesToString());
 }
 
 // ____________________________________________________________________________
-size_t Values::getResultWidth() const { return _values._variables.size(); }
+size_t Values::getResultWidth() const {
+  return parsedValues_._variables.size();
+}
 
 // ____________________________________________________________________________
 vector<size_t> Values::resultSortedOn() const { return {}; }
@@ -41,70 +44,59 @@ vector<size_t> Values::resultSortedOn() const { return {}; }
 // ____________________________________________________________________________
 VariableToColumnMap Values::computeVariableToColumnMap() const {
   VariableToColumnMap map;
-  for (size_t i = 0; i < _values._variables.size(); i++) {
+  for (size_t i = 0; i < parsedValues_._variables.size(); i++) {
     // TODO<joka921> Make the `_variables` also `Variable`s
-    map[Variable{_values._variables[i]}] = i;
+    map[Variable{parsedValues_._variables[i]}] = i;
   }
   return map;
 }
 
 // ____________________________________________________________________________
 float Values::getMultiplicity(size_t col) {
-  if (_multiplicities.empty()) {
+  if (multiplicities_.empty()) {
     computeMultiplicities();
   }
-  if (col < _multiplicities.size()) {
-    return _multiplicities[col];
+  if (col < multiplicities_.size()) {
+    return multiplicities_[col];
   }
   return 1;
 }
 
 // ____________________________________________________________________________
-size_t Values::getSizeEstimate() { return _values._values.size(); }
+size_t Values::getSizeEstimate() { return parsedValues_._values.size(); }
 
 // ____________________________________________________________________________
-size_t Values::getCostEstimate() { return _values._values.size(); }
+size_t Values::getCostEstimate() { return parsedValues_._values.size(); }
 
 // ____________________________________________________________________________
 void Values::computeMultiplicities() {
-  if (_values._variables.empty()) {
+  if (parsedValues_._variables.empty()) {
     // If the result is empty we still add a column to the multiplicities to
     // mark them as computed.
-    _multiplicities.resize(1, 1);
+    multiplicities_.resize(1, 1);
     return;
   }
-  _multiplicities.resize(_values._variables.size());
+  multiplicities_.resize(parsedValues_._variables.size());
   ad_utility::HashSet<TripleComponent> distinctValues;
-  size_t numValues = _values._values.size();
-  for (size_t col = 0; col < _values._variables.size(); col++) {
+  size_t numValues = parsedValues_._values.size();
+  for (size_t col = 0; col < parsedValues_._variables.size(); col++) {
     distinctValues.clear();
-    for (const auto& valuesTuple : _values._values) {
+    for (const auto& valuesTuple : parsedValues_._values) {
       distinctValues.insert(valuesTuple[col]);
     }
     size_t numDistinctValues = distinctValues.size();
-    _multiplicities[col] = float(numValues) / float(numDistinctValues);
+    multiplicities_[col] = float(numValues) / float(numDistinctValues);
   }
-}
-
-// ____________________________________________________________________________
-void Values::computeResult(ResultTable* result) {
-  const Index& index = getIndex();
-
-  result->_sortedBy = resultSortedOn();
-  result->_idTable.setNumColumns(getResultWidth());
-  result->_resultTypes.resize(_values._variables.size(),
-                              ResultTable::ResultType::KB);
-
-  size_t resWidth = getResultWidth();
-  CALL_FIXED_SIZE(resWidth, &Values::writeValues, this, &result->_idTable,
-                  index, _values, result->_localVocab);
 }
 
 // ____________________________________________________________________________
 auto Values::sanitizeValues(SparqlValues&& values) -> SparqlValues {
+  // Find all UNDEF values and remember tuples (rows) where all values are
+  // UNDEF as well as for each variable when it had a value that was not UNDEF
+  // at least once.
   std::vector<std::pair<std::size_t, std::size_t>> variableBound;
   for (size_t i = 0; i < values._variables.size(); ++i) {
-    variableBound.emplace_back(i, 0);  // variable i is unbound so far;
+    variableBound.emplace_back(i, 0);
   }
   std::vector<std::size_t> emptyValues;
   for (std::size_t i = 0; i < values._values.size(); ++i) {
@@ -120,63 +112,72 @@ auto Values::sanitizeValues(SparqlValues&& values) -> SparqlValues {
       }
     }
   }
-  // erase all the values where every variable is "UNDEF"
+
+  // Remove all value tuples where every value is "UNDEF".
   for (auto it = emptyValues.rbegin(); it != emptyValues.rend(); ++it) {
-    getWarnings().push_back(
-        "Found a value line, where no variable is bound, ignoring it");
+    getWarnings().push_back("Removing VALUES tuple where all values are UNDEF");
     values._values.erase(values._values.begin() + *it);
   }
 
-  // completely erase all the variables which are never bound.
+  // Remove all variables that are not bound in a single value tuple.
   for (auto it = variableBound.rbegin(); it != variableBound.rend(); ++it) {
     if (it->second) {
       continue;
     }
     getWarnings().push_back(
-        "Found a VALUES variable , which is never bound in the value clause "
-        ",ignoring it");
+        "Removing VALUES variable for which all values were UNDEF");
     values._variables.erase(values._variables.begin() + it->first);
     for (auto& val : values._values) {
       val.erase(val.begin() + it->first);
     }
   }
+
+  // If no variables or tuples remain, throw an exception.
   if (values._values.empty() || values._variables.empty()) {
     AD_THROW(
-        "After removing undefined values and variables, a VALUES clause was "
-        "found to be empty. This"
-        "(the neutral element for JOIN) is currently not supported by QLever");
+        "After removing all UNDEF values and variables, a VALUES clause was "
+        "found to be empty. Such an operation result (the neutral element for "
+        "JOIN) is currently not supported by QLever");
   }
+
   return std::move(values);
 }
 
 // ____________________________________________________________________________
+void Values::computeResult(ResultTable* result) {
+  // Set basic properties of the result table.
+  result->_sortedBy = resultSortedOn();
+  result->_idTable.setNumColumns(getResultWidth());
+  result->_resultTypes.resize(parsedValues_._variables.size(),
+                              ResultTable::ResultType::KB);
+
+  // Fill the result table using the `writeValues` method below.
+  size_t resWidth = getResultWidth();
+  CALL_FIXED_SIZE(resWidth, &Values::writeValues, this, result);
+}
+
+// ____________________________________________________________________________
 template <size_t I>
-void Values::writeValues(IdTable* res, const Index& index,
-                         const SparqlValues& values,
-                         std::shared_ptr<LocalVocab> localVocab) {
-  IdTableStatic<I> result = std::move(*res).toStatic<I>();
-  result.resize(values._values.size());
-  size_t numTuples = 0;
-  std::vector<size_t> numLocalVocabPerColumn(result.numColumns());
-  for (const auto& row : values._values) {
-    for (size_t colIdx = 0; colIdx < result.numColumns(); colIdx++) {
-      const TripleComponent& tc = row[colIdx];
-      std::optional<Id> id = tc.toValueId(index.getVocab());
-      if (!id) {
-        AD_CONTRACT_CHECK(tc.isString());
-        auto& newWord = tc.getString();
+void Values::writeValues(ResultTable* result) {
+  IdTableStatic<I> idTable = std::move(result->_idTable).toStatic<I>();
+  idTable.resize(parsedValues_._values.size());
+  size_t rowIdx = 0;
+  std::vector<size_t> numLocalVocabPerColumn(idTable.numColumns());
+  for (auto& row : parsedValues_._values) {
+    for (size_t colIdx = 0; colIdx < idTable.numColumns(); colIdx++) {
+      TripleComponent& tc = row[colIdx];
+      Id id = std::move(tc).toValueId(getIndex().getVocab(),
+                                      *result->getLocalVocab());
+      idTable(rowIdx, colIdx) = id;
+      if (id.getDatatype() == Datatype::LocalVocabIndex) {
         ++numLocalVocabPerColumn[colIdx];
-        id = Id::makeFromLocalVocabIndex(
-            localVocab->getIndexAndAddIfNotContained(std::move(newWord)));
       }
-      result(numTuples, colIdx) = id.value();
     }
-    numTuples++;
+    rowIdx++;
   }
-  AD_CONTRACT_CHECK(numTuples == values._values.size());
-  LOG(INFO) << "Number of tuples in VALUES clause: " << numTuples << std::endl;
-  LOG(DEBUG) << "Number of entries in local vocabulary per column: "
-             << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
-  result.resize(numTuples);
-  *res = std::move(result).toDynamic();
+  AD_CORRECTNESS_CHECK(rowIdx == parsedValues_._values.size());
+  LOG(INFO) << "Number of tuples in VALUES clause: " << rowIdx << std::endl;
+  LOG(INFO) << "Number of entries in local vocabulary per column: "
+            << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
+  result->_idTable = std::move(idTable).toDynamic();
 }

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -13,14 +13,14 @@ class Values : public Operation {
   using SparqlValues = parsedQuery::SparqlValues;
 
  private:
-  std::vector<size_t> _multiplicities;
+  std::vector<size_t> multiplicities_;
 
-  SparqlValues _values;
+  SparqlValues parsedValues_;
 
  public:
-  /// constructor sanitizes the input by removing completely undefined variables
-  /// and values.
-  Values(QueryExecutionContext* qec, SparqlValues values);
+  // Create operation from parsed values. This calls `sanitizeValues`.
+  // and values.
+  Values(QueryExecutionContext* qec, SparqlValues parsedValues);
 
  protected:
   virtual string asStringImpl(size_t indent = 0) const override;
@@ -35,7 +35,7 @@ class Values : public Operation {
   virtual void setTextLimit(size_t limit) override { (void)limit; }
 
   virtual bool knownEmptyResult() override {
-    return _values._variables.empty() || _values._values.empty();
+    return parsedValues_._variables.empty() || parsedValues_._values.empty();
   }
 
   virtual float getMultiplicity(size_t col) override;
@@ -53,13 +53,18 @@ class Values : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
  private:
-  template <size_t I>
-  void writeValues(IdTable* res, const Index& index, const SparqlValues& values,
-                   std::shared_ptr<LocalVocab> localVocab);
-
-  /// remove all completely undefined values and variables
-  /// throw if nothing remains
+  // Remove all UNDEF values and with it all tuples with only UNDEF values as
+  // well as variables with only UNDEF values. Throws an exception if nothing
+  // remains.
   SparqlValues sanitizeValues(SparqlValues&& values);
 
+  // Compute the per-column multiplicity of the parsed values.
   void computeMultiplicities();
+
+  // Write `parsedValues_` to the given result object.
+  //
+  // NOTE: this moves the values out of `parsedValues_` (to save a string copy
+  // for those values that end up in the local vocabulary).
+  template <size_t I>
+  void writeValues(ResultTable* result);
 };

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -11,49 +11,35 @@
 #include "util/OverloadCallOperator.h"
 
 namespace valueIdComparators {
-// This enum encodes the different numeric comparators LessThan, LessEqual,
-// Equal, NotEqual, GreaterEqual, GreaterThan.
+/// This enum encodes the different numeric comparators LessThan, LessEqual,
+/// EQual, NotEqual, GreaterEqual, GreaterThan.
 enum struct Comparison { LT, LE, EQ, NE, GE, GT };
 
-// This enum can be used to configure the behavior of the `compareIds` method
-// below in the case when two `Id`s have incompatible datatypes (e.g.
-// `VocabIndex` and a numeric type, or `Undefined` and any other type).
-// For `AlwaysFalse`, the comparison will always be false, so for example `"x"`
-// is neither smaller than nor greater than nor equal to `42`. This behavior is
-// similar to the behavior of floating point `NaN` values. It is used for
-// example for filter expressions like `FILTER (?x < 42)` which will filter out
-// all string values. For `CompareByType` such pairs of `Id`s will be compared
-// by the numeric order of their datatypes, so for example all `Undefined` IDs
-// will be smaller than all IDs with a type different from `Undefined`. This
-// behavior is used e.g. in `ORDER BY` expressions where we need a consistent
-// partial ordering on all possible IDs.
-enum struct ComparisonForIncompatibleTypes { AlwaysFalse, CompareByType };
-
-// Compares two `ValueId`s directly on the underlying representation. Note
-// that because the type bits are the most significant bits, all values of
-// the same `Datatype` will be adjacent to each other. Unsigned index types
-// are also ordered correctly. Signed integers are ordered as follows: first
-// the positive integers (>= 0) in order and then the negative integers (< 0)
-// in order. For doubles it is first the positive doubles in order, then the
-// negative doubles in reversed order. In detail it is [0.0 ... infinity, NaN,
-// -0.0, ... -infinity]. This is a direct consequence of comparing the bit
-// representation of these values as unsigned integers.
+/// Compares two `ValueId`s directly on the underlying representation. Note
+/// that because the type bits are the most significant bits, all values of
+/// the same `Datatype` will be adjacent to each other. Unsigned index types
+/// are also ordered correctly. Signed integers are ordered as follows: first
+/// the positive integers (>= 0) in order and then the negative integers (< 0)
+/// in order. For doubles it is first the positive doubles in order, then the
+/// negative doubles in reversed order. In detail it is [0.0 ... infinity, NaN,
+/// -0.0, ... -infinity]. This is a direct consequence of comparing the bit
+/// representation of these values as unsigned integers.
 inline bool compareByBits(ValueId a, ValueId b) {
   return a.getBits() < b.getBits();
 }
 
 namespace detail {
 
-// Returns a comparator predicate `pred` that can be called with two arguments:
-// a `ValueId` and a templated `Value`. The predicate first calls the
-// `valueIdProjection` on the `ValueId` and then calls the `comparator` with
-// the `value` and the result of the projection. The predicate is symmetric, so
-// both `pred(ValueId, Value)` and `pred(Value, ValueId)` work as expected.
-// This function is useful for `std::equal_range` which expects both orders to
-// work. Example: `makeSymmetricComparator(&ValueId::getDatatype,
-// std::equal_to<>{})` returns a predicate that can be called with
-// `pred(Datatype, ValueId)` and pred(ValueId, Datatype)` and returns true iff
-// `Datatype` and the datatype of the Id are the same.
+/// Returns a comparator predicate `pred` that can be called with two arguments:
+/// a `ValueId` and a templated `Value`. The predicate first calls the
+/// `valueIdProjection` on the `ValueId` and then calls the `comparator` with
+/// the `value` and the result of the projection. The predicate is symmetric, so
+/// both `pred(ValueId, Value)` and `pred(Value, ValueId)` work as expected.
+/// This function is useful for `std::equal_range` which expects both orders to
+/// work. Example: `makeSymmetricComparator(&ValueId::getDatatype,
+/// std::equal_to<>{})` returns a predicate that can be called with
+/// `pred(Datatype, ValueId)` and pred(ValueId, Datatype)` and returns true iff
+/// `Datatype` and the datatype of the Id are the same.
 template <typename Projection, typename Comparator = std::less<>>
 auto makeSymmetricComparator(Projection valueIdProjection,
                              Comparator comparator = Comparator{}) {
@@ -67,9 +53,9 @@ auto makeSymmetricComparator(Projection valueIdProjection,
 }
 }  // namespace detail
 
-// For a range of `ValueId`s that is represented by `[begin, end)` and has to
-// be sorted according to `compareByBits`, return the contiguous range of
-// `ValueIds` (as a pair of iterators) where the Ids have the `datatype`.
+/// For a range of `ValueId`s that is represented by `[begin, end)` and has to
+/// be sorted according to `compareByBits`, return the contiguous range of
+/// `ValueIds` (as a pair of iterators) where the Ids have the `datatype`.
 template <typename RandomIt>
 inline std::pair<RandomIt, RandomIt> getRangeForDatatype(RandomIt begin,
                                                          RandomIt end,
@@ -369,11 +355,11 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
   AD_FAIL();
 }
 
-// Similar to `getRangesForId` above but takes a range [valueIdBegin,
-// valueIdEnd) of Ids that are considered to be equal. `valueIdBegin` and
-// `valueIdEnd` must have the same datatype which must be one of the index
-// types `VocabIndex, LocalVocabIndex, ...`, otherwise an `AD_CONTRACT_CHECK`
-// will fail at runtime.
+/// Similar to `getRangesForId` above but takes a range [valueIdBegin,
+/// valueIdEnd) of Ids that are considered to be equal. `valueIdBegin` and
+/// `valueIdEnd` must have the same datatype which must be one of the index
+/// types `VocabIndex, LocalVocabIndex, ...`, otherwise an `AD_CONTRACT_CHECK`
+/// will fail at runtime.
 template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
     RandomIt begin, RandomIt end, ValueId valueIdBegin, ValueId valueIdEnd,
@@ -401,8 +387,6 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
 namespace detail {
 
 // This function is part of the implementation of `compareIds` (see below).
-template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
-              ComparisonForIncompatibleTypes::AlwaysFalse>
 bool compareIdsImpl(ValueId a, ValueId b, auto comparator) {
   auto isNumeric = [](ValueId id) {
     return id.getDatatype() == Datatype::Double ||
@@ -411,13 +395,7 @@ bool compareIdsImpl(ValueId a, ValueId b, auto comparator) {
   bool compatible =
       (a.getDatatype() == b.getDatatype()) || (isNumeric(a) && isNumeric(b));
   if (!compatible) {
-    using enum ComparisonForIncompatibleTypes;
-    if constexpr (comparisonForIncompatibleTypes == AlwaysFalse) {
-      return false;
-    } else {
-      static_assert(comparisonForIncompatibleTypes == CompareByType);
-      return comparator(a.getDatatype(), b.getDatatype());
-    }
+    return false;
   }
 
   auto visitor = [comparator](const auto& aValue, const auto& bValue) -> bool {
@@ -438,38 +416,28 @@ bool compareIdsImpl(ValueId a, ValueId b, auto comparator) {
 // bValue are the values contained in `a` and `b`.
 // 2. The datatype of `a` and `b` are compatible, s.t. the comparison in
 // condition one is well-defined.
-// For the definition of the template parameter `comparisonForIncompatibleTypes`
-// see the documentation of the enum `ComparisonForIncompatibleTypes` above.
-template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
-              ComparisonForIncompatibleTypes::AlwaysFalse>
 inline bool compareIds(ValueId a, ValueId b, Comparison comparison) {
-  // A helper lambda to factor out common code
-  auto compare = [&](auto comparator) {
-    return detail::compareIdsImpl<comparisonForIncompatibleTypes>(a, b,
-                                                                  comparator);
-  };
-  using enum Comparison;
   switch (comparison) {
-    case LT:
-      return compare(std::less{});
-    case LE:
-      return compare(std::less_equal{});
-    case EQ:
-      return compare(std::equal_to{});
-    case NE:
+    case Comparison::LT:
+      return detail::compareIdsImpl(a, b, std::less<>());
+    case Comparison::LE:
+      return detail::compareIdsImpl(a, b, std::less_equal<>());
+    case Comparison::EQ:
+      return detail::compareIdsImpl(a, b, std::equal_to<>());
+    case Comparison::NE:
       // IDs with incompatible datatypes are also considered "not equal".
-      return !compare(std::equal_to{});
-    case GE:
-      return compare(std::greater_equal{});
-    case GT:
-      return compare(std::greater{});
+      return !compareIds(a, b, Comparison::EQ);
+    case Comparison::GE:
+      return detail::compareIdsImpl(a, b, std::greater_equal<>());
+    case Comparison::GT:
+      return detail::compareIdsImpl(a, b, std::greater<>());
     default:
       AD_FAIL();
   }
 }
 
-// Similar to `compareIds` above but takes a range [bBegin, bEnd) of Ids that
-// are considered to be equal.
+/// Similar to `compareIds` above but takes a range [bBegin, bEnd) of Ids that
+/// are considered to be equal.
 inline bool compareWithEqualIds(ValueId a, ValueId bBegin, ValueId bEnd,
                                 Comparison comparison) {
   // The case `bBegin == bEnd` happens when IDs from QLever's vocabulary are
@@ -478,26 +446,20 @@ inline bool compareWithEqualIds(ValueId a, ValueId bBegin, ValueId bEnd,
   // vocabulary entry that is larger than the non-existing word that it
   // represents.
   AD_CONTRACT_CHECK(bBegin <= bEnd);
-
-  // The comparison for `equal` is also used for the `not equal` case, so we
-  // factor it out.
-  auto compareEqual = [&]() {
-    return detail::compareIdsImpl(a, bBegin, std::greater_equal<>()) &&
-           detail::compareIdsImpl(a, bEnd, std::less<>());
-  };
-  using enum Comparison;
   switch (comparison) {
-    case LT:
+    case Comparison::LT:
       return detail::compareIdsImpl(a, bBegin, std::less<>());
-    case LE:
+    case Comparison::LE:
       return detail::compareIdsImpl(a, bEnd, std::less<>());
-    case EQ:
-      return compareEqual();
-    case NE:
-      return !compareEqual();
-    case GE:
+    case Comparison::EQ:
+      return detail::compareIdsImpl(a, bBegin, std::greater_equal<>()) &&
+             detail::compareIdsImpl(a, bEnd, std::less<>());
+    case Comparison::NE:
+      // IDs with incompatible datatypes are also considered "not equal".
+      return !compareWithEqualIds(a, bBegin, bEnd, Comparison::EQ);
+    case Comparison::GE:
       return detail::compareIdsImpl(a, bBegin, std::greater_equal<>());
-    case GT:
+    case Comparison::GT:
       return detail::compareIdsImpl(a, bEnd, std::greater_equal<>());
     default:
       AD_FAIL();

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -12,8 +12,6 @@
 #include "global/Id.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "util/BufferedVector.h"
-#include "util/Cache.h"
-#include "util/ConcurrentCache.h"
 #include "util/File.h"
 #include "util/Serializer/ByteBufferSerializer.h"
 #include "util/Serializer/SerializeVector.h"
@@ -119,6 +117,89 @@ struct CompressedRelationMetadata {
 
   // Two of these are equal if all members are equal.
   bool operator==(const CompressedRelationMetadata&) const = default;
+
+  /**
+   * @brief For a permutation XYZ, retrieve all YZ for a given X.
+   *
+   * @param metadata The metadata of the given X.
+   * @param blockMetadata The metadata of the on-disk blocks for the given
+   * permutation.
+   * @param permutationName A human readable name that identifies the
+   *          permutation. It is used to uniquely identify a cache for recently
+   *          decompressed blocks.
+   * @param file The file in which the permutation is stored.
+   * @param result The ID table to which we write the result. It must have
+   * exactly two columns.
+   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
+   *          if the timer runs out during the exeuction of this function.
+   *
+   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The same `CompressedRelationWriter` (see below).
+   */
+  static void scan(const CompressedRelationMetadata& metadata,
+                   const vector<CompressedBlockMetadata>& blockMetadata,
+                   const std::string& permutationName, ad_utility::File& file,
+                   IdTable* result,
+                   ad_utility::SharedConcurrentTimeoutTimer timer);
+
+  /**
+   * @brief For a permutation XYZ, retrieve all Z for given X and Y.
+   *
+   * @param metaData The metadata of the given X.
+   * @param col1Id The ID for Y.
+   * @param blocks The metadata of the on-disk blocks for the given permutation.
+   * @param file The file in which the permutation is stored.
+   * @param result The ID table to which we write the result. It must have
+   * exactly one column.
+   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
+   *              if the timer runs out during the exeuction of this function.
+   *
+   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The same `CompressedRelationWriter` (see below).
+   */
+  static void scan(const CompressedRelationMetadata& metaData, Id col1Id,
+                   const vector<CompressedBlockMetadata>& blocks,
+                   ad_utility::File& file, IdTable* result,
+                   ad_utility::SharedConcurrentTimeoutTimer timer = nullptr);
+
+ private:
+  // Read the block that is identified by the `blockMetaData` from the `file`.
+  // If `columnIndices` is `nullopt`, then all columns of the block are read,
+  // else only the specified columns are read.
+  static CompressedBlock readCompressedBlockFromFile(
+      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
+      std::optional<std::vector<size_t>> columnIndices);
+
+  // Decompress the `compressedBlock`. The number of rows that the block will
+  // have after decompression must be passed in via the `numRowsToRead`
+  // argument. It is typically obtained from the corresponding
+  // `CompressedBlockMetaData`.
+  static DecompressedBlock decompressBlock(
+      const CompressedBlock& compressedBlock, size_t numRowsToRead);
+
+  // Similar to `decompressBlock`, but the block is directly decompressed into
+  // the `table`, starting at the `offsetInTable`-th row. The `table` and the
+  // `compressedBlock` must have the same number of columns, and the `table`
+  // must have at least `numRowsToRead + offsetInTable` rows.
+  static void decompressBlockToExistingIdTable(
+      const CompressedBlock& compressedBlock, size_t numRowsToRead,
+      IdTable& table, size_t offsetInTable);
+
+  // Helper function used by `decompressBlock` and
+  // `decompressBlockToExistingIdTable`. Decompress the `compressedColumn` and
+  // store the result at the `iterator`. For the `numRowsToRead` argument, see
+  // the documentation of `decompressBlock`.
+  template <typename Iterator>
+  static void decompressColumn(const std::vector<char>& compressedColumn,
+                               size_t numRowsToRead, Iterator iterator);
+
+  // Read the block that is identified by the `blockMetaData` from the `file`,
+  // decompress and return it.
+  // If `columnIndices` is `nullopt`, then all columns of the block are read,
+  // else only the specified columns are read.
+  static DecompressedBlock readAndDecompressBlock(
+      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
+      std::optional<std::vector<size_t>> columnIndices);
 };
 
 // Serialization of the compressed "relation" meta data.
@@ -216,101 +297,6 @@ class CompressedRelationWriter {
   // size of the compressed column in the `_outfile`.
   CompressedBlockMetadata::OffsetAndCompressedSize compressAndWriteColumn(
       std::span<const Id> column);
-};
-
-/// Manage the reading of relations from disk that have been previously written
-/// using the `CompressedRelationWriter`.
-class CompressedRelationReader {
- private:
-  // This cache stores a small number of decompressed blocks. Its current
-  // purpose is to make the e2e-tests run fast. They contain many SPARQL queries
-  // with ?s ?p ?o triples in the body.
-  // Note: The cache is thread-safe and using it does not change the semantics
-  // of this class, so it is safe to mark it as `mutable` to make the `scan`
-  // functions below `const`.
-  mutable ad_utility::ConcurrentCache<
-      ad_utility::HeapBasedLRUCache<off_t, DecompressedBlock>>
-      blockCache_{20ul};
-
- public:
-  /**
-   * @brief For a permutation XYZ, retrieve all YZ for a given X.
-   *
-   * @param metadata The metadata of the given X.
-   * @param blockMetadata The metadata of the on-disk blocks for the given
-   * permutation.
-   * @param file The file in which the permutation is stored.
-   * @param result The ID table to which we write the result. It must have
-   * exactly two columns.
-   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
-   *          if the timer runs out during the exeuction of this function.
-   *
-   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
-   * The same `CompressedRelationWriter` (see below).
-   */
-  void scan(const CompressedRelationMetadata& metadata,
-            const vector<CompressedBlockMetadata>& blockMetadata,
-            ad_utility::File& file, IdTable* result,
-            ad_utility::SharedConcurrentTimeoutTimer timer) const;
-
-  /**
-   * @brief For a permutation XYZ, retrieve all Z for given X and Y.
-   *
-   * @param metaData The metadata of the given X.
-   * @param col1Id The ID for Y.
-   * @param blocks The metadata of the on-disk blocks for the given permutation.
-   * @param file The file in which the permutation is stored.
-   * @param result The ID table to which we write the result. It must have
-   * exactly one column.
-   * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
-   *              if the timer runs out during the exeuction of this function.
-   *
-   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
-   * The same `CompressedRelationWriter` (see below).
-   */
-  void scan(const CompressedRelationMetadata& metaData, Id col1Id,
-            const vector<CompressedBlockMetadata>& blocks,
-            ad_utility::File& file, IdTable* result,
-            ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
-
- private:
-  // Read the block that is identified by the `blockMetaData` from the `file`.
-  // If `columnIndices` is `nullopt`, then all columns of the block are read,
-  // else only the specified columns are read.
-  static CompressedBlock readCompressedBlockFromFile(
-      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
-      std::optional<std::vector<size_t>> columnIndices);
-
-  // Decompress the `compressedBlock`. The number of rows that the block will
-  // have after decompression must be passed in via the `numRowsToRead`
-  // argument. It is typically obtained from the corresponding
-  // `CompressedBlockMetaData`.
-  static DecompressedBlock decompressBlock(
-      const CompressedBlock& compressedBlock, size_t numRowsToRead);
-
-  // Similar to `decompressBlock`, but the block is directly decompressed into
-  // the `table`, starting at the `offsetInTable`-th row. The `table` and the
-  // `compressedBlock` must have the same number of columns, and the `table`
-  // must have at least `numRowsToRead + offsetInTable` rows.
-  static void decompressBlockToExistingIdTable(
-      const CompressedBlock& compressedBlock, size_t numRowsToRead,
-      IdTable& table, size_t offsetInTable);
-
-  // Helper function used by `decompressBlock` and
-  // `decompressBlockToExistingIdTable`. Decompress the `compressedColumn` and
-  // store the result at the `iterator`. For the `numRowsToRead` argument, see
-  // the documentation of `decompressBlock`.
-  template <typename Iterator>
-  static void decompressColumn(const std::vector<char>& compressedColumn,
-                               size_t numRowsToRead, Iterator iterator);
-
-  // Read the block that is identified by the `blockMetaData` from the `file`,
-  // decompress and return it.
-  // If `columnIndices` is `nullopt`, then all columns of the block are read,
-  // else only the specified columns are read.
-  static DecompressedBlock readAndDecompressBlock(
-      const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
-      std::optional<std::vector<size_t>> columnIndices);
 };
 
 #endif  // QLEVER_COMPRESSEDRELATION_H

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -64,8 +64,9 @@ class PermutationImpl {
       return;
     }
     const auto& metaData = _meta.getMetaData(col0Id);
-    return _reader.scan(metaData, _meta.blockData(), _file, result,
-                        std::move(timer));
+    return CompressedRelationMetadata::scan(metaData, _meta.blockData(),
+                                            _readableName, _file, result,
+                                            std::move(timer));
   }
   /// For given IDs for the first and second column, retrieve all IDs of the
   /// third column, and store them in `result`. This is just a thin wrapper
@@ -78,8 +79,8 @@ class PermutationImpl {
     }
     const auto& metaData = _meta.getMetaData(col0Id);
 
-    return _reader.scan(metaData, col1Id, _meta.blockData(), _file, result,
-                        timer);
+    return CompressedRelationMetadata::scan(metaData, col1Id, _meta.blockData(),
+                                            _file, result, timer);
   }
 
   // _______________________________________________________
@@ -100,8 +101,6 @@ class PermutationImpl {
   MetaData _meta;
 
   mutable ad_utility::File _file;
-
-  CompressedRelationReader _reader;
 
   bool _isLoaded = false;
 };

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -14,10 +14,7 @@ namespace parsedQuery {
 
 // _____________________________________________________________________________
 std::string SparqlValues::variablesToString() const {
-  return absl::StrJoin(_variables, " ",
-                       [](std::string* out, const Variable& variable) {
-                         out->append(variable.name());
-                       });
+  return absl::StrJoin(_variables, "\t", Variable::AbslFormatter);
 }
 
 // _____________________________________________________________________________

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -11,6 +11,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/GraphPattern.h"
 #include "parser/TripleComponent.h"
+#include "parser/data/VarOrTerm.h"
 #include "parser/data/Variable.h"
 #include "util/Algorithm.h"
 #include "util/VisitMixin.h"
@@ -35,7 +36,7 @@ struct SparqlValues {
   std::vector<Variable> _variables;
   // A table storing the values in their string form
   std::vector<std::vector<TripleComponent>> _values;
-  // The `_variable` as a string, in the format like so: "?x ?y ?z".
+  // The `_variables` as a string, in the format like so: "?x ?y ?z".
   std::string variablesToString() const;
   // The `_values` as a string, in the format like so: "(<v12> <v12> <v13>)
   // (<v21> <v22> <v23>)".

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -56,13 +56,15 @@ void SelectClause::setSelected(std::vector<Variable> variables) {
   setSelected(v);
 }
 
-// ____________________________________________________________________
+// ____________________________________________________________________________
 [[nodiscard]] const std::vector<Variable>& SelectClause::getSelectedVariables()
     const {
   return isAsterisk()
              ? visibleVariables_
              : std::get<VarsAndAliases>(varsAndAliasesOrAsterisk_).vars_;
 }
+
+// ____________________________________________________________________________
 [[nodiscard]] std::vector<std::string>
 SelectClause::getSelectedVariablesAsStrings() const {
   std::vector<std::string> result;

--- a/src/parser/SelectClause.h
+++ b/src/parser/SelectClause.h
@@ -51,7 +51,7 @@ struct SelectClause : ClauseBase {
   [[nodiscard]] bool isAsterisk() const;
 
   // Set the selector to '*', which means that all variables for which
-  // `addVariableForAsterisk()` is called are implicitly selected.
+  // `addVisibleVariable()` is called are implicitly selected.
   void setAsterisk();
 
   // Set the (manually) selected variables and aliases. All variables

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -10,9 +10,13 @@ using AntlrParser = SparqlAutomaticParser;
 
 // _____________________________________________________________________________
 ParsedQuery SparqlParser::parseQuery(std::string query) {
+  // The second argument is the `PrefixMap` for QLever's internal IRIs.
   sparqlParserHelpers::ParserAndVisitor p{
       std::move(query),
       {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+  // Note: `AntlrParser::query` is a method of `AntlrParser` (which is an alias
+  // for `SparqlAutomaticParser`) that returns the `QueryContext*` for the whole
+  // query.
   auto resultOfParseAndRemainingText = p.parseTypesafe(&AntlrParser::query);
   // The query rule ends with <EOF> so the parse always has to consume the whole
   // input. If this is not the case a ParseException should have been thrown at

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -10,7 +10,7 @@ namespace sparqlParserHelpers {
 using std::string;
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string input)
+ParserAndVisitor::ParserAndVisitor(std::string input)
     : input_{std::move(input)}, visitor_{} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
@@ -22,7 +22,7 @@ ParserAndVisitor::ParserAndVisitor(string input)
 }
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(string input,
+ParserAndVisitor::ParserAndVisitor(std::string input,
                                    SparqlQleverVisitor::PrefixMap prefixes)
     : ParserAndVisitor{std::move(input)} {
   visitor_.setPrefixMapManually(std::move(prefixes));

--- a/src/parser/data/VarOrTerm.h
+++ b/src/parser/data/VarOrTerm.h
@@ -7,22 +7,23 @@
 #include <string>
 #include <variant>
 
-#include "../../engine/ResultTable.h"
-#include "../../index/Index.h"
-#include "../../util/VisitMixin.h"
-#include "./GraphTerm.h"
-#include "./Variable.h"
+#include "engine/ResultTable.h"
+#include "index/Index.h"
+#include "parser/data/GraphTerm.h"
+#include "parser/data/Variable.h"
+#include "util/VisitMixin.h"
 
 using VarOrTermBase = std::variant<Variable, GraphTerm>;
 
+// TODO: This class should have some documentation.
 class VarOrTerm : public VarOrTermBase,
                   public VisitMixin<VarOrTerm, VarOrTermBase> {
  public:
   using VarOrTermBase::VarOrTermBase;
 
   // ___________________________________________________________________________
-  [[nodiscard]] std::optional<std::string> evaluate(
-      const ConstructQueryExportContext& context, PositionInTriple role) const {
+  [[nodiscard]] std::optional<std::string> evaluate(const Context& context,
+                                                    ContextRole role) const {
     // TODO<C++23>: Use std::visit when it is possible
     return visit([&context, &role](const auto& object) {
       return object.evaluate(context, role);

--- a/src/parser/data/Variable.h
+++ b/src/parser/data/Variable.h
@@ -11,8 +11,8 @@
 // Forward declaration because of cyclic dependencies
 // TODO<joka921> The coupling of the `Variable` with its `evaluate` methods
 // is not very clean and should be refactored.
-struct ConstructQueryExportContext;
-enum struct PositionInTriple : int;
+struct Context;
+enum ContextRole : int;
 
 class Variable {
  public:
@@ -24,8 +24,7 @@ class Variable {
   // the codebase. Unify them!
   // ___________________________________________________________________________
   [[nodiscard]] std::optional<std::string> evaluate(
-      const ConstructQueryExportContext& context,
-      [[maybe_unused]] PositionInTriple positionInTriple) const;
+      const Context& context, [[maybe_unused]] ContextRole role) const;
 
   // ___________________________________________________________________________
   [[nodiscard]] std::string toSparql() const { return _name; }
@@ -46,5 +45,10 @@ class Variable {
   template <typename H>
   friend H AbslHashValue(H h, const Variable& v) {
     return H::combine(std::move(h), v._name);
+  }
+
+  // Formatter for use in `absl::StrJoin` (we need this in several places).
+  static void AbslFormatter(std::string* out, const Variable& variable) {
+    out->append(variable.name());
   }
 };

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -1,16 +1,19 @@
-// Copyright 2022, University of Freiburg,
+// Copyright 2022 - 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+// Authors: Julian Mundhahs <mundhahj@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #ifndef QLEVER_ALGORITHM_H
 #define QLEVER_ALGORITHM_H
 
+#include <algorithm>
 #include <numeric>
 #include <string>
 #include <string_view>
 #include <utility>
 
 #include "util/Forward.h"
+#include "util/HashSet.h"
 #include "util/Iterators.h"
 #include "util/TypeTraits.h"
 
@@ -84,7 +87,8 @@ auto transform(Range&& input, F unaryOp) {
 template <typename T>
 std::vector<T> flatten(std::vector<std::vector<T>>&& input) {
   std::vector<T> out;
-  // Reserve the total required space. It is the sum of all the vectors lengths.
+  // Reserve the total required space. It is the sum of all the vectors
+  // lengths.
   out.reserve(std::accumulate(
       input.begin(), input.end(), 0,
       [](size_t i, const std::vector<T>& elem) { return i + elem.size(); }));
@@ -93,6 +97,27 @@ std::vector<T> flatten(std::vector<std::vector<T>>&& input) {
     appendVector(out, std::move(sub));
   }
   return out;
+}
+
+// Remove duplicates in the given vector without changing the order. For
+// example: 4, 6, 6, 2, 2, 4, 2 becomes 4, 6, 2.
+//
+// NOTE: This makes two copies of the first element in `input` with a
+// particular value. One copy for the result, and one copy for the hash set
+// used to keep track of which values we have already seen. One of these
+// copies could be avoided, but our current uses of this function are
+// currently not at all performance-critical (small `input` and small `T`).
+template <typename T>
+std::vector<T> removeDuplicates(const std::vector<T>& input) {
+  std::vector<T> result;
+  ad_utility::HashSet<T> distinctElements;
+  for (const T& element : input) {
+    if (!distinctElements.contains(element)) {
+      result.emplace_back(element);
+      distinctElements.insert(element);
+    }
+  }
+  return result;
 }
 
 }  // namespace ad_utility

--- a/src/util/Conversions.cpp
+++ b/src/util/Conversions.cpp
@@ -240,7 +240,8 @@ string convertFloatStringToIndexWord(const string& orig,
 
 // _____________________________________________________________________________
 string convertIndexWordToFloatString(const string& indexWord) {
-  const static size_t prefixLength = sizeof(VALUE_FLOAT_PREFIX) - 1;
+  const static size_t prefixLength =
+      std::char_traits<char>::length(VALUE_FLOAT_PREFIX);
   AD_CONTRACT_CHECK(indexWord.size() > prefixLength + 1);
   // the -1 accounts for the originally float/int identifier suffix
   string number =
@@ -517,7 +518,7 @@ string convertDateToIndexWord(const string& value) {
 
 // _____________________________________________________________________________
 string convertIndexWordToDate(const string& indexWord) {
-  size_t prefixLength = sizeof(VALUE_DATE_PREFIX) - 1;
+  size_t prefixLength = std::char_traits<char>::length(VALUE_DATE_PREFIX);
   std::ostringstream os;
   if (indexWord[prefixLength] == '-') {
     os << '-'

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -26,12 +26,9 @@ class AbortException : public std::exception {
   string what_;
 
  public:
-  explicit AbortException(const std::exception& original)
-      : what_{original.what()} {}
-  explicit AbortException(std::string what) : what_{std::move(what)} {}
-  [[nodiscard]] const char* what() const noexcept override {
-    return what_.c_str();
-  }
+  AbortException(const std::exception& original) : what_(original.what()) {}
+  AbortException(const std::string& what) : what_(what) {}
+  const char* what() const noexcept { return what_.c_str(); }
 };
 
 // An exception that stores a message as well as the `source_location` where
@@ -43,9 +40,9 @@ class Exception : public std::exception {
   ad_utility::source_location location_;
 
  public:
-  explicit Exception(const std::string& message,
-                     ad_utility::source_location location =
-                         ad_utility::source_location::current())
+  Exception(const std::string& message,
+            ad_utility::source_location location =
+                ad_utility::source_location::current())
       : location_{location} {
     std::stringstream str;
     // TODO<GCC13> Use `std::format`.
@@ -53,9 +50,7 @@ class Exception : public std::exception {
         << location_.line();
     message_ = std::move(str).str();
   }
-  [[nodiscard]] const char* what() const noexcept override {
-    return message_.c_str();
-  }
+  const char* what() const noexcept override { return message_.c_str(); }
 };
 }  // namespace ad_utility
 
@@ -73,13 +68,15 @@ class Exception : public std::exception {
 //! very insignificantly. Counterexample: don't use this in an inner loop that
 //! is executed million of times, and has otherwise little code.
 // --------------------------------------------------------------------------
+// Needed for Cygwin (will be an identical redefine  for *nixes)
+#define __STRING(x) #x
 
 // Custom assert that will always fail and report the file and line. Note that
 // for code that is truly unreachable (not even by setting up artificially
 // faulty input in a unit test), our code coverage tools will always consider
 // this macro uncovered. This cannot even be changed by changing it to something
 // like `__builtin_unreachable()` (last checked by Johannes in Jan 2023).
-#define AD_FAIL() AD_THROW("This code should be unreachable")
+#define AD_FAIL() AD_THROW("This code should be unreachable");
 
 // Custom assert which does not abort but throws an exception. Use this for
 // conditions that can be violated by calling a public (member) function with
@@ -92,8 +89,7 @@ class Exception : public std::exception {
     AD_THROW(                                                                                                                                              \
         "Assertion `"s + std::string(__STRING(condition)) +                                                                                                \
         "` failed. Likely cause: A function was called with arguments that violate the contract of the function. Please report this to the developers."s); \
-  }                                                                                                                                                        \
-  void(0)
+  }
 
 // Custom assert which does not abort but throws an exception. Use this for
 // conditions that can never be violated via a public (member) function. It is

--- a/src/util/GeoSparqlHelpers.cpp
+++ b/src/util/GeoSparqlHelpers.cpp
@@ -4,9 +4,6 @@
 
 #include "./GeoSparqlHelpers.h"
 
-#include <absl/strings/charconv.h>
-#include <ctre/ctre.h>
-
 #include <cmath>
 #include <limits>
 #include <numbers>
@@ -15,6 +12,8 @@
 #include <string_view>
 
 #include "./Exception.h"
+#include "absl/strings/charconv.h"
+#include "ctre/ctre.h"
 
 namespace ad_utility {
 

--- a/test/AlgorithmTest.cpp
+++ b/test/AlgorithmTest.cpp
@@ -1,6 +1,7 @@
-//  Copyright 2023, University of Freiburg,
-//                  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+// Copyright 2022 - 2023, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include <gtest/gtest.h>
 
@@ -10,6 +11,7 @@
 
 using namespace ad_utility;
 
+// _____________________________________________________________________________
 TEST(Algorithm, Contains) {
   std::vector v{1, 42, 5, 3};
   ASSERT_TRUE(
@@ -54,6 +56,7 @@ TEST(Algorithm, Contains) {
   testStringLike.template operator()<std::string_view>();
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, ContainsIF) {
   std::vector v{1, 3, 42};
   ASSERT_TRUE(contains_if(v, [](const auto& el) { return el > 5; }));
@@ -63,6 +66,7 @@ TEST(Algorithm, ContainsIF) {
   ASSERT_FALSE(contains_if(v, [](const auto& el) { return el < 0; }));
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, AppendVector) {
   using V = std::vector<std::string>;
   V v{"1", "2", "7"};
@@ -82,6 +86,7 @@ TEST(Algorithm, AppendVector) {
   ASSERT_TRUE(v3[1].empty());
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, Transform) {
   std::vector<std::string> v{"hi", "bye", "why"};
   auto vCopy = v;
@@ -99,6 +104,7 @@ TEST(Algorithm, Transform) {
   ASSERT_TRUE(std::ranges::all_of(v, &std::string::empty));
 }
 
+// _____________________________________________________________________________
 TEST(Algorithm, Flatten) {
   std::vector<std::vector<std::string>> v{{"hi"}, {"bye", "why"}, {"me"}};
   auto v3 = flatten(std::move(v));
@@ -109,3 +115,20 @@ TEST(Algorithm, Flatten) {
     return std::ranges::all_of(inner, &std::string::empty);
   }));
 }
+
+// _____________________________________________________________________________
+TEST(AlgorithmTest, removeDuplicates) {
+  // Test with ints.
+  ASSERT_EQ(ad_utility::removeDuplicates(std::vector<int>{4, 6, 6, 2, 2, 4, 2}),
+            (std::vector<int>{4, 6, 2}));
+  // Test with strings.
+  std::string s1 = "four";
+  std::string s2 = "six";
+  std::string s3 = "abcdefghijklmnopqrstuvwxzy";
+  ASSERT_EQ(ad_utility::removeDuplicates(
+                std::vector<std::string>{s1, s2, s1, s1, s3, s1, s3}),
+            (std::vector<std::string>{s1, s2, s3}));
+  // Test with empty input.
+  ASSERT_EQ(ad_utility::removeDuplicates(std::vector<int>{}),
+            (std::vector<int>{}));
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,30 +33,14 @@ function(linkAndDiscoverTestSerial basename)
             TRUE)
 endfunction()
 
-if (SINGLE_TEST_BINARY)
-    message(STATUS "All tests are linked into a single executable `QLeverAllUnitTestsMain`")
-    add_executable(QLeverAllUnitTestsMain)
-    target_link_libraries(QLeverAllUnitTestsMain gmock_main ${CMAKE_THREAD_LIBS_INIT})
-    gtest_discover_tests(QLeverAllUnitTestsMain QLeverAllUnitTestsMain PROPERTIES RUN_SERIAL
-            TRUE)
-else()
-    message(STATUS "The tests are split over multiple binaries")
-
-endif()
 # Usage: `addAndLinkTest(basename, [additionalLibraries...]`
 # Add a GTest/GMock test case that is called `basename` and compiled from a file called
 # `basename.cpp`. All tests are linked against `gmock_main` and the threading library.
 # additional libraries against which the test case has to be linked can be specified as
 # additional arguments after the `basename`
 function(addLinkAndDiscoverTest basename)
-  if (SINGLE_TEST_BINARY)
-      target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
-      target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
-  else()
     addTest(${basename})
     linkAndDiscoverTest(${basename} ${ARGN})
-  endif()
-
 endfunction()
 
 # Usage: `addAndLinkTestSerial(basename, [additionalLibraries...]`
@@ -64,13 +48,8 @@ endfunction()
 # (without any of the other test cases running in parallel). This can be
 # required e.g. if several tests cases write to the same file.
 function(addLinkAndDiscoverTestSerial basename)
-  if (SINGLE_TEST_BINARY)
-    target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
-    target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
-  else()
     addTest(${basename})
     linkAndDiscoverTestSerial(${basename} ${ARGN})
-  endif()
 endfunction()
 
 # Only compile and link the test, but do not run it.
@@ -131,13 +110,8 @@ addLinkAndDiscoverTestSerial(BufferedVectorTest absl::strings)
 
 addLinkAndDiscoverTest(UnionTest engine)
 
-if (SINGLE_TEST_BINARY)
-    target_sources(QLeverAllUnitTestsMain PUBLIC TokenTest.cpp TokenTestCtreHelper.cpp)
-    target_link_libraries(QLeverAllUnitTestsMain parser re2 util ${ICU_LIBRARIES})
-else()
-    add_executable(TokenTest TokenTest.cpp TokenTestCtreHelper.cpp)
-    linkAndDiscoverTest(TokenTest parser re2 util ${ICU_LIBRARIES})
-endif()
+add_executable(TokenTest TokenTest.cpp TokenTestCtreHelper.cpp)
+linkAndDiscoverTest(TokenTest parser re2 util ${ICU_LIBRARIES})
 
 addLinkAndDiscoverTest(TurtleParserTest parser absl::flat_hash_map re2)
 
@@ -250,7 +224,7 @@ addLinkAndDiscoverTest(HttpUtilsTest util http)
 
 addLinkAndDiscoverTest(DateTest)
 
-addLinkAndDiscoverTest(TripleComponentTest absl::strings parser)
+addLinkAndDiscoverTest(TripleObjectTest absl::strings parser)
 
 addLinkAndDiscoverTest(ValueIdTest absl::flat_hash_set)
 
@@ -262,13 +236,15 @@ addLinkAndDiscoverTest(TransparentFunctorsTest)
 
 addLinkAndDiscoverTest(SelectClauseTest parser engine)
 
-addLinkAndDiscoverTestSerial(RelationalExpressionTest parser sparqlExpressions index engine)
+addLinkAndDiscoverTestSerial(RelationalExpressionTest sparqlExpressions index engine)
 
 addLinkAndDiscoverTest(CheckUsePatternTrickTest parser engine)
 
-addLinkAndDiscoverTestSerial(RegexExpressionTest parser sparqlExpressions index engine parser)
+addLinkAndDiscoverTestSerial(RegexExpressionTest sparqlExpressions index engine)
 
 addLinkAndDiscoverTestSerial(LocalVocabTest engine)
+
+addLinkAndDiscoverTest(ValuesTest engine)
 
 addLinkAndDiscoverTest(HttpTest boost_iostreams http)
 
@@ -280,18 +256,8 @@ addLinkAndDiscoverTest(ResetWhenMovedTest)
 
 addLinkAndDiscoverTest(TimerTest absl::strings)
 
-addLinkAndDiscoverTest(AlgorithmTest)
+addLinkAndDiscoverTest(AlgorithmTest absl::flat_hash_set)
 
 addLinkAndDiscoverTest(CompressedRelationsTest index)
 
 addLinkAndDiscoverTest(ExceptionTest)
-
-addLinkAndDiscoverTestSerial(RandomExpressionTest absl::flat_hash_map index)
-
-addLinkAndDiscoverTestSerial(SortTest engine)
-
-addLinkAndDiscoverTestSerial(OrderByTest engine)
-
-addLinkAndDiscoverTestSerial(ValuesForTestingTest index)
-
-addLinkAndDiscoverTestSerial(ExportQueryExecutionTreeTest index engine parser)

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -75,9 +75,6 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
       // The last argument is the number of distinct elements in `col1`. We
       // store a dummy value here that we can check later.
       writer.addRelation(V(input.col0_), buffer, i + 1);
-      buffer.clear();
-      ASSERT_THROW(writer.addRelation(V(input.col0_), buffer, i + 1),
-                   ad_utility::Exception);
       ++i;
     }
   }
@@ -100,8 +97,6 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
   auto timer = std::make_shared<ad_utility::ConcurrentTimeoutTimer>(
       ad_utility::TimeoutTimer::unlimited());
   // Check the contents of the metadata.
-
-  CompressedRelationReader reader;
   for (size_t i = 0; i < metaData.size(); ++i) {
     const auto& m = metaData[i];
     ASSERT_EQ(V(inputs[i].col0_), m._col0Id);
@@ -112,12 +107,9 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
                     m._multiplicityCol1);
     // Scan for all distinct `col0` and check that we get the expected result.
     IdTable table{2, ad_utility::testing::makeAllocator()};
-    reader.scan(metaData[i], blocks, file, &table, timer);
-    {
-      IdTable wrongNumCols{3, ad_utility::testing::makeAllocator()};
-      ASSERT_THROW(reader.scan(metaData[i], blocks, file, &wrongNumCols, timer),
-                   ad_utility::Exception);
-    }
+    CompressedRelationMetadata::scan(metaData[i], blocks,
+                                     testCaseName + std::to_string(blocksize),
+                                     file, &table, timer);
     const auto& col1And2 = inputs[i].col1And2_;
     checkThatTablesAreEqual(col1And2, table);
 
@@ -129,15 +121,9 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
 
     auto scanAndCheck = [&]() {
       IdTable tableWidthOne{1, ad_utility::testing::makeAllocator()};
-      reader.scan(metaData[i], V(lastCol1Id), blocks, file, &tableWidthOne,
-                  timer);
+      CompressedRelationMetadata::scan(metaData[i], V(lastCol1Id), blocks, file,
+                                       &tableWidthOne, timer);
       checkThatTablesAreEqual(col3, tableWidthOne);
-      {
-        IdTable wrongNumCols{2, ad_utility::testing::makeAllocator()};
-        ASSERT_THROW(reader.scan(metaData[i], V(lastCol1Id), blocks, file,
-                                 &wrongNumCols, timer),
-                     ad_utility::Exception);
-      }
     };
     for (size_t j = 0; j < col1And2.size(); ++j) {
       if (col1And2[j][0] == lastCol1Id) {

--- a/test/FTSAlgorithmsTest.cpp
+++ b/test/FTSAlgorithmsTest.cpp
@@ -4,18 +4,22 @@
 
 #include <gtest/gtest.h>
 
-#include "./IndexTestHelpers.h"
-#include "./util/IdTestHelpers.h"
-#include "engine/CallFixedSize.h"
-#include "index/FTSAlgorithms.h"
+#include "../src/engine/CallFixedSize.h"
+#include "../src/index/FTSAlgorithms.h"
 #include "util/DisableWarningsClang13.h"
 
-using namespace ad_utility::testing;
-
-namespace {
+ad_utility::AllocatorWithLimit<Id>& allocator() {
+  static ad_utility::AllocatorWithLimit<Id> a{
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          std::numeric_limits<size_t>::max())};
+  return a;
+}
+auto I = [](const auto& id) {
+  return Id::makeFromVocabIndex(VocabIndex::make(id));
+};
 auto T = [](const auto& id) { return TextRecordIndex::make(id); };
-auto V = VocabId;
-}  // namespace
+auto TextId = [](const auto& id) { return Id::makeFromTextRecordIndex(T(id)); };
+auto IntId = [](const auto& id) { return Id::makeFromInt(id); };
 
 TEST(FTSAlgorithmsTest, filterByRangeTest) {
   IdRange idRange;
@@ -107,10 +111,10 @@ TEST(FTSAlgorithmsTest, intersectTest) {
   eBlockCids.push_back(T(2));
   eBlockCids.push_back(T(2));
   eBlockCids.push_back(T(4));
-  eBlockWids.push_back(V(10));
-  eBlockWids.push_back(V(1));
-  eBlockWids.push_back(V(1));
-  eBlockWids.push_back(V(2));
+  eBlockWids.push_back(I(10));
+  eBlockWids.push_back(I(1));
+  eBlockWids.push_back(I(1));
+  eBlockWids.push_back(I(2));
   eBlockScores.push_back(1);
   eBlockScores.push_back(1);
   eBlockScores.push_back(1);
@@ -201,12 +205,12 @@ TEST(FTSAlgorithmsTest, intersectKWayTest) {
   ASSERT_EQ(5u, resScores[1]);
 
   // With eids
-  eids.push_back(V(1));
-  eids.push_back(V(4));
-  eids.push_back(V(1));
-  eids.push_back(V(4));
-  eids.push_back(V(1));
-  eids.push_back(V(2));
+  eids.push_back(I(1));
+  eids.push_back(I(4));
+  eids.push_back(I(1));
+  eids.push_back(I(4));
+  eids.push_back(I(1));
+  eids.push_back(I(2));
 
   vector<TextRecordIndex> cids2;
   vector<Score> scores2;
@@ -235,14 +239,14 @@ TEST(FTSAlgorithmsTest, intersectKWayTest) {
   ASSERT_EQ(2u, resScores.size());
   ASSERT_EQ(10, resCids[0].get());
   ASSERT_EQ(10, resCids[1].get());
-  ASSERT_EQ(V(1), resEids[0]);
-  ASSERT_EQ(V(2), resEids[1]);
+  ASSERT_EQ(I(1), resEids[0]);
+  ASSERT_EQ(I(2), resEids[1]);
   ASSERT_EQ(6u, resScores[0]);
   ASSERT_EQ(9u, resScores[1]);
 };
 
 TEST(FTSAlgorithmsTest, aggScoresAndTakeTopKContextsTest) {
-  IdTable result{makeAllocator()};
+  IdTable result{allocator()};
   result.setNumColumns(3);
   vector<TextRecordIndex> cids;
   vector<Id> eids;
@@ -255,9 +259,9 @@ TEST(FTSAlgorithmsTest, aggScoresAndTakeTopKContextsTest) {
   cids.push_back(T(1));
   cids.push_back(T(2));
 
-  eids.push_back(V(0));
-  eids.push_back(V(0));
-  eids.push_back(V(0));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
 
   scores.push_back(0);
   scores.push_back(1);
@@ -265,15 +269,15 @@ TEST(FTSAlgorithmsTest, aggScoresAndTakeTopKContextsTest) {
 
   FTSAlgorithms::aggScoresAndTakeTopKContexts(cids, eids, scores, 2, &result);
   ASSERT_EQ(2u, result.size());
-  ASSERT_EQ(TextRecordId(2u), result(0, 0));
+  ASSERT_EQ(TextId(2u), result(0, 0));
   ASSERT_EQ(IntId(3u), result(0, 1));
-  ASSERT_EQ(V(0u), result(0, 2));
-  ASSERT_EQ(TextRecordId(1u), result(1, 0));
+  ASSERT_EQ(I(0u), result(0, 2));
+  ASSERT_EQ(TextId(1u), result(1, 0));
   ASSERT_EQ(IntId(3u), result(1, 1));
-  ASSERT_EQ(V(0u), result(1, 2));
+  ASSERT_EQ(I(0u), result(1, 2));
 
   cids.push_back(T(4));
-  eids.push_back(V(1));
+  eids.push_back(I(1));
   scores.push_back(1);
 
   result.clear();
@@ -281,13 +285,13 @@ TEST(FTSAlgorithmsTest, aggScoresAndTakeTopKContextsTest) {
   ASSERT_EQ(3u, result.size());
   std::sort(result.begin(), result.end(),
             [](const auto& a, const auto& b) { return a[0] < b[0]; });
-  ASSERT_EQ(TextRecordId(4u), result(2, 0));
+  ASSERT_EQ(TextId(4u), result(2, 0));
   ASSERT_EQ(IntId(1u), result(2, 1));
-  ASSERT_EQ(V(1u), result(2, 2));
+  ASSERT_EQ(I(1u), result(2, 2));
 };
 
 TEST(FTSAlgorithmsTest, aggScoresAndTakeTopContextTest) {
-  IdTable result{makeAllocator()};
+  IdTable result{allocator()};
   result.setNumColumns(3);
   vector<TextRecordIndex> cids;
   vector<Id> eids;
@@ -312,9 +316,9 @@ TEST(FTSAlgorithmsTest, aggScoresAndTakeTopContextTest) {
   cids.push_back(T(1));
   cids.push_back(T(2));
 
-  eids.push_back(V(0));
-  eids.push_back(V(0));
-  eids.push_back(V(0));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
 
   scores.push_back(0);
   scores.push_back(1);
@@ -322,27 +326,27 @@ TEST(FTSAlgorithmsTest, aggScoresAndTakeTopContextTest) {
 
   callFixed(width, cids, eids, scores, &result);
   ASSERT_EQ(1u, result.size());
-  ASSERT_EQ(TextRecordId(2u), result(0, 0));
+  ASSERT_EQ(TextId(2u), result(0, 0));
   ASSERT_EQ(IntId(3u), result(0, 1));
-  ASSERT_EQ(V(0u), result(0, 2));
+  ASSERT_EQ(I(0u), result(0, 2));
 
   cids.push_back(T(3));
-  eids.push_back(V(1));
+  eids.push_back(I(1));
   scores.push_back(1);
 
   callFixed(width, cids, eids, scores, &result);
   ASSERT_EQ(2u, result.size());
   std::sort(result.begin(), result.end(),
             [](const auto& a, const auto& b) { return a[2] < b[2]; });
-  ASSERT_EQ(TextRecordId(2u), result(0, 0));
+  ASSERT_EQ(TextId(2u), result(0, 0));
   ASSERT_EQ(IntId(3u), result(0, 1));
-  ASSERT_EQ(V(0u), result(0, 2));
-  ASSERT_EQ(TextRecordId(3u), result(1, 0));
+  ASSERT_EQ(I(0u), result(0, 2));
+  ASSERT_EQ(TextId(3u), result(1, 0));
   ASSERT_EQ(IntId(1u), result(1, 1));
-  ASSERT_EQ(V(1u), result(1, 2));
+  ASSERT_EQ(I(1u), result(1, 2));
 
   cids.push_back(T(4));
-  eids.push_back(V(0));
+  eids.push_back(I(0));
   scores.push_back(10);
 
   DISABLE_WARNINGS_CLANG_13
@@ -356,17 +360,17 @@ TEST(FTSAlgorithmsTest, aggScoresAndTakeTopContextTest) {
   std::sort(result.begin(), result.end(),
             [](const auto& a, const auto& b) { return a[2] < b[2]; });
 
-  ASSERT_EQ(TextRecordId(4u), result(0, 0));
+  ASSERT_EQ(TextId(4u), result(0, 0));
   ASSERT_EQ(IntId(4u), result(0, 1));
-  ASSERT_EQ(V(0u), result(0, 2));
-  ASSERT_EQ(TextRecordId(3u), result(1, 0));
+  ASSERT_EQ(I(0u), result(0, 2));
+  ASSERT_EQ(TextId(3u), result(1, 0));
   ASSERT_EQ(IntId(1u), result(1, 1));
-  ASSERT_EQ(V(1u), result(1, 2));
+  ASSERT_EQ(I(1u), result(1, 2));
 };
 
 TEST(FTSAlgorithmsTest, appendCrossProductWithSingleOtherTest) {
   ad_utility::HashMap<Id, vector<array<Id, 1>>> subRes;
-  subRes[V(1)] = vector<array<Id, 1>>{{{V(1)}}};
+  subRes[I(1)] = vector<array<Id, 1>>{{{I(1)}}};
 
   vector<array<Id, 4>> res;
 
@@ -375,8 +379,8 @@ TEST(FTSAlgorithmsTest, appendCrossProductWithSingleOtherTest) {
   cids.push_back(T(1));
 
   vector<Id> eids;
-  eids.push_back(V(0));
-  eids.push_back(V(1));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
 
   vector<Score> scores;
   scores.push_back(2);
@@ -385,46 +389,46 @@ TEST(FTSAlgorithmsTest, appendCrossProductWithSingleOtherTest) {
   FTSAlgorithms::appendCrossProduct(cids, eids, scores, 0, 2, subRes, res);
 
   ASSERT_EQ(2, res.size());
-  ASSERT_EQ(V(0), res[0][0]);
+  ASSERT_EQ(I(0), res[0][0]);
   ASSERT_EQ(IntId(2), res[0][1]);
-  ASSERT_EQ(TextRecordId(1), res[0][2]);
-  ASSERT_EQ(V(1), res[0][3]);
-  ASSERT_EQ(V(1), res[1][0]);
+  ASSERT_EQ(TextId(1), res[0][2]);
+  ASSERT_EQ(I(1), res[0][3]);
+  ASSERT_EQ(I(1), res[1][0]);
   ASSERT_EQ(IntId(2), res[1][1]);
-  ASSERT_EQ(TextRecordId(1), res[1][2]);
-  ASSERT_EQ(V(1), res[1][3]);
+  ASSERT_EQ(TextId(1), res[1][2]);
+  ASSERT_EQ(I(1), res[1][3]);
 
-  subRes[V(0)] = vector<array<Id, 1>>{{{V(0)}}};
+  subRes[I(0)] = vector<array<Id, 1>>{{{I(0)}}};
   res.clear();
   FTSAlgorithms::appendCrossProduct(cids, eids, scores, 0, 2, subRes, res);
 
   ASSERT_EQ(4u, res.size());
-  ASSERT_EQ(V(0), res[0][0]);
+  ASSERT_EQ(I(0), res[0][0]);
   ASSERT_EQ(IntId(2), res[0][1]);
-  ASSERT_EQ(TextRecordId(1), res[0][2]);
-  ASSERT_EQ(V(0), res[0][3]);
-  ASSERT_EQ(V(0), res[1][0]);
+  ASSERT_EQ(TextId(1), res[0][2]);
+  ASSERT_EQ(I(0), res[0][3]);
+  ASSERT_EQ(I(0), res[1][0]);
   ASSERT_EQ(IntId(2), res[1][1]);
-  ASSERT_EQ(TextRecordId(1), res[1][2]);
-  ASSERT_EQ(V(1), res[1][3]);
-  ASSERT_EQ(V(1), res[2][0]);
+  ASSERT_EQ(TextId(1), res[1][2]);
+  ASSERT_EQ(I(1), res[1][3]);
+  ASSERT_EQ(I(1), res[2][0]);
   ASSERT_EQ(IntId(2), res[2][1]);
-  ASSERT_EQ(TextRecordId(1), res[2][2]);
-  ASSERT_EQ(V(0), res[2][3]);
-  ASSERT_EQ(V(1), res[3][0]);
+  ASSERT_EQ(TextId(1), res[2][2]);
+  ASSERT_EQ(I(0), res[2][3]);
+  ASSERT_EQ(I(1), res[3][0]);
   ASSERT_EQ(IntId(2), res[3][1]);
-  ASSERT_EQ(TextRecordId(1), res[3][2]);
-  ASSERT_EQ(V(1), res[3][3]);
+  ASSERT_EQ(TextId(1), res[3][2]);
+  ASSERT_EQ(I(1), res[3][3]);
 }
 
 TEST(FTSAlgorithmsTest, appendCrossProductWithTwoW1Test) {
   ad_utility::HashSet<Id> subRes1;
-  subRes1.insert(V(1));
-  subRes1.insert(V(2));
+  subRes1.insert(I(1));
+  subRes1.insert(I(2));
 
   ad_utility::HashSet<Id> subRes2;
-  subRes2.insert(V(0));
-  subRes2.insert(V(5));
+  subRes2.insert(I(0));
+  subRes2.insert(I(5));
 
   vector<array<Id, 5>> res;
 
@@ -433,8 +437,8 @@ TEST(FTSAlgorithmsTest, appendCrossProductWithTwoW1Test) {
   cids.push_back(T(1));
 
   vector<Id> eids;
-  eids.push_back(V(0));
-  eids.push_back(V(1));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
 
   vector<Score> scores;
   scores.push_back(2);
@@ -444,16 +448,16 @@ TEST(FTSAlgorithmsTest, appendCrossProductWithTwoW1Test) {
                                     res);
 
   ASSERT_EQ(2u, res.size());
-  ASSERT_EQ(V(0), res[0][0]);
+  ASSERT_EQ(I(0), res[0][0]);
   ASSERT_EQ(IntId(2), res[0][1]);
-  ASSERT_EQ(TextRecordId(1), res[0][2]);
-  ASSERT_EQ(V(1), res[0][3]);
-  ASSERT_EQ(V(0), res[0][4]);
-  ASSERT_EQ(V(1), res[1][0]);
+  ASSERT_EQ(TextId(1), res[0][2]);
+  ASSERT_EQ(I(1), res[0][3]);
+  ASSERT_EQ(I(0), res[0][4]);
+  ASSERT_EQ(I(1), res[1][0]);
   ASSERT_EQ(IntId(2), res[1][1]);
-  ASSERT_EQ(TextRecordId(1), res[1][2]);
-  ASSERT_EQ(V(1), res[1][3]);
-  ASSERT_EQ(V(0), res[0][4]);
+  ASSERT_EQ(TextId(1), res[1][2]);
+  ASSERT_EQ(I(1), res[1][3]);
+  ASSERT_EQ(I(0), res[0][4]);
 }
 
 TEST(FTSAlgorithmsTest, multVarsAggScoresAndTakeTopKContexts) {
@@ -471,13 +475,13 @@ TEST(FTSAlgorithmsTest, multVarsAggScoresAndTakeTopKContexts) {
   vector<Score> scores;
   size_t nofVars = 2;
   size_t k = 1;
-  IdTable resW4{4, makeAllocator()};
+  IdTable resW4{4, allocator()};
   int width = resW4.numColumns();
   callFixed(width, cids, eids, scores, nofVars, k, &resW4);
   ASSERT_EQ(0u, resW4.size());
   nofVars = 5;
   k = 10;
-  IdTable resWV{13, makeAllocator()};
+  IdTable resWV{13, allocator()};
   width = resWV.numColumns();
   callFixed(width, cids, eids, scores, nofVars, k, &resWV);
   ASSERT_EQ(0u, resWV.size());
@@ -489,12 +493,12 @@ TEST(FTSAlgorithmsTest, multVarsAggScoresAndTakeTopKContexts) {
   cids.push_back(T(2));
   cids.push_back(T(2));
 
-  eids.push_back(V(0));
-  eids.push_back(V(0));
-  eids.push_back(V(1));
-  eids.push_back(V(0));
-  eids.push_back(V(1));
-  eids.push_back(V(2));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
+  eids.push_back(I(2));
 
   scores.push_back(10);
   scores.push_back(1);
@@ -512,10 +516,10 @@ TEST(FTSAlgorithmsTest, multVarsAggScoresAndTakeTopKContexts) {
   ASSERT_EQ(9u, resW4.size());
   std::sort(std::begin(resW4), std::end(resW4),
             [](const auto& a, const auto& b) { return a[1] > b[1]; });
-  ASSERT_EQ(TextRecordId(0), resW4(0, 0));
+  ASSERT_EQ(TextId(0), resW4(0, 0));
   ASSERT_EQ(IntId(3), resW4(0, 1));
-  ASSERT_EQ(V(0), resW4(0, 2));
-  ASSERT_EQ(V(0), resW4(0, 3));
+  ASSERT_EQ(I(0), resW4(0, 2));
+  ASSERT_EQ(I(0), resW4(0, 3));
   ASSERT_EQ(IntId(2), resW4(1, 1));
   ASSERT_EQ(IntId(2), resW4(2, 1));
   ASSERT_EQ(IntId(2), resW4(3, 1));
@@ -529,18 +533,18 @@ TEST(FTSAlgorithmsTest, multVarsAggScoresAndTakeTopKContexts) {
             [](const auto& a, const auto& b) {
               return a[1] != b[1] ? a[1] > b[1] : a[0] < b[0];
             });
-  ASSERT_EQ(TextRecordId(0), resW4(0, 0));
+  ASSERT_EQ(TextId(0), resW4(0, 0));
   ASSERT_EQ(IntId(3), resW4(0, 1));
-  ASSERT_EQ(V(0), resW4(0, 2));
-  ASSERT_EQ(V(0), resW4(0, 3));
-  ASSERT_EQ(TextRecordId(1), resW4(1, 0));
+  ASSERT_EQ(I(0), resW4(0, 2));
+  ASSERT_EQ(I(0), resW4(0, 3));
+  ASSERT_EQ(TextId(1), resW4(1, 0));
   ASSERT_EQ(IntId(3), resW4(1, 1));
-  ASSERT_EQ(V(0), resW4(1, 2));
-  ASSERT_EQ(V(0), resW4(1, 3));
+  ASSERT_EQ(I(0), resW4(1, 2));
+  ASSERT_EQ(I(0), resW4(1, 3));
 
   nofVars = 3;
   k = 1;
-  IdTable resW5{5, makeAllocator()};
+  IdTable resW5{5, allocator()};
   width = resW5.numColumns();
   callFixed(width, cids, eids, scores, nofVars, k, &resW5);
   ASSERT_EQ(27u, resW5.size());  // Res size 3^3
@@ -556,7 +560,7 @@ TEST(FTSAlgorithmsTest, oneVarFilterAggScoresAndTakeTopKContexts) {
   vector<Id> eids;
   vector<Score> scores;
   size_t k = 1;
-  IdTable resW3{3, makeAllocator()};
+  IdTable resW3{3, allocator()};
   ad_utility::HashMap<Id, IdTable> fMap1;
 
   int width = resW3.numColumns();
@@ -572,12 +576,12 @@ TEST(FTSAlgorithmsTest, oneVarFilterAggScoresAndTakeTopKContexts) {
   cids.push_back(T(2));
   cids.push_back(T(2));
 
-  eids.push_back(V(0));
-  eids.push_back(V(0));
-  eids.push_back(V(1));
-  eids.push_back(V(0));
-  eids.push_back(V(1));
-  eids.push_back(V(2));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
+  eids.push_back(I(2));
 
   scores.push_back(10);
   scores.push_back(1);
@@ -591,9 +595,9 @@ TEST(FTSAlgorithmsTest, oneVarFilterAggScoresAndTakeTopKContexts) {
                   eids, scores, fMap1, k, &resW3);
   ASSERT_EQ(0u, resW3.size());
 
-  auto [it, success] = fMap1.emplace(V(1), IdTable{1, makeAllocator()});
+  auto [it, success] = fMap1.emplace(I(1), IdTable{1, allocator()});
   ASSERT_TRUE(success);
-  it->second.push_back({V(1)});
+  it->second.push_back({I(1)});
 
   CALL_FIXED_SIZE(width,
                   FTSAlgorithms::oneVarFilterAggScoresAndTakeTopKContexts, cids,
@@ -607,9 +611,9 @@ TEST(FTSAlgorithmsTest, oneVarFilterAggScoresAndTakeTopKContexts) {
   ASSERT_EQ(2u, resW3.size());
 
   {
-    auto [it, suc] = fMap1.emplace(V(0), IdTable{1, makeAllocator()});
+    auto [it, suc] = fMap1.emplace(I(0), IdTable{1, allocator()});
     ASSERT_TRUE(suc);
-    it->second.push_back({V(0)});
+    it->second.push_back({I(0)});
   }
   resW3.clear();
   CALL_FIXED_SIZE(width,
@@ -619,14 +623,14 @@ TEST(FTSAlgorithmsTest, oneVarFilterAggScoresAndTakeTopKContexts) {
 
   ad_utility::HashMap<Id, IdTable> fMap4;
   {
-    auto [it, suc] = fMap4.emplace(V(0), IdTable{4, makeAllocator()});
+    auto [it, suc] = fMap4.emplace(I(0), IdTable{4, allocator()});
     ASSERT_TRUE(suc);
     auto& el = it->second;
-    el.push_back({V(0), V(0), V(0), V(0)});
-    el.push_back({V(0), V(1), V(0), V(0)});
-    el.push_back({V(0), V(2), V(0), V(0)});
+    el.push_back({I(0), I(0), I(0), I(0)});
+    el.push_back({I(0), I(1), I(0), I(0)});
+    el.push_back({I(0), I(2), I(0), I(0)});
   }
-  IdTable resVar{7, makeAllocator()};
+  IdTable resVar{7, allocator()};
   k = 1;
   width = 7;
   CALL_FIXED_SIZE(width,
@@ -635,9 +639,9 @@ TEST(FTSAlgorithmsTest, oneVarFilterAggScoresAndTakeTopKContexts) {
   ASSERT_EQ(3u, resVar.size());
 
   {
-    auto [it, suc] = fMap4.emplace(V(2), IdTable(4, makeAllocator()));
+    auto [it, suc] = fMap4.emplace(I(2), IdTable(4, allocator()));
     ASSERT_TRUE(suc);
-    it->second.push_back({V(2), V(2), V(2), V(2)});
+    it->second.push_back({I(2), I(2), I(2), I(2)});
   }
   resVar.clear();
   CALL_FIXED_SIZE(width,
@@ -657,12 +661,12 @@ TEST(FTSAlgorithmsTest, multVarsFilterAggScoresAndTakeTopKContexts) {
   cids.push_back(T(2));
   cids.push_back(T(2));
 
-  eids.push_back(V(0));
-  eids.push_back(V(0));
-  eids.push_back(V(1));
-  eids.push_back(V(0));
-  eids.push_back(V(1));
-  eids.push_back(V(2));
+  eids.push_back(I(0));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
+  eids.push_back(I(0));
+  eids.push_back(I(1));
+  eids.push_back(I(2));
 
   scores.push_back(10);
   scores.push_back(3);
@@ -672,7 +676,7 @@ TEST(FTSAlgorithmsTest, multVarsFilterAggScoresAndTakeTopKContexts) {
   scores.push_back(1);
 
   size_t k = 1;
-  IdTable resW4{4, makeAllocator()};
+  IdTable resW4{4, allocator()};
   ad_utility::HashMap<Id, IdTable> fMap1;
 
   size_t nofVars = 2;
@@ -684,17 +688,17 @@ TEST(FTSAlgorithmsTest, multVarsFilterAggScoresAndTakeTopKContexts) {
 
   auto test = [&](int width, auto&&... args) {
     ad_utility::callFixedSize(
-        DISABLE_WARNINGS_CLANG_13 width, [&]<int V>() mutable {
+        DISABLE_WARNINGS_CLANG_13 width, [&]<int I>() mutable {
           ENABLE_WARNINGS_CLANG_13
-          FTSAlgorithms::multVarsFilterAggScoresAndTakeTopKContexts<V>(
+          FTSAlgorithms::multVarsFilterAggScoresAndTakeTopKContexts<I>(
               AD_FWD(args)...);
         });
   };
   test(width, cids, eids, scores, fMap1, nofVars, k, &resW4);
   ASSERT_EQ(0u, resW4.size());
 
-  auto [it, suc] = fMap1.emplace(V(1), IdTable{1, makeAllocator()});
-  it->second.push_back({V(1)});
+  auto [it, suc] = fMap1.emplace(I(1), IdTable{1, allocator()});
+  it->second.push_back({I(1)});
 
   test(width,
 
@@ -712,18 +716,18 @@ TEST(FTSAlgorithmsTest, multVarsFilterAggScoresAndTakeTopKContexts) {
     return a[1] > b[1];
   });
 
-  ASSERT_EQ(TextRecordId(1), resW4(0, 0));
+  ASSERT_EQ(TextId(1), resW4(0, 0));
   ASSERT_EQ(IntId(2), resW4(0, 1));
-  ASSERT_EQ(V(0), resW4(0, 2));
-  ASSERT_EQ(V(1), resW4(0, 3));
-  ASSERT_EQ(TextRecordId(1), resW4(1, 0));
+  ASSERT_EQ(I(0), resW4(0, 2));
+  ASSERT_EQ(I(1), resW4(0, 3));
+  ASSERT_EQ(TextId(1), resW4(1, 0));
   ASSERT_EQ(IntId(2), resW4(1, 1));
-  ASSERT_EQ(V(1), resW4(1, 2));
-  ASSERT_EQ(V(1), resW4(1, 3));
-  ASSERT_EQ(TextRecordId(2), resW4(2, 0));
+  ASSERT_EQ(I(1), resW4(1, 2));
+  ASSERT_EQ(I(1), resW4(1, 3));
+  ASSERT_EQ(TextId(2), resW4(2, 0));
   ASSERT_EQ(IntId(1), resW4(2, 1));
-  ASSERT_EQ(V(2), resW4(2, 2));
-  ASSERT_EQ(V(1), resW4(2, 3));
+  ASSERT_EQ(I(2), resW4(2, 2));
+  ASSERT_EQ(I(1), resW4(2, 3));
 
   resW4.clear();
   test(width,
@@ -742,26 +746,26 @@ TEST(FTSAlgorithmsTest, multVarsFilterAggScoresAndTakeTopKContexts) {
               return a[1] > b[1];
             });
 
-  ASSERT_EQ(TextRecordId(1u), resW4(0, 0));
+  ASSERT_EQ(TextId(1u), resW4(0, 0));
   ASSERT_EQ(IntId(2u), resW4(0, 1));
-  ASSERT_EQ(V(0u), resW4(0, 2));
-  ASSERT_EQ(V(1u), resW4(0, 3));
-  ASSERT_EQ(TextRecordId(2u), resW4(1, 0));
+  ASSERT_EQ(I(0u), resW4(0, 2));
+  ASSERT_EQ(I(1u), resW4(0, 3));
+  ASSERT_EQ(TextId(2u), resW4(1, 0));
   ASSERT_EQ(IntId(2u), resW4(1, 1));
-  ASSERT_EQ(V(0u), resW4(1, 2));
-  ASSERT_EQ(V(1u), resW4(1, 3));
+  ASSERT_EQ(I(0u), resW4(1, 2));
+  ASSERT_EQ(I(1u), resW4(1, 3));
 
-  ASSERT_EQ(TextRecordId(1u), resW4(2, 0));
+  ASSERT_EQ(TextId(1u), resW4(2, 0));
   ASSERT_EQ(IntId(2u), resW4(2, 1));
-  ASSERT_EQ(V(1u), resW4(2, 2));
-  ASSERT_EQ(V(1u), resW4(2, 3));
-  ASSERT_EQ(TextRecordId(2u), resW4(3, 0));
+  ASSERT_EQ(I(1u), resW4(2, 2));
+  ASSERT_EQ(I(1u), resW4(2, 3));
+  ASSERT_EQ(TextId(2u), resW4(3, 0));
   ASSERT_EQ(IntId(2u), resW4(3, 1));
-  ASSERT_EQ(V(1u), resW4(3, 2));
-  ASSERT_EQ(V(1u), resW4(3, 3));
+  ASSERT_EQ(I(1u), resW4(3, 2));
+  ASSERT_EQ(I(1u), resW4(3, 3));
 
-  ASSERT_EQ(TextRecordId(2u), resW4(4, 0));
+  ASSERT_EQ(TextId(2u), resW4(4, 0));
   ASSERT_EQ(IntId(1u), resW4(4, 1));
-  ASSERT_EQ(V(2u), resW4(4, 2));
-  ASSERT_EQ(V(1u), resW4(4, 3));
+  ASSERT_EQ(I(2u), resW4(4, 2));
+  ASSERT_EQ(I(1u), resW4(4, 3));
 }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -100,9 +100,9 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // create an input result table with a local vocabulary
   ResultTable inTable{makeAllocator()};
-  inTable._localVocab->getIndexAndAddIfNotContained("<local1>");
-  inTable._localVocab->getIndexAndAddIfNotContained("<local2>");
-  inTable._localVocab->getIndexAndAddIfNotContained("<local3>");
+  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local1>");
+  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local2>");
+  inTable.getLocalVocab()->getIndexAndAddIfNotContained("<local3>");
 
   IdTable inputData(6, makeAllocator());
   // The input data types are

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -6,19 +6,18 @@
 
 #include <fstream>
 
-#include "./util/IdTestHelpers.h"
-#include "index/IndexMetaData.h"
-#include "util/File.h"
-#include "util/Serializer/FileSerializer.h"
+#include "../src/index/IndexMetaData.h"
+#include "../src/util/File.h"
+#include "../src/util/Serializer/FileSerializer.h"
 
-namespace {
-auto V = ad_utility::testing::VocabId;
-}
+auto I = [](const auto& id) {
+  return Id::makeFromVocabIndex(VocabIndex::make(id));
+};
 
 TEST(RelationMetaDataTest, writeReadTest) {
   CompressedBlockMetadata rmdB{
-      {{12, 34}, {46, 11}}, 5, V(0), V(2), V(13), V(24)};
-  CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
+      {{12, 34}, {46, 11}}, 5, I(0), I(2), I(13), I(24)};
+  CompressedRelationMetadata rmdF{I(1), 3, 2.0, 42.0, 16};
 
   ad_utility::serialization::FileWriteSerializer f("_testtmp.rmd");
   f << rmdF;
@@ -39,11 +38,11 @@ TEST(RelationMetaDataTest, writeReadTest) {
 TEST(IndexMetaDataTest, writeReadTest2Hmap) {
   vector<CompressedBlockMetadata> bs;
   bs.push_back(CompressedBlockMetadata{
-      {{12, 34}, {42, 5}}, 5, V(0), V(2), V(13), V(24)});
+      {{12, 34}, {42, 5}}, 5, I(0), I(2), I(13), I(24)});
   bs.push_back(CompressedBlockMetadata{
-      {{16, 34}, {165, 3}}, 5, V(0), V(2), V(13), V(24)});
-  CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
-  CompressedRelationMetadata rmdF2{V(2), 5, 3.0, 43.0, 10};
+      {{16, 34}, {165, 3}}, 5, I(0), I(2), I(13), I(24)});
+  CompressedRelationMetadata rmdF{I(1), 3, 2.0, 42.0, 16};
+  CompressedRelationMetadata rmdF2{I(2), 5, 3.0, 43.0, 10};
   IndexMetaDataHmap imd;
   imd.add(rmdF);
   imd.add(rmdF2);
@@ -57,8 +56,8 @@ TEST(IndexMetaDataTest, writeReadTest2Hmap) {
   imd2.readFromFile(&in);
   remove("_testtmp.rmd");
 
-  auto rmdFn = imd2.getMetaData(V(1));
-  auto rmdFn2 = imd2.getMetaData(V(2));
+  auto rmdFn = imd2.getMetaData(I(1));
+  auto rmdFn2 = imd2.getMetaData(I(2));
 
   ASSERT_EQ(rmdF, rmdFn);
   ASSERT_EQ(rmdF2, rmdFn2);
@@ -71,11 +70,11 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
   std::string mmapFilename = imdFilename + ".mmap";
   vector<CompressedBlockMetadata> bs;
   bs.push_back(CompressedBlockMetadata{
-      {{12, 34}, {42, 17}}, 5, V(0), V(2), V(13), V(24)});
+      {{12, 34}, {42, 17}}, 5, I(0), I(2), I(13), I(24)});
   bs.push_back(CompressedBlockMetadata{
-      {{12, 34}, {16, 12}}, 5, V(0), V(2), V(13), V(24)});
-  CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
-  CompressedRelationMetadata rmdF2{V(2), 5, 3.0, 43.0, 10};
+      {{12, 34}, {16, 12}}, 5, I(0), I(2), I(13), I(24)});
+  CompressedRelationMetadata rmdF{I(1), 3, 2.0, 42.0, 16};
+  CompressedRelationMetadata rmdF2{I(2), 5, 3.0, 43.0, 10};
   // The index MetaData does not have an explicit clear, so we
   // force destruction to close and reopen the mmap-File
   {
@@ -94,8 +93,8 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
     imd2.setup(mmapFilename, ad_utility::ReuseTag());
     imd2.readFromFile(&in);
 
-    auto rmdFn = imd2.getMetaData(V(1));
-    auto rmdFn2 = imd2.getMetaData(V(2));
+    auto rmdFn = imd2.getMetaData(I(1));
+    auto rmdFn2 = imd2.getMetaData(I(2));
 
     ASSERT_EQ(rmdF, rmdFn);
     ASSERT_EQ(rmdF2, rmdFn2);

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -10,14 +10,22 @@
 
 #include "./IndexTestHelpers.h"
 #include "./util/IdTableHelpers.h"
-#include "./util/IdTestHelpers.h"
 #include "global/Pattern.h"
 #include "index/Index.h"
 #include "index/IndexImpl.h"
 
 using namespace ad_utility::testing;
 
-namespace {
+// Return a lambda that takes a string and converts it into an ID by looking
+// it up in the vocabulary of `index`.
+auto makeGetId = [](const IndexImpl& index) {
+  return [&index](const std::string& el) {
+    Id id;
+    bool success = index.getId(el, &id);
+    AD_CONTRACT_CHECK(success);
+    return id;
+  };
+};
 
 // Return a lambda that runs a scan for two fixed elements `c0` and `c1`
 // on the `permutation` (e.g. a fixed P and S in the PSO permutation)
@@ -45,7 +53,6 @@ auto makeTestScanWidthTwo = [](const IndexImpl& index) {
     ASSERT_EQ(wol, makeIdTableFromIdVector(expected));
   };
 };
-}  // namespace
 
 TEST(IndexTest, createFromTurtleTest) {
   {
@@ -56,7 +63,7 @@ TEST(IndexTest, createFromTurtleTest) {
         "<a2> <b2> <c2> .";
     const IndexImpl& index = getQec(kb)->getIndex().getImpl();
 
-    auto getId = makeGetId(getQec(kb)->getIndex());
+    auto getId = makeGetId(index);
     Id a = getId("<a>");
     Id b = getId("<b>");
     Id c = getId("<c>");
@@ -113,7 +120,7 @@ TEST(IndexTest, createFromTurtleTest) {
 
     const IndexImpl& index = getQec(kb)->getIndex().getImpl();
 
-    auto getId = makeGetId(getQec(kb)->getIndex());
+    auto getId = makeGetId(index);
     Id zero = getId("<0>");
     Id one = getId("<1>");
     Id two = getId("<2>");
@@ -205,7 +212,7 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
       "<a2> <b2> <c2> .";
   const IndexImpl& index = getQec(kb)->getIndex().getImpl();
 
-  auto getId = makeGetId(getQec(kb)->getIndex());
+  auto getId = makeGetId(index);
   Id b = getId("<b>");
   Id b2 = getId("<b2>");
   Id a = getId("<a>");
@@ -238,7 +245,7 @@ TEST(IndexTest, scanTest) {
     IdTable wol(1, makeAllocator());
     IdTable wtl(2, makeAllocator());
 
-    auto getId = makeGetId(getQec(kb)->getIndex());
+    auto getId = makeGetId(index);
     Id a = getId("<a>");
     Id c = getId("<c>");
     Id a2 = getId("<a2>");
@@ -257,7 +264,6 @@ TEST(IndexTest, scanTest) {
     testOne("<b>", "<a>", index._PSO, {{c}, {c2}});
     testOne("<b>", "<c>", index._PSO, {});
     testOne("<b2>", "<c2>", index._POS, {{a2}});
-    testOne("<notExisting>", "<a>", index._PSO, {});
   }
   kb = "<a> <is-a> <1> . \n"
        "<a> <is-a> <2> . \n"
@@ -271,7 +277,7 @@ TEST(IndexTest, scanTest) {
     const IndexImpl& index =
         ad_utility::testing::getQec(kb)->getIndex().getImpl();
 
-    auto getId = makeGetId(ad_utility::testing::getQec(kb)->getIndex());
+    auto getId = makeGetId(index);
     Id a = getId("<a>");
     Id b = getId("<b>");
     Id c = getId("<c>");

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -119,11 +119,9 @@ TEST(LocalVocab, clone) {
 
 // _____________________________________________________________________________
 TEST(LocalVocab, propagation) {
-  // Query execution context (with small test index) and allocator for testing,
-  // see `IndexTestHelpers.h`.
+  // Query execution context (with small test index), see `IndexTestHelpers.h`.
   using ad_utility::AllocatorWithLimit;
   QueryExecutionContext* testQec = ad_utility::testing::getQec();
-  AllocatorWithLimit<Id> testAllocator = ad_utility::testing::makeAllocator();
 
   // Lambda that checks the contents of the local vocabulary after the specified
   // operation.
@@ -136,9 +134,9 @@ TEST(LocalVocab, propagation) {
     ASSERT_TRUE(resultTable)
         << "Operation: " << operation.getDescriptor() << std::endl;
     std::vector<std::string> localVocabWords;
-    for (size_t i = 0; i < resultTable->_localVocab->size(); ++i) {
+    for (size_t i = 0; i < resultTable->getLocalVocab()->size(); ++i) {
       localVocabWords.emplace_back(
-          resultTable->_localVocab->getWord(LocalVocabIndex::make(i)));
+          resultTable->getLocalVocab()->getWord(LocalVocabIndex::make(i)));
     }
     ASSERT_EQ(localVocabWords, expectedWords)
         << "Operation: " << operation.getDescriptor() << std::endl;
@@ -159,20 +157,27 @@ TEST(LocalVocab, propagation) {
 
   // VALUES operation with two variables and two rows. Adds four new literals.
   //
-  // Note: For literals, the quotes are part of the name, so if we wanted the
+  // Note 1: It is important to pass a copy of `values1` (and `values2` below)
+  // to `checkLocalVocab` because when the operation is executed, the parsed
+  // values are moved out by `Values::writeValues` and would then no longer be
+  // there in the subsequent uses of `values1` and `values2` if it were not
+  // copied.
+  //
+  // Note 2: For literals, the quotes are part of the name, so if we wanted the
   // literal "x", we would have to write TripleComponent{"\"x\""}. For the
   // purposes of this test, we just want something that's not yet in the index,
   // so "x" etc. is just fine (and also different from the "<x>" below).
-  //
   Values values1(testQec, {{Variable{"?x"}, Variable{"?y"}},
                            {{TripleComponent{"x"}, TripleComponent{"y1"}},
                             {TripleComponent{"x"}, TripleComponent{"y2"}}}});
-  checkLocalVocab(values1, std::vector<std::string>{"x", "y1", "y2"});
+  Values values1copy = values1;
+  checkLocalVocab(values1copy, std::vector<std::string>{"x", "y1", "y2"});
 
   // VALUES operation that uses an existing literal (from the test index).
   Values values2(testQec, {{Variable{"?x"}, Variable{"?y"}},
                            {{TripleComponent{"<x>"}, TripleComponent{"<y>"}}}});
-  checkLocalVocab(values2, std::vector<std::string>{});
+  Values values2copy = values2;
+  checkLocalVocab(values2copy, std::vector<std::string>{});
 
   // JOIN operation with exactly one non-empty local vocab and with two
   // non-empty local vocabs (the last two arguments are the two join columns).

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -552,18 +552,18 @@ TEST(QueryPlannerTest, testActorsBornInEurope) {
       "ORDER BY ?a");
   QueryPlanner qp(nullptr);
   QueryExecutionTree qet = qp.createExecutionTree(pq);
-  ASSERT_EQ(27493u, qet.getCostEstimate());
+  ASSERT_EQ(18340u, qet.getCostEstimate());
   ASSERT_EQ(
-      "{\n  ORDER BY on columns:asc(0) \n  {\n    JOIN\n    {\n      SCAN "
-      "POS with P = \"<pre/profession>\", O = \"<pre/Actor>\"\n      "
-      "qet-width: 1 \n    } join-column: [0]\n    |X|\n    {\n      "
-      "SORT(internal) on columns:asc(1) \n      {\n        JOIN\n        {\n "
-      "         SCAN POS with P = \"<pre/born-in>\"\n          qet-width: 2 "
-      "\n        } join-column: [0]\n        |X|\n        {\n          SCAN "
-      "POS with P = \"<pre/in>\", O = \"<pre/Europe>\"\n          qet-width: "
-      "1 \n        } join-column: [0]\n        qet-width: 2 \n      }\n      "
-      "qet-width: 2 \n    } join-column: [1]\n    qet-width: 2 \n  }\n  "
-      "qet-width: 2 \n}",
+      "{\n  JOIN\n  {\n    SCAN POS with P = \"<pre/profession>\", "
+      "O = \"<pre/Actor>\"\n    qet-width: 1 \n  } join-column:"
+      " [0]\n  |X|\n  {\n    SORT / ORDER BY on columns:asc(1) \n    {\n     "
+      " "
+      "JOIN\n      {\n        SCAN POS with P = \"<pre/born-i"
+      "n>\"\n        qet-width: 2 \n      } join-column: [0]\n "
+      "     |X|\n      {\n        SCAN POS with P = \"<pre/in>\""
+      ", O = \"<pre/Europe>\"\n        qet-width: 1 \n      }"
+      " join-column: [0]\n      qet-width: 2 \n    }\n    "
+      "qet-width: 2 \n  } join-column: [1]\n  qet-width: 2 \n}",
       qet.asString());
 }
 
@@ -634,7 +634,7 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN PSO with P = \"<p>\", S = \"<s>\"\n    "
-        "qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    SORT(internal) "
+        "qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    SORT / ORDER BY "
         "on columns:asc(1) \n    {\n      SCAN FOR FULL INDEX OSP (DUMMY "
         "OPERATION)\n      qet-width: 3 \n    }\n    qet-width: 3 \n  } "
         "join-column: [1]\n  qet-width: 3 \n}",
@@ -648,7 +648,7 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN SOP with S = \"<s>\", O = \"<o>\"\n    "
-        "qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    SORT(internal) "
+        "qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    SORT / ORDER BY "
         "on columns:asc(1) \n    {\n      SCAN FOR FULL INDEX OSP (DUMMY "
         "OPERATION)\n      qet-width: 3 \n    }\n    qet-width: 3 \n  } "
         "join-column: [1]\n  qet-width: 3 \n}",
@@ -662,7 +662,7 @@ TEST(QueryPlannerTest, threeVarTriples) {
     QueryExecutionTree qet = qp.createExecutionTree(pq);
     ASSERT_EQ(
         "{\n  JOIN\n  {\n    SCAN PSO with P = \"<p>\", S = \"<s>\"\n    "
-        "qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    SORT(internal) "
+        "qet-width: 1 \n  } join-column: [0]\n  |X|\n  {\n    SORT / ORDER BY "
         "on columns:asc(1) \n    {\n      SCAN FOR FULL INDEX OPS (DUMMY "
         "OPERATION)\n      qet-width: 3 \n    }\n    qet-width: 3 \n  } "
         "join-column: [1]\n  qet-width: 3 \n}",
@@ -835,7 +835,7 @@ TEST(QueryExecutionTreeTest, testPoliticiansFriendWithScieManHatProj) {
       "\"manhattan project\" and 1 variables with textLimit = 1 filtered "
       "by\n  {\n    JOIN\n    {\n      SCAN POS with P = \"<is-a>\", O = "
       "\"<Scientist>\"\n      qet-width: 1 \n    } join-column: [0]\n    "
-      "|X|\n    {\n      SORT(internal) on columns:asc(2) \n      {\n       "
+      "|X|\n    {\n      SORT / ORDER BY on columns:asc(2) \n      {\n       "
       " TEXT OPERATION "
       "WITH FILTER: co-occurrence with words: \"friend*\" and 2 variables "
       "with textLimit = 1 filtered by\n        {\n          SCAN POS with P "
@@ -865,7 +865,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
   std::string possible1 = strip(
       "{\n  MULTI_COLUMN_JOIN\n    {\n    SCAN PSO with P = "
       "\"<Film_performance>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & "
-      "1]\n  |X|\n    {\n    SORT(internal) on columns:asc(2) asc(1) \n    "
+      "1]\n  |X|\n    {\n    SORT / ORDER BY on columns:asc(2) asc(1) \n    "
       "{\n      JOIN\n      {\n        SCAN PSO with P = "
       "\"<Film_performance>\"\n        qet-width: 2 \n      } join-column: "
       "[0]\n      |X|\n      {\n        SCAN PSO with P = "
@@ -875,7 +875,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
   std::string possible2 = strip(
       "{\n  MULTI_COLUMN_JOIN\n    {\n    SCAN POS with P = "
       "\"<Film_performance>\"\n    qet-width: 2 \n  }\n  join-columns: [0 & "
-      "1]\n  |X|\n    {\n    SORT(internal) on columns:asc(1) asc(2) \n    "
+      "1]\n  |X|\n    {\n    SORT / ORDER BY on columns:asc(1) asc(2) \n    "
       "{\n      JOIN\n      {\n        SCAN PSO with P = "
       "\"<Film_performance>\"\n        qet-width: 2 \n      } join-column: "
       "[0]\n      |X|\n      {\n        SCAN PSO with P = "
@@ -885,7 +885,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
   std::string possible3 = strip(
       "{\n  MULTI_COLUMN_JOIN\n    {\n    SCAN POS with P = "
       "\"<Spouse_(or_domestic_partner)>\"\n    qet-width: 2 \n  }\n  "
-      "join-columns: [0 & 1]\n  |X|\n    {\n    SORT(internal) on "
+      "join-columns: [0 & 1]\n  |X|\n    {\n    SORT / ORDER BY on "
       "columns:asc(1) asc(2) \n    {\n      JOIN\n      {\n        SCAN POS "
       "with P = \"<Film_performance>\"\n        qet-width: 2 \n      } "
       "join-column: [0]\n      |X|\n      {\n        SCAN POS with P = "
@@ -899,7 +899,7 @@ TEST(QueryExecutionTreeTest, testCyclicQuery) {
         } join-columns: [0 & 1]
         |X|
         {
-          SORT(internal) on columns:asc(1) asc(2)
+          SORT / ORDER BY on columns:asc(1) asc(2)
           {
             JOIN
             {
@@ -998,7 +998,7 @@ TEST(QueryPlannerTest, testSimpleOptional) {
       "OPTIONAL { ?a <rel2> ?c }} ORDER BY ?b");
   QueryExecutionTree qet2 = qp.createExecutionTree(pq2);
   ASSERT_EQ(
-      "{\n  ORDER BY on columns:asc(1) \n  {\n    OPTIONAL_JOIN\n    "
+      "{\n  SORT / ORDER BY on columns:asc(1) \n  {\n    OPTIONAL_JOIN\n    "
       "{\n      SCAN PSO with P = \"<rel1>\"\n      qet-width: 2 \n    } "
       "join-columns: [0]\n    |X|\n    {\n      SCAN PSO with P = "
       "\"<rel2>\"\n      qet-width: 2 \n    } join-columns: [0]\n    "
@@ -1030,25 +1030,25 @@ TEST(QueryPlannerTest, SimpleTripleTwoVariables) {
       "SELECT * WHERE { ?s <p> ?o }",
       h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {POS_FREE_O, PSO_FREE_S}));
   // Must always be a single index scan, never index scan + sorting.
-  h::expect("SELECT * WHERE { ?s <p> ?o } INTERNAL SORT BY ?o",
+  h::expect("SELECT * WHERE { ?s <p> ?o } ORDER BY ?o",
             h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {POS_FREE_O}));
-  h::expect("SELECT * WHERE { ?s <p> ?o } INTERNAL SORT BY ?s",
+  h::expect("SELECT * WHERE { ?s <p> ?o } ORDER BY ?s",
             h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {PSO_FREE_S}));
 
   // Fixed subject.
   h::expect("SELECT * WHERE { <s> ?p ?o }",
             h::IndexScan("<s>", "?p", Var{"?o"}, {SOP_FREE_O, SPO_FREE_P}));
-  h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?o",
+  h::expect("SELECT * WHERE { <s> ?p ?o } ORDER BY ?o",
             h::IndexScan("<s>", "?p", Var{"?o"}, {SOP_FREE_O}));
-  h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?p",
+  h::expect("SELECT * WHERE { <s> ?p ?o } ORDER BY ?p",
             h::IndexScan("<s>", "?p", Var{"?o"}, {SPO_FREE_P}));
 
   // Fixed object.
   h::expect("SELECT * WHERE { <s> ?p ?o }",
             h::IndexScan("<s>", "?p", Var{"?o"}, {SOP_FREE_O, SPO_FREE_P}));
-  h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?o",
+  h::expect("SELECT * WHERE { <s> ?p ?o } ORDER BY ?o",
             h::IndexScan("<s>", "?p", Var{"?o"}, {SOP_FREE_O}));
-  h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?p",
+  h::expect("SELECT * WHERE { <s> ?p ?o } ORDER BY ?p",
             h::IndexScan("<s>", "?p", Var{"?o"}, {SPO_FREE_P}));
 }
 
@@ -1064,27 +1064,27 @@ TEST(QueryPlannerTest, SimpleTripleThreeVariables) {
                           FULL_INDEX_SCAN_OSP, FULL_INDEX_SCAN_OPS}));
 
   // Sorted by one variable, two possible permutations remain.
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?s",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?s",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"},
                          {FULL_INDEX_SCAN_SPO, FULL_INDEX_SCAN_SOP}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?p",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?p",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"},
                          {FULL_INDEX_SCAN_POS, FULL_INDEX_SCAN_PSO}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?o",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?o",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"},
                          {FULL_INDEX_SCAN_OSP, FULL_INDEX_SCAN_OPS}));
 
   // Sorted by two variables, this makes the permutation unique.
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?s ?o",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?s ?o",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"}, {FULL_INDEX_SCAN_SOP}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?s ?p",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?s ?p",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"}, {FULL_INDEX_SCAN_SPO}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?o ?s",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?o ?s",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"}, {FULL_INDEX_SCAN_OSP}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?o ?p",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?o ?p",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"}, {FULL_INDEX_SCAN_OPS}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?p ?s",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?p ?s",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"}, {FULL_INDEX_SCAN_PSO}));
-  h::expect("SELECT * WHERE { ?s ?p ?o } INTERNAL SORT BY ?p ?o",
+  h::expect("SELECT * WHERE { ?s ?p ?o } ORDER BY ?p ?o",
             h::IndexScan(Var{"?s"}, "?p", Var{"?o"}, {FULL_INDEX_SCAN_POS}));
 }

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -1,0 +1,83 @@
+//  Copyright 2022, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "./IndexTestHelpers.h"
+#include "engine/ResultTable.h"
+#include "engine/Values.h"
+#include "engine/idTable/IdTable.h"
+
+using TC = TripleComponent;
+using ValuesComponents = std::vector<std::vector<TripleComponent>>;
+
+// ____________________________________________________________________________
+TEST(Values, sanitizeValues) {
+  // Query execution context (with small test index), see `IndexTestHelpers.h`.
+  using ad_utility::AllocatorWithLimit;
+  QueryExecutionContext* testQec = ad_utility::testing::getQec();
+  AllocatorWithLimit<Id> testAllocator = ad_utility::testing::makeAllocator();
+
+  // Make sure that the `UNDEF` value gets assigned `LocalVocabIndex:0`.
+  Id undefId = Id::makeFromLocalVocabIndex(LocalVocabIndex::make(0));
+
+  // Lambda for checking that the given `ResultTable` contains the given
+  // `IdTable`.
+  auto checkResult = [&](const ResultTable& result,
+                         const ValuesComponents values) -> void {
+    ASSERT_EQ(result.size(), values.size());
+    for (size_t i = 0; i < result.size(); ++i) {
+      ASSERT_EQ(result.width(), values[i].size()) << "row " << i;
+      for (size_t j = 0; j < result.width(); ++j) {
+        std::optional<Id> idOrNullIfUndef = result._idTable[i][j];
+        if (idOrNullIfUndef.value() == undefId) {
+          idOrNullIfUndef = std::nullopt;
+        }
+        ASSERT_EQ(idOrNullIfUndef,
+                  values[i][j].toValueId(testQec->getIndex().getVocab()))
+            << "row " << i << ", column " << j;
+      }
+    }
+  };
+
+  // No UNDEF values, nothing filtered out.
+  {
+    ValuesComponents values{{TC{"<x>"}, TC{"<y>"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), values);
+  }
+
+  // Some UNDEF values, but no row or columns with only UNDEF values, so nothing
+  // filtered out (but the "UNDEF" are added to the local vocabulary, which is
+  // weird, but that's how it currently is).
+  {
+    ValuesComponents values{{TC{"UNDEF"}, TC{"<y>"}}, {TC{"<x>"}, TC{"UNDEF"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), values);
+  }
+
+  // A row full of UNDEF values (which then gets removed).
+  {
+    ValuesComponents values{{TC{"<x>"}, TC{"<y>"}}, {TC{"UNDEF"}, TC{"UNDEF"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), {{TC{"<x>"}, TC{"<y>"}}});
+  }
+
+  // A column full of UNDEF values (which then gets removed).
+  {
+    ValuesComponents values{{TC{"UNDEF"}, TC{"<x>"}}, {TC{"UNDEF"}, TC{"<y>"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), {{TC{"<x>"}}, {{TC{"<y>"}}}});
+  }
+
+  // A row and a column full of UNDEF values (which both get removed).
+  {
+    ValuesComponents values{{TC{"UNDEF"}, TC{"UNDEF"}},
+                            {TC{"UNDEF"}, TC{"<y>"}}};
+    Values valuesOperation(testQec, {{Variable{"?x"}, Variable{"?y"}}, values});
+    checkResult(*valuesOperation.getResult(), {{{TC{"<y>"}}}});
+  }
+}


### PR DESCRIPTION
Clean up and improve the `Values` class. Most notably: in `writeValues`, move the values out of `parsedValues_` to avoid unncessary copies. This necessitates a change in `test/LocalVocabTest`. Write a unit test for the `sanitizeValues` function.

In the `ResultTable` class, make `localVocab_` private and provide a public getter and setter and use them everywhere. Also improve the documentation of the class.

Add an algorithm for removing the duplicates in a given `std::vector` without changing the order of the elements.

Several associated improvements in the code and also some minor unrelated stuff I stumbled upon.