### PR TITLE
Try to reduce the memory footprint of the text index

### DIFF
--- a/src/global/IndexTypes.h
+++ b/src/global/IndexTypes.h
@@ -11,5 +11,6 @@
 using VocabIndex = ad_utility::TypedIndex<uint64_t, "VocabIndex">;
 using LocalVocabIndex = ad_utility::TypedIndex<uint64_t, "LocalVocabIndex">;
 using TextRecordIndex = ad_utility::TypedIndex<uint64_t, "TextRecordIndex">;
+using WordVocabIndex = ad_utility::TypedIndex<uint64_t, "WordVocabIndex">;
 
 #endif  // QLEVER_INDEXTYPES_H

--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -16,7 +16,8 @@ using std::pair;
 
 // _____________________________________________________________________________
 Index::WordEntityPostings FTSAlgorithms::filterByRange(
-    const IdRange& idRange, const Index::WordEntityPostings& wepPreFilter) {
+    const IdRange<WordVocabIndex>& idRange,
+    const Index::WordEntityPostings& wepPreFilter) {
   AD_CONTRACT_CHECK(wepPreFilter.cids_.size() == wepPreFilter.wids_.size());
   AD_CONTRACT_CHECK(wepPreFilter.cids_.size() == wepPreFilter.scores_.size());
   LOG(DEBUG) << "Filtering " << wepPreFilter.cids_.size()

--- a/src/index/FTSAlgorithms.h
+++ b/src/index/FTSAlgorithms.h
@@ -29,7 +29,8 @@ class FTSAlgorithms {
   typedef vector<vector<Id>> VarWidthList;
 
   static Index::WordEntityPostings filterByRange(
-      const IdRange& idRange, const Index::WordEntityPostings& wepPreFilter);
+      const IdRange<WordVocabIndex>& idRange,
+      const Index::WordEntityPostings& wepPreFilter);
 
   static Index::WordEntityPostings intersect(
       const Index::WordEntityPostings& matchingContextsWep,

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -100,11 +100,13 @@ class Index {
   // Read necessary metadata into memory and open file handles.
   void addTextFromOnDiskIndex();
 
-  using Vocab = Vocabulary<CompressedString, TripleComponentComparator>;
+  using Vocab =
+      Vocabulary<CompressedString, TripleComponentComparator, VocabIndex>;
   [[nodiscard]] const Vocab& getVocab() const;
   Vocab& getNonConstVocabForTesting();
 
-  using TextVocab = Vocabulary<std::string, SimpleStringComparator>;
+  using TextVocab =
+      Vocabulary<std::string, SimpleStringComparator, WordVocabIndex>;
   [[nodiscard]] const TextVocab& getTextVocab() const;
 
   // --------------------------------------------------------------------------

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -185,6 +185,7 @@ void IndexImpl::addTextFromOnDiskIndex() {
       std::move(textIndexFile_));
   serializer.setSerializationPosition(metaFrom);
   serializer >> textMeta_;
+  textMeta_.removeEntityBlocks();
   textIndexFile_ = std::move(serializer).file();
   LOG(INFO) << "Registered text index: " << textMeta_.statistics() << std::endl;
 

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -9,6 +9,7 @@
 #include <absl/strings/str_split.h>
 
 #include <algorithm>
+#include <ranges>
 #include <stxxl/algorithm>
 #include <tuple>
 #include <utility>
@@ -271,7 +272,7 @@ void IndexImpl::processWordsForInvertedLists(const string& contextFile,
     } else {
       ++nofWordPostings;
       // TODO<joka921> Let the `textVocab_` return a `WordIndex` directly.
-      VocabIndex vid;
+      WordVocabIndex vid;
       bool ret = textVocab_.getId(line._word, &vid);
       WordIndex wid = vid.get();
       if (!ret) {
@@ -597,7 +598,7 @@ void IndexImpl::calculateBlockBoundariesImpl(
     }
   };
 
-  auto getLengthAndPrefixSortKey = [&](VocabIndex i) {
+  auto getLengthAndPrefixSortKey = [&](WordVocabIndex i) {
     auto word = index.textVocab_[i].value();
     auto [len, prefixSortKey] =
         locManager.getPrefixSortKey(word, MIN_WORD_PREFIX_SIZE);
@@ -612,13 +613,13 @@ void IndexImpl::calculateBlockBoundariesImpl(
     return std::tuple{std::move(len), std::move(prefixSortKey)};
   };
   auto [currentLen, prefixSortKey] =
-      getLengthAndPrefixSortKey(VocabIndex::make(0));
+      getLengthAndPrefixSortKey(WordVocabIndex::make(0));
   for (size_t i = 0; i < index.textVocab_.size() - 1; ++i) {
     // we need foo.value().get() because the vocab returns
     // a std::optional<std::reference_wrapper<string>> and the "." currently
     // doesn't implicitly convert to a true reference (unlike function calls)
     const auto& [nextLen, nextPrefixSortKey] =
-        getLengthAndPrefixSortKey(VocabIndex::make(i + 1));
+        getLengthAndPrefixSortKey(WordVocabIndex::make(i + 1));
 
     bool tooShortButNotEqual =
         (currentLen < MIN_WORD_PREFIX_SIZE || nextLen < MIN_WORD_PREFIX_SIZE) &&
@@ -646,20 +647,6 @@ void IndexImpl::calculateBlockBoundaries() {
     blockBoundaries_.push_back(i);
   };
   return calculateBlockBoundariesImpl(*this, addToBlockBoundaries);
-}
-
-// _____________________________________________________________________________
-void IndexImpl::printBlockBoundariesToFile(const string& filename) const {
-  std::ofstream of{filename};
-  of << "Printing block boundaries ot text vocabulary\n"
-     << "Format: <Last word of Block> <First word of next Block>\n";
-  auto printBlockToFile = [this, &of](size_t i) {
-    of << textVocab_[VocabIndex::make(i)].value() << " ";
-    if (i + 1 < textVocab_.size()) {
-      of << textVocab_[VocabIndex::make(i + 1)].value() << '\n';
-    }
-  };
-  return calculateBlockBoundariesImpl(*this, printBlockToFile);
 }
 
 // _____________________________________________________________________________
@@ -763,7 +750,7 @@ void IndexImpl::openTextFileHandle() {
 
 // _____________________________________________________________________________
 std::string_view IndexImpl::wordIdToString(WordIndex wordIndex) const {
-  return textVocab_[VocabIndex::make(wordIndex)].value();
+  return textVocab_[WordVocabIndex::make(wordIndex)].value();
 }
 
 // _____________________________________________________________________________
@@ -844,42 +831,16 @@ Index::WordEntityPostings IndexImpl::readWordEntityCl(
 // _____________________________________________________________________________
 Index::WordEntityPostings IndexImpl::getWordPostingsForTerm(
     const string& term) const {
-  assert(!term.empty());
   LOG(DEBUG) << "Getting word postings for term: " << term << '\n';
-  IdRange idRange;
   Index::WordEntityPostings wep;
-  bool entityTerm = (term[0] == '<' && term.back() == '>');
-  if (term[term.size() - 1] == PREFIX_CHAR) {
-    if (!textVocab_.getIdRangeForFullTextPrefix(term, &idRange)) {
-      LOG(INFO) << "Prefix: " << term << " not in vocabulary\n";
-      return wep;
-    }
-  } else {
-    if (entityTerm) {
-      if (!vocab_.getId(term, &idRange._first)) {
-        LOG(INFO) << "Term: " << term << " not in entity vocabulary\n";
-        return wep;
-      }
-    } else if (!textVocab_.getId(term, &idRange._first)) {
-      LOG(INFO) << "Term: " << term << " not in vocabulary\n";
-      return wep;
-    }
-    idRange._last = idRange._first;
-  }
-  if (entityTerm &&
-      !textMeta_.existsTextBlockForEntityId(idRange._first.get())) {
-    LOG(INFO) << "Entity " << term << " not contained in the text.\n";
+  auto optionalTbmd = getTextBlockMetaDataForWordOrPrefix(term);
+  if (!optionalTbmd.has_value()) {
     return wep;
   }
-  const auto& tbmd =
-      entityTerm ? textMeta_.getBlockInfoByEntityId(idRange._first.get())
-                 : textMeta_.getBlockInfoByWordRange(idRange._first.get(),
-                                                     idRange._last.get());
+  const auto& tbmd = optionalTbmd.value().tbmd_;
   wep = readWordCl(tbmd);
-  if (tbmd._cl.hasMultipleWords() &&
-      !(tbmd._firstWordId == idRange._first.get() &&
-        tbmd._lastWordId == idRange._last.get())) {
-    wep = FTSAlgorithms::filterByRange(idRange, wep);
+  if (optionalTbmd.value().hasToBeFiltered_) {
+    wep = FTSAlgorithms::filterByRange(optionalTbmd.value().idRange_, wep);
   }
   LOG(DEBUG) << "Word postings for term: " << term
              << ": cids: " << wep.cids_.size() << " scores "
@@ -1043,37 +1004,13 @@ void IndexImpl::getFilteredECListForWordsWidthOne(const string& words,
 Index::WordEntityPostings IndexImpl::getEntityPostingsForTerm(
     const string& term) const {
   LOG(DEBUG) << "Getting entity postings for term: " << term << '\n';
-  IdRange idRange;
   Index::WordEntityPostings resultWep;
-  bool entityTerm = (term[0] == '<' && term.back() == '>');
-  if (term.back() == PREFIX_CHAR) {
-    if (!textVocab_.getIdRangeForFullTextPrefix(term, &idRange)) {
-      LOG(INFO) << "Prefix: " << term << " not in vocabulary\n";
-      return resultWep;
-    }
-  } else {
-    if (entityTerm) {
-      if (!vocab_.getId(term, &idRange._first)) {
-        LOG(DEBUG) << "Term: " << term << " not in entity vocabulary\n";
-        return resultWep;
-      }
-    } else if (!textVocab_.getId(term, &idRange._first)) {
-      LOG(DEBUG) << "Term: " << term << " not in vocabulary\n";
-      return resultWep;
-    }
-    idRange._last = idRange._first;
+  auto optTbmd = getTextBlockMetaDataForWordOrPrefix(term);
+  if (!optTbmd.has_value()) {
+    return resultWep;
   }
-
-  // TODO<joka921> Find out which ID types the `getBlockInfo...` functions
-  // should take.
-  const auto& tbmd =
-      entityTerm ? textMeta_.getBlockInfoByEntityId(idRange._first.get())
-                 : textMeta_.getBlockInfoByWordRange(idRange._first.get(),
-                                                     idRange._last.get());
-
-  if (!tbmd._cl.hasMultipleWords() ||
-      (tbmd._firstWordId == idRange._first.get() &&
-       tbmd._lastWordId == idRange._last.get())) {
+  const auto& tbmd = optTbmd.value().tbmd_;
+  if (!optTbmd.value().hasToBeFiltered_) {
     // CASE: Only one word in the block or full block should be matched.
     // Hence we can just read the entity CL lists for co-occurring
     // entity postings.
@@ -1410,33 +1347,17 @@ size_t IndexImpl::getIndexOfBestSuitedElTerm(
   // Apart from that, entity lists are usually larger by a factor.
   // Hence it makes sense to choose the smallest.
 
-  // Heuristic: Always prefer no-filtering terms over otheres, then
+  // Heuristic: Always prefer no-filtering terms over others, then
   // pick the one with the smallest EL block to be read.
   std::vector<std::tuple<size_t, bool, size_t>> toBeSorted;
   for (size_t i = 0; i < terms.size(); ++i) {
-    bool entityTerm = (terms[i][0] == '<' && terms[i].back() == '>');
-    IdRange range;
-    if (terms[i].back() == PREFIX_CHAR) {
-      textVocab_.getIdRangeForFullTextPrefix(terms[i], &range);
-    } else {
-      if (entityTerm) {
-        if (!vocab_.getId(terms[i], &range._first)) {
-          LOG(DEBUG) << "Term: " << terms[i] << " not in entity vocabulary\n";
-          return i;
-        } else {
-        }
-      } else if (!textVocab_.getId(terms[i], &range._first)) {
-        LOG(DEBUG) << "Term: " << terms[i] << " not in vocabulary\n";
-        return i;
-      }
-      range._last = range._first;
+    auto optTbmd = getTextBlockMetaDataForWordOrPrefix(terms[i]);
+    if (!optTbmd.has_value()) {
+      return i;
     }
-    const auto& tbmd =
-        entityTerm ? textMeta_.getBlockInfoByEntityId(range._first.get())
-                   : textMeta_.getBlockInfoByWordRange(range._first.get(),
-                                                       range._last.get());
-    toBeSorted.emplace_back(std::make_tuple(
-        i, tbmd._firstWordId == tbmd._lastWordId, tbmd._entityCl._nofElements));
+    const auto& tbmd = optTbmd.value().tbmd_;
+    toBeSorted.emplace_back(i, tbmd._firstWordId == tbmd._lastWordId,
+                            tbmd._entityCl._nofElements);
   }
   std::sort(toBeSorted.begin(), toBeSorted.end(),
             [](const std::tuple<size_t, bool, size_t>& a,
@@ -1607,38 +1528,21 @@ void IndexImpl::getECListForWordsAndSubtrees(
 
 // _____________________________________________________________________________
 size_t IndexImpl::getSizeEstimate(const string& words) const {
-  size_t minElLength = std::numeric_limits<size_t>::max();
   // TODO vector can be of type std::string_view if called functions
   //  are updated to accept std::string_view instead of const std::string&
   std::vector<std::string> terms = absl::StrSplit(words, ' ');
-  for (size_t i = 0; i < terms.size(); ++i) {
-    IdRange range;
-    bool entityTerm = (terms[i][0] == '<' && terms[i].back() == '>');
-    if (terms[i].back() == PREFIX_CHAR) {
-      if (!textVocab_.getIdRangeForFullTextPrefix(terms[i], &range)) {
-        return 0;
-      }
-    } else {
-      if (entityTerm) {
-        if (!vocab_.getId(terms[i], &range._first)) {
-          LOG(DEBUG) << "Term: " << terms[i] << " not in entity vocabulary\n";
-          return 0;
-        }
-      } else if (!textVocab_.getId(terms[i], &range._first)) {
-        LOG(DEBUG) << "Term: " << terms[i] << " not in vocabulary\n";
-        return 0;
-      }
-      range._last = range._first;
-    }
-    const auto& tbmd =
-        entityTerm ? textMeta_.getBlockInfoByEntityId(range._first.get())
-                   : textMeta_.getBlockInfoByWordRange(range._first.get(),
-                                                       range._last.get());
-    if (minElLength > tbmd._entityCl._nofElements) {
-      minElLength = tbmd._entityCl._nofElements;
-    }
+  if (terms.empty()) {
+    return 0;
   }
-  return 1 + minElLength / 100;
+  auto termToEstimate = [&](const std::string& term) -> size_t {
+    auto optTbmd = getTextBlockMetaDataForWordOrPrefix(term);
+    // TODO<C++23> Use `std::optional::transform`.
+    if (!optTbmd.has_value()) {
+      return 0;
+    }
+    return 1 + optTbmd.value().tbmd_._entityCl._nofElements / 100;
+  };
+  return std::ranges::min(terms | std::views::transform(termToEstimate));
 }
 
 // _____________________________________________________________________________
@@ -1667,3 +1571,28 @@ void IndexImpl::getRhsForSingleLhs(const IdTable& in, Id lhsId,
 
 // _____________________________________________________________________________
 void IndexImpl::setTextName(const string& name) { textMeta_.setName(name); }
+
+// _____________________________________________________________________________
+auto IndexImpl::getTextBlockMetaDataForWordOrPrefix(const std::string& word)
+    const -> std::optional<TextBlockMetaDataAndWordInfo> {
+  AD_CORRECTNESS_CHECK(!word.empty());
+  IdRange<WordVocabIndex> idRange;
+  if (word.ends_with(PREFIX_CHAR)) {
+    if (!textVocab_.getIdRangeForFullTextPrefix(word, &idRange)) {
+      LOG(INFO) << "Prefix: " << word << " not in vocabulary\n";
+      return std::nullopt;
+    }
+  } else {
+    if (!textVocab_.getId(word, &idRange._first)) {
+      LOG(INFO) << "Term: " << word << " not in vocabulary\n";
+      return std::nullopt;
+    }
+    idRange._last = idRange._first;
+  }
+  const auto& tbmd = textMeta_.getBlockInfoByWordRange(idRange._first.get(),
+                                                       idRange._last.get());
+  bool hasToBeFiltered = tbmd._cl.hasMultipleWords() &&
+                         !(tbmd._firstWordId == idRange._first.get() &&
+                           tbmd._lastWordId == idRange._last.get());
+  return TextBlockMetaDataAndWordInfo{tbmd, hasToBeFiltered, idRange};
+}

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -115,10 +115,10 @@ class IndexImpl {
   bool keepTempFiles_ = false;
   uint64_t stxxlMemoryInBytes_ = DEFAULT_STXXL_MEMORY_IN_BYTES;
   json configurationJson_;
-  Vocabulary<CompressedString, TripleComponentComparator> vocab_;
+  Index::Vocab vocab_;
   size_t totalVocabularySize_ = 0;
   bool vocabPrefixCompressed_ = true;
-  Vocabulary<std::string, SimpleStringComparator> textVocab_;
+  Index::TextVocab textVocab_;
 
   TextMetaData textMeta_;
   DocsDB docsDB_;
@@ -565,6 +565,23 @@ class IndexImpl {
 
   size_t getIndexOfBestSuitedElTerm(const vector<string>& terms) const;
 
+  // Get the metadata for the block from the text index that contains the
+  // `word`. Also works for prefixes that are terminated with a * like "astro*".
+  // Returns `nullopt` if no suitable block was found because no matching word
+  // is contained in the text index. Some additional information is also
+  // returned that is often required by the calling functions:
+  // `hasToBeFiltered_` is true iff `word` is NOT the only word in the text
+  // block, and additional filtering is thus required. `idRange_` is the range
+  // `[first, last]` of the `WordVocabIndex`es that correspond to the word
+  // (which might also be a prefix, thus it is a range).
+  struct TextBlockMetaDataAndWordInfo {
+    TextBlockMetaData tbmd_;
+    bool hasToBeFiltered_;
+    IdRange<WordVocabIndex> idRange_;
+  };
+  std::optional<TextBlockMetaDataAndWordInfo>
+  getTextBlockMetaDataForWordOrPrefix(const std::string& word) const;
+
   /// Calculate the block boundaries for the text index. The boundary of a
   /// block is the index in the `textVocab_` of the last word that belongs
   /// to this block.
@@ -579,12 +596,6 @@ class IndexImpl {
   /// Calculate the block boundaries for the text index, and store them in the
   /// blockBoundaries_ member.
   void calculateBlockBoundaries();
-
-  /// Calculate the block boundaries for the text index, and store the
-  /// corresponding words in a human-readable text file at `filename`.
-  /// This is for debugging the text index. Internally uses
-  /// `caluclateBlockBoundariesImpl`.
-  void printBlockBoundariesToFile(const string& filename) const;
 
   TextBlockIndex getWordBlockId(WordIndex wordIndex) const;
 

--- a/src/index/TextMetaData.cpp
+++ b/src/index/TextMetaData.cpp
@@ -44,40 +44,6 @@ const TextBlockMetaData& TextMetaData::getBlockInfoByWordRange(
 }
 
 // _____________________________________________________________________________
-bool TextMetaData::existsTextBlockForEntityId(const uint64_t eid) const {
-  assert(_blocks.size() > 0);
-  assert(_blocks.size() ==
-         _blockUpperBoundWordIds.size() + _blockUpperBoundEntityIds.size());
-
-  // Binary search in the sorted _blockUpperBoundWordIds vector.
-  auto it = std::lower_bound(_blockUpperBoundEntityIds.begin(),
-                             _blockUpperBoundEntityIds.end(), eid);
-
-  return (*it == eid);
-}
-
-// _____________________________________________________________________________
-const TextBlockMetaData& TextMetaData::getBlockInfoByEntityId(
-    const uint64_t eid) const {
-  assert(_blocks.size() > 0);
-  assert(_blocks.size() ==
-         _blockUpperBoundWordIds.size() + _blockUpperBoundEntityIds.size());
-
-  // Binary search in the sorted _blockUpperBoundWordIds vector.
-  auto it = std::lower_bound(_blockUpperBoundEntityIds.begin(),
-                             _blockUpperBoundEntityIds.end(), eid);
-
-  assert(*it == eid);
-
-  // Use the info to retrieve an index.
-  size_t index = static_cast<size_t>(it - _blockUpperBoundEntityIds.begin()) +
-                 _blockUpperBoundWordIds.size();
-  assert(eid == _blocks[index]._lastWordId);
-  assert(eid == _blocks[index]._firstWordId);
-  return _blocks[index];
-}
-
-// _____________________________________________________________________________
 size_t TextMetaData::getBlockCount() const { return _blocks.size(); }
 
 // _____________________________________________________________________________
@@ -117,4 +83,10 @@ void TextMetaData::addBlock(const TextBlockMetaData& md, bool isEntityBlock) {
 // _____________________________________________________________________________
 off_t TextMetaData::getOffsetAfter() {
   return _blocks.back()._entityCl._lastByte + 1;
+}
+
+void TextMetaData::removeEntityBlocks() {
+  _blocks.resize(_blockUpperBoundWordIds.size());
+  _blocks.shrink_to_fit();
+  _blockUpperBoundEntityIds.clear();
 }

--- a/src/index/TextMetaData.h
+++ b/src/index/TextMetaData.h
@@ -76,15 +76,14 @@ class TextMetaData {
   const TextBlockMetaData& getBlockInfoByWordRange(const uint64_t lower,
                                                    const uint64_t upper) const;
 
-  const TextBlockMetaData& getBlockInfoByEntityId(const uint64_t eid) const;
-
-  bool existsTextBlockForEntityId(const uint64_t eid) const;
-
   size_t getBlockCount() const;
 
   string statistics() const;
 
   void addBlock(const TextBlockMetaData& md, bool isEntityBlock);
+
+  // TODO<joka921> This is just for testing.
+  void removeEntityBlocks();
 
   off_t getOffsetAfter();
 

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -35,31 +35,24 @@ using std::string;
 using std::vector;
 
 template <class StringType>
-struct AccessReturnTypeGetter {};
+using AccessReturnType_t =
+    std::conditional_t<std::is_same_v<StringType, CompressedString>,
+                       std::string, std::string_view>;
 
-template <>
-struct AccessReturnTypeGetter<string> {
-  using type = std::string_view;
-};
-template <>
-struct AccessReturnTypeGetter<CompressedString> {
-  using type = string;
-};
-
-template <class StringType>
-using AccessReturnType_t = typename AccessReturnTypeGetter<StringType>::type;
-
+template <typename IndexT = WordVocabIndex>
 struct IdRange {
   IdRange() : _first(), _last() {}
 
-  IdRange(VocabIndex first, VocabIndex last) : _first(first), _last(last) {}
+  IdRange(IndexT first, IndexT last) : _first(first), _last(last) {}
 
-  VocabIndex _first;
-  VocabIndex _last;
+  IndexT _first;
+  IndexT _last;
 };
 
 //! Stream operator for convenience.
-inline std::ostream& operator<<(std::ostream& stream, const IdRange& idRange) {
+template <typename IndexT>
+inline std::ostream& operator<<(std::ostream& stream,
+                                const IdRange<IndexT>& idRange) {
   return stream << '[' << idRange._first << ", " << idRange._last << ']';
 }
 
@@ -78,7 +71,8 @@ struct Prefix {
 //! Template parameters that are supported are:
 //! std::string -> no compression is applied
 //! CompressedString -> prefix compression is applied
-template <class StringType, class ComparatorType>
+template <typename StringType, typename ComparatorType,
+          typename IndexT = VocabIndex>
 class Vocabulary {
   // The different type of data that is stored in the vocabulary
   enum class Datatypes { Literal, Iri, Float, Date };
@@ -93,6 +87,7 @@ class Vocabulary {
 
  public:
   using SortLevel = typename ComparatorType::Level;
+  using IndexType = IndexT;
 
   template <
       typename = std::enable_if_t<std::is_same_v<StringType, string> ||
@@ -125,20 +120,20 @@ class Vocabulary {
   //! word is not in the vocabulary.
   //! Only enabled when uncompressed which also means no externalization
   template <typename U = StringType, typename = enable_if_uncompressed<U>>
-  const std::optional<std::string_view> operator[](VocabIndex idx) const;
+  std::optional<std::string_view> operator[](IndexType idx) const;
 
   //! Get the word with the given idx or an empty optional if the
   //! word is not in the vocabulary. Returns an lvalue because compressed or
   //! externalized words don't allow references
   template <typename U = StringType>
   [[nodiscard]] std::optional<string> indexToOptionalString(
-      VocabIndex idx) const;
+      IndexType idx) const;
 
   //! Get the word with the given idx.
   //! lvalue for compressedString and const& for string-based vocabulary
-  AccessReturnType_t<StringType> at(VocabIndex idx) const;
+  AccessReturnType_t<StringType> at(IndexType idx) const;
 
-  // AccessReturnType_t<StringType> at(VocabIndex idx) const { return
+  // AccessReturnType_t<StringType> at(IndexType idx) const { return
   // operator[](id); }
 
   //! Get the number of words in the vocabulary.
@@ -146,33 +141,7 @@ class Vocabulary {
 
   //! Get an Id from the vocabulary for some "normal" word.
   //! Return value signals if something was found at all.
-  bool getId(const string& word, VocabIndex* idx) const;
-
-  VocabIndex getValueIdForLT(const string& indexWord,
-                             const SortLevel level) const {
-    VocabIndex lb = lower_bound(indexWord, level);
-    return lb;
-  }
-  VocabIndex getValueIdForGE(const string& indexWord,
-                             const SortLevel level) const {
-    return getValueIdForLT(indexWord, level);
-  }
-
-  VocabIndex getValueIdForLE(const string& indexWord,
-                             const SortLevel level) const {
-    VocabIndex lb = upper_bound(indexWord, level);
-    if (lb.get() > 0) {
-      // We actually retrieved the first word that is bigger than our entry.
-      // TODO<joka921>: What to do, if the 0th entry is already too big?
-      lb = lb.decremented();
-    }
-    return lb;
-  }
-
-  VocabIndex getValueIdForGT(const string& indexWord,
-                             const SortLevel level) const {
-    return getValueIdForLE(indexWord, level);
-  }
+  bool getId(const string& word, IndexType* idx) const;
 
   //! Get an Id range that matches a prefix.
   //! Return value signals if something was found at all.
@@ -180,9 +149,10 @@ class Vocabulary {
   //! and uses a range, where the last index is still within the range which is
   //! against C++ conventions!
   // consider using the prefixRange function.
-  bool getIdRangeForFullTextPrefix(const string& word, IdRange* range) const;
+  bool getIdRangeForFullTextPrefix(const string& word,
+                                   IdRange<IndexType>* range) const;
 
-  ad_utility::HashMap<Datatypes, std::pair<VocabIndex, VocabIndex>>
+  ad_utility::HashMap<Datatypes, std::pair<IndexType, IndexType>>
   getRangesForDatatypes() const;
 
   template <typename U = StringType, typename = enable_if_compressed<U>>
@@ -249,18 +219,18 @@ class Vocabulary {
   /// prefix according to the collation level the first Id is included in the
   /// range, the last one not. Currently only supports the Primary collation
   /// level, due to limitations in the StringSortComparators
-  std::pair<VocabIndex, VocabIndex> prefix_range(const string& prefix) const;
+  std::pair<IndexType, IndexType> prefix_range(const string& prefix) const;
 
   [[nodiscard]] const LocaleManager& getLocaleManager() const {
     return getCaseComparator().getLocaleManager();
   }
 
   // Wraps std::lower_bound and returns an index instead of an iterator
-  VocabIndex lower_bound(const string& word,
-                         const SortLevel level = SortLevel::QUARTERNARY) const;
+  IndexType lower_bound(const string& word,
+                        const SortLevel level = SortLevel::QUARTERNARY) const;
 
   // _______________________________________________________________
-  VocabIndex upper_bound(const string& word, const SortLevel level) const;
+  IndexType upper_bound(const string& word, const SortLevel level) const;
 
  private:
   // If a word starts with one of those prefixes it will be externalized
@@ -304,15 +274,16 @@ class Vocabulary {
   }
 };
 
-using RdfsVocabulary = Vocabulary<CompressedString, TripleComponentComparator>;
-using TextVocabulary = Vocabulary<std::string, SimpleStringComparator>;
-using TextVocabulary = Vocabulary<std::string, SimpleStringComparator>;
+using RdfsVocabulary =
+    Vocabulary<CompressedString, TripleComponentComparator, VocabIndex>;
+using TextVocabulary =
+    Vocabulary<std::string, SimpleStringComparator, WordVocabIndex>;
 
 // _______________________________________________________________
-template <typename S, typename C>
+template <typename S, typename C, typename I>
 template <typename>
-std::optional<string> Vocabulary<S, C>::indexToOptionalString(
-    VocabIndex idx) const {
+std::optional<string> Vocabulary<S, C, I>::indexToOptionalString(
+    IndexType idx) const {
   if (idx.get() < _internalVocabulary.size()) {
     return std::optional<string>(_internalVocabulary[idx.get()]);
   } else {

--- a/test/FTSAlgorithmsTest.cpp
+++ b/test/FTSAlgorithmsTest.cpp
@@ -17,9 +17,9 @@ auto V = VocabId;
 }  // namespace
 
 TEST(FTSAlgorithmsTest, filterByRangeTest) {
-  IdRange idRange;
-  idRange._first = VocabIndex::make(5);
-  idRange._last = VocabIndex::make(7);
+  IdRange<WordVocabIndex> idRange;
+  idRange._first = WordVocabIndex::make(5);
+  idRange._last = WordVocabIndex::make(7);
 
   Index::WordEntityPostings wep;
   Index::WordEntityPostings resultWep;

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -315,7 +315,7 @@ TEST(LocalVocab, propagation) {
   // vocabulary of the operation remains empty (but it doesn't harm to check
   // that that is indeed the case).
   TextOperationWithFilter text1(
-      testQec, "", {Variable{"?x"}, Variable{"?y"}, Variable{"?text"}},
+      testQec, "someWord", {Variable{"?x"}, Variable{"?y"}, Variable{"?text"}},
       Variable{"?text"}, qet(values1), 0);
   checkLocalVocab(text1, std::vector<std::string>{"x", "y1", "y2"});
   TextOperationWithoutFilter text2(testQec, {"someWord"}, {Variable{"?text"}},

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -19,7 +19,7 @@ TEST(VocabularyTest, getIdForWordTest) {
   ad_utility::HashSet<std::string> s{"a", "ab", "ba", "car"};
   for (auto& v : vec) {
     v.createFromSet(s);
-    VocabIndex idx;
+    WordVocabIndex idx;
     ASSERT_TRUE(v.getId("ba", &idx));
     ASSERT_EQ(2u, idx.get());
     ASSERT_TRUE(v.getId("a", &idx));
@@ -32,14 +32,14 @@ TEST(VocabularyTest, getIdForWordTest) {
   voc.setLocale("en", "US", false);
   ad_utility::HashSet<string> s2{"a", "A", "Ba", "car"};
   voc.createFromSet(s2);
-  VocabIndex idx;
+  WordVocabIndex idx;
   ASSERT_TRUE(voc.getId("Ba", &idx));
   ASSERT_EQ(2u, idx.get());
   ASSERT_TRUE(voc.getId("a", &idx));
   ASSERT_EQ(0u, idx.get());
   // getId only gets exact matches;
   ASSERT_FALSE(voc.getId("ba", &idx));
-};
+}
 
 TEST(VocabularyTest, getIdRangeForFullTextPrefixTest) {
   TextVocabulary v;
@@ -97,13 +97,13 @@ TEST(VocabularyTest, createFromSetTest) {
   s.insert("car");
   TextVocabulary v;
   v.createFromSet(s);
-  VocabIndex idx;
+  WordVocabIndex idx;
   ASSERT_TRUE(v.getId("ba", &idx));
   ASSERT_EQ(2u, idx.get());
   ASSERT_TRUE(v.getId("a", &idx));
   ASSERT_EQ(0u, idx.get());
   ASSERT_FALSE(v.getId("foo", &idx));
-};
+}
 
 TEST(VocabularyTest, IncompleteLiterals) {
   TripleComponentComparator comp("en", "US", false);


### PR DESCRIPTION
The (probably unused) blocks from the entities are loaded, but immediately erased again. 
Let's see if this 
* works
* frees the unused memory.