### PR TITLE
Correct printing of benchmark table with zero rows

### DIFF
--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -217,6 +217,9 @@ class BMTables : public BenchmarkInterface {
     tableAddingExponents.setEntry(2, 0, "1024+1024 and 1024+2048");
     tableAddingExponents.setEntry(2, 1, "1024+2048 and 2048+2048");
 
+    // TODO Delete.
+    results.addTable("empty table", {}, {"column 1", "column 2"});
+
     return results;
   }
 };

--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -217,9 +217,6 @@ class BMTables : public BenchmarkInterface {
     tableAddingExponents.setEntry(2, 0, "1024+1024 and 1024+2048");
     tableAddingExponents.setEntry(2, 1, "1024+2048 and 2048+2048");
 
-    // TODO Delete.
-    results.addTable("empty table", {}, {"column 1", "column 2"});
-
     return results;
   }
 };

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -147,17 +147,22 @@ ResultTable::operator std::string() const {
   // to only combine them at the end.
   std::string prefix = absl::StrCat("Table '", descriptor_, "'\n");
 
+  // It's allowed to have tables without rows. In that case, we are already
+  // done, because there is no table content to print.
+  if (numRows() == 0) {
+    // In the case of no metadata, we don't need the line break at the end of
+    // the prefix.
+    return absl::StrCat(
+        prefix.substr(0, prefix.size() - 1),
+        addIndentation(getMetadataPrettyString(metadata(), "\nmetadata: ", ""),
+                       1));
+  }
+
   // For printing the table.
   std::ostringstream stream;
 
   // Adding the metadata.
   stream << getMetadataPrettyString(metadata(), "metadata: ", "\n");
-
-  // It's allowed to have tables without rows. In that case, we are already
-  // done, because there is no table content to print.
-  if (numRows() == 0) {
-    return absl::StrCat(prefix, addIndentation(stream.str(), 1));
-  }
 
   // For easier usage.
   const size_t numberColumns = columnNames_.size();

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -83,13 +83,12 @@ ResultTable::ResultTable(const std::string& descriptor,
       rowNames_{rowNames},
       columnNames_{columnNames},
       entries_(rowNames.size(), std::vector<EntryType>(columnNames.size())) {
-  // Having a table without any rows/columns makes no sense.
-  if (rowNames.empty() || columnNames.empty()) {
+  // Having a table without any columns makes no sense.
+  if (columnNames.empty()) {
     throw ad_utility::Exception(
         absl::StrCat("A `ResultTable` must have at"
-                     " least one column and one row. Table '",
-                     descriptor, "' has ", rowNames.size(), " rows and ",
-                     columnNames.size(), " columns"));
+                     " least one column. Table '",
+                     descriptor, "' has ", columnNames.size(), " columns"));
   }
 }
 

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -11,7 +13,6 @@
 #include <sstream>
 #include <string_view>
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -12,7 +14,6 @@
 #include <string_view>
 #include <utility>
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
-
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -13,6 +11,7 @@
 #include <sstream>
 #include <string_view>
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"
@@ -228,16 +227,15 @@ void ResultTable::addRow(std::string_view rowName) {
 }
 
 // ____________________________________________________________________________
-size_t ResultTable::numRows() const { return entries_.size(); }
+size_t ResultTable::numRows() const { return rowNames_.size(); }
 
 // ____________________________________________________________________________
 size_t ResultTable::numColumns() const {
   /*
-  If nobody played around with the private member variables, every row
-  should have the same amount of columns and there should be AT LEAST one row,
-  and one column. So we can just return the length of the first row.
+  If nobody played around with the private member variables, the amount of
+  columns and column names should be the same.
   */
-  return entries_.at(0).size();
+  return columnNames_.size();
 }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -154,6 +154,12 @@ ResultTable::operator std::string() const {
   // Adding the metadata.
   stream << getMetadataPrettyString(metadata(), "metadata: ", "\n");
 
+  // It's allowed to have tables without rows. In that case, we are already
+  // done, because there is no table content to print.
+  if (numRows() == 0) {
+    return absl::StrCat(prefix, addIndentation(stream.str(), 1));
+  }
+
   // For easier usage.
   const size_t numberColumns = columnNames_.size();
   const size_t numberRows = rowNames_.size();

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -237,8 +237,8 @@ ResultTable::operator std::string() const {
   auto insertEntryInFrontOfRValueVector =
       [](std::vector<std::pair<std::string, size_t>>&& vec,
          std::pair<std::string, size_t>&& entry) {
-        vec.insert(vec.begin(), AD_FWD(entry));
-        return AD_FWD(vec);
+        vec.insert(vec.begin(), std::move(entry));
+        return std::move(vec);
       };
 
   // Print the top row of names.

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -2,11 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkResultToString.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_replace.h>
 #include <bits/ranges_algo.h>
 
-#include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"

--- a/benchmark/infrastructure/BenchmarkResultToString.cpp
+++ b/benchmark/infrastructure/BenchmarkResultToString.cpp
@@ -2,12 +2,11 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel February of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkResultToString.h"
-
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_replace.h>
 #include <bits/ranges_algo.h>
 
+#include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMeasurementContainer.h"
 #include "BenchmarkMetadata.h"
 #include "util/Exception.h"
@@ -56,25 +55,6 @@ std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
   } else {
     return "";
   }
-}
-
-/*
-@brief Applies the given function `regularFunction` to all elements in `r`,
-except for the last one. Instead, `lastOneFunction` is applied to that one.
-
-@tparam Range Needs to be a data type supported by `std::ranges`.
-
-@param r Must hold at least one element.
-*/
-template <typename Range, typename RegularFunction, typename LastOneFunction>
-static void forEachExcludingTheLastOne(Range&& r,
-                                       RegularFunction regularFunction,
-                                       LastOneFunction lastOneFunction) {
-  // Throw an error, if there are no elements in `r`.
-  AD_CONTRACT_CHECK(r.size() > 0);
-
-  std::ranges::for_each_n(r.begin(), r.size() - 1, regularFunction, {});
-  lastOneFunction(r.back());
 }
 
 /*

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -39,7 +39,7 @@ except for the last one. Instead, `lastOneFunction` is applied to that one.
 @param r Must hold at least one element.
 */
 template <typename Range, typename RegularFunction, typename LastOneFunction>
-static void forEachExcludingTheLastOne(Range&& r,
+static void forEachExcludingTheLastOne(const Range& r,
                                        RegularFunction regularFunction,
                                        LastOneFunction lastOneFunction) {
   // Throw an error, if there are no elements in `r`.

--- a/benchmark/infrastructure/BenchmarkResultToString.h
+++ b/benchmark/infrastructure/BenchmarkResultToString.h
@@ -31,6 +31,25 @@ void addCategoryTitleToOStringstream(std::ostringstream* stream,
                                      std::string_view categoryTitle);
 
 /*
+@brief Applies the given function `regularFunction` to all elements in `r`,
+except for the last one. Instead, `lastOneFunction` is applied to that one.
+
+@tparam Range Needs to be a data type supported by `std::ranges`.
+
+@param r Must hold at least one element.
+*/
+template <typename Range, typename RegularFunction, typename LastOneFunction>
+static void forEachExcludingTheLastOne(Range&& r,
+                                       RegularFunction regularFunction,
+                                       LastOneFunction lastOneFunction) {
+  // Throw an error, if there are no elements in `r`.
+  AD_CONTRACT_CHECK(r.size() > 0);
+
+  std::ranges::for_each_n(r.begin(), r.size() - 1, regularFunction, {});
+  lastOneFunction(r.back());
+}
+
+/*
 @brief Adds indention before the given string and directly after new line
 characters.
 

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -108,14 +108,19 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
     };
     ((check(wantedContent)), ...);
   };
+
   /*
-  Special case: A table with no rows, or columns. Should throw an exception
-  on creation, because it's quite the stupid idea.
-  Additionally, operations on such an empty table can create segmentation
-  faults. The string conversion of `ResultTable` uses `std::ranges::max`, which
-  really doesn't play well with empty vectors.
+  Special case: A table with no columns. Should throw an exception
+  on creation, because you can't add columns after creation and a table without
+  columns is quite the stupid idea. Additionally, operations on such an empty
+  table can create segmentation faults. The string conversion of `ResultTable`
+  uses `std::ranges::max`, which really doesn't play well with empty vectors.
   */
-  ASSERT_ANY_THROW(ResultTable("0 by 0 table", {}, {}));
+  ASSERT_ANY_THROW(ResultTable("1 by 0 table", {"Test"}, {}));
+
+  // In the same sense, because you can add rows after creation, a table without
+  // rows should be creatable.
+  ASSERT_NO_THROW(ResultTable("0 by 1 table", {}, {"Test"}));
 
   // Normal case.
   const std::vector<std::string> rowNames{"row1", "row2"};


### PR DESCRIPTION
Up to this point, it was possible, and allowed, to create table without rows. However, they threw exceptions, when one tried to convert them to `std::string`, or print them.
This PR fixes that problem.