### PR TITLE
Fix CMake compiler compatibility error 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0.0")
-        MESSAGE(FATAL_ERROR "Clang++ versions older than 14.0 are not supported by QLever")
-    elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0")
-        add_compile_options(-fcoroutines-ts)
-        # starting from Clang 16, coroutines are enabled by default for C++ 20
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0")
+        MESSAGE(FATAL_ERROR "Clang++ versions older than 16.0 are not supported by QLever")
     endif()
 else()
     MESSAGE(FATAL_ERROR "QLever currently only supports the G++ or LLVM-Clang++ compilers. Found ${CMAKE_CXX_COMPILER_ID}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(QLever C CXX)
 
 # C/C++ Versions
-set (CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -11,20 +11,20 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # on clang and g++
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11.0.0")
-      MESSAGE(FATAL_ERROR, "G++ versions older than 11.0 are not supported by QLever")
+      MESSAGE(FATAL_ERROR "G++ versions older than 11.0 are not supported by QLever")
   else()
       add_compile_options(-fcoroutines)
   endif()
 
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0.0")
-        MESSAGE(FATAL_ERROR, "Clang++ versions older than 14.0 are not supported by QLever")
+        MESSAGE(FATAL_ERROR "Clang++ versions older than 14.0 are not supported by QLever")
     elseif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0.0")
         add_compile_options(-fcoroutines-ts)
         # starting from Clang 16, coroutines are enabled by default for C++ 20
     endif()
 else()
-    MESSAGE(FATAL_ERROR, "QLever currently only supports the G++ or LLVM-Clang++ compilers")
+    MESSAGE(FATAL_ERROR "QLever currently only supports the G++ or LLVM-Clang++ compilers. Found ${CMAKE_CXX_COMPILER_ID}")
 endif()
 
 ## Build targets for address sanitizer


### PR DESCRIPTION
When I tried building this on MacOS, I noticed that running `cmake` was printing a _warning_ about the compiler version, but still tried to compile the project and then ultimately produced an error about `std::source_location` not being found, as it [is not supported by Apple Clang](https://en.cppreference.com/w/cpp/compiler_support).

I believe the problem is a syntax error in the CMakelists.txt file. The presence of an extra comma changes how the `FATAL_ERROR` is interpreted.

With this fix to remove the comma, the error message is actually fatal as seems to be intended, and now it would print a more helpful message:

```
QLever currently only supports the G++ or LLVM-Clang++ compilers.  Found
  AppleClang
```

Note: it's still possible to build this on a Mac, just requires installing LLVM using homebrew and some other fixes.