### PR TITLE
Fix a bug in the Benchmark library when reading a configuration from file

### DIFF
--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -40,14 +40,14 @@ static void writeJsonToFile(nlohmann::json j, const std::string& fileName,
 
 static std::string readFileToString(const std::string& fileName) {
   // The string gets build using a string stream.
-  std::ostringstream transchribedString{};
+  std::ostringstream transcribedString{};
 
   // Adding a buffer using `<<` causes the content of the buffer to be
   // individually added to the string stream. In other words: The entire
   // content of the opened file will be added.
-  transchribedString << ad_utility::makeOfstream(fileName).rdbuf();
+  transcribedString << ad_utility::makeIfstream(fileName).rdbuf();
 
-  return transchribedString.str();
+  return transcribedString.str();
 }
 
 /*


### PR DESCRIPTION
# How to replicate the error

1. Compile the current master.
2. In your build folder, create a `ExampleConfig.json` file and fill it with valid json.
3. Call `benchmark/BenchmarkExamples -p -j ExampleConfig.json`.
4. The program will throw a parser exception and the content of `ExampleConfig.json` deleted.

# The fix
The actual error was another case of the good, old, "Wait, was `std::ofstream` for writing to a file, or for reading from one?" and getting the answer wrong.
I simply changed it to a `std::ifstream` and now everything seems to work as intended.