### PR TITLE
New operation status "lazily materialized" and rename "completed" to "fully materialized"

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -257,8 +257,9 @@ void Operation::updateRuntimeInformationOnSuccess(
 
 // _____________________________________________________________________________
 void Operation::updateRuntimeInformationWhenOptimizedOut(
-    std::vector<RuntimeInformation> children) {
-  _runtimeInfo.status_ = RuntimeInformation::Status::optimizedOut;
+    std::vector<RuntimeInformation> children,
+    RuntimeInformation::Status status) {
+  _runtimeInfo.status_ = status;
   _runtimeInfo.children_ = std::move(children);
   // This operation was optimized out, so its operation time is zero.
   // The operation time is computed as
@@ -271,9 +272,11 @@ void Operation::updateRuntimeInformationWhenOptimizedOut(
 }
 
 // _____________________________________________________________________________
-void Operation::updateRuntimeInformationWhenOptimizedOut() {
-  auto setStatus = [](RuntimeInformation& rti, const auto& self) -> void {
-    rti.status_ = RuntimeInformation::Status::optimizedOut;
+void Operation::updateRuntimeInformationWhenOptimizedOut(
+    RuntimeInformation::Status status) {
+  auto setStatus = [&status](RuntimeInformation& rti,
+                             const auto& self) -> void {
+    rti.status_ = status;
     rti.totalTime_ = 0;
     for (auto& child : rti.children_) {
       self(child, self);

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -216,7 +216,7 @@ void Operation::updateRuntimeInformationOnSuccess(
   _runtimeInfo.numRows_ = resultTable.size();
   _runtimeInfo.cacheStatus_ = cacheStatus;
 
-  _runtimeInfo.status_ = RuntimeInformation::Status::completed;
+  _runtimeInfo.status_ = RuntimeInformation::Status::fullyMaterialized;
 
   bool wasCached = cacheStatus != ad_utility::CacheStatus::computed;
   // If the result was read from the cache, then we need the additional

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -253,14 +253,18 @@ class Operation {
   // children were evaluated nevertheless. For an example usage of this feature
   // see `GroupBy.cpp`
   virtual void updateRuntimeInformationWhenOptimizedOut(
-      std::vector<RuntimeInformation> children);
+      std::vector<RuntimeInformation> children,
+      RuntimeInformation::Status status =
+          RuntimeInformation::Status::optimizedOut);
 
   // Use the already stored runtime info for the children,
   // but set all of them to `optimizedOut`. This can be used, when a complete
   // tree was optimized out. For example when one child of a JOIN operation is
   // empty, the result will be empty, and it is not necessary to evaluate the
   // other child.
-  virtual void updateRuntimeInformationWhenOptimizedOut();
+  virtual void updateRuntimeInformationWhenOptimizedOut(
+      RuntimeInformation::Status status =
+          RuntimeInformation::Status::optimizedOut);
 
  private:
   // Create the runtime information in case the evaluation of this operation has

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -141,6 +141,8 @@ std::string_view RuntimeInformation::toString(Status status) {
   switch (status) {
     case completed:
       return "completed";
+    case lazilyCompleted:
+      return "lazily completed";
     case notStarted:
       return "not started";
     case optimizedOut:
@@ -149,9 +151,8 @@ std::string_view RuntimeInformation::toString(Status status) {
       return "failed";
     case failedBecauseChildFailed:
       return "failed because child failed";
-    default:
-      AD_FAIL();
   }
+  AD_FAIL();
 }
 
 // ________________________________________________________________________________________________________________

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -139,10 +139,10 @@ size_t RuntimeInformation::getOperationCostEstimate() const {
 // __________________________________________________________________________
 std::string_view RuntimeInformation::toString(Status status) {
   switch (status) {
-    case completed:
-      return "completed";
-    case lazilyCompleted:
-      return "lazily completed";
+    case fullyMaterialized:
+      return "fully materialized";
+    case lazilyMaterialized:
+      return "lazily materialized";
     case notStarted:
       return "not started";
     case optimizedOut:

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -26,8 +26,8 @@ class RuntimeInformation {
   /// The computation status of an operation.
   enum struct Status {
     notStarted,
-    completed,
-    lazilyCompleted,
+    fullyMaterialized,
+    lazilyMaterialized,
     optimizedOut,
     failed,
     failedBecauseChildFailed

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -27,6 +27,7 @@ class RuntimeInformation {
   enum struct Status {
     notStarted,
     completed,
+    lazilyCompleted,
     optimizedOut,
     failed,
     failedBecauseChildFailed

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -41,7 +41,8 @@ TEST(OperationTest, getResultOnlyCached) {
   NeutralElementOperation n2{qec};
   auto result = n2.getResult();
   EXPECT_NE(result, nullptr);
-  EXPECT_EQ(n2.getRuntimeInfo().status_, RuntimeInformation::Status::completed);
+  EXPECT_EQ(n2.getRuntimeInfo().status_,
+            RuntimeInformation::Status::fullyMaterialized);
   EXPECT_EQ(n2.getRuntimeInfo().cacheStatus_,
             ad_utility::CacheStatus::computed);
   EXPECT_EQ(qec->getQueryTreeCache().numNonPinnedEntries(), 1);

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -76,8 +76,8 @@ TEST(RuntimeInformation, setColumnNames) {
 TEST(RuntimeInformation, statusToString) {
   using enum RuntimeInformation::Status;
   using R = RuntimeInformation;
-  EXPECT_EQ(R::toString(completed), "completed");
-  EXPECT_EQ(R::toString(lazilyCompleted), "lazily completed");
+  EXPECT_EQ(R::toString(fullyMaterialized), "fully materialized");
+  EXPECT_EQ(R::toString(lazilyMaterialized), "lazily materialized");
   EXPECT_EQ(R::toString(notStarted), "not started");
   EXPECT_EQ(R::toString(optimizedOut), "optimized out");
   EXPECT_EQ(R::toString(failed), "failed");
@@ -136,7 +136,7 @@ TEST(RuntimeInformation, toStringAndJson) {
   parent.columnNames_.push_back("?alpha");
   parent.totalTime_ = 6.2;
   parent.cacheStatus_ = ad_utility::CacheStatus::computed;
-  parent.status_ = RuntimeInformation::Status::completed;
+  parent.status_ = RuntimeInformation::Status::fullyMaterialized;
 
   parent.children_.push_back(child);
 
@@ -148,7 +148,7 @@ TEST(RuntimeInformation, toStringAndJson) {
 │  columns: ?alpha
 │  total_time: 6.20 ms
 │  operation_time: 2.80 ms
-│  status: completed
+│  status: fully materialized
 │  cache_status: computed
 │  ┬
 │  │
@@ -182,7 +182,7 @@ TEST(RuntimeInformation, toStringAndJson) {
 "estimated_operation_cost": 0,
 "estimated_column_multiplicities": [],
 "estimated_size": 0,
-"status": "completed",
+"status": "fully materialized",
 "children": [
     {
         "description": "child",

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -77,6 +77,7 @@ TEST(RuntimeInformation, statusToString) {
   using enum RuntimeInformation::Status;
   using R = RuntimeInformation;
   EXPECT_EQ(R::toString(completed), "completed");
+  EXPECT_EQ(R::toString(lazilyCompleted), "lazily completed");
   EXPECT_EQ(R::toString(notStarted), "not started");
   EXPECT_EQ(R::toString(optimizedOut), "optimized out");
   EXPECT_EQ(R::toString(failed), "failed");


### PR DESCRIPTION
When an `Operation` is not computed "normally" via a call to `getResult` but by a specialized and optimized implementation directly, we can now explicitly set the status of the runtime information via the
`updateRuntimeInformationWhenOptimizedOut` function.