### PR TITLE
Benchmark table without explicit row names

### DIFF
--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -172,11 +172,11 @@ class BMTables : public BenchmarkInterface {
     // Measuring functions.
     auto& tableExponentsWithBasis = results.addTable(
         "Exponents with the given basis", {"2", "3", "Time difference"},
-        {"0", "1", "2", "3", "4"});
+        {"Basis", "0", "1", "2", "3", "4"});
 
     auto& tableAddingExponents = results.addTable(
         "Adding exponents", {"2^10", "2^11", "Values written out"},
-        {"2^10", "2^11"});
+        {"", "2^10", "2^11"});
     // Adding some metadata.
     tableAddingExponents.metadata().addKeyValuePair("Manually set fields",
                                                     "Row 2");
@@ -184,28 +184,28 @@ class BMTables : public BenchmarkInterface {
     // Measure the calculating of the exponents.
     for (int i = 0; i < 5; i++) {
       tableExponentsWithBasis.addMeasurement(
-          0, i, [&exponentiateNTimes, &i]() { exponentiateNTimes(2, i); });
+          0, i + 1, [&exponentiateNTimes, &i]() { exponentiateNTimes(2, i); });
     }
     for (int i = 0; i < 5; i++) {
       tableExponentsWithBasis.addMeasurement(
-          1, i, [&exponentiateNTimes, &i]() { exponentiateNTimes(3, i); });
+          1, i + 1, [&exponentiateNTimes, &i]() { exponentiateNTimes(3, i); });
     }
     // Manually adding the entries of the third column by computing the timing
     // difference between the first two columns.
     for (size_t column = 0; column < 5; column++) {
       float entryWithBasis2 =
-          tableExponentsWithBasis.getEntry<float>(0, column);
+          tableExponentsWithBasis.getEntry<float>(0, column + 1);
       float entryWithBasis3 =
-          tableExponentsWithBasis.getEntry<float>(1, column);
+          tableExponentsWithBasis.getEntry<float>(1, column + 1);
       tableExponentsWithBasis.setEntry(
-          2, column, std::abs(entryWithBasis3 - entryWithBasis2));
+          2, column + 1, std::abs(entryWithBasis3 - entryWithBasis2));
     }
 
     // Measuers for calculating and adding the exponents.
     for (int row = 0; row < 2; row++) {
       for (int column = 0; column < 2; column++) {
         tableAddingExponents.addMeasurement(
-            row, column, [&exponentiateNTimes, &row, &column]() {
+            row, column + 1, [&exponentiateNTimes, &row, &column]() {
               size_t temp __attribute__((unused));
               temp = exponentiateNTimes(2, row + 10) +
                      exponentiateNTimes(2, column + 10);
@@ -214,8 +214,8 @@ class BMTables : public BenchmarkInterface {
     }
 
     // Manually setting strings.
-    tableAddingExponents.setEntry(2, 0, "1024+1024 and 1024+2048");
-    tableAddingExponents.setEntry(2, 1, "1024+2048 and 2048+2048");
+    tableAddingExponents.setEntry(2, 1, "1024+1024 and 1024+2048");
+    tableAddingExponents.setEntry(2, 2, "1024+2048 and 2048+2048");
 
     return results;
   }

--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -51,7 +51,7 @@ BenchmarkResults runAllBenchmarks(){
   // organization, require an identifier. A.k.a. a name.
   const std::string identifier = "Some identifier";
 
-  // Just saves the meausered execution time.
+  // Just saves the measured execution time.
   results.addMeasurement(identifier, dummyFunctionToMeasure);
 
   // Creates an enpty group. Doesn't measure anything.

--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -51,7 +51,7 @@ BenchmarkResults runAllBenchmarks(){
   // organization, require an identifier. A.k.a. a name.
   const std::string identifier = "Some identifier";
 
-  // Just saves the meausred execution time.
+  // Just saves the meausered execution time.
   results.addMeasurement(identifier, dummyFunctionToMeasure);
 
   // Creates an enpty group. Doesn't measure anything.
@@ -59,15 +59,23 @@ BenchmarkResults runAllBenchmarks(){
   // You add the measurements as group members.
   group.addMeasurement(identifier, dummyFunctionToMeasure);
 
-  // Create an empty table with a set number of rows and columns. Doesn't
-  // measure anything.
+  /*
+  Create an empty table with a set number of rows and columns. Doesn't
+  measure anything.
+  Important: The row names aren't saved in a seperate container, but INSIDE the
+  first column of the table.
+  */
   auto& table = results.addTable(identifier, {"rowName1", "rowName2", "etc."},
-    {"columnName1", "columnName2", "etc."});
+    {"Column for row names", "columnName1", "columnName2", "etc."});
+
   // You can add measurements to the table as entries, but you can also
   // read and set entries.
-  table.addMeasurement(0, 1, dummyFunctionToMeasure); // Row 0, column 1.
-  table.setEntry(0, 0, "A custom entry can be a float, or a string.");
-  table.getEntry(0, 1); // The measured time of the dummy function.
+  table.addMeasurement(0, 2, dummyFunctionToMeasure); // Row 0, column 1.
+  table.setEntry(0, 1, "A custom entry can be a float, or a string.");
+  table.getEntry(0, 2); // The measured time of the dummy function.
+
+  // Replacing a row name.
+  table.setEntry(0, 0, "rowName1++");
 
   return results;
 }

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -12,7 +14,6 @@
 #include <string_view>
 #include <utility>
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
-
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -14,6 +12,7 @@
 #include <string_view>
 #include <utility>
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkResultToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"
@@ -84,7 +83,6 @@ ResultTable::ResultTable(const std::string& descriptor,
                          const std::vector<std::string>& rowNames,
                          const std::vector<std::string>& columnNames)
     : descriptor_{descriptor},
-      rowNames_{rowNames},
       columnNames_{columnNames},
       entries_(rowNames.size(), std::vector<EntryType>(columnNames.size())) {
   // Having a table without any columns makes no sense.
@@ -93,6 +91,11 @@ ResultTable::ResultTable(const std::string& descriptor,
         absl::StrCat("A `ResultTable` must have at"
                      " least one column. Table '",
                      descriptor, "' has ", columnNames.size(), " columns"));
+  }
+
+  // Setting the row names.
+  for (size_t row = 0; row < rowNames.size(); row++) {
+    setEntry(row, 0, rowNames.at(row));
   }
 }
 
@@ -118,10 +121,10 @@ ResultTable::operator std::string() const {
     // types, that all need different handeling.
     // Fortunaly, we can decide the handeling at compile time and throw the
     // others away, using `if constexpr(std::is_same<...,...>::value)`.
-    if constexpr (std::is_same<T, std::monostate>::value) {
+    if constexpr (std::is_same_v<T, std::monostate>) {
       // No value, print it as NA.
       return (std::string) "NA";
-    } else if constexpr (std::is_same<T, float>::value) {
+    } else if constexpr (std::is_same_v<T, float>) {
       // There is a value, format it as specified.
       return absl::StrFormat(floatFormatSpecifier, entry);
     } else {
@@ -182,7 +185,7 @@ ResultTable::operator std::string() const {
   stream << getMetadataPrettyString(metadata(), "metadata: ", "\n");
 
   // It's allowed to have tables without rows. In that case, we are already
-  // nearly done,ause we only to have add the column names.
+  // nearly done, cause we only to have add the column names.
   if (numRows() == 0) {
     // Adding the column names. We don't need any padding.
     addRow(stream, ad_utility::transform(columnNames_, [](const auto& name) {
@@ -201,18 +204,6 @@ ResultTable::operator std::string() const {
 
   // For formating: What is the maximum string width of a column, if you
   // compare all it's entries?
-
-  // `std::ranges::max` has undefined behaviour, when given empty vectors.
-  // So, a quick check beforehand, using the names.
-  AD_CONTRACT_CHECK(!rowNames_.empty());
-
-  // The max width of the column containing the row names.
-  const size_t rowNameMaxStringWidth =
-      std::ranges::max(rowNames_, {}, [](std::string_view name) {
-        return name.length();
-      }).length();
-
-  // The max width for columns with actual entries.
   std::vector<size_t> columnMaxStringWidth(numberColumns, 0);
   for (size_t column = 0; column < numberColumns; column++) {
     // Which of the entries is the longest?
@@ -231,21 +222,8 @@ ResultTable::operator std::string() const {
             : columnNames_[column].length();
   }
 
-  /*
-  @brief Adds an entry to an rvalue vector and returns the resulting vector.
-  */
-  auto insertEntryInFrontOfRValueVector =
-      [](std::vector<std::pair<std::string, size_t>>&& vec,
-         std::pair<std::string, size_t>&& entry) {
-        vec.insert(vec.begin(), std::move(entry));
-        return std::move(vec);
-      };
-
   // Print the top row of names.
-  addRow(stream, insertEntryInFrontOfRValueVector(
-                     ad_utility::zipVectors(columnNames_, columnMaxStringWidth),
-                     std::make_pair(std::string(rowNameMaxStringWidth, ' '),
-                                    rowNameMaxStringWidth)));
+  addRow(stream, ad_utility::zipVectors(columnNames_, columnMaxStringWidth));
 
   // Print the rows.
   for (size_t row = 0; row < numberRows; row++) {
@@ -253,27 +231,22 @@ ResultTable::operator std::string() const {
     stream << "\n";
 
     // Actually printing the row.
-    addRow(stream,
-           insertEntryInFrontOfRValueVector(
-               ad_utility::zipVectors(
-                   ad_utility::transform(entries_.at(row), entryToString),
-                   columnMaxStringWidth),
-               std::make_pair(rowNames_[row], rowNameMaxStringWidth)));
+    addRow(stream, ad_utility::zipVectors(
+                       ad_utility::transform(entries_.at(row), entryToString),
+                       columnMaxStringWidth));
   }
 
   return absl::StrCat(prefix, addIndentation(stream.str(), 1));
 }
 
 // ____________________________________________________________________________
-void ResultTable::addRow(std::string_view rowName) {
-  // Add the row name.
-  rowNames_.emplace_back(rowName);
+void ResultTable::addRow() {
   // Create an emptry row of the same size as every other row.
   entries_.emplace_back(numColumns());
 }
 
 // ____________________________________________________________________________
-size_t ResultTable::numRows() const { return rowNames_.size(); }
+size_t ResultTable::numRows() const { return entries_.size(); }
 
 // ____________________________________________________________________________
 size_t ResultTable::numColumns() const {
@@ -287,7 +260,6 @@ size_t ResultTable::numColumns() const {
 // ____________________________________________________________________________
 void to_json(nlohmann::json& j, const ResultTable& resultTable) {
   j = nlohmann::json{{"descriptor", resultTable.descriptor_},
-                     {"rowNames", resultTable.rowNames_},
                      {"columnNames", resultTable.columnNames_},
                      {"entries", resultTable.entries_},
                      {"metadata", resultTable.metadata()}};

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -141,11 +141,10 @@ class ResultGroup : public BenchmarkMetadataGetter {
 class ResultTable : public BenchmarkMetadataGetter {
   // For identification.
   std::string descriptor_;
-  // The names of the columns and rows.
-  std::vector<std::string> rowNames_;
+  // The names of the columns.
   std::vector<std::string> columnNames_;
   // The entries in the table. Access is [row, column]. Can be the time in
-  // seconds, a string, or empty.
+  // seconds, a string, or empty. This is also, where you can put in row names.
   using EntryType = std::variant<std::monostate, float, std::string>;
   std::vector<std::vector<EntryType>> entries_;
 
@@ -158,7 +157,8 @@ class ResultTable : public BenchmarkMetadataGetter {
 
   @param descriptor A string to identify this instance in json format later.
   @param rowNames The names for the rows. The amount of rows in this table is
-  equal to the amount of row names.
+  equal to the amount of row names. Important: This first column will be filled
+  with those names.
   @param columnNames The names for the columns. The amount of columns in this
   table is equal to the amount of column names.
   */
@@ -180,7 +180,7 @@ class ResultTable : public BenchmarkMetadataGetter {
   requires std::invocable<Function>
   void addMeasurement(const size_t& row, const size_t& column,
                       const Function& functionToMeasure) {
-    AD_CONTRACT_CHECK(row < rowNames_.size() && column < columnNames_.size());
+    AD_CONTRACT_CHECK(row < numRows() && column < numColumns());
     entries_.at(row).at(column) = measureTimeOfFunction(functionToMeasure);
   }
 
@@ -207,6 +207,8 @@ class ResultTable : public BenchmarkMetadataGetter {
   template <typename T>
   requires std::is_same_v<T, float> || std::is_same_v<T, std::string>
   T getEntry(const size_t row, const size_t column) const {
+    AD_CONTRACT_CHECK(row < numRows() && column < numColumns());
+
     // There is a chance, that the entry of the table does NOT have type T,
     // in which case this will cause an error. As this is a mistake on the
     // side of the user, we don't really care.
@@ -218,10 +220,8 @@ class ResultTable : public BenchmarkMetadataGetter {
 
   /*
   @brief Adds a new empty row at the bottom of the table.
-
-  @param rowName The name of the row.
   */
-  void addRow(std::string_view rowName);
+  void addRow();
 
   /*
   The number of rows.

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -144,7 +144,7 @@ class ResultTable : public BenchmarkMetadataGetter {
   // The names of the columns.
   std::vector<std::string> columnNames_;
   // The entries in the table. Access is [row, column]. Can be the time in
-  // seconds, a string, or empty. This is also, where you can put in row names.
+  // seconds, a string, or empty.
   using EntryType = std::variant<std::monostate, float, std::string>;
   std::vector<std::vector<EntryType>> entries_;
 


### PR DESCRIPTION
On wish of my 'supervisor', I moved the names for rows in benchmark tables from a separate container object, to the container object for the normal table entries.