### PR TITLE
Update `actions/github-script` to version 6

### DIFF
--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -28,7 +28,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         # The following script is taken from the link stated at the
         # beginning of this file. It manually downloads an artifact
         # from another workflow.

--- a/.github/workflows/upload-sonarcloud.yml
+++ b/.github/workflows/upload-sonarcloud.yml
@@ -37,7 +37,7 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
       - name: 'Download artifact'
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v6
         if: github.event.workflow_run.event == 'pull_request'
         # The following script is taken from the link stated at the
         # beginning of this file. It manually downloads an artifact


### PR DESCRIPTION
There were several warnings about (external) actions that are used by our workflows which had to be updated to newer versions because the old versions
use deprecated features from GitHub actions that will be deactivated soon.