### PR TITLE
Minor refactoring of `AD_EXPENSIVE_CHECK` and expand unit test

### DIFF
--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -125,24 +125,16 @@ inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
 // `AD_ENABLE_EXPENSIVE_CHECKS` is enabled (which can be set via cmake). This
 // check should be used when checking has a significant and measurable runtime
 // overhead, but is still feasible for a release build on a large dataset.
+#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
 namespace ad_utility {
-// A function to check at compile time or runtime whether expensive checks are
-// enabled.
-static constexpr bool areExpensiveChecksEnabled() {
-#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
-  return true;
-#else
-  return false;
-#endif
+static constexpr bool areExpensiveChecksEnabled = true;
 }
-}  // namespace ad_utility
-#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
-#define AD_EXPENSIVE_CHECK(condition)                     \
-  static_assert(ad_utility::areExpensiveChecksEnabled()); \
-  AD_CORRECTNESS_CHECK(condition);                        \
+#define AD_EXPENSIVE_CHECK(condition) \
+  AD_CORRECTNESS_CHECK(condition);    \
   void(0)
 #else
-#define AD_EXPENSIVE_CHECK(condition)                      \
-  static_assert(!ad_utility::areExpensiveChecksEnabled()); \
-  void(0)
+namespace ad_utility {
+static constexpr bool areExpensiveChecksEnabled = false;
+}
+#define AD_EXPENSIVE_CHECK(condition) void(0)
 #endif

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -125,10 +125,24 @@ inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
 // `AD_ENABLE_EXPENSIVE_CHECKS` is enabled (which can be set via cmake). This
 // check should be used when checking has a significant and measurable runtime
 // overhead, but is still feasible for a release build on a large dataset.
+namespace ad_utility {
+// A function to check at compile time or runtime whether expensive checks are
+// enabled.
+static constexpr bool areExpensiveChecksEnabled() {
 #if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
-#define AD_EXPENSIVE_CHECK(condition) \
-  AD_CORRECTNESS_CHECK(condition);    \
+  return true;
+#else
+  return false;
+#endif
+}
+}  // namespace ad_utility
+#if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
+#define AD_EXPENSIVE_CHECK(condition)                     \
+  static_assert(ad_utility::areExpensiveChecksEnabled()); \
+  AD_CORRECTNESS_CHECK(condition);                        \
   void(0)
 #else
-#define AD_EXPENSIVE_CHECK(condition) void(0)
+#define AD_EXPENSIVE_CHECK(condition)                      \
+  static_assert(!ad_utility::areExpensiveChecksEnabled()); \
+  void(0)
 #endif

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -129,9 +129,7 @@ inline void adCorrectnessCheckImpl(bool condition, std::string_view message,
 namespace ad_utility {
 static constexpr bool areExpensiveChecksEnabled = true;
 }
-#define AD_EXPENSIVE_CHECK(condition) \
-  AD_CORRECTNESS_CHECK(condition);    \
-  void(0)
+#define AD_EXPENSIVE_CHECK(condition) AD_CORRECTNESS_CHECK(condition)
 #else
 namespace ad_utility {
 static constexpr bool areExpensiveChecksEnabled = false;

--- a/test/ExceptionTest.cpp
+++ b/test/ExceptionTest.cpp
@@ -95,7 +95,7 @@ TEST(Excpetion, AD_EXPENSIVE_CHECK) {
 #else
   ASSERT_NO_THROW(AD_EXPENSIVE_CHECK(3 > 5));
 #endif
-  if (ad_utility::areExpensiveChecksEnabled()) {
+  if (ad_utility::areExpensiveChecksEnabled) {
     ASSERT_ANY_THROW(AD_EXPENSIVE_CHECK(3 > 5));
   } else {
     ASSERT_NO_THROW(AD_EXPENSIVE_CHECK(3 > 5));

--- a/test/ExceptionTest.cpp
+++ b/test/ExceptionTest.cpp
@@ -92,5 +92,12 @@ TEST(Exception, AD_FAIL) {
 TEST(Excpetion, AD_EXPENSIVE_CHECK) {
 #if (!defined(NDEBUG) || defined(AD_ENABLE_EXPENSIVE_CHECKS))
   ASSERT_ANY_THROW(AD_EXPENSIVE_CHECK(3 > 5));
+#else
+  ASSERT_NO_THROW(AD_EXPENSIVE_CHECK(3 > 5));
 #endif
+  if (ad_utility::areExpensiveChecksEnabled()) {
+    ASSERT_ANY_THROW(AD_EXPENSIVE_CHECK(3 > 5));
+  } else {
+    ASSERT_NO_THROW(AD_EXPENSIVE_CHECK(3 > 5));
+  }
 }


### PR DESCRIPTION
Add a function that allows to check at compile time or runtime whether the expensive checks (`AD_EXPENSIVE_CHECK(condition)`) are enabled.