### PR TITLE
Additional type changes required for MacOS build

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -14,7 +14,7 @@
 size_t Bind::getResultWidth() const { return _subtree->getResultWidth() + 1; }
 
 // BIND doesn't change the number of result rows
-size_t Bind::getSizeEstimateBeforeLimit() {
+uint64_t Bind::getSizeEstimateBeforeLimit() {
   return _subtree->getSizeEstimate();
 }
 

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -31,7 +31,7 @@ class Bind : public Operation {
   size_t getCostEstimate() override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   float getMultiplicity(size_t col) override;

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -79,7 +79,7 @@ float CountAvailablePredicates::getMultiplicity([[maybe_unused]] size_t col) {
 }
 
 // _____________________________________________________________________________
-size_t CountAvailablePredicates::getSizeEstimateBeforeLimit() {
+uint64_t CountAvailablePredicates::getSizeEstimateBeforeLimit() {
   if (_subtree.get() != nullptr) {
     // Predicates are only computed for entities in the subtrees result.
 

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -81,7 +81,7 @@ class CountAvailablePredicates : public Operation {
   float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -40,7 +40,7 @@ class Distinct : public Operation {
   }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override {
+  uint64_t getSizeEstimateBeforeLimit() override {
     return _subtree->getSizeEstimate();
   }
 

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -469,7 +469,7 @@ ExportQueryExecutionTrees::constructQueryResultToTsvOrCsv(
 // _____________________________________________________________________________
 nlohmann::json ExportQueryExecutionTrees::computeQueryResultAsQLeverJSON(
     const ParsedQuery& query, const QueryExecutionTree& qet,
-    ad_utility::Timer& requestTimer, size_t maxSend) {
+    ad_utility::Timer& requestTimer, uint64_t maxSend) {
   shared_ptr<const ResultTable> resultTable = qet.getResult();
   resultTable->logResultSize();
   auto timeResultComputation = requestTimer.value();
@@ -562,7 +562,7 @@ ExportQueryExecutionTrees::computeConstructQueryResultAsTurtle(
 // _____________________________________________________________________________
 nlohmann::json ExportQueryExecutionTrees::computeSelectQueryResultAsSparqlJSON(
     const ParsedQuery& query, const QueryExecutionTree& qet,
-    [[maybe_unused]] ad_utility::Timer& requestTimer, size_t maxSend) {
+    [[maybe_unused]] ad_utility::Timer& requestTimer, uint64_t maxSend) {
   if (!query.hasSelectClause()) {
     AD_THROW(
         "SPARQL-compliant JSON format is only supported for SELECT queries");
@@ -580,7 +580,7 @@ nlohmann::json ExportQueryExecutionTrees::computeSelectQueryResultAsSparqlJSON(
 // _____________________________________________________________________________
 nlohmann::json ExportQueryExecutionTrees::computeResultAsJSON(
     const ParsedQuery& parsedQuery, const QueryExecutionTree& qet,
-    ad_utility::Timer& requestTimer, size_t maxSend,
+    ad_utility::Timer& requestTimer, uint64_t maxSend,
     ad_utility::MediaType mediaType) {
   switch (mediaType) {
     case ad_utility::MediaType::qleverJson:

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -54,7 +54,7 @@ class ExportQueryExecutionTrees {
   static nlohmann::json computeResultAsJSON(const ParsedQuery& parsedQuery,
                                             const QueryExecutionTree& qet,
                                             ad_utility::Timer& requestTimer,
-                                            size_t maxSend,
+                                            uint64_t maxSend,
                                             MediaType mediaType);
 
   // Convert the `id` to a human-readable string. The `index` is used to resolve
@@ -92,11 +92,11 @@ class ExportQueryExecutionTrees {
   // Similar to `queryToJSON`, but always returns the `QLeverJSON` format.
   static nlohmann::json computeQueryResultAsQLeverJSON(
       const ParsedQuery& query, const QueryExecutionTree& qet,
-      ad_utility::Timer& requestTimer, size_t maxSend);
+      ad_utility::Timer& requestTimer, uint64_t maxSend);
   // Similar to `queryToJSON`, but always returns the `SparqlJSON` format.
   static nlohmann::json computeSelectQueryResultAsSparqlJSON(
       const ParsedQuery& query, const QueryExecutionTree& qet,
-      ad_utility::Timer& requestTimer, size_t maxSend);
+      ad_utility::Timer& requestTimer, uint64_t maxSend);
 
   // ___________________________________________________________________________
   static ad_utility::streams::stream_generator

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -134,7 +134,7 @@ void Filter::computeFilterImpl(IdTable* outputIdTable,
 }
 
 // _____________________________________________________________________________
-size_t Filter::getSizeEstimateBeforeLimit() {
+uint64_t Filter::getSizeEstimateBeforeLimit() {
   return _expression
       .getEstimatesForFilterExpression(
           _subtree->getSizeEstimate(),

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -39,7 +39,7 @@ class Filter : public Operation {
   void setTextLimit(size_t limit) override { _subtree->setTextLimit(limit); }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -148,7 +148,7 @@ float GroupBy::getMultiplicity(size_t col) {
   return 1;
 }
 
-size_t GroupBy::getSizeEstimateBeforeLimit() {
+uint64_t GroupBy::getSizeEstimateBeforeLimit() {
   if (_groupByVariables.empty()) {
     return 1;
   }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -66,7 +66,7 @@ class GroupBy : public Operation {
   virtual float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -180,7 +180,7 @@ float HasPredicateScan::getMultiplicity(size_t col) {
   return 1;
 }
 
-size_t HasPredicateScan::getSizeEstimateBeforeLimit() {
+uint64_t HasPredicateScan::getSizeEstimateBeforeLimit() {
   switch (_type) {
     case ScanType::FREE_S:
       return static_cast<size_t>(

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -65,7 +65,7 @@ class HasPredicateScan : public Operation {
   float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -69,7 +69,7 @@ class IndexScan : public Operation {
  private:
   // TODO<joka921> Make the `getSizeEstimateBeforeLimit()` function `const` for
   // ALL the `Operations`.
-  size_t getSizeEstimateBeforeLimit() override { return getExactSize(); }
+  uint64_t getSizeEstimateBeforeLimit() override { return getExactSize(); }
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -61,7 +61,7 @@ class Join : public Operation {
   }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override {
+  uint64_t getSizeEstimateBeforeLimit() override {
     if (!_sizeEstimateComputed) {
       computeSizeEstimateAndMultiplicities();
       _sizeEstimateComputed = true;

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -93,7 +93,7 @@ float Minus::getMultiplicity(size_t col) {
 }
 
 // _____________________________________________________________________________
-size_t Minus::getSizeEstimateBeforeLimit() {
+uint64_t Minus::getSizeEstimateBeforeLimit() {
   // This is an upper bound on the size as an arbitrary number
   // of rows might be deleted in this operation.
   return _left->getSizeEstimate();

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -48,7 +48,7 @@ class Minus : public Operation {
   float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -132,7 +132,7 @@ float MultiColumnJoin::getMultiplicity(size_t col) {
 }
 
 // _____________________________________________________________________________
-size_t MultiColumnJoin::getSizeEstimateBeforeLimit() {
+uint64_t MultiColumnJoin::getSizeEstimateBeforeLimit() {
   if (!_multiplicitiesComputed) {
     computeSizeEstimateAndMultiplicities();
   }

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -48,7 +48,7 @@ class MultiColumnJoin : public Operation {
   virtual float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -29,7 +29,7 @@ class NeutralElementOperation : public Operation {
   size_t getCostEstimate() override { return 0; }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override { return 1; }
+  uint64_t getSizeEstimateBeforeLimit() override { return 1; }
 
  public:
   float getMultiplicity(size_t) override { return 0; };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -88,7 +88,7 @@ class Operation {
   virtual void setTextLimit(size_t limit) = 0;
   virtual size_t getCostEstimate() = 0;
 
-  virtual size_t getSizeEstimate() final {
+  virtual uint64_t getSizeEstimate() final {
     if (_limit._limit.has_value()) {
       return std::min(_limit._limit.value(), getSizeEstimateBeforeLimit());
     } else {
@@ -97,7 +97,7 @@ class Operation {
   }
 
  private:
-  virtual size_t getSizeEstimateBeforeLimit() = 0;
+  virtual uint64_t getSizeEstimateBeforeLimit() = 0;
 
  public:
   virtual float getMultiplicity(size_t col) = 0;

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -158,7 +158,7 @@ float OptionalJoin::getMultiplicity(size_t col) {
 }
 
 // _____________________________________________________________________________
-size_t OptionalJoin::getSizeEstimateBeforeLimit() {
+uint64_t OptionalJoin::getSizeEstimateBeforeLimit() {
   if (!_multiplicitiesComputed) {
     computeSizeEstimateAndMultiplicities();
   }

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -59,7 +59,7 @@ class OptionalJoin : public Operation {
   float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -46,7 +46,7 @@ class OrderBy : public Operation {
   void setTextLimit(size_t limit) override { subtree_->setTextLimit(limit); }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override {
+  uint64_t getSizeEstimateBeforeLimit() override {
     return subtree_->getSizeEstimate();
   }
 

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -70,7 +70,7 @@ float Service::getMultiplicity([[maybe_unused]] size_t col) {
 }
 
 // ____________________________________________________________________________
-size_t Service::getSizeEstimateBeforeLimit() {
+uint64_t Service::getSizeEstimateBeforeLimit() {
   // TODO: For now, we don't have any information about the result size at
   // query planning time, so we just return `100'000`.
   return 100'000;

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -61,7 +61,7 @@ class Service : public Operation {
   float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -37,7 +37,7 @@ class Sort : public Operation {
   }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override {
+  uint64_t getSizeEstimateBeforeLimit() override {
     return subtree_->getSizeEstimate();
   }
 

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -165,7 +165,7 @@ void TextOperationWithFilter::computeMultiplicities() {
 }
 
 // _____________________________________________________________________________
-size_t TextOperationWithFilter::getSizeEstimateBeforeLimit() {
+uint64_t TextOperationWithFilter::getSizeEstimateBeforeLimit() {
   if (_sizeEstimate == std::numeric_limits<size_t>::max()) {
     if (_executionContext) {
       // NEW at 05 Dec 2016:

--- a/src/engine/TextOperationWithFilter.h
+++ b/src/engine/TextOperationWithFilter.h
@@ -59,7 +59,7 @@ class TextOperationWithFilter : public Operation {
   }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -105,7 +105,7 @@ void TextOperationWithoutFilter::computeResultMultVars(IdTable* idTable) const {
 }
 
 // _____________________________________________________________________________
-size_t TextOperationWithoutFilter::getSizeEstimateBeforeLimit() {
+uint64_t TextOperationWithoutFilter::getSizeEstimateBeforeLimit() {
   if (_sizeEstimate == std::numeric_limits<size_t>::max()) {
     double nofEntitiesSingleVar;
     if (_executionContext) {

--- a/src/engine/TextOperationWithoutFilter.h
+++ b/src/engine/TextOperationWithoutFilter.h
@@ -53,7 +53,7 @@ class TextOperationWithoutFilter : public Operation {
   }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -165,7 +165,7 @@ float TransitivePath::getMultiplicity(size_t col) {
 }
 
 // _____________________________________________________________________________
-size_t TransitivePath::getSizeEstimateBeforeLimit() {
+uint64_t TransitivePath::getSizeEstimateBeforeLimit() {
   if (!_leftIsVar || !_rightIsVar) {
     // If the subject or object is fixed, assume that the number of matching
     // triples is 1000. This will usually be an overestimate, but it will do the

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -90,7 +90,7 @@ class TransitivePath : public Operation {
   virtual float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -157,7 +157,7 @@ float Union::getMultiplicity(size_t col) {
   return 1;
 }
 
-size_t Union::getSizeEstimateBeforeLimit() {
+uint64_t Union::getSizeEstimateBeforeLimit() {
   return _subtrees[0]->getSizeEstimate() + _subtrees[1]->getSizeEstimate();
 }
 

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -46,7 +46,7 @@ class Union : public Operation {
   virtual float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -79,7 +79,7 @@ float Values::getMultiplicity(size_t col) {
 }
 
 // ____________________________________________________________________________
-size_t Values::getSizeEstimateBeforeLimit() {
+uint64_t Values::getSizeEstimateBeforeLimit() {
   return parsedValues_._values.size();
 }
 

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -41,7 +41,7 @@ class Values : public Operation {
   virtual float getMultiplicity(size_t col) override;
 
  private:
-  size_t getSizeEstimateBeforeLimit() override;
+  uint64_t getSizeEstimateBeforeLimit() override;
 
  public:
   virtual size_t getCostEstimate() override;

--- a/src/engine/ValuesForTesting.h
+++ b/src/engine/ValuesForTesting.h
@@ -65,7 +65,7 @@ class ValuesForTesting : public Operation {
   size_t getCostEstimate() override { return table_.numRows(); }
 
  private:
-  size_t getSizeEstimateBeforeLimit() override { return table_.numRows(); }
+  uint64_t getSizeEstimateBeforeLimit() override { return table_.numRows(); }
 
  public:
   // For unit testing purposes it is useful that the columns have different

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -192,7 +192,7 @@ const size_t dayIndex = monthIndex + 3;
 // for year because of the potential two's complement.
 template <size_t Pos1, size_t Pos2>
 inline auto extractNumberFromDate =
-    [](std::string_view dateAsString) -> long int {
+    [](std::string_view dateAsString) -> int64_t {
   static_assert(Pos2 > Pos1);
   auto pos1 = Pos1;
   auto pos2 = Pos2;
@@ -234,7 +234,7 @@ using DayExpression = NARY<1, FV<decltype(extractDay), StringValueGetter>>;
 using StrExpression = NARY<1, FV<std::identity, StringValueGetter>>;
 
 // Compute string length.
-inline auto strlen = [](const auto& s) -> long int { return s.size(); };
+inline auto strlen = [](const auto& s) -> int64_t { return s.size(); };
 using StrlenExpression = NARY<1, FV<decltype(strlen), StringValueGetter>>;
 
 }  // namespace detail

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -133,7 +133,7 @@ class IndexImpl {
   bool usePatterns_ = false;
   double avgNumDistinctPredicatesPerSubject_;
   double avgNumDistinctSubjectsPerPredicate_;
-  size_t numDistinctSubjectPredicatePairs_;
+  uint64_t numDistinctSubjectPredicatePairs_;
 
   size_t parserBatchSize_ = PARSER_BATCH_SIZE;
   size_t numTriplesPerBatch_ = NUM_TRIPLES_PER_PARTIAL_VOCAB;

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -28,7 +28,7 @@ std::optional<OffsetAndSize> VocabularyOnDisk::getOffsetAndSize(
 
 // ____________________________________________________________________________
 VocabularyOnDisk::OffsetSizeId VocabularyOnDisk::getOffsetSizeIdForIthElement(
-    size_t i) const {
+    uint64_t i) const {
   AD_CONTRACT_CHECK(i < size());
   const auto offset = _idsAndOffsets[i]._offset;
   const auto nextOffset = _idsAndOffsets[i + 1]._offset;

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -50,7 +50,7 @@ class DummyOperation : public Operation {
   virtual size_t getCostEstimate() override { return 10; }
 
  private:
-  virtual size_t getSizeEstimateBeforeLimit() override { return 10; }
+  virtual uint64_t getSizeEstimateBeforeLimit() override { return 10; }
 
  public:
   virtual float getMultiplicity(size_t col) override {

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -247,10 +247,10 @@ TEST(SparqlExpression, dateOperators) {
   // result on the given date.
   auto check = [](const string& date, int expectedYear, int expectedMonth,
                   int expectedDay) {
-    auto checkYear = testUnaryExpression<YearExpression, std::string, long int>;
+    auto checkYear = testUnaryExpression<YearExpression, std::string, int64_t>;
     auto checkMonth =
-        testUnaryExpression<MonthExpression, std::string, long int>;
-    auto checkDay = testUnaryExpression<DayExpression, std::string, long int>;
+        testUnaryExpression<MonthExpression, std::string, int64_t>;
+    auto checkDay = testUnaryExpression<DayExpression, std::string, int64_t>;
     checkYear({date}, {expectedYear});
     checkMonth({date}, {expectedMonth});
     checkDay({date}, {expectedDay});
@@ -270,7 +270,7 @@ TEST(SparqlExpression, dateOperators) {
 }
 
 // Test `StrlenExpression` and `StrExpression`.
-auto checkStrlen = testUnaryExpression<StrlenExpression, std::string, long int>;
+auto checkStrlen = testUnaryExpression<StrlenExpression, std::string, int64_t>;
 template <typename OperandType>
 auto checkStr = [](std::vector<OperandType>&& operand,
                    std::vector<std::string>&& expected) {


### PR DESCRIPTION
In order to get this repo to build with LLCM clang 16 on MacOS, I had to change some ambiguous types to more explicit `uint64_t` and `int64_t` types.

See #989 and #990 for more context.