### PR TITLE
Macro AD_EXPENSIVE_CHECK for checks with significant runtime overhead

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=DEBUG -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DLOGLEVEL=DEBUG -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}} ${{env.coverage-flags}}" -DADDITIONAL_LINKER_FLAGS="${{env.coverage-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=false -DSINGLE_TEST_BINARY=ON -DENABLE_EXPENSIVE_CHECKS=true
 
     - name: Build
         # Build your program with the given configuration

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -96,7 +96,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{matrix.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{matrix.warnings}} ${{matrix.asan-flags}} ${{matrix.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=true
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{matrix.compiler}}${{matrix.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{matrix.warnings}} ${{matrix.asan-flags}} ${{matrix.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=true -DENABLE_EXPENSIVE_CHECKS=true
 
     - name: Build
         # Build your program with the given configuration

--- a/.github/workflows/upload-sonarcloud.yml
+++ b/.github/workflows/upload-sonarcloud.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=true
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.build-type}} -DCMAKE_TOOLCHAIN_FILE="$(pwd)/toolchains/${{env.compiler}}${{env.compiler-version}}.cmake" -DADDITIONAL_COMPILER_FLAGS="${{env.warnings}} ${{env.asan-flags}} ${{env.ubsan-flags}}" -DUSE_PARALLEL=true -DRUN_EXPENSIVE_TESTS=true -DENABLE_EXPENSIVE_CHECKS=true
       - name: Build
         # Build your program with the given configuration
         run: build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build ${{github.workspace}}/build --config ${{env.build-type}} -- -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ if (RUN_EXPENSIVE_TESTS)
 endif()
 
 if (ENABLE_EXPENSIVE_CHECKS)
-    message(STATUS "Enabling checks that have a measurable runtime overhead")
+    message(STATUS "Enabling checks that potentially have a significant runtime overhead")
     add_definitions("-DAD_ENABLE_EXPENSIVE_CHECKS")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,11 @@ endif()
 
 if (RUN_EXPENSIVE_TESTS)
     message(STATUS "Running expensive unit tests. This is only recommended in release builds")
-    add_definitions("-DQLEVER_RUN_EXPENSIVE_TESTS")
+    add_definitions("-DAD_EXPENSIVE_CHECKS_ENABLED")
+endif()
+
+if (ENABLE_EXPENSIVE_CHECKS)
+    message(STATUS "Enabling checks that have a measurable runtime overhead")
 endif()
 
 ################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,11 +178,12 @@ endif()
 
 if (RUN_EXPENSIVE_TESTS)
     message(STATUS "Running expensive unit tests. This is only recommended in release builds")
-    add_definitions("-DAD_EXPENSIVE_CHECKS_ENABLED")
+    add_definitions("-DQLEVER_RUN_EXPENSIVE_TESTS")
 endif()
 
 if (ENABLE_EXPENSIVE_CHECKS)
     message(STATUS "Enabling checks that have a measurable runtime overhead")
+    add_definitions("-DAD_ENABLE_EXPENSIVE_CHECKS")
 endif()
 
 ################################

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -278,8 +278,8 @@ class IdTable {
   // TODO<joka921, C++23> Use the multidimensional subscript operator.
   // TODO<joka921, C++23> Use explicit object parameters ("deducing this").
   T& operator()(size_t row, size_t column) requires(!isView) {
-    assert(column < data().size());
-    assert(row < data().at(column).size());
+    AD_EXPENSIVE_CHECK(column < data().size());
+    AD_EXPENSIVE_CHECK(row < data().at(column).size());
     return data()[column][row];
   }
   const T& operator()(size_t row, size_t column) const {
@@ -377,7 +377,7 @@ class IdTable {
   // this check cannot be performed, a wrong size of `newRow` will lead to
   // undefined behavior which is caught by an `assert` in Debug builds.
   void push_back(const std::initializer_list<T>& newRow) requires(!isView) {
-    assert(newRow.size() == numColumns());
+    AD_EXPENSIVE_CHECK(newRow.size() == numColumns());
     ++numRows_;
     for (size_t i = 0; i < numColumns(); ++i) {
       data()[i].push_back(*(newRow.begin() + i));
@@ -392,7 +392,7 @@ class IdTable {
                                                           (isDynamic ||
                                                            NumColumns == N)) {
     if constexpr (isDynamic) {
-      assert(newRow.size() == numColumns());
+      AD_EXPENSIVE_CHECK(newRow.size() == numColumns());
     }
     ++numRows_;
     for (size_t i = 0; i < numColumns(); ++i) {
@@ -413,7 +413,7 @@ class IdTable {
                        const_row_reference_view_restricted>>
   void push_back(const RowT& newRow) requires(!isView) {
     if constexpr (isDynamic) {
-      assert(newRow.numColumns() == numColumns());
+      AD_EXPENSIVE_CHECK(newRow.numColumns() == numColumns());
     }
     ++numRows_;
     for (size_t i = 0; i < numColumns(); ++i) {
@@ -560,7 +560,8 @@ class IdTable {
   // out-of-place algorithm that only writes the distinct elements. The the
   // follwing two functions can be deleted.
   void erase(const iterator& beginIt, const iterator& endIt) requires(!isView) {
-    assert(begin() <= beginIt && beginIt <= endIt && endIt <= end());
+    AD_EXPENSIVE_CHECK(begin() <= beginIt && beginIt <= endIt &&
+                       endIt <= end());
     auto startIndex = beginIt - begin();
     auto endIndex = endIt - begin();
     auto numErasedElements = endIndex - startIndex;

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -118,3 +118,21 @@ inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
   ad_utility::detail::adCorrectnessCheckImpl(            \
       static_cast<bool>(condition), __STRING(condition), \
       ad_utility::source_location::current())
+
+#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
+#define AD_EXPENSIVE_CHECKS_ENABLED true
+#else
+#define AD_EXPENSIVE_CHECKS_ENABLED false
+#endif
+
+// This check is similar to `AD_CORRECTNESS_CHECK` (see above), but the check is
+// only compiled and executed when either the `NDEBUG` constant is NOT defined
+// (which also enables the classic `assert()` macro), or the constant
+// `AD_ENABLE_EXPENSIVE_CHECKS` is enabled (which can be set via cmake). This
+// check should be used when checking has a significant and measurable runtime
+// overhead, but is still feasible for a release build on a large dataset.
+#define AD_EXPENSIVE_CHECK(condition)          \
+  if constexpr (AD_EXPENSIVE_CHECKS_ENABLED) { \
+    AD_CORRECTNESS_CHECK(condition);           \
+  }                                            \
+  void(0)

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -119,20 +119,16 @@ inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
       static_cast<bool>(condition), __STRING(condition), \
       ad_utility::source_location::current())
 
-#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
-#define AD_EXPENSIVE_CHECKS_ENABLED true
-#else
-#define AD_EXPENSIVE_CHECKS_ENABLED false
-#endif
-
 // This check is similar to `AD_CORRECTNESS_CHECK` (see above), but the check is
 // only compiled and executed when either the `NDEBUG` constant is NOT defined
 // (which also enables the classic `assert()` macro), or the constant
 // `AD_ENABLE_EXPENSIVE_CHECKS` is enabled (which can be set via cmake). This
 // check should be used when checking has a significant and measurable runtime
 // overhead, but is still feasible for a release build on a large dataset.
-#define AD_EXPENSIVE_CHECK(condition)          \
-  if constexpr (AD_EXPENSIVE_CHECKS_ENABLED) { \
-    AD_CORRECTNESS_CHECK(condition);           \
-  }                                            \
+#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
+#define AD_EXPENSIVE_CHECK(condition) \
+  AD_CORRECTNESS_CHECK(condition);    \
   void(0)
+#else
+#define AD_EXPENSIVE_CHECK(condition) void(0)
+#endif

--- a/test/ExceptionTest.cpp
+++ b/test/ExceptionTest.cpp
@@ -90,7 +90,7 @@ TEST(Exception, AD_FAIL) {
 }
 
 TEST(Excpetion, AD_EXPENSIVE_CHECK) {
-  if constexpr (AD_EXPENSIVE_CHECKS_ENABLED) {
-    ASSERT_ANY_THROW(AD_EXPENSIVE_CHECK(3 > 5));
-  }
+#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
+  ASSERT_ANY_THROW(AD_EXPENSIVE_CHECK(3 > 5));
+#endif
 }

--- a/test/ExceptionTest.cpp
+++ b/test/ExceptionTest.cpp
@@ -60,7 +60,7 @@ TEST(Exception, AD_CONTRACT_CHECK) {
   }
 }
 
-TEST(Exception, AD_UNSATISFIABLE) {
+TEST(Exception, AD_CORRECTNESS_CHECK) {
   ad_utility::source_location l;
   ASSERT_NO_THROW(AD_CORRECTNESS_CHECK(3 < 5));
   std::vector<int> v;

--- a/test/ExceptionTest.cpp
+++ b/test/ExceptionTest.cpp
@@ -88,3 +88,9 @@ TEST(Exception, AD_FAIL) {
                 ::testing::StartsWith("This code should be unreachable."));
   }
 }
+
+TEST(Excpetion, AD_EXPENSIVE_CHECK) {
+  if constexpr (AD_EXPENSIVE_CHECKS_ENABLED) {
+    ASSERT_ANY_THROW(AD_EXPENSIVE_CHECK(3 > 5));
+  }
+}


### PR DESCRIPTION
These tests should not be enabled when performance is crucial, but it is still feasible to enable them for debugging and verification even on very large knowledge graphs.