### PR TITLE
Fix comparisons involving UNDEF or incompatible types

### DIFF
--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -181,57 +181,46 @@ using AvgExpression =
 // types like an int and a bool. Then we need to manually specify the
 // return type.
 
-// MIN
-inline auto minLambdaForAllTypes = []<SingleExpressionResult T>(const T& a,
-                                                                const T& b) {
-  if constexpr (std::is_arithmetic_v<T> || ad_utility::isSimilar<T, Bool> ||
-                ad_utility::isSimilar<T, std::string>) {
-    // TODO<joka921> Also implement correct comparisons for `std::string` using
-    // ICU that respect the locale
-    return std::min(a, b);
-  } else if constexpr (ad_utility::isSimilar<T, Id>) {
-    if (a.getDatatype() == Datatype::Undefined ||
-        b.getDatatype() == Datatype::Undefined) {
-      // If one of the values is undefined, we just return the other.
-      static_assert(0u == Id::makeUndefined().getBits());
-      return Id::fromBits(a.getBits() | b.getBits());
-    }
-    return valueIdComparators::compareIds<
-               valueIdComparators::ComparisonForIncompatibleTypes::
-                   CompareByType>(a, b, valueIdComparators::Comparison::LT)
-               ? a
-               : b;
-  } else {
-    return ad_utility::alwaysFalse<T>;
-  }
+template <typename comparator, valueIdComparators::Comparison comparison>
+inline auto minMaxLambdaForAllTypes =
+    []<SingleExpressionResult T>(const T& a, const T& b) {
+      if constexpr (std::is_arithmetic_v<T> || ad_utility::isSimilar<T, Bool> ||
+                    ad_utility::isSimilar<T, std::string>) {
+        // TODO<joka921> Also implement correct comparisons for `std::string`
+        // using ICU that respect the locale
+        return comparator{}(a, b);
+      } else if constexpr (ad_utility::isSimilar<T, Id>) {
+        if (a.getDatatype() == Datatype::Undefined ||
+            b.getDatatype() == Datatype::Undefined) {
+          // If one of the values is undefined, we just return the other.
+          static_assert(0u == Id::makeUndefined().getBits());
+          return Id::fromBits(a.getBits() | b.getBits());
+        }
+        return valueIdComparators::compareIds<
+                   valueIdComparators::ComparisonForIncompatibleTypes::
+                       CompareByType>(a, b, comparison)
+                   ? a
+                   : b;
+      } else {
+        return ad_utility::alwaysFalse<T>;
+      }
+    };
+
+constexpr inline auto min = [](const auto& a, const auto& b) {
+  return std::min(a, b);
 };
+constexpr inline auto max = [](const auto& a, const auto& b) {
+  return std::max(a, b);
+};
+constexpr inline auto minLambdaForAllTypes =
+    minMaxLambdaForAllTypes<decltype(min), valueIdComparators::Comparison::LT>;
+constexpr inline auto maxLambdaForAllTypes =
+    minMaxLambdaForAllTypes<decltype(max), valueIdComparators::Comparison::GT>;
+// MIN
 using MinExpression =
     AGG_EXP<decltype(minLambdaForAllTypes), ActualValueGetter>;
 
 // MAX
-inline auto maxLambdaForAllTypes = []<SingleExpressionResult T>(const T& a,
-                                                                const T& b) {
-  if constexpr (std::is_arithmetic_v<T> || ad_utility::isSimilar<T, Bool> ||
-                ad_utility::isSimilar<T, std::string>) {
-    // TODO<joka921> Also implement correct comparisons for `std::string` using
-    // ICU that respect the locale
-    return std::max(a, b);
-  } else if constexpr (ad_utility::isSimilar<T, Id>) {
-    if (a.getDatatype() == Datatype::Undefined ||
-        b.getDatatype() == Datatype::Undefined) {
-      // If one of the values is undefined, we just return the other.
-      static_assert(0u == Id::makeUndefined().getBits());
-      return Id::fromBits(a.getBits() | b.getBits());
-    }
-    return valueIdComparators::compareIds<
-               valueIdComparators::ComparisonForIncompatibleTypes::
-                   CompareByType>(a, b, valueIdComparators::Comparison::GT)
-               ? a
-               : b;
-  } else {
-    return ad_utility::alwaysFalse<T>;
-  }
-};
 using MaxExpression =
     AGG_EXP<decltype(maxLambdaForAllTypes), ActualValueGetter>;
 

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -182,19 +182,23 @@ using AvgExpression =
 // return type.
 
 // MIN
-inline auto minLambda = []<typename T, typename U>(const T& a, const U& b) {
-  using C = std::common_type_t<T, U>;
-  return a < b ? static_cast<C>(a) : static_cast<C>(b);
-};
-
 inline auto minLambdaForAllTypes = []<SingleExpressionResult T>(const T& a,
                                                                 const T& b) {
   if constexpr (std::is_arithmetic_v<T> || ad_utility::isSimilar<T, Bool> ||
                 ad_utility::isSimilar<T, std::string>) {
+    // TODO<joka921> Also implement correct comparisons for `std::string` using
+    // ICU that respect the locale
     return std::min(a, b);
   } else if constexpr (ad_utility::isSimilar<T, Id>) {
-    return valueIdComparators::compareIds(a, b,
-                                          valueIdComparators::Comparison::LT)
+    if (a.getDatatype() == Datatype::Undefined ||
+        b.getDatatype() == Datatype::Undefined) {
+      // If one of the values is undefined, we just return the other.
+      static_assert(0u == Id::makeUndefined().getBits());
+      return Id::fromBits(a.getBits() | b.getBits());
+    }
+    return valueIdComparators::compareIds<
+               valueIdComparators::ComparisonForIncompatibleTypes::
+                   CompareByType>(a, b, valueIdComparators::Comparison::LT)
                ? a
                : b;
   } else {
@@ -205,19 +209,23 @@ using MinExpression =
     AGG_EXP<decltype(minLambdaForAllTypes), ActualValueGetter>;
 
 // MAX
-inline auto maxLambda = []<typename T, typename U>(const T& a, const U& b) {
-  using C = std::common_type_t<T, U>;
-  return a > b ? static_cast<C>(a) : static_cast<C>(b);
-};
-
 inline auto maxLambdaForAllTypes = []<SingleExpressionResult T>(const T& a,
                                                                 const T& b) {
   if constexpr (std::is_arithmetic_v<T> || ad_utility::isSimilar<T, Bool> ||
                 ad_utility::isSimilar<T, std::string>) {
+    // TODO<joka921> Also implement correct comparisons for `std::string` using
+    // ICU that respect the locale
     return std::max(a, b);
   } else if constexpr (ad_utility::isSimilar<T, Id>) {
-    return valueIdComparators::compareIds(a, b,
-                                          valueIdComparators::Comparison::GT)
+    if (a.getDatatype() == Datatype::Undefined ||
+        b.getDatatype() == Datatype::Undefined) {
+      // If one of the values is undefined, we just return the other.
+      static_assert(0u == Id::makeUndefined().getBits());
+      return Id::fromBits(a.getBits() | b.getBits());
+    }
+    return valueIdComparators::compareIds<
+               valueIdComparators::ComparisonForIncompatibleTypes::
+                   CompareByType>(a, b, valueIdComparators::Comparison::GT)
                ? a
                : b;
   } else {

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -73,7 +73,10 @@ class ValueId {
 
   /// A struct that represents the single undefined value. This is required for
   /// generic code like in the `visit` method.
-  struct UndefinedType {};
+  struct UndefinedType {
+    // Two undefined values are always equal to themselves by default.
+    auto operator<=>(const UndefinedType&) const = default;
+  };
 
  private:
   // The actual bits.

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -73,10 +73,7 @@ class ValueId {
 
   /// A struct that represents the single undefined value. This is required for
   /// generic code like in the `visit` method.
-  struct UndefinedType {
-    // Two undefined values are always equal to themselves by default.
-    auto operator<=>(const UndefinedType&) const = default;
-  };
+  struct UndefinedType {};
 
  private:
   // The actual bits.

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -260,18 +260,6 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIntsAndDoubles(
   auto result = getRangesForDouble(begin, end, value, comparison);
   auto resultInt = getRangesForInt(begin, end, value, comparison);
   result.insert(result.end(), resultInt.begin(), resultInt.end());
-
-  // If the comparison is "not equal" we also have to add the ranges for
-  // non-matching datatypes.
-  if (comparison == Comparison::NE) {
-    // auto rangeOfDoubles = getRangeForDatatype(begin, end, Datatype::Double);
-    // auto rangeOfInts = getRangeForDatatype(begin, end, Datatype::Int);
-    // AD_CONTRACT_CHECK(rangeOfInts.first <= rangeOfDoubles.first);
-    // result.push_back({begin, rangeOfInts.first});
-    // result.push_back({rangeOfInts.second, rangeOfDoubles.first});
-    // result.push_back({rangeOfDoubles.second, end});
-  }
-
   return result;
 }
 
@@ -286,11 +274,9 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIndexTypes(
   RangeFilter<RandomIt> rangeFilter{comparison};
   auto [eqBegin, eqEnd] =
       std::equal_range(beginType, endType, valueId, &compareByBits);
-  // rangeFilter.addNotEqual(begin, beginType);
   rangeFilter.addSmaller(beginType, eqBegin);
   rangeFilter.addEqual(eqBegin, eqEnd);
   rangeFilter.addGreater(eqEnd, endType);
-  // rangeFilter.addNotEqual(endType, end);
   return std::move(rangeFilter).getResult();
 }
 
@@ -308,11 +294,9 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIndexTypes(
       std::lower_bound(beginOfType, endOfType, valueIdBegin, &compareByBits);
   auto eqEnd =
       std::lower_bound(beginOfType, endOfType, valueIdEnd, &compareByBits);
-  // rangeFilter.addNotEqual(begin, beginOfType);
   rangeFilter.addSmaller(beginOfType, eqBegin);
   rangeFilter.addEqual(eqBegin, eqEnd);
   rangeFilter.addGreater(eqEnd, endOfType);
-  // rangeFilter.addNotEqual(endOfType, end);
   return std::move(rangeFilter).getResult();
 }
 
@@ -406,8 +390,8 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
 namespace detail {
 
 // Determine whether the two datatypes can be compared. If they cannot be
-// compared, a comparison always is an `expression error` (term from the SPARQL
-// standard) which we currently denote by all the comparisons returning `false`.
+// compared, a comparison is always an `expression error` (term from the SPARQL
+// standard) which we currently handle by all the comparisons returning `false`.
 inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
   auto isNumeric = [](Datatype type) {
     return type == Datatype::Double || type == Datatype::Int;

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -264,12 +264,12 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIntsAndDoubles(
   // If the comparison is "not equal" we also have to add the ranges for
   // non-matching datatypes.
   if (comparison == Comparison::NE) {
-    auto rangeOfDoubles = getRangeForDatatype(begin, end, Datatype::Double);
-    auto rangeOfInts = getRangeForDatatype(begin, end, Datatype::Int);
-    AD_CONTRACT_CHECK(rangeOfInts.first <= rangeOfDoubles.first);
-    result.push_back({begin, rangeOfInts.first});
-    result.push_back({rangeOfInts.second, rangeOfDoubles.first});
-    result.push_back({rangeOfDoubles.second, end});
+    // auto rangeOfDoubles = getRangeForDatatype(begin, end, Datatype::Double);
+    // auto rangeOfInts = getRangeForDatatype(begin, end, Datatype::Int);
+    // AD_CONTRACT_CHECK(rangeOfInts.first <= rangeOfDoubles.first);
+    // result.push_back({begin, rangeOfInts.first});
+    // result.push_back({rangeOfInts.second, rangeOfDoubles.first});
+    // result.push_back({rangeOfDoubles.second, end});
   }
 
   return result;
@@ -286,11 +286,11 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIndexTypes(
   RangeFilter<RandomIt> rangeFilter{comparison};
   auto [eqBegin, eqEnd] =
       std::equal_range(beginType, endType, valueId, &compareByBits);
-  rangeFilter.addNotEqual(begin, beginType);
+  // rangeFilter.addNotEqual(begin, beginType);
   rangeFilter.addSmaller(beginType, eqBegin);
   rangeFilter.addEqual(eqBegin, eqEnd);
   rangeFilter.addGreater(eqEnd, endType);
-  rangeFilter.addNotEqual(endType, end);
+  // rangeFilter.addNotEqual(endType, end);
   return std::move(rangeFilter).getResult();
 }
 
@@ -308,11 +308,11 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForIndexTypes(
       std::lower_bound(beginOfType, endOfType, valueIdBegin, &compareByBits);
   auto eqEnd =
       std::lower_bound(beginOfType, endOfType, valueIdEnd, &compareByBits);
-  rangeFilter.addNotEqual(begin, beginOfType);
+  // rangeFilter.addNotEqual(begin, beginOfType);
   rangeFilter.addSmaller(beginOfType, eqBegin);
   rangeFilter.addEqual(eqBegin, eqEnd);
   rangeFilter.addGreater(eqEnd, endOfType);
-  rangeFilter.addNotEqual(endOfType, end);
+  // rangeFilter.addNotEqual(endOfType, end);
   return std::move(rangeFilter).getResult();
 }
 
@@ -351,6 +351,11 @@ inline auto simplifyRanges =
 template <typename RandomIt>
 inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForId(
     RandomIt begin, RandomIt end, ValueId valueId, Comparison comparison) {
+  // For the evaluation of FILTERs, comparisons that involve undefined values
+  // are always false.
+  if (valueId.getDatatype() == Datatype::Undefined) {
+    return {};
+  }
   // This lambda enforces the invariants `non-empty` and `sorted`.
   switch (valueId.getDatatype()) {
     case Datatype::Double:
@@ -400,17 +405,26 @@ inline std::vector<std::pair<RandomIt, RandomIt>> getRangesForEqualIds(
 
 namespace detail {
 
+// Determine whether the two datatypes can be compared. If they cannot be
+// compared, a comparison always is an `expression error` (term from the SPARQL
+// standard) which we currently denote by all the comparisons returning `false`.
+inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
+  auto isNumeric = [](Datatype type) {
+    return type == Datatype::Double || type == Datatype::Int;
+  };
+  auto isUndefined = [](Datatype type) { return type == Datatype::Undefined; };
+  // Note: Undefined values cannot be compared to other undefined values.
+  return (!isUndefined(typeA)) &&
+         ((typeA == typeB) || (isNumeric(typeA) && isNumeric(typeB)));
+}
+
 // This function is part of the implementation of `compareIds` (see below).
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
               ComparisonForIncompatibleTypes::AlwaysFalse>
 bool compareIdsImpl(ValueId a, ValueId b, auto comparator) {
-  auto isNumeric = [](ValueId id) {
-    return id.getDatatype() == Datatype::Double ||
-           id.getDatatype() == Datatype::Int;
-  };
-  bool compatible =
-      (a.getDatatype() == b.getDatatype()) || (isNumeric(a) && isNumeric(b));
-  if (!compatible) {
+  Datatype typeA = a.getDatatype();
+  Datatype typeB = b.getDatatype();
+  if (!areTypesCompatible(typeA, typeB)) {
     using enum ComparisonForIncompatibleTypes;
     if constexpr (comparisonForIncompatibleTypes == AlwaysFalse) {
       return false;
@@ -457,8 +471,7 @@ inline bool compareIds(ValueId a, ValueId b, Comparison comparison) {
     case EQ:
       return compare(std::equal_to{});
     case NE:
-      // IDs with incompatible datatypes are also considered "not equal".
-      return !compare(std::equal_to{});
+      return compare(std::not_equal_to{});
     case GE:
       return compare(std::greater_equal{});
     case GT:
@@ -494,7 +507,11 @@ inline bool compareWithEqualIds(ValueId a, ValueId bBegin, ValueId bEnd,
     case EQ:
       return compareEqual();
     case NE:
-      return !compareEqual();
+      // If the datatypes are not compatible then we always yield `false`. This
+      // is the correct behavior for SPARQL filters where this is called an
+      // `expression error`.
+      return !compareEqual() &&
+             detail::areTypesCompatible(a.getDatatype(), bBegin.getDatatype());
     case GE:
       return detail::compareIdsImpl(a, bBegin, std::greater_equal<>());
     case GT:

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023, University of Freiburg,
+// Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#include "./SparqlExpressionTestHelpers.h"
+#include "./util/GTestHelpers.h"
+#include "./util/IdTableHelpers.h"
+#include "./util/IdTestHelpers.h"
+#include "engine/ValuesForTesting.h"
+#include "engine/sparqlExpressions/AggregateExpression.h"
+#include "gtest/gtest.h"
+
+using namespace sparqlExpression;
+using namespace ad_utility::testing;
+using ad_utility::source_location;
+
+namespace {
+auto I = IntId;
+auto V = VocabId;
+auto U = Id::makeUndefined();
+auto L = LocalVocabId;
+}  // namespace
+
+// Test that an expression of type `AggregateExpressionT` when run on the
+// `input` yields the `expectedResult`. This function can only be used for
+// aggregate expressions where the input type and the output type are the same,
+// e.g. MIN and MAX, but not for e.g. COUNT.
+template <typename AggregateExpressionT, typename T>
+auto testAggregate = [](std::vector<T> inputAsVector, T expectedResult,
+                        bool distinct = false,
+                        source_location l = source_location::current()) {
+  auto trace = generateLocationTrace(l);
+  VectorWithMemoryLimit<T> input(inputAsVector.begin(), inputAsVector.end(),
+                                 makeAllocator());
+  auto d = std::make_unique<DummyExpression>(input.clone());
+
+  auto t = TestContext{};
+  t.context._endIndex = input.size();
+
+  AggregateExpressionT m{distinct, std::move(d)};
+
+  auto resAsVariant = m.evaluate(&t.context);
+
+  auto res = std::get<T>(resAsVariant);
+  EXPECT_EQ(res, expectedResult);
+};
+
+TEST(AggregateExpression, max) {
+  auto testId = testAggregate<MaxExpression, Id>;
+  testId({I(3), U, I(0), I(4), U, (I(-1))}, I(4));
+  testId({V(7), U, V(2), V(4)}, V(7));
+  testId({I(3), U, V(0), L(3), U, (I(-1))}, L(3));
+
+  auto testString = testAggregate<MaxExpression, std::string>;
+  // TODO<joka921> Implement correct comparison on strings
+  testString({"alpha", "äpfel", "Beta", "unfug"}, "äpfel");
+}
+
+TEST(AggregateExpression, min) {
+  auto testId = testAggregate<MinExpression, Id>;
+  testId({I(3), U, I(0), I(4), U, (I(-1))}, I(-1));
+  testId({V(7), U, V(2), V(4)}, V(2));
+  testId({I(3), U, V(0), L(3), U, (I(-1))}, I(-1));
+
+  auto testString = testAggregate<MinExpression, std::string>;
+  // TODO<joka921> Implement correct comparison on strings
+  testString({"alpha", "äpfel", "Beta", "unfug"}, "Beta");
+}

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -33,36 +33,32 @@ auto testAggregate = [](std::vector<T> inputAsVector, T expectedResult,
   VectorWithMemoryLimit<T> input(inputAsVector.begin(), inputAsVector.end(),
                                  makeAllocator());
   auto d = std::make_unique<DummyExpression>(input.clone());
-
   auto t = TestContext{};
   t.context._endIndex = input.size();
-
   AggregateExpressionT m{distinct, std::move(d)};
-
   auto resAsVariant = m.evaluate(&t.context);
-
   auto res = std::get<T>(resAsVariant);
   EXPECT_EQ(res, expectedResult);
 };
 
 TEST(AggregateExpression, max) {
-  auto testId = testAggregate<MaxExpression, Id>;
-  testId({I(3), U, I(0), I(4), U, (I(-1))}, I(4));
-  testId({V(7), U, V(2), V(4)}, V(7));
-  testId({I(3), U, V(0), L(3), U, (I(-1))}, L(3));
+  auto testMaxId = testAggregate<MaxExpression, Id>;
+  testMaxId({I(3), U, I(0), I(4), U, (I(-1))}, I(4));
+  testMaxId({V(7), U, V(2), V(4)}, V(7));
+  testMaxId({I(3), U, V(0), L(3), U, (I(-1))}, L(3));
 
-  auto testString = testAggregate<MaxExpression, std::string>;
+  auto testMaxString = testAggregate<MaxExpression, std::string>;
   // TODO<joka921> Implement correct comparison on strings
-  testString({"alpha", "äpfel", "Beta", "unfug"}, "äpfel");
+  testMaxString({"alpha", "äpfel", "Beta", "unfug"}, "äpfel");
 }
 
 TEST(AggregateExpression, min) {
-  auto testId = testAggregate<MinExpression, Id>;
-  testId({I(3), U, I(0), I(4), U, (I(-1))}, I(-1));
-  testId({V(7), U, V(2), V(4)}, V(2));
-  testId({I(3), U, V(0), L(3), U, (I(-1))}, I(-1));
+  auto testMinId = testAggregate<MinExpression, Id>;
+  testMinId({I(3), U, I(0), I(4), U, (I(-1))}, I(-1));
+  testMinId({V(7), U, V(2), V(4)}, V(2));
+  testMinId({I(3), U, V(0), L(3), U, (I(-1))}, I(-1));
 
-  auto testString = testAggregate<MinExpression, std::string>;
+  auto testMinString = testAggregate<MinExpression, std::string>;
   // TODO<joka921> Implement correct comparison on strings
-  testString({"alpha", "äpfel", "Beta", "unfug"}, "Beta");
+  testMinString({"alpha", "äpfel", "Beta", "unfug"}, "Beta");
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -295,3 +295,5 @@ addLinkAndDiscoverTestSerial(OrderByTest engine)
 addLinkAndDiscoverTestSerial(ValuesForTestingTest index)
 
 addLinkAndDiscoverTestSerial(ExportQueryExecutionTreeTest index engine parser)
+
+addLinkAndDiscoverTestSerial(AggregateExpressionTest parser sparqlExpressions index engine)

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -5,11 +5,13 @@
 #include <gtest/gtest.h>
 
 #include "./ValueIdTestHelpers.h"
+#include "./util/GTestHelpers.h"
 #include "./util/IdTestHelpers.h"
 #include "global/ValueIdComparators.h"
 #include "util/Random.h"
 
 using namespace valueIdComparators;
+using ad_utility::source_location;
 
 TEST(ValueIdComparators, GetRangeForDatatype) {
   std::vector<Datatype> datatypes{Datatype::Int,
@@ -58,7 +60,9 @@ auto getComparisonFunctor() {
 // (`isMatchingDatatype(a) and `isMatchingDatatype(b)` both are true when
 // `applyComparator` is called.
 auto testGetRangesForId(auto begin, auto end, ValueId id,
-                        auto isMatchingDatatype, auto applyComparator) {
+                        auto isMatchingDatatype, auto applyComparator,
+                        source_location l = source_location::current()) {
+  auto trage = generateLocationTrace(l);
   // Perform the testing for a single `Comparison`
   auto testImpl = [&]<Comparison comparison>() {
     auto ranges = getRangesForId(begin, end, id, comparison);
@@ -66,11 +70,7 @@ auto testGetRangesForId(auto begin, auto end, ValueId id,
     auto it = begin;
 
     auto isMatching = [&](ValueId a, ValueId b) {
-      if (comparison == Comparison::NE && !isMatchingDatatype(a)) {
-        return true;
-      } else {
-        return isMatchingDatatype(a) && applyComparator(comparator, a, b);
-      }
+      return isMatchingDatatype(a) && applyComparator(comparator, a, b);
     };
     for (auto [rangeBegin, rangeEnd] : ranges) {
       while (it != rangeBegin) {
@@ -149,26 +149,11 @@ TEST(ValueIdComparators, Undefined) {
   std::sort(ids.begin(), ids.end(), compareByBits);
   auto undefined = ValueId::makeUndefined();
 
-  auto undefinedRange =
-      getRangeForDatatype(ids.begin(), ids.end(), Datatype::Undefined);
-
-  for (auto comparison : {Comparison::EQ, Comparison::LE, Comparison::GE}) {
+  for (auto comparison : {Comparison::EQ, Comparison::LE, Comparison::GE,
+                          Comparison::GT, Comparison::LT, Comparison::NE}) {
     auto equalRange =
         getRangesForId(ids.begin(), ids.end(), undefined, comparison);
-    ASSERT_EQ(equalRange.size(), 1);
-    ASSERT_EQ(equalRange[0], undefinedRange);
-  }
-  {
-    auto equalRange =
-        getRangesForId(ids.begin(), ids.end(), undefined, Comparison::NE);
-    ASSERT_EQ(equalRange.size(), 1);
-    ASSERT_EQ(equalRange[0].first, undefinedRange.second);
-    ASSERT_EQ(equalRange[0].second, ids.end());
-  }
-  for (auto comparison : {Comparison::GT, Comparison::LT}) {
-    auto equalRange =
-        getRangesForId(ids.begin(), ids.end(), undefined, comparison);
-    ASSERT_TRUE(equalRange.empty());
+    ASSERT_EQ(equalRange.size(), 0);
   }
 }
 
@@ -259,11 +244,11 @@ TEST(ValueIdComparators, IndexTypes) {
 TEST(ValueIdComparators, undefinedWithItself) {
   auto u = ValueId::makeUndefined();
   ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::LT));
-  ASSERT_TRUE(valueIdComparators::compareIds(u, u, Comparison::LE));
-  ASSERT_TRUE(valueIdComparators::compareIds(u, u, Comparison::EQ));
+  ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::LE));
+  ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::EQ));
   ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::NE));
   ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::GT));
-  ASSERT_TRUE(valueIdComparators::compareIds(u, u, Comparison::GE));
+  ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::GE));
 }
 
 // _______________________________________________________________________

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -255,6 +255,18 @@ TEST(ValueIdComparators, IndexTypes) {
   testImpl.operator()<Datatype::LocalVocabIndex>(&getLocalVocabIndex);
 }
 
+// _______________________________________________________________________
+TEST(ValueIdComparators, undefinedWithItself) {
+  auto u = ValueId::makeUndefined();
+  ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::LT));
+  ASSERT_TRUE(valueIdComparators::compareIds(u, u, Comparison::LE));
+  ASSERT_TRUE(valueIdComparators::compareIds(u, u, Comparison::EQ));
+  ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::NE));
+  ASSERT_FALSE(valueIdComparators::compareIds(u, u, Comparison::GT));
+  ASSERT_TRUE(valueIdComparators::compareIds(u, u, Comparison::GE));
+}
+
+// _______________________________________________________________________
 TEST(ValueIdComparators, contractViolations) {
   auto u = ValueId::makeUndefined();
   auto I = ad_utility::testing::IntId;

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -17,6 +17,10 @@ inline auto VocabId = [](const auto& v) {
   return Id::makeFromVocabIndex(VocabIndex::make(v));
 };
 
+inline auto LocalVocabId = [](const auto& v) {
+  return Id::makeFromLocalVocabIndex(LocalVocabIndex::make(v));
+};
+
 inline auto TextRecordId = [](const auto& t) {
   return Id::makeFromTextRecordIndex(TextRecordIndex ::make(t));
 };


### PR DESCRIPTION
They will now always return a bound (not NULL) value if one exists, and otherwise use the same ordering as ORDER BY clauses (this behavior is mandated by the SPARQL standard.)

Fixes #857 