### PR TITLE
Make  Codecov and ASAN checks faster

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -30,8 +30,8 @@ jobs:
           build-type: Debug
           warnings: "-Wall -Wextra "
           # we disable the `assert()` macro as it messes with the coverage reports
-          asan-flags: "-fsanitize=address -fno-omit-frame-pointer -DNDEBUG"
-          ubsan-flags: " -fsanitize=undefined"
+          asan-flags: "-DNDEBUG"
+          ubsan-flags: ""
           coverage-flags: "-fprofile-instr-generate -fcoverage-mapping"
           cmake-flags: "-DCMAKE_C_COMPILER=clang-16 -DCMAKE_CXX_COMPILER=clang++-16"
 

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -36,6 +36,7 @@ jobs:
             compiler-version: 13
         include:
           - compiler: clang
+            compiler-version: 16
             asan-flags: "-fsanitize=address -fno-omit-frame-pointer"
             build-type: Release
             expensive-tests: false

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -37,6 +37,8 @@ jobs:
         include:
           - compiler: clang
             asan-flags: "-fsanitize=address -fno-omit-frame-pointer"
+            build-type: Release
+            expensive-tests: false
           - compiler: clang
             compiler-version: 16
             ubsan-flags: " -fsanitize=undefined"


### PR DESCRIPTION
The codecov run now doesn't run any sanitizers (We already have those in separate actions).
The address sanitizer runs don't perform the expensive checks.