### PR TITLE
Add math functions `log`, `exp`, `sqrt`, `sin`, `cos`, `tan`

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -39,6 +39,9 @@ SparqlExpression::Ptr makeFloorExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeLogExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeExpExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeSqrtExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeSinExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeCosExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeTanExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeDistExpression(SparqlExpression::Ptr child1,
                                          SparqlExpression::Ptr child2);

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -36,6 +36,8 @@ SparqlExpression::Ptr makeRoundExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeAbsExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeCeilExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeFloorExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeLogExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeExpExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeDistExpression(SparqlExpression::Ptr child1,
                                          SparqlExpression::Ptr child2);

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -38,6 +38,7 @@ SparqlExpression::Ptr makeCeilExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeFloorExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeLogExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeExpExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeSqrtExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeDistExpression(SparqlExpression::Ptr child1,
                                          SparqlExpression::Ptr child2);

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -92,6 +92,17 @@ inline const auto expImpl = []<typename T>(T num) {
 inline const auto exp = makeNumericExpression<decltype(expImpl)>();
 using ExpExpression = NARY<1, FV<decltype(exp), NumericValueGetter>>;
 
+// Square root.
+inline const auto sqrtImpl = []<typename T>(T num) {
+  if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>) {
+    return num >= 0 ? std::sqrt(num) : std::numeric_limits<double>::quiet_NaN();
+  } else {
+    return Id::makeUndefined();
+  }
+};
+inline const auto sqrt = makeNumericExpression<decltype(sqrtImpl)>();
+using SqrtExpression = NARY<1, FV<decltype(sqrt), NumericValueGetter>>;
+
 }  // namespace detail
 
 using namespace detail;
@@ -112,6 +123,9 @@ SparqlExpression::Ptr makeLogExpression(SparqlExpression::Ptr child) {
 }
 SparqlExpression::Ptr makeExpExpression(SparqlExpression::Ptr child) {
   return std::make_unique<ExpExpression>(std::move(child));
+}
+SparqlExpression::Ptr makeSqrtExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<SqrtExpression>(std::move(child));
 }
 
 SparqlExpression::Ptr makeUnaryMinusExpression(SparqlExpression::Ptr child) {

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -71,9 +71,7 @@ inline const auto floor = makeNumericExpression<decltype(floorImpl)>();
 using FloorExpression = NARY<1, FV<decltype(floor), NumericValueGetter>>;
 
 // Natural Logarithm.
-inline const auto logImpl = []<typename T>(T num) {
-  return num > 0 ? std::log(num) : std::numeric_limits<double>::quiet_NaN();
-};
+inline const auto logImpl = []<typename T>(T num) { return std::log(num); };
 inline const auto log = makeNumericExpression<decltype(logImpl)>();
 using LogExpression = NARY<1, FV<decltype(log), NumericValueGetter>>;
 
@@ -83,23 +81,21 @@ inline const auto exp = makeNumericExpression<decltype(expImpl)>();
 using ExpExpression = NARY<1, FV<decltype(exp), NumericValueGetter>>;
 
 // Square root.
-inline const auto sqrtImpl = []<typename T>(T num) {
-  return num >= 0 ? std::sqrt(num) : std::numeric_limits<double>::quiet_NaN();
-};
+inline const auto sqrtImpl = []<typename T>(T num) { return std::sqrt(num); };
 inline const auto sqrt = makeNumericExpression<decltype(sqrtImpl)>();
 using SqrtExpression = NARY<1, FV<decltype(sqrt), NumericValueGetter>>;
 
-// Sinus.
+// Sine.
 inline const auto sinImpl = []<typename T>(T num) { return std::sin(num); };
 inline const auto sin = makeNumericExpression<decltype(sinImpl)>();
 using SinExpression = NARY<1, FV<decltype(sin), NumericValueGetter>>;
 
-// Cosinus.
+// Cosine.
 inline const auto cosImpl = []<typename T>(T num) { return std::cos(num); };
 inline const auto cos = makeNumericExpression<decltype(cosImpl)>();
 using CosExpression = NARY<1, FV<decltype(cos), NumericValueGetter>>;
 
-// Tangens.
+// Tangent.
 inline const auto tanImpl = []<typename T>(T num) { return std::tan(num); };
 inline const auto tan = makeNumericExpression<decltype(tanImpl)>();
 using TanExpression = NARY<1, FV<decltype(tan), NumericValueGetter>>;

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -69,6 +69,29 @@ inline const auto floorImpl = []<typename T>(T num) {
 };
 inline const auto floor = makeNumericExpression<decltype(floorImpl)>();
 using FloorExpression = NARY<1, FV<decltype(floor), NumericValueGetter>>;
+
+// Natural Logarithm.
+inline const auto logImpl = []<typename T>(T num) {
+  if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>) {
+    return num > 0 ? std::log(num) : std::numeric_limits<double>::quiet_NaN();
+  } else {
+    return Id::makeUndefined();
+  }
+};
+inline const auto log = makeNumericExpression<decltype(logImpl)>();
+using LogExpression = NARY<1, FV<decltype(log), NumericValueGetter>>;
+
+// Exponentiation.
+inline const auto expImpl = []<typename T>(T num) {
+  if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>) {
+    return std::exp(num);
+  } else {
+    return Id::makeUndefined();
+  }
+};
+inline const auto exp = makeNumericExpression<decltype(expImpl)>();
+using ExpExpression = NARY<1, FV<decltype(exp), NumericValueGetter>>;
+
 }  // namespace detail
 
 using namespace detail;
@@ -83,6 +106,12 @@ SparqlExpression::Ptr makeCeilExpression(SparqlExpression::Ptr child) {
 }
 SparqlExpression::Ptr makeFloorExpression(SparqlExpression::Ptr child) {
   return std::make_unique<FloorExpression>(std::move(child));
+}
+SparqlExpression::Ptr makeLogExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<LogExpression>(std::move(child));
+}
+SparqlExpression::Ptr makeExpExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<ExpExpression>(std::move(child));
 }
 
 SparqlExpression::Ptr makeUnaryMinusExpression(SparqlExpression::Ptr child) {

--- a/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericUnaryExpressions.cpp
@@ -72,36 +72,37 @@ using FloorExpression = NARY<1, FV<decltype(floor), NumericValueGetter>>;
 
 // Natural Logarithm.
 inline const auto logImpl = []<typename T>(T num) {
-  if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>) {
-    return num > 0 ? std::log(num) : std::numeric_limits<double>::quiet_NaN();
-  } else {
-    return Id::makeUndefined();
-  }
+  return num > 0 ? std::log(num) : std::numeric_limits<double>::quiet_NaN();
 };
 inline const auto log = makeNumericExpression<decltype(logImpl)>();
 using LogExpression = NARY<1, FV<decltype(log), NumericValueGetter>>;
 
 // Exponentiation.
-inline const auto expImpl = []<typename T>(T num) {
-  if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>) {
-    return std::exp(num);
-  } else {
-    return Id::makeUndefined();
-  }
-};
+inline const auto expImpl = []<typename T>(T num) { return std::exp(num); };
 inline const auto exp = makeNumericExpression<decltype(expImpl)>();
 using ExpExpression = NARY<1, FV<decltype(exp), NumericValueGetter>>;
 
 // Square root.
 inline const auto sqrtImpl = []<typename T>(T num) {
-  if constexpr (std::is_floating_point_v<T> || std::is_integral_v<T>) {
-    return num >= 0 ? std::sqrt(num) : std::numeric_limits<double>::quiet_NaN();
-  } else {
-    return Id::makeUndefined();
-  }
+  return num >= 0 ? std::sqrt(num) : std::numeric_limits<double>::quiet_NaN();
 };
 inline const auto sqrt = makeNumericExpression<decltype(sqrtImpl)>();
 using SqrtExpression = NARY<1, FV<decltype(sqrt), NumericValueGetter>>;
+
+// Sinus.
+inline const auto sinImpl = []<typename T>(T num) { return std::sin(num); };
+inline const auto sin = makeNumericExpression<decltype(sinImpl)>();
+using SinExpression = NARY<1, FV<decltype(sin), NumericValueGetter>>;
+
+// Cosinus.
+inline const auto cosImpl = []<typename T>(T num) { return std::cos(num); };
+inline const auto cos = makeNumericExpression<decltype(cosImpl)>();
+using CosExpression = NARY<1, FV<decltype(cos), NumericValueGetter>>;
+
+// Tangens.
+inline const auto tanImpl = []<typename T>(T num) { return std::tan(num); };
+inline const auto tan = makeNumericExpression<decltype(tanImpl)>();
+using TanExpression = NARY<1, FV<decltype(tan), NumericValueGetter>>;
 
 }  // namespace detail
 
@@ -126,6 +127,15 @@ SparqlExpression::Ptr makeExpExpression(SparqlExpression::Ptr child) {
 }
 SparqlExpression::Ptr makeSqrtExpression(SparqlExpression::Ptr child) {
   return std::make_unique<SqrtExpression>(std::move(child));
+}
+SparqlExpression::Ptr makeSinExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<SinExpression>(std::move(child));
+}
+SparqlExpression::Ptr makeCosExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<CosExpression>(std::move(child));
+}
+SparqlExpression::Ptr makeTanExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<TanExpression>(std::move(child));
 }
 
 SparqlExpression::Ptr makeUnaryMinusExpression(SparqlExpression::Ptr child) {

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -47,6 +47,10 @@ static const char INTERNAL_TEXT_MATCH_PREDICATE[] =
     "<QLever-internal-function/text>";
 static const char HAS_PREDICATE_PREDICATE[] =
     "<QLever-internal-function/has-predicate>";
+static constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
+    "geof:", "<http://www.opengis.net/def/function/geosparql/"};
+static constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
+    "math:", "<http://www.w3.org/2005/xpath-functions/math#"};
 
 static const std::string INTERNAL_VARIABLE_PREFIX =
     "?_QLever_internal_variable_";

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -72,7 +72,10 @@ ExpressionPtr Visitor::processIriFunctionCall(
 
   constexpr static std::string_view geofPrefix =
       "<http://www.opengis.net/def/function/geosparql/";
-  if (std::string_view iriView = iri; iriView.starts_with(geofPrefix)) {
+  constexpr static std::string_view qfnPrefix =
+      "<http://qlever.cs.uni-freiburg.de/function#";
+  std::string_view iriView = iri;
+  if (iriView.starts_with(geofPrefix)) {
     iriView.remove_prefix(geofPrefix.size());
     AD_CONTRACT_CHECK(iriView.ends_with('>'));
     iriView.remove_suffix(1);
@@ -86,6 +89,17 @@ ExpressionPtr Visitor::processIriFunctionCall(
     } else if (iriView == "latitude") {
       checkNumArgs("geof:", iriView, 1);
       return sparqlExpression::makeLatitudeExpression(std::move(argList[0]));
+    }
+  } else if (iriView.starts_with(qfnPrefix)) {
+    iriView.remove_prefix(qfnPrefix.size());
+    AD_CONTRACT_CHECK(iriView.ends_with('>'));
+    iriView.remove_suffix(1);
+    if (iriView == "log") {
+      checkNumArgs("qfn:", iriView, 1);
+      return sparqlExpression::makeLogExpression(std::move(argList[0]));
+    } else if (iriView == "exp") {
+      checkNumArgs("qfn:", iriView, 1);
+      return sparqlExpression::makeExpExpression(std::move(argList[0]));
     }
   }
   reportNotSupported(ctx, "Function \"" + iri + "\" is");

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -55,55 +55,70 @@ std::string Visitor::getOriginalInputForContext(
 ExpressionPtr Visitor::processIriFunctionCall(
     const std::string& iri, std::vector<ExpressionPtr> argList,
     const antlr4::ParserRuleContext* ctx) {
-  // Lambda that checks the number of arguments and throws an error if it's
-  // not right.
-  auto checkNumArgs = [&argList, &ctx](const std::string_view prefix,
-                                       const std::string_view functionName,
-                                       size_t numArgs) {
+  std::string_view functionName = iri;
+  std::string_view prefixName;
+  // Helper lambda that checks if `functionName` starts with the given prefix.
+  // If yes, remove the prefix and the final `>` from `functionName` and set
+  // `prefixName` to the short name of the prefix; see `global/Constants.h`.
+  auto checkPrefix = [&functionName, &prefixName](
+                         std::pair<std::string_view, std::string_view> prefix) {
+    if (functionName.starts_with(prefix.second)) {
+      prefixName = prefix.first;
+      functionName.remove_prefix(prefix.second.size());
+      AD_CONTRACT_CHECK(functionName.ends_with('>'));
+      functionName.remove_suffix(1);
+      return true;
+    } else {
+      return false;
+    }
+  };
+  // Helper lambda that checks the number of arguments and throws an error
+  // if it's not right. The `functionName` and `prefixName` are used for the
+  // error message.
+  auto checkNumArgs = [&argList, &ctx, &functionName,
+                       &prefixName](size_t numArgs) {
     static std::array<std::string, 6> wordForNumArgs = {
         "no", "one", "two", "three", "four", "five"};
     if (argList.size() != numArgs) {
       reportError(ctx,
-                  absl::StrCat("Function ", prefix, functionName, " takes ",
+                  absl::StrCat("Function ", prefixName, functionName, " takes ",
                                numArgs < 5 ? wordForNumArgs[numArgs]
                                            : std::to_string(numArgs),
                                numArgs == 1 ? " argument" : " arguments"));
     }
   };
-
-  constexpr static std::string_view geofPrefix =
-      "<http://www.opengis.net/def/function/geosparql/";
-  constexpr static std::string_view qfnPrefix =
-      "<http://qlever.cs.uni-freiburg.de/function#";
-  std::string_view iriView = iri;
-  if (iriView.starts_with(geofPrefix)) {
-    iriView.remove_prefix(geofPrefix.size());
-    AD_CONTRACT_CHECK(iriView.ends_with('>'));
-    iriView.remove_suffix(1);
-    if (iriView == "distance") {
-      checkNumArgs("geof:", iriView, 2);
+  // Geo functions.
+  if (checkPrefix(GEOF_PREFIX)) {
+    if (functionName == "distance") {
+      checkNumArgs(2);
       return sparqlExpression::makeDistExpression(std::move(argList[0]),
                                                   std::move(argList[1]));
-    } else if (iriView == "longitude") {
-      checkNumArgs("geof:", iriView, 1);
+    } else if (functionName == "longitude") {
+      checkNumArgs(1);
       return sparqlExpression::makeLongitudeExpression(std::move(argList[0]));
-    } else if (iriView == "latitude") {
-      checkNumArgs("geof:", iriView, 1);
+    } else if (functionName == "latitude") {
+      checkNumArgs(1);
       return sparqlExpression::makeLatitudeExpression(std::move(argList[0]));
     }
-  } else if (iriView.starts_with(qfnPrefix)) {
-    iriView.remove_prefix(qfnPrefix.size());
-    AD_CONTRACT_CHECK(iriView.ends_with('>'));
-    iriView.remove_suffix(1);
-    if (iriView == "log") {
-      checkNumArgs("qfn:", iriView, 1);
+  } else if (checkPrefix(MATH_PREFIX)) {
+    if (functionName == "log") {
+      checkNumArgs(1);
       return sparqlExpression::makeLogExpression(std::move(argList[0]));
-    } else if (iriView == "exp") {
-      checkNumArgs("qfn:", iriView, 1);
+    } else if (functionName == "exp") {
+      checkNumArgs(1);
       return sparqlExpression::makeExpExpression(std::move(argList[0]));
-    } else if (iriView == "sqrt") {
-      checkNumArgs("qfn:", iriView, 1);
+    } else if (functionName == "sqrt") {
+      checkNumArgs(1);
       return sparqlExpression::makeSqrtExpression(std::move(argList[0]));
+    } else if (functionName == "sin") {
+      checkNumArgs(1);
+      return sparqlExpression::makeSinExpression(std::move(argList[0]));
+    } else if (functionName == "cos") {
+      checkNumArgs(1);
+      return sparqlExpression::makeCosExpression(std::move(argList[0]));
+    } else if (functionName == "tan") {
+      checkNumArgs(1);
+      return sparqlExpression::makeTanExpression(std::move(argList[0]));
     }
   }
   reportNotSupported(ctx, "Function \"" + iri + "\" is");

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -100,6 +100,9 @@ ExpressionPtr Visitor::processIriFunctionCall(
     } else if (iriView == "exp") {
       checkNumArgs("qfn:", iriView, 1);
       return sparqlExpression::makeExpExpression(std::move(argList[0]));
+    } else if (iriView == "sqrt") {
+      checkNumArgs("qfn:", iriView, 1);
+      return sparqlExpression::makeSqrtExpression(std::move(argList[0]));
     }
   }
   reportNotSupported(ctx, "Function \"" + iri + "\" is");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1387,17 +1387,23 @@ TEST(SparqlParser, FunctionCall) {
   using namespace builtInCallTestHelpers;
   auto expectFunctionCall = ExpectCompleteParse<&Parser::functionCall>{};
   auto expectFunctionCallFails = ExpectParseFails<&Parser::functionCall>{};
+  auto geof = "http://www.opengis.net/def/function/geosparql/";
+  auto qfn = "http://qlever.cs.uni-freiburg.de/function#";
 
   // Correct function calls. Check that the parser picks the correct expression.
+  expectFunctionCall(absl::StrCat("<", geof, "latitude>(?x)"),
+                     matchUnary(&makeLatitudeExpression));
+  expectFunctionCall(absl::StrCat("<", geof, "longitude>(?x)"),
+                     matchUnary(&makeLongitudeExpression));
   expectFunctionCall(
-      "<http://www.opengis.net/def/function/geosparql/latitude>(?x)",
-      matchUnary(&makeLatitudeExpression));
-  expectFunctionCall(
-      "<http://www.opengis.net/def/function/geosparql/longitude>(?x)",
-      matchUnary(&makeLongitudeExpression));
-  expectFunctionCall(
-      "<http://www.opengis.net/def/function/geosparql/distance>(?a, ?b)",
+      absl::StrCat("<", geof, "distance>(?a, ?b)"),
       matchNary(&makeDistExpression, Variable{"?a"}, Variable{"?b"}));
+  expectFunctionCall(absl::StrCat("<", qfn, "log>(?x)"),
+                     matchUnary(&makeLogExpression));
+  expectFunctionCall(absl::StrCat("<", qfn, "exp>(?x)"),
+                     matchUnary(&makeExpExpression));
+  expectFunctionCall(absl::StrCat("<", qfn, "sqrt>(?x)"),
+                     matchUnary(&makeSqrtExpression));
 
   // Wrong number of arguments.
   expectFunctionCallFails(

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -87,7 +87,7 @@ struct ExpectCompleteParse {
                   SparqlQleverVisitor::PrefixMap prefixMap,
                   ad_utility::source_location l =
                       ad_utility::source_location::current()) const {
-    auto tr = generateLocationTrace(l, "succesful parsing was expected here");
+    auto tr = generateLocationTrace(l, "successful parsing was expected here");
     EXPECT_NO_THROW({
       return expectCompleteParse(
           parse<Clause>(input, std::move(prefixMap), disableSomeChecks),
@@ -1387,23 +1387,29 @@ TEST(SparqlParser, FunctionCall) {
   using namespace builtInCallTestHelpers;
   auto expectFunctionCall = ExpectCompleteParse<&Parser::functionCall>{};
   auto expectFunctionCallFails = ExpectParseFails<&Parser::functionCall>{};
-  auto geof = "http://www.opengis.net/def/function/geosparql/";
-  auto qfn = "http://qlever.cs.uni-freiburg.de/function#";
+  auto geof = GEOF_PREFIX.second;
+  auto math = MATH_PREFIX.second;
 
   // Correct function calls. Check that the parser picks the correct expression.
-  expectFunctionCall(absl::StrCat("<", geof, "latitude>(?x)"),
+  expectFunctionCall(absl::StrCat(geof, "latitude>(?x)"),
                      matchUnary(&makeLatitudeExpression));
-  expectFunctionCall(absl::StrCat("<", geof, "longitude>(?x)"),
+  expectFunctionCall(absl::StrCat(geof, "longitude>(?x)"),
                      matchUnary(&makeLongitudeExpression));
   expectFunctionCall(
-      absl::StrCat("<", geof, "distance>(?a, ?b)"),
+      absl::StrCat(geof, "distance>(?a, ?b)"),
       matchNary(&makeDistExpression, Variable{"?a"}, Variable{"?b"}));
-  expectFunctionCall(absl::StrCat("<", qfn, "log>(?x)"),
+  expectFunctionCall(absl::StrCat(math, "log>(?x)"),
                      matchUnary(&makeLogExpression));
-  expectFunctionCall(absl::StrCat("<", qfn, "exp>(?x)"),
+  expectFunctionCall(absl::StrCat(math, "exp>(?x)"),
                      matchUnary(&makeExpExpression));
-  expectFunctionCall(absl::StrCat("<", qfn, "sqrt>(?x)"),
+  expectFunctionCall(absl::StrCat(math, "sqrt>(?x)"),
                      matchUnary(&makeSqrtExpression));
+  expectFunctionCall(absl::StrCat(math, "sin>(?x)"),
+                     matchUnary(&makeSinExpression));
+  expectFunctionCall(absl::StrCat(math, "cos>(?x)"),
+                     matchUnary(&makeCosExpression));
+  expectFunctionCall(absl::StrCat(math, "tan>(?x)"),
+                     matchUnary(&makeTanExpression));
 
   // Wrong number of arguments.
   expectFunctionCallFails(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -439,7 +439,8 @@ TEST(SparqlExpression, unaryMinus) {
   checkMinus(Strings{"true", "false", "", "<blibb>"}, Ids{U, U, U, U});
 }
 
-TEST(SparqlExpression, ceilFloorAbsRound) {
+// Test the built-in numeric functions (floor, abs, round, ceil).
+TEST(SparqlExpression, builtInNumericFunctions) {
   auto bindUnary = [](auto f) {
     return std::bind_front(testUnaryExpression, f);
   };
@@ -466,6 +467,17 @@ TEST(SparqlExpression, ceilFloorAbsRound) {
   checkFloor(input, floor);
   checkCeil(input, ceil);
   checkRound(input, round);
+}
+
+// Test the custom numeric functions implemented so far (log, exp).
+TEST(SparqlExpression, customNumericFunctions) {
+  auto nan = std::numeric_limits<double>::quiet_NaN();
+  testUnaryExpression(makeLogExpression,
+                      std::vector<Id>{B(false), B(true), I(1), D(exp(1)), U},
+                      std::vector<Id>{D(nan), D(0), D(0), D(1), U});
+  testUnaryExpression(makeExpExpression,
+                      std::vector<Id>{B(false), B(true), I(0), D(1), U},
+                      std::vector<Id>{D(1), D(exp(1)), D(1), D(exp(1)), U});
 }
 
 // ________________________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -478,6 +478,9 @@ TEST(SparqlExpression, customNumericFunctions) {
   testUnaryExpression(makeExpExpression,
                       std::vector<Id>{B(false), B(true), I(0), D(1), U},
                       std::vector<Id>{D(1), D(exp(1)), D(1), D(exp(1)), U});
+  testUnaryExpression(makeSqrtExpression,
+                      std::vector<Id>{B(false), B(true), I(0), D(2), I(-1), U},
+                      std::vector<Id>{D(0), D(1), D(0), D(sqrt(2)), D(nan), U});
 }
 
 // ________________________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -509,7 +509,7 @@ TEST(SparqlExpression, builtInNumericFunctions) {
   checkRound(input, round);
 }
 
-// Test the custom numeric functions implemented so far (log, exp).
+// Test the correctness of the math functions.
 TEST(SparqlExpression, customNumericFunctions) {
   auto nan = std::numeric_limits<double>::quiet_NaN();
   testUnaryExpression(makeLogExpression,
@@ -521,6 +521,15 @@ TEST(SparqlExpression, customNumericFunctions) {
   testUnaryExpression(makeSqrtExpression,
                       std::vector<Id>{B(false), B(true), I(0), D(2), I(-1), U},
                       std::vector<Id>{D(0), D(1), D(0), D(sqrt(2)), D(nan), U});
+  testUnaryExpression(makeSinExpression,
+                      std::vector<Id>{B(false), I(0), D(1), U},
+                      std::vector<Id>{D(0), D(0), D(sin(1)), U});
+  testUnaryExpression(makeCosExpression,
+                      std::vector<Id>{B(false), I(0), D(1), U},
+                      std::vector<Id>{D(1), D(1), D(cos(1)), U});
+  testUnaryExpression(makeTanExpression,
+                      std::vector<Id>{B(false), I(0), D(1), U},
+                      std::vector<Id>{D(0), D(0), D(tan(1)), U});
 }
 
 // ________________________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -581,24 +581,25 @@ TEST(SparqlExpression, builtInNumericFunctions) {
 // Test the correctness of the math functions.
 TEST(SparqlExpression, customNumericFunctions) {
   auto nan = std::numeric_limits<double>::quiet_NaN();
+  auto inf = std::numeric_limits<double>::infinity();
   testUnaryExpression(makeLogExpression,
-                      std::vector<Id>{B(false), B(true), I(1), D(exp(1)), U},
-                      std::vector<Id>{D(nan), D(0), D(0), D(1), U});
+                      std::vector<Id>{I(1), D(2), D(exp(1)), D(0)},
+                      std::vector<Id>{D(0), D(log(2)), D(1), D(-inf)});
   testUnaryExpression(makeExpExpression,
-                      std::vector<Id>{B(false), B(true), I(0), D(1), U},
-                      std::vector<Id>{D(1), D(exp(1)), D(1), D(exp(1)), U});
+                      std::vector<Id>{I(0), D(1), D(2), D(-inf)},
+                      std::vector<Id>{D(1), D(exp(1)), D(exp(2)), D(0)});
   testUnaryExpression(makeSqrtExpression,
-                      std::vector<Id>{B(false), B(true), I(0), D(2), I(-1), U},
-                      std::vector<Id>{D(0), D(1), D(0), D(sqrt(2)), D(nan), U});
+                      std::vector<Id>{I(0), D(1), D(2), D(-1)},
+                      std::vector<Id>{D(0), D(1), D(sqrt(2)), D(nan)});
   testUnaryExpression(makeSinExpression,
-                      std::vector<Id>{B(false), I(0), D(1), U},
-                      std::vector<Id>{D(0), D(0), D(sin(1)), U});
+                      std::vector<Id>{I(0), D(1), D(2), D(-1)},
+                      std::vector<Id>{D(0), D(sin(1)), D(sin(2)), D(sin(-1))});
   testUnaryExpression(makeCosExpression,
-                      std::vector<Id>{B(false), I(0), D(1), U},
-                      std::vector<Id>{D(1), D(1), D(cos(1)), U});
+                      std::vector<Id>{I(0), D(1), D(2), D(-1)},
+                      std::vector<Id>{D(1), D(cos(1)), D(cos(2)), D(cos(-1))});
   testUnaryExpression(makeTanExpression,
-                      std::vector<Id>{B(false), I(0), D(1), U},
-                      std::vector<Id>{D(0), D(0), D(tan(1)), U});
+                      std::vector<Id>{I(0), D(1), D(2), D(-1)},
+                      std::vector<Id>{D(0), D(tan(1)), D(tan(2)), D(tan(-1))});
 }
 
 // ________________________________________________________________________________________


### PR DESCRIPTION
There does not seem to be a standard prefix for those, so I am using `<http://qlever.cs.uni-freiburg.de/function#>` for now (abbreviated as prefix `qfn` in the QLever UI).