### PR TITLE
Removed some code smells related to CALL_FIXED_SIZE

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -97,8 +97,8 @@ ResultTable Bind::computeResult() {
   // added. Same for GROUP BY.
   auto localVocab = subRes->getCopyOfLocalVocab();
 
-  int inwidth = subRes->idTable().numColumns();
-  int outwidth = getResultWidth();
+  size_t inwidth = subRes->idTable().numColumns();
+  size_t outwidth = getResultWidth();
 
   CALL_FIXED_SIZE((std::array{inwidth, outwidth}), &Bind::computeExpressionBind,
                   this, &idTable, &localVocab, *subRes,
@@ -109,7 +109,7 @@ ResultTable Bind::computeResult() {
 }
 
 // _____________________________________________________________________________
-template <int IN_WIDTH, int OUT_WIDTH>
+template <size_t IN_WIDTH, size_t OUT_WIDTH>
 void Bind::computeExpressionBind(
     IdTable* outputIdTable, LocalVocab* outputLocalVocab,
     const ResultTable& inputResultTable,

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -45,7 +45,7 @@ class Bind : public Operation {
   ResultTable computeResult() override;
 
   // Implementation for the binding of arbitrary expressions.
-  template <int IN_WIDTH, int OUT_WIDTH>
+  template <size_t IN_WIDTH, size_t OUT_WIDTH>
   void computeExpressionBind(
       IdTable* outputIdTable, LocalVocab* outputLocalVocab,
       const ResultTable& inputResultTable,

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -134,7 +134,7 @@ ResultTable CountAvailablePredicates::computeResult() {
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
 
-    int width = subresult->idTable().numColumns();
+    size_t width = subresult->idTable().numColumns();
     CALL_FIXED_SIZE(width, &computePatternTrick, subresult->idTable(), &idTable,
                     hasPattern, hasPredicate, patterns, _subjectColumnIndex,
                     &runtimeInfo);
@@ -203,7 +203,7 @@ class MergeableHashMap : public ad_utility::HashMap<T, size_t> {
   }
 };
 
-template <int WIDTH>
+template <size_t WIDTH>
 void CountAvailablePredicates::computePatternTrick(
     const IdTable& dynInput, IdTable* dynResult,
     const vector<PatternID>& hasPattern,

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -97,7 +97,7 @@ class CountAvailablePredicates : public Operation {
    * @param subjectColumn The column containing the entities for which the
    *                      relations should be counted.
    */
-  template <int I>
+  template <size_t I>
   static void computePatternTrick(
       const IdTable& input, IdTable* result,
       const vector<PatternID>& hasPattern,

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -46,7 +46,7 @@ ResultTable Distinct::computeResult() {
 
   LOG(DEBUG) << "Distinct result computation..." << endl;
   idTable.setNumColumns(subRes->idTable().numColumns());
-  int width = subRes->idTable().numColumns();
+  size_t width = subRes->idTable().numColumns();
   CALL_FIXED_SIZE(width, &Engine::distinct, subRes->idTable(), _keepIndices,
                   &idTable);
   LOG(DEBUG) << "Distinct result computation done." << endl;

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -96,7 +96,7 @@ class Engine {
                << " elements.\n";
   }
 
-  template <int WIDTH>
+  template <size_t WIDTH>
   static void sort(IdTable* tab, const size_t keyColumn) {
     LOG(DEBUG) << "Sorting " << tab->size() << " elements ..." << std::endl;
     IdTableStatic<WIDTH> stab = std::move(*tab).toStatic<WIDTH>();
@@ -143,14 +143,14 @@ class Engine {
    *        in keepIndices. The input needs to be sorted on the keep indices,
    *        otherwise the result of this function is undefined.
    **/
-  template <int WIDTH>
+  template <size_t WIDTH>
   static void distinct(const IdTable& dynInput,
                        const std::vector<size_t>& keepIndices,
                        IdTable* dynResult) {
     LOG(DEBUG) << "Distinct on " << dynInput.size() << " elements.\n";
     const IdTableView<WIDTH> input = dynInput.asStaticView<WIDTH>();
     IdTableStatic<WIDTH> result = std::move(*dynResult).toStatic<WIDTH>();
-    if (input.size() > 0) {
+    if (!input.empty()) {
       AD_CONTRACT_CHECK(keepIndices.size() <= input.numColumns());
       result = input.clone();
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -53,7 +53,7 @@ ResultTable Filter::computeResult() {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(subRes->idTable().numColumns());
 
-  int width = idTable.numColumns();
+  size_t width = idTable.numColumns();
   CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this, &idTable, *subRes);
   LOG(DEBUG) << "Filter result computation done." << endl;
 
@@ -61,7 +61,7 @@ ResultTable Filter::computeResult() {
 }
 
 // _____________________________________________________________________________
-template <int WIDTH>
+template <size_t WIDTH>
 void Filter::computeFilterImpl(IdTable* outputIdTable,
                                const ResultTable& inputResultTable) {
   sparqlExpression::EvaluationContext evaluationContext(

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -60,7 +60,7 @@ class Filter : public Operation {
 
   ResultTable computeResult() override;
 
-  template <int WIDTH>
+  template <size_t WIDTH>
   void computeFilterImpl(IdTable* outputIdTable,
                          const ResultTable& inputResultTable);
 };

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -165,7 +165,7 @@ size_t GroupBy::getCostEstimate() {
   return _subtree->getCostEstimate();
 }
 
-template <int OUT_WIDTH>
+template <size_t OUT_WIDTH>
 void GroupBy::processGroup(
     const GroupBy::Aggregate& aggregate,
     sparqlExpression::EvaluationContext& evaluationContext, size_t blockStart,
@@ -219,14 +219,14 @@ void GroupBy::processGroup(
  *                        its already allocated storage.
  */
 
-template <int IN_WIDTH, int OUT_WIDTH>
+template <size_t IN_WIDTH, size_t OUT_WIDTH>
 void GroupBy::doGroupBy(const IdTable& dynInput,
                         const vector<size_t>& groupByCols,
                         const vector<GroupBy::Aggregate>& aggregates,
                         IdTable* dynResult, const IdTable* inTable,
                         LocalVocab* outLocalVocab) const {
   LOG(DEBUG) << "Group by input size " << dynInput.size() << std::endl;
-  if (dynInput.size() == 0) {
+  if (dynInput.empty()) {
     return;
   }
   const IdTableView<IN_WIDTH> input = dynInput.asStaticView<IN_WIDTH>();
@@ -253,8 +253,8 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
       result(rowIdx, i) = input(blockStart, groupByCols[i]);
     }
     for (const GroupBy::Aggregate& a : aggregates) {
-      processGroup(a, evaluationContext, blockStart, blockEnd, &result, rowIdx,
-                   a._outCol, outLocalVocab);
+      processGroup<OUT_WIDTH>(a, evaluationContext, blockStart, blockEnd,
+                              &result, rowIdx, a._outCol, outLocalVocab);
     }
   };
 
@@ -350,8 +350,8 @@ ResultTable GroupBy::computeResult() {
     groupByCols.push_back(subtreeVarCols.at(var));
   }
 
-  int inWidth = subresult->idTable().numColumns();
-  int outWidth = idTable.numColumns();
+  size_t inWidth = subresult->idTable().numColumns();
+  size_t outWidth = idTable.numColumns();
 
   CALL_FIXED_SIZE((std::array{inWidth, outWidth}), &GroupBy::doGroupBy, this,
                   subresult->idTable(), groupByCols, aggregates, &idTable,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -86,14 +86,14 @@ class GroupBy : public Operation {
 
   ResultTable computeResult() override;
 
-  template <int OUT_WIDTH>
+  template <size_t OUT_WIDTH>
   void processGroup(const Aggregate& expression,
                     sparqlExpression::EvaluationContext& evaluationContext,
                     size_t blockStart, size_t blockEnd,
                     IdTableStatic<OUT_WIDTH>* result, size_t resultRow,
                     size_t resultColumn, LocalVocab* localVocab) const;
 
-  template <int IN_WIDTH, int OUT_WIDTH>
+  template <size_t IN_WIDTH, size_t OUT_WIDTH>
   void doGroupBy(const IdTable& dynInput, const vector<size_t>& groupByCols,
                  const vector<GroupBy::Aggregate>& aggregates,
                  IdTable* dynResult, const IdTable* inTable,

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -88,7 +88,7 @@ ResultTable OrderBy::computeResult() {
   LOG(DEBUG) << "OrderBy result computation..." << endl;
   IdTable idTable = subRes->idTable().clone();
 
-  int width = idTable.numColumns();
+  size_t width = idTable.numColumns();
 
   // TODO<joka921> Measure (as soon as we have the benchmark merged)
   // whether it is beneficial to manually instantiate the comparison when
@@ -128,7 +128,7 @@ ResultTable OrderBy::computeResult() {
   // We cannot use the `CALL_FIXED_SIZE` macro here because the `sort` function
   // is templated not only on the integer `I` (which the `callFixedSize`
   // function deals with) but also on the `comparison`.
-  ad_utility::callFixedSize(width, [&idTable, &comparison]<int I>() {
+  ad_utility::callFixedSize(width, [&idTable, &comparison]<size_t I>() {
     Engine::sort<I>(&idTable, comparison);
   });
   LOG(DEBUG) << "OrderBy result computation done." << endl;

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -62,7 +62,7 @@ namespace {
 // compiler versions as soon as we don't support Clang 13 anymore.
 void callFixedSizeForSort(auto& idTable, auto comparison) {
   ad_utility::callFixedSize(idTable.numColumns(),
-                            [&idTable, comparison]<int I>() {
+                            [&idTable, comparison]<size_t I>() {
                               Engine::sort<I>(&idTable, comparison);
                             });
 }
@@ -70,7 +70,7 @@ void callFixedSizeForSort(auto& idTable, auto comparison) {
 // The actual implementation of sorting an `IdTable` according to the
 // `sortCols`.
 void sortImpl(IdTable& idTable, const std::vector<ColumnIndex>& sortCols) {
-  int width = idTable.numColumns();
+  size_t width = idTable.numColumns();
 
   // Instantiate specialized comparison lambdas for one and two sort columns
   // and use a generic comparison for a higher number of sort columns.

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -210,7 +210,7 @@ size_t TransitivePath::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-template <int SUB_WIDTH>
+template <size_t SUB_WIDTH>
 void TransitivePath::computeTransitivePath(IdTable* res, const IdTable& sub,
                                            bool leftIsVar, bool rightIsVar,
                                            size_t leftSubCol,
@@ -247,7 +247,7 @@ template void TransitivePath::computeTransitivePath<2>(
     size_t minDist, size_t maxDist);
 
 // _____________________________________________________________________________
-template <int SUB_WIDTH, bool leftIsVar, bool rightIsVar>
+template <size_t SUB_WIDTH, bool leftIsVar, bool rightIsVar>
 void TransitivePath::computeTransitivePath(IdTable* dynRes,
                                            const IdTable& dynSub,
                                            size_t leftSubCol,
@@ -390,7 +390,7 @@ void TransitivePath::computeTransitivePath(IdTable* dynRes,
   *dynRes = std::move(res).toDynamic();
 }
 
-template <int SUB_WIDTH, int LEFT_WIDTH, int RES_WIDTH>
+template <size_t SUB_WIDTH, size_t LEFT_WIDTH, size_t RES_WIDTH>
 void TransitivePath::computeTransitivePathLeftBound(
     IdTable* dynRes, const IdTable& dynSub, const IdTable& dynLeft,
     size_t leftSideCol, bool rightIsVar, size_t leftSubCol, size_t rightSubCol,
@@ -673,25 +673,23 @@ ResultTable TransitivePath::computeResult() {
 
   idTable.setNumColumns(getResultWidth());
 
-  int subWidth = subRes->idTable().numColumns();
+  size_t subWidth = subRes->idTable().numColumns();
   if (_leftSideTree != nullptr) {
     shared_ptr<const ResultTable> leftRes = _leftSideTree->getResult();
-    int leftWidth = leftRes->idTable().numColumns();
-    CALL_FIXED_SIZE(
-        (std::array{subWidth, leftWidth, static_cast<int>(_resultWidth)}),
-        &TransitivePath::computeTransitivePathLeftBound, this, &idTable,
-        subRes->idTable(), leftRes->idTable(), _leftSideCol, _rightIsVar,
-        _leftSubCol, _rightSubCol, _rightValue, _minDist, _maxDist,
-        _resultWidth);
+    size_t leftWidth = leftRes->idTable().numColumns();
+    CALL_FIXED_SIZE((std::array{subWidth, leftWidth, _resultWidth}),
+                    &TransitivePath::computeTransitivePathLeftBound, this,
+                    &idTable, subRes->idTable(), leftRes->idTable(),
+                    _leftSideCol, _rightIsVar, _leftSubCol, _rightSubCol,
+                    _rightValue, _minDist, _maxDist, _resultWidth);
   } else if (_rightSideTree != nullptr) {
     shared_ptr<const ResultTable> rightRes = _rightSideTree->getResult();
-    int rightWidth = rightRes->idTable().numColumns();
-    CALL_FIXED_SIZE(
-        (std::array{subWidth, rightWidth, static_cast<int>(_resultWidth)}),
-        &TransitivePath::computeTransitivePathRightBound, this, &idTable,
-        subRes->idTable(), rightRes->idTable(), _rightSideCol, _leftIsVar,
-        _leftSubCol, _rightSubCol, _leftValue, _minDist, _maxDist,
-        _resultWidth);
+    size_t rightWidth = rightRes->idTable().numColumns();
+    CALL_FIXED_SIZE((std::array{subWidth, rightWidth, _resultWidth}),
+                    &TransitivePath::computeTransitivePathRightBound, this,
+                    &idTable, subRes->idTable(), rightRes->idTable(),
+                    _rightSideCol, _leftIsVar, _leftSubCol, _rightSubCol,
+                    _leftValue, _minDist, _maxDist, _resultWidth);
   } else {
     CALL_FIXED_SIZE(subWidth, &TransitivePath::computeTransitivePath, this,
                     &idTable, subRes->idTable(), _leftIsVar, _rightIsVar,

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -107,19 +107,19 @@ class TransitivePath : public Operation {
 
   // The method is declared here to make it unit testable
 
-  template <int SUB_WIDTH, bool leftIsVar, bool rightIsVar>
+  template <size_t SUB_WIDTH, bool leftIsVar, bool rightIsVar>
   void computeTransitivePath(IdTable* res, const IdTable& sub,
                              size_t leftSubCol, size_t rightSubCol,
                              Id leftValue, Id rightValue, size_t minDist,
                              size_t maxDist);
 
-  template <int SUB_WIDTH>
+  template <size_t SUB_WIDTH>
   void computeTransitivePath(IdTable* res, const IdTable& sub, bool leftIsVar,
                              bool rightIsVar, size_t leftSubCol,
                              size_t rightSubCol, Id leftValue, Id rightValue,
                              size_t minDist, size_t maxDist);
 
-  template <int SUB_WIDTH, int LEFT_WIDTH, int RES_WIDTH>
+  template <size_t SUB_WIDTH, size_t LEFT_WIDTH, size_t RES_WIDTH>
   void computeTransitivePathLeftBound(IdTable* res, const IdTable& sub,
                                       const IdTable& left, size_t leftSideCol,
                                       bool rightIsVar, size_t leftSubCol,


### PR DESCRIPTION
Traditionally,
most of the templates involving the `CALL_FIXED_SIZE` mechanism use `int`s as template parameters where they should be using `size_t`. This leads to implicit conversions that static analysis (correctly) complains about.