### PR TITLE
Consistently use the `ColumnIndex` typedef

### DIFF
--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -18,7 +18,7 @@ for source in "${SOURCE_FILES[@]}" ;do
 		printf "Use clang-format with the .clang-format provided in the QLever\n"
 		printf "repository's root to ensure all code files are formatted "
 		printf "properly. We currently use clang-format 16\n"
-		printf "(See `.github/workflows/format-check.yml` for instructions on how to install it.\n"
+		printf "(See '.github/workflows/format-check.yml' for instructions on how to install it.\n"
 		printf "\x1b[m"
 		ERROR=1
 	fi

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -42,7 +42,7 @@ float Bind::getMultiplicity(size_t col) {
 string Bind::getDescriptor() const { return _bind.getDescriptor(); }
 
 // _____________________________________________________________________________
-[[nodiscard]] vector<size_t> Bind::resultSortedOn() const {
+[[nodiscard]] vector<ColumnIndex> Bind::resultSortedOn() const {
   // We always append the result column of the BIND at the end and this column
   // is not sorted, so the sequence of indices of the sorted columns do not
   // change.

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -43,7 +43,7 @@ class Bind : public Operation {
   }
 
  protected:
-  [[nodiscard]] vector<size_t> resultSortedOn() const override;
+  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
  private:
   ResultTable computeResult() override;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -55,7 +55,7 @@ string CountAvailablePredicates::getDescriptor() const {
 size_t CountAvailablePredicates::getResultWidth() const { return 2; }
 
 // _____________________________________________________________________________
-vector<size_t> CountAvailablePredicates::resultSortedOn() const {
+vector<ColumnIndex> CountAvailablePredicates::resultSortedOn() const {
   // The result is not sorted on any column.
   return {};
 }

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -58,7 +58,7 @@ class CountAvailablePredicates : public Operation {
 
   [[nodiscard]] size_t getResultWidth() const override;
 
-  [[nodiscard]] vector<size_t> resultSortedOn() const override;
+  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
   vector<QueryExecutionTree*> getChildren() override {
     using R = vector<QueryExecutionTree*>;

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -17,7 +17,7 @@ size_t Distinct::getResultWidth() const { return _subtree->getResultWidth(); }
 // _____________________________________________________________________________
 Distinct::Distinct(QueryExecutionContext* qec,
                    std::shared_ptr<QueryExecutionTree> subtree,
-                   const vector<size_t>& keepIndices)
+                   const vector<ColumnIndex>& keepIndices)
     : Operation(qec), _subtree(subtree), _keepIndices(keepIndices) {}
 
 // _____________________________________________________________________________

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -19,19 +19,19 @@ using std::vector;
 class Distinct : public Operation {
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
-  vector<size_t> _keepIndices;
+  vector<ColumnIndex> _keepIndices;
 
  public:
   Distinct(QueryExecutionContext* qec,
            std::shared_ptr<QueryExecutionTree> subtree,
-           const vector<size_t>& keepIndices);
+           const vector<ColumnIndex>& keepIndices);
 
   [[nodiscard]] size_t getResultWidth() const override;
 
  public:
   [[nodiscard]] string getDescriptor() const override;
 
-  [[nodiscard]] vector<size_t> resultSortedOn() const override {
+  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override {
     return _subtree->resultSortedOn();
   }
 

--- a/src/engine/Engine.h
+++ b/src/engine/Engine.h
@@ -147,7 +147,7 @@ class Engine {
    **/
   template <size_t WIDTH>
   static void distinct(const IdTable& dynInput,
-                       const std::vector<size_t>& keepIndices,
+                       const std::vector<ColumnIndex>& keepIndices,
                        IdTable* dynResult) {
     LOG(DEBUG) << "Distinct on " << dynInput.size() << " elements.\n";
     const IdTableView<WIDTH> input = dynInput.asStaticView<WIDTH>();
@@ -158,7 +158,7 @@ class Engine {
 
       auto last = std::unique(result.begin(), result.end(),
                               [&keepIndices](const auto& a, const auto& b) {
-                                for (size_t i : keepIndices) {
+                                for (ColumnIndex i : keepIndices) {
                                   if (a[i] != b[i]) {
                                     return false;
                                   }

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -32,7 +32,7 @@ class Filter : public Operation {
  public:
   string getDescriptor() const override;
 
-  std::vector<size_t> resultSortedOn() const override {
+  std::vector<ColumnIndex> resultSortedOn() const override {
     return _subtree->resultSortedOn();
   }
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -86,9 +86,9 @@ size_t GroupBy::getResultWidth() const {
   return getInternallyVisibleVariableColumns().size();
 }
 
-vector<size_t> GroupBy::resultSortedOn() const {
+vector<ColumnIndex> GroupBy::resultSortedOn() const {
   auto varCols = getInternallyVisibleVariableColumns();
-  vector<size_t> sortedOn;
+  vector<ColumnIndex> sortedOn;
   sortedOn.reserve(_groupByVariables.size());
   for (const auto& var : _groupByVariables) {
     sortedOn.push_back(varCols[var].columnIndex_);
@@ -96,8 +96,8 @@ vector<size_t> GroupBy::resultSortedOn() const {
   return sortedOn;
 }
 
-vector<size_t> GroupBy::computeSortColumns(const QueryExecutionTree* subtree) {
-  vector<size_t> cols;
+vector<ColumnIndex> GroupBy::computeSortColumns(const QueryExecutionTree* subtree) {
+  vector<ColumnIndex> cols;
   if (_groupByVariables.empty()) {
     // the entire input is a single group, no sorting needs to be done
     return cols;
@@ -105,10 +105,10 @@ vector<size_t> GroupBy::computeSortColumns(const QueryExecutionTree* subtree) {
 
   const auto& inVarColMap = subtree->getVariableColumns();
 
-  std::unordered_set<size_t> sortColSet;
+  std::unordered_set<ColumnIndex> sortColSet;
 
   for (const auto& var : _groupByVariables) {
-    size_t col = inVarColMap.at(var).columnIndex_;
+    ColumnIndex col = inVarColMap.at(var).columnIndex_;
     // avoid sorting by a column twice
     if (sortColSet.find(col) == sortColSet.end()) {
       sortColSet.insert(col);

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -96,7 +96,8 @@ vector<ColumnIndex> GroupBy::resultSortedOn() const {
   return sortedOn;
 }
 
-vector<ColumnIndex> GroupBy::computeSortColumns(const QueryExecutionTree* subtree) {
+vector<ColumnIndex> GroupBy::computeSortColumns(
+    const QueryExecutionTree* subtree) {
   vector<ColumnIndex> cols;
   if (_groupByVariables.empty()) {
     // the entire input is a single group, no sorting needs to be done

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -53,7 +53,7 @@ class GroupBy : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _subtree->setTextLimit(limit);
@@ -77,7 +77,7 @@ class GroupBy : public Operation {
    * @param subtree The QueryExecutionTree that contains the operations
    *                  creating the sorting operation inputs.
    */
-  vector<size_t> computeSortColumns(const QueryExecutionTree* subtree);
+  vector<ColumnIndex> computeSortColumns(const QueryExecutionTree* subtree);
 
   vector<QueryExecutionTree*> getChildren() override {
     return {_subtree.get()};

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -93,7 +93,7 @@ size_t HasPredicateScan::getResultWidth() const {
   return -1;
 }
 
-vector<size_t> HasPredicateScan::resultSortedOn() const {
+vector<ColumnIndex> HasPredicateScan::resultSortedOn() const {
   switch (_type) {
     case ScanType::FREE_S:
       // is the lack of sorting here a problem?

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -56,7 +56,7 @@ class HasPredicateScan : public Operation {
 
   [[nodiscard]] size_t getResultWidth() const override;
 
-  [[nodiscard]] vector<size_t> resultSortedOn() const override;
+  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
   void setTextLimit(size_t limit) override;
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -115,26 +115,26 @@ size_t IndexScan::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<size_t> IndexScan::resultSortedOn() const {
+vector<ColumnIndex> IndexScan::resultSortedOn() const {
   switch (_type) {
     case PSO_BOUND_S:
     case POS_BOUND_O:
     case SOP_BOUND_O:
-      return {0};
+      return {ColumnIndex{0}};
     case PSO_FREE_S:
     case POS_FREE_O:
     case SPO_FREE_P:
     case SOP_FREE_O:
     case OSP_FREE_S:
     case OPS_FREE_P:
-      return {0, 1};
+      return {ColumnIndex{0}, ColumnIndex{1}};
     case FULL_INDEX_SCAN_SPO:
     case FULL_INDEX_SCAN_SOP:
     case FULL_INDEX_SCAN_PSO:
     case FULL_INDEX_SCAN_POS:
     case FULL_INDEX_SCAN_OSP:
     case FULL_INDEX_SCAN_OPS:
-      return {0, 1, 2};
+      return {ColumnIndex{0}, ColumnIndex{1}, ColumnIndex{2}};
     default:
       AD_FAIL();
   }
@@ -145,7 +145,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
   VariableToColumnMap res;
   // All the columns of an index scan only contain defined values.
   auto makeCol = makeAlwaysDefinedColumn;
-  size_t col = 0;
+  auto col = ColumnIndex{0};
 
   // Helper lambdas that add the respective triple component as the next column.
   auto addSubject = [&]() {

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -56,7 +56,7 @@ class IndexScan : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<size_t> resultSortedOn() const override;
+  vector<ColumnIndex> resultSortedOn() const override;
 
   void setTextLimit(size_t) override {
     // Do nothing.

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -347,8 +347,8 @@ void Join::computeSizeEstimateAndMultiplicities() {
              << " * " << jcMultiplicityInResult << " * " << nofDistinctInResult
              << std::endl;
 
-  for (auto i = isFullScanDummy(_left) ? ColumnIndex{1} : ColumnIndex{0}; i < _left->getResultWidth();
-       ++i) {
+  for (auto i = isFullScanDummy(_left) ? ColumnIndex{1} : ColumnIndex{0};
+       i < _left->getResultWidth(); ++i) {
     double oldMult = _left->getMultiplicity(i);
     double m = std::max(
         1.0, oldMult * _right->getMultiplicity(_rightJoinCol) * corrFactor);
@@ -401,8 +401,8 @@ void Join::appendCrossProduct(const IdTable::const_iterator& leftBegin,
 
 // ______________________________________________________________________________
 
-void Join::join(const IdTable& a, ColumnIndex jc1, const IdTable& b, ColumnIndex jc2,
-                IdTable* result) const {
+void Join::join(const IdTable& a, ColumnIndex jc1, const IdTable& b,
+                ColumnIndex jc2, IdTable* result) const {
   LOG(DEBUG) << "Performing join between two tables.\n";
   LOG(DEBUG) << "A: width = " << a.numColumns() << ", size = " << a.size()
              << "\n";
@@ -501,8 +501,8 @@ void Join::join(const IdTable& a, ColumnIndex jc1, const IdTable& b, ColumnIndex
 
 // ______________________________________________________________________________
 template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
-void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
-                        ColumnIndex jc2, IdTable* dynRes) {
+void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
+                        const IdTable& dynB, ColumnIndex jc2, IdTable* dynRes) {
   const IdTableView<L_WIDTH> a = dynA.asStaticView<L_WIDTH>();
   const IdTableView<R_WIDTH> b = dynB.asStaticView<R_WIDTH>();
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -23,8 +23,8 @@ using std::string;
 
 // _____________________________________________________________________________
 Join::Join(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
-           std::shared_ptr<QueryExecutionTree> t2, size_t t1JoinCol,
-           size_t t2JoinCol, bool keepJoinColumn)
+           std::shared_ptr<QueryExecutionTree> t2, ColumnIndex t1JoinCol,
+           ColumnIndex t2JoinCol, bool keepJoinColumn)
     : Operation(qec) {
   AD_CONTRACT_CHECK(t1 && t2);
   // Currently all join algorithms require both inputs to be sorted, so we
@@ -134,7 +134,7 @@ ResultTable Join::computeResult() {
 VariableToColumnMap Join::computeVariableToColumnMap() const {
   AD_CORRECTNESS_CHECK(!isFullScanDummy(_left));
   if (isFullScanDummy(_right)) {
-    AD_CORRECTNESS_CHECK(_rightJoinCol == 0u);
+    AD_CORRECTNESS_CHECK(_rightJoinCol == ColumnIndex{0});
   }
   return makeVarToColMapForJoinOperation(
       _left->getVariableColumns(), _right->getVariableColumns(),
@@ -151,11 +151,11 @@ size_t Join::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<size_t> Join::resultSortedOn() const {
+vector<ColumnIndex> Join::resultSortedOn() const {
   if (!isFullScanDummy(_left)) {
     return {_leftJoinCol};
   } else {
-    return {2 + _rightJoinCol};
+    return {ColumnIndex{2 + _rightJoinCol}};
   }
 }
 
@@ -347,7 +347,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
              << " * " << jcMultiplicityInResult << " * " << nofDistinctInResult
              << std::endl;
 
-  for (size_t i = isFullScanDummy(_left) ? 1 : 0; i < _left->getResultWidth();
+  for (auto i = isFullScanDummy(_left) ? ColumnIndex{1} : ColumnIndex{0}; i < _left->getResultWidth();
        ++i) {
     double oldMult = _left->getMultiplicity(i);
     double m = std::max(
@@ -359,7 +359,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
     }
     _multiplicities.emplace_back(m);
   }
-  for (size_t i = 0; i < _right->getResultWidth(); ++i) {
+  for (auto i = ColumnIndex{0}; i < _right->getResultWidth(); ++i) {
     if (i == _rightJoinCol && !isFullScanDummy(_left)) {
       continue;
     }
@@ -401,7 +401,7 @@ void Join::appendCrossProduct(const IdTable::const_iterator& leftBegin,
 
 // ______________________________________________________________________________
 
-void Join::join(const IdTable& a, size_t jc1, const IdTable& b, size_t jc2,
+void Join::join(const IdTable& a, ColumnIndex jc1, const IdTable& b, ColumnIndex jc2,
                 IdTable* result) const {
   LOG(DEBUG) << "Performing join between two tables.\n";
   LOG(DEBUG) << "A: width = " << a.numColumns() << ", size = " << a.size()
@@ -501,8 +501,8 @@ void Join::join(const IdTable& a, size_t jc1, const IdTable& b, size_t jc2,
 
 // ______________________________________________________________________________
 template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
-void Join::hashJoinImpl(const IdTable& dynA, size_t jc1, const IdTable& dynB,
-                        size_t jc2, IdTable* dynRes) {
+void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
+                        ColumnIndex jc2, IdTable* dynRes) {
   const IdTableView<L_WIDTH> a = dynA.asStaticView<L_WIDTH>();
   const IdTableView<R_WIDTH> b = dynB.asStaticView<R_WIDTH>();
 
@@ -522,7 +522,7 @@ void Join::hashJoinImpl(const IdTable& dynA, size_t jc1, const IdTable& dynB,
   // Puts the rows of the given table into a hash map, with the value of
   // the join column of a row as the key, and returns the hash map.
   auto idTableToHashMap = []<typename Table>(const Table& table,
-                                             const size_t jc) {
+                                             const ColumnIndex jc) {
     // This declaration works, because generic lambdas are just syntactic sugar
     // for templates.
     ad_utility::HashMap<Id, std::vector<typename Table::row_type>> map;
@@ -550,9 +550,9 @@ void Join::hashJoinImpl(const IdTable& dynA, size_t jc1, const IdTable& dynB,
                           &result]<bool leftIsLarger, typename LargerTableType,
                                    typename SmallerTableType>(
                              const LargerTableType& largerTable,
-                             const size_t largerTableJoinColumn,
+                             const ColumnIndex largerTableJoinColumn,
                              const SmallerTableType& smallerTable,
-                             const size_t smallerTableJoinColumn) {
+                             const ColumnIndex smallerTableJoinColumn) {
     // Put the smaller table into the hash table.
     auto map = idTableToHashMap(smallerTable, smallerTableJoinColumn);
 
@@ -598,8 +598,8 @@ void Join::hashJoinImpl(const IdTable& dynA, size_t jc1, const IdTable& dynB,
 }
 
 // ______________________________________________________________________________
-void Join::hashJoin(const IdTable& dynA, size_t jc1, const IdTable& dynB,
-                    size_t jc2, IdTable* dynRes) {
+void Join::hashJoin(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
+                    ColumnIndex jc2, IdTable* dynRes) {
   CALL_FIXED_SIZE(
       (std::array{dynA.numColumns(), dynB.numColumns(), dynRes->numColumns()}),
       &Join::hashJoinImpl, this, dynA, jc1, dynB, jc2, dynRes);
@@ -608,24 +608,24 @@ void Join::hashJoin(const IdTable& dynA, size_t jc1, const IdTable& dynB,
 // ___________________________________________________________________________
 template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
 void Join::addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
-                                   const size_t jcRowB,
+                                   const ColumnIndex jcRowB,
                                    IdTableStatic<TABLE_WIDTH>* table) {
   // Add a new, empty row.
   const size_t backIndex = table->size();
   table->emplace_back();
 
   // Copy the entire rowA in the table.
-  for (size_t h = 0; h < rowA.numColumns(); h++) {
+  for (auto h = ColumnIndex{0}; h < rowA.numColumns(); h++) {
     (*table)(backIndex, h) = rowA[h];
   }
 
   // Copy rowB columns before the join column.
-  for (size_t h = 0; h < jcRowB; h++) {
+  for (auto h = ColumnIndex{0}; h < jcRowB; h++) {
     (*table)(backIndex, h + rowA.numColumns()) = rowB[h];
   }
 
   // Copy rowB columns after the join column.
-  for (size_t h = jcRowB + 1; h < rowB.numColumns(); h++) {
+  for (auto h = jcRowB + 1; h < rowB.numColumns(); h++) {
     (*table)(backIndex, h + rowA.numColumns() - 1) = rowB[h];
   }
 }

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -21,8 +21,8 @@ class Join : public Operation {
   std::shared_ptr<QueryExecutionTree> _left;
   std::shared_ptr<QueryExecutionTree> _right;
 
-  size_t _leftJoinCol;
-  size_t _rightJoinCol;
+  ColumnIndex _leftJoinCol;
+  ColumnIndex _rightJoinCol;
 
   bool _keepJoinColumn;
 
@@ -33,8 +33,8 @@ class Join : public Operation {
 
  public:
   Join(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
-       std::shared_ptr<QueryExecutionTree> t2, size_t t1JoinCol,
-       size_t t2JoinCol, bool keepJoinColumn = true);
+       std::shared_ptr<QueryExecutionTree> t2, ColumnIndex t1JoinCol,
+       ColumnIndex t2JoinCol, bool keepJoinColumn = true);
 
   // A very explicit constructor, which initializes an invalid join object (it
   // has no subtrees, which violates class invariants). These invalid Join
@@ -52,7 +52,7 @@ class Join : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);
@@ -99,7 +99,7 @@ class Join : public Operation {
    * TODO Move the merge join into it's own function and make this function
    * a proper switch.
    **/
-  void join(const IdTable& a, size_t jc1, const IdTable& b, size_t jc2,
+  void join(const IdTable& a, ColumnIndex jc1, const IdTable& b, ColumnIndex jc2,
             IdTable* result) const;
 
   /**
@@ -115,8 +115,8 @@ class Join : public Operation {
    * @return The result is only sorted, if the bigger table is sorted.
    * Otherwise it is not sorted.
    **/
-  void hashJoin(const IdTable& dynA, size_t jc1, const IdTable& dynB,
-                size_t jc2, IdTable* dynRes);
+  void hashJoin(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
+                ColumnIndex jc2, IdTable* dynRes);
 
   static bool isFullScanDummy(std::shared_ptr<QueryExecutionTree> tree) {
     return tree->getType() == QueryExecutionTree::SCAN &&
@@ -159,13 +159,13 @@ class Join : public Operation {
    */
   template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
   static void addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
-                                      const size_t jcRowB,
+                                      const ColumnIndex jcRowB,
                                       IdTableStatic<TABLE_WIDTH>* table);
 
   /*
    * @brief The implementation of hashJoin.
    */
   template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
-  void hashJoinImpl(const IdTable& dynA, size_t jc1, const IdTable& dynB,
-                    size_t jc2, IdTable* dynRes);
+  void hashJoinImpl(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
+                    ColumnIndex jc2, IdTable* dynRes);
 };

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -99,8 +99,8 @@ class Join : public Operation {
    * TODO Move the merge join into it's own function and make this function
    * a proper switch.
    **/
-  void join(const IdTable& a, ColumnIndex jc1, const IdTable& b, ColumnIndex jc2,
-            IdTable* result) const;
+  void join(const IdTable& a, ColumnIndex jc1, const IdTable& b,
+            ColumnIndex jc2, IdTable* result) const;
 
   /**
    * @brief Joins IdTables dynA and dynB on join column jc2, returning

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -13,7 +13,7 @@ using std::string;
 Minus::Minus(QueryExecutionContext* qec,
              std::shared_ptr<QueryExecutionTree> left,
              std::shared_ptr<QueryExecutionTree> right,
-             std::vector<std::array<size_t, 2>> matchedColumns)
+             std::vector<std::array<ColumnIndex, 2>> matchedColumns)
     : Operation{qec},
       _left{std::move(left)},
       _right{std::move(right)},
@@ -81,7 +81,7 @@ VariableToColumnMap Minus::computeVariableToColumnMap() const {
 size_t Minus::getResultWidth() const { return _left->getResultWidth(); }
 
 // _____________________________________________________________________________
-vector<size_t> Minus::resultSortedOn() const { return _left->resultSortedOn(); }
+vector<ColumnIndex> Minus::resultSortedOn() const { return _left->resultSortedOn(); }
 
 // _____________________________________________________________________________
 float Minus::getMultiplicity(size_t col) {
@@ -212,7 +212,7 @@ finish:
 template <int A_WIDTH, int B_WIDTH>
 Minus::RowComparison Minus::isRowEqSkipFirst(
     const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
-    size_t ib, const std::vector<std::array<size_t, 2>>& joinColumns) {
+    size_t ib, const std::vector<std::array<ColumnIndex, 2>>& joinColumns) {
   for (size_t i = 1; i < joinColumns.size(); ++i) {
     Id va{a(ia, joinColumns[i][0])};
     Id vb{b(ib, joinColumns[i][1])};

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -81,7 +81,9 @@ VariableToColumnMap Minus::computeVariableToColumnMap() const {
 size_t Minus::getResultWidth() const { return _left->getResultWidth(); }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> Minus::resultSortedOn() const { return _left->resultSortedOn(); }
+vector<ColumnIndex> Minus::resultSortedOn() const {
+  return _left->resultSortedOn();
+}
 
 // _____________________________________________________________________________
 float Minus::getMultiplicity(size_t col) {

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -15,14 +15,14 @@ class Minus : public Operation {
   std::shared_ptr<QueryExecutionTree> _right;
 
   vector<float> _multiplicities;
-  std::vector<std::array<size_t, 2>> _matchedColumns;
+  std::vector<std::array<ColumnIndex, 2>> _matchedColumns;
 
   enum class RowComparison { EQUAL, LEFT_SMALLER, RIGHT_SMALLER };
 
  public:
   Minus(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> left,
         std::shared_ptr<QueryExecutionTree> right,
-        std::vector<std::array<size_t, 2>> matchedColumns);
+        std::vector<std::array<ColumnIndex, 2>> matchedColumns);
 
   // Uninitialized Object for testing the computeMinus method
   struct OnlyForTestingTag {};
@@ -36,7 +36,7 @@ class Minus : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<size_t> resultSortedOn() const override;
+  vector<ColumnIndex> resultSortedOn() const override;
 
   void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);
@@ -65,7 +65,7 @@ class Minus : public Operation {
    **/
   template <int A_WIDTH, int B_WIDTH>
   void computeMinus(const IdTable& a, const IdTable& b,
-                    const vector<std::array<size_t, 2>>& matchedColumns,
+                    const vector<std::array<ColumnIndex, 2>>& matchedColumns,
                     IdTable* result) const;
 
  private:
@@ -76,7 +76,7 @@ class Minus : public Operation {
   template <int A_WIDTH, int B_WIDTH>
   static RowComparison isRowEqSkipFirst(
       const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
-      size_t ib, const vector<std::array<size_t, 2>>& matchedColumns);
+      size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
   ResultTable computeResult() override;
 

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -114,8 +114,8 @@ size_t MultiColumnJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<size_t> MultiColumnJoin::resultSortedOn() const {
-  std::vector<size_t> sortedOn;
+vector<ColumnIndex> MultiColumnJoin::resultSortedOn() const {
+  std::vector<ColumnIndex> sortedOn;
   // The result is sorted on all join columns from the left subtree.
   for (const auto& a : _joinColumns) {
     sortedOn.push_back(a[0]);

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -34,7 +34,7 @@ class MultiColumnJoin : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -36,7 +36,7 @@ class NeutralElementOperation : public Operation {
   bool knownEmptyResult() override { return false; };
 
  protected:
-  [[nodiscard]] vector<size_t> resultSortedOn() const override { return {}; };
+  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override { return {}; };
 
  private:
   ResultTable computeResult() override {

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -36,7 +36,9 @@ class NeutralElementOperation : public Operation {
   bool knownEmptyResult() override { return false; };
 
  protected:
-  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override { return {}; };
+  [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override {
+    return {};
+  };
 
  private:
   ResultTable computeResult() override {

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -418,7 +418,7 @@ std::optional<Variable> Operation::getPrimarySortKeyVariable() const {
 }
 
 // ___________________________________________________________________________
-const vector<size_t>& Operation::getResultSortedOn() const {
+const vector<ColumnIndex>& Operation::getResultSortedOn() const {
   // TODO<joka921> refactor this without a mutex (for details see the
   // `getVariableColumns` method for details.
   std::lock_guard l{_resultSortedColumnsMutex};

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -334,5 +334,6 @@ class Operation {
   mutable CopyableMutex _resultSortedColumnsMutex;
 
   // Store the list of columns by which the result is sorted.
-  mutable std::optional<vector<ColumnIndex>> _resultSortedColumns = std::nullopt;
+  mutable std::optional<vector<ColumnIndex>> _resultSortedColumns =
+      std::nullopt;
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -57,7 +57,7 @@ class Operation {
   /**
    * @return A list of columns on which the result of this operation is sorted.
    */
-  const vector<size_t>& getResultSortedOn() const;
+  const vector<ColumnIndex>& getResultSortedOn() const;
 
   const Index& getIndex() const { return _executionContext->getIndex(); }
 
@@ -181,7 +181,7 @@ class Operation {
    * @brief Compute and return the columns on which the result will be sorted
    * @return The columns on which the result will be sorted.
    */
-  [[nodiscard]] virtual vector<size_t> resultSortedOn() const = 0;
+  [[nodiscard]] virtual vector<ColumnIndex> resultSortedOn() const = 0;
 
   const auto& getLimit() const { return _limit; }
 
@@ -334,5 +334,5 @@ class Operation {
   mutable CopyableMutex _resultSortedColumnsMutex;
 
   // Store the list of columns by which the result is sorted.
-  mutable std::optional<vector<size_t>> _resultSortedColumns = std::nullopt;
+  mutable std::optional<vector<ColumnIndex>> _resultSortedColumns = std::nullopt;
 };

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -139,8 +139,8 @@ size_t OptionalJoin::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<size_t> OptionalJoin::resultSortedOn() const {
-  std::vector<size_t> sortedOn;
+vector<ColumnIndex> OptionalJoin::resultSortedOn() const {
+  std::vector<ColumnIndex> sortedOn;
   // The result is sorted on all join columns from the left subtree.
   for (const auto& [joinColumnLeft, joinColumnRight] : _joinColumns) {
     (void)joinColumnRight;

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -47,7 +47,7 @@ class OptionalJoin : public Operation {
 
   size_t getResultWidth() const override;
 
-  vector<size_t> resultSortedOn() const override;
+  vector<ColumnIndex> resultSortedOn() const override;
 
   void setTextLimit(size_t limit) override {
     _left->setTextLimit(limit);

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -20,7 +20,7 @@ size_t OrderBy::getResultWidth() const { return subtree_->getResultWidth(); }
 // _____________________________________________________________________________
 OrderBy::OrderBy(QueryExecutionContext* qec,
                  std::shared_ptr<QueryExecutionTree> subtree,
-                 vector<pair<size_t, bool>> sortIndices)
+                 vector<pair<ColumnIndex, bool>> sortIndices)
     : Operation{qec},
       subtree_{std::move(subtree)},
       sortIndices_{std::move(sortIndices)} {

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -41,7 +41,7 @@ class OrderBy : public Operation {
   // The function `resultSortedOn` refers to the `internal` sorting by ID value.
   // This is different from the `semantic` sorting that the ORDER BY operation
   // computes.
-  std::vector<size_t> resultSortedOn() const override { return {}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {}; }
 
   void setTextLimit(size_t limit) override { subtree_->setTextLimit(limit); }
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -255,7 +255,7 @@ template void QueryExecutionTree::setOperation(
 // ________________________________________________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     std::shared_ptr<QueryExecutionTree> qet,
-    const vector<size_t>& sortColumns) {
+    const vector<ColumnIndex>& sortColumns) {
   auto inputSortedOn = qet->resultSortedOn();
   bool inputSorted = sortColumns.size() <= inputSortedOn.size();
   for (size_t i = 0; inputSorted && i < sortColumns.size(); ++i) {
@@ -275,8 +275,8 @@ std::array<std::shared_ptr<QueryExecutionTree>, 2>
 QueryExecutionTree::createSortedTrees(
     std::shared_ptr<QueryExecutionTree> qetA,
     std::shared_ptr<QueryExecutionTree> qetB,
-    const vector<std::array<size_t, 2>>& sortColumns) {
-  std::vector<size_t> sortColumnsA, sortColumnsB;
+    const vector<std::array<ColumnIndex, 2>>& sortColumns) {
+  std::vector<ColumnIndex> sortColumnsA, sortColumnsB;
   for (auto [sortColumnA, sortColumnB] : sortColumns) {
     sortColumnsA.push_back(sortColumnA);
     sortColumnsB.push_back(sortColumnB);

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -117,7 +117,7 @@ class QueryExecutionTree {
       const parsedQuery::SelectClause& selectClause,
       bool includeQuestionMark = true) const;
 
-  const std::vector<size_t>& resultSortedOn() const {
+  const std::vector<ColumnIndex>& resultSortedOn() const {
     return _rootOperation->getResultSortedOn();
   }
 
@@ -194,7 +194,7 @@ class QueryExecutionTree {
   // sorted accordingly, it is simply returned.
   static std::shared_ptr<QueryExecutionTree> createSortedTree(
       std::shared_ptr<QueryExecutionTree> qet,
-      const vector<size_t>& sortColumns);
+      const vector<ColumnIndex>& sortColumns);
 
   // Similar to `createSortedTree` (see directly above), but create the sorted
   // trees for two different trees, the sort columns of which are specified as
@@ -203,7 +203,7 @@ class QueryExecutionTree {
   static std::array<std::shared_ptr<QueryExecutionTree>, 2> createSortedTrees(
       std::shared_ptr<QueryExecutionTree> qetA,
       std::shared_ptr<QueryExecutionTree> qetB,
-      const vector<std::array<size_t, 2>>& sortColumns);
+      const vector<std::array<ColumnIndex, 2>>& sortColumns);
 
   // If the result of this `Operation` is sorted (either because this
   // `Operation` enforces this sorting, or because it preserves the sorting of

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -512,8 +512,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
   added.reserve(previous.size());
   for (const auto& parent : previous) {
     SubtreePlan distinctPlan(_qec);
-    vector<size_t> keepIndices;
-    ad_utility::HashSet<size_t> indDone;
+    vector<ColumnIndex> keepIndices;
+    ad_utility::HashSet<ColumnIndex> indDone;
     const auto& colMap = parent._qet->getVariableColumns();
     for (const auto& var : selectClause.getSelectedVariables()) {
       // There used to be a special treatment for `?ql_textscore_` variables
@@ -526,7 +526,7 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getDistinctRow(
         }
       }
     }
-    const std::vector<size_t>& resultSortedOn =
+    const std::vector<ColumnIndex>& resultSortedOn =
         parent._qet->getRootOperation()->getResultSortedOn();
     // check if the current result is sorted on all columns of the distinct
     // with the order of the sorting
@@ -635,14 +635,14 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getOrderByRow(
     auto& tree = plan._qet;
     plan._idsOfIncludedNodes = parent._idsOfIncludedNodes;
     plan._idsOfIncludedFilters = parent._idsOfIncludedFilters;
-    vector<pair<size_t, bool>> sortIndices;
+    vector<pair<ColumnIndex, bool>> sortIndices;
     for (auto& ord : pq._orderBy) {
       sortIndices.emplace_back(parent._qet->getVariableColumn(ord.variable_),
                                ord.isDescending_);
     }
 
     if (pq._isInternalSort == IsInternalSort::True) {
-      std::vector<size_t> sortColumns;
+      std::vector<ColumnIndex> sortColumns;
       for (auto& [index, isDescending] : sortIndices) {
         AD_CONTRACT_CHECK(!isDescending);
         sortColumns.push_back(index);
@@ -1366,11 +1366,11 @@ std::vector<std::array<ColumnIndex, 2>> QueryPlanner::getJoinColumns(
 // _____________________________________________________________________________
 string QueryPlanner::getPruningKey(
     const QueryPlanner::SubtreePlan& plan,
-    const vector<size_t>& orderedOnColumns) const {
+    const vector<ColumnIndex>& orderedOnColumns) const {
   // Get the ordered var
   std::ostringstream os;
   const auto& varCols = plan._qet->getVariableColumns();
-  for (size_t orderedOnCol : orderedOnColumns) {
+  for (ColumnIndex orderedOnCol : orderedOnColumns) {
     for (const auto& [variable, columnIndexWithType] : varCols) {
       if (columnIndexWithType.columnIndex_ == orderedOnCol) {
         os << variable.name() << ", ";

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -320,7 +320,8 @@ class QueryPlanner {
       const SubtreePlan& a, const SubtreePlan& b) const;
 
   [[nodiscard]] string getPruningKey(
-      const SubtreePlan& plan, const vector<ColumnIndex>& orderedOnColumns) const;
+      const SubtreePlan& plan,
+      const vector<ColumnIndex>& orderedOnColumns) const;
 
   [[nodiscard]] void applyFiltersIfPossible(
       std::vector<SubtreePlan>& row, const std::vector<SparqlFilter>& filters,

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -320,7 +320,7 @@ class QueryPlanner {
       const SubtreePlan& a, const SubtreePlan& b) const;
 
   [[nodiscard]] string getPruningKey(
-      const SubtreePlan& plan, const vector<size_t>& orderedOnColumns) const;
+      const SubtreePlan& plan, const vector<ColumnIndex>& orderedOnColumns) const;
 
   [[nodiscard]] void applyFiltersIfPossible(
       std::vector<SubtreePlan>& row, const std::vector<SparqlFilter>& filters,

--- a/src/engine/ResultTable.cpp
+++ b/src/engine/ResultTable.cpp
@@ -43,7 +43,7 @@ LocalVocab ResultTable::getCopyOfLocalVocab() const {
 }
 
 // _____________________________________________________________________________
-ResultTable::ResultTable(IdTable idTable, vector<size_t> sortedBy,
+ResultTable::ResultTable(IdTable idTable, vector<ColumnIndex> sortedBy,
                          SharedLocalVocabWrapper localVocab)
     : _idTable{std::move(idTable)},
       _sortedBy{std::move(sortedBy)},
@@ -67,7 +67,7 @@ ResultTable::ResultTable(IdTable idTable, vector<size_t> sortedBy,
 }
 
 // _____________________________________________________________________________
-ResultTable::ResultTable(IdTable idTable, vector<size_t> sortedBy,
+ResultTable::ResultTable(IdTable idTable, vector<ColumnIndex> sortedBy,
                          LocalVocab&& localVocab)
     : ResultTable(std::move(idTable), std::move(sortedBy),
                   SharedLocalVocabWrapper{std::move(localVocab)}) {}

--- a/src/engine/ResultTable.h
+++ b/src/engine/ResultTable.h
@@ -31,7 +31,7 @@ class ResultTable {
 
   // The column indices by which the result is sorted (primary sort key first).
   // Empty if the result is not sorted on any column.
-  std::vector<size_t> _sortedBy;
+  std::vector<ColumnIndex> _sortedBy;
 
   using LocalVocabPtr = std::shared_ptr<const LocalVocab>;
   // The local vocabulary of the result.
@@ -85,9 +85,9 @@ class ResultTable {
   // The first overload of the constructor is for local vocabs that are shared
   // with another `ResultTable` via the `getSharedLocalVocab...` methods below.
   // The second overload is for newly created local vocabularies.
-  ResultTable(IdTable idTable, std::vector<size_t> sortedBy,
+  ResultTable(IdTable idTable, std::vector<ColumnIndex> sortedBy,
               SharedLocalVocabWrapper localVocab);
-  ResultTable(IdTable idTable, std::vector<size_t> sortedBy,
+  ResultTable(IdTable idTable, std::vector<ColumnIndex> sortedBy,
               LocalVocab&& localVocab);
 
   // Prevent accidental copying of a result table.
@@ -111,7 +111,7 @@ class ResultTable {
   const IdTable& idTable() const { return _idTable; }
 
   // Const access to the columns by which the `idTable()` is sorted.
-  const std::vector<size_t>& sortedBy() const { return _sortedBy; }
+  const std::vector<ColumnIndex>& sortedBy() const { return _sortedBy; }
 
   // Get the local vocabulary of this result, used for lookup only.
   //

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -57,7 +57,7 @@ class Service : public Operation {
   // Methods inherited from base class `Operation`.
   std::string getDescriptor() const override;
   size_t getResultWidth() const override;
-  std::vector<size_t> resultSortedOn() const override { return {}; }
+  std::vector<ColumnIndex> resultSortedOn() const override { return {}; }
   float getMultiplicity(size_t col) override;
 
  private:

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -28,7 +28,7 @@ class Sort : public Operation {
  public:
   virtual string getDescriptor() const override;
 
-  virtual vector<size_t> resultSortedOn() const override {
+  virtual vector<ColumnIndex> resultSortedOn() const override {
     return sortColumnIndices_;
   }
 

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -57,8 +57,9 @@ VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
   for (const auto& varcol : filterColumns) {
     // TODO<joka921> It is possible that UNDEF values in the filter are never
     // propagated to the  result, but this has to be further examined.
-    vcmap[varcol.first] = ColumnIndexAndTypeInfo{
-        ColumnIndex{colN + varcol.second.columnIndex_}, varcol.second.mightContainUndef_};
+    vcmap[varcol.first] =
+        ColumnIndexAndTypeInfo{ColumnIndex{colN + varcol.second.columnIndex_},
+                               varcol.second.mightContainUndef_};
   }
   return vcmap;
 }

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -36,9 +36,9 @@ VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
   VariableToColumnMap vcmap;
   // Subtract one because the entity that we filtered on
   // is provided by the filter table and still has the same place there.
-  vcmap[_cvar] = makeAlwaysDefinedColumn(0);
-  vcmap[_cvar.getTextScoreVariable()] = makeAlwaysDefinedColumn(1);
-  size_t colN = 2;
+  vcmap[_cvar] = makeAlwaysDefinedColumn(ColumnIndex{0});
+  vcmap[_cvar.getTextScoreVariable()] = makeAlwaysDefinedColumn(ColumnIndex{1});
+  auto colN = ColumnIndex{2};
   const auto& filterColumns = _filterResult->getVariableColumns();
   // TODO<joka921> The order of the `_variables` is not deterministic,
   // check whether this is correct (especially in the presence of caching).
@@ -58,7 +58,7 @@ VariableToColumnMap TextOperationWithFilter::computeVariableToColumnMap()
     // TODO<joka921> It is possible that UNDEF values in the filter are never
     // propagated to the  result, but this has to be further examined.
     vcmap[varcol.first] = ColumnIndexAndTypeInfo{
-        colN + varcol.second.columnIndex_, varcol.second.mightContainUndef_};
+        ColumnIndex{colN + varcol.second.columnIndex_}, varcol.second.mightContainUndef_};
   }
   return vcmap;
 }

--- a/src/engine/TextOperationWithFilter.h
+++ b/src/engine/TextOperationWithFilter.h
@@ -46,7 +46,7 @@ class TextOperationWithFilter : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override {
+  virtual vector<ColumnIndex> resultSortedOn() const override {
     // unsorted, obtained from iterating over a hash map.
     return {};
   }

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -31,7 +31,7 @@ TextOperationWithoutFilter::TextOperationWithoutFilter(
 VariableToColumnMap TextOperationWithoutFilter::computeVariableToColumnMap()
     const {
   VariableToColumnMap vcmap;
-  auto addDefinedVar = [&vcmap, index = 0](const Variable& var) mutable {
+  auto addDefinedVar = [&vcmap, index = ColumnIndex{0}](const Variable& var) mutable {
     vcmap[var] = makeAlwaysDefinedColumn(index);
     ++index;
   };

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -31,7 +31,8 @@ TextOperationWithoutFilter::TextOperationWithoutFilter(
 VariableToColumnMap TextOperationWithoutFilter::computeVariableToColumnMap()
     const {
   VariableToColumnMap vcmap;
-  auto addDefinedVar = [&vcmap, index = ColumnIndex{0}](const Variable& var) mutable {
+  auto addDefinedVar = [&vcmap,
+                        index = ColumnIndex{0}](const Variable& var) mutable {
     vcmap[var] = makeAlwaysDefinedColumn(index);
     ++index;
   };

--- a/src/engine/TextOperationWithoutFilter.h
+++ b/src/engine/TextOperationWithoutFilter.h
@@ -41,7 +41,7 @@ class TextOperationWithoutFilter : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override {
+  virtual vector<ColumnIndex> resultSortedOn() const override {
     // unsorted, obtained from iterating over a hash map.
     return {};
   }

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -113,8 +113,8 @@ std::string TransitivePath::getDescriptor() const {
 size_t TransitivePath::getResultWidth() const { return _resultWidth; }
 
 // _____________________________________________________________________________
-vector<size_t> TransitivePath::resultSortedOn() const {
-  const std::vector<size_t>& subSortedOn =
+vector<ColumnIndex> TransitivePath::resultSortedOn() const {
+  const std::vector<ColumnIndex>& subSortedOn =
       _subtree->getRootOperation()->getResultSortedOn();
   if (_leftSideTree == nullptr && _rightSideTree == nullptr && _leftIsVar &&
       _rightIsVar && subSortedOn.size() > 0 && subSortedOn[0] == _leftSubCol) {
@@ -122,14 +122,14 @@ vector<size_t> TransitivePath::resultSortedOn() const {
     return {0};
   }
   if (_leftSideTree != nullptr) {
-    const std::vector<size_t>& leftSortedOn =
+    const std::vector<ColumnIndex>& leftSortedOn =
         _leftSideTree->getRootOperation()->getResultSortedOn();
     if (leftSortedOn.size() > 0 && leftSortedOn[0] == _leftSideCol) {
       return {0};
     }
   }
   if (_rightSideTree != nullptr) {
-    const std::vector<size_t>& rightSortedOn =
+    const std::vector<ColumnIndex>& rightSortedOn =
         _rightSideTree->getRootOperation()->getResultSortedOn();
     if (rightSortedOn.size() > 0 && rightSortedOn[0] == _rightSideCol) {
       return {1};

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -81,7 +81,7 @@ class TransitivePath : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual void setTextLimit(size_t limit) override;
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -66,7 +66,7 @@ size_t Union::getResultWidth() const {
   return _columnOrigins.size();
 }
 
-vector<size_t> Union::resultSortedOn() const { return {}; }
+vector<ColumnIndex> Union::resultSortedOn() const { return {}; }
 
 // _____________________________________________________________________________
 VariableToColumnMap Union::computeVariableToColumnMap() const {

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -37,7 +37,7 @@ class Union : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual void setTextLimit(size_t limit) override;
 

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -42,7 +42,7 @@ size_t Values::getResultWidth() const {
 }
 
 // ____________________________________________________________________________
-vector<size_t> Values::resultSortedOn() const { return {}; }
+vector<ColumnIndex> Values::resultSortedOn() const { return {}; }
 
 // ____________________________________________________________________________
 VariableToColumnMap Values::computeVariableToColumnMap() const {

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -30,7 +30,7 @@ class Values : public Operation {
 
   virtual size_t getResultWidth() const override;
 
-  virtual vector<size_t> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
   virtual void setTextLimit(size_t limit) override { (void)limit; }
 

--- a/src/engine/ValuesForTesting.h
+++ b/src/engine/ValuesForTesting.h
@@ -58,7 +58,7 @@ class ValuesForTesting : public Operation {
 
   // TODO<joka921> Maybe we will need to store sorted tables for future unit
   // tests.
-  vector<size_t> resultSortedOn() const override { return {}; }
+  vector<ColumnIndex> resultSortedOn() const override { return {}; }
 
   void setTextLimit(size_t limit) override { (void)limit; }
 
@@ -82,7 +82,7 @@ class ValuesForTesting : public Operation {
  private:
   VariableToColumnMap computeVariableToColumnMap() const override {
     VariableToColumnMap m;
-    for (size_t i = 0; i < variables_.size(); ++i) {
+    for (auto i = ColumnIndex{0}; i < variables_.size(); ++i) {
       bool containsUndef =
           ad_utility::contains(table_.getColumn(i), Id::makeUndefined());
       using enum ColumnIndexAndTypeInfo::UndefStatus;

--- a/src/engine/VariableToColumnMap.h
+++ b/src/engine/VariableToColumnMap.h
@@ -27,7 +27,7 @@ struct ColumnIndexAndTypeInfo {
   static_assert(static_cast<bool>(PossiblyUndefined) == true);
 
   // The column index.
-  size_t columnIndex_;
+  ColumnIndex columnIndex_;
 
   // The information whether this column *might* contain UNDEF values.
   UndefStatus mightContainUndef_;
@@ -39,14 +39,14 @@ struct ColumnIndexAndTypeInfo {
 // Return a `ColumnIndexAndType` info with the given `columnIndex` that is
 // guaranteed to always be defined.
 inline auto makeAlwaysDefinedColumn =
-    [](size_t columnIndex) -> ColumnIndexAndTypeInfo {
+    [](ColumnIndex columnIndex) -> ColumnIndexAndTypeInfo {
   return {columnIndex, ColumnIndexAndTypeInfo::UndefStatus::AlwaysDefined};
 };
 
 // Return a `ColumnIndexAndType` info with the given `columnIndex` that might
 // contain UNDEF values.
 inline auto makePossiblyUndefinedColumn =
-    [](size_t columnIndex) -> ColumnIndexAndTypeInfo {
+    [](ColumnIndex columnIndex) -> ColumnIndexAndTypeInfo {
   return {columnIndex, ColumnIndexAndTypeInfo::UndefStatus::PossiblyUndefined};
 };
 

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -523,12 +523,12 @@ class IdTable {
   // the columns that may be permuted. The subset of the columns is specified by
   // the argument `columnIndices`.
   IdTable<T, 0, ColumnStorage, IsView::True> asColumnSubsetView(
-      std::span<const size_t> columnIndices) const requires isDynamic {
+      std::span<const ColumnIndex> columnIndices) const requires isDynamic {
     AD_CONTRACT_CHECK(std::ranges::all_of(
         columnIndices, [this](size_t idx) { return idx < numColumns(); }));
     ViewSpans viewSpans;
     viewSpans.reserve(columnIndices.size());
-    for (size_t idx : columnIndices) {
+    for (auto idx : columnIndices) {
       viewSpans.push_back(getColumn(idx));
     }
     return IdTable<T, 0, ColumnStorage, IsView::True>{
@@ -540,18 +540,18 @@ class IdTable {
   // with the old index `permutation[i]` will become the `i`-th column after the
   // permutation. For example, `permuteColumns({1, 2, 0})` rotates the columns
   // of a table with three columns left by one element.
-  void permuteColumns(std::span<const size_t> permutation) {
+  void permuteColumns(std::span<const ColumnIndex> permutation) {
     // First check that the `permutation` is indeed a permutation of the column
     // indices.
-    std::vector<size_t> check{permutation.begin(), permutation.end()};
+    std::vector<ColumnIndex> check{permutation.begin(), permutation.end()};
     std::ranges::sort(check);
-    std::vector<size_t> expected(numColumns());
-    std::iota(expected.begin(), expected.end(), size_t{0});
+    std::vector<ColumnIndex> expected(numColumns());
+    std::iota(expected.begin(), expected.end(), ColumnIndex{0});
     AD_CONTRACT_CHECK(check == expected);
 
     Data newData;
     newData.reserve(numColumns());
-    for (size_t colIdx : permutation) {
+    for (auto colIdx : permutation) {
       newData.push_back(std::move(data().at(colIdx)));
     }
     data() = std::move(newData);

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -170,7 +170,7 @@ struct EvaluationContext {
 
   /// The input is sorted on these columns. This information can be used to
   /// perform efficient relational operations like `equal` or `less than`
-  std::vector<size_t> _columnsByWhichResultIsSorted;
+  std::vector<ColumnIndex> _columnsByWhichResultIsSorted;
 
   /// Let the expression evaluation also respect the memory limit.
   ad_utility::AllocatorWithLimit<Id> _allocator;
@@ -236,7 +236,7 @@ struct EvaluationContext {
   [[nodiscard]] size_t size() const { return _endIndex - _beginIndex; }
 
   // ____________________________________________________________________________
-  [[nodiscard]] size_t getColumnIndexForVariable(const Variable& var) const {
+  [[nodiscard]] ColumnIndex getColumnIndexForVariable(const Variable& var) const {
     const auto& map = _variableToColumnMap;
     if (!map.contains(var)) {
       throw std::runtime_error(absl::StrCat(

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -236,7 +236,8 @@ struct EvaluationContext {
   [[nodiscard]] size_t size() const { return _endIndex - _beginIndex; }
 
   // ____________________________________________________________________________
-  [[nodiscard]] ColumnIndex getColumnIndexForVariable(const Variable& var) const {
+  [[nodiscard]] ColumnIndex getColumnIndexForVariable(
+      const Variable& var) const {
     const auto& map = _variableToColumnMap;
     if (!map.contains(var)) {
       throw std::runtime_error(absl::StrCat(

--- a/src/global/Id.h
+++ b/src/global/Id.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <absl/strings/str_cat.h>
-// #include <boost/serialization/strong_typedef.hpp>
 
 #include <cstdint>
 #include <limits>
@@ -17,7 +16,6 @@ using Id = ValueId;
 typedef uint16_t Score;
 
 // TODO<joka921> Make the following ID and index types strong.
-// BOOST_STRONG_TYPEDEF(uint64_t, ColumnIndex)
 using ColumnIndex = uint64_t;
 
 // TODO<joka921> The following IDs only appear within the text index in the

--- a/src/global/Id.h
+++ b/src/global/Id.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <absl/strings/str_cat.h>
+// #include <boost/serialization/strong_typedef.hpp>
 
 #include <cstdint>
 #include <limits>
@@ -16,6 +17,7 @@ using Id = ValueId;
 typedef uint16_t Score;
 
 // TODO<joka921> Make the following ID and index types strong.
+// BOOST_STRONG_TYPEDEF(uint64_t, ColumnIndex)
 using ColumnIndex = uint64_t;
 
 // TODO<joka921> The following IDs only appear within the text index in the

--- a/src/util/JoinAlgorithms/JoinColumnMapping.h
+++ b/src/util/JoinAlgorithms/JoinColumnMapping.h
@@ -28,43 +28,43 @@ class JoinColumnMapping {
  private:
   // For a documentation of those members, see the getter function with the same
   // name below.
-  std::vector<size_t> jcsLeft_;
-  std::vector<size_t> jcsRight_;
-  std::vector<size_t> permutationLeft_;
-  std::vector<size_t> permutationRight_;
-  std::vector<size_t> permutationResult_;
+  std::vector<ColumnIndex> jcsLeft_;
+  std::vector<ColumnIndex> jcsRight_;
+  std::vector<ColumnIndex> permutationLeft_;
+  std::vector<ColumnIndex> permutationRight_;
+  std::vector<ColumnIndex> permutationResult_;
 
  public:
   // The join columns in the left input. For example if `jcsLeft()` is `[3, 0]`
   // this means that the primary join column is the third column of the left
   // input, and the secondary join column is the 0-th column of the left input.
-  const std::vector<size_t>& jcsLeft() const { return jcsLeft_; }
+  const std::vector<ColumnIndex>& jcsLeft() const { return jcsLeft_; }
   // The same, but for the right input.
-  const std::vector<size_t>& jcsRight() const { return jcsRight_; }
+  const std::vector<ColumnIndex>& jcsRight() const { return jcsRight_; }
 
   // This permutation has to be applied to the left input to obtain the column
   // order expected by the join algorithms (see above for details on the
   // different orderings). For example `permutationLeft()[0]` is `jcsLeft_[0]`
   // and `permutationLeft()[numJoinColumns]` is the index of the first non-join
   // column in the left input.
-  const std::vector<size_t>& permutationLeft() const {
+  const std::vector<ColumnIndex>& permutationLeft() const {
     return permutationLeft_;
   };
   // The same, but for the right input.
-  const std::vector<size_t>& permutationRight() const {
+  const std::vector<ColumnIndex>& permutationRight() const {
     return permutationRight_;
   }
   // This permutation has to be applied to the result of the join algorithms to
   // obtain the column order that the `Join` subclasses of `Operation` expect.
   // For example, `permutationResult[jcsLeft[0]] = 0`.
-  const std::vector<size_t>& permutationResult() const {
+  const std::vector<ColumnIndex>& permutationResult() const {
     return permutationResult_;
   }
 
   // Construct the mapping from the `joinColumn` (given as pairs of
   // (leftColIndex, rightColIndex)`), and the total number of columns in the
   // left and right input respectively.
-  JoinColumnMapping(const std::vector<std::array<size_t, 2>>& joinColumns,
+  JoinColumnMapping(const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
                     size_t numColsLeft, size_t numColsRight) {
     permutationResult_.resize(numColsLeft + numColsRight - joinColumns.size());
     for (auto [colA, colB] : joinColumns) {
@@ -76,7 +76,7 @@ class JoinColumnMapping {
     permutationLeft_ = jcsLeft_;
     permutationRight_ = jcsRight_;
 
-    for (size_t i = 0; i < numColsLeft; ++i) {
+    for (auto i = ColumnIndex{0}; i < numColsLeft; ++i) {
       if (!ad_utility::contains(jcsLeft_, i)) {
         permutationResult_.at(i) = permutationLeft_.size();
         permutationLeft_.push_back(i);
@@ -84,7 +84,7 @@ class JoinColumnMapping {
     }
 
     size_t numSkippedJoinColumns = 0;
-    for (size_t i = 0; i < numColsRight; ++i) {
+    for (auto i = ColumnIndex{0}; i < numColsRight; ++i) {
       if (!ad_utility::contains(jcsRight_, i)) {
         permutationResult_.at(i - numSkippedJoinColumns + numColsLeft) =
             i - numSkippedJoinColumns + numColsLeft;

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -56,7 +56,8 @@ TEST(EngineTest, distinctWithEmptyInput) {
   // Deliberately input a non-empty result to check that it is
   // overwritten by the (empty) input.
   IdTable result = makeIdTableFromVector({{3}});
-  CALL_FIXED_SIZE(1, Engine::distinct, input, std::vector<ColumnIndex>{}, &result);
+  CALL_FIXED_SIZE(1, Engine::distinct, input, std::vector<ColumnIndex>{},
+                  &result);
   ASSERT_EQ(input, result);
 }
 

--- a/test/EngineTest.cpp
+++ b/test/EngineTest.cpp
@@ -42,7 +42,7 @@ TEST(EngineTest, distinctTest) {
 
   IdTable result{4, makeAllocator()};
 
-  std::vector<size_t> keepIndices{{1, 2}};
+  std::vector<ColumnIndex> keepIndices{{1, 2}};
   CALL_FIXED_SIZE(4, Engine::distinct, input, keepIndices, &result);
 
   // For easier checking.
@@ -56,7 +56,7 @@ TEST(EngineTest, distinctWithEmptyInput) {
   // Deliberately input a non-empty result to check that it is
   // overwritten by the (empty) input.
   IdTable result = makeIdTableFromVector({{3}});
-  CALL_FIXED_SIZE(1, Engine::distinct, input, std::vector<size_t>{}, &result);
+  CALL_FIXED_SIZE(1, Engine::distinct, input, std::vector<ColumnIndex>{}, &result);
   ASSERT_EQ(input, result);
 }
 

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -43,7 +43,7 @@ class DummyOperation : public Operation {
 
   virtual size_t getResultWidth() const override { return 2; }
 
-  virtual vector<size_t> resultSortedOn() const override { return {1}; }
+  virtual vector<ColumnIndex> resultSortedOn() const override { return {1}; }
 
   virtual void setTextLimit(size_t limit) override { (void)limit; }
 

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -17,10 +17,10 @@ using ad_utility::source_location;
 namespace {
 
 // Create a `Sort` operation that sorts the `input` by the `sortColumns`.
-Sort makeSort(IdTable input, const std::vector<size_t>& sortColumns) {
+Sort makeSort(IdTable input, const std::vector<ColumnIndex>& sortColumns) {
   std::vector<Variable> vars;
   auto qec = ad_utility::testing::getQec();
-  for (size_t i = 0; i < input.numColumns(); ++i) {
+  for (ColumnIndex i = 0; i < input.numColumns(); ++i) {
     vars.emplace_back("?"s + std::to_string(i));
   }
   auto subtree = ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -39,8 +39,8 @@ void testSort(IdTable input, const IdTable& expected,
   auto qec = ad_utility::testing::getQec();
 
   // Set up the vector of sort columns. Those will later be permuted.
-  std::vector<size_t> sortColumns;
-  for (size_t i = 0; i < input.numColumns(); ++i) {
+  std::vector<ColumnIndex> sortColumns;
+  for (ColumnIndex i = 0; i < input.numColumns(); ++i) {
     sortColumns.push_back(i);
   }
 


### PR DESCRIPTION
In `Id.h`, a `ColumnIndex` data type is defined:

https://github.com/ad-freiburg/qlever/blob/c9abf998ace7edc3ff16b3abb346f19d41c22fc3/src/global/Id.h#L18-L19

and this is used in many places in the code:

https://github.com/ad-freiburg/qlever/blob/c9abf998ace7edc3ff16b3abb346f19d41c22fc3/src/engine/Sort.h#L22

https://github.com/ad-freiburg/qlever/blob/c9abf998ace7edc3ff16b3abb346f19d41c22fc3/src/engine/OptionalJoin.h#L29

https://github.com/ad-freiburg/qlever/blob/c9abf998ace7edc3ff16b3abb346f19d41c22fc3/src/engine/TransitivePath.cpp#L757

etc.

However, many other places in the code instead use `size_t` for column indices. This creates a problem on 64-bit MacOS, because for whatever reason `size_t` on that platform is 32-bits, not 64 bits, so it's not equal to `ColumnIndex` / `uint64_t`.

For example, this piece of code uses both types:

https://github.com/ad-freiburg/qlever/blob/c9abf998ace7edc3ff16b3abb346f19d41c22fc3/src/engine/Sort.h#L19-L33

On MacOS, this results in compilation errors like:

```
src/engine/Sort.h:32:12: error: no viable conversion from returned value of type
'const vector<ColumnIndex>' to function return type 'vector<size_t>'
    return sortColumnIndices_;
           ^~~~~~~~~~~~~~~~~~
```

To resolve the error, I just changed all references to column indices to use the `ColumnIndex` type consistently. That made the errors go away.

## Enforcing with a stronger type

I did notice the comment "TODO<joka921> Make the following ID and index types strong." so I tried doing that with:

```
#include <boost/serialization/strong_typedef.hpp>
BOOST_STRONG_TYPEDEF(uint64_t, ColumnIndex)
```
and it _mostly_ worked, and did make it much easier to ensure that the `ColumnIndex` type was used everywhere, but I ran into a compilation issue because the usage of the strongly-typed version doesn't quite work out of the box with abseil's hashing for some reason.

```
third_party/abseil-cpp/absl/container/internal/raw_hash_set.h:1160:73: error: type 'const absl::hash_internal::Hash<ColumnIndex>' does not provide a call operator
  auto KeyTypeCanBeHashed(const Hash& h, const key_type& k) -> decltype(h(k));
```

So for now I just left it as a regular type alias.