### PR TITLE
Give each index a (reasonably) unique ID

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -312,6 +312,10 @@ Awaitable<void> Server::process(
   } else if (auto cmd = checkParameter("cmd", "get-settings")) {
     logCommand(cmd, "get server settings");
     response = createJsonResponse(RuntimeParameters().toMap(), request);
+  } else if (auto cmd = checkParameter("cmd", "get-index-id")) {
+    logCommand(cmd, "get index ID");
+    response = createOkResponse(index_.getIndexId(), request,
+                                ad_utility::MediaType::textPlain);
   } else if (auto cmd =
                  checkParameter("cmd", "dump-active-queries", accessTokenOk)) {
     logCommand(cmd, "dump active queries");

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -267,6 +267,9 @@ const std::string& Index::getTextName() const { return pimpl_->getTextName(); }
 const std::string& Index::getKbName() const { return pimpl_->getKbName(); }
 
 // ____________________________________________________________________________
+const std::string& Index::getIndexId() const { return pimpl_->getIndexId(); }
+
+// ____________________________________________________________________________
 Index::NumNormalAndInternal Index::numTriples() const {
   return pimpl_->numTriples();
 }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -237,6 +237,8 @@ class Index {
 
   const std::string& getKbName() const;
 
+  const std::string& getIndexId() const;
+
   NumNormalAndInternal numTriples() const;
 
   size_t getNofTextRecords() const;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1025,12 +1025,19 @@ void IndexImpl::readConfiguration() {
   };
 
   loadDataMember("has-all-permutations", loadAllPermutations_, true);
-
   loadDataMember("num-predicates-normal", numPredicatesNormal_);
   // These might be missing if there are only two permutations.
   loadDataMember("num-subjects-normal", numSubjectsNormal_, 0);
   loadDataMember("num-objects-normal", numObjectsNormal_, 0);
   loadDataMember("num-triples-normal", numTriplesNormal_);
+
+  // Compute unique ID for this index.
+  //
+  // TODO: This is a simplistic way. It would be better to incorporate bytes
+  // from the index files.
+  indexId_ = absl::StrCat("#", getKbName(), ".", numTriplesNormal_, ".",
+                          numSubjectsNormal_, ".", numPredicatesNormal_, ".",
+                          numObjectsNormal_);
 }
 
 // ___________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -158,6 +158,7 @@ class IndexImpl {
   size_t numPredicatesNormal_ = 0;
   size_t numObjectsNormal_ = 0;
   size_t numTriplesNormal_ = 0;
+  string indexId_;
   /**
    * @brief Maps pattern ids to sets of predicate ids.
    */
@@ -420,6 +421,8 @@ class IndexImpl {
   const string& getTextName() const { return textMeta_.getName(); }
 
   const string& getKbName() const { return pso_.metaData().getName(); }
+
+  const string& getIndexId() const { return indexId_; }
 
   size_t getNofTextRecords() const { return textMeta_.getNofTextRecords(); }
   size_t getNofWordPostings() const { return textMeta_.getNofWordPostings(); }

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -215,6 +215,19 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
   ASSERT_TRUE(index.POS().metaData().getMetaData(b2).isFunctional());
 };
 
+TEST(IndexTest, indexId) {
+  std::string kb =
+      "<a1> <b> <c1> .\n"
+      "<a2> <b> <c2> .\n"
+      "<a2> <b> <c1> .\n"
+      "<a3> <b> <c2> .";
+  // Build index with all permutations (arg 2) and no patterns (arg 3). That
+  // way, we get four triples, two distinct subjects, one distinct predicate
+  // and two distinct objects.
+  const Index& index = getQec(kb, true, false)->getIndex();
+  ASSERT_EQ(index.getIndexId(), "#.4.3.1.2");
+}
+
 TEST(IndexTest, scanTest) {
   auto testWithAndWithoutPrefixCompression = [](bool useCompression) {
     using enum Permutation::Enum;


### PR DESCRIPTION
The index ID is currently just a concatenation of the index name, and the number of triples, subjects, predicates, and objects. This makes it unlikely (but not impossible) that two different indexes have the same ID. The ID can be obtained via the API with `cmd=get-index-id`. 

This feature is useful for applications like https://github.com/ad-freiburg/qlever-petrimaps, which have an internal cache that depends on the index. When the index changes, the application should be able to notice that, and with the index ID, it now can.