### PR TITLE
Guard against timing attacks

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -271,7 +271,8 @@ Awaitable<void> Server::process(
       throw std::runtime_error(absl::StrCat(
           accessTokenProvidedMsg,
           " but server was started without --access-token", requestIgnoredMsg));
-    } else if (!ad_utility::constantTimeEquals(*accessToken, accessToken_)) {
+    } else if (!ad_utility::constantTimeEquals(accessToken.value(),
+                                               accessToken_)) {
       throw std::runtime_error(absl::StrCat(
           accessTokenProvidedMsg, " but not correct", requestIgnoredMsg));
     } else {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -260,7 +260,7 @@ Awaitable<void> Server::process(
 
   // Check the access token. If an access token is provided and the check fails,
   // throw an exception and do not process any part of the query (even if the
-  // processing would have been allowed without access token).
+  // processing had been allowed without access token).
   auto accessToken = checkParameter("access-token", std::nullopt);
   bool accessTokenOk = false;
   if (accessToken) {
@@ -271,7 +271,7 @@ Awaitable<void> Server::process(
       throw std::runtime_error(absl::StrCat(
           accessTokenProvidedMsg,
           " but server was started without --access-token", requestIgnoredMsg));
-    } else if (accessToken != accessToken_) {
+    } else if (!ad_utility::constantTimeEquals(*accessToken, accessToken_)) {
       throw std::runtime_error(absl::StrCat(
           accessTokenProvidedMsg, " but not correct", requestIgnoredMsg));
     } else {

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -209,7 +209,7 @@ inline size_t findLiteralEnd(const std::string_view input,
 
 // Implementation based on https://stackoverflow.com/a/25374036
 inline bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
-                            std::basic_string_view<volatile char> str2) {
+                                   std::basic_string_view<volatile char> str2) {
   if (str1.length() != str2.length()) {
     return false;
   }
@@ -220,7 +220,8 @@ inline bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
   return c == 0;
 }
 
-constexpr std::basic_string_view<volatile char> toVolatile(std::string_view view) {
+constexpr std::basic_string_view<volatile char> toVolatile(
+    std::string_view view) {
   return {view.data(), view.size()};
 }
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -208,6 +208,9 @@ inline size_t findLiteralEnd(const std::string_view input,
 }
 
 // Implementation based on https://stackoverflow.com/a/25374036
+// Note because of ambiguous overload resolution the function name
+// here has the 'Impl' suffix, even though the explicit conversion is required
+// for it to compile (so only one overload actually works in practice)
 inline bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
                                    std::basic_string_view<volatile char> str2) {
   if (str1.length() != str2.length()) {
@@ -215,6 +218,8 @@ inline bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
   }
   volatile char c = 0;
   for (size_t i = 0; i < str1.length(); ++i) {
+    // In C++20 compound assignment of volatile variables causes a warning,
+    // so we can't use 'c |=' until compiling with C++23 where it is fine again.
     c = c | (str1[i] ^ str2[i]);
   }
   return c == 0;

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -208,7 +208,7 @@ inline size_t findLiteralEnd(const std::string_view input,
 }
 
 // Implementation based on https://stackoverflow.com/a/25374036
-bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
+inline bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
                             std::basic_string_view<volatile char> str2) {
   if (str1.length() != str2.length()) {
     return false;
@@ -220,11 +220,11 @@ bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
   return c == 0;
 }
 
-std::basic_string_view<volatile char> toVolatile(std::string_view view) {
+constexpr std::basic_string_view<volatile char> toVolatile(std::string_view view) {
   return {view.data(), view.size()};
 }
 
-bool constantTimeEquals(std::string_view str1, std::string_view str2) {
+inline bool constantTimeEquals(std::string_view str1, std::string_view str2) {
   return constantTimeEqualsImpl(toVolatile(str1), toVolatile(str2));
 }
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -216,10 +216,10 @@ inline size_t findLiteralEnd(const std::string_view input,
 // characters. An equally safe, but slower method to achieve the same thing
 // would be to compute cryptographically secure hashes (like SHA-3 for example)
 // and compare the hashes instead of the actual strings.
-constexpr bool constantTimeEquals(std::string_view str1,
-                                  std::string_view str2) {
+constexpr bool constantTimeEquals(std::string_view view1,
+                                  std::string_view view2) {
   using byte_view = std::basic_string_view<volatile std::byte>;
-  auto impl = [](byte_view str1, byte_view str2) -> bool {
+  auto impl = [](byte_view str1, byte_view str2) {
     if (str1.length() != str2.length()) {
       return false;
     }
@@ -241,7 +241,7 @@ constexpr bool constantTimeEquals(std::string_view str1,
         static_cast<const std::byte*>(static_cast<const void*>(view.data())),
         view.size()};
   };
-  return impl(toVolatile(str1), toVolatile(str2));
+  return impl(toVolatile(view1), toVolatile(view2));
 }
 
 }  // namespace ad_utility

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -207,31 +207,41 @@ inline size_t findLiteralEnd(const std::string_view input,
   return endPos;
 }
 
+// A "constant-time" comparison for strings.
 // Implementation based on https://stackoverflow.com/a/25374036
-// Note because of ambiguous overload resolution the function name
-// here has the 'Impl' suffix, even though the explicit conversion is required
-// for it to compile (so only one overload actually works in practice)
-inline bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
-                                   std::basic_string_view<volatile char> str2) {
-  if (str1.length() != str2.length()) {
-    return false;
-  }
-  volatile char c = 0;
-  for (size_t i = 0; i < str1.length(); ++i) {
-    // In C++20 compound assignment of volatile variables causes a warning,
-    // so we can't use 'c |=' until compiling with C++23 where it is fine again.
-    c = c | (str1[i] ^ str2[i]);
-  }
-  return c == 0;
-}
-
-constexpr std::basic_string_view<volatile char> toVolatile(
-    std::string_view view) {
-  return {view.data(), view.size()};
-}
-
-inline bool constantTimeEquals(std::string_view str1, std::string_view str2) {
-  return constantTimeEqualsImpl(toVolatile(str1), toVolatile(str2));
+// Basically for 2 strings of equal length this function will always
+// take the same time to compute regardless of how many characters are
+// matching. This is to prevent analysing the secret comparison string
+// by analysing response times to incrementally figure out individual
+// characters. An equally safe, but slower method to achieve the same thing
+// would be to compute cryptographically secure hashes (like SHA-3 for example)
+// and compare the hashes instead of the actual strings.
+constexpr bool constantTimeEquals(std::string_view str1,
+                                  std::string_view str2) {
+  using byte_view = std::basic_string_view<volatile std::byte>;
+  auto impl = [](byte_view str1, byte_view str2) -> bool {
+    if (str1.length() != str2.length()) {
+      return false;
+    }
+    volatile std::byte mismatchFound{0};
+    for (size_t i = 0; i < str1.length(); ++i) {
+      // In C++20 compound assignment of volatile variables causes a warning,
+      // so we can't use 'mismatchFound |=' until compiling with C++23 where it
+      // is fine again. mismatchFound can be interpreted as bool and "is false"
+      // until the first mismatch in the strings is found.
+      mismatchFound = mismatchFound | (str1[i] ^ str2[i]);
+    }
+    return !static_cast<bool>(mismatchFound);
+  };
+  auto toVolatile = [](std::string_view view) constexpr -> byte_view {
+    // Casting is safe because both types have the same size
+    static_assert(sizeof(std::string_view::value_type) ==
+                  sizeof(byte_view::value_type));
+    return {
+        static_cast<const std::byte*>(static_cast<const void*>(view.data())),
+        view.size()};
+  };
+  return impl(toVolatile(str1), toVolatile(str2));
 }
 
 }  // namespace ad_utility

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -215,7 +215,7 @@ bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
   }
   volatile char c = 0;
   for (size_t i = 0; i < str1.length(); ++i) {
-    c |= str1[i] ^ str2[i];
+    c = c | (str1[i] ^ str2[i]);
   }
   return c == 0;
 }

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -207,6 +207,27 @@ inline size_t findLiteralEnd(const std::string_view input,
   return endPos;
 }
 
+// Implementation based on https://stackoverflow.com/a/25374036
+bool constantTimeEqualsImpl(std::basic_string_view<volatile char> str1,
+                            std::basic_string_view<volatile char> str2) {
+  if (str1.length() != str2.length()) {
+    return false;
+  }
+  volatile char c = 0;
+  for (size_t i = 0; i < str1.length(); ++i) {
+    c |= str1[i] ^ str2[i];
+  }
+  return c == 0;
+}
+
+std::basic_string_view<volatile char> toVolatile(std::string_view view) {
+  return {view.data(), view.size()};
+}
+
+bool constantTimeEquals(std::string_view str1, std::string_view str2) {
+  return constantTimeEqualsImpl(toVolatile(str1), toVolatile(str2));
+}
+
 }  // namespace ad_utility
 
 // these overloads are missing in the STL

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -6,6 +6,7 @@
 
 #include "util/StringUtils.h"
 
+using ad_utility::constantTimeEquals;
 using ad_utility::getLowercaseUtf8;
 using ad_utility::getUTF8Substring;
 
@@ -46,4 +47,15 @@ TEST(StringUtilsTest, getUTF8Substring) {
   // start+size > number of codepoints
   ASSERT_EQ("Apfelsaft", getUTF8Substring("Apfelsaft", 0, 100));
   ASSERT_EQ("\u00A9", getUTF8Substring("\u2702\u231A\u00A9", 2, 2));
+}
+
+// It should just work like the == operator for strings, just without
+// the typical short circuit optimization
+TEST(StringUtilsTest, constantTimeEquals) {
+  EXPECT_TRUE(constantTimeEquals("", ""));
+  EXPECT_TRUE(constantTimeEquals("Abcdefg", "Abcdefg"));
+  EXPECT_FALSE(constantTimeEquals("Abcdefg", "abcdefg"));
+  EXPECT_FALSE(constantTimeEquals("", "Abcdefg"));
+  EXPECT_FALSE(constantTimeEquals("Abcdefg", ""));
+  EXPECT_FALSE(constantTimeEquals("Abc", "defg"));
 }


### PR DESCRIPTION
While working on the upcoming changes on websockets I stumbled across the access token verification mechanism and noticed it's potentially vurlerable to timing attacks. See https://en.wikipedia.org/wiki/Timing_attack for more information. Basically I changed the code to no longer use the equality operator (which short circuits and therefore causes the problem) to code that given the strings have the same length always checks every single char before returning, even if previous chars already mismatched. The implementation is based on https://stackoverflow.com/a/25374036

I didn't try to perform an actual timing attack locally. I think such an attack is non-trivial but definitely plausible. The security implications a rather minor in comparison, but better safe than sorry.

/cc @joka921 