### PR TITLE
Use Clang 15 when computing the coverage data for Codecov

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     env:
           compiler: clang
-          compiler-version: 16
+          compiler-version: 15
           build-type: Debug
           warnings: "-Wall -Wextra "
           # we disable the `assert()` macro as it messes with the coverage reports
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install dependencies
       run:  sudo apt update && sudo apt-get install -y libicu-dev tzdata gcc-10 libzstd-dev libjemalloc-dev libboost-all-dev
-    - name: Install clang 16
+    - name: Install clang 15
       # The sed command fixes a bug in `llvm.sh` in combination with the latest version of
       # `apt-key`. Without it the GPG key for the llvm repository is downloaded but deleted
       # immediately after.
@@ -46,7 +46,7 @@ jobs:
         wget https://apt.llvm.org/llvm.sh
         sudo chmod +x llvm.sh
         sed   's/apt-key del/echo/' llvm.sh -iy
-        sudo ./llvm.sh 16 all
+        sudo ./llvm.sh 15 all
     - name: Python dependencies
       run: sudo apt-get install python3-yaml unzip pkg-config python3-icu
     - name: Configure CMake
@@ -71,8 +71,8 @@ jobs:
     - name: Process coverage info
       working-directory: ${{github.workspace}}/build/test
       run:  >
-        llvm-profdata-16 merge -sparse *.profraw -o default.profdata;
-        xargs -a tests.txt llvm-cov-16 export --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" > ./coverage.lcov
+        llvm-profdata-15 merge -sparse *.profraw -o default.profdata;
+        xargs -a tests.txt llvm-cov-15 export --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" > ./coverage.lcov
 
 # Only upload the coverage directly if this is not a pull request. In this
 # case we are on the master branch and have access to the Codecov token.


### PR DESCRIPTION
The coverage tools in the (brandnew) Clang 16 don't
seem to work properly right now (they sometimes
crash and sometimes get stuck).