### PR TITLE
Improve the formatting of benchmark outputs when printing to the screen

### DIFF
--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -106,10 +106,10 @@ class BMGroups : public BenchmarkInterface {
 
     // Measuring functions.
     auto& loopAddGroup = results.addGroup("loopAdd");
-    loopAddGroup.metadata().addKeyValuePair("Operator", '+');
+    loopAddGroup.metadata().addKeyValuePair("Operator", "+");
 
     auto& loopMultiplyGroup = results.addGroup("loopMultiply");
-    loopMultiplyGroup.metadata().addKeyValuePair("Operator", '*');
+    loopMultiplyGroup.metadata().addKeyValuePair("Operator", "*");
 
     auto& addMember1 =
         loopAddGroup.addMeasurement("1+1", [&loopAdd]() { loopAdd(1, 1); });

--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -31,6 +31,11 @@ Using the functions described there would require including
 // Single Measurements
 class BMSingleMeasurements : public BenchmarkInterface {
  public:
+
+  std::string name() const final{
+    return "Example for single measurements";
+  }
+
   void parseConfiguration(const BenchmarkConfiguration&) final {
     // Nothing to actually do here.
   }
@@ -75,6 +80,11 @@ class BMSingleMeasurements : public BenchmarkInterface {
 // Groups
 class BMGroups : public BenchmarkInterface {
  public:
+
+  std::string name() const final{
+    return "Example for group benchmarks";
+  }
+
   void parseConfiguration(const BenchmarkConfiguration&) final {
     // Nothing to actually do here.
   }
@@ -142,6 +152,11 @@ class BMGroups : public BenchmarkInterface {
 // Tables
 class BMTables : public BenchmarkInterface {
  public:
+
+  std::string name() const final{
+    return "Example for table benchmarks";
+  }
+
   void parseConfiguration(const BenchmarkConfiguration&) final {
     // Nothing to actually do here.
   }
@@ -224,6 +239,11 @@ class BMConfigurationAndMetadataExample : public BenchmarkInterface {
   BenchmarkMetadata generalMetadata_;
 
  public:
+
+  std::string name() const final{
+    return "Example for the usage of configuration and metadata";
+  }
+
   void parseConfiguration(const BenchmarkConfiguration& config) final {
     // Collect some arbitrary values.
     std::string dateString{

--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -31,10 +31,7 @@ Using the functions described there would require including
 // Single Measurements
 class BMSingleMeasurements : public BenchmarkInterface {
  public:
-
-  std::string name() const final{
-    return "Example for single measurements";
-  }
+  std::string name() const final { return "Example for single measurements"; }
 
   void parseConfiguration(const BenchmarkConfiguration&) final {
     // Nothing to actually do here.
@@ -80,10 +77,7 @@ class BMSingleMeasurements : public BenchmarkInterface {
 // Groups
 class BMGroups : public BenchmarkInterface {
  public:
-
-  std::string name() const final{
-    return "Example for group benchmarks";
-  }
+  std::string name() const final { return "Example for group benchmarks"; }
 
   void parseConfiguration(const BenchmarkConfiguration&) final {
     // Nothing to actually do here.
@@ -152,10 +146,7 @@ class BMGroups : public BenchmarkInterface {
 // Tables
 class BMTables : public BenchmarkInterface {
  public:
-
-  std::string name() const final{
-    return "Example for table benchmarks";
-  }
+  std::string name() const final { return "Example for table benchmarks"; }
 
   void parseConfiguration(const BenchmarkConfiguration&) final {
     // Nothing to actually do here.
@@ -239,8 +230,7 @@ class BMConfigurationAndMetadataExample : public BenchmarkInterface {
   BenchmarkMetadata generalMetadata_;
 
  public:
-
-  std::string name() const final{
+  std::string name() const final {
     return "Example for the usage of configuration and metadata";
   }
 

--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -86,7 +86,7 @@ It will now be compiled. The compiled version can be found inside the `benchmark
 
 # Using advanced benchmark features
 ## Metadata
-Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata information will not be included in the printed output of a compiled benchmark file, but it will be included in the JSON file export.
+Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata information will be included in the printed output of a compiled benchmark file and in the JSON file export.
 
 You can find instances of `BenchmarkMetadata` for your usage at 4 locations:
 - At `metadata_` of created `ResultEntry` objects, in order to give metadata information about the benchmark measurement.

--- a/benchmark/infrastructure/Benchmark.cpp
+++ b/benchmark/infrastructure/Benchmark.cpp
@@ -30,15 +30,6 @@ void BenchmarkRegister::passConfigurationToAllRegisteredBenchmarks(
 }
 
 // ____________________________________________________________________________
-std::vector<BenchmarkMetadata> BenchmarkRegister::getAllGeneralMetadata() {
-  // Go through every registered instance of a benchmark class and collect
-  // their general metadata.
-  return ad_utility::transform(registeredBenchmarks, [](const auto& instance) {
-    return instance->getMetadata();
-  });
-}
-
-// ____________________________________________________________________________
 std::vector<BenchmarkResults> BenchmarkRegister::runAllRegisteredBenchmarks() {
   // Go through every registered instance of a benchmark class, measure their
   // benchmarks and return the resulting `BenchmarkResults` in a new vector.
@@ -52,6 +43,15 @@ BenchmarkRegister::BenchmarkRegister(
     BenchmarkPointer&& benchmarkClassInstance) {
   // Append the benchmark to the internal register.
   registeredBenchmarks.push_back(std::move(benchmarkClassInstance));
+}
+
+std::vector<const BenchmarkInterface*>
+BenchmarkRegister::getAllRegisteredBenchmarks() {
+  return ad_utility::transform(
+      registeredBenchmarks,
+      [](BenchmarkPointer& instance)->const BenchmarkInterface*{
+        return instance.get();
+      });
 }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/Benchmark.cpp
+++ b/benchmark/infrastructure/Benchmark.cpp
@@ -45,11 +45,12 @@ BenchmarkRegister::BenchmarkRegister(
   registeredBenchmarks.push_back(std::move(benchmarkClassInstance));
 }
 
+// ____________________________________________________________________________
 std::vector<const BenchmarkInterface*>
 BenchmarkRegister::getAllRegisteredBenchmarks() {
   return ad_utility::transform(
       registeredBenchmarks,
-      [](BenchmarkPointer& instance) -> const BenchmarkInterface* {
+      [](const BenchmarkPointer& instance) -> const BenchmarkInterface* {
         return instance.get();
       });
 }

--- a/benchmark/infrastructure/Benchmark.cpp
+++ b/benchmark/infrastructure/Benchmark.cpp
@@ -49,7 +49,7 @@ std::vector<const BenchmarkInterface*>
 BenchmarkRegister::getAllRegisteredBenchmarks() {
   return ad_utility::transform(
       registeredBenchmarks,
-      [](BenchmarkPointer& instance)->const BenchmarkInterface*{
+      [](BenchmarkPointer& instance) -> const BenchmarkInterface* {
         return instance.get();
       });
 }

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -204,13 +204,10 @@ class BenchmarkRegister {
   static std::vector<BenchmarkResults> runAllRegisteredBenchmarks();
 
   /*
-   * @brief Returns the general metadata of all the registered benchmarks. As
-   *  in, it collects and return the outputs of all those `getMetadata`
-   *  functions from the interface.
-   *
-   * @return They should be in the same order as the registrations.
-   */
-  static std::vector<BenchmarkMetadata> getAllGeneralMetadata();
+  @brief Returns pointer to all the registered benchmark class objects.
+  */
+  static std::vector<const BenchmarkInterface*>
+  getAllRegisteredBenchmarks();
 };
 
 /*

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -127,6 +127,10 @@ the processing/management of those benchmarks.
 */
 class BenchmarkInterface {
  public:
+
+  // Used for identification of the class later.
+  virtual std::string name() const = 0;
+
   // Used to transport values, that you want to set at runtime.
   virtual void parseConfiguration(
       [[maybe_unused]] const BenchmarkConfiguration& config) {

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -127,7 +127,6 @@ the processing/management of those benchmarks.
 */
 class BenchmarkInterface {
  public:
-
   // Used for identification of the class later.
   virtual std::string name() const = 0;
 
@@ -210,8 +209,7 @@ class BenchmarkRegister {
   /*
   @brief Returns pointer to all the registered benchmark class objects.
   */
-  static std::vector<const BenchmarkInterface*>
-  getAllRegisteredBenchmarks();
+  static std::vector<const BenchmarkInterface*> getAllRegisteredBenchmarks();
 };
 
 /*

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -127,7 +127,7 @@ the processing/management of those benchmarks.
 */
 class BenchmarkInterface {
  public:
-  // Used for identification of the class later.
+  // A human-readable name that will be printed as part of the output.
   virtual std::string name() const = 0;
 
   // Used to transport values, that you want to set at runtime.
@@ -207,7 +207,7 @@ class BenchmarkRegister {
   static std::vector<BenchmarkResults> runAllRegisteredBenchmarks();
 
   /*
-  @brief Returns pointer to all the registered benchmark class objects.
+  @brief Returns pointers to all the registered benchmark class objects.
   */
   static std::vector<const BenchmarkInterface*> getAllRegisteredBenchmarks();
 };

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -140,13 +140,13 @@ int main(int argc, char** argv) {
 
   // Actually processing the arguments.
   if (vm.count("print")) {
-    std::ranges::for_each(
-        benchmarkClassAndResults,
-        [](const auto& pair) {
-          std::cout << benchmarkResultsToString(pair.first, pair.second)
-                    << "\n\n";
-        },
-        {});
+    std::ranges::for_each(benchmarkClassAndResults,
+                          [](const auto& pair) {
+                            std::cout << benchmarkResultsToString(pair.first,
+                                                                  pair.second)
+                                      << "\n\n";
+                          },
+                          {});
   }
 
   if (vm.count("write")) {

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -137,7 +137,7 @@ int main(int argc, char** argv) {
   the same order. So the metadata and benchmark results are always at the
   same index position, and are grouped togehter correctly.
   */
-  const auto& generalMetadataAndResults{ad_utility::pairTwoVectorTogether(
+  const auto& generalMetadataAndResults{ad_utility::zipVectors(
       BenchmarkRegister::getAllGeneralMetadata(), results)};
 
   // Actually processing the arguments.

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -138,23 +138,22 @@ int main(int argc, char** argv) {
   same index position, and are grouped togehter correctly.
   */
   const auto& generalMetadataAndResults{ad_utility::pairTwoVectorTogether(
-    BenchmarkRegister::getAllGeneralMetadata(), results)};
+      BenchmarkRegister::getAllGeneralMetadata(), results)};
 
   // Actually processing the arguments.
   if (vm.count("print")) {
-    std::ranges::for_each(generalMetadataAndResults,
-                          [](const std::pair<BenchmarkMetadata,
-                             BenchmarkResults>& result) {
-                            std::cout << benchmarkResultsToString(result.first,
-                                         result.second)
-                                      << "\n";
-                          },
-                          {});
+    std::ranges::for_each(
+        generalMetadataAndResults,
+        [](const std::pair<BenchmarkMetadata, BenchmarkResults>& result) {
+          std::cout << benchmarkResultsToString(result.first, result.second)
+                    << "\n";
+        },
+        {});
   }
 
   if (vm.count("write")) {
-    writeJsonToFile(zipGeneralMetadataAndBenchmarkResultsToJson(
-                        generalMetadataAndResults),
-                    writeFileName, vm.count("append"));
+    writeJsonToFile(
+        zipGeneralMetadataAndBenchmarkResultsToJson(generalMetadataAndResults),
+        writeFileName, vm.count("append"));
   }
 }

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -129,23 +129,21 @@ int main(int argc, char** argv) {
   const std::vector<BenchmarkResults>& results{
       BenchmarkRegister::runAllRegisteredBenchmarks()};
   /*
-  Pairing the measured times up togehter with the general metadata of the
-  classes. We do it this way around, so that it's assured, that the classes
-  ran their benchmarks and that in the case, of them creating metadata based
-  on those benchmark results, those values are able to exist.
-  Note: All the classes registered in `BenchmarkRegister` are always ran in
-  the same order. So the metadata and benchmark results are always at the
-  same index position, and are grouped togehter correctly.
+  Pairing the measured times up together with the the benchmark classes,
+  that created them. Note: All the classes registered in `BenchmarkRegister`
+  are always ran in the same order. So the benchmark class and benchmark
+  results are always at the same index position, and are grouped togehter
+  correctly.
   */
-  const auto& generalMetadataAndResults{ad_utility::zipVectors(
-      BenchmarkRegister::getAllGeneralMetadata(), results)};
+  const auto& benchmarkClassAndResults{ad_utility::zipVectors(
+      BenchmarkRegister::getAllRegisteredBenchmarks(), results)};
 
   // Actually processing the arguments.
   if (vm.count("print")) {
     std::ranges::for_each(
-        generalMetadataAndResults,
-        [](const std::pair<BenchmarkMetadata, BenchmarkResults>& result) {
-          std::cout << benchmarkResultsToString(result.first, result.second)
+        benchmarkClassAndResults,
+        [](const auto& pair) {
+          std::cout << benchmarkResultsToString(pair.first, pair.second)
                     << "\n\n";
         },
         {});
@@ -153,7 +151,7 @@ int main(int argc, char** argv) {
 
   if (vm.count("write")) {
     writeJsonToFile(
-        zipGeneralMetadataAndBenchmarkResultsToJson(generalMetadataAndResults),
+        zipBenchmarkClassAndBenchmarkResultsToJson(benchmarkClassAndResults),
         writeFileName, vm.count("append"));
   }
 }

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -146,7 +146,7 @@ int main(int argc, char** argv) {
         generalMetadataAndResults,
         [](const std::pair<BenchmarkMetadata, BenchmarkResults>& result) {
           std::cout << benchmarkResultsToString(result.first, result.second)
-                    << "\n";
+                    << "\n\n";
         },
         {});
   }

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -63,7 +63,7 @@ ResultGroup::operator std::string() const {
       &stream,
       ad_utility::transform(entries_,
                             [](const auto& pointer) { return (*pointer); }),
-      outputIndention, outputIndention);
+      std::string{outputIndentation}, std::string{outputIndentation});
 
   return absl::StrCat(prefix, addIndtention(stream.str(), 1));
 }

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -31,7 +31,7 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 ResultEntry::operator std::string() const {
   return absl::StrCat(
       "Single measurement '", descriptor_, "'\n",
-      addIndtention(
+      addIndentation(
           absl::StrCat(getMetadataPrettyString(metadata(), "metadata: ", "\n"),
                        "time: ", measuredTime_, "s"),
           1));
@@ -65,7 +65,7 @@ ResultGroup::operator std::string() const {
                             [](const auto& pointer) { return (*pointer); }),
       std::string{outputIndentation}, std::string{outputIndentation});
 
-  return absl::StrCat(prefix, addIndtention(stream.str(), 1));
+  return absl::StrCat(prefix, addIndentation(stream.str(), 1));
 }
 
 // ____________________________________________________________________________
@@ -215,7 +215,7 @@ ResultTable::operator std::string() const {
     }
   }
 
-  return absl::StrCat(prefix, addIndtention(stream.str(), 1));
+  return absl::StrCat(prefix, addIndentation(stream.str(), 1));
 }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -30,8 +30,8 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 
 // ____________________________________________________________________________
 ResultEntry::operator std::string() const {
-  return absl::StrCat("metadata: ", metadata().asJsonString(true),"\n'",
-    descriptor_, "' took ", measuredTime_, " seconds.");
+  return absl::StrCat("metadata: ", metadata().asJsonString(true), "\n'",
+                      descriptor_, "' took ", measuredTime_, " seconds.");
 }
 
 // ____________________________________________________________________________
@@ -49,7 +49,7 @@ ResultGroup::operator std::string() const {
 
   // The normal foreword.
   stream << "metadata: " << metadata().asJsonString(true) << "\nGroup '"
-    << descriptor_ << "':";
+         << descriptor_ << "':";
 
   // Listing all the entries.
   addVectorOfResultEntryToOStringstream(

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -30,9 +30,12 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 
 // ____________________________________________________________________________
 ResultEntry::operator std::string() const {
-  return absl::StrCat("Single measurement '", descriptor_, "'\n",
-  addIndtention(absl::StrCat(getMetadataPrettyString(metadata(), "metadata: ",
-  "\n"), "time: ", measuredTime_, "s"), 1));
+  return absl::StrCat(
+      "Single measurement '", descriptor_, "'\n",
+      addIndtention(
+          absl::StrCat(getMetadataPrettyString(metadata(), "metadata: ", "\n"),
+                       "time: ", measuredTime_, "s"),
+          1));
 }
 
 // ____________________________________________________________________________
@@ -52,8 +55,9 @@ ResultGroup::operator std::string() const {
   // so  using a stream is the best idea.
   std::ostringstream stream;
 
-  stream << absl::StrCat(getMetadataPrettyString(metadata(), "metadata: ",
-    "\n"), "Measurements:\n\n");
+  stream << absl::StrCat(
+      getMetadataPrettyString(metadata(), "metadata: ", "\n"),
+      "Measurements:\n\n");
 
   // Listing all the entries.
   addVectorOfResultEntryToOStringstream(

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -30,7 +30,8 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 
 // ____________________________________________________________________________
 ResultEntry::operator std::string() const {
-  return absl::StrCat("'", descriptor_, "' took ", measuredTime_, " seconds.");
+  return absl::StrCat("metadata: ", metadata().asJsonString(true),"\n'",
+    descriptor_, "' took ", measuredTime_, " seconds.");
 }
 
 // ____________________________________________________________________________
@@ -47,14 +48,15 @@ ResultGroup::operator std::string() const {
   std::ostringstream stream;
 
   // The normal foreword.
-  stream << "Group '" << descriptor_ << "':";
+  stream << "metadata: " << metadata().asJsonString(true) << "\nGroup '"
+    << descriptor_ << "':";
 
   // Listing all the entries.
   addVectorOfResultEntryToOStringstream(
       &stream,
       ad_utility::transform(entries_,
                             [](const auto& pointer) { return (*pointer); }),
-      "\t");
+      "\tSingle measurment benchmark ", "\t");
 
   return stream.str();
 }
@@ -137,6 +139,9 @@ ResultTable::operator std::string() const {
 
   // For printing the table.
   std::ostringstream stream;
+
+  // Adding the metadata.
+  stream << "metadata: " << metadata().asJsonString(true) << "\n";
 
   // Adding the table to the stream.
   stream << "Table '" << descriptor_ << "':\n\n";

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -31,7 +31,7 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 // ____________________________________________________________________________
 ResultEntry::operator std::string() const {
   return absl::StrCat("Single measurement '", descriptor_, "'\n",
-  getMetadataPrettyString(metadata(), "metadata: "), "time: ", measuredTime_,
+  getMetadataPrettyString(metadata(), "metadata: ", "\n"), "time: ", measuredTime_,
   "s");
 }
 
@@ -50,7 +50,8 @@ ResultGroup::operator std::string() const {
 
   // Foreword.
   stream << absl::StrCat("Group '", descriptor_, "'\n",
-    getMetadataPrettyString(metadata(), "metadata: "), "Measurements:\n");
+    getMetadataPrettyString(metadata(), "metadata: ", "\n"),
+    "Measurements:\n\n");
 
   // Listing all the entries.
   addVectorOfResultEntryToOStringstream(
@@ -145,7 +146,7 @@ ResultTable::operator std::string() const {
   stream << "Table '" << descriptor_ << "'\n";
 
   // Adding the metadata.
-  stream << absl::StrCat(getMetadataPrettyString(metadata(), "metadata"), "\n");
+  stream << getMetadataPrettyString(metadata(), "metadata: ", "\n");
 
   // For easier usage.
   const size_t numberColumns = columnNames_.size();

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -30,8 +30,9 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 
 // ____________________________________________________________________________
 ResultEntry::operator std::string() const {
-  return absl::StrCat("metadata: ", metadata().asJsonString(true), "\n'",
-                      descriptor_, "' took ", measuredTime_, " seconds.");
+  return absl::StrCat("Single measurement '", descriptor_, "'\n",
+  getMetadataPrettyString(metadata(), "metadata: "), "time: ", measuredTime_,
+  "s");
 }
 
 // ____________________________________________________________________________
@@ -47,16 +48,16 @@ ResultGroup::operator std::string() const {
   // so doing everything using a stream is the best idea.
   std::ostringstream stream;
 
-  // The normal foreword.
-  stream << "metadata: " << metadata().asJsonString(true) << "\nGroup '"
-         << descriptor_ << "':";
+  // Foreword.
+  stream << absl::StrCat("Group '", descriptor_, "'\n",
+    getMetadataPrettyString(metadata(), "metadata: "), "Measurements:\n");
 
   // Listing all the entries.
   addVectorOfResultEntryToOStringstream(
       &stream,
       ad_utility::transform(entries_,
                             [](const auto& pointer) { return (*pointer); }),
-      "\tSingle measurment benchmark ", "\t");
+      "\t", "\t");
 
   return stream.str();
 }
@@ -140,11 +141,11 @@ ResultTable::operator std::string() const {
   // For printing the table.
   std::ostringstream stream;
 
-  // Adding the metadata.
-  stream << "metadata: " << metadata().asJsonString(true) << "\n";
-
   // Adding the table to the stream.
-  stream << "Table '" << descriptor_ << "':\n\n";
+  stream << "Table '" << descriptor_ << "'\n";
+
+  // Adding the metadata.
+  stream << absl::StrCat(getMetadataPrettyString(metadata(), "metadata"), "\n");
 
   // For easier usage.
   const size_t numberColumns = columnNames_.size();

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -11,7 +13,6 @@
 #include <sstream>
 #include <string_view>
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
-
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -13,6 +11,7 @@
 #include <sstream>
 #include <string_view>
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"
@@ -47,9 +46,9 @@ void to_json(nlohmann::json& j, const ResultEntry& resultEntry) {
 
 // ____________________________________________________________________________
 ResultGroup::operator std::string() const {
-  // The foreword. Everything after this will be indented, so it's better
+  // The prefix. Everything after this will be indented, so it's better
   // to only combine them at the end.
-  std::string foreword = absl::StrCat("Group '", descriptor_, "'\n");
+  std::string prefix = absl::StrCat("Group '", descriptor_, "'\n");
 
   // We need to add all the string representations of the group members,
   // so  using a stream is the best idea.
@@ -66,7 +65,7 @@ ResultGroup::operator std::string() const {
                             [](const auto& pointer) { return (*pointer); }),
       outputIndention, outputIndention);
 
-  return absl::StrCat(foreword, addIndtention(stream.str(), 1));
+  return absl::StrCat(prefix, addIndtention(stream.str(), 1));
 }
 
 // ____________________________________________________________________________
@@ -145,9 +144,9 @@ ResultTable::operator std::string() const {
     stream << text << padding;
   };
 
-  // The foreword. Everything after this will be indented, so it's better
+  // The prefix. Everything after this will be indented, so it's better
   // to only combine them at the end.
-  std::string foreword = absl::StrCat("Table '", descriptor_, "'\n");
+  std::string prefix = absl::StrCat("Table '", descriptor_, "'\n");
 
   // For printing the table.
   std::ostringstream stream;
@@ -216,7 +215,7 @@ ResultTable::operator std::string() const {
     }
   }
 
-  return absl::StrCat(foreword, addIndtention(stream.str(), 1));
+  return absl::StrCat(prefix, addIndtention(stream.str(), 1));
 }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -31,8 +31,8 @@ const BenchmarkMetadata& BenchmarkMetadataGetter::metadata() const {
 // ____________________________________________________________________________
 ResultEntry::operator std::string() const {
   return absl::StrCat("Single measurement '", descriptor_, "'\n",
-  getMetadataPrettyString(metadata(), "metadata: ", "\n"), "time: ", measuredTime_,
-  "s");
+  addIndtention(absl::StrCat(getMetadataPrettyString(metadata(), "metadata: ",
+  "\n"), "time: ", measuredTime_, "s"), 1));
 }
 
 // ____________________________________________________________________________
@@ -44,23 +44,25 @@ void to_json(nlohmann::json& j, const ResultEntry& resultEntry) {
 
 // ____________________________________________________________________________
 ResultGroup::operator std::string() const {
+  // The foreword. Everything after this will be indented, so it's better
+  // to only combine them at the end.
+  std::string foreword = absl::StrCat("Group '", descriptor_, "'\n");
+
   // We need to add all the string representations of the group members,
-  // so doing everything using a stream is the best idea.
+  // so  using a stream is the best idea.
   std::ostringstream stream;
 
-  // Foreword.
-  stream << absl::StrCat("Group '", descriptor_, "'\n",
-    getMetadataPrettyString(metadata(), "metadata: ", "\n"),
-    "Measurements:\n\n");
+  stream << absl::StrCat(getMetadataPrettyString(metadata(), "metadata: ",
+    "\n"), "Measurements:\n\n");
 
   // Listing all the entries.
   addVectorOfResultEntryToOStringstream(
       &stream,
       ad_utility::transform(entries_,
                             [](const auto& pointer) { return (*pointer); }),
-      "\t", "\t");
+      outputIndention, outputIndention);
 
-  return stream.str();
+  return absl::StrCat(foreword, addIndtention(stream.str(), 1));
 }
 
 // ____________________________________________________________________________
@@ -139,11 +141,12 @@ ResultTable::operator std::string() const {
     stream << text << padding;
   };
 
+  // The foreword. Everything after this will be indented, so it's better
+  // to only combine them at the end.
+  std::string foreword = absl::StrCat("Table '", descriptor_, "'\n");
+
   // For printing the table.
   std::ostringstream stream;
-
-  // Adding the table to the stream.
-  stream << "Table '" << descriptor_ << "'\n";
 
   // Adding the metadata.
   stream << getMetadataPrettyString(metadata(), "metadata: ", "\n");
@@ -209,7 +212,7 @@ ResultTable::operator std::string() const {
     }
   }
 
-  return stream.str();
+  return absl::StrCat(foreword, addIndtention(stream.str(), 1));
 }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkMetadata.h
+++ b/benchmark/infrastructure/BenchmarkMetadata.h
@@ -34,8 +34,14 @@ class BenchmarkMetadata {
 
   /*
    * @brief Returns the metadata in form of a json string.
+   *
+   * @param prettyPrint If false, the json string will contain no new lines
+   * and will be in the most compact form available. If true, the json string
+   * will have new lines and indention.
    */
-  std::string asJsonString() const { return data_.dump(); }
+  std::string asJsonString(bool prettyPrint) const {
+    return data_.dump(prettyPrint ? 0 : -1);
+  }
 
   // JSON serialization.
   friend void to_json(nlohmann::json& j, const BenchmarkMetadata& metadata) {

--- a/benchmark/infrastructure/BenchmarkMetadata.h
+++ b/benchmark/infrastructure/BenchmarkMetadata.h
@@ -37,10 +37,22 @@ class BenchmarkMetadata {
    *
    * @param prettyPrint If false, the json string will contain no new lines
    * and will be in the most compact form available. If true, the json string
-   * will have new lines and indention.
+   * will have new lines and indention, if his compact form is longer than 50
+   * symbols.
    */
   std::string asJsonString(bool prettyPrint) const {
-    return data_.dump(prettyPrint ? 2 : -1);
+    std::string stringToReturn = data_.dump();
+
+    /*
+    Only if the string representation is to long for a single line, do we
+    actually listen to `prettyPrint`. Otherwise, a short representation it
+    always better.
+    */
+    if (stringToReturn.length() > 50 && prettyPrint) {
+      stringToReturn = data_.dump(2);
+    }
+
+    return stringToReturn;
   }
 
   // JSON serialization.

--- a/benchmark/infrastructure/BenchmarkMetadata.h
+++ b/benchmark/infrastructure/BenchmarkMetadata.h
@@ -40,7 +40,7 @@ class BenchmarkMetadata {
    * will have new lines and indention.
    */
   std::string asJsonString(bool prettyPrint) const {
-    return data_.dump(prettyPrint ? 0 : -1);
+    return data_.dump(prettyPrint ? 2 : -1);
   }
 
   // JSON serialization.

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -137,12 +137,10 @@ void addTablesToOStringstream(std::ostringstream* stream,
 // ___________________________________________________________________________
 static void addMetadataToOStringstream(std::ostringstream* stream,
   const BenchmarkMetadata& meta){
-  addCategoryTitleToOStringstream(stream,
-                                  "General metadata for the"
-                                  " following benchmarks");
-  (*stream) << "\n";
+  (*stream) << "General metadata: ";
 
   const std::string& metaString = getMetadataPrettyString(meta, "", "");
+
   // Just add none, if there isn't any.
   if (metaString == ""){
     (*stream) << "None";
@@ -184,6 +182,11 @@ std::string benchmarkResultsToString(
           categoryAddPrintStreamFunction(stringStream, categoryResult);
         }
       };
+
+  addCategoryTitleToOStringstream(&visualization,
+    absl::StrCat("Benchmark class '", benchmarkClass->name(), "'"));
+  visualization << "\n";
+
 
   // Visualize the general metadata.
   addMetadataToOStringstream(&visualization, benchmarkClass->getMetadata());

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -60,11 +60,18 @@ std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
 /*
 @brief Applies the given function `regularFunction` to all elements in `r`,
 except for the last one. Instead, `lastOneFunction` is applied to that one.
+
+@tparam Range Needs to be a data type supported by `std::ranges`.
+
+@param r Must hold at least one element.
 */
 template <typename Range, typename RegularFunction, typename LastOneFunction>
 static void forEachExcludingTheLastOne(Range&& r,
                                        RegularFunction regularFunction,
                                        LastOneFunction lastOneFunction) {
+  // Throw an error, if there are no elements in `r`.
+  AD_CONTRACT_CHECK(r.size() > 0);
+
   std::ranges::for_each_n(r.begin(), r.size() - 1, regularFunction, {});
   lastOneFunction(r.back());
 }

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -2,11 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkResultToString.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_replace.h>
 #include <bits/ranges_algo.h>
 
-#include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"
@@ -90,6 +91,11 @@ template <typename Range, typename TranslationFunction>
 static void addListToOStringStream(std::ostringstream* stream, Range&& r,
                                    TranslationFunction translationFunction,
                                    std::string_view listItemSeparator = "\n") {
+  /*
+  TODO<C++23>: This can be a combination of `std::views::transform` and
+  `std::views::join_with`. After that, we just have to insert all the elements
+  of the new view into the stream.
+  */
   forEachExcludingTheLastOne(
       AD_FWD(r),
       [&stream, &translationFunction,

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -3,6 +3,7 @@
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
+#include <bits/ranges_algo.h>
 
 namespace ad_benchmark {
 // ___________________________________________________________________________
@@ -18,9 +19,23 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
 // ___________________________________________________________________________
 void addVectorOfResultEntryToOStringstream(
     std::ostringstream* stream, const std::vector<ResultEntry>& entries,
-    const std::string& prefix) {
+    const std::string& vectorEntryPrefix, const std::string& newLinePrefix) {
   for (const auto& entry : entries) {
-    (*stream) << "\n" << prefix << (std::string)entry;
+    // The beginning of the first row.
+    (*stream) << "\n\n" << vectorEntryPrefix;
+
+    /*
+    In order to effectivly add the prefix at the start of every new line, we
+    feed the content of the string into the stream char for char.
+    */
+    std::ranges::for_each(static_cast<std::string>(entry),
+      [&stream, &newLinePrefix](const char& currentSymbol){
+        if (currentSymbol == '\n'){
+          (*stream) << "\n" << newLinePrefix;
+        } else {
+          (*stream) << currentSymbol;
+        }
+      }, {});
   }
 };
 
@@ -29,7 +44,7 @@ void addSingleMeasurementsToOStringstream(
     std::ostringstream* stream, const std::vector<ResultEntry>& resultEntries) {
   addCategoryTitleToOStringstream(stream, "Single measurment benchmarks");
   addVectorOfResultEntryToOStringstream(stream, resultEntries,
-                                        "Single measurment benchmark ");
+                                        "Single measurment benchmark ", "");
 }
 
 // ___________________________________________________________________________
@@ -52,7 +67,8 @@ void addTablesToOStringstream(std::ostringstream* stream,
 }
 
 // ___________________________________________________________________________
-std::string benchmarkResultsToString(const BenchmarkResults& results) {
+std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
+  const BenchmarkResults& results) {
   // The values for all the categories of benchmarks.
   const std::vector<ResultEntry>& singleMeasurements =
       results.getSingleMeasurements();
@@ -83,6 +99,11 @@ std::string benchmarkResultsToString(const BenchmarkResults& results) {
           (*stringStream) << suffix;
         }
       };
+
+  // Visualize the general metadata.
+  addCategoryTitleToOStringstream(&visualization, "General metadata for the"
+    " following benchmarks");
+  visualization << "\n\n" << meta.asJsonString(true) << "\n\n";
 
   // Visualization for single measurments, if there are any.
   addNonEmptyCategorieToStringSteam(&visualization, singleMeasurements,

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -152,8 +152,9 @@ static void addMetadataToOStringstream(std::ostringstream* stream,
 }
 
 // ___________________________________________________________________________
-std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
-                                     const BenchmarkResults& results) {
+std::string benchmarkResultsToString(
+  const BenchmarkInterface* const benchmarkClass,
+  const BenchmarkResults& results) {
   // The values for all the categories of benchmarks.
   const std::vector<ResultEntry>& singleMeasurements =
       results.getSingleMeasurements();
@@ -185,7 +186,7 @@ std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
       };
 
   // Visualize the general metadata.
-  addMetadataToOStringstream(&visualization, meta);
+  addMetadataToOStringstream(&visualization, benchmarkClass->getMetadata());
 
   // Visualization for single measurments, if there are any.
   addNonEmptyCategorieToStringSteam(&visualization, singleMeasurements,

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -3,6 +3,7 @@
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
+
 #include <bits/ranges_algo.h>
 
 namespace ad_benchmark {
@@ -29,13 +30,14 @@ void addVectorOfResultEntryToOStringstream(
     feed the content of the string into the stream char for char.
     */
     std::ranges::for_each(static_cast<std::string>(entry),
-      [&stream, &newLinePrefix](const char& currentSymbol){
-        if (currentSymbol == '\n'){
-          (*stream) << "\n" << newLinePrefix;
-        } else {
-          (*stream) << currentSymbol;
-        }
-      }, {});
+                          [&stream, &newLinePrefix](const char& currentSymbol) {
+                            if (currentSymbol == '\n') {
+                              (*stream) << "\n" << newLinePrefix;
+                            } else {
+                              (*stream) << currentSymbol;
+                            }
+                          },
+                          {});
   }
 };
 
@@ -68,7 +70,7 @@ void addTablesToOStringstream(std::ostringstream* stream,
 
 // ___________________________________________________________________________
 std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
-  const BenchmarkResults& results) {
+                                     const BenchmarkResults& results) {
   // The values for all the categories of benchmarks.
   const std::vector<ResultEntry>& singleMeasurements =
       results.getSingleMeasurements();
@@ -101,8 +103,9 @@ std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
       };
 
   // Visualize the general metadata.
-  addCategoryTitleToOStringstream(&visualization, "General metadata for the"
-    " following benchmarks");
+  addCategoryTitleToOStringstream(&visualization,
+                                  "General metadata for the"
+                                  " following benchmarks");
   visualization << "\n\n" << meta.asJsonString(true) << "\n\n";
 
   // Visualization for single measurments, if there are any.

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -3,13 +3,14 @@
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
+
+#include <absl/strings/str_cat.h>
+#include <bits/ranges_algo.h>
+
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"
 #include "util/Forward.h"
-
-#include <absl/strings/str_cat.h>
-#include <bits/ranges_algo.h>
 
 namespace ad_benchmark {
 
@@ -27,16 +28,16 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
 
 // ___________________________________________________________________________
 std::string addIndtention(const std::string_view str,
-  const size_t& indentionLevel){
+                          const size_t& indentionLevel) {
   // An indention level of 0 makes no sense. Must be an error.
   AD_CONTRACT_CHECK(indentionLevel > 0);
 
   // The indention symbols for this level of indention.
   std::string indentionSymbols{""};
   indentionSymbols.reserve(outputIndention.size() * indentionLevel);
-  for (size_t i = 0; i < indentionLevel; i++){
-      indentionSymbols.append(outputIndention);
-    }
+  for (size_t i = 0; i < indentionLevel; i++) {
+    indentionSymbols.append(outputIndention);
+  }
 
   std::ostringstream stream;
   stream << indentionSymbols;
@@ -44,21 +45,23 @@ std::string addIndtention(const std::string_view str,
   // Adding the content of the string char per char, so that we can easily
   // identify the new line symbols.
   std::ranges::for_each(str,
-    [&indentionSymbols, &stream](const char& symbol){
-      stream << symbol;
-      if (symbol == '\n'){
-        stream << indentionSymbols;
-      }
-    }, {});
+                        [&indentionSymbols, &stream](const char& symbol) {
+                          stream << symbol;
+                          if (symbol == '\n') {
+                            stream << indentionSymbols;
+                          }
+                        },
+                        {});
 
   return stream.str();
 }
 
 // ___________________________________________________________________________
 std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
-  std::string_view prefix, std::string_view suffix){
+                                    std::string_view prefix,
+                                    std::string_view suffix) {
   const std::string& metadataString = meta.asJsonString(true);
-  if (metadataString != "null"){
+  if (metadataString != "null") {
     return absl::StrCat(prefix, metadataString, suffix);
   } else {
     return "";
@@ -69,9 +72,10 @@ std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
 @brief Applies the given function `regularFunction` to all elements in `r`,
 except for the last one. Instead, `lastOneFunction` is applied to that one.
 */
-template<typename Range, typename RegularFunction, typename LastOneFunction>
+template <typename Range, typename RegularFunction, typename LastOneFunction>
 static void forEachExcludingTheLastOne(Range&& r,
-  RegularFunction regularFunction, LastOneFunction lastOneFunction){
+                                       RegularFunction regularFunction,
+                                       LastOneFunction lastOneFunction) {
   std::ranges::for_each_n(r.begin(), r.size() - 1, regularFunction, {});
   lastOneFunction(r.back());
 }
@@ -86,17 +90,19 @@ string.
 @param listItemSeperator Will be put between each of the string representations
 of the range elements.
 */
-template<typename Range, typename TranslationFunction>
+template <typename Range, typename TranslationFunction>
 static void addListToOStringStream(std::ostringstream* stream, Range&& r,
-  TranslationFunction translationFunction,
-  std::string_view listItemSeperator = "\n"){
-  forEachExcludingTheLastOne(AD_FWD(r),
-    [&stream, &translationFunction, &listItemSeperator](const auto& listItem){
-      (*stream) << translationFunction(listItem) << listItemSeperator;
-    },
-    [&stream, &translationFunction](const auto& listItem){
-      (*stream) << translationFunction(listItem);
-    });
+                                   TranslationFunction translationFunction,
+                                   std::string_view listItemSeperator = "\n") {
+  forEachExcludingTheLastOne(
+      AD_FWD(r),
+      [&stream, &translationFunction,
+       &listItemSeperator](const auto& listItem) {
+        (*stream) << translationFunction(listItem) << listItemSeperator;
+      },
+      [&stream, &translationFunction](const auto& listItem) {
+        (*stream) << translationFunction(listItem);
+      });
 }
 
 // ___________________________________________________________________________
@@ -108,35 +114,35 @@ void addVectorOfResultEntryToOStringstream(
 
   // Adds a single `ResultEntry` to the stream.
   auto addResultEntry = [&stream, &vectorEntryPrefix,
-                         &newLinePrefix](const ResultEntry& entry){
-      (*stream) << vectorEntryPrefix;
+                         &newLinePrefix](const ResultEntry& entry) {
+    (*stream) << vectorEntryPrefix;
 
-      /*
-      In order to effectivly add the prefix at the start of every new line, we
-      feed the content of the string into the stream char for char.
-      */
-      std::ranges::for_each(static_cast<std::string>(entry),
-                            [&stream,
-                             &newLinePrefix](const char& currentSymbol) {
-                              if (currentSymbol == '\n') {
-                                (*stream) << "\n" << newLinePrefix;
-                              } else {
-                                (*stream) << currentSymbol;
-                              }
-                            },
-                            {});
-    };
+    /*
+    In order to effectivly add the prefix at the start of every new line, we
+    feed the content of the string into the stream char for char.
+    */
+    std::ranges::for_each(static_cast<std::string>(entry),
+                          [&stream, &newLinePrefix](const char& currentSymbol) {
+                            if (currentSymbol == '\n') {
+                              (*stream) << "\n" << newLinePrefix;
+                            } else {
+                              (*stream) << currentSymbol;
+                            }
+                          },
+                          {});
+  };
 
   /*
   Adding the entries to the stream in such a way, that we don't have a line
   seperator at the end of that list.
   */
-  forEachExcludingTheLastOne(entries,
-    [&addResultEntry, &stream, &lineSeperator](const ResultEntry& entry){
-      addResultEntry(entry);
-      (*stream) << lineSeperator;
-    },
-    addResultEntry);
+  forEachExcludingTheLastOne(
+      entries,
+      [&addResultEntry, &stream, &lineSeperator](const ResultEntry& entry) {
+        addResultEntry(entry);
+        (*stream) << lineSeperator;
+      },
+      addResultEntry);
 };
 
 // ___________________________________________________________________________
@@ -152,9 +158,10 @@ void addGroupsToOStringstream(std::ostringstream* stream,
                               const std::vector<ResultGroup>& resultGroups) {
   addCategoryTitleToOStringstream(stream, "Group benchmarks");
   (*stream) << "\n";
-  addListToOStringStream(stream, resultGroups,
-    [](const ResultGroup& group){return static_cast<std::string>(group);},
-    "\n\n");
+  addListToOStringStream(
+      stream, resultGroups,
+      [](const ResultGroup& group) { return static_cast<std::string>(group); },
+      "\n\n");
 }
 
 // ___________________________________________________________________________
@@ -162,20 +169,21 @@ void addTablesToOStringstream(std::ostringstream* stream,
                               const std::vector<ResultTable>& resultTables) {
   addCategoryTitleToOStringstream(stream, "Table benchmarks");
   (*stream) << "\n";
-  addListToOStringStream(stream, resultTables,
-    [](const ResultTable& table){return static_cast<std::string>(table);},
-    "\n\n");
+  addListToOStringStream(
+      stream, resultTables,
+      [](const ResultTable& table) { return static_cast<std::string>(table); },
+      "\n\n");
 }
 
 // ___________________________________________________________________________
 static void addMetadataToOStringstream(std::ostringstream* stream,
-  const BenchmarkMetadata& meta){
+                                       const BenchmarkMetadata& meta) {
   (*stream) << "General metadata: ";
 
   const std::string& metaString = getMetadataPrettyString(meta, "", "");
 
   // Just add none, if there isn't any.
-  if (metaString == ""){
+  if (metaString == "") {
     (*stream) << "None";
   } else {
     (*stream) << metaString;
@@ -184,8 +192,8 @@ static void addMetadataToOStringstream(std::ostringstream* stream,
 
 // ___________________________________________________________________________
 std::string benchmarkResultsToString(
-  const BenchmarkInterface* const benchmarkClass,
-  const BenchmarkResults& results) {
+    const BenchmarkInterface* const benchmarkClass,
+    const BenchmarkResults& results) {
   // The values for all the categories of benchmarks.
   const std::vector<ResultEntry>& singleMeasurements =
       results.getSingleMeasurements();
@@ -209,17 +217,17 @@ std::string benchmarkResultsToString(
   //  to the stringstream.
   auto addNonEmptyCategorieToStringSteam =
       [&seperator](std::ostringstream* stringStream, const auto& categoryResult,
-         const auto& categoryAddPrintStreamFunction) {
+                   const auto& categoryAddPrintStreamFunction) {
         if (categoryResult.size() > 0) {
           (*stringStream) << seperator;
           categoryAddPrintStreamFunction(stringStream, categoryResult);
         }
       };
 
-  addCategoryTitleToOStringstream(&visualization,
-    absl::StrCat("Benchmark class '", benchmarkClass->name(), "'"));
+  addCategoryTitleToOStringstream(
+      &visualization,
+      absl::StrCat("Benchmark class '", benchmarkClass->name(), "'"));
   visualization << "\n";
-
 
   // Visualize the general metadata.
   addMetadataToOStringstream(&visualization, benchmarkClass->getMetadata());

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -2,19 +2,16 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkResultToString.h"
-
 #include <absl/strings/str_cat.h>
 #include <bits/ranges_algo.h>
 
+#include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"
 #include "util/Forward.h"
 
 namespace ad_benchmark {
-
-extern const std::string outputIndention = "    ";
 
 // ___________________________________________________________________________
 void addCategoryTitleToOStringstream(std::ostringstream* stream,
@@ -34,9 +31,9 @@ std::string addIndtention(const std::string_view str,
 
   // The indention symbols for this level of indention.
   std::string indentionSymbols{""};
-  indentionSymbols.reserve(outputIndention.size() * indentionLevel);
+  indentionSymbols.reserve(outputIndentation.size() * indentionLevel);
   for (size_t i = 0; i < indentionLevel; i++) {
-    indentionSymbols.append(outputIndention);
+    indentionSymbols.append(outputIndentation);
   }
 
   std::ostringstream stream;

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -2,10 +2,11 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkResultToString.h"
+
 #include <absl/strings/str_cat.h>
 #include <bits/ranges_algo.h>
 
-#include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -83,18 +83,18 @@ static void forEachExcludingTheLastOne(Range&& r,
 string.
 
 @param translationFunction Converts range elements into string.
-@param listItemSeperator Will be put between each of the string representations
+@param listItemSeparator Will be put between each of the string representations
 of the range elements.
 */
 template <typename Range, typename TranslationFunction>
 static void addListToOStringStream(std::ostringstream* stream, Range&& r,
                                    TranslationFunction translationFunction,
-                                   std::string_view listItemSeperator = "\n") {
+                                   std::string_view listItemSeparator = "\n") {
   forEachExcludingTheLastOne(
       AD_FWD(r),
       [&stream, &translationFunction,
-       &listItemSeperator](const auto& listItem) {
-        (*stream) << translationFunction(listItem) << listItemSeperator;
+       &listItemSeparator](const auto& listItem) {
+        (*stream) << translationFunction(listItem) << listItemSeparator;
       },
       [&stream, &translationFunction](const auto& listItem) {
         (*stream) << translationFunction(listItem);
@@ -106,7 +106,7 @@ void addVectorOfResultEntryToOStringstream(
     std::ostringstream* stream, const std::vector<ResultEntry>& entries,
     const std::string& vectorEntryPrefix, const std::string& newLinePrefix) {
   // What we use to seperat single vector entries.
-  std::string_view lineSeperator{"\n\n"};
+  std::string_view lineSeparator{"\n\n"};
 
   // Adds a single `ResultEntry` to the stream.
   auto addResultEntry = [&stream, &vectorEntryPrefix,
@@ -119,13 +119,13 @@ void addVectorOfResultEntryToOStringstream(
 
   /*
   Adding the entries to the stream in such a way, that we don't have a line
-  seperator at the end of that list.
+  separator at the end of that list.
   */
   forEachExcludingTheLastOne(
       entries,
-      [&addResultEntry, &stream, &lineSeperator](const ResultEntry& entry) {
+      [&addResultEntry, &stream, &lineSeparator](const ResultEntry& entry) {
         addResultEntry(entry);
-        (*stream) << lineSeperator;
+        (*stream) << lineSeparator;
       },
       addResultEntry);
 };
@@ -201,7 +201,7 @@ std::string benchmarkResultsToString(
       [](std::ostringstream* stringStream, const auto& categoryResult,
          const auto& categoryAddPrintStreamFunction) {
         if (categoryResult.size() > 0) {
-          // The seperator between the printed categories.
+          // The separator between the printed categories.
           (*stringStream) << "\n\n";
 
           categoryAddPrintStreamFunction(stringStream, categoryResult);

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -5,12 +5,16 @@
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
+#include "util/Exception.h"
 #include "util/Forward.h"
 
 #include <absl/strings/str_cat.h>
 #include <bits/ranges_algo.h>
 
 namespace ad_benchmark {
+
+extern const std::string outputIndention = "\t";
+
 // ___________________________________________________________________________
 void addCategoryTitleToOStringstream(std::ostringstream* stream,
                                      std::string_view categoryTitle) {
@@ -19,6 +23,35 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
   const std::string bar(barLength, '#');
 
   (*stream) << bar << "\n# " << categoryTitle << " #\n" << bar;
+}
+
+// ___________________________________________________________________________
+std::string addIndtention(const std::string_view str,
+  const size_t& indentionLevel){
+  // An indention level of 0 makes no sense. Must be an error.
+  AD_CONTRACT_CHECK(indentionLevel > 0);
+
+  // The indention symbols for this level of indention.
+  std::string indentionSymbols{""};
+  indentionSymbols.reserve(outputIndention.size() * indentionLevel);
+  for (size_t i = 0; i < indentionLevel; i++){
+      indentionSymbols.append(outputIndention);
+    }
+
+  std::ostringstream stream;
+  stream << indentionSymbols;
+
+  // Adding the content of the string char per char, so that we can easily
+  // identify the new line symbols.
+  std::ranges::for_each(str,
+    [&indentionSymbols, &stream](const char& symbol){
+      stream << symbol;
+      if (symbol == '\n'){
+        stream << indentionSymbols;
+      }
+    }, {});
+
+  return stream.str();
 }
 
 // ___________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -24,28 +24,28 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
 }
 
 // ___________________________________________________________________________
-std::string addIndtention(const std::string_view str,
-                          const size_t& indentionLevel) {
+std::string addIndentation(const std::string_view str,
+                           const size_t& indentationLevel) {
   // An indention level of 0 makes no sense. Must be an error.
-  AD_CONTRACT_CHECK(indentionLevel > 0);
+  AD_CONTRACT_CHECK(indentationLevel > 0);
 
   // The indention symbols for this level of indention.
-  std::string indentionSymbols{""};
-  indentionSymbols.reserve(outputIndentation.size() * indentionLevel);
-  for (size_t i = 0; i < indentionLevel; i++) {
-    indentionSymbols.append(outputIndentation);
+  std::string indentationSymbols{""};
+  indentationSymbols.reserve(outputIndentation.size() * indentationLevel);
+  for (size_t i = 0; i < indentationLevel; i++) {
+    indentationSymbols.append(outputIndentation);
   }
 
   std::ostringstream stream;
-  stream << indentionSymbols;
+  stream << indentationSymbols;
 
   // Adding the content of the string char per char, so that we can easily
   // identify the new line symbols.
   std::ranges::for_each(str,
-                        [&indentionSymbols, &stream](const char& symbol) {
+                        [&indentationSymbols, &stream](const char& symbol) {
                           stream << symbol;
                           if (symbol == '\n') {
-                            stream << indentionSymbols;
+                            stream << indentationSymbols;
                           }
                         },
                         {});

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -214,7 +214,7 @@ std::string benchmarkResultsToString(
   //  to the stringstream.
   auto addNonEmptyCategorieToStringSteam =
       [](std::ostringstream* stringStream, const auto& categoryResult,
-                   const auto& categoryAddPrintStreamFunction) {
+         const auto& categoryAddPrintStreamFunction) {
         if (categoryResult.size() > 0) {
           // The seperator between the printed categories.
           (*stringStream) << "\n\n";

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -2,11 +2,10 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkResultToString.h"
-
 #include <absl/strings/str_cat.h>
 #include <bits/ranges_algo.h>
 
+#include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"
@@ -14,7 +13,7 @@
 
 namespace ad_benchmark {
 
-extern const std::string outputIndention = "\t";
+extern const std::string outputIndention = "    ";
 
 // ___________________________________________________________________________
 void addCategoryTitleToOStringstream(std::ostringstream* stream,

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -200,9 +200,6 @@ std::string benchmarkResultsToString(
   const std::vector<ResultGroup>& resultGroups = results.getGroups();
   const std::vector<ResultTable>& resultTables = results.getTables();
 
-  // The seperator between the printed categories.
-  constexpr std::string_view seperator = "\n\n";
-
   // Visualizes the measured times.
   std::ostringstream visualization;
 
@@ -216,10 +213,12 @@ std::string benchmarkResultsToString(
   //  benchmark category information, converts them to text, and adds that text
   //  to the stringstream.
   auto addNonEmptyCategorieToStringSteam =
-      [&seperator](std::ostringstream* stringStream, const auto& categoryResult,
+      [](std::ostringstream* stringStream, const auto& categoryResult,
                    const auto& categoryAddPrintStreamFunction) {
         if (categoryResult.size() > 0) {
-          (*stringStream) << seperator;
+          // The seperator between the printed categories.
+          (*stringStream) << "\n\n";
+
           categoryAddPrintStreamFunction(stringStream, categoryResult);
         }
       };

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -32,12 +32,12 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
 
 /*
 @brief Adds indention before the given string and directly after new line
-characters. 
+characters.
 
 @param indentionLevel How deep is the indention? `0` is no indention.
 */
 std::string addIndtention(const std::string_view str,
-  const size_t& indentionLevel);
+                          const size_t& indentionLevel);
 
 /*
 @brief If `meta` is a non empty metadata object, return it's non compact
@@ -47,7 +47,8 @@ json string representation. Otherwise, return an empty string.
 @param suffix Will be printed after the json string.
 */
 std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
-  std::string_view prefix, std::string_view suffix);
+                                    std::string_view prefix,
+                                    std::string_view suffix);
 
 /*
 @brief Add a vector of `ResultEntry` in their string form to the string stream
@@ -78,6 +79,6 @@ void addTablesToOStringstream(std::ostringstream* stream,
  * @brief Returns a formated string containing all the benchmark information.
  */
 std::string benchmarkResultsToString(
-  const BenchmarkInterface* const benchmarkClass,
-  const BenchmarkResults& results);
+    const BenchmarkInterface* const benchmarkClass,
+    const BenchmarkResults& results);
 }  // namespace ad_benchmark

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -16,6 +16,10 @@
 #include "util/json.h"
 
 namespace ad_benchmark {
+
+// How the indention should look like.
+extern const std::string outputIndention;
+
 /*
  * @brief Add a string of the form
  * "#################
@@ -25,6 +29,15 @@ namespace ad_benchmark {
  */
 void addCategoryTitleToOStringstream(std::ostringstream* stream,
                                      std::string_view categoryTitle);
+
+/*
+@brief Adds indention before the given string and directly after new line
+characters. 
+
+@param indentionLevel How deep is the indention? `0` is no indention.
+*/
+std::string addIndtention(const std::string_view str,
+  const size_t& indentionLevel);
 
 /*
 @brief If `meta` is a non empty metadata object, return it's non compact

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -59,5 +59,5 @@ void addTablesToOStringstream(std::ostringstream* stream,
  * by all the benchmark information.
  */
 std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
-  const BenchmarkResults& results);
+                                     const BenchmarkResults& results);
 }  // namespace ad_benchmark

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -18,7 +18,7 @@
 namespace ad_benchmark {
 
 // How the indention should look like.
-extern const std::string outputIndention;
+static constexpr std::string_view outputIndentation = "    ";
 
 /*
  * @brief Add a string of the form

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -36,8 +36,8 @@ characters.
 
 @param indentionLevel How deep is the indention? `0` is no indention.
 */
-std::string addIndtention(const std::string_view str,
-                          const size_t& indentionLevel);
+std::string addIndentation(const std::string_view str,
+                           const size_t& indentationLevel);
 
 /*
 @brief If `meta` is a non empty metadata object, return it's non compact

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -12,6 +12,7 @@
 #include "../benchmark/infrastructure/Benchmark.h"
 #include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
+#include "BenchmarkMetadata.h"
 #include "util/json.h"
 
 namespace ad_benchmark {
@@ -28,11 +29,18 @@ namespace ad_benchmark {
 void addCategoryTitleToOStringstream(std::ostringstream* stream,
                                      std::string_view categoryTitle);
 
+/*
+@brief Add a vector of `ResultEntry` in their string form to the string stream
+in form of a list.
+
+@param vectorEntryPrefix A prefix added before every entry in the vector.
+@param newLinePrefix A prefix added before at the start of a new line.
+*/
 // Default way of adding a vector of ResultEntrys to a `ostringstream` with
-// optional prefix.
+// optional prefix, which will be inserted at the start of every new line.
 void addVectorOfResultEntryToOStringstream(
     std::ostringstream* stream, const std::vector<ResultEntry>& entries,
-    const std::string& prefix = "");
+    const std::string& vectorEntryPrefix, const std::string& newLinePrefix);
 
 // Visualization for single measurments.
 void addSingleMeasurementsToOStringstream(
@@ -47,7 +55,9 @@ void addTablesToOStringstream(std::ostringstream* stream,
                               const std::vector<ResultTable>& resultTables);
 
 /*
- * @brief Returns a formated string containing all benchmark information.
+ * @brief Returns a formated string containing the given metadata, followed
+ * by all the benchmark information.
  */
-std::string benchmarkResultsToString(const BenchmarkResults& results);
+std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
+  const BenchmarkResults& results);
 }  // namespace ad_benchmark

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -30,11 +30,20 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
                                      std::string_view categoryTitle);
 
 /*
+@brief If `meta` is a non empty metadata object, return it's non compact
+json string representation. Otherwise, return an empty string.
+
+@param prefix Will be printed before the json string.
+*/
+std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
+  std::string_view prefix);
+
+/*
 @brief Add a vector of `ResultEntry` in their string form to the string stream
 in form of a list.
 
 @param vectorEntryPrefix A prefix added before every entry in the vector.
-@param newLinePrefix A prefix added before at the start of a new line.
+@param newLinePrefix A prefix added before the start of a new line.
 */
 // Default way of adding a vector of ResultEntrys to a `ostringstream` with
 // optional prefix, which will be inserted at the start of every new line.

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -62,9 +62,9 @@ void addTablesToOStringstream(std::ostringstream* stream,
                               const std::vector<ResultTable>& resultTables);
 
 /*
- * @brief Returns a formated string containing the given metadata, followed
- * by all the benchmark information.
+ * @brief Returns a formated string containing all the benchmark information.
  */
-std::string benchmarkResultsToString(const BenchmarkMetadata& meta,
-                                     const BenchmarkResults& results);
+std::string benchmarkResultsToString(
+  const BenchmarkInterface* const benchmarkClass,
+  const BenchmarkResults& results);
 }  // namespace ad_benchmark

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -18,12 +18,9 @@
 namespace ad_benchmark {
 /*
  * @brief Add a string of the form
- * "
- *  #################
- *  # categoryTitle #
- *  #################
- *
- *  "
+ * "#################
+ * # categoryTitle #
+ * #################"
  *  to the stream.
  */
 void addCategoryTitleToOStringstream(std::ostringstream* stream,
@@ -34,9 +31,10 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
 json string representation. Otherwise, return an empty string.
 
 @param prefix Will be printed before the json string.
+@param suffix Will be printed after the json string.
 */
 std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
-  std::string_view prefix);
+  std::string_view prefix, std::string_view suffix);
 
 /*
 @brief Add a vector of `ResultEntry` in their string form to the string stream

--- a/benchmark/infrastructure/BenchmarkToJson.cpp
+++ b/benchmark/infrastructure/BenchmarkToJson.cpp
@@ -77,18 +77,4 @@ nlohmann::json zipGeneralMetadataAndBenchmarkResultsToJson(
       });
 }
 
-// ___________________________________________________________________________
-nlohmann::json zipGeneralMetadataAndBenchmarkResultsToJson(
-    const std::vector<BenchmarkMetadata>& generalMetadata,
-    const std::vector<BenchmarkResults>& benchmarkResults) {
-  // We can just pass this, after transforming it.
-  std::vector<std::pair<BenchmarkMetadata, BenchmarkResults>> vectorsPairedUp{};
-  vectorsPairedUp.reserve(generalMetadata.size());
-
-  std::ranges::transform(generalMetadata, benchmarkResults,
-                         std::back_inserter(vectorsPairedUp),
-                         [](auto& a, auto& b) { return std::make_pair(a, b); });
-
-  return zipGeneralMetadataAndBenchmarkResultsToJson(vectorsPairedUp);
-}
 }  // namespace ad_benchmark

--- a/benchmark/infrastructure/BenchmarkToJson.cpp
+++ b/benchmark/infrastructure/BenchmarkToJson.cpp
@@ -72,7 +72,7 @@ nlohmann::json zipBenchmarkClassAndBenchmarkResultsToJson(
         benchmarkClassAndBenchmarkResults) {
   return transformIntoJsonArray(
       benchmarkClassAndBenchmarkResults, [](const auto& pair) {
-        return nlohmann::json{{"name", pair.first->getMetadata()},
+        return nlohmann::json{{"name", pair.first->name()},
                               {"general metadata", pair.first->getMetadata()},
                               {"measurements", pair.second}};
       });

--- a/benchmark/infrastructure/BenchmarkToJson.cpp
+++ b/benchmark/infrastructure/BenchmarkToJson.cpp
@@ -72,7 +72,8 @@ nlohmann::json zipBenchmarkClassAndBenchmarkResultsToJson(
         benchmarkClassAndBenchmarkResults) {
   return transformIntoJsonArray(
       benchmarkClassAndBenchmarkResults, [](const auto& pair) {
-        return nlohmann::json{{"general metadata", pair.first->getMetadata()},
+        return nlohmann::json{{"name", pair.first->getMetadata()},
+                              {"general metadata", pair.first->getMetadata()},
                               {"measurements", pair.second}};
       });
 }

--- a/benchmark/infrastructure/BenchmarkToJson.cpp
+++ b/benchmark/infrastructure/BenchmarkToJson.cpp
@@ -67,12 +67,12 @@ nlohmann::json benchmarkResultsToJson(
 }
 
 // ___________________________________________________________________________
-nlohmann::json zipGeneralMetadataAndBenchmarkResultsToJson(
-    const std::vector<std::pair<BenchmarkMetadata, BenchmarkResults>>&
-        generalMetadataAndBenchmarkResults) {
+nlohmann::json zipBenchmarkClassAndBenchmarkResultsToJson(
+    const std::vector<std::pair<const BenchmarkInterface*, BenchmarkResults>>&
+        benchmarkClassAndBenchmarkResults) {
   return transformIntoJsonArray(
-      generalMetadataAndBenchmarkResults, [](const auto& pair) {
-        return nlohmann::json{{"general metadata", pair.first},
+      benchmarkClassAndBenchmarkResults, [](const auto& pair) {
+        return nlohmann::json{{"general metadata", pair.first->getMetadata()},
                               {"measurements", pair.second}};
       });
 }

--- a/benchmark/infrastructure/BenchmarkToJson.h
+++ b/benchmark/infrastructure/BenchmarkToJson.h
@@ -21,10 +21,9 @@ nlohmann::json benchmarkResultsToJson(
 
 /*
 @brief Create a nlohmann::json array with all relevant informations
-given by the pairs. That is, all the `BenchmarkMetadata` and all information
-defined by benchmarks, with every pair grouped up.
+given by the pairs.
 */
-nlohmann::json zipGeneralMetadataAndBenchmarkResultsToJson(
-    const std::vector<std::pair<BenchmarkMetadata, BenchmarkResults>>&
-        generalMetadataAndBenchmarkResults);
+nlohmann::json zipBenchmarkClassAndBenchmarkResultsToJson(
+    const std::vector<std::pair<const BenchmarkInterface*, BenchmarkResults>>&
+        benchmarkClassAndBenchmarkResults);
 }  // namespace ad_benchmark

--- a/benchmark/infrastructure/BenchmarkToJson.h
+++ b/benchmark/infrastructure/BenchmarkToJson.h
@@ -27,14 +27,4 @@ defined by benchmarks, with every pair grouped up.
 nlohmann::json zipGeneralMetadataAndBenchmarkResultsToJson(
     const std::vector<std::pair<BenchmarkMetadata, BenchmarkResults>>&
         generalMetadataAndBenchmarkResults);
-
-/*
-@brief Create a nlohmann::json array with all relevant informations
-given by the two vectors. That is, all the `BenchmarkMetadata` and all
-information defined by benchmarks, with every entry in a vector paired up
-with the entry at the same place in the other vector.
-*/
-nlohmann::json zipGeneralMetadataAndBenchmarkResultsToJson(
-    const std::vector<BenchmarkMetadata>& generalMetadata,
-    const std::vector<BenchmarkResults>& benchmarkResults);
 }  // namespace ad_benchmark

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -12,6 +12,7 @@
 #include <string_view>
 #include <utility>
 
+#include "util/Exception.h"
 #include "util/Forward.h"
 #include "util/HashSet.h"
 #include "util/Iterators.h"
@@ -78,6 +79,31 @@ auto transform(Range&& input, F unaryOp) {
                  ad_utility::makeForwardingIterator<Range>(input.end()),
                  std::back_inserter(out), unaryOp);
   return out;
+}
+
+/*
+@brief Takes two vectors, pairs up their content at the same index positions
+and copies them into `std::pair`s, who are returned inside a vector.
+Example: `{1,2}` and `{3,4}` are returned as `{(1,3), (2,4)}`.
+*/
+template<typename VectorAContentType, typename VectorBContentType>
+std::vector<std::pair<VectorAContentType, VectorBContentType>>
+pairTwoVectorTogether(const std::vector<VectorAContentType>& vectorA,
+  const std::vector<VectorBContentType>& vectorB){
+  // Both vectors must have the same length.
+  AD_CONTRACT_CHECK(vectorA.size() == vectorB.size());
+
+  std::vector<std::pair<VectorAContentType, VectorBContentType>>
+  vectorsPairedUp{};
+  vectorsPairedUp.reserve(vectorA.size());
+
+  std::ranges::transform(vectorA, vectorB,
+                         std::back_inserter(vectorsPairedUp),
+                         [](const auto& a, const auto& b) {
+                           return std::make_pair(a, b);
+                         });
+
+  return vectorsPairedUp;
 }
 
 /**

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -88,12 +88,11 @@ Example: `{1,2}` and `{3,4}` are returned as `{(1,3), (2,4)}`.
 */
 template <typename T1, typename T2>
 std::vector<std::pair<T1, T2>> zipVectors(const std::vector<T1>& vectorA,
-  const std::vector<T2>& vectorB) {
+                                          const std::vector<T2>& vectorB) {
   // Both vectors must have the same length.
   AD_CONTRACT_CHECK(vectorA.size() == vectorB.size());
 
-  std::vector<std::pair<T1, T2>>
-      vectorsPairedUp{};
+  std::vector<std::pair<T1, T2>> vectorsPairedUp{};
   vectorsPairedUp.reserve(vectorA.size());
 
   std::ranges::transform(

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -86,22 +86,20 @@ auto transform(Range&& input, F unaryOp) {
 and copies them into `std::pair`s, who are returned inside a vector.
 Example: `{1,2}` and `{3,4}` are returned as `{(1,3), (2,4)}`.
 */
-template<typename VectorAContentType, typename VectorBContentType>
+template <typename VectorAContentType, typename VectorBContentType>
 std::vector<std::pair<VectorAContentType, VectorBContentType>>
 pairTwoVectorTogether(const std::vector<VectorAContentType>& vectorA,
-  const std::vector<VectorBContentType>& vectorB){
+                      const std::vector<VectorBContentType>& vectorB) {
   // Both vectors must have the same length.
   AD_CONTRACT_CHECK(vectorA.size() == vectorB.size());
 
   std::vector<std::pair<VectorAContentType, VectorBContentType>>
-  vectorsPairedUp{};
+      vectorsPairedUp{};
   vectorsPairedUp.reserve(vectorA.size());
 
-  std::ranges::transform(vectorA, vectorB,
-                         std::back_inserter(vectorsPairedUp),
-                         [](const auto& a, const auto& b) {
-                           return std::make_pair(a, b);
-                         });
+  std::ranges::transform(
+      vectorA, vectorB, std::back_inserter(vectorsPairedUp),
+      [](const auto& a, const auto& b) { return std::make_pair(a, b); });
 
   return vectorsPairedUp;
 }

--- a/src/util/Algorithm.h
+++ b/src/util/Algorithm.h
@@ -86,14 +86,13 @@ auto transform(Range&& input, F unaryOp) {
 and copies them into `std::pair`s, who are returned inside a vector.
 Example: `{1,2}` and `{3,4}` are returned as `{(1,3), (2,4)}`.
 */
-template <typename VectorAContentType, typename VectorBContentType>
-std::vector<std::pair<VectorAContentType, VectorBContentType>>
-pairTwoVectorTogether(const std::vector<VectorAContentType>& vectorA,
-                      const std::vector<VectorBContentType>& vectorB) {
+template <typename T1, typename T2>
+std::vector<std::pair<T1, T2>> zipVectors(const std::vector<T1>& vectorA,
+  const std::vector<T2>& vectorB) {
   // Both vectors must have the same length.
   AD_CONTRACT_CHECK(vectorA.size() == vectorB.size());
 
-  std::vector<std::pair<VectorAContentType, VectorBContentType>>
+  std::vector<std::pair<T1, T2>>
       vectorsPairedUp{};
   vectorsPairedUp.reserve(vectorA.size());
 

--- a/test/AlgorithmTest.cpp
+++ b/test/AlgorithmTest.cpp
@@ -132,3 +132,22 @@ TEST(AlgorithmTest, removeDuplicates) {
   ASSERT_EQ(ad_utility::removeDuplicates(std::vector<int>{}),
             (std::vector<int>{}));
 };
+
+// _____________________________________________________________________________
+TEST(AlgorithmTest, ZipVectors) {
+  // Vectors of different size are not allowed.
+  ASSERT_ANY_THROW(
+      zipVectors(std::vector<size_t>{1}, std::vector<size_t>{1, 2}));
+
+  // Do a simple test.
+  std::vector<char> charVector{'a', 'b', 'c'};
+  std::vector<float> floatVector{4.0, 4.1, 4.2};
+  const auto& combinedVector = zipVectors(charVector, floatVector);
+
+  for (size_t i = 0; i < charVector.size(); i++) {
+    ASSERT_EQ(charVector.at(i), combinedVector.at(i).first);
+  }
+  for (size_t i = 0; i < charVector.size(); i++) {
+    ASSERT_FLOAT_EQ(floatVector.at(i), combinedVector.at(i).second);
+  }
+};


### PR DESCRIPTION
Instead of just printing the taken measurements, compiled benchmark files now also print the general metadata of the benchmark class and the metadata of every benchmark group, table, etc. together with the taken measurements.