### PR TITLE
Fix DISTINCT for empty result

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1527,4 +1527,15 @@ queries:
       - contains_row: [ 2, 2 ]
       - contains_row: [ 3, 34 ]
 
+  - query: distinct-with-empty-input
+    type: no-text
+    sparql: |
+      SELECT ?x WHERE {
+        ?x <not_existing_310131492157> <adjfoie.axjdi>
+      }
+    checks:
+      - num_cols: 1
+      - num_rows : 0
+      - selected: [ "?x" ]
+
 

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1530,7 +1530,7 @@ queries:
   - query: distinct-with-empty-input
     type: no-text
     sparql: |
-      SELECT ?x WHERE {
+      SELECT DISTINCT ?x WHERE {
         ?x <not_existing_310131492157> <adjfoie.axjdi>
       }
     checks:

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -152,9 +152,9 @@ class Engine {
     LOG(DEBUG) << "Distinct on " << dynInput.size() << " elements.\n";
     const IdTableView<WIDTH> input = dynInput.asStaticView<WIDTH>();
     IdTableStatic<WIDTH> result = std::move(*dynResult).toStatic<WIDTH>();
+    result = input.clone();
     if (!input.empty()) {
       AD_CONTRACT_CHECK(keepIndices.size() <= input.numColumns());
-      result = input.clone();
 
       auto last = std::unique(result.begin(), result.end(),
                               [&keepIndices](const auto& a, const auto& b) {
@@ -166,8 +166,8 @@ class Engine {
                                 return true;
                               });
       result.erase(last, result.end());
-      *dynResult = std::move(result).toDynamic();
-      LOG(DEBUG) << "Distinct done.\n";
     }
+    *dynResult = std::move(result).toDynamic();
+    LOG(DEBUG) << "Distinct done.\n";
   }
 };

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -51,6 +51,15 @@ TEST(EngineTest, distinctTest) {
   ASSERT_EQ(expectedResult, result);
 }
 
+TEST(EngineTest, distinctWithEmptyInput) {
+  IdTable inp{1, makeAllocator()};
+  // Deliberately input a non-empty result to check that it is
+  // overwritten by the (empty) input.
+  IdTable result = makeIdTableFromVector({{3}});
+  CALL_FIXED_SIZE(1, Engine::distinct, inp, std::vector<size_t>{}, &result);
+  ASSERT_EQ(inp, result);
+}
+
 void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,
                       JoinColumns jcls, const IdTable& expectedResult) {
   {

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -37,13 +37,13 @@ using JoinColumns = std::vector<std::array<ColumnIndex, 2>>;
 }  // namespace
 
 TEST(EngineTest, distinctTest) {
-  IdTable inp{makeIdTableFromVector(
+  IdTable input{makeIdTableFromVector(
       {{1, 1, 3, 7}, {6, 1, 3, 6}, {2, 2, 3, 5}, {3, 6, 5, 4}, {1, 6, 5, 1}})};
 
   IdTable result{4, makeAllocator()};
 
   std::vector<size_t> keepIndices{{1, 2}};
-  CALL_FIXED_SIZE(4, Engine::distinct, inp, keepIndices, &result);
+  CALL_FIXED_SIZE(4, Engine::distinct, input, keepIndices, &result);
 
   // For easier checking.
   IdTable expectedResult{
@@ -52,12 +52,12 @@ TEST(EngineTest, distinctTest) {
 }
 
 TEST(EngineTest, distinctWithEmptyInput) {
-  IdTable inp{1, makeAllocator()};
+  IdTable input{1, makeAllocator()};
   // Deliberately input a non-empty result to check that it is
   // overwritten by the (empty) input.
   IdTable result = makeIdTableFromVector({{3}});
-  CALL_FIXED_SIZE(1, Engine::distinct, inp, std::vector<size_t>{}, &result);
-  ASSERT_EQ(inp, result);
+  CALL_FIXED_SIZE(1, Engine::distinct, input, std::vector<size_t>{}, &result);
+  ASSERT_EQ(input, result);
 }
 
 void testOptionalJoin(const IdTable& inputA, const IdTable& inputB,


### PR DESCRIPTION
This previously led to a n internal `vector::_M_range_check` exception,
because a moved-from `IdTable` was used.