### PR TITLE
Make it possible to add a row to a Benchmark table

### DIFF
--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -206,6 +206,14 @@ ResultTable::operator std::string() const {
 }
 
 // ____________________________________________________________________________
+void ResultTable::addRow(std::string_view rowName){
+    // Add the row name.
+    rowNames_.emplace_back(rowName);
+    // Create an emptry row of the same size as every other row.
+    entries_.emplace_back(numColumns());
+  }
+
+// ____________________________________________________________________________
 size_t ResultTable::numRows() const { return entries_.size(); }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -206,6 +206,19 @@ ResultTable::operator std::string() const {
 }
 
 // ____________________________________________________________________________
+size_t ResultTable::numRows() const { return entries_.size(); }
+
+// ____________________________________________________________________________
+size_t ResultTable::numColumns() const {
+  /*
+  If nobody played around with the private member variables, every row
+  should have the same amount of columns and there should be AT LEAST one row,
+  and one column. So we can just return the length of the first row.
+  */
+  return entries_.at(0).size();
+}
+
+// ____________________________________________________________________________
 void to_json(nlohmann::json& j, const ResultTable& resultTable) {
   j = nlohmann::json{{"descriptor", resultTable.descriptor_},
                      {"rowNames", resultTable.rowNames_},

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -206,12 +206,12 @@ ResultTable::operator std::string() const {
 }
 
 // ____________________________________________________________________________
-void ResultTable::addRow(std::string_view rowName){
-    // Add the row name.
-    rowNames_.emplace_back(rowName);
-    // Create an emptry row of the same size as every other row.
-    entries_.emplace_back(numColumns());
-  }
+void ResultTable::addRow(std::string_view rowName) {
+  // Add the row name.
+  rowNames_.emplace_back(rowName);
+  // Create an emptry row of the same size as every other row.
+  entries_.emplace_back(numColumns());
+}
 
 // ____________________________________________________________________________
 size_t ResultTable::numRows() const { return entries_.size(); }

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -206,7 +206,7 @@ class ResultTable : public BenchmarkMetadataGetter {
   */
   template <typename T>
   requires std::is_same_v<T, float> || std::is_same_v<T, std::string>
-  T getEntry(const size_t row, const size_t column) const{
+  T getEntry(const size_t row, const size_t column) const {
     // There is a chance, that the entry of the table does NOT have type T,
     // in which case this will cause an error. As this is a mistake on the
     // side of the user, we don't really care.

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -206,7 +206,7 @@ class ResultTable : public BenchmarkMetadataGetter {
   */
   template <typename T>
   requires std::is_same_v<T, float> || std::is_same_v<T, std::string>
-  T getEntry(const size_t row, const size_t column) {
+  T getEntry(const size_t row, const size_t column) const{
     // There is a chance, that the entry of the table does NOT have type T,
     // in which case this will cause an error. As this is a mistake on the
     // side of the user, we don't really care.
@@ -215,6 +215,13 @@ class ResultTable : public BenchmarkMetadataGetter {
 
   // User defined conversion to `std::string`.
   explicit operator std::string() const;
+
+  /*
+  @brief Adds a new empty row at the bottom of the table.
+
+  @param rowName The name of the row.
+  */
+  void addRow(std::string_view rowName);
 
   /*
   The number of rows.

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -216,6 +216,16 @@ class ResultTable : public BenchmarkMetadataGetter {
   // User defined conversion to `std::string`.
   explicit operator std::string() const;
 
+  /*
+  The number of rows.
+  */
+  size_t numRows() const;
+
+  /*
+  The number of columns.
+  */
+  size_t numColumns() const;
+
   // JSON serialization.
   friend void to_json(nlohmann::json& j, const ResultTable& resultTable);
 };

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <type_traits>
+#include <variant>
 
 #include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "util/Timer.h"
@@ -60,6 +61,53 @@ TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultTable) {
+  // Looks, if the general form is correct.
+  auto checkForm = [](const ResultTable& table, const std::string& name,
+    const std::vector<std::string>& rowNames,
+    const std::vector<std::string>& columnNames){
+    ASSERT_EQ(name, table.descriptor_);
+    ASSERT_EQ(rowNames, table.rowNames_);
+    ASSERT_EQ(columnNames, table.columnNames_);
+    ASSERT_EQ(rowNames.size(), table.numRows());
+    ASSERT_EQ(columnNames.size(), table.numColumns());
+  };
+
+  // Calls the correct assert function based on type.
+  auto assertEqual = []<typename T>(const T& a, const T& b){
+    if constexpr(std::is_floating_point_v<T>){
+      ASSERT_NEAR(a, b, 0.01);
+    } else {
+      ASSERT_EQ(a, b);
+    }
+  };
+
+  // Checks, if a table entry was never set.
+  auto checkNeverSet = [](const ResultTable& table, const size_t& row,
+    const size_t& column){
+      // Is it empty?
+      ASSERT_TRUE(
+        std::holds_alternative<std::monostate>(
+        table.entries_.at(row).at(column)));
+
+      // Does trying to access it anyway cause an error?
+      ASSERT_ANY_THROW(table.getEntry<std::string>(row, column));
+      ASSERT_ANY_THROW(table.getEntry<float>(row, column));
+    };
+
+  /*
+  Check the content of a tables row.
+  */
+  auto checkRow = [&assertEqual](const ResultTable& table, const size_t& rowNumber,
+    const auto&... wantedContent){
+    size_t column = 0;
+    auto check = [&table, &rowNumber, &column, &assertEqual](
+      const auto& wantedContent)mutable{
+      assertEqual(wantedContent,
+          table.getEntry<std::decay_t<decltype(wantedContent)>>(rowNumber,
+          column++));
+    };
+    ((check(wantedContent)), ...);
+  };
   /*
   Special case: A table with no rows, or columns. Should throw an exception
   on creation, because it's quite the stupid idea.
@@ -75,31 +123,37 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   ResultTable table("My table", rowNames, columnNames);
 
   // Was it created correctly?
-  ASSERT_EQ("My table", table.descriptor_);
-  ASSERT_EQ(rowNames, table.rowNames_);
-  ASSERT_EQ(columnNames, table.columnNames_);
-  ASSERT_EQ(2, table.entries_.size());
-  ASSERT_EQ(2, table.entries_.at(0).size());
-  ASSERT_EQ(2, table.entries_.at(1).size());
+  checkForm(table, "My table", rowNames, columnNames);
 
   // Add measured function to it.
   table.addMeasurement(0, 0, createWaitLambda(100));
-  ASSERT_NEAR(0.1, table.getEntry<float>(0, 0), 0.01);
 
   // Set custom entries.
   table.setEntry(0, 1, (float)4.9);
-  table.setEntry(1, 1, "Custom entry");
+  table.setEntry(1, 0, "Custom entry");
 
-  ASSERT_FLOAT_EQ(table.getEntry<float>(0, 1), 4.9);
-  ASSERT_EQ(table.getEntry<std::string>(1, 1), "Custom entry");
+  // Check the entries.
+  checkRow(table, 0,  static_cast<float>(0.1), static_cast<float>(4.9));
+  checkRow(table, 1, std::string{"Custom entry"});
+  checkNeverSet(table, 1, 1);
 
   // Trying to get entries with the wrong type, should cause an error.
   ASSERT_ANY_THROW(table.getEntry<std::string>(0, 1));
-  ASSERT_ANY_THROW(table.getEntry<float>(1, 1));
-
-  // Same for trying to get the value of an entry, who has never been set,
-  // or added.
-  ASSERT_ANY_THROW(table.getEntry<std::string>(1, 0));
   ASSERT_ANY_THROW(table.getEntry<float>(1, 0));
+
+  // Can we add a new row, without changing things?
+  table.addRow("row3");
+  checkForm(table, "My table", {"row1", "row2", "row3"}, columnNames);
+  checkRow(table, 0,  static_cast<float>(0.1), static_cast<float>(4.9));
+  checkRow(table, 1, std::string{"Custom entry"});
+
+  // Are the entries of the new row empty?
+  checkNeverSet(table, 2, 0);
+  checkNeverSet(table, 2, 1);
+
+  // To those new fields work like the old ones?
+  table.addMeasurement(2, 0, createWaitLambda(290));
+  table.setEntry(2, 1, "Custom entry #2");
+  checkRow(table, 2, static_cast<float>(0.29), std::string{"Custom entry #2"});
 }
 }  // namespace ad_benchmark

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -63,8 +63,8 @@ TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
 TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   // Looks, if the general form is correct.
   auto checkForm = [](const ResultTable& table, const std::string& name,
-    const std::vector<std::string>& rowNames,
-    const std::vector<std::string>& columnNames){
+                      const std::vector<std::string>& rowNames,
+                      const std::vector<std::string>& columnNames) {
     ASSERT_EQ(name, table.descriptor_);
     ASSERT_EQ(rowNames, table.rowNames_);
     ASSERT_EQ(columnNames, table.columnNames_);
@@ -73,8 +73,8 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   };
 
   // Calls the correct assert function based on type.
-  auto assertEqual = []<typename T>(const T& a, const T& b){
-    if constexpr(std::is_floating_point_v<T>){
+  auto assertEqual = []<typename T>(const T& a, const T& b) {
+    if constexpr (std::is_floating_point_v<T>) {
       ASSERT_NEAR(a, b, 0.01);
     } else {
       ASSERT_EQ(a, b);
@@ -83,28 +83,28 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
 
   // Checks, if a table entry was never set.
   auto checkNeverSet = [](const ResultTable& table, const size_t& row,
-    const size_t& column){
-      // Is it empty?
-      ASSERT_TRUE(
-        std::holds_alternative<std::monostate>(
+                          const size_t& column) {
+    // Is it empty?
+    ASSERT_TRUE(std::holds_alternative<std::monostate>(
         table.entries_.at(row).at(column)));
 
-      // Does trying to access it anyway cause an error?
-      ASSERT_ANY_THROW(table.getEntry<std::string>(row, column));
-      ASSERT_ANY_THROW(table.getEntry<float>(row, column));
-    };
+    // Does trying to access it anyway cause an error?
+    ASSERT_ANY_THROW(table.getEntry<std::string>(row, column));
+    ASSERT_ANY_THROW(table.getEntry<float>(row, column));
+  };
 
   /*
   Check the content of a tables row.
   */
-  auto checkRow = [&assertEqual](const ResultTable& table, const size_t& rowNumber,
-    const auto&... wantedContent){
+  auto checkRow = [&assertEqual](const ResultTable& table,
+                                 const size_t& rowNumber,
+                                 const auto&... wantedContent) {
     size_t column = 0;
-    auto check = [&table, &rowNumber, &column, &assertEqual](
-      const auto& wantedContent)mutable{
+    auto check = [&table, &rowNumber, &column,
+                  &assertEqual](const auto& wantedContent) mutable {
       assertEqual(wantedContent,
-          table.getEntry<std::decay_t<decltype(wantedContent)>>(rowNumber,
-          column++));
+                  table.getEntry<std::decay_t<decltype(wantedContent)>>(
+                      rowNumber, column++));
     };
     ((check(wantedContent)), ...);
   };
@@ -133,7 +133,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   table.setEntry(1, 0, "Custom entry");
 
   // Check the entries.
-  checkRow(table, 0,  static_cast<float>(0.1), static_cast<float>(4.9));
+  checkRow(table, 0, static_cast<float>(0.1), static_cast<float>(4.9));
   checkRow(table, 1, std::string{"Custom entry"});
   checkNeverSet(table, 1, 1);
 
@@ -144,7 +144,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   // Can we add a new row, without changing things?
   table.addRow("row3");
   checkForm(table, "My table", {"row1", "row2", "row3"}, columnNames);
-  checkRow(table, 0,  static_cast<float>(0.1), static_cast<float>(4.9));
+  checkRow(table, 0, static_cast<float>(0.1), static_cast<float>(4.9));
   checkRow(table, 1, std::string{"Custom entry"});
 
   // Are the entries of the new row empty?


### PR DESCRIPTION
This just adds a function to `ResultTable` for adding a row, even after creating the object.