### PR TITLE
Earlier prefix compression of vocabulary during index build

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -376,6 +376,9 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
     sizeInternalVocabulary = mergeResult.numWordsTotal_;
     LOG(INFO) << "Number of words in internal vocabulary: "
               << sizeInternalVocabulary << std::endl;
+    // Flush and close the created vocabulary, s.t. the prefix compression sees
+    // all of its contents.
+    compressionOutfile.close();
     // We have to use the "normally" sorted vocabulary for the prefix
     // compression.
     std::string vocabFileForPrefixCalculation =

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -63,6 +63,7 @@ using PsoSorter = StxxlSorter<SortByPSO>;
 // index builder.
 struct IndexBuilderDataBase {
   VocabularyMerger::VocabularyMetaData vocabularyMetaData_;
+  // The prefixes that are used for the prefix compression.
   std::vector<std::string> prefixes_;
 };
 


### PR DESCRIPTION
Previously, the calculation of the prefixes for the prefix compression was performed in parallel with the first STXXL sort of the result. This could lead to
out of memory issues.
This is now fixed by performing this step directly after the first merging phase.