### PR TITLE
Build fixes for MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,12 @@ if (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") AND
     else()
 endif ()
 
+IF(APPLE)
+    # Fix linking to homebrew-install libs like jemalloc on MacOS.
+    # See https://stackoverflow.com/questions/54068035
+    LINK_DIRECTORIES(/opt/homebrew/lib /usr/local/lib)
+ENDIF()
+
 ###############################################################################
 ##### Essential settings #####
 ###############################################################################

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -111,6 +111,7 @@ void MmapVector<T>::mapForWriting() {
 // ________________________________________________________________
 template <class T>
 void MmapVector<T>::remapLinux(size_t oldBytesize) {
+#ifdef __linux__
   void* ptr =
       mremap(static_cast<void*>(_ptr), oldBytesize, _bytesize, MREMAP_MAYMOVE);
   AD_CONTRACT_CHECK(ptr != MAP_FAILED);
@@ -118,6 +119,10 @@ void MmapVector<T>::remapLinux(size_t oldBytesize) {
   // after closing, because mmap increases the count by one
   _ptr = static_cast<T*>(ptr);
   advise(_pattern);
+#else
+  (void)oldBytesize; // tell compiler we know we're not using this parameter
+  throw ad_utility::Exception("remap only supported on Linux.");
+#endif
 }
 
 // __________________________________________________________________
@@ -153,6 +158,7 @@ void MmapVector<T>::adaptCapacity(size_t newCapacity) {
   writeMetaDataToEnd();
   remapLinux(oldBytesize);
 #else
+  (void)oldBytesize; // tell compiler we know we're not using this variable
   unmap();
   writeMetaDataToEnd();
   // renew the mapping because the file has changed


### PR DESCRIPTION
I tried to build this on a 64-bit ARM Mac, and ran into some minor issues:
* CMake wasn't properly configuring the linker to be able to link to `jemalloc`, when it gets installed by homebrew. Eventually I found the fix that's in this PR, which should make CMake automatically compatible with homebrew-installed libraries like `jemalloc` on either ARM64 or AMD64 Macs (which use different folders).
* There was a compilation error because `MREMAP_MAYMOVE` is not defined on MacOS (remap is not supported). It seems like the code was already _mostly_ in place to work around this on non-LInux platforms, which is great - I just had to use a preprocessor directive to avoid referencing `MREMAP_MAYMOVE`.