### PR TITLE
More efficient OPTIONAL join

### DIFF
--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -16,15 +16,15 @@ class OptionalJoin : public Operation {
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
-  // This enum keeps track of which columns in the input contain UNDEF values.
+  // This `enum` keeps track of which columns in the input contain UNDEF values.
   // This is then used to choose the cheapest possible implementation.
-  enum struct ImplementationEnum {
-    GeneralAlgorithm,  // No special implementation possible
-    NoUndef,           // None of the join columns contains UNDEF
+  enum struct Implementation {
+    GeneralCase,  // No special implementation possible
+    NoUndef,      // None of the join columns contains UNDEF
     OnlyUndefInLastJoinColumnOfLeft
   };
 
-  ImplementationEnum implementationEnum_ = ImplementationEnum::GeneralAlgorithm;
+  Implementation implementation_ = Implementation::GeneralCase;
 
   std::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
@@ -80,7 +80,7 @@ class OptionalJoin : public Operation {
       const IdTable& left, const IdTable& right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
       IdTable* dynResult,
-      ImplementationEnum implementation = ImplementationEnum::GeneralAlgorithm);
+      Implementation implementation = Implementation::GeneralCase);
 
  private:
   void computeSizeEstimateAndMultiplicities();
@@ -90,8 +90,8 @@ class OptionalJoin : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
   // Check which of the join columns in `left` and `right` contain UNDEF values
-  // and return the appropriate `ImplementationEnum`.
-  static ImplementationEnum computeImplementationFromIdTables(
+  // and return the appropriate `Implementation`.
+  static Implementation computeImplementationFromIdTables(
       const IdTable& left, const IdTable& right,
       const std::vector<std::array<ColumnIndex, 2>>&);
 };

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -16,9 +16,11 @@ class OptionalJoin : public Operation {
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
+  // This enum keeps track of which columns in the input contain UNDEF values.
+  // This is then used to choose the cheapest possible implementation.
   enum struct ImplementationEnum {
-    GeneralAlgorithm,
-    NoUndef,
+    GeneralAlgorithm,  // No special implementation possible
+    NoUndef,           // None of the join columns contains UNDEF
     OnlyUndefInLastJoinColumnOfLeft
   };
 
@@ -86,4 +88,10 @@ class OptionalJoin : public Operation {
   ResultTable computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
+
+  // Check which of the join columns in `left` and `right` contain UNDEF values
+  // and return the appropriate `ImplementationEnum`.
+  static ImplementationEnum computeImplementationFromIdTables(
+      const IdTable& left, const IdTable& right,
+      const std::vector<std::array<ColumnIndex, 2>>&);
 };

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -16,6 +16,14 @@ class OptionalJoin : public Operation {
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
+  enum struct ImplementationEnum {
+    GeneralAlgorithm,
+    NoUndef,
+    OnlyUndefInLastJoinColumnOfLeft
+  };
+
+  ImplementationEnum implementationEnum_ = ImplementationEnum::GeneralAlgorithm;
+
   std::vector<std::array<ColumnIndex, 2>> _joinColumns;
 
   std::vector<float> _multiplicities;
@@ -69,7 +77,8 @@ class OptionalJoin : public Operation {
   static void optionalJoin(
       const IdTable& left, const IdTable& right,
       const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
-      IdTable* dynResult);
+      IdTable* dynResult,
+      ImplementationEnum implementation = ImplementationEnum::GeneralAlgorithm);
 
  private:
   void computeSizeEstimateAndMultiplicities();

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -311,6 +311,10 @@ template <
  * entryFromLarger), this function is called with the iterators to the matching
  * entries as arguments. These calls will be in ascending order wrt `lessThan`,
  * meaning that the result will be sorted.
+ * @param elementFromSmallerNotFoundAction Is called for each element in
+ * `smaller` that has no matching counterpart in `larger`. Can be used to
+ * implement very efficient OPTIONAL or MINUS if neither of the inputs contains
+ * UNDEF values, and if the left operand is much smaller.
  */
 template <std::ranges::random_access_range Range,
           typename ElementFromSmallerNotFoundAction = Noop>

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -372,7 +372,7 @@ void gallopingJoin(
                            return lessThan(a, b);
                          });
     if (itLarge == endLarge) {
-      return;
+      break;
     }
 
     // Find the ranges where both inputs are equal and add them to the result.
@@ -389,6 +389,13 @@ void gallopingJoin(
     }
     itSmall = endSameSmall;
     itLarge = endSameLarge;
+  }
+  if constexpr (!ad_utility::isSimilar<ElementFromSmallerNotFoundAction,
+                                       Noop>) {
+    while (itSmall != endSmall) {
+      elementFromSmallerNotFoundAction(itSmall);
+      ++itSmall;
+    }
   }
 }
 

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -312,10 +312,13 @@ template <
  * entries as arguments. These calls will be in ascending order wrt `lessThan`,
  * meaning that the result will be sorted.
  */
-template <std::ranges::random_access_range Range>
-void gallopingJoin(const Range& smaller, const Range& larger,
-                   BinaryRangePredicate<Range> auto const& lessThan,
-                   BinaryIteratorFunction<Range> auto const& action) {
+template <std::ranges::random_access_range Range,
+          typename ElementFromSmallerNotFoundAction = Noop>
+void gallopingJoin(
+    const Range& smaller, const Range& larger,
+    BinaryRangePredicate<Range> auto const& lessThan,
+    BinaryIteratorFunction<Range> auto const& action,
+    ElementFromSmallerNotFoundAction elementFromSmallerNotFoundAction = {}) {
   auto itSmall = std::begin(smaller);
   auto endSmall = std::end(smaller);
   auto itLarge = std::begin(larger);
@@ -348,14 +351,18 @@ void gallopingJoin(const Range& smaller, const Range& larger,
     return std::pair{lower, itL + 1};
   };
   while (itSmall < endSmall && itLarge < endLarge) {
+    const auto& elLarge = *itLarge;
     // Linear search in the smaller input.
-    itSmall = std::find_if_not(
-        itSmall, endSmall,
-        [&lessThan, &itLarge](auto el) { return lessThan(el, *itLarge); });
-    if (itSmall >= endSmall) {
-      return;
+    while (lessThan(*itSmall, elLarge)) {
+      if constexpr (!ad_utility::isSimilar<ElementFromSmallerNotFoundAction,
+                                           Noop>) {
+        elementFromSmallerNotFoundAction(itSmall);
+      }
+      ++itSmall;
+      if (itSmall >= endSmall) {
+        return;
+      }
     }
-
     // Exponential search followed by binary search on the larger input.
     auto [lower, upper] = exponentialSearch(itLarge, itSmall);
     const auto& needle = *itSmall;

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -337,7 +337,9 @@ TEST(OptionalJoin, gallopingJoin) {
     for (int64_t i = 0; i < 300; ++i) {
       bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
     }
-    for (int64_t i = 400; i < 10000; ++i) {
+    auto numElementsInLarger = static_cast<int64_t>(
+        std::max(10000ul, a.numRows() * GALLOP_THRESHOLD + 1));
+    for (int64_t i = 400; i < numElementsInLarger; ++i) {
       bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
     }
     IdTable b{makeIdTableFromVector(bInput)};
@@ -357,7 +359,9 @@ TEST(OptionalJoin, gallopingJoin) {
     for (int64_t i = 0; i < 300; ++i) {
       bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
     }
-    for (int64_t i = 400; i < 10000; ++i) {
+    auto numElementsInLarger = static_cast<int64_t>(
+        std::max(10000ul, a.numRows() * GALLOP_THRESHOLD + 1));
+    for (int64_t i = 400; i < numElementsInLarger; ++i) {
       bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
     }
     IdTable b{makeIdTableFromVector(bInput)};

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -329,10 +329,9 @@ TEST(OptionalJoin, specialOptionalJoinTwoColumns) {
 
 TEST(OptionalJoin, gallopingJoin) {
   {
-    IdTable a{
-        makeIdTableFromVector({{5}, {327}, {4938}, {100000000}})};
-    IdTable expectedResult{
-        makeIdTableFromVector({{5, 17}, {327, U}, {4938, 4950}, {100000000, U}})};
+    IdTable a{makeIdTableFromVector({{5}, {327}, {4938}, {100000000}})};
+    IdTable expectedResult{makeIdTableFromVector(
+        {{5, 17}, {327, U}, {4938, 4950}, {100000000, U}})};
 
     VectorTable bInput;
     for (int64_t i = 0; i < 300; ++i) {

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -326,3 +326,25 @@ TEST(OptionalJoin, specialOptionalJoinTwoColumns) {
     testOptionalJoin(a, b, jcls, expectedResult);
   }
 }
+
+TEST(OptionalJoin, gallopingJoin) {
+  {
+    IdTable a{
+        makeIdTableFromVector({{5}, {327}, {4938}, {100000000}})};
+    IdTable expectedResult{
+        makeIdTableFromVector({{5, 17}, {327, U}, {4938, 4950}, {100000000, U}})};
+
+    VectorTable bInput;
+    for (int64_t i = 0; i < 300; ++i) {
+      bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
+    }
+    for (int64_t i = 400; i < 10000; ++i) {
+      bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
+    }
+    IdTable b{makeIdTableFromVector(bInput)};
+    // Join on the first column
+    JoinColumns jcls{{0, 0}};
+
+    testOptionalJoin(a, b, jcls, expectedResult);
+  }
+}

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -346,4 +346,24 @@ TEST(OptionalJoin, gallopingJoin) {
 
     testOptionalJoin(a, b, jcls, expectedResult);
   }
+  // Also test the case that the largest element of `a` is less than the largest
+  // element of `b`.
+  {
+    IdTable a{makeIdTableFromVector({{5}, {327}, {328}})};
+    IdTable expectedResult{
+        makeIdTableFromVector({{5, 17}, {327, U}, {328, U}})};
+
+    VectorTable bInput;
+    for (int64_t i = 0; i < 300; ++i) {
+      bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
+    }
+    for (int64_t i = 400; i < 10000; ++i) {
+      bInput.emplace_back(std::vector<IntOrId>{i, i + 12});
+    }
+    IdTable b{makeIdTableFromVector(bInput)};
+    // Join on the first column
+    JoinColumns jcls{{0, 0}};
+
+    testOptionalJoin(a, b, jcls, expectedResult);
+  }
 }


### PR DESCRIPTION
* Make the case when none of the inputs contains UNDEF values even more efficient, and also enable the galloping join implementation in this case.

* When it is already known from the query planning that one of the cheap cases can be applied, then the runtime check for UNDEF values in the input is skipped.