### PR TITLE
Store the first and last triple of each block in the metadata

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -32,6 +32,7 @@ Server::Server(unsigned short port, int numThreads, size_t maxMemGB,
             cache_.makeRoomAsMuchAsPossible(MAKE_ROOM_SLACK_FACTOR *
                                             numBytesToAllocate / sizeof(Id));
           }},
+      index_{allocator_},
       enablePatternTrick_(usePatternTrick),
       // The number of server threads currently also is the number of queries
       // that can be processed simultaneously.

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -21,27 +21,11 @@ void CompressedRelationReader::scan(
     ad_utility::SharedConcurrentTimeoutTimer timer) const {
   AD_CONTRACT_CHECK(result->numColumns() == NumColumns);
 
-  // get all the blocks where col0FirstId_ <= col0Id <= col0LastId_
-  struct KeyLhs {
-    Id col0FirstId_;
-    Id col0LastId_;
-  };
+  auto relevantBlocks =
+      getBlocksFromMetadata(metadata, std::nullopt, blockMetadata);
+  auto beginBlock = relevantBlocks.begin();
+  auto endBlock = relevantBlocks.end();
   Id col0Id = metadata.col0Id_;
-  // TODO<joka921, Clang16> Use a structured binding. Structured bindings are
-  // currently not supported by clang when using OpenMP because clang internally
-  // transforms the `#pragma`s into lambdas, and capturing structured bindings
-  // is only supported in clang >= 16.
-  decltype(blockMetadata.begin()) beginBlock, endBlock;
-  std::tie(beginBlock, endBlock) = std::equal_range(
-      // TODO<joka921> For some reason we can't use `std::ranges::equal_range`,
-      // find out why. Note: possibly it has something to do with the limited
-      // support of ranges in clang with versions < 16. Revisit this when
-      // we use clang 16.
-      blockMetadata.begin(), blockMetadata.end(), KeyLhs{col0Id, col0Id},
-      [](const auto& a, const auto& b) {
-        return a.col0FirstId_ < b.col0FirstId_ && a.col0LastId_ < b.col0LastId_;
-      });
-
   // The total size of the result is now known.
   result->resize(metadata.getNofElements());
 
@@ -56,13 +40,13 @@ void CompressedRelationReader::scan(
   // The first block might contain entries that are not part of our
   // actual scan result.
   bool firstBlockIsIncomplete =
-      beginBlock < endBlock &&
-      (beginBlock->col0FirstId_ < col0Id || beginBlock->col0LastId_ > col0Id);
+      beginBlock < endBlock && (beginBlock->firstTriple_[0] < col0Id ||
+                                beginBlock->lastTriple_[0] > col0Id);
   auto lastBlock = endBlock - 1;
 
   bool lastBlockIsIncomplete =
-      beginBlock < lastBlock &&
-      (lastBlock->col0FirstId_ < col0Id || lastBlock->col0LastId_ > col0Id);
+      beginBlock < lastBlock && (lastBlock->firstTriple_[0] < col0Id ||
+                                 lastBlock->lastTriple_[0] > col0Id);
 
   // Invariant: A relation spans multiple blocks exclusively or several
   // entities are stored completely in the same Block.
@@ -154,40 +138,21 @@ void CompressedRelationReader::scan(
 
 // _____________________________________________________________________________
 void CompressedRelationReader::scan(
-    const CompressedRelationMetadata& metaData, Id col1Id,
+    const CompressedRelationMetadata& metadata, Id col1Id,
     const vector<CompressedBlockMetadata>& blocks, ad_utility::File& file,
     IdTable* result, ad_utility::SharedConcurrentTimeoutTimer timer) const {
   AD_CONTRACT_CHECK(result->numColumns() == 1);
 
   // Get all the blocks  that possibly might contain our pair of col0Id and
   // col1Id
-  struct KeyLhs {
-    Id col0FirstId_;
-    Id col0LastId_;
-    Id col1FirstId_;
-    Id col1LastId_;
-  };
-
-  auto comp = [](const auto& a, const auto& b) {
-    bool endBeforeBegin = a.col0LastId_ < b.col0FirstId_;
-    endBeforeBegin |=
-        (a.col0LastId_ == b.col0FirstId_ && a.col1LastId_ < b.col1FirstId_);
-    return endBeforeBegin;
-  };
-
-  Id col0Id = metaData.col0Id_;
-
-  // Note: See the comment in the other overload for `scan` above for the
-  // reason why we (currently) can't use a structured binding here.
-  decltype(blocks.begin()) beginBlock, endBlock;
-  std::tie(beginBlock, endBlock) =
-      std::equal_range(blocks.begin(), blocks.end(),
-                       KeyLhs{col0Id, col0Id, col1Id, col1Id}, comp);
+  auto relevantBlocks = getBlocksFromMetadata(metadata, col1Id, blocks);
+  auto beginBlock = relevantBlocks.begin();
+  auto endBlock = relevantBlocks.end();
 
   // Invariant: The col0Id is completely stored in a single block, or it is
   // contained in multiple blocks that only contain this col0Id,
   bool col0IdHasExclusiveBlocks =
-      metaData.offsetInBlock_ == std::numeric_limits<uint64_t>::max();
+      metadata.offsetInBlock_ == std::numeric_limits<uint64_t>::max();
   if (!col0IdHasExclusiveBlocks) {
     // This might also be zero if no block was found at all.
     AD_CORRECTNESS_CHECK(endBlock - beginBlock <= 1);
@@ -207,13 +172,13 @@ void CompressedRelationReader::scan(
 
     // Find the range in the block, that belongs to the same relation `col0Id`
     bool containedInOnlyOneBlock =
-        metaData.offsetInBlock_ != std::numeric_limits<uint64_t>::max();
+        metadata.offsetInBlock_ != std::numeric_limits<uint64_t>::max();
     auto begin = col1Column.begin();
     if (containedInOnlyOneBlock) {
-      begin += metaData.offsetInBlock_;
+      begin += metadata.offsetInBlock_;
     }
     auto end =
-        containedInOnlyOneBlock ? begin + metaData.numRows_ : col1Column.end();
+        containedInOnlyOneBlock ? begin + metadata.numRows_ : col1Column.end();
 
     // Find the range in the block, where also the col1Id matches (the second
     // ID in the `std::array` does not matter).
@@ -329,7 +294,7 @@ CompressedRelationMetadata CompressedRelationWriter::addRelation(
   float multC2 = 42.42;
   // This sets everything except the offsetInBlock_, which will be set
   // explicitly below.
-  CompressedRelationMetadata metaData{col0Id, col1And2Ids.numRows(), multC1,
+  CompressedRelationMetadata metadata{col0Id, col1And2Ids.numRows(), multC1,
                                       multC2};
 
   // Determine the number of bytes the IDs stored in an IdTable consume.
@@ -355,18 +320,18 @@ CompressedRelationMetadata CompressedRelationWriter::addRelation(
     // The relation is large, immediately write the relation to a set of
     // exclusive blocks.
     writeRelationToExclusiveBlocks(col0Id, col1And2Ids);
-    metaData.offsetInBlock_ = std::numeric_limits<uint64_t>::max();
+    metadata.offsetInBlock_ = std::numeric_limits<uint64_t>::max();
   } else {
     // Append to the current buffered block.
-    metaData.offsetInBlock_ = buffer_.numRows();
+    metadata.offsetInBlock_ = buffer_.numRows();
     static_assert(sizeof(col1And2Ids[0][0]) == sizeof(Id));
     if (buffer_.numRows() == 0) {
-      currentBlockData_.col0FirstId_ = col0Id;
-      currentBlockData_.col1FirstId_ = col1And2Ids(0, 0);
+      currentBlockData_.firstTriple_ = {col0Id, col1And2Ids(0, 0),
+                                        col1And2Ids(0, 1)};
     }
-    currentBlockData_.col0LastId_ = col0Id;
-    currentBlockData_.col1LastId_ = col1And2Ids(col1And2Ids.numRows() - 1, 0);
-    currentBlockData_.col2LastId_ = col1And2Ids(col1And2Ids.numRows() - 1, 1);
+    currentBlockData_.lastTriple_ = {col0Id,
+                                     col1And2Ids(col1And2Ids.numRows() - 1, 0),
+                                     col1And2Ids(col1And2Ids.numRows() - 1, 1)};
     AD_CORRECTNESS_CHECK(buffer_.numColumns() == col1And2Ids.numColumns());
     auto bufferOldSize = buffer_.numRows();
     buffer_.resize(buffer_.numRows() + col1And2Ids.numRows());
@@ -375,7 +340,7 @@ CompressedRelationMetadata CompressedRelationWriter::addRelation(
       std::ranges::copy(column, buffer_.getColumn(i).begin() + bufferOldSize);
     }
   }
-  return metaData;
+  return metadata;
 }
 
 // _____________________________________________________________________________
@@ -394,10 +359,12 @@ void CompressedRelationWriter::writeRelationToExclusiveBlocks(
           {column.begin() + i, column.begin() + i + actualNumRowsPerBlock}));
     }
 
-    blockBuffer_.push_back(CompressedBlockMetadata{
-        std::move(offsets), actualNumRowsPerBlock, col0Id, col0Id, data[i][0],
-        data[i + actualNumRowsPerBlock - 1][0],
-        data[i + actualNumRowsPerBlock - 1][1]});
+    blockBuffer_.push_back(
+        CompressedBlockMetadata{std::move(offsets),
+                                actualNumRowsPerBlock,
+                                {col0Id, data[i][0], data[i][1]},
+                                {col0Id, data[i + actualNumRowsPerBlock - 1][0],
+                                 data[i + actualNumRowsPerBlock - 1][1]}});
   }
 }
 
@@ -459,8 +426,8 @@ CompressedBlock CompressedRelationReader::readCompressedBlockFromFile(
 
 // ____________________________________________________________________________
 DecompressedBlock CompressedRelationReader::decompressBlock(
-    const CompressedBlock& compressedBlock, size_t numRowsToRead) {
-  DecompressedBlock decompressedBlock{compressedBlock.size()};
+    const CompressedBlock& compressedBlock, size_t numRowsToRead) const {
+  DecompressedBlock decompressedBlock{compressedBlock.size(), allocator_};
   decompressedBlock.resize(numRowsToRead);
   for (size_t i = 0; i < compressedBlock.size(); ++i) {
     auto col = decompressedBlock.getColumn(i);
@@ -498,7 +465,7 @@ void CompressedRelationReader::decompressColumn(
 // _____________________________________________________________________________
 DecompressedBlock CompressedRelationReader::readAndDecompressBlock(
     const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
-    std::optional<std::vector<size_t>> columnIndices) {
+    std::optional<std::vector<size_t>> columnIndices) const {
   CompressedBlock compressedColumns = readCompressedBlockFromFile(
       blockMetaData, file, std::move(columnIndices));
   const auto numRowsToRead = blockMetaData.numRows_;
@@ -515,3 +482,27 @@ CompressedRelationWriter::compressAndWriteColumn(std::span<const Id> column) {
   outfile_.write(compressedBlock.data(), compressedBlock.size());
   return {offsetInFile, compressedSize};
 };
+
+// _____________________________________________________________________________
+std::span<const CompressedBlockMetadata>
+CompressedRelationReader::getBlocksFromMetadata(
+    const CompressedRelationMetadata& metadata, std::optional<Id> col1Id,
+    std::span<const CompressedBlockMetadata> blockMetadata) {
+  // Get all the blocks  that possibly might contain our pair of col0Id and
+  // col1Id
+  Id col0Id = metadata.col0Id_;
+  CompressedBlockMetadata key;
+  key.firstTriple_[0] = col0Id;
+  key.lastTriple_[0] = col0Id;
+  key.firstTriple_[1] = col1Id.value_or(Id::min());
+  key.lastTriple_[1] = col1Id.value_or(Id::max());
+
+  auto comp = [](const auto& a, const auto& b) {
+    bool endBeforeBegin = a.lastTriple_[0] < b.firstTriple_[0];
+    endBeforeBegin |= (a.lastTriple_[0] == b.firstTriple_[0] &&
+                       a.lastTriple_[1] < b.firstTriple_[1]);
+    return endBeforeBegin;
+  };
+
+  return std::ranges::equal_range(blockMetadata, key, comp);
+}

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -16,6 +16,7 @@
 #include "util/ConcurrentCache.h"
 #include "util/File.h"
 #include "util/Serializer/ByteBufferSerializer.h"
+#include "util/Serializer/SerializeArray.h"
 #include "util/Serializer/SerializeVector.h"
 #include "util/Serializer/Serializer.h"
 #include "util/Timer.h"
@@ -40,7 +41,7 @@ using SmallRelationsBuffer = columnBasedIdTable::IdTable<Id, NumColumns>;
 
 // Sometimes we do not read/decompress  all the columns of a block, so we have
 // to use a dynamic `IdTable`.
-using DecompressedBlock = columnBasedIdTable::IdTable<Id, 0>;
+using DecompressedBlock = IdTable;
 
 // After compression the columns have different sizes, so we cannot use an
 // `IdTable`.
@@ -57,23 +58,23 @@ struct CompressedBlockMetadata {
   };
   std::vector<OffsetAndCompressedSize> offsetsAndCompressedSize_;
   size_t numRows_;
-  // For example, in the PSO permutation, col0 is the P and col1 is the S. The
-  // col0 ID is not stored in the block. First and last are meant inclusively,
-  // that is, they are both part of the block.
-  //
-  // NOTE: Strictly speaking, we don't need `col0FirstId_` and `col1FirstId_`.
-  // However, they are convenient to have and don't really harm with respect to
-  // space efficiency. For example, for Wikidata, we have only around 50K blocks
-  // with block size 8M and around 5M blocks with block size 80K; even the
-  // latter takes only half a GB in total.
-  Id col0FirstId_;
-  Id col0LastId_;
-  Id col1FirstId_;
-  Id col1LastId_;
 
-  // For our `DeltaTriples` (https://github.com/ad-freiburg/qlever/pull/916), we
-  // need to know the least significant `Id` of the last triple as well.
-  Id col2LastId_;
+  // Store the first and the last triple of the block. First and last are meant
+  // inclusively, that is, they are both part of the block. The order of the
+  // triples depends on the stored permutation: For example, in the PSO
+  // permutation, the first element of the triples is the P, the second one is
+  // the S and the third one is the O. Note that the first key of the
+  // permutation (for example the P in the PSO permutation) is not stored in the
+  // blocks, but has to be retrieved via the corresponding
+  // `CompressedRelationMetadata`. NOTE: Strictly speaking, storing one of
+  // `firstTriple_` or `lastTriple_` would probably suffice. However, they make
+  // several functions much easier to implement and don't really harm with
+  // respect to space efficiency. For example, for Wikidata, we have only around
+  // 50K blocks with block size 8M and around 5M blocks with block size 80K;
+  // even the latter takes only half a GB in total.
+  //
+  std::array<Id, 3> firstTriple_;
+  std::array<Id, 3> lastTriple_;
 
   // Two of these are equal if all members are equal.
   bool operator==(const CompressedBlockMetadata&) const = default;
@@ -89,11 +90,8 @@ AD_SERIALIZE_FUNCTION(CompressedBlockMetadata::OffsetAndCompressedSize) {
 AD_SERIALIZE_FUNCTION(CompressedBlockMetadata) {
   serializer | arg.offsetsAndCompressedSize_;
   serializer | arg.numRows_;
-  serializer | arg.col0FirstId_;
-  serializer | arg.col0LastId_;
-  serializer | arg.col1FirstId_;
-  serializer | arg.col1LastId_;
-  serializer | arg.col2LastId_;
+  serializer | arg.firstTriple_;
+  serializer | arg.lastTriple_;
 }
 
 // The metadata of a whole compressed "relation", where relation refers to a
@@ -222,6 +220,9 @@ class CompressedRelationWriter {
 /// Manage the reading of relations from disk that have been previously written
 /// using the `CompressedRelationWriter`.
 class CompressedRelationReader {
+ public:
+  using Allocator = ad_utility::AllocatorWithLimit<Id>;
+
  private:
   // This cache stores a small number of decompressed blocks. Its current
   // purpose is to make the e2e-tests run fast. They contain many SPARQL queries
@@ -233,7 +234,12 @@ class CompressedRelationReader {
       ad_utility::HeapBasedLRUCache<off_t, DecompressedBlock>>
       blockCache_{20ul};
 
+  // The allocator used to allocate intermediate buffers.
+  mutable Allocator allocator_;
+
  public:
+  CompressedRelationReader(Allocator allocator)
+      : allocator_{std::move(allocator)} {}
   /**
    * @brief For a permutation XYZ, retrieve all YZ for a given X.
    *
@@ -246,7 +252,7 @@ class CompressedRelationReader {
    * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
    *          if the timer runs out during the exeuction of this function.
    *
-   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The arguments `metadata`, `blocks`, and `file` must all be obtained from
    * The same `CompressedRelationWriter` (see below).
    */
   void scan(const CompressedRelationMetadata& metadata,
@@ -257,7 +263,7 @@ class CompressedRelationReader {
   /**
    * @brief For a permutation XYZ, retrieve all Z for given X and Y.
    *
-   * @param metaData The metadata of the given X.
+   * @param metadata The metadata of the given X.
    * @param col1Id The ID for Y.
    * @param blocks The metadata of the on-disk blocks for the given permutation.
    * @param file The file in which the permutation is stored.
@@ -266,13 +272,21 @@ class CompressedRelationReader {
    * @param timer If specified (!= nullptr) a `TimeoutException` will be thrown
    *              if the timer runs out during the exeuction of this function.
    *
-   * The arguments `metaData`, `blocks`, and `file` must all be obtained from
+   * The arguments `metadata`, `blocks`, and `file` must all be obtained from
    * The same `CompressedRelationWriter` (see below).
    */
-  void scan(const CompressedRelationMetadata& metaData, Id col1Id,
+  void scan(const CompressedRelationMetadata& metadata, Id col1Id,
             const vector<CompressedBlockMetadata>& blocks,
             ad_utility::File& file, IdTable* result,
             ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+
+  // Get the contiguous subrange of the given `blockMetadata` for the blocks
+  // that contain the triples that have the relation/col0Id that was specified
+  // by the `medata`. If the `col1Id` is specified (not `nullopt`), then the
+  // blocks are additionally filtered by the given `col1Id`.
+  static std::span<const CompressedBlockMetadata> getBlocksFromMetadata(
+      const CompressedRelationMetadata& metadata, std::optional<Id> col1Id,
+      std::span<const CompressedBlockMetadata> blockMetadata);
 
  private:
   // Read the block that is identified by the `blockMetaData` from the `file`.
@@ -286,8 +300,8 @@ class CompressedRelationReader {
   // have after decompression must be passed in via the `numRowsToRead`
   // argument. It is typically obtained from the corresponding
   // `CompressedBlockMetaData`.
-  static DecompressedBlock decompressBlock(
-      const CompressedBlock& compressedBlock, size_t numRowsToRead);
+  DecompressedBlock decompressBlock(const CompressedBlock& compressedBlock,
+                                    size_t numRowsToRead) const;
 
   // Similar to `decompressBlock`, but the block is directly decompressed into
   // the `table`, starting at the `offsetInTable`-th row. The `table` and the
@@ -309,9 +323,9 @@ class CompressedRelationReader {
   // decompress and return it.
   // If `columnIndices` is `nullopt`, then all columns of the block are read,
   // else only the specified columns are read.
-  static DecompressedBlock readAndDecompressBlock(
+  DecompressedBlock readAndDecompressBlock(
       const CompressedBlockMetadata& blockMetaData, ad_utility::File& file,
-      std::optional<std::vector<size_t>> columnIndices);
+      std::optional<std::vector<size_t>> columnIndices) const;
 };
 
 #endif  // QLEVER_COMPRESSEDRELATION_H

--- a/src/index/CreatePatternsMain.cpp
+++ b/src/index/CreatePatternsMain.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
   cout << "Set locale LC_CTYPE to: " << locale << endl;
 
   try {
-    Index index;
+    Index index{ad_utility::makeUnlimitedAllocator<Id>()};
     index.setUsePatterns(false);
     index.createFromOnDiskIndex(baseName);
     index.addPatternsToExistingIndex();

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -9,7 +9,8 @@
 #include "./IndexImpl.h"
 
 // ____________________________________________________________
-Index::Index() : pimpl_{std::make_unique<IndexImpl>()} {}
+Index::Index(ad_utility::AllocatorWithLimit<Id> allocator)
+    : pimpl_{std::make_unique<IndexImpl>(std::move(allocator))} {}
 Index::Index(Index&&) noexcept = default;
 
 // Needs to be in the .cpp file because of the unique_ptr to a forwarded class.

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -67,7 +67,7 @@ class Index {
   /// Allow move construction, which is mostly used in unit tests.
   Index(Index&&) noexcept;
 
-  Index();
+  Index(ad_utility::AllocatorWithLimit<Id> allocator);
   ~Index();
 
   // Get underlying access to the Pimpl where necessary.

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
   std::optional<ad_utility::NonNegative> stxxlMemoryGB;
   optind = 1;
 
-  Index index;
+  Index index{ad_utility::makeUnlimitedAllocator<Id>()};
 
   boost::program_options::options_description boostOptions(
       "Options for IndexBuilderMain");

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -30,7 +30,8 @@
 using std::array;
 
 // _____________________________________________________________________________
-IndexImpl::IndexImpl() = default;
+IndexImpl::IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator)
+    : allocator_{std::move(allocator)} {};
 
 // _____________________________________________________________________________
 template <class Parser>

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -157,18 +157,20 @@ class IndexImpl {
    */
   CompactVectorOfStrings<Id> hasPredicate_;
 
+  ad_utility::AllocatorWithLimit<Id> allocator_;
+
   // TODO: make those private and allow only const access
   // instantiations for the six permutations used in QLever.
   // They simplify the creation of permutations in the index class.
-  Permutation pos_{"POS", ".pos", {1, 2, 0}};
-  Permutation pso_{"PSO", ".pso", {1, 0, 2}};
-  Permutation sop_{"SOP", ".sop", {0, 2, 1}};
-  Permutation spo_{"SPO", ".spo", {0, 1, 2}};
-  Permutation ops_{"OPS", ".ops", {2, 1, 0}};
-  Permutation osp_{"OSP", ".osp", {2, 0, 1}};
+  Permutation pos_{"POS", ".pos", {1, 2, 0}, allocator_};
+  Permutation pso_{"PSO", ".pso", {1, 0, 2}, allocator_};
+  Permutation sop_{"SOP", ".sop", {0, 2, 1}, allocator_};
+  Permutation spo_{"SPO", ".spo", {0, 1, 2}, allocator_};
+  Permutation ops_{"OPS", ".ops", {2, 1, 0}, allocator_};
+  Permutation osp_{"OSP", ".osp", {2, 0, 1}, allocator_};
 
  public:
-  IndexImpl();
+  IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator);
 
   // Forbid copying.
   IndexImpl& operator=(const IndexImpl&) = delete;

--- a/src/index/PermutationExporterMain.cpp
+++ b/src/index/PermutationExporterMain.cpp
@@ -40,7 +40,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
-  Index i;
+  Index i{ad_utility::makeUnlimitedAllocator<Id>()};
   IndexImpl& impl = i.getImpl();
   std::string indexName{argv[1]};
   std::string p{argv[2]};

--- a/src/index/Permutations.h
+++ b/src/index/Permutations.h
@@ -27,10 +27,13 @@ class Permutation {
   static constexpr auto OPS = Enum::OPS;
   static constexpr auto OSP = Enum::OSP;
   using MetaData = IndexMetaDataMmapView;
-  Permutation(string name, string suffix, array<unsigned short, 3> order)
+  using Allocator = ad_utility::AllocatorWithLimit<Id>;
+  Permutation(string name, string suffix, array<unsigned short, 3> order,
+              Allocator allocator)
       : _readableName(std::move(name)),
         _fileSuffix(std::move(suffix)),
-        _keyOrder(order) {}
+        _keyOrder(order),
+        _reader(std::move(allocator)) {}
 
   // everything that has to be done when reading an index from disk
   void loadFromDisk(const std::string& onDiskBase) {

--- a/src/util/AllocatorWithLimit.h
+++ b/src/util/AllocatorWithLimit.h
@@ -216,6 +216,18 @@ class AllocatorWithLimit {
   }
 };
 
+// Return a new allocator with the specified limit.
+template <typename T>
+AllocatorWithLimit<T> makeAllocatorWithLimit(size_t limit) {
+  return AllocatorWithLimit<T>{makeAllocationMemoryLeftThreadsafeObject(limit)};
+}
+
+// Return a new allocator with the maximal possible limit.
+template <typename T>
+AllocatorWithLimit<T> makeUnlimitedAllocator() {
+  return makeAllocatorWithLimit<T>(std::numeric_limits<size_t>::max());
+}
+
 }  // namespace ad_utility
 
 #endif  // QLEVER_ALLOCATORWITHLIMIT_H

--- a/src/util/Serializer/SerializeArray.h
+++ b/src/util/Serializer/SerializeArray.h
@@ -1,0 +1,25 @@
+// Copyright 2023, University of Freiburg,
+//                 Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#pragma once
+
+#include <array>
+
+#include "util/Serializer/Serializer.h"
+#include "util/TypeTraits.h"
+
+namespace ad_utility::serialization {
+AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT((ad_utility::isArray<std::decay_t<T>>)) {
+  using V = typename std::decay_t<T>::value_type;
+  if constexpr (TriviallySerializable<V>) {
+    using CharPtr = std::conditional_t<ReadSerializer<S>, char*, const char*>;
+    serializer.serializeBytes(reinterpret_cast<CharPtr>(arg.data()),
+                              arg.size() * sizeof(V));
+  } else {
+    for (size_t i = 0; i < arg.size(); ++i) {
+      serializer | arg[i];
+    }
+  }
+}
+}  // namespace ad_utility::serialization

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -97,6 +97,13 @@ constexpr static bool isTuple = isInstantiation<T, std::tuple>;
 template <typename T>
 constexpr static bool isVariant = isInstantiation<T, std::variant>;
 
+/// isArray<T> is true if and only if `T` is an instantiation of `std::array`.
+template <typename T>
+constexpr static bool isArray = false;
+
+template <typename T, size_t N>
+constexpr static bool isArray<std::array<T, N>> = true;
+
 /// Two types are similar, if they are the same when we remove all cv (const or
 /// volatile) qualifiers and all references
 template <typename T, typename U>

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -105,7 +105,7 @@ void testCompressedRelations(const std::vector<RelationInput>& inputs,
       ad_utility::TimeoutTimer::unlimited());
   // Check the contents of the metadata.
 
-  CompressedRelationReader reader;
+  CompressedRelationReader reader{ad_utility::makeUnlimitedAllocator<Id>()};
   for (size_t i = 0; i < metaData.size(); ++i) {
     const auto& m = metaData[i];
     ASSERT_EQ(V(inputs[i].col0_), m.col0Id_);

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -245,7 +245,7 @@ TEST(HasPredicateScan, subtreeS) {
   CompactVectorOfStrings<Id> hasRelation(hasRelationSrc);
   CompactVectorOfStrings<Id> patterns(patternsSrc);
 
-  Index index;
+  Index index{ad_utility::makeUnlimitedAllocator<Id>()};
   QueryResultCache cache{};
   QueryExecutionContext ctx(index, &cache, makeAllocator(),
                             SortPerformanceEstimator{});

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -17,7 +17,7 @@ auto V = ad_utility::testing::VocabId;
 
 TEST(RelationMetaDataTest, writeReadTest) {
   CompressedBlockMetadata rmdB{
-      {{12, 34}, {46, 11}}, 5, V(0), V(2), V(13), V(24), V(62)};
+      {{12, 34}, {46, 11}}, 5, {V(0), V(2), V(13)}, {V(3), V(24), V(62)}};
   CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
 
   ad_utility::serialization::FileWriteSerializer f("_testtmp.rmd");
@@ -41,9 +41,9 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
   std::string mmapFilename = imdFilename + ".mmap";
   vector<CompressedBlockMetadata> bs;
   bs.push_back(CompressedBlockMetadata{
-      {{12, 34}, {42, 17}}, 5, V(0), V(2), V(13), V(24), V(62)});
+      {{12, 34}, {42, 17}}, 5, {V(0), V(2), V(13)}, {V(2), V(24), V(62)}});
   bs.push_back(CompressedBlockMetadata{
-      {{12, 34}, {16, 12}}, 5, V(0), V(2), V(13), V(24), V(62)});
+      {{12, 34}, {16, 12}}, 5, {V(0), V(2), V(13)}, {V(3), V(24), V(62)}});
   CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
   CompressedRelationMetadata rmdF2{V(2), 5, 3.0, 43.0, 10};
   // The index MetaData does not have an explicit clear, so we

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -338,7 +338,7 @@ MATCHER_P2(IsPossiblyExternalString, content, isExternal, "") {
 
 TEST(IndexTest, TripleToInternalRepresentation) {
   {
-    IndexImpl index;
+    IndexImpl index{ad_utility::makeUnlimitedAllocator<Id>()};
     TurtleTriple turtleTriple{"<subject>", "<predicate>", lit("\"literal\"")};
     LangtagAndTriple res =
         index.tripleToInternalRepresentation(std::move(turtleTriple));
@@ -348,7 +348,7 @@ TEST(IndexTest, TripleToInternalRepresentation) {
     EXPECT_THAT(res._triple[2], IsPossiblyExternalString("\"literal\"", false));
   }
   {
-    IndexImpl index;
+    IndexImpl index{ad_utility::makeUnlimitedAllocator<Id>()};
     index.getNonConstVocabForTesting().initializeExternalizePrefixes(
         std::vector{"<subj"s});
     TurtleTriple turtleTriple{"<subject>", "<predicate>",
@@ -363,7 +363,7 @@ TEST(IndexTest, TripleToInternalRepresentation) {
                 IsPossiblyExternalString("\"literal\"@fr", true));
   }
   {
-    IndexImpl index;
+    IndexImpl index{ad_utility::makeUnlimitedAllocator<Id>()};
     TurtleTriple turtleTriple{"<subject>", "<predicate>", 42.0};
     LangtagAndTriple res =
         index.tripleToInternalRepresentation(std::move(turtleTriple));

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -19,7 +19,7 @@ namespace ad_utility::testing {
 // such that very small indices, as they are typically used for unit tests,
 // can be built without a lot of time and memory overhead.
 inline Index makeIndexWithTestSettings() {
-  Index index;
+  Index index{ad_utility::makeUnlimitedAllocator<Id>()};
   index.setNumTriplesPerBatch(2);
   index.stxxlMemoryInBytes() = 1024ul * 1024ul * 50;
   return index;
@@ -88,7 +88,7 @@ inline Index makeTestIndex(const std::string& indexBasename,
     index.setPrefixCompression(usePrefixCompression);
     index.createFromFile<TurtleParserAuto>(inputFilename);
   }
-  Index index;
+  Index index{ad_utility::makeUnlimitedAllocator<Id>()};
   index.setUsePatterns(usePatterns);
   index.setLoadAllPermutations(loadAllPermutations);
   index.createFromOnDiskIndex(indexBasename);

--- a/test/SparqlDataTypesTest.cpp
+++ b/test/SparqlDataTypesTest.cpp
@@ -13,7 +13,7 @@ using enum PositionInTriple;
 
 namespace {
 struct ContextWrapper {
-  Index _index{};
+  Index _index{ad_utility::makeUnlimitedAllocator<Id>()};
   ResultTable _resultTable{
       IdTable{ad_utility::testing::makeAllocator()}, {}, LocalVocab{}};
   // TODO<joka921> `VariableToColumnMap`


### PR DESCRIPTION
Also respect the memory limit for temporary blocks that are stored during the reading of a relation.