### PR TITLE
Add unit tests for `RuntimeInformation` class

### DIFF
--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -23,10 +23,14 @@ std::string RuntimeInformation::toString() const {
 
 namespace {
 // A small formatting helper used inside RuntimeInformation::writeToStream.
-std::string indentStr(size_t indent) {
+std::string indentStr(size_t indent, bool stripped = false) {
   std::string ind;
   for (size_t i = 0; i < indent; i++) {
-    ind += "│  ";
+    if (stripped && i == indent - 1) {
+      ind += "│";
+    } else {
+      ind += "│  ";
+    }
   }
   return ind;
 }
@@ -35,7 +39,7 @@ std::string indentStr(size_t indent) {
 // ________________________________________________________________________________________________________________
 void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
   using json = nlohmann::json;
-  out << indentStr(indent) << '\n';
+  out << indentStr(indent, true) << '\n';
   out << indentStr(indent - 1) << "├─ " << descriptor_ << '\n';
   out << indentStr(indent) << "result_size: " << numRows_ << " x " << numCols_
       << '\n';
@@ -45,6 +49,7 @@ void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
       << '\n';
   out << indentStr(indent) << "operation_time: " << getOperationTime() << " ms"
       << '\n';
+  out << indentStr(indent) << "status: " << toString(status_) << '\n';
   out << indentStr(indent)
       << "cache_status: " << ad_utility::toString(cacheStatus_) << '\n';
   if (cacheStatus_ != ad_utility::CacheStatus::computed) {

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -9,7 +9,7 @@
 
 #include <ranges>
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 std::string RuntimeInformation::toString() const {
   std::ostringstream buffer;
   // Imbue with the same locale as std::cout which uses for example
@@ -36,14 +36,14 @@ std::string indentStr(size_t indent, bool stripped = false) {
 }
 }  // namespace
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 void RuntimeInformation::formatDetailValue(std::ostream& out,
                                            std::string_view key,
                                            const nlohmann::json& value) {
   using nlohmann::json;
   // We want to print doubles with fixed precision and stream ints as their
   // native type so they get thousands separators. For everything else we
-  // let nlohmann::json handle it
+  // let nlohmann::json handle it.
   if (value.type() == json::value_t::number_float) {
     out << ad_utility::to_string(value.get<double>(), 2);
   } else if (value.type() == json::value_t::number_unsigned) {
@@ -58,7 +58,7 @@ void RuntimeInformation::formatDetailValue(std::ostream& out,
   }
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
   out << indentStr(indent, true) << '\n';
   out << indentStr(indent - 1) << "├─ " << descriptor_ << '\n';
@@ -93,7 +93,7 @@ void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
   }
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 void RuntimeInformation::setColumnNames(const VariableToColumnMap& columnMap) {
   if (columnMap.empty()) {
     columnNames_.clear();
@@ -113,7 +113,7 @@ void RuntimeInformation::setColumnNames(const VariableToColumnMap& columnMap) {
   }
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 double RuntimeInformation::getOperationTime() const {
   if (cacheStatus_ != ad_utility::CacheStatus::computed) {
     return totalTime_;
@@ -131,7 +131,7 @@ double RuntimeInformation::getOperationTime() const {
   }
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 size_t RuntimeInformation::getOperationCostEstimate() const {
   size_t result = costEstimate_;
   for (const auto& child : children_) {
@@ -140,7 +140,7 @@ size_t RuntimeInformation::getOperationCostEstimate() const {
   return result;
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 std::string_view RuntimeInformation::toString(Status status) {
   switch (status) {
     case completed:
@@ -160,7 +160,7 @@ std::string_view RuntimeInformation::toString(Status status) {
   }
 }
 
-// _____________________________________________________________________________
+// __________________________________________________________________________
 double RuntimeInformation::getTotalTimeCorrected() const {
   double timeOfChildrenComputedDuringQueryPlanning = 0;
 
@@ -186,7 +186,7 @@ double RuntimeInformation::getTotalTimeCorrected() const {
   return totalTime_ + timeOfChildrenComputedDuringQueryPlanning;
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 void to_json(nlohmann::ordered_json& j, const RuntimeInformation& rti) {
   j = nlohmann::ordered_json{
       {"description", rti.descriptor_},
@@ -207,7 +207,7 @@ void to_json(nlohmann::ordered_json& j, const RuntimeInformation& rti) {
       {"children", rti.children_}};
 }
 
-// ________________________________________________________________________________________________________________
+// __________________________________________________________________________
 void to_json(nlohmann::ordered_json& j,
              const RuntimeInformationWholeQuery& rti) {
   j = nlohmann::ordered_json{
@@ -215,7 +215,7 @@ void to_json(nlohmann::ordered_json& j,
       {"time_index_scans_query_planning", rti.timeIndexScansQueryPlanning}};
 }
 
-// ___________________________________________________________________________________
+// __________________________________________________________________________
 void RuntimeInformation::addLimitOffsetRow(const LimitOffsetClause& l,
                                            size_t timeForLimit,
                                            bool fullResultIsNotCached) {

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -40,15 +40,15 @@ std::string indentStr(size_t indent, bool stripped = false) {
 void RuntimeInformation::formatDetailValue(std::ostream& out,
                                            std::string_view key,
                                            const nlohmann::json& value) {
-  using nlohmann::json;
+  using enum nlohmann::json::value_t;
   // We want to print doubles with fixed precision and stream ints as their
   // native type so they get thousands separators. For everything else we
   // let nlohmann::json handle it.
-  if (value.type() == json::value_t::number_float) {
+  if (value.type() == number_float) {
     out << ad_utility::to_string(value.get<double>(), 2);
-  } else if (value.type() == json::value_t::number_unsigned) {
+  } else if (value.type() == number_unsigned) {
     out << value.template get<uint64_t>();
-  } else if (value.type() == json::value_t::number_integer) {
+  } else if (value.type() == number_integer) {
     out << value.get<int64_t>();
   } else {
     out << value;

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -84,6 +84,7 @@ void RuntimeInformation::writeToStream(std::ostream& out, size_t indent) const {
 // ________________________________________________________________________________________________________________
 void RuntimeInformation::setColumnNames(const VariableToColumnMap& columnMap) {
   if (columnMap.empty()) {
+    columnNames_.clear();
     return;
   }
 

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -118,6 +118,10 @@ class RuntimeInformation {
                          bool fullResultIsNotCached);
 
   static std::string_view toString(Status status);
+
+  // A helper function for printing the details as a string.
+  static void formatDetailValue(std::ostream& out, std::string_view key,
+                                const nlohmann::json& value);
 };
 
 // A class to store information about the execution of a complete query, e.g.

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -117,7 +117,6 @@ class RuntimeInformation {
   void addLimitOffsetRow(const LimitOffsetClause& l, size_t timeForLimit,
                          bool fullResultIsNotCached);
 
- private:
   static std::string_view toString(Status status);
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -310,7 +310,7 @@ addLinkAndDiscoverTest(LimitOffsetClauseTest)
 
 addLinkAndDiscoverTest(OperationTest engine)
 
-addLinkAndDiscoverTest(RuntimeInformationTest engine)
+addLinkAndDiscoverTest(RuntimeInformationTest engine index)
 
 addLinkAndDiscoverTest(VariableToColumnMapTest parser)
 

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -7,6 +7,7 @@
 
 #include "engine/RuntimeInformation.h"
 
+// ________________________________________________________________
 TEST(RuntimeInformation, addLimitOffsetRow) {
   RuntimeInformation rti;
   rti.descriptor_ = "BaseOperation";
@@ -34,9 +35,30 @@ TEST(RuntimeInformation, addLimitOffsetRow) {
   EXPECT_EQ(rti.descriptor_, "LIMIT 42");
 }
 
+// ________________________________________________________________
+TEST(RuntimeInformation, getOperationTimeAndCostEstimate) {
+  RuntimeInformation child1;
+  child1.totalTime_ = 3.0;
+  child1.costEstimate_ = 12;
+  RuntimeInformation child2;
+  child2.totalTime_ = 4.5;
+  child2.costEstimate_ = 43;
+
+  RuntimeInformation parent;
+  parent.totalTime_ = 10.0;
+  parent.costEstimate_ = 100;
+
+  parent.children_.push_back(child1);
+  parent.children_.push_back(child2);
+
+  ASSERT_DOUBLE_EQ(parent.getOperationTime(), 2.5);
+  ASSERT_EQ(parent.getOperationCostEstimate(), 45);
+}
+
+// ________________________________________________________________
 TEST(RuntimeInformation, setColumnNames) {
   RuntimeInformation rti;
-  rti.columnNames_.push_back("blimbim");
+  rti.columnNames_.push_back("?blimbim");
   rti.setColumnNames({});
   EXPECT_TRUE(rti.columnNames_.empty());
 
@@ -45,4 +67,116 @@ TEST(RuntimeInformation, setColumnNames) {
   VariableToColumnMap m{{V{"?x"}, col(1)}, {V{"?y"}, col(0)}};
   rti.setColumnNames(m);
   EXPECT_THAT(rti.columnNames_, ::testing::ElementsAre("?y", "?x"));
+}
+
+// ________________________________________________________________
+TEST(RuntimeInformattion, statusToString) {
+  using enum RuntimeInformation::Status;
+  using R = RuntimeInformation;
+  EXPECT_EQ(R::toString(completed), "completed");
+  EXPECT_EQ(R::toString(completedDuringQueryPlanning),
+            "completed during query planning");
+  EXPECT_EQ(R::toString(notStarted), "not started");
+  EXPECT_EQ(R::toString(optimizedOut), "optimized out");
+  EXPECT_EQ(R::toString(failed), "failed");
+  EXPECT_EQ(R::toString(failedBecauseChildFailed),
+            "failed because child failed");
+  EXPECT_ANY_THROW(R::toString(static_cast<RuntimeInformation::Status>(72)));
+}
+
+// ________________________________________________________________
+TEST(RuntimeInformation, toStringAndJson) {
+  RuntimeInformation child;
+  child.descriptor_ = "child";
+  child.numCols_ = 2;
+  child.numRows_ = 7;
+  child.columnNames_.push_back("?x");
+  child.columnNames_.push_back("?y");
+  child.totalTime_ = 3.4;
+  child.cacheStatus_ = ad_utility::CacheStatus::cachedPinned;
+  child.status_ = RuntimeInformation::Status::optimizedOut;
+  child.addDetail("minor detail", 42);
+
+  RuntimeInformation parent;
+  parent.descriptor_ = "parent";
+  parent.numCols_ = 6;
+  parent.numRows_ = 4;
+  parent.columnNames_.push_back("?alpha");
+  parent.totalTime_ = 6.2;
+  parent.cacheStatus_ = ad_utility::CacheStatus::computed;
+  parent.status_ = RuntimeInformation::Status::completed;
+
+  parent.children_.push_back(child);
+
+  auto str = parent.toString();
+  ASSERT_EQ(str,
+            "│\n"
+            R"(├─ parent
+│  result_size: 4 x 6
+│  columns: ?alpha
+│  total_time: 6.20 ms
+│  operation_time: 2.80 ms
+│  status: completed
+│  cache_status: computed
+│  ┬
+│  │
+│  ├─ child
+│  │  result_size: 7 x 2
+│  │  columns: ?x, ?y
+│  │  total_time: 3.40 ms
+│  │  operation_time: 3.40 ms
+│  │  status: optimized out
+│  │  cache_status: cached_pinned
+│  │  original_total_time: 0.00 ms
+│  │  original_operation_time: 0.00 ms
+│  │    minor detail: 42
+)");
+  nlohmann::ordered_json j = parent;
+  std::string expectedJson = R"(
+{
+"description": "parent",
+"result_rows": 4,
+"result_cols": 6,
+"column_names": [
+    "?alpha"
+],
+"total_time": 6.2,
+"operation_time": 2.8000000000000003,
+"original_total_time": 0.0,
+"original_operation_time": 0.0,
+"cache_status": "computed",
+"details": null,
+"estimated_total_cost": 0,
+"estimated_operation_cost": 0,
+"estimated_column_multiplicities": [],
+"estimated_size": 0,
+"status": "completed",
+"children": [
+    {
+        "description": "child",
+        "result_rows": 7,
+        "result_cols": 2,
+        "column_names": [
+            "?x",
+            "?y"
+        ],
+        "total_time": 3.4,
+        "operation_time": 3.4,
+        "original_total_time": 0.0,
+        "original_operation_time": 0.0,
+        "cache_status": "cached_pinned",
+        "details": {
+            "minor detail": 42
+        },
+        "estimated_total_cost": 0,
+        "estimated_operation_cost": 0,
+        "estimated_column_multiplicities": [],
+        "estimated_size": 0,
+        "status": "optimized out",
+        "children": []
+    }
+]
+}
+)";
+  ASSERT_EQ(j, nlohmann::ordered_json::parse(expectedJson));
 }

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -120,8 +120,8 @@ TEST(RuntimeInformation, toStringAndJson) {
   child.descriptor_ = "child";
   child.numCols_ = 2;
   child.numRows_ = 7;
-  child.columnNames_.push_back("?x");
-  child.columnNames_.push_back("?y");
+  child.columnNames_.emplace_back("?x");
+  child.columnNames_.emplace_back("?y");
   child.totalTime_ = 3.4;
   child.cacheStatus_ = ad_utility::CacheStatus::cachedPinned;
   child.status_ = RuntimeInformation::Status::optimizedOut;

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -77,8 +77,6 @@ TEST(RuntimeInformation, statusToString) {
   using enum RuntimeInformation::Status;
   using R = RuntimeInformation;
   EXPECT_EQ(R::toString(completed), "completed");
-  EXPECT_EQ(R::toString(completedDuringQueryPlanning),
-            "completed during query planning");
   EXPECT_EQ(R::toString(notStarted), "not started");
   EXPECT_EQ(R::toString(optimizedOut), "optimized out");
   EXPECT_EQ(R::toString(failed), "failed");

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -2,8 +2,10 @@
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
 #include "engine/RuntimeInformation.h"
-#include "gtest/gtest.h"
 
 TEST(RuntimeInformation, addLimitOffsetRow) {
   RuntimeInformation rti;
@@ -30,4 +32,17 @@ TEST(RuntimeInformation, addLimitOffsetRow) {
 
   rti.addLimitOffsetRow(LimitOffsetClause{42, 1, 0}, 15, true);
   EXPECT_EQ(rti.descriptor_, "LIMIT 42");
+}
+
+TEST(RuntimeInformation, setColumnNames) {
+  RuntimeInformation rti;
+  rti.columnNames_.push_back("blimbim");
+  rti.setColumnNames({});
+  EXPECT_TRUE(rti.columnNames_.empty());
+
+  auto col = makeAlwaysDefinedColumn;
+  using V = Variable;
+  VariableToColumnMap m{{V{"?x"}, col(1)}, {V{"?y"}, col(0)}};
+  rti.setColumnNames(m);
+  EXPECT_THAT(rti.columnNames_, ::testing::ElementsAre("?y", "?x"));
 }

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -51,7 +51,10 @@ TEST(RuntimeInformation, getOperationTimeAndCostEstimate) {
   parent.children_.push_back(child1);
   parent.children_.push_back(child2);
 
+  // 2.5 == 10.0 - 4.5 - 3.0
   ASSERT_DOUBLE_EQ(parent.getOperationTime(), 2.5);
+
+  // 45 == 100 - 43 - 12
   ASSERT_EQ(parent.getOperationCostEstimate(), 45);
 }
 

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -70,7 +70,7 @@ TEST(RuntimeInformation, setColumnNames) {
 }
 
 // ________________________________________________________________
-TEST(RuntimeInformattion, statusToString) {
+TEST(RuntimeInformation, statusToString) {
   using enum RuntimeInformation::Status;
   using R = RuntimeInformation;
   EXPECT_EQ(R::toString(completed), "completed");
@@ -82,6 +82,36 @@ TEST(RuntimeInformattion, statusToString) {
   EXPECT_EQ(R::toString(failedBecauseChildFailed),
             "failed because child failed");
   EXPECT_ANY_THROW(R::toString(static_cast<RuntimeInformation::Status>(72)));
+}
+
+// ________________________________________________________________
+TEST(RuntimeInformation, formatDetailValue) {
+  std::ostringstream s;
+  // Imbue with the same locale as std::cout which uses for example
+  // thousands separators.
+  s.imbue(ad_utility::commaLocale);
+  // So floats use fixed precision
+  s << std::fixed << std::setprecision(2);
+  using R = RuntimeInformation;
+  R::formatDetailValue(s, "", 421234u);
+  EXPECT_EQ(s.str(), "421,234");
+  s.str("");
+
+  R::formatDetailValue(s, "", -421234);
+  EXPECT_EQ(s.str(), "-421,234");
+  s.str("");
+
+  R::formatDetailValue(s, "", -421.234);
+  EXPECT_EQ(s.str(), "-421.23");
+  s.str("");
+
+  R::formatDetailValue(s, "", true);
+  EXPECT_EQ(s.str(), "true");
+  s.str("");
+
+  R::formatDetailValue(s, "someTime", 48);
+  EXPECT_EQ(s.str(), "48 ms");
+  s.str("");
 }
 
 // ________________________________________________________________


### PR DESCRIPTION
This makes Codecov more robust to unrelated changes that "accidentally" affect the coverage of this class.