### PR TITLE
More correct implementation of AS

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -34,7 +34,7 @@ jobs:
         # from another workflow.
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -42,7 +42,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "coverage-report"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,

--- a/.github/workflows/upload-sonarcloud.yml
+++ b/.github/workflows/upload-sonarcloud.yml
@@ -44,7 +44,7 @@ jobs:
         # from another workflow.
         with:
           script: |
-            var artifacts = await github.actions.listWorkflowRunArtifacts({
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
                run_id: ${{github.event.workflow_run.id }},
@@ -52,7 +52,7 @@ jobs:
             var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "sonarcloud-report"
             })[0];
-            var download = await github.actions.downloadArtifact({
+            var download = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
                artifact_id: matchArtifact.id,

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -93,7 +93,7 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createExecutionTrees(
   bool doGroupBy = !pq._groupByVariables.empty() ||
                    patternTrickTuple.has_value() ||
                    std::ranges::any_of(pq.getAliases(), [](const Alias& alias) {
-                     return alias._expression.isAggregate({});
+                     return alias._expression.containsAggregate();
                    });
 
   // Optimize the graph pattern tree

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -37,6 +37,9 @@ class AggregateExpression : public SparqlExpression {
   // _________________________________________________________________________
   vector<std::string> getUnaggregatedVariables() override;
 
+  // This is an aggregate!
+  bool containsAggregate() const override { return true; }
+
   // __________________________________________________________________________
   [[nodiscard]] string getCacheKey(
       const VariableToColumnMap& varColMap) const override;

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -37,7 +37,7 @@ class AggregateExpression : public SparqlExpression {
   // _________________________________________________________________________
   vector<std::string> getUnaggregatedVariables() override;
 
-  // This is an aggregate!
+  // An `AggregateExpression` (obviously) contains an aggregate.
   bool containsAggregate() const override { return true; }
 
   // __________________________________________________________________________

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -49,10 +49,14 @@ class GroupConcatExpression : public SparqlExpression {
     return {&_actualExpression, 1};
   }
 
+  // _________________________________________________________________________
   vector<std::string> getUnaggregatedVariables() override {
     // This is an aggregation, so it never leaves any unaggregated variables.
     return {};
   }
+
+  // _________________________________________________________________________
+  bool containsAggregate() const override { return true; }
 
   [[nodiscard]] string getCacheKey(
       const VariableToColumnMap& varColMap) const override {

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -49,13 +49,11 @@ class GroupConcatExpression : public SparqlExpression {
     return {&_actualExpression, 1};
   }
 
-  // _________________________________________________________________________
-  vector<std::string> getUnaggregatedVariables() override {
-    // This is an aggregation, so it never leaves any unaggregated variables.
-    return {};
-  }
+  // A `GroupConcatExpression` is an aggregate, so it never leaves any
+  // unaggregated variables.
+  vector<std::string> getUnaggregatedVariables() override { return {}; }
 
-  // _________________________________________________________________________
+  // A `GroupConcatExpression` is an aggregate.
   bool containsAggregate() const override { return true; }
 
   [[nodiscard]] string getCacheKey(

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -73,6 +73,15 @@ class SparqlExpression {
     return result;
   }
 
+  // Return true iff this expression contains an aggregate like SUM, COUNT etc.
+  // This information is needed to check if there is an implicit GROUP BY in a
+  // query because any of the selected aliases contains an aggregate.
+  virtual bool containsAggregate() const {
+    return std::ranges::any_of(children(), [](const Ptr& child) {
+      return child->containsAggregate();
+    });
+  }
+
   /// Get a unique identifier for this expression, used as cache key.
   virtual string getCacheKey(const VariableToColumnMap& varColMap) const = 0;
 

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -42,6 +42,7 @@ std::vector<std::string> SparqlExpressionPimpl::getUnaggregatedVariables(
                               return groupedVariables.contains(var);
                             }),
              vars.end());
+  return vars;
 }
 
 // ___________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -98,4 +98,9 @@ auto SparqlExpressionPimpl::getEstimatesForFilterExpression(
 bool SparqlExpressionPimpl::containsLangExpression() const {
   return _pimpl->containsLangExpression();
 }
+
+// _____________________________________________________________________________
+bool SparqlExpressionPimpl::containsAggregate() const {
+  return _pimpl->containsAggregate();
+}
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -37,11 +37,8 @@ SparqlExpressionPimpl& SparqlExpressionPimpl::operator=(
 std::vector<std::string> SparqlExpressionPimpl::getUnaggregatedVariables(
     const ad_utility::HashSet<string>& groupedVariables) const {
   auto vars = _pimpl->getUnaggregatedVariables();
-  vars.erase(std::remove_if(vars.begin(), vars.end(),
-                            [&](const auto& var) {
-                              return groupedVariables.contains(var);
-                            }),
-             vars.end());
+  std::erase_if(
+      vars, [&](const auto& var) { return groupedVariables.contains(var); });
   return vars;
 }
 

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -34,9 +34,14 @@ SparqlExpressionPimpl& SparqlExpressionPimpl::operator=(
     const SparqlExpressionPimpl&) = default;
 
 // ____________________________________________________________________________
-std::vector<std::string> SparqlExpressionPimpl::getUnaggregatedVariables()
-    const {
-  return _pimpl->getUnaggregatedVariables();
+std::vector<std::string> SparqlExpressionPimpl::getUnaggregatedVariables(
+    const ad_utility::HashSet<string>& groupedVariables) const {
+  auto vars = _pimpl->getUnaggregatedVariables();
+  vars.erase(std::remove_if(vars.begin(), vars.end(),
+                            [&](const auto& var) {
+                              return groupedVariables.contains(var);
+                            }),
+             vars.end());
 }
 
 // ___________________________________________________________________________

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -48,6 +48,10 @@ class SparqlExpressionPimpl {
     return true;
   }
 
+  // Returns true iff this expression contain one of the aggregate expressions
+  // SUM, AVG, COUNT, etc. in any form.
+  bool containsAggregate() const;
+
   struct VariableAndDistinctness {
     ::Variable variable_;
     bool isDistinct_;

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -27,7 +27,8 @@ class SparqlExpressionPimpl {
   void setDescriptor(std::string descriptor);
 
   // Get the variables that are not aggregated by this expression.
-  [[nodiscard]] std::vector<std::string> getUnaggregatedVariables() const;
+  [[nodiscard]] std::vector<std::string> getUnaggregatedVariables(
+      const ad_utility::HashSet<string>& groupedVariables = {}) const;
 
   // Does this expression aggregate over all variables that are not in
   // `groupedVariables`. For example, COUNT(<subex>) always returns true.

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -26,7 +26,9 @@ class SparqlExpressionPimpl {
   [[nodiscard]] const std::string& getDescriptor() const;
   void setDescriptor(std::string descriptor);
 
-  // Get the variables that are not aggregated by this expression.
+  // Get the variables that are not aggregated by this expression. The variables
+  // in the argument `groupedVariables` are deleted from the result (grouped
+  // variables do not have to be aggregated).
   [[nodiscard]] std::vector<std::string> getUnaggregatedVariables(
       const ad_utility::HashSet<string>& groupedVariables = {}) const;
 

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -106,7 +106,8 @@ void GraphPatternOperation::toString(std::ostringstream& os,
       }
 
     } else if constexpr (std::is_same_v<T, Bind>) {
-      os << "Some kind of BIND\n";
+      os << "BIND " << arg._expression.getDescriptor() << " as "
+         << arg._target.name() << "\n";
       // TODO<joka921> proper ToString (are they used for something?)
     } else if constexpr (std::is_same_v<T, Minus>) {
       os << "MINUS ";

--- a/src/parser/ParseException.cpp
+++ b/src/parser/ParseException.cpp
@@ -6,6 +6,7 @@
 #include <parser/ParseException.h>
 #include <util/Exception.h>
 
+// ___________________________________________________________________________
 std::string ExceptionMetadata::coloredError() const {
   // stopIndex_ == startIndex_ - 1 might happen if the offending string is
   // empty.
@@ -19,4 +20,15 @@ std::string ExceptionMetadata::coloredError() const {
   auto end = ad_utility::getUTF8Substring(query, stopIndex_ + 1);
 
   return absl::StrCat(first, "\x1b[1m\x1b[4m\x1b[31m", middle, "\x1b[0m", end);
+}
+
+// ___________________________________________________________________________
+std::string_view ExceptionMetadata::offendingClause() const {
+  // stopIndex_ == startIndex_ - 1 might happen if the offending string is
+  // empty.
+  AD_CONTRACT_CHECK(stopIndex_ + 1 >= startIndex_);
+  // The `startIndex_` and `stopIndex_` are wrt Unicode codepoints, but the
+  // `query_` is UTF-8 encoded.
+  return ad_utility::getUTF8Substring(query_, startIndex_,
+                                      stopIndex_ + 1 - startIndex_);
 }

--- a/src/parser/ParseException.cpp
+++ b/src/parser/ParseException.cpp
@@ -32,3 +32,19 @@ std::string_view ExceptionMetadata::offendingClause() const {
   return ad_utility::getUTF8Substring(query_, startIndex_,
                                       stopIndex_ + 1 - startIndex_);
 }
+
+// ___________________________________________________________________________
+ParseException::ParseException(std::string_view cause,
+                               std::optional<ExceptionMetadata> metadata,
+                               std::string_view prefix)
+    : causeRaw_{cause},
+      cause_{absl::StrCat(prefix, " ", cause)},
+      metadata_{std::move(metadata)} {
+  if (metadata_.has_value()) {
+    causeWithMetadata_ =
+        absl::StrCat(cause_, " in \"", metadata_->offendingClause(),
+                     "\" at line ", metadata_->line_);
+  } else {
+    causeWithMetadata_ = cause_;
+  }
+};

--- a/src/parser/ParseException.h
+++ b/src/parser/ParseException.h
@@ -40,10 +40,10 @@ class ParseException : public std::exception {
  public:
   ParseException(std::string_view cause,
                  std::optional<ExceptionMetadata> metadata = std::nullopt)
-      : cause_{absl::StrCat("ParseException, cause: ", cause)},
+      : cause_{absl::StrCat("Parse error: ", cause)},
         metadata_{std::move(metadata)} {};
 
-  virtual const char* what() const throw() { return cause_.c_str(); }
+  const char* what() const noexcept override { return cause_.c_str(); }
   [[nodiscard]] const std::optional<ExceptionMetadata>& metadata() const {
     return metadata_;
   }

--- a/src/parser/ParseException.h
+++ b/src/parser/ParseException.h
@@ -44,18 +44,7 @@ class ParseException : public std::exception {
   explicit ParseException(
       std::string_view cause,
       std::optional<ExceptionMetadata> metadata = std::nullopt,
-      std::string_view prefix = "")
-      : causeRaw_{cause},
-        cause_{absl::StrCat(prefix, " ", cause)},
-        metadata_{std::move(metadata)} {
-    if (metadata_.has_value()) {
-      causeWithMetadata_ =
-          absl::StrCat(cause_, " in \"", metadata_->offendingClause(),
-                       "\" at line ", metadata_->line_);
-    } else {
-      causeWithMetadata_ = cause_;
-    }
-  };
+      std::string_view prefix = "");
 
  public:
   const char* what() const noexcept override {
@@ -91,5 +80,5 @@ class NotSupportedException : public ParseException {
   explicit NotSupportedException(
       std::string_view cause,
       std::optional<ExceptionMetadata> metadata = std::nullopt)
-      : ParseException{cause, std::move(metadata), "Not Supported:"} {}
+      : ParseException{cause, std::move(metadata), "Not supported:"} {}
 };

--- a/src/parser/ParseException.h
+++ b/src/parser/ParseException.h
@@ -31,19 +31,36 @@ struct ExceptionMetadata {
 
   bool operator==(const ExceptionMetadata& rhs) const = default;
 
-  // Returns the query with the faulty clause highlighted using ANSI Escape
+  // Return the query with the faulty clause highlighted using ANSI Escape
   // Sequences. The faulty clause is made bold, underlined and red.
   [[nodiscard]] std::string coloredError() const;
+
+  // Return only the faulty clause.
+  std::string_view offendingClause() const;
 };
 
 class ParseException : public std::exception {
  public:
-  ParseException(std::string_view cause,
-                 std::optional<ExceptionMetadata> metadata = std::nullopt)
-      : cause_{absl::StrCat("Parse error: ", cause)},
-        metadata_{std::move(metadata)} {};
+  explicit ParseException(
+      std::string_view cause,
+      std::optional<ExceptionMetadata> metadata = std::nullopt,
+      std::string_view prefix = "")
+      : causeRaw_{cause},
+        cause_{absl::StrCat(prefix, " ", cause)},
+        metadata_{std::move(metadata)} {
+    if (metadata_.has_value()) {
+      causeWithMetadata_ =
+          absl::StrCat(cause_, " in \"", metadata_->offendingClause(),
+                       "\" at line ", metadata_->line_);
+    } else {
+      causeWithMetadata_ = cause_;
+    }
+  };
 
-  const char* what() const noexcept override { return cause_.c_str(); }
+ public:
+  const char* what() const noexcept override {
+    return causeWithMetadata_.c_str();
+  }
   [[nodiscard]] const std::optional<ExceptionMetadata>& metadata() const {
     return metadata_;
   }
@@ -52,7 +69,27 @@ class ParseException : public std::exception {
     return cause_;
   }
 
+  const std::string& errorMessageWithoutPrefix() const { return causeRaw_; }
+
  private:
+  std::string causeRaw_;
   std::string cause_;
   std::optional<ExceptionMetadata> metadata_;
+  std::string causeWithMetadata_;
+};
+
+class InvalidQueryException : public ParseException {
+ public:
+  explicit InvalidQueryException(
+      std::string_view cause,
+      std::optional<ExceptionMetadata> metadata = std::nullopt)
+      : ParseException{cause, std::move(metadata), "Invalid SPARQL query:"} {}
+};
+
+class NotSupportedException : public ParseException {
+ public:
+  explicit NotSupportedException(
+      std::string_view cause,
+      std::optional<ExceptionMetadata> metadata = std::nullopt)
+      : ParseException{cause, std::move(metadata), "Not Supported:"} {}
 };

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -186,7 +186,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
   const bool isImplicitGroupBy =
       std::ranges::any_of(getAliases(),
                           [](const Alias& alias) {
-                            return alias._expression.isAggregate({});
+                            return alias._expression.containsAggregate();
                           }) &&
       !isExplicitGroupBy;
   const bool isGroupBy = isExplicitGroupBy || isImplicitGroupBy;

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -196,7 +196,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
           ? " Note: The GROUP BY in this query is implicit because an aggregate expression was used in the SELECT clause"s
           : ""s;
   std::string noteForGroupByError =
-      ". All non-aggregated variables must be part of the GROUP BY "
+      " All non-aggregated variables must be part of the GROUP BY "
       "clause." +
       noteForImplicitGroupBy;
 
@@ -305,12 +305,12 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
             throw ParseException(absl::StrCat(
                 "The expression \"", alias._expression.getDescriptor(),
                 "\" does not aggregate ", absl::StrJoin(unaggregatedVars, ", "),
-                ". " + noteForGroupByError));
+                "." + noteForGroupByError));
           }
         }
         if (!ad_utility::contains(_groupByVariables, var)) {
           throw ParseException(absl::StrCat("Variable ", var.name(),
-                                            " is selected but not aggregated. ",
+                                            " is selected but not aggregated.",
                                             noteForGroupByError));
         }
       }
@@ -360,7 +360,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
       if (!ad_utility::contains(_groupByVariables, variable)) {
         throw ParseException("Variable " + variable.name() +
                              " is used but not "
-                             "aggregated. " +
+                             "aggregated." +
                              noteForGroupByError);
       }
     }

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -323,9 +323,9 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
                                        variablesBoundInAliases);
           std::string_view note =
               " Note: This variable was defined previously in the SELECT "
-              "clause, "
-              "which is supported by the SPARQL standard, but currently not "
-              "supported by QLever when the query contains a GROUP BY clause.";
+              "clause, which is supported by the SPARQL standard, but "
+              "currently not supported by QLever when the query contains a "
+              "GROUP BY clause.";
           throw NotSupportedException{
               absl::StrCat(ex.errorMessageWithoutPrefix(), note,
                            noteForGroupByError),

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -351,7 +351,8 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
 
       checkUsedVariablesAreVisible(a._expression, "Alias");
     }
-  } else if (hasConstructClause()) {
+  } else {
+    AD_CORRECTNESS_CHECK(hasConstructClause());
     if (_groupByVariables.empty()) {
       return;
     }

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -259,8 +259,6 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
   // Process limitOffsetClause
   _limitOffset = modifiers.limitOffset_;
 
-  // Check that the query is valid
-
   auto checkAliasOutNamesHaveNoOverlapWithVisibleVariables = [this]() {
     for (const auto& alias : selectClause().getAliases()) {
       if (ad_utility::contains(selectClause().getVisibleVariables(),

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -281,17 +281,16 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
       if (ad_utility::contains(selectClause().getVisibleVariables(),
                                alias._target)) {
         throw ParseException(absl::StrCat(alias._target.name(),
-                                          " is the target of an alias although "
+                                          " is the target of an AS clause although "
                                           "it is also visible in the query "
-                                          "body. This is not allowed."));
+                                          "body."));
       }
 
       // The variable was already added to the selected variables while
       // parsing the alias, thus it should appear exactly once
       if (variable_counts[alias._target] > 1) {
-        throw ParseException("The variable name " + alias._target.name() +
-                             " used in an alias was already prviously used in "
-                             "the SELECT clause.");
+        throw ParseException("The target " + alias._target.name() +
+                             " of an AS clause was already used before in the SELECT clause.");
       }
     }
   };

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -138,7 +138,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
             !additionalVisibleVariables.contains(var)) {
           throw ParseException("Variable " + var.name() + " was used in " +
                                locationDescription +
-                               ", but is not visible in the Query Body.");
+                               ", but is not visible in the query body.");
         }
       };
   auto checkUsedVariablesAreVisible =
@@ -149,7 +149,7 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
               {}) {
         for (const auto* var : expression.containedVariables()) {
           checkVariableIsVisible(*var,
-                                 locationDescription + " in Expression " +
+                                 locationDescription + " in expression " +
                                      expression.getDescriptor(),
                                  additionalVisibleVariables);
         }
@@ -300,7 +300,8 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
 
     // Check that all the variables that are used in aliases are either visible
     // in the query body or are bound by a previous alias from the same SELECT
-    // clause. Note: Currently the reusage of variables from previous aliases
+    // clause.
+    // Note: Currently the reusage of variables from previous aliases
     // like SELECT (?a AS ?b) (?b AS ?c) is only supported by QLever if there is
     // no GROUP BY in the query. To support this we would also need changes in
     // the `GroupBy` class.
@@ -328,8 +329,8 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
 
       // Check if all selected variables are either aggregated or
       // part of the group by statement.
-      for (const Variable& var : selectClause().getSelectedVariables()) {
         const auto& aliases = selectClause().getAliases();
+        for (const Variable& var : selectClause().getSelectedVariables()) {
         if (auto it = std::ranges::find(aliases, var, &Alias::_target);
             it != aliases.end()) {
           const auto& alias = *it;

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -292,10 +292,9 @@ void ParsedQuery::addSolutionModifiers(SolutionModifiers modifiers) {
       // Check if all selected variables are either aggregated or
       // part of the group by statement.
       for (const Variable& var : selectClause().getSelectedVariables()) {
-        auto it = std::ranges::find_if(
-            selectClause().getAliases(),
-            [&var](const Alias& alias) { return alias._target == var; });
-        if (it != selectClause().getAliases().end()) {
+        const auto& aliases = selectClause().getAliases();
+        if (auto it = std::ranges::find(aliases, var, &Alias::_target);
+            it != aliases.end()) {
           const auto& alias = *it;
           if (alias._expression.isAggregate(groupVariables)) {
             continue;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -171,8 +171,8 @@ class ParsedQuery {
   void addBind(sparqlExpression::SparqlExpressionPimpl expression,
                Variable targetVariable, bool targetIsVisible);
 
-  // Generates an internal bind that binds the given expression using a bind.
-  // The bind is added to the query as child. The variable that the expression
+  // Generates an internal BIND that binds the given expression using a BIND.
+  // The BIND is added to the query as child. The variable that the expression
   // is bound to is returned.
   Variable addInternalBind(sparqlExpression::SparqlExpressionPimpl expression);
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -171,9 +171,9 @@ class ParsedQuery {
   void addBind(sparqlExpression::SparqlExpressionPimpl expression,
                Variable targetVariable, bool targetIsVisible);
 
-  // Generates an internal BIND that binds the given expression.
-  // The BIND is added to the query as child. The variable that the expression
-  // is bound to is returned.
+  // Generates an internal BIND that binds the given expression. The BIND is
+  // added to the query as a child. The variable that the expression is bound to
+  // is returned.
   Variable addInternalBind(sparqlExpression::SparqlExpressionPimpl expression);
 
  public:

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -164,13 +164,15 @@ class ParsedQuery {
   }
 
  private:
-  // Add a BIND clause to the body of the query
+  // Add a BIND clause to the body of the query. The second argument determines whether the `targetVariable` will
+  // be part of the visible variables that are selected by `SELECT *`. For an example usage see `addInternalBind` and
+  // `addSolutionModifiers`.
   void addBind(sparqlExpression::SparqlExpressionPimpl expression,
                Variable targetVariable, bool targetIsVisible);
 
-  /// Generates an internal bind that binds the given expression using a bind.
-  /// The bind is added to the query as child. The variable that the expression
-  /// is bound to is returned.
+  // Generates an internal bind that binds the given expression using a bind.
+  // The bind is added to the query as child. The variable that the expression
+  // is bound to is returned.
   Variable addInternalBind(sparqlExpression::SparqlExpressionPimpl expression);
 
  public:

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -164,8 +164,9 @@ class ParsedQuery {
   }
 
  private:
-  // Add a BIND clause to the body of the query. The second argument determines whether the `targetVariable` will
-  // be part of the visible variables that are selected by `SELECT *`. For an example usage see `addInternalBind` and
+  // Add a BIND clause to the body of the query. The second argument determines
+  // whether the `targetVariable` will be part of the visible variables that are
+  // selected by `SELECT *`. For an example usage see `addInternalBind` and
   // `addSolutionModifiers`.
   void addBind(sparqlExpression::SparqlExpressionPimpl expression,
                Variable targetVariable, bool targetIsVisible);

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -163,10 +163,17 @@ class ParsedQuery {
     numInternalVariables_ = numInternalVariables;
   }
 
+ private:
+  // Add a BIND clause to the body of the query
+  void addBind(sparqlExpression::SparqlExpressionPimpl expression,
+               Variable targetVariable, bool targetIsVisible);
+
   /// Generates an internal bind that binds the given expression using a bind.
   /// The bind is added to the query as child. The variable that the expression
   /// is bound to is returned.
   Variable addInternalBind(sparqlExpression::SparqlExpressionPimpl expression);
+
+ public:
   void addSolutionModifiers(SolutionModifiers modifiers);
 
   /**

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -171,7 +171,7 @@ class ParsedQuery {
   void addBind(sparqlExpression::SparqlExpressionPimpl expression,
                Variable targetVariable, bool targetIsVisible);
 
-  // Generates an internal BIND that binds the given expression using a BIND.
+  // Generates an internal BIND that binds the given expression.
   // The BIND is added to the query as child. The variable that the expression
   // is bound to is returned.
   Variable addInternalBind(sparqlExpression::SparqlExpressionPimpl expression);

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -84,3 +84,13 @@ SelectClause::getSelectedVariablesAsStrings() const {
     return std::get<VarsAndAliases>(varsAndAliasesOrAsterisk_).aliases_;
   }
 }
+
+void SelectClause::deleteAliasesButKeepVariables() {
+  if (isAsterisk()) {
+    return;
+  }
+  auto& varsAndAliases = std::get<VarsAndAliases>(varsAndAliasesOrAsterisk_);
+  // The variables that the aliases are bound to have previously been stored
+  // seperately in `varsAndAliases.vars_`, so we can simply delete the aliases.
+  varsAndAliases.aliases_.clear();
+}

--- a/src/parser/SelectClause.h
+++ b/src/parser/SelectClause.h
@@ -79,5 +79,11 @@ struct SelectClause : ClauseBase {
   /// example for `SELECT ?x (?a + ?b AS ?c)`,
   /// `{(?a + ?b AS ?c)}` will be returned.
   [[nodiscard]] const std::vector<Alias>& getAliases() const;
+
+  /// Delete all the aliases, but keep the variables that they are bound to as
+  /// selected. This is used in the case of queries that have aliases, but no
+  /// GROUP BY clause. There these aliases become ordinary BIND clauses and are
+  /// then deleted from the SELECT clause
+  void deleteAliasesButKeepVariables();
 };
 }  // namespace parsedQuery

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -10,8 +10,10 @@ namespace sparqlParserHelpers {
 using std::string;
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(std::string input)
-    : input_{std::move(input)}, visitor_{} {
+ParserAndVisitor::ParserAndVisitor(
+    std::string input,
+    SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
+    : input_{std::move(input)}, visitor_{{}, disableSomeChecks} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
   // propagate them to the user.
@@ -22,9 +24,10 @@ ParserAndVisitor::ParserAndVisitor(std::string input)
 }
 
 // _____________________________________________________________________________
-ParserAndVisitor::ParserAndVisitor(std::string input,
-                                   SparqlQleverVisitor::PrefixMap prefixes)
-    : ParserAndVisitor{std::move(input)} {
+ParserAndVisitor::ParserAndVisitor(
+    std::string input, SparqlQleverVisitor::PrefixMap prefixes,
+    SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
+    : ParserAndVisitor{std::move(input), disableSomeChecks} {
   visitor_.setPrefixMapManually(std::move(prefixes));
 }
 }  // namespace sparqlParserHelpers

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -37,8 +37,14 @@ struct ParserAndVisitor {
  public:
   SparqlAutomaticParser parser_{&tokens_};
   SparqlQleverVisitor visitor_;
-  explicit ParserAndVisitor(string input);
-  ParserAndVisitor(string input, SparqlQleverVisitor::PrefixMap prefixes);
+  explicit ParserAndVisitor(
+      string input,
+      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
+          SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False);
+  ParserAndVisitor(
+      string input, SparqlQleverVisitor::PrefixMap prefixes,
+      SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
+          SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False);
 
   template <typename ContextType>
   auto parseTypesafe(ContextType* (SparqlAutomaticParser::*F)(void)) {

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -206,7 +206,7 @@ class TurtleParser {
       LOG(INFO) << "The next " << num_bytes << " bytes are:\n"
                 << std::string_view(d.data(), s) << std::endl;
     }
-    throw ParseException("Error while parsing turtle input");
+    throw ParseException{"Error while parsing turtle input"};
   }
 
   // Throw an exception or simply ignore the current triple, depending on the

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -206,7 +206,7 @@ class TurtleParser {
       LOG(INFO) << "The next " << num_bytes << " bytes are:\n"
                 << std::string_view(d.data(), s) << std::endl;
     }
-    throw ParseException{"Error while parsing turtle input"};
+    throw ParseException{"Error while parsing Turtle input"};
   }
 
   // Throw an exception or simply ignore the current triple, depending on the

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -270,8 +270,7 @@ GraphPatternOperation Visitor::visit(Parser::BindContext* ctx) {
   Variable target = visit(ctx->var());
   if (ad_utility::contains(visibleVariables_, target)) {
     reportError(ctx, absl::StrCat("The target variable ", target.name(),
-                                  " of a BIND clause is used in the query body "
-                                  "before the BIND. This is not allowed"));
+                                  " of an AS clause was already used before in the query body."));
   }
 
   auto expression = visitExpressionPimpl(ctx->expression());

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -142,7 +142,7 @@ PathTuples joinPredicateAndObject(VarOrPath predicate, ObjectList objectList) {
         }
       }
     }
-    tuples.push_back({predicate, std::move(object)});
+    tuples.emplace_back(predicate, std::move(object));
   }
   return tuples;
 }
@@ -150,7 +150,7 @@ PathTuples joinPredicateAndObject(VarOrPath predicate, ObjectList objectList) {
 // ___________________________________________________________________________
 SparqlExpressionPimpl Visitor::visitExpressionPimpl(auto* ctx,
                                                     bool allowLanguageFilters) {
-  SparqlExpressionPimpl result{visit(ctx), std::move(ctx->getText())};
+  SparqlExpressionPimpl result{visit(ctx), getOriginalInputForContext(ctx)};
   if (allowLanguageFilters) {
     checkUnsupportedLangOperationAllowFilters(ctx, result);
   } else {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -73,6 +73,8 @@ class SparqlQleverVisitor {
   using ExpressionPtr = sparqlExpression::SparqlExpression::Ptr;
   using IntOrDouble = std::variant<int64_t, double>;
 
+  enum struct DisableSomeChecksOnlyForTesting { False, True };
+
  private:
   size_t _blankNodeCounter = 0;
   int64_t numInternalVariables_ = 0;
@@ -87,9 +89,16 @@ class SparqlQleverVisitor {
   // prologue, this string simply remains empty.
   std::string prologueString_;
 
+  DisableSomeChecksOnlyForTesting disableSomeChecksOnlyForTesting_;
+
  public:
   SparqlQleverVisitor() = default;
-  SparqlQleverVisitor(PrefixMap prefixMap) : prefixMap_{std::move(prefixMap)} {}
+  SparqlQleverVisitor(
+      PrefixMap prefixMap,
+      DisableSomeChecksOnlyForTesting disableSomeChecksOnlyForTesting =
+          DisableSomeChecksOnlyForTesting::False)
+      : prefixMap_{std::move(prefixMap)},
+        disableSomeChecksOnlyForTesting_{disableSomeChecksOnlyForTesting} {}
 
   const PrefixMap& prefixMap() const { return prefixMap_; }
   void setPrefixMapManually(PrefixMap map) { prefixMap_ = std::move(map); }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -518,14 +518,15 @@ class SparqlQleverVisitor {
  private:
   // Throw an exception if the `expression` contains the `LANG()` function. The
   // `context` will be used to create the exception metadata.
-  void checkUnsupportedLangOperation(antlr4::ParserRuleContext* context,
-                                     SparqlExpressionPimpl expression);
+  static void checkUnsupportedLangOperation(
+      antlr4::ParserRuleContext* context,
+      const SparqlExpressionPimpl& expression);
 
   // Similar to `checkUnsupportedLangOperation` but doesn't throw for the
   // expression `LANG(?someVariable) = "someLangtag"` which is supported by
   // QLever inside a FILTER clause.
-  void checkUnsupportedLangOperationAllowFilters(
-      antlr4::ParserRuleContext* ctx, SparqlExpressionPimpl expression);
+  static void checkUnsupportedLangOperationAllowFilters(
+      antlr4::ParserRuleContext* ctx, const SparqlExpressionPimpl& expression);
 
   // Parse both `ConstructTriplesContext` and `TriplesTemplateContext` because
   // they have the same structure.

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -441,12 +441,14 @@ class SparqlQleverVisitor {
   // for readability (for example, in an error message), and even more so when
   // using such parts for further processing (like the body of a SERVICE query,
   // which is not valid SPARQL anymore when you remove all whitespace).
-  std::string getOriginalInputForContext(antlr4::ParserRuleContext* context);
+  static std::string getOriginalInputForContext(
+      antlr4::ParserRuleContext* context);
 
   // Process an IRI function call. This is used in both `visitFunctionCall` and
   // `visitIriOrFunction`.
   [[nodiscard]] ExpressionPtr processIriFunctionCall(
-      const std::string& iri, std::vector<ExpressionPtr> argList);
+      const std::string& iri, std::vector<ExpressionPtr> argList,
+      antlr4::ParserRuleContext*);
 
   // TODO: Remove addVisibleVariable(const string&) when all Types use the
   //  strong type `Variable`.
@@ -506,12 +508,14 @@ class SparqlQleverVisitor {
   template <typename Ctx>
   void visitIf(Ctx* ctx) requires voidWhenVisited<SparqlQleverVisitor, Ctx>;
 
-  [[noreturn]] void reportError(antlr4::ParserRuleContext* ctx,
-                                const std::string& msg);
+ public:
+  [[noreturn]] static void reportError(antlr4::ParserRuleContext* ctx,
+                                       const std::string& msg);
 
-  [[noreturn]] void reportNotSupported(antlr4::ParserRuleContext* ctx,
-                                       const std::string& feature);
+  [[noreturn]] static void reportNotSupported(antlr4::ParserRuleContext* ctx,
+                                              const std::string& feature);
 
+ private:
   // Throw an exception if the `expression` contains the `LANG()` function. The
   // `context` will be used to create the exception metadata.
   void checkUnsupportedLangOperation(antlr4::ParserRuleContext* context,

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(http)
 add_library(util GeoSparqlHelpers.h GeoSparqlHelpers.cpp VisitMixin.h
         antlr/ANTLRErrorHandling.cpp antlr/ANTLRErrorHandling.h Conversions.cpp ResetWhenMoved.h)
-target_link_libraries(util absl::strings)
+target_link_libraries(util absl::strings parser)

--- a/src/util/antlr/ANTLRErrorHandling.cpp
+++ b/src/util/antlr/ANTLRErrorHandling.cpp
@@ -75,7 +75,7 @@ void ThrowingErrorListener::syntaxError(antlr4::Recognizer* recognizer,
                                         size_t line, size_t charPositionInLine,
                                         const std::string& msg,
                                         [[maybe_unused]] std::exception_ptr e) {
-  throw ParseException{
+  throw InvalidQueryException{
       generateExceptionMessage(offendingSymbol, msg),
       generateMetadata(recognizer, offendingSymbol, line, charPositionInLine)};
 }

--- a/src/util/http/CMakeLists.txt
+++ b/src/util/http/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(HttpParser)
 add_library(mediaTypes MediaTypes.h MediaTypes.cpp)
 target_compile_options(mediaTypes PUBLIC -Wno-attributes)
-target_link_libraries(mediaTypes ${ICU_LIBRARIES} absl::flat_hash_map)
+target_link_libraries(mediaTypes util ${ICU_LIBRARIES} absl::flat_hash_map)
 add_library(http HttpServer.h HttpClient.h HttpClient.cpp HttpUtils.h HttpUtils.cpp UrlParser.h UrlParser.cpp "HttpParser/AcceptHeaderQleverVisitor.h")
 
 target_link_libraries(http mediaTypes httpParser ${ICU_LIBRARIES} OpenSSL::SSL OpenSSL::Crypto)

--- a/test/CheckUsePatternTrickTest.cpp
+++ b/test/CheckUsePatternTrickTest.cpp
@@ -77,7 +77,7 @@ TEST(CheckUsePatternTrick, isVariableContainedInGraphPattern) {
   expectXYZContained("{?x <is-a> ?y} UNION {?z <is-a> <something>}");
   expectXYZContained("?x <is-a> ?y {SELECT ?z WHERE {?z <is-a> ?not}}");
   expectXYZContained("BIND (3 AS ?x) . ?y <is-a> ?z");
-  expectXYZContained("?x <is-a> ?z. BIND(?y AS ?t)");
+  expectXYZContained("?x <is-a> ?z. BIND(?z AS ?y)");
   expectXYZContained("VALUES ?x {<a> <b>}. ?y <is-a> ?z");
   expectXYZContained("VALUES ?x {<a> <b>}. ?y <is-a> ?z");
   expectXYZContained("?x <is-a> ?y { SERVICE <endpoint> { ?x ?y ?z } }");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -774,13 +774,11 @@ TEST(SparqlParser, HavingCondition) {
 }
 
 TEST(SparqlParser, GroupGraphPattern) {
-  // TODO<joka921> This shouldn't be True, we have to adapt some tests.
-  auto noChecks = SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False;
   auto expectGraphPattern = ExpectCompleteParse<&Parser::groupGraphPattern>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}},
-      noChecks};
+      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}
+      };
   auto expectGroupGraphPatternFails =
-      ExpectParseFails<&Parser::groupGraphPattern>{{}, noChecks};
+      ExpectParseFails<&Parser::groupGraphPattern>{{} };
   auto DummyTriplesMatcher = m::Triples({{Var{"?x"}, "?y", Var{"?z"}}});
 
   // Empty GraphPatterns are not supported.

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -909,16 +909,23 @@ TEST(SparqlParser, SelectQuery) {
           m::SelectQuery(m::Select({Var{"?x"}}), DummyGraphPatternMatcher),
           m::pq::Having({"(?x>5)"}), m::pq::OrderKeys({{Var{"?y"}, false}})));
 
-  // When there is no
+  // When there is no GROUP BY, the aliases are equivalently transformed into
+  // BINDs and then deleted from the SELECT clause.
   expectSelectQuery("SELECT (?x AS ?y) (?y AS ?z) WHERE { BIND(1 AS ?x)}",
                     m::SelectQuery(m::Select({Var("?y"), Var("?z")}),
                                    m::GraphPattern(m::Bind(Var("?x"), "1"),
                                                    m::Bind(Var("?y"), "?x"),
                                                    m::Bind(Var{"?z"}, "?y"))));
+
   // The variable in the implicit BIND expression in the alias binds to the
   // variable `?y` which is already in scope. This is forbidden by the SPARQL
   // standard.
   expectSelectQueryFails("SELECT (?x AS ?y) WHERE { ?x <is-a> ?y }");
+
+  // It is also illegal to reuse a variable from the body of a query with a
+  // GROUP BY as the target of an alias
+  expectSelectQueryFails(
+      "SELECT (SUM(?y) AS ?y) WHERE { ?x <is-a> ?y } GROUP BY ?x");
 
   // Grouping by a variable or expression which contains a variable
   // that is not visible in the query body is not allowed.

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -931,13 +931,13 @@ TEST(SparqlParser, SelectQuery) {
                                                    m::Bind(Var("?y"), "?x"),
                                                    m::Bind(Var{"?z"}, "?y"))));
 
-  // The variable in the implicit BIND expression in the alias binds to the
-  // variable `?y` which is already in scope. This is forbidden by the SPARQL
-  // standard.
+  // The target of the alias (`?y`) is already bound in the WHERE clause. This
+  // is forbidden by the SPARQL standard.
   expectSelectQueryFails("SELECT (?x AS ?y) WHERE { ?x <is-a> ?y }");
 
   // It is also illegal to reuse a variable from the body of a query with a
-  // GROUP BY as the target of an alias
+  // GROUP BY as the target of an alias, even if it is the aggregated variable
+  // itself.
   expectSelectQueryFails(
       "SELECT (SUM(?y) AS ?y) WHERE { ?x <is-a> ?y } GROUP BY ?x");
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1057,6 +1057,21 @@ TEST(SparqlParser, Query) {
           m::pq::LimitOffset({10}),
           m::VisibleVariables({Var{"?x"}, Var{"?y"}, Var{"?z"}})));
 
+  // Construct query with GROUP BY
+  // TODO<joka921> Check the GROUP BY variables.
+  expectQuery(
+      "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } GROUP BY ?x",
+      testing::AllOf(
+          m::ConstructQuery(
+              {{Var{"?x"}, Iri{"<foo>"}, Iri{"<bar>"}}},
+              m::GraphPattern(m::Triples({{Var{"?x"}, "?y", Var{"?z"}}}))),
+          m::pq::OriginalString(
+              "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } GROUP BY ?x"),
+          m::VisibleVariables({Var{"?x"}, Var{"?y"}, Var{"?z"}})));
+  // Construct query with GROUP BY, but a variable that is not grouped is used.
+  expectQueryFails(
+      "CONSTRUCT { ?x <foo> <bar> } WHERE { ?x ?y ?z } GROUP BY ?y");
+
   // Test that the prologue is parsed properly. We use `m::Service` here
   // because the parsing of a SERVICE clause is the only place where the
   // prologue is explicitly passed on to a `parsedQuery::` object.

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -846,7 +846,7 @@ TEST(SparqlParser, GroupGraphPattern) {
                       {Var{"?c"}, CONTAINS_ENTITY_PREDICATE, Var{"?x"}},
                       {Var{"?c"}, CONTAINS_WORD_PREDICATE, "coca* abuse"}})));
 
-  // Scoping of variables in combination with BIND clauses
+  // Scoping of variables in combination with a BIND clause.
   expectGraphPattern(
       "{?x <is-a> <Actor> . BIND(10 - ?x as ?y) }",
       m::GraphPattern(m::Triples({{Var{"?x"}, "<is-a>", "<Actor>"}}),

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -78,7 +78,28 @@ inline std::ostream& operator<<(std::ostream& out,
       << ::testing::PrintToString(values._inlineValues._values);
   return out;
 }
+
+inline void PrintTo(const parsedQuery::GraphPattern& pattern,
+                    std::ostream* os) {
+  auto& s = *os;
+  s << ::testing::PrintToString(pattern._graphPatterns);
+}
+
+inline void PrintTo(const parsedQuery::GraphPatternOperation& op,
+                    std::ostream* os) {
+  std::ostringstream str;
+  op.toString(str);
+  (*os) << str.str();
+}
 }  // namespace parsedQuery
+
+inline void PrintTo(const ParsedQuery& pq, std::ostream* os) {
+  (*os) << "is select query: " << pq.hasSelectClause() << '\n';
+  (*os) << "Variables: " << ::testing::PrintToString(pq.getVisibleVariables())
+        << '\n';
+  (*os) << "Graph pattern:";
+  PrintTo(pq._rootGraphPattern, os);
+}
 
 // _____________________________________________________________________________
 

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -125,7 +125,7 @@ namespace sparqlExpression {
 inline std::ostream& operator<<(
     std::ostream& out,
     const sparqlExpression::SparqlExpressionPimpl& groupKey) {
-  out << "Group by " << groupKey.getDescriptor();
+  out << "Expression:" << groupKey.getDescriptor();
   return out;
 }
 }  // namespace sparqlExpression

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -124,8 +124,8 @@ namespace sparqlExpression {
 
 inline std::ostream& operator<<(
     std::ostream& out,
-    const sparqlExpression::SparqlExpressionPimpl& groupKey) {
-  out << "Expression:" << groupKey.getDescriptor();
+    const sparqlExpression::SparqlExpressionPimpl& expression) {
+  out << "Expression:" << expression.getDescriptor();
   return out;
 }
 }  // namespace sparqlExpression

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -122,8 +122,8 @@ TEST(ParserTest, testParse) {
     const auto& triples = pq.children()[0].getBasic()._triples;
     auto filters = pq._rootGraphPattern._filters;
     ASSERT_EQ(2u, filters.size());
-    ASSERT_EQ("(?x!=?y)", filters[0].expression_.getDescriptor());
-    ASSERT_EQ("(?y<?x)", filters[1].expression_.getDescriptor());
+    ASSERT_EQ("(?x != ?y)", filters[0].expression_.getDescriptor());
+    ASSERT_EQ("(?y < ?x)", filters[1].expression_.getDescriptor());
     ASSERT_EQ(2u, triples.size());
   }
 
@@ -135,7 +135,7 @@ TEST(ParserTest, testParse) {
     const auto& triples = pq.children()[0].getBasic()._triples;
     auto filters = pq._rootGraphPattern._filters;
     ASSERT_EQ(1u, filters.size());
-    ASSERT_EQ("(?x!=?y)", filters[0].expression_.getDescriptor());
+    ASSERT_EQ("(?x != ?y)", filters[0].expression_.getDescriptor());
     ASSERT_EQ(2u, triples.size());
   }
 
@@ -148,7 +148,7 @@ TEST(ParserTest, testParse) {
     const auto& triples = pq.children()[0].getBasic()._triples;
     auto filters = pq._rootGraphPattern._filters;
     ASSERT_EQ(1u, filters.size());
-    ASSERT_EQ("(?x!=?y)", filters[0].expression_.getDescriptor());
+    ASSERT_EQ("(?x != ?y)", filters[0].expression_.getDescriptor());
     ASSERT_EQ(4u, triples.size());
     ASSERT_EQ(Var{"?c"}, triples[2]._s);
     ASSERT_EQ(CONTAINS_ENTITY_PREDICATE, triples[2]._p._iri);
@@ -503,7 +503,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(2u, c_subquery._triples.size());
     ASSERT_EQ(1u, parsed_sub_query.get()._rootGraphPattern._filters.size());
     const auto& filter = parsed_sub_query.get()._rootGraphPattern._filters[0];
-    ASSERT_EQ("(?year>\"00-00-2000\")", filter.expression_.getDescriptor());
+    ASSERT_EQ("(?year > \"00-00-2000\")", filter.expression_.getDescriptor());
     ASSERT_EQ(0, parsed_sub_query.get()._limitOffset._offset);
 
     ASSERT_EQ(c_subquery._triples[0]._s, Var{"?movie"});
@@ -581,7 +581,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(1u, c_subquery._triples.size());
     ASSERT_EQ(1u, parsed_sub_query.get()._rootGraphPattern._filters.size());
     const auto& filter = parsed_sub_query.get()._rootGraphPattern._filters[0];
-    ASSERT_EQ("(?year>\"00-00-2000\")", filter.expression_.getDescriptor());
+    ASSERT_EQ("(?year > \"00-00-2000\")", filter.expression_.getDescriptor());
     ASSERT_EQ(0, parsed_sub_query.get()._limitOffset._offset);
 
     ASSERT_EQ(c_subquery._triples[0]._s, Var{"?movie"});
@@ -703,9 +703,9 @@ TEST(ParserTest, testFilterWithoutDot) {
   ASSERT_EQ(3u, c._triples.size());
   const auto& filters = pq._rootGraphPattern._filters;
   ASSERT_EQ(3u, filters.size());
-  ASSERT_EQ("(?1!=fb:m.0fkvn)", filters[0].expression_.getDescriptor());
-  ASSERT_EQ("(?1!=fb:m.0vmt)", filters[1].expression_.getDescriptor());
-  ASSERT_EQ("(?1!=fb:m.018mts)", filters[2].expression_.getDescriptor());
+  ASSERT_EQ("(?1 != fb:m.0fkvn)", filters[0].expression_.getDescriptor());
+  ASSERT_EQ("(?1 != fb:m.0vmt)", filters[1].expression_.getDescriptor());
+  ASSERT_EQ("(?1 != fb:m.018mts)", filters[2].expression_.getDescriptor());
 }
 
 TEST(ParserTest, testExpandPrefixes) {
@@ -987,7 +987,7 @@ TEST(ParserTest, Bind) {
   ASSERT_TRUE(holds_alternative<p::Bind>(child));
   p::Bind bind = get<p::Bind>(child);
   ASSERT_EQ(bind._target, Var{"?a"});
-  ASSERT_EQ(bind._expression.getDescriptor(), "10-5");
+  ASSERT_EQ(bind._expression.getDescriptor(), "10 - 5");
 }
 
 TEST(ParserTest, Order) {
@@ -1049,7 +1049,7 @@ TEST(ParserTest, Order) {
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
-    ASSERT_EQ(helperBind._expression.getDescriptor(), "(?x-?y)");
+    ASSERT_EQ(helperBind._expression.getDescriptor(), "(?x - ?y)");
     ASSERT_EQ(pq._orderBy[0].variable_, helperBind._target);
   }
   {
@@ -1094,7 +1094,7 @@ TEST(ParserTest, Group) {
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);
-    ASSERT_THAT(helperBind, m::BindExpression("?x-?y"));
+    ASSERT_THAT(helperBind, m::BindExpression("?x - ?y"));
     EXPECT_THAT(pq, m::GroupByVariables({helperBind._target, Var{"?x"}}));
   }
   {
@@ -1103,7 +1103,7 @@ TEST(ParserTest, Group) {
         "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY (?x "
         "- ?y AS ?foo) ?x");
     EXPECT_THAT(pq._rootGraphPattern._graphPatterns[1],
-                m::Bind(Var{"?foo"}, "?x-?y"));
+                m::Bind(Var{"?foo"}, "?x - ?y"));
     EXPECT_THAT(pq, m::GroupByVariables({Var{"?foo"}, Var{"?x"}}));
   }
   {
@@ -1121,7 +1121,7 @@ TEST(ParserTest, Group) {
     ParsedQuery pq = SparqlParser::parseQuery(
         "SELECT ?x WHERE { ?x <test/myrel> ?y } GROUP BY "
         "<http://www.opengis.net/def/function/geosparql/"
-        "latitude> (?y) ?x");
+        "latitude>(?y) ?x");
     auto variant = pq._rootGraphPattern._graphPatterns[1];
     ASSERT_TRUE(holds_alternative<p::Bind>(variant));
     auto helperBind = get<p::Bind>(variant);

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -446,7 +446,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, pq._orderBy[0].isDescending_);
     ASSERT_EQ(Var{"?movie"}, pq._orderBy[0].variable_);
 
-    auto sc = get<ParsedQuery::SelectClause>(pq._clause);
+    auto sc = pq.selectClause();
     ASSERT_EQ(true, sc.distinct_);
     ASSERT_EQ(true, sc.isAsterisk());
 
@@ -486,7 +486,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, pq._orderBy[0].isDescending_);
     ASSERT_EQ(Var{"?movie"}, pq._orderBy[0].variable_);
 
-    auto sc = get<ParsedQuery::SelectClause>(pq._clause);
+    auto sc = pq.selectClause();
     ASSERT_EQ(true, sc.distinct_);
     ASSERT_EQ(true, sc.isAsterisk());
 
@@ -519,8 +519,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, parsed_sub_query.get()._orderBy[0].isDescending_);
     ASSERT_EQ(Var{"?director"}, parsed_sub_query.get()._orderBy[0].variable_);
 
-    auto sc_subquery =
-        get<ParsedQuery::SelectClause>(parsed_sub_query.get()._clause);
+    auto sc_subquery = parsed_sub_query.get().selectClause();
     ASSERT_EQ(false, sc_subquery.distinct_);
     ASSERT_EQ(false, sc_subquery.reduced_);
     ASSERT_EQ(true, sc_subquery.isAsterisk());
@@ -565,7 +564,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, pq._orderBy[0].isDescending_);
     ASSERT_EQ(Var{"?movie"}, pq._orderBy[0].variable_);
 
-    auto sc = get<ParsedQuery::SelectClause>(pq._clause);
+    auto sc = pq.selectClause();
     ASSERT_EQ(true, sc.distinct_);
     ASSERT_EQ(true, sc.isAsterisk());
 
@@ -594,8 +593,7 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(true, parsed_sub_query.get()._orderBy[0].isDescending_);
     ASSERT_EQ(Var{"?director"}, parsed_sub_query.get()._orderBy[0].variable_);
 
-    auto sc_subquery =
-        get<ParsedQuery::SelectClause>(parsed_sub_query.get()._clause);
+    auto sc_subquery = parsed_sub_query.get().selectClause();
     ASSERT_EQ(false, sc_subquery.distinct_);
     ASSERT_EQ(false, sc_subquery.reduced_);
     ASSERT_EQ(true, sc_subquery.isAsterisk());
@@ -621,8 +619,7 @@ TEST(ParserTest, testParse) {
               aux_parsed_sub_sub_query._limitOffset._limit);
     ASSERT_EQ(0u, aux_parsed_sub_sub_query._orderBy.size());
 
-    auto sc_sub_subquery =
-        get<ParsedQuery::SelectClause>(aux_parsed_sub_sub_query._clause);
+    auto sc_sub_subquery = aux_parsed_sub_sub_query.selectClause();
     ASSERT_EQ(false, sc_sub_subquery.distinct_);
     ASSERT_EQ(false, sc_sub_subquery.reduced_);
     ASSERT_EQ(false, sc_sub_subquery.isAsterisk());


### PR DESCRIPTION
Fixes #856 

Previously, aliases like `SELECT (?x as ?y)` were ignored in queries without a GROUP BY clause. This is now fixed (they are simply added as BIND expressions at the end of the query body).

TODO: This still requires unit tests that would have caught this behavior.