### PR TITLE
Enhance `Operation::getResult` by option `onlyReadFromCache`

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -2,7 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach  (johannes.kalmbach@gmail.com)
 
-#include "./Operation.h"
+#include "engine/Operation.h"
 
 #include "engine/QueryExecutionTree.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
@@ -58,9 +58,9 @@ void Operation::recursivelySetTimeoutTimer(
   }
 }
 
-// Get the result for the subtree rooted at this element. Use existing results
-// if they are already available, otherwise trigger computation.
-shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
+// ________________________________________________________________________
+shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
+                                                   bool onlyReadFromCache) {
   ad_utility::Timer timer{ad_utility::Timer::Started};
 
   if (isRoot) {
@@ -154,6 +154,15 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot) {
       return CacheValue{std::move(result), getRuntimeInfo()};
     };
 
+    if (onlyReadFromCache) {
+      AD_CORRECTNESS_CHECK(!pinResult);
+      auto optionalResult = cache.getIfContained(cacheKey);
+      if (!optionalResult.has_value()) {
+        return nullptr;
+      }
+      updateRuntimeInformationOnSuccess(optionalResult.value(), timer.msecs());
+      return optionalResult.value()._resultPointer->resultTable();
+    }
     auto result = (pinResult) ? cache.computeOncePinned(cacheKey, computeLambda)
                               : cache.computeOnce(cacheKey, computeLambda);
 

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -154,6 +154,8 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       return CacheValue{std::move(result), getRuntimeInfo()};
     };
 
+    // Handle the case that we only want the result if it was contained in the
+    // cache, and `nullptr` else.
     if (onlyReadFromCache) {
       AD_CORRECTNESS_CHECK(!pinResult);
       auto optionalResult = cache.getIfContained(cacheKey);

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -116,9 +116,20 @@ class Operation {
     return _runtimeInfoWholeQuery;
   }
 
-  // Get the result for the subtree rooted at this element.
-  // Use existing results if they are already available, otherwise
-  // trigger computation.
+  /**
+   * @brief Get the result for the subtree rooted at this element. Use existing
+   * results if they are already available, otherwise trigger computation.
+   * Always returns a non-null pointer, except for when `onlyReadFromCache` is
+   * true (see below).
+   * @param isRoot Has be set to `true` iff this is the root operation of a
+   * complete query to obtain the expected behavior wrt cache pinning and
+   * runtime information in error cases.
+   * @param onlyReadFromCache If set to true the result is only returned if it
+   * can be read from the cache without any computation. If the result is not in
+   * the cache, `nullptr` will be returned.
+   * @return A shared pointer to the result. May only be `nullptr` if
+   * `onlyReadFromCache` is true.
+   */
   shared_ptr<const ResultTable> getResult(bool isRoot = false,
                                           bool onlyReadFromCache = false);
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -119,7 +119,8 @@ class Operation {
   // Get the result for the subtree rooted at this element.
   // Use existing results if they are already available, otherwise
   // trigger computation.
-  shared_ptr<const ResultTable> getResult(bool isRoot = false);
+  shared_ptr<const ResultTable> getResult(bool isRoot = false,
+                                          bool onlyReadFromCache = false);
 
   // Use the same timeout timer for all children of an operation (= query plan
   // rooted at that operation). As soon as one child times out, the whole

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -122,8 +122,8 @@ class QueryExecutionContext {
 
   ad_utility::AllocatorWithLimit<Id> getAllocator() { return _allocator; }
 
-  const bool _pinSubtrees;
-  const bool _pinResult;
+  bool _pinSubtrees;
+  bool _pinResult;
 
  private:
   const Index& _index;

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -302,3 +302,15 @@ TEST(ConcurrentCache, abortPinned) {
   ASSERT_EQ(0ul, a.getStorage().wlock()->_inProgress.size());
   ASSERT_THROW(fut.get(), std::runtime_error);
 }
+
+TEST(ConcurrentCache, cacheStatusToString) {
+  using enum ad_utility::CacheStatus;
+  EXPECT_EQ(toString(cachedNotPinned), "cached_not_pinned");
+  EXPECT_EQ(toString(cachedPinned), "cached_pinned");
+  EXPECT_EQ(toString(computed), "computed");
+  EXPECT_EQ(toString(notInCacheAndNotComputed), "not_in_cache_not_computed");
+
+  auto outOfBounds = static_cast<ad_utility::CacheStatus>(
+      static_cast<int>(notInCacheAndNotComputed) + 1);
+  EXPECT_ANY_THROW(toString(outOfBounds));
+}

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -62,13 +62,13 @@ TEST(OperationTest, getResultOnlyCached) {
   EXPECT_EQ(n4.getResult(true, true), result);
 
   // The cache status is `cachedNotPinned` because we found the element cached
-  // but not pinned (it does reflect the status BEFORE the operation.
+  // but not pinned (it does reflect the status BEFORE the operation).
   EXPECT_EQ(n4.getRuntimeInfo().cacheStatus_,
             ad_utility::CacheStatus::cachedNotPinned);
   EXPECT_EQ(qec->getQueryTreeCache().numNonPinnedEntries(), 0);
   EXPECT_EQ(qec->getQueryTreeCache().numPinnedEntries(), 1);
 
-  // We have pinned the result, so requesting it again should returned a pinned
+  // We have pinned the result, so requesting it again should return a pinned
   // result.
   qecCopy._pinResult = false;
   EXPECT_EQ(n4.getResult(true, true), result);

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -30,7 +30,7 @@ TEST(OperationTest, getResultOnlyCached) {
   qec->getQueryTreeCache().clearAll();
   NeutralElementOperation n{qec};
   // The second `true` means "only read the result if it was cached".
-  // We have just cleared the cache, and so this should return false.
+  // We have just cleared the cache, and so this should return `nullptr`.
   EXPECT_EQ(n.getResult(true, true), nullptr);
   EXPECT_EQ(n.getRuntimeInfo().status_, RuntimeInformation::Status::notStarted);
   // Nothing has been stored in the cache by this call.


### PR DESCRIPTION
Make it possible to only get the result of an operation if it can be read from the cache.