### PR TITLE
Only allow const access to the `IndexMetaData` once it has been created

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -321,9 +321,8 @@ float CompressedRelationWriter::computeMultiplicity(
 }
 
 // ___________________________________________________________________________
-void CompressedRelationWriter::addRelation(Id col0Id,
-                                           const BufferedIdTable& col1And2Ids,
-                                           size_t numDistinctCol1) {
+CompressedRelationMetadata CompressedRelationWriter::addRelation(
+    Id col0Id, const BufferedIdTable& col1And2Ids, size_t numDistinctCol1) {
   AD_CONTRACT_CHECK(!col1And2Ids.empty());
   float multC1 = computeMultiplicity(col1And2Ids.numRows(), numDistinctCol1);
   // Dummy value that will be overwritten later
@@ -376,7 +375,7 @@ void CompressedRelationWriter::addRelation(Id col0Id,
       std::ranges::copy(column, buffer_.getColumn(i).begin() + bufferOldSize);
     }
   }
-  metaDataBuffer_.push_back(metaData);
+  return metaData;
 }
 
 // _____________________________________________________________________________

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -146,7 +146,6 @@ AD_SERIALIZE_FUNCTION(CompressedRelationMetadata) {
 class CompressedRelationWriter {
  private:
   ad_utility::File outfile_;
-  std::vector<CompressedRelationMetadata> metaDataBuffer_;
   std::vector<CompressedBlockMetadata> blockBuffer_;
   CompressedBlockMetadata currentBlockData_;
   SmallRelationsBuffer buffer_;
@@ -172,25 +171,18 @@ class CompressedRelationWriter {
    * can also calculate the average multiplicity and whether the relation is
    * functional, so we don't need to store that
    * explicitly).
+   *
+   * \return The Metadata of the relation that was added.
    */
-  void addRelation(Id col0Id, const BufferedIdTable& col1And2Ids,
-                   size_t numDistinctCol1);
+  CompressedRelationMetadata addRelation(Id col0Id,
+                                         const BufferedIdTable& col1And2Ids,
+                                         size_t numDistinctCol1);
 
   /// Finish writing all relations which have previously been added, but might
   /// still be in some internal buffer.
   void finish() {
     writeBufferedRelationsToSingleBlock();
     outfile_.close();
-  }
-
-  /// Get the complete CompressedRelationMetaData created by the calls to
-  /// addRelation. This meta data is then deleted from the
-  /// CompressedRelationWriter. The typical workflow is: add all relations,
-  /// then call `finish()` and then call this method.
-  auto getFinishedMetaData() {
-    auto result = std::move(metaDataBuffer_);
-    metaDataBuffer_.clear();
-    return result;
   }
 
   /// Get all the CompressedBlockMetaData that were created by the calls to

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -517,7 +517,7 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
   size_t distinctCol1 = 0;
   Id lastLhs = ID_NO_VALUE;
   uint64_t totalNumTriples = 0;
-  auto addCurrentRelation = [this, &metaData1, &metaData2, &writer1, &writer2,
+  auto addCurrentRelation = [&metaData1, &metaData2, &writer1, &writer2,
                              &currentRel, &buffer, &distinctCol1]() {
     auto md1 = writer1.addRelation(currentRel.value(), buffer, distinctCol1);
     auto md2 = writeSwitchedRel(&writer2, currentRel.value(), &buffer);

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -548,10 +548,8 @@ IndexImpl::createPermutationPairImpl(const string& fileName1,
     addCurrentRelation();
   }
 
-  writer1.finish();
-  writer2.finish();
-  metaData1.blockData() = writer1.getFinishedBlocks();
-  metaData2.blockData() = writer2.getFinishedBlocks();
+  metaData1.blockData() = std::move(writer1).getFinishedBlocks();
+  metaData2.blockData() = std::move(writer2).getFinishedBlocks();
 
   return std::make_pair(std::move(metaData1), std::move(metaData2));
 }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -696,8 +696,9 @@ class IndexImpl {
                             SortedTriples&& sortedTriples, size_t c0, size_t c1,
                             size_t c2, auto&&... perTripleCallbacks);
 
-  void writeSwitchedRel(CompressedRelationWriter* out, Id currentRel,
-                        BufferedIdTable* bufPtr);
+  CompressedRelationMetadata writeSwitchedRel(CompressedRelationWriter* out,
+                                              Id currentRel,
+                                              BufferedIdTable* bufPtr);
 
   // _______________________________________________________________________
   // Create a pair of permutations. Only works for valid pairs (PSO-POS,

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -696,9 +696,8 @@ class IndexImpl {
                             SortedTriples&& sortedTriples, size_t c0, size_t c1,
                             size_t c2, auto&&... perTripleCallbacks);
 
-  CompressedRelationMetadata writeSwitchedRel(CompressedRelationWriter* out,
-                                              Id currentRel,
-                                              BufferedIdTable* bufPtr);
+  static CompressedRelationMetadata writeSwitchedRel(
+      CompressedRelationWriter* out, Id currentRel, BufferedIdTable* bufPtr);
 
   // _______________________________________________________________________
   // Create a pair of permutations. Only works for valid pairs (PSO-POS,

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -720,14 +720,6 @@ class IndexImpl {
           p2,
       auto&&... perTripleCallbacks);
 
-  // The pairs of permutations are PSO-POS, OSP-OPS and SPO-SOP
-  // the multiplicity of column 1 in partner 1 of the pair is equal to the
-  // multiplity of column 2 in partner 2
-  // This functions writes the multiplicities of the first column of one
-  // arguments to the 2nd column multiplicities of the other
-  template <class MetaData>
-  void exchangeMultiplicities(MetaData* m1, MetaData* m2);
-
   // wrapper for createPermutation that saves a lot of code duplications
   // Writes the permutation that is specified by argument permutation
   // performs std::unique on arg vec iff arg performUnique is true (normally

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -174,7 +174,6 @@ class IndexMetaData {
 
   size_t getVersion() const { return _version; }
 
-  MapType& data() { return _data; }
   const MapType& data() const { return _data; }
 
   BlocksType& blockData() { return _blockData; }

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -168,9 +168,6 @@ class MetaDataWrapperHashMap {
   ConstIterator cbegin() const { return _map.begin(); }
   ConstIterator begin() const { return _map.begin(); }
 
-  // __________________________________________________________________
-  Iterator begin() { return _map.begin(); }
-
   // _________________________________________________________________________
   ConstOrderedIterator ordered_begin() const {
     return ConstOrderedIterator{this, 0};
@@ -179,9 +176,6 @@ class MetaDataWrapperHashMap {
   // ____________________________________________________________
   ConstIterator cend() const { return _map.end(); }
   ConstIterator end() const { return _map.end(); }
-
-  // ____________________________________________________________
-  Iterator end() { return _map.end(); }
 
   // _________________________________________________________________________
   ConstOrderedIterator ordered_end() const {

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -72,9 +72,6 @@ class MetaDataWrapperDense {
   ConstIterator cbegin() const { return _vec.begin(); }
 
   // __________________________________________________________________
-  Iterator begin() { return _vec.begin(); }
-
-  // __________________________________________________________________
   ConstIterator begin() const { return _vec.begin(); }
 
   // __________________________________________________________________________
@@ -85,7 +82,6 @@ class MetaDataWrapperDense {
 
   // __________________________________________________________________________
   ConstIterator end() const { return _vec.end(); }
-  Iterator end() { return _vec.end(); }
 
   // __________________________________________________________________________
   ConstOrderedIterator ordered_end() const { return end(); }
@@ -104,13 +100,6 @@ class MetaDataWrapperDense {
     return *it;
   }
 
-  // _________________________________________________________
-  value_type& operator[](Id id) {
-    auto it = lower_bound(id);
-    AD_CONTRACT_CHECK(it != _vec.end() && it->col0Id_ == id);
-    return *it;
-  }
-
   // ________________________________________________________
   size_t count(Id id) const {
     auto it = lower_bound(id);
@@ -122,12 +111,6 @@ class MetaDataWrapperDense {
 
  private:
   ConstIterator lower_bound(Id id) const {
-    auto cmp = [](const auto& metaData, Id id) {
-      return metaData.col0Id_ < id;
-    };
-    return std::lower_bound(_vec.begin(), _vec.end(), id, cmp);
-  }
-  Iterator lower_bound(Id id) {
     auto cmp = [](const auto& metaData, Id id) {
       return metaData.col0Id_ < id;
     };
@@ -222,13 +205,6 @@ class MetaDataWrapperHashMap {
     auto it = _map.find(id);
     AD_CONTRACT_CHECK(it != _map.end());
     return std::cref(it->second);
-  }
-
-  // __________________________________________________________
-  value_type& operator[](Id id) {
-    auto it = _map.find(id);
-    AD_CONTRACT_CHECK(it != _map.end());
-    return std::ref(it->second);
   }
 
   // ________________________________________________________

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -62,6 +62,7 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
 
   // First create the on-disk permutation.
   CompressedRelationWriter writer{ad_utility::File{filename, "w"}, blocksize};
+  vector<CompressedRelationMetadata> metaData;
   {
     size_t i = 0;
     for (const auto& input : inputs) {
@@ -78,7 +79,8 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
       }
       // The last argument is the number of distinct elements in `col1`. We
       // store a dummy value here that we can check later.
-      writer.addRelation(V(input.col0_), buffer, i + 1);
+      auto md = writer.addRelation(V(input.col0_), buffer, i + 1);
+      metaData.push_back(md);
       buffer.clear();
       ASSERT_THROW(writer.addRelation(V(input.col0_), buffer, i + 1),
                    ad_utility::Exception);
@@ -86,7 +88,6 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
     }
   }
   writer.finish();
-  auto metaData = writer.getFinishedMetaData();
   auto blocks = writer.getFinishedBlocks();
   // Test the serialization of the blocks and the metaData.
   ad_utility::serialization::ByteBufferWriteSerializer w;

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -87,8 +87,7 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
       ++i;
     }
   }
-  writer.finish();
-  auto blocks = writer.getFinishedBlocks();
+  auto blocks = std::move(writer).getFinishedBlocks();
   // Test the serialization of the blocks and the metaData.
   ad_utility::serialization::ByteBufferWriteSerializer w;
   w << metaData;


### PR DESCRIPTION
This PR pulls the exchange of the multiplicities down a couple functions into `createPermutationPairImpl`. The buffering of the `ComrpessionRelationMetadata` by `CompressedRelationWriter` has also been removed.