### PR TITLE
 Sub managers for the `ConfigOptionManager` class

### DIFF
--- a/src/util/ConfigManager/ConfigExceptions.cpp
+++ b/src/util/ConfigManager/ConfigExceptions.cpp
@@ -2,12 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (June of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "util/ConfigManager/ConfigExceptions.h"
+
 #include <absl/strings/str_cat.h>
 
 #include <exception>
 #include <string>
-
-#include "util/ConfigManager/ConfigExceptions.h"
 
 namespace ad_utility {
 //_____________________________________________________________________________

--- a/src/util/ConfigManager/ConfigExceptions.cpp
+++ b/src/util/ConfigManager/ConfigExceptions.cpp
@@ -2,12 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (June of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "util/ConfigManager/ConfigExceptions.h"
-
 #include <absl/strings/str_cat.h>
 
 #include <exception>
 #include <string>
+
+#include "util/ConfigManager/ConfigExceptions.h"
 
 namespace ad_utility {
 //_____________________________________________________________________________
@@ -55,16 +55,6 @@ NotValidShortHandNameException::NotValidShortHandNameException(
       "Key error: The key '", notValidName, "' in '", pathToOption,
       "' doesn't describe a valid name, according to the short hand "
       "grammar.");
-}
-
-//_____________________________________________________________________________
-ConfigManagerOptionPathAlreadyinUseException::
-    ConfigManagerOptionPathAlreadyinUseException(
-        std::string_view pathToOption,
-        std::string_view allPathsCurrentlyInUse) {
-  getMessage() = absl::StrCat(
-      "Key error: There is already a configuration option with the path '",
-      pathToOption, "'\n", allPathsCurrentlyInUse, "\n");
 }
 
 //_____________________________________________________________________________

--- a/src/util/ConfigManager/ConfigExceptions.h
+++ b/src/util/ConfigManager/ConfigExceptions.h
@@ -95,22 +95,6 @@ class NotValidShortHandNameException : public ExceptionWithMessage {
 };
 
 /*
-@brief A custom exception, for when somebody tries to add a `ConfigOption` to a
-`ConfigManager`, but the given path is already in use.
-*/
-class ConfigManagerOptionPathAlreadyinUseException
-    : public ExceptionWithMessage {
- public:
-  /*
-  @param pathToOption The path to the option.
-  @param allPathsCurrentlyInUse A string representation of all the paths, that
-  are already in use.
-  */
-  explicit ConfigManagerOptionPathAlreadyinUseException(
-      std::string_view pathToOption, std::string_view allPathsCurrentlyInUse);
-};
-
-/*
 @brief A custom exception, for when somebody tries to set a `ConfigOption` with
 a json value, that represents the wrong type.
 */

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -54,7 +54,7 @@ ConfigManager::configurationOptionsImpl(auto& configurationOptions,
               if constexpr (isSimilar<T, ConfigOption>) {
                 collectedOptions.emplace_back(pathToCurrentEntry, &var);
               } else {
-                AD_CORRECTNESS_CHECK((isSimilar<T, ConfigManager>));
+                static_assert(isSimilar<T, ConfigManager>);
                 ad_utility::appendVector(
                     collectedOptions,
                     configurationOptionsImpl<ReturnPointer>(

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -52,8 +52,7 @@ ConfigManager::configurationOptionsImpl(auto& configurationOptions,
               // A normal `ConfigOption` can be directly added. For a
               // `ConfigManager` we have to recursively collect the options.
               if constexpr (isSimilar<T, ConfigOption>) {
-                collectedOptions.push_back(
-                    std::make_pair(pathToCurrentEntry, &var));
+                collectedOptions.emplace_back(pathToCurrentEntry, &var);
               } else {
                 AD_CORRECTNESS_CHECK((isSimilar<T, ConfigManager>));
                 ad_utility::appendVector(

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -57,7 +57,7 @@ ConfigManager::configurationOptionsImpl(auto& configurationOptions,
             std::get_if<ConfigManager>(pair.second.get());
         ptr != nullptr && ptr->configurationOptions_.empty()) {
       throw std::runtime_error(
-          absl::StrCat("The sub manager at '", pathPrefix, std::get<0>(pair),
+          absl::StrCat("The sub manager at '", pathPrefix, pair.first,
                        "' is empty. Either fill it, or delete it."));
     }
 
@@ -529,10 +529,10 @@ void ConfigManager::verifyWithValidators() const {
 // ____________________________________________________________________________
 bool ConfigManager::containsOption(const ConfigOption& opt) const {
   const auto allOptions = configurationOptions();
-  const auto allOptionsPointerToValues =
+  return ad_utility::contains(
       std::views::values(allOptions) |
-      std::views::transform([](const ConfigOption& option) { return &option; });
-  return std::ranges::find(allOptionsPointerToValues, &opt) !=
-         allOptionsPointerToValues.end();
+          std::views::transform(
+              [](const ConfigOption& option) { return &option; }),
+      &opt);
 }
 }  // namespace ad_utility

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -129,8 +129,8 @@ void ConfigManager::verifyPath(const std::vector<std::string>& path) const {
   // We need at least a name in the path.
   if (path.empty()) {
     throw std::runtime_error(
-        "It is forbidden to call `addConfigOption` with an empty vector as the "
-        "first argument, because we need a name for the added option.");
+        "It is forbidden to call `addConfigOption`, or `addSubManager`, with "
+        "an empty vector as the first argument.");
   }
 
   /*

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -288,10 +288,12 @@ void ConfigManager::parseConfig(const nlohmann::json& j) {
   const auto& jFlattend = j.flatten();
 
   // All the configuration options together with their paths.
-  std::vector<std::pair<std::string, ConfigOption*>> allConfigOption =
-      configurationOptions("");
-  ad_utility::HashMap<std::string, ConfigOption*> allConfigOptionHashMap(
-      allConfigOption.begin(), allConfigOption.end());
+  const auto allConfigOptions{[this]() {
+    std::vector<std::pair<std::string, ConfigOption*>> allConfigOption =
+        configurationOptions("");
+    return ad_utility::HashMap<std::string, ConfigOption*>(
+        allConfigOption.begin(), allConfigOption.end());
+  }()};
 
   /*
   We can skip the following check, if `j` is empty. Note: Even if the JSON
@@ -311,8 +313,8 @@ void ConfigManager::parseConfig(const nlohmann::json& j) {
       // Only returns true, if the given pointer is the path to a
       // configuration option.
       auto isPointerToConfigurationOption =
-          [&allConfigOptionHashMap](const nlohmann::json::json_pointer& ptr) {
-            return allConfigOptionHashMap.contains(ptr.to_string());
+          [&allConfigOptions](const nlohmann::json::json_pointer& ptr) {
+            return allConfigOptions.contains(ptr.to_string());
           };
 
       /*
@@ -345,7 +347,7 @@ void ConfigManager::parseConfig(const nlohmann::json& j) {
   or if it HAD to be set, but wasn't.
   */
   for (auto&& [key, option] : std::views::transform(
-           allConfigOption,
+           allConfigOptions,
            [](auto& pair) { return std::tie(pair.first, *pair.second); })) {
     // Set the option, if possible, with the pointer to the position of the
     // current configuration in json.

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "util/ConfigManager/ConfigManager.h"
+
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -21,7 +23,6 @@
 
 #include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigExceptions.h"
-#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -104,16 +104,15 @@ ConfigManager::configurationOptionsImpl(auto& configurationOptions,
 
 // ____________________________________________________________________________
 std::vector<std::pair<std::string, ConfigOption&>>
-ConfigManager::configurationOptions(std::string_view pathPrefix) {
-  return configurationOptionsImpl<ConfigOption&>(configurationOptions_,
-                                                 pathPrefix);
+ConfigManager::configurationOptions() {
+  return configurationOptionsImpl<ConfigOption&>(configurationOptions_, "");
 }
 
 // ____________________________________________________________________________
 std::vector<std::pair<std::string, const ConfigOption&>>
-ConfigManager::configurationOptions(std::string_view pathPrefix) const {
+ConfigManager::configurationOptions() const {
   return configurationOptionsImpl<const ConfigOption&>(configurationOptions_,
-                                                       pathPrefix);
+                                                       "");
 }
 
 // ____________________________________________________________________________
@@ -295,7 +294,7 @@ void ConfigManager::parseConfig(const nlohmann::json& j) {
   // All the configuration options together with their paths.
   const auto allConfigOptions{[this]() {
     std::vector<std::pair<std::string, ConfigOption&>> allConfigOption =
-        configurationOptions("");
+        configurationOptions();
 
     // You can't put references into hash maps. Instead, we use pointer.
     auto pointerVersion = std::views::transform(
@@ -388,7 +387,7 @@ std::string ConfigManager::printConfigurationDoc(
     bool printCurrentJsonConfiguration) const {
   // All the configuration options together with their paths.
   const std::vector<std::pair<std::string, const ConfigOption&>>
-      allConfigOptions = configurationOptions("");
+      allConfigOptions = configurationOptions();
 
   // Handeling, for when there are no configuration options.
   if (allConfigOptions.empty()) {
@@ -470,7 +469,7 @@ ConfigManager::getListOfNotChangedConfigOptionsWithDefaultValuesAsString()
     const {
   // All the configuration options together with their paths.
   const std::vector<std::pair<std::string, const ConfigOption&>>
-      allConfigOptions = configurationOptions("");
+      allConfigOptions = configurationOptions();
 
   // For only looking at the configuration options in our map.
   auto onlyConfigurationOptionsView = std::views::values(allConfigOptions);

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -221,11 +221,12 @@ ConfigManager& ConfigManager::addSubManager(
   // The path in json format.
   const std::string jsonPath = createJsonPointerString(path);
 
-  // Add the configuration manager.
-  configurationOptions_.emplace(
-      jsonPath, std::make_unique<HashMapEntry::element_type>(ConfigManager{}));
-
-  return std::get<ConfigManager>(*configurationOptions_.at(jsonPath));
+  // Add the configuration manager and return the inserted element.
+  return std::get<ConfigManager>(
+      *configurationOptions_
+           .emplace(jsonPath, std::make_unique<HashMapEntry::element_type>(
+                                  ConfigManager{}))
+           .first->second);
 }
 
 // ____________________________________________________________________________

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "util/ConfigManager/ConfigManager.h"
+
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -22,7 +24,6 @@
 
 #include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigExceptions.h"
-#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -51,7 +51,8 @@ Manages a bunch of `ConfigOption`s.
 */
 class ConfigManager {
   /*
-  The added configuration options.
+  The added configuration options. Configuration managers are used by the user
+  to describe a json object literal more explicitly.
 
   A configuration option tends to be placed like a key value pair in a json
   object. For example: `{"object 1" : [{"object 2" : { "The configuration option
@@ -60,8 +61,9 @@ class ConfigManager {
   The string key describes their location in the json object literal, by
   representing a json pointer in string form.
   */
-  ad_utility::HashMap<std::string, std::unique_ptr<ConfigOption>>
-      configurationOptions_;
+  using HashMapEntry =
+      std::unique_ptr<std::variant<ConfigOption, ConfigManager>>;
+  ad_utility::HashMap<std::string, HashMapEntry> configurationOptions_;
 
   /*
   List of the added validators. Whenever the values of the options are set,
@@ -174,12 +176,25 @@ class ConfigManager {
   }
 
   /*
+  @brief Creates and adds a new configuration manager with a prefix path for
+  it's internally held configuration options and managers.
+
+  @param pathToOption Describes a path in json, which will be a prefix to all
+  the other paths held in the newly created ConfigManager.
+
+  @return A reference to the newly created configuration manager. This reference
+  will stay valid, even after adding more options.
+  */
+  ConfigManager& addSubManager(const std::vector<std::string>& path);
+
+  /*
   @brief Sets the configuration options based on the given json.
 
   @param j There will be an exception thrown, if:
   - `j` doesn't contain values for all configuration options, that must be set
   at runtime.
-  - Same, if there are values for configuration options, that do not exist.
+  - Same, if there are values for configuration options, that do not exist, or
+  are not contained in this manager, or its sub mangangers.
   - `j` is anything but a json object literal.
   - Any of the added validators return false.
   */
@@ -272,6 +287,7 @@ class ConfigManager {
   FRIEND_TEST(ConfigManagerTest, ParseConfigExceptionTest);
   FRIEND_TEST(ConfigManagerTest, ParseShortHandTest);
   FRIEND_TEST(ConfigManagerTest, ContainsOption);
+  FRIEND_TEST(ConfigManagerTest, CheckForBrokenPaths);
 
   /*
   @brief Creates the string representation of a valid `nlohmann::json` pointer
@@ -354,11 +370,31 @@ class ConfigManager {
   }
 
   /*
-  @brief Provide a range of tuples, that hold references to the key value pairs
-  in `configurationOptions_`, but with the pointer dereferenced.
+  @brief A vector to all the configuratio options, held by this manager,
+  represented with their json paths and reference to them. Options held by a sub
+  manager, are also included with the path to the sub manager as prefix.
+
+  @param pathPrefix This prefix will be added to all configuration option json
+  paths, that will be returned.
   */
-  auto configurationOptions();
-  auto configurationOptions() const;
+  std::vector<std::pair<std::string, ConfigOption*>> configurationOptions(
+      std::string_view pathPrefix = "");
+  std::vector<std::pair<std::string, const ConfigOption*>> configurationOptions(
+      std::string_view pathPrefix = "") const;
+
+  /*
+  @brief The implementation for `configurationOptions`.
+
+  @tparam ReturnPointe Should be either `ConfigOption*`, or `const
+  ConfigOption*`.
+
+  @param pathPrefix This prefix will be added to all configuration option json
+  paths, that will be returned.
+  */
+  template <typename ReturnPointer>
+  static std::vector<std::pair<std::string, ReturnPointer>>
+  configurationOptionsImpl(auto& configurationOptions,
+                           std::string_view pathPrefix = "");
 
   /*
   @brief Call all the validators to check, if the current value is valid.

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -377,22 +377,24 @@ class ConfigManager {
   @param pathPrefix This prefix will be added to all configuration option json
   paths, that will be returned.
   */
-  std::vector<std::pair<std::string, ConfigOption*>> configurationOptions(
+  std::vector<std::pair<std::string, ConfigOption&>> configurationOptions(
       std::string_view pathPrefix = "");
-  std::vector<std::pair<std::string, const ConfigOption*>> configurationOptions(
+  std::vector<std::pair<std::string, const ConfigOption&>> configurationOptions(
       std::string_view pathPrefix = "") const;
 
   /*
   @brief The implementation for `configurationOptions`.
 
-  @tparam ReturnPointe Should be either `ConfigOption*`, or `const
-  ConfigOption*`.
+  @tparam ReturnReference Should be either `ConfigOption&`, or `const
+  ConfigOption&`.
 
   @param pathPrefix This prefix will be added to all configuration option json
   paths, that will be returned.
   */
-  template <typename ReturnPointer>
-  static std::vector<std::pair<std::string, ReturnPointer>>
+  template <typename ReturnReference>
+  requires std::same_as<ReturnReference, ConfigOption&> ||
+           std::same_as<ReturnReference, const ConfigOption&>
+  static std::vector<std::pair<std::string, ReturnReference>>
   configurationOptionsImpl(auto& configurationOptions,
                            std::string_view pathPrefix = "");
 

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -373,14 +373,10 @@ class ConfigManager {
   @brief A vector to all the configuratio options, held by this manager,
   represented with their json paths and reference to them. Options held by a sub
   manager, are also included with the path to the sub manager as prefix.
-
-  @param pathPrefix This prefix will be added to all configuration option json
-  paths, that will be returned.
   */
-  std::vector<std::pair<std::string, ConfigOption&>> configurationOptions(
-      std::string_view pathPrefix = "");
-  std::vector<std::pair<std::string, const ConfigOption&>> configurationOptions(
-      std::string_view pathPrefix = "") const;
+  std::vector<std::pair<std::string, ConfigOption&>> configurationOptions();
+  std::vector<std::pair<std::string, const ConfigOption&>>
+  configurationOptions() const;
 
   /*
   @brief The implementation for `configurationOptions`.

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -297,8 +297,8 @@ class ConfigManager {
       const std::vector<std::string>& keys);
 
   /*
-  @brief Verifies, that the given path is a valid path for an option. If not,
-  throws exceptions.
+  @brief Verifies, that the given path is a valid path for an option, or sub
+  manager. If not, throws exceptions.
 
   @param pathToOption Describes a path in json.
   */

--- a/src/util/TransparentFunctors.h
+++ b/src/util/TransparentFunctors.h
@@ -98,7 +98,7 @@ static constexpr detail::HoldsAlternativeImpl<T> holdsAlternative;
 /// Transparent functor for `std::get`. Currently only works for `std::variant`
 /// and not for `std::array` or `std::tuple`.
 template <typename T>
-static constexpr detail::HoldsAlternativeImpl<T> get;
+static constexpr detail::GetImpl<T> get;
 
 /// Transparent functor for `std::get_if`. As an extension to `std::get_if`,
 /// `ad_utility::getIf` may also be called with a `variant` object or reference,

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -33,8 +33,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
-                 const bool wasSet, const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
+                 const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -51,23 +51,20 @@ TEST(ConfigManagerTest, CreateConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
-  ASSERT_THROW(config.addOption(
-      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed,
-      42);
-               , ad_utility::ConfigManagerOptionPathAlreadyinUseException);
+  ASSERT_THROW(
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+      , ad_utility::ConfigManagerOptionPathAlreadyinUseException);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(
-      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -76,12 +73,41 @@ TEST(ConfigManagerTest, CreateConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
-                                &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 }
 
-TEST(ConfigManagerTest, ParseConfig) {
+/*
+The exceptions for adding sub managers.
+*/
+TEST(ConfigManagerTest, addSubManagerExceptionTest) {
+  ad_utility::ConfigManager config{};
+
+  // Sub manager for testing. Empty sub manager are not allowed.
+  int notUsed;
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+      .addOption("ignore", "", &notUsed);
+
+  // Trying to add a sub manager with the same name at the same place, should
+  // cause an error.
+  ASSERT_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+               ad_utility::ConfigManagerOptionPathAlreadyinUseException);
+
+  // An empty vector that should cause an exception.
+  ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
+
+  /*
+  Trying to add a sub manager with a path containing strings with
+  spaces should cause an error.
+  Reason: A string with spaces in it, can't be read by the short hand
+  configuration grammar. Ergo, you can't set values, with such paths per
+  short hand, which we don't want.
+  */
+  ASSERT_THROW(config.addSubManager({"Shared part"s, "Sense_of_existence"s});
+               , ad_utility::NotValidShortHandNameException);
+}
+
+TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   ad_utility::ConfigManager config{};
 
   // Adding the options.
@@ -90,13 +116,10 @@ TEST(ConfigManagerTest, ParseConfig) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s},
-                       "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne =
-      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                       "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo =
-      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                                              "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -126,17 +149,232 @@ TEST(ConfigManagerTest, ParseConfig) {
   checkOption<int>(optionTwo, thirdInt, true, 12);
 }
 
-TEST(ConfigManagerTest, ParseConfigExceptionTest) {
+TEST(ConfigManagerTest, ParseConfigWithSubManager) {
+  // Parse the given configManager with the given json and check, that all the
+  // configOption were set correctly.
+  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
+                          const std::vector<std::pair<int*, int>>& wantedValues) {
+    m.parseConfig(j);
+
+    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+      ASSERT_EQ(*wantedValue.first, wantedValue.second);
+    });
+  };
+
+  // Simple manager, with only one sub manager and no recursion.
+  ad_utility::ConfigManager managerWithOneSubNoRecursion{};
+  ad_utility::ConfigManager& managerSteve =
+      managerWithOneSubNoRecursion.addSubManager({"personal"s, "Steve"s});
+  int steveId;
+  managerSteve.addOption("Id", "", &steveId, 4);
+  int steveInfractions;
+  managerSteve.addOption("Infractions", "", &steveInfractions, 6);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "personal": {
+   "Steve": {
+     "Id": 40, "Infractions" : 60
+   }
+ }
+ })--"),
+                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+
+  // Adding configuration options to the top level manager.
+  int amountOfPersonal;
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "AmountOfPersonal" : 1,
+ "personal": {
+   "Steve": {
+     "Id": 30, "Infractions" : 70
+   }
+ }
+ })--"),
+                managerWithOneSubNoRecursion,
+                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+
+  // Simple manager, with multiple sub manager and no recursion.
+  ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
+  ad_utility::ConfigManager& managerDave =
+      managerWithMultipleSubNoRecursion.addSubManager({"personal"s, "Dave"s});
+  ad_utility::ConfigManager& managerJanice =
+      managerWithMultipleSubNoRecursion.addSubManager({"personal"s, "Janice"s});
+  int daveId;
+  managerDave.addOption("Id", "", &daveId, 7);
+  int janiceId;
+  managerJanice.addOption("Id", "", &janiceId, 11);
+  int daveInfractions;
+  managerDave.addOption("Infractions", "", &daveInfractions, 1);
+  int janiceInfractions;
+  managerJanice.addOption("Infractions", "", &janiceInfractions, 143);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "personal": {
+   "Dave": {
+     "Id": 4, "Infractions" : 0
+   },
+   "Janice": {
+     "Id": 0, "Infractions" : 6
+   }
+ }
+ })--"),
+                managerWithMultipleSubNoRecursion,
+                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+
+  // Adding configuration options to the top level manager.
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "AmountOfPersonal" : 1,
+ "personal": {
+   "Dave": {
+     "Id": 6, "Infractions" : 2
+   },
+   "Janice": {
+     "Id": 2, "Infractions" : 8
+   }
+ }
+ })--"),
+                managerWithMultipleSubNoRecursion,
+                {{&amountOfPersonal, 1},
+                 {&daveId, 6},
+                 {&daveInfractions, 2},
+                 {&janiceId, 2},
+                 {&janiceInfractions, 8}});
+
+  // Complex manager with recursion.
+  ad_utility::ConfigManager managerWithRecursion{};
+  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+
+  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  int alexId;
+  managerAlex.addOption("Id", "", &alexId, 8);
+  int alexInfractions;
+  managerAlex.addOption("Infractions", "", &alexInfractions, 4);
+
+  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  int peterId;
+  managerPeter.addOption("Id", "", &peterId, 8);
+  int peterInfractions;
+  managerPeter.addOption("Infractions", "", &peterInfractions, 4);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "depth1": {
+     "depth2": {
+         "personal": {
+           "Alex": {
+             "Id": 4, "Infractions" : 0
+           },
+           "Peter": {
+             "Id": 0, "Infractions" : 6
+           }
+         }
+     }
+ }
+ })--"),
+                managerWithRecursion,
+                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+
+  // Add an option to `managerDepth2`.
+  int someOptionAtDepth2;
+  managerDepth2.addOption("someOption", "", &someOptionAtDepth2, 7);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "depth1": {
+     "depth2": {
+         "someOption" : 9,
+         "personal": {
+           "Alex": {
+             "Id": 6, "Infractions" : 2
+           },
+           "Peter": {
+             "Id": 2, "Infractions" : 8
+           }
+         }
+     }
+ }
+ })--"),
+                managerWithRecursion,
+                {{&someOptionAtDepth2, 9},
+                 {&alexId, 6},
+                 {&alexInfractions, 2},
+                 {&peterId, 2},
+                 {&peterInfractions, 8}});
+
+  // Add an option to `managerDepth1`.
+  int someOptionAtDepth1;
+  managerDepth1.addOption("someOption", "", &someOptionAtDepth1, 10);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "depth1": {
+     "someOption" : 3,
+     "depth2": {
+         "someOption" : 7,
+         "personal": {
+           "Alex": {
+             "Id": 4, "Infractions" : 0
+           },
+           "Peter": {
+             "Id": 0, "Infractions" : 6
+           }
+         }
+     }
+ }
+ })--"),
+                managerWithRecursion,
+                {{&someOptionAtDepth1, 3},
+                 {&someOptionAtDepth2, 7},
+                 {&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
+
+  // Add a second sub manager to `managerDepth1`.
+  int someOptionInSecondSubManagerAtDepth1;
+  managerDepth1.addSubManager({"random"s})
+      .addOption("someOption", "", &someOptionInSecondSubManagerAtDepth1, 1);
+
+  parseAndCheck(nlohmann::json::parse(R"--({
+ "depth1": {
+     "random": {
+       "someOption" : 8
+     },
+     "someOption" : 1,
+     "depth2": {
+         "someOption" : 5,
+         "personal": {
+           "Alex": {
+             "Id": 2, "Infractions" : -2
+           },
+           "Peter": {
+             "Id": -2, "Infractions" : 4
+           }
+         }
+     }
+ }
+ })--"),
+                managerWithRecursion,
+                {{&someOptionInSecondSubManagerAtDepth1, 8},
+                 {&someOptionAtDepth1, 1},
+                 {&someOptionAtDepth2, 5},
+                 {&alexId, 2},
+                 {&alexInfractions, -2},
+                 {&peterId, -2},
+                 {&peterInfractions, 4}});
+}
+
+TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   ad_utility::ConfigManager config{};
 
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s},
-                   "Must be set. Has no default value.", &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s},
-                   "Must not be set. Has default value.", &notUsedVector,
-                   {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                   &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                   &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -163,27 +401,115 @@ TEST(ConfigManagerTest, ParseConfigExceptionTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_integer)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+}
+
+TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
+  ad_utility::ConfigManager config{};
+
+  // Empty sub managers are not allowed.
+  ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
+  int notUsedInt;
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
+
+  // Add one option with default and one without.
+  std::vector<int> notUsedVector;
+  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
+               {40, 41});
+
+  // Should throw an exception, if we don't set all options, that must be set.
+  ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+               ad_utility::ConfigOptionWasntSetException);
+
+  // Should throw an exception, if we try set an option, that isn't there.
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+           "with_default" : [39]}}}})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+           "test_string" : "test"}}}})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+
+  /*
+  Should throw an exception, if we try set an option with a value, that we
+  already know, can't be valid, regardless of the actual internal type of the
+  configuration option. That is, it's neither an array, nor a primitive.
+  */
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+           "With_default" : {"value" : 4}}}}})--")),
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+
+  // Repeat all those tests, but with a second sub manager added to the first
+  // one.
+  ad_utility::ConfigManager config2{};
+
+  // Empty sub managers are not allowed.
+  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+
+  // Add one option with default and one without.
+  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                      &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                      &notUsedVector, {40, 41});
+
+  // Should throw an exception, if we don't set all options, that must be set.
+  ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+               ad_utility::ConfigOptionWasntSetException);
+
+  // Should throw an exception, if we try set an option, that isn't there.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"some":{ "manager":
+           {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"some":{ "manager":
+           {"depth_0":{"Without_default":42, "test_string" :
+           "test"}}}}}})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+
+  /*
+  Should throw an exception, if we try set an option with a value, that we
+  already know, can't be valid, regardless of the actual internal type of the
+  configuration option. That is, it's neither an array, nor a primitive.
+  */
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"some":{ "manager":
+           {"depth_0":{"Without_default":42, "With_default" : {"value" :
+           4}}}}}}})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -192,65 +518,59 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.",
-      &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.",
-      &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist =
-      config.addOption("someIntegerlist", "Must be set. Has no default value.",
-                       &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist = config.addOption(
+      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint = config.addOption(
-      "somePositiveFloatingPoint", "Must be set. Has no default value.",
-      &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint =
+      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
+                       &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint = config.addOption(
-      "someNegativFloatingPoint", "Must be set. Has no default value.",
-      &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint =
+      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
+                       &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList = config.addOption(
-      "someFloatingPointList", "Must be set. Has no default value.",
-      &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList =
+      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
+                       &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue = config.addOption(
-      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue =
+      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse = config.addOption(
-      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse =
+      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList =
-      config.addOption("someBooleanList", "Must be set. Has no default value.",
-                       &someBooleanListBoolVector);
+  decltype(auto) someBooleanList = config.addOption(
+      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName = config.addOption(
-      "myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName =
+      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList =
-      config.addOption("someStringList", "Must be set. Has no default value.",
-                       &someStringListStringVector);
+  decltype(auto) someStringList = config.addOption(
+      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption =
-      config.addOption({"depth"s, "here"s, "list"s},
-                       "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption = config.addOption(
+      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -261,49 +581,39 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   config.parseConfig(ad_utility::ConfigManager::parseShortHand(
       R"--(somePositiveNumber : 42, someNegativNumber : -42, someIntegerlist : [40, 41], somePositiveFloatingPoint : 4.2, someNegativFloatingPoint : -4.2, someFloatingPointList : [4.1, 4.2], boolTrue : true, boolFalse : false, someBooleanList : [true, false, true], myName : "Bernd", someStringList : ["t1", "t2"], depth : { here : {list : [7,8]}})--"));
 
-  checkOption<int>(somePositiveNumber, somePositiveNumberInt, true, 42);
-  checkOption<int>(someNegativNumber, someNegativNumberInt, true, -42);
+  checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
+  checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption<std::vector<int>>(someIntegerlist, someIntegerlistIntVector, true,
-                                std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
 
-  checkOption<float>(somePositiveFloatingPoint, somePositiveFloatingPointFloat,
-                     true, 4.2f);
-  checkOption<float>(someNegativFloatingPoint, someNegativFloatingPointFloat,
-                     true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
 
-  checkOption<std::vector<float>>(someFloatingPointList,
-                                  someFloatingPointListFloatVector, true,
-                                  {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
 
-  checkOption<bool>(boolTrue, boolTrueBool, true, true);
-  checkOption<bool>(boolFalse, boolFalseBool, true, false);
+  checkOption(boolTrue, boolTrueBool, true, true);
+  checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption<std::vector<bool>>(someBooleanList, someBooleanListBoolVector,
-                                 true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
 
-  checkOption<std::string>(myName, myNameString, true, std::string{"Bernd"});
+  checkOption(myName, myNameString, true, std::string{"Bernd"});
 
-  checkOption<std::vector<std::string>>(someStringList,
-                                        someStringListStringVector, true,
-                                        std::vector<std::string>{"t1", "t2"});
+  checkOption(someStringList, someStringListStringVector, true,
+              std::vector<std::string>{"t1", "t2"});
 
-  checkOption<std::vector<int>>(deeperIntVectorOption, deeperIntVector, true,
-                                std::vector{7, 8});
+  checkOption(deeperIntVectorOption, deeperIntVector, true, std::vector{7, 8});
 
   // Is the "No Change" unchanged?
-  checkOption<int>(noChange, noChangeInt, true, 10);
+  checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
-                                   R"(complicatedKey:42, complicatedKey:43)");
-                               , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
+      , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
-      R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(
-      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -319,6 +629,21 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   config.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
+
+  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  subMan.addOption("WithDefault", "", &notUsed, 42);
+  subMan.addOption("WithoutDefault", "", &notUsed);
+  ASSERT_NO_THROW(config.printConfigurationDoc(false));
+  ASSERT_NO_THROW(config.printConfigurationDoc(true));
+
+  // Printing with an empty sub manager should never be possible.
+  subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.printConfigurationDoc(false),
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.printConfigurationDoc(true),
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -330,14 +655,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager,
-                    const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      manager.parseConfig(jsonWithNonValidValues),
-      ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
+                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator`.
@@ -347,12 +670,11 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption =
-      m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; },
-                 "'numberInRange' must be <=100.", numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; },
-                 "'numberInRange' must be >=50.", numberInRangeOption);
+  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
+                 numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
+                 numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -366,15 +688,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption =
-      m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) ||
-               (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
-      boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -389,16 +708,12 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption =
-      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-      "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
-      nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+                                     "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption =
-      mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -409,25 +724,19 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter =
-      mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) {
-        return opt.getIdentifier().starts_with('d');
-      },
+      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') &&
-               opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter,
-      wrongLetter);
-  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
-      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter, wrongLetter);
+  ASSERT_ANY_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -447,8 +756,7 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> ||
-                       std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -483,10 +791,8 @@ what the exact difference is, see the code.
 */
 template <typename ParameterType>
 auto generateSingleParameterValidatorFunction(size_t variant) {
-  if constexpr (std::is_same_v<ParameterType, bool> ||
-                std::is_same_v<ParameterType, std::string> ||
-                std::is_same_v<ParameterType, int> ||
-                std::is_same_v<ParameterType, size_t> ||
+  if constexpr (std::is_same_v<ParameterType, bool> || std::is_same_v<ParameterType, std::string> ||
+                std::is_same_v<ParameterType, int> || std::is_same_v<ParameterType, size_t> ||
                 std::is_same_v<ParameterType, float>) {
     return [compareTo = createDummyValueForValidator<ParameterType>(variant)](
                const ParameterType& n) { return n != compareTo; };
@@ -502,8 +808,8 @@ auto generateSingleParameterValidatorFunction(size_t variant) {
       }
 
       for (size_t i = 0; i < variant + 1; i++) {
-        if (generateSingleParameterValidatorFunction<
-                typename ParameterType::value_type>(i)(v.at(i))) {
+        if (generateSingleParameterValidatorFunction<typename ParameterType::value_type>(i)(
+                v.at(i))) {
           return true;
         }
       }
@@ -535,12 +841,10 @@ TEST(ConfigManagerTest, AddValidator) {
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes,
-               &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func),
-                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -556,8 +860,7 @@ TEST(ConfigManagerTest, AddValidator) {
   @tparam T Same `T` as for `createDummyValueForValidator` and
   `generateSingleParameterValidatorFunction`.
   */
-  auto adjustVariantArgument =
-      []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
+  auto adjustVariantArgument = []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
     if constexpr (std::is_same_v<T, bool>) {
       /*
       Even numbers for `variant` always result in true, regardless if
@@ -583,9 +886,7 @@ TEST(ConfigManagerTest, AddValidator) {
   auto generateValidatorName = []<typename... Ts>(size_t id) {
     return absl::StrCat(
         "Config manager validator<",
-        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
-                    ", "),
-        "> ", id);
+        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), "> ", id);
   };
 
   /*
@@ -603,19 +904,16 @@ TEST(ConfigManagerTest, AddValidator) {
   */
   auto addValidatorToConfigManager =
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
-          size_t variant, ConfigManager & m,
-          ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
     m.addValidator(
         [variant, &adjustVariantArgument](const Ts&... args) {
           return (generateSingleParameterValidatorFunction<Ts>(
-                      adjustVariantArgument.template operator()<Ts>(variant))(
-                      args) ||
+                      adjustVariantArgument.template operator()<Ts>(variant))(args) ||
                   ...);
         },
-        generateValidatorName.template operator()<Ts...>(variant),
-        validatorArguments...);
+        generateValidatorName.template operator()<Ts...>(variant), validatorArguments...);
   };
 
   /*
@@ -640,13 +938,11 @@ TEST(ConfigManagerTest, AddValidator) {
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
           size_t variantStart, size_t variantEnd, ConfigManager & m,
           const nlohmann::json& defaultValues,
-          const std::same_as<
-              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
           requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
-         validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -668,17 +964,15 @@ TEST(ConfigManagerTest, AddValidator) {
         checkValidator(m, validJson, invalidJson,
                        generateValidatorName.template operator()<Ts...>(0));
       } else {
-        checkValidator(
-            m, validJson, invalidJson,
-            generateValidatorName.template operator()<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName.template operator()<Ts...>(validatorNumber));
       }
     }
   };
 
   /*
-  @brief Does the validator tests for given config manager, by adding validators
-  generated via `addValidatorToConfigManager` and testing them via
-  `testGeneratedValidatorsOfConfigManager`.
+  @brief Does the tests for config manager, where there either is no sub
+  manager, or only the top manager has validators.
 
   @tparam Ts The parameter types for the validator functions.
 
@@ -695,8 +989,7 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -706,8 +999,60 @@ TEST(ConfigManagerTest, AddValidator) {
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+
+      // Test all the added validators.
+      testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
+          0, i + 1, m, defaultValues, validatorArguments.first...);
+    }
+  };
+
+  /*
+  @brief Do the tests for config manager with one sub manager. The sub manager
+  always has validators added to them.
+
+  @tparam Ts The parameter types for the validator functions.
+
+  @param m The config manager, to which validators will be added and on which
+  `parseConfig` will be called. Note, that those validators will **not** be
+  deleted and that the given config manager should have zero already existing
+  validators.
+  @param subM The sub manager, to which validators will be added. Note, that
+  those validators will
+  **not** be deleted and that the given sub manager should have zero already
+  existing validators.
+  @param defaultValues The values for all the configuration options, that will
+  not be checked via the validator.
+  @param validatorArguments As list of pairs, that contain a json pointer to the
+  position of the configuration option in the configuration manager and a proxy
+  to the `ConfigOption` object itself. The described configuration options will
+  be passed as arguments to the validator function, in the same order as given
+  here.
+  */
+  auto doTestAlwaysValidatorInSubManager =
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+          const std::pair<nlohmann::json::json_pointer,
+                          ConstConfigOptionProxy<Ts>>&... validatorArguments)
+          requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
+    // How many validators are to be added to each of the managers?
+    constexpr size_t NUMBER_OF_VALIDATORS{5};
+
+    // Add validators to the sub manager and check, if parsing with the top
+    // manager goes correctly.
+    for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
+      // Add a new validator
+      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+
+      // Test all the added validators.
+      testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
+          0, i + 1, m, defaultValues, validatorArguments.first...);
+    }
+
+    // Now, we add additional validators to the top manager.
+    for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
+      // Add a new validator
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -716,43 +1061,97 @@ TEST(ConfigManagerTest, AddValidator) {
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests =
-      [&doTestNoValidatorInSubManager]<typename Type>() {
-        // Variables needed for configuration options.
-        Type firstVar;
+  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
+    // Variables needed for configuration options.
+    Type firstVar;
 
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption =
-            mNoSub.addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue"),
-                           mNoSubOption));
-      };
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    decltype(auto) mSubNoValidatorOption =
+        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubNoValidatorOption));
+
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption =
+        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubWithValidatorOption));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests =
-      [&doTestNoValidatorInSubManager]<typename Type1, typename Type2>() {
-        // Variables needed for configuration options.
-        Type1 firstVar;
-        Type2 secondVar;
+  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
+                                                                     typename Type2>() {
+    // Variables needed for configuration options.
+    Type1 firstVar;
+    Type2 secondVar;
 
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 =
-            mNoSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mNoSubOption2 =
-            mNoSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
-                           mNoSubOption1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
-                           mNoSubOption2));
-      };
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubNoValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubNoValidatorOption2));
+
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption1 =
+        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubWithValidatorOption2 =
+        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubWithValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubWithValidatorOption2));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -760,8 +1159,7 @@ TEST(ConfigManagerTest, AddValidator) {
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
   auto doDifferentParameterTests = [&addValidatorToConfigManager,
-                                    &generateValidatorName]<typename Type1,
-                                                            typename Type2>() {
+                                    &generateValidatorName]<typename Type1, typename Type2>() {
     // Variables for config options.
     Type1 var1;
     Type2 var2;
@@ -781,8 +1179,7 @@ TEST(ConfigManagerTest, AddValidator) {
     */
     auto checkAllValidAndInvalidValueCombinations =
         [&generateValidatorName]<typename T1, typename T2>(
-            ConfigManager& m,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
             const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
           /*
           Input for `parseConfig`. One contains values, that are valid for all
@@ -804,8 +1201,7 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second + 1);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type1>(
-                             validator1.second));
+                         generateValidatorName.template operator()<Type1>(validator1.second));
 
           // Value for `validator1` is valid. Value for `validator2` is invalid.
           invalidValueJson[validator1.first] =
@@ -813,20 +1209,66 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type2>(
-                             validator2.second));
+                         generateValidatorName.template operator()<Type2>(validator2.second));
         };
 
+    // No sub manager.
     ConfigManager mNoSub;
     decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
-                                                           mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
-                                                           mNoSubOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
         std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 = mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 = mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
+                                                           mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
+                                                           mSubNoValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mSubNoValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+
+    // Sub manager has validators of its own, however the manager does not.
+    ConfigManager mNoValidatorSubValidator;
+    ConfigManager& mNoValidatorSubValidatorSub =
+        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mNoValidatorSubValidatorOption1 =
+        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoValidatorSubValidatorOption2 =
+        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
+                                                           mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
+                                                           mNoValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+
+    // Sub manager has validators of its own, as does the manager.
+    ConfigManager mValidatorSubValidator;
+    ConfigManager& mValidatorSubValidatorSub =
+        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mValidatorSubValidatorOption1 =
+        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mValidatorSubValidatorOption2 =
+        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
+                                                           mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
+                                                           mValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
   };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
@@ -848,27 +1290,51 @@ TEST(ConfigManagerTest, AddValidatorException) {
     /*
     @brief Check, if a call to the `addValidator` function behaves as wanted.
     */
-    auto checkAddValidatorBehavior =
-        [&validatorDummyFunction](ConfigManager& m,
-                                  ConstConfigOptionProxy<T> validOption,
-                                  ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(
-              m.addValidator(validatorDummyFunction, "", validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              m.addValidator(validatorDummyFunction,
-                             notValidOption.getConfigOption().getIdentifier(),
-                             notValidOption),
-              ::testing::ContainsRegex(
-                  notValidOption.getConfigOption().getIdentifier()));
-        };
+    auto checkAddValidatorBehavior = [&validatorDummyFunction](
+                                         ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                                         ConstConfigOptionProxy<T> notValidOption) {
+      ASSERT_NO_THROW(m.addValidator(validatorDummyFunction, "", validOption));
+      AD_EXPECT_THROW_WITH_MESSAGE(
+          m.addValidator(validatorDummyFunction, notValidOption.getConfigOption().getIdentifier(),
+                         notValidOption),
+          ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+    };
 
     // An outside configuration option.
     ConfigOption outsideOption("outside", "", &var);
     ConstConfigOptionProxy<T> outsideOptionProxy(outsideOption);
 
+    // No sub manager.
     ConfigManager mNoSub;
     decltype(auto) mNoSubOption = mNoSub.addOption("someOption", "", &var);
     checkAddValidatorBehavior(mNoSub, mNoSubOption, outsideOptionProxy);
+
+    // With sub manager.
+    ConfigManager mWithSub;
+    decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+    ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
+    decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+    checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+
+    // With 2 sub manager.
+    ConfigManager mWith2Sub;
+    decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+    ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+    decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+    ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+    decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
   };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -877,38 +1343,96 @@ TEST(ConfigManagerTest, AddValidatorException) {
 TEST(ConfigManagerTest, AddOptionValidator) {
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison =
-      [](std::string_view valueStringRepresentation) {
-        return [wantedString = std::string(valueStringRepresentation)](
-                   const auto&... options) {
-          return ((options.getValueAsString() == wantedString) && ...);
-        };
-      };
+  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
+    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
+      return ((options.getValueAsString() == wantedString) && ...);
+    };
+  };
 
   // Variables for configuration options.
   int firstVar;
   int secondVar;
 
+  // Manager without a sub manager.
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  managerWithNoSubManager.addOptionValidator(
-      generateValueAsStringComparison("10"), "someOption1",
-      managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
-                 "someOption1");
+  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "someOption1",
+                                             managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  managerWithNoSubManager.addOptionValidator(
+  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "Both options",
+                                             managerWithNoSubManagerOption1,
+                                             managerWithNoSubManagerOption2);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+                 "Both options");
+
+  // With sub manager. Sub manager has no validators of its own.
+  ConfigManager managerWithSubManagerWhoHasNoValidators;
+  decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+  ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
+      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+  decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+  managerWithSubManagerWhoHasNoValidators.addOptionValidator(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+  checkValidator(managerWithSubManagerWhoHasNoValidators,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
+  managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Both options",
-      managerWithNoSubManagerOption1, managerWithNoSubManagerOption2);
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+      managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
-      managerWithNoSubManager,
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
+
+  // Sub manager has validators of its own, however the manager does not.
+  ConfigManager managerHasNoValidatorsButSubManagerDoes;
+  ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
+      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+  decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
+  managerHasNoValidatorsButSubManagerDoesSubManager.addOptionValidator(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(managerHasNoValidatorsButSubManagerDoes,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
+
+  // Sub manager has validators of its own, as does the manager.
+  ConfigManager bothHaveValidators;
+  decltype(auto) bothHaveValidatorsOption =
+      bothHaveValidators.addOption("someOption", "", &firstVar, 4);
+  ConfigManager& bothHaveValidatorsSubManager =
+      bothHaveValidators.addSubManager({"Sub"s, "manager"s});
+  decltype(auto) bothHaveValidatorsSubManagerOption =
+      bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"), "Top manager option",
+                                        bothHaveValidatorsOption);
+  bothHaveValidatorsSubManager.addOptionValidator(generateValueAsStringComparison("20"),
+                                                  "Sub manager option",
+                                                  bothHaveValidatorsSubManagerOption);
+  checkValidator(
+      bothHaveValidators,
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      "Top manager option");
+  checkValidator(
+      bothHaveValidators,
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionValidatorException) {
@@ -923,27 +1447,50 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   wanted.
   */
   auto checkAddOptionValidatorBehavior =
-      [&validatorDummyFunction]<typename T>(
-          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-          ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(
-            m.addOptionValidator(validatorDummyFunction, "", validOption));
+      [&validatorDummyFunction]<typename T>(ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                                            ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(m.addOptionValidator(validatorDummyFunction, "", validOption));
         AD_EXPECT_THROW_WITH_MESSAGE(
-            m.addOptionValidator(
-                validatorDummyFunction,
-                notValidOption.getConfigOption().getIdentifier(),
-                notValidOption),
-            ::testing::ContainsRegex(
-                notValidOption.getConfigOption().getIdentifier()));
+            m.addOptionValidator(validatorDummyFunction,
+                                 notValidOption.getConfigOption().getIdentifier(), notValidOption),
+            ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
       };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
   ConstConfigOptionProxy<int> outsideOptionProxy(outsideOption);
 
+  // No sub manager.
   ConfigManager mNoSub;
   decltype(auto) mNoSubOption = mNoSub.addOption("someOption", "", &var);
   checkAddOptionValidatorBehavior(mNoSub, mNoSubOption, outsideOptionProxy);
+
+  // With sub manager.
+  ConfigManager mWithSub;
+  decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+  ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
+  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+
+  // With 2 sub manager.
+  ConfigManager mWith2Sub;
+  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, ContainsOption) {
@@ -955,21 +1502,18 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector =
-      std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus =
-      [](const ConfigManager& m,
-         const ContainmentStatusVector& optionsAndWantedStatus) {
-        std::ranges::for_each(
-            optionsAndWantedStatus,
-            [&m](const ContainmentStatusVector::value_type& p) {
-              if (p.second) {
-                ASSERT_TRUE(m.containsOption(*p.first));
-              } else {
-                ASSERT_FALSE(m.containsOption(*p.first));
-              }
-            });
-      };
+  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus = [](const ConfigManager& m,
+                                   const ContainmentStatusVector& optionsAndWantedStatus) {
+    std::ranges::for_each(optionsAndWantedStatus,
+                          [&m](const ContainmentStatusVector::value_type& p) {
+                            if (p.second) {
+                              ASSERT_TRUE(m.containsOption(*p.first));
+                            } else {
+                              ASSERT_FALSE(m.containsOption(*p.first));
+                            }
+                          });
+  };
 
   // Variable for the configuration options.
   int var;
@@ -977,11 +1521,71 @@ TEST(ConfigManagerTest, ContainsOption) {
   // Outside configuration option.
   const ConfigOption outsideOption("OutsideOption", "", &var);
 
+  // The vectors for all `ConfigManager` for the vector parameter in
+  // `checkContainmentStatus`. Mainly to reduce duplication.
+  ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+
+  // Without sub manager.
   ConfigManager m;
-  checkContainmentStatus(m, {{&outsideOption, false}});
+  checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  checkContainmentStatus(m, {{&outsideOption, false},
-                             {&topManagerOption.getConfigOption(), true}});
+  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  subManagerDepth1Num1ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth1Num2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  checkContainmentStatus(m, mContainmentStatusVector);
+
+  // Single sub manager.
+  ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  decltype(auto) subManagerDepth1Num1Option =
+      subManagerDepth1Num1.addOption("SubManager1", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  subManagerDepth1Num1ContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
+  subManagerDepth1Num2ContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), false});
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(m, mContainmentStatusVector);
+
+  // Second sub manager.
+  ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  decltype(auto) subManagerDepth1Num2Option =
+      subManagerDepth1Num2.addOption("SubManager2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  subManagerDepth1Num1ContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), false});
+  subManagerDepth1Num2ContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), false});
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(m, mContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+
+  // Sub manager in the second sub manager.
+  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  subManagerDepth1Num1ContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), false});
+  subManagerDepth1Num2ContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(m, mContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -1002,8 +1606,7 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction =
-      decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -1013,87 +1616,65 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
-                                       std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
-                                       std::string>);
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(
-      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<
-                decltype([](FirstParameter, SecondParameter) { return true; }),
-                int, int>);
+            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
+                                   int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -33,8 +33,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
-                 const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
+                 const bool wasSet, const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -51,14 +51,16 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(
+      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -67,62 +69,69 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
+                                &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
+          &notUsed, 42),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
-  Trying to add a configuration option, whose entire path is a prefix of the path of an already
-  added option, should cause an exception.
-  After all, this would imply, that the already existing option is part of this new option. Which is
-  not supported at the moment.
+  Trying to add a configuration option, whose entire path is a prefix of the
+  path of an already added option, should cause an exception. After all, this
+  would imply, that the already existing option is part of this new option.
+  Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.addOption({"Shared_part"s, "Unique_part_1"s}, "", &notUsed, 42),
       ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
-  Trying to add a configuration option, who contains the entire path of an already added
-  configuration option as prefix, should cause an exception.
-  After all, this would imply, that the new option is part of the already existing option. Which is
-  not supported at the moment.
+  Trying to add a configuration option, who contains the entire path of an
+  already added configuration option as prefix, should cause an exception. After
+  all, this would imply, that the new option is part of the already existing
+  option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
+                        "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
   /*
-  Trying to add a configuration option, whose entire path is a prefix of the path of an already
-  added sub manager, should cause an exception.
-  After all, this would imply, that the sub manger is part of this new option. Which is not
+  Trying to add a configuration option, whose entire path is a prefix of the
+  path of an already added sub manager, should cause an exception. After all,
+  this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
   /*
-  Trying to add a configuration option, who contains the entire path of an already added
-  sub manger as prefix, should cause an exception.
-  After all, such recursive builds should have been done on `C++` level, not json level.
+  Trying to add a configuration option, who contains the entire path of an
+  already added sub manger as prefix, should cause an exception. After all, such
+  recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.addOption({"sub"s, "manager"s, "someOption"s}, "", &notUsed, 42),
       ::testing::ContainsRegex(R"('\[sub\]\[manager\]\[someOption\]')"));
 
   /*
-  Trying to add a configuration option, whose path is the path of an already added sub manger,
-  should cause an exception.
+  Trying to add a configuration option, whose path is the path of an already
+  added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -133,7 +142,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -151,32 +161,35 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
-  Trying to add a sub manager, whose entire path is a prefix of the path of an already
-  added sub manger, should cause an exception.
-  After all, such recursive builds should have been done on `C++` level, not json level.
-  */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
-
-  /*
-  Trying to add a sub manager, whose path contains the entire path of an already added sub manager
-  as prefix, should cause an exception.
-  After all, such recursive builds should have been done on `C++` level, not json level.
+  Trying to add a sub manager, whose entire path is a prefix of the path of an
+  already added sub manger, should cause an exception. After all, such recursive
+  builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+
+  /*
+  Trying to add a sub manager, whose path contains the entire path of an already
+  added sub manager as prefix, should cause an exception. After all, such
+  recursive builds should have been done on `C++` level, not json level.
+  */
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
+                            "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
   /*
-  Trying to add a sub manger, whose entire path is a prefix of the path of an already
-  added config option, should cause an exception.
-  After all, such recursive builds should have been done on `C++` level, not json level.
+  Trying to add a sub manger, whose entire path is a prefix of the path of an
+  already added config option, should cause an exception. After all, such
+  recursive builds should have been done on `C++` level, not json level.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s}),
@@ -185,18 +198,20 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   /*
   Trying to add a sub manager, who contains the entire path of an already added
   config option as prefix, should cause an exception.
-  After all, this would imply, that the sub manger is part of this option. Which is not
-  supported at the moment.
+  After all, this would imply, that the sub manger is part of this option. Which
+  is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s, "manager"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
-  Trying to add a sub manager, whose path is the path of an already added config option, should
-  cause an exception.
+  Trying to add a sub manager, whose path is the path of an already added config
+  option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -208,10 +223,13 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                                              "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s},
+                       "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne =
+      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                       "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo =
+      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -244,14 +262,16 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
-                          const std::vector<std::pair<int*, int>>& wantedValues) {
-    m.parseConfig(j);
+  auto parseAndCheck =
+      [](const nlohmann::json& j, ConfigManager& m,
+         const std::vector<std::pair<int*, int>>& wantedValues) {
+        m.parseConfig(j);
 
-    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-      ASSERT_EQ(*wantedValue.first, wantedValue.second);
-    });
-  };
+        std::ranges::for_each(
+            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+              ASSERT_EQ(*wantedValue.first, wantedValue.second);
+            });
+      };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -269,13 +289,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion,
+                {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
+                                         &amountOfPersonal, 0);
 
-  parseAndCheck(nlohmann::json::parse(R"--({
+  parseAndCheck(
+      nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -283,8 +306,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+      managerWithOneSubNoRecursion,
+      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -312,10 +335,14 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+                {{&daveId, 4},
+                 {&daveInfractions, 0},
+                 {&janiceId, 0},
+                 {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
+                                              &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -337,16 +364,20 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 =
+      managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 =
+      managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex =
+      managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter =
+      managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -367,7 +398,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+                {{&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -463,10 +497,11 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                   &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                   &notUsedVector, {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s},
+                   "Must be set. Has no default value.", &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s},
+                   "Must not be set. Has default value.", &notUsedVector,
+                   {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -493,20 +528,27 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_integer)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -514,32 +556,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
+                   41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
-               {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s},
+               "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s},
+               "Must not be set. Has default value.", &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -550,29 +598,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 =
+      config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 =
+      config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.",
+                    &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.",
+                      &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                      &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                      &notUsedVector, {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s},
+                      "Must be set. Has no default value.", &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s},
+                      "Must not be set. Has default value.", &notUsedVector,
+                      {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -583,13 +640,15 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -601,7 +660,8 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -610,59 +670,65 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.",
+      &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.",
+      &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist = config.addOption(
-      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist =
+      config.addOption("someIntegerlist", "Must be set. Has no default value.",
+                       &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint =
-      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
-                       &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint = config.addOption(
+      "somePositiveFloatingPoint", "Must be set. Has no default value.",
+      &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint =
-      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
-                       &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint = config.addOption(
+      "someNegativFloatingPoint", "Must be set. Has no default value.",
+      &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList =
-      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
-                       &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList = config.addOption(
+      "someFloatingPointList", "Must be set. Has no default value.",
+      &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue =
-      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue = config.addOption(
+      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse =
-      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse = config.addOption(
+      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList = config.addOption(
-      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
+  decltype(auto) someBooleanList =
+      config.addOption("someBooleanList", "Must be set. Has no default value.",
+                       &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName =
-      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName = config.addOption(
+      "myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList = config.addOption(
-      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
+  decltype(auto) someStringList =
+      config.addOption("someStringList", "Must be set. Has no default value.",
+                       &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption = config.addOption(
-      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption =
+      config.addOption({"depth"s, "here"s, "list"s},
+                       "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -676,17 +742,22 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true,
+              std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
+              4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
+              -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
+              {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true,
+              std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -699,13 +770,15 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
-      , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
+                                   R"(complicatedKey:42, complicatedKey:43)");
+                               , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
+      R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(
+      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -722,7 +795,8 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan =
+      config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -732,10 +806,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -747,12 +823,14 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager,
+                    const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
-                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.parseConfig(jsonWithNonValidValues),
+      ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator`.
@@ -762,11 +840,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
-                 numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
-                 numberInRangeOption);
+  decltype(auto) numberInRangeOption =
+      m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; },
+                 "'numberInRange' must be <=100.", numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; },
+                 "'numberInRange' must be >=50.", numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -780,12 +859,15 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption =
+      m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) ||
+               (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
+      boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -800,12 +882,16 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-                                     "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption =
+      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator(
+      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+      "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
+      nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption =
+      mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -816,19 +902,25 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter =
+      mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
+      [](const ConfigOption& opt) {
+        return opt.getIdentifier().starts_with('d');
+      },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') &&
+               opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter, wrongLetter);
-  ASSERT_ANY_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter,
+      wrongLetter);
+  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
+      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -848,7 +940,8 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> ||
+                       std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -883,8 +976,10 @@ what the exact difference is, see the code.
 */
 template <typename ParameterType>
 auto generateSingleParameterValidatorFunction(size_t variant) {
-  if constexpr (std::is_same_v<ParameterType, bool> || std::is_same_v<ParameterType, std::string> ||
-                std::is_same_v<ParameterType, int> || std::is_same_v<ParameterType, size_t> ||
+  if constexpr (std::is_same_v<ParameterType, bool> ||
+                std::is_same_v<ParameterType, std::string> ||
+                std::is_same_v<ParameterType, int> ||
+                std::is_same_v<ParameterType, size_t> ||
                 std::is_same_v<ParameterType, float>) {
     return [compareTo = createDummyValueForValidator<ParameterType>(variant)](
                const ParameterType& n) { return n != compareTo; };
@@ -900,8 +995,8 @@ auto generateSingleParameterValidatorFunction(size_t variant) {
       }
 
       for (size_t i = 0; i < variant + 1; i++) {
-        if (generateSingleParameterValidatorFunction<typename ParameterType::value_type>(i)(
-                v.at(i))) {
+        if (generateSingleParameterValidatorFunction<
+                typename ParameterType::value_type>(i)(v.at(i))) {
           return true;
         }
       }
@@ -933,10 +1028,12 @@ TEST(ConfigManagerTest, AddValidator) {
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes,
+               &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func),
+                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -952,7 +1049,8 @@ TEST(ConfigManagerTest, AddValidator) {
   @tparam T Same `T` as for `createDummyValueForValidator` and
   `generateSingleParameterValidatorFunction`.
   */
-  auto adjustVariantArgument = []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
+  auto adjustVariantArgument =
+      []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
     if constexpr (std::is_same_v<T, bool>) {
       /*
       Even numbers for `variant` always result in true, regardless if
@@ -978,7 +1076,9 @@ TEST(ConfigManagerTest, AddValidator) {
   auto generateValidatorName = []<typename... Ts>(size_t id) {
     return absl::StrCat(
         "Config manager validator<",
-        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), "> ", id);
+        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
+                    ", "),
+        "> ", id);
   };
 
   /*
@@ -996,16 +1096,19 @@ TEST(ConfigManagerTest, AddValidator) {
   */
   auto addValidatorToConfigManager =
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
-          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m,
+          ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
     m.addValidator(
         [variant, &adjustVariantArgument](const Ts&... args) {
           return (generateSingleParameterValidatorFunction<Ts>(
-                      adjustVariantArgument.template operator()<Ts>(variant))(args) ||
+                      adjustVariantArgument.template operator()<Ts>(variant))(
+                      args) ||
                   ...);
         },
-        generateValidatorName.template operator()<Ts...>(variant), validatorArguments...);
+        generateValidatorName.template operator()<Ts...>(variant),
+        validatorArguments...);
   };
 
   /*
@@ -1030,11 +1133,13 @@ TEST(ConfigManagerTest, AddValidator) {
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
           size_t variantStart, size_t variantEnd, ConfigManager & m,
           const nlohmann::json& defaultValues,
-          const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
+          const std::same_as<
+              nlohmann::json::json_pointer> auto&... configOptionPaths)
           requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
+         validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1056,8 +1161,9 @@ TEST(ConfigManagerTest, AddValidator) {
         checkValidator(m, validJson, invalidJson,
                        generateValidatorName.template operator()<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName.template operator()<Ts...>(validatorNumber));
+        checkValidator(
+            m, validJson, invalidJson,
+            generateValidatorName.template operator()<Ts...>(validatorNumber));
       }
     }
   };
@@ -1081,7 +1187,8 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1091,7 +1198,8 @@ TEST(ConfigManagerTest, AddValidator) {
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1122,8 +1230,10 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM,
+          const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1134,7 +1244,8 @@ TEST(ConfigManagerTest, AddValidator) {
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1144,7 +1255,8 @@ TEST(ConfigManagerTest, AddValidator) {
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1153,97 +1265,116 @@ TEST(ConfigManagerTest, AddValidator) {
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
-    // Variables needed for configuration options.
-    Type firstVar;
+  auto doSingleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type>() {
+        // Variables needed for configuration options.
+        Type firstVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption =
+            mNoSub.addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue"),
+                           mNoSubOption));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    decltype(auto) mSubNoValidatorOption =
-        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubNoValidatorOption));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        decltype(auto) mSubNoValidatorOption =
+            mSubNoValidator.addSubManager({"some"s, "manager"s})
+                .addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubNoValidatorOption));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption =
-        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubWithValidatorOption));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption =
+            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubWithValidatorOption));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
-                                                                     typename Type2>() {
-    // Variables needed for configuration options.
-    Type1 firstVar;
-    Type2 secondVar;
+  auto doDoubleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
+        // Variables needed for configuration options.
+        Type1 firstVar;
+        Type2 secondVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 =
+            mNoSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mNoSubOption2 =
+            mNoSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
+                           mNoSubOption1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
+                           mNoSubOption2));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubNoValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubNoValidatorOption2));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub =
+            mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubNoValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubNoValidatorOption2));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption1 =
-        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubWithValidatorOption2 =
-        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubWithValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubWithValidatorOption2));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption1 =
+            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubWithValidatorOption2 =
+            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubWithValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubWithValidatorOption2));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1251,7 +1382,8 @@ TEST(ConfigManagerTest, AddValidator) {
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
   auto doDifferentParameterTests = [&addValidatorToConfigManager,
-                                    &generateValidatorName]<typename Type1, typename Type2>() {
+                                    &generateValidatorName]<typename Type1,
+                                                            typename Type2>() {
     // Variables for config options.
     Type1 var1;
     Type2 var2;
@@ -1271,7 +1403,8 @@ TEST(ConfigManagerTest, AddValidator) {
     */
     auto checkAllValidAndInvalidValueCombinations =
         [&generateValidatorName]<typename T1, typename T2>(
-            ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            ConfigManager& m,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
             const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
           /*
           Input for `parseConfig`. One contains values, that are valid for all
@@ -1293,7 +1426,8 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second + 1);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type1>(validator1.second));
+                         generateValidatorName.template operator()<Type1>(
+                             validator1.second));
 
           // Value for `validator1` is valid. Value for `validator2` is invalid.
           invalidValueJson[validator1.first] =
@@ -1301,32 +1435,40 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type2>(validator2.second));
+                         generateValidatorName.template operator()<Type2>(
+                             validator2.second));
         };
 
     // No sub manager.
     ConfigManager mNoSub;
     decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
+                                                           mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
+                                                           mNoSubOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
         std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
     // With sub manager. Sub manager has no validators of its own.
     ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 = mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 = mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
-                                                           mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
-                                                           mSubNoValidatorOption2);
+    ConfigManager& mSubNoValidatorSub =
+        mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mSubNoValidator, mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mSubNoValidator, mSubNoValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
     // Sub manager has validators of its own, however the manager does not.
     ConfigManager mNoValidatorSubValidator;
@@ -1336,14 +1478,16 @@ TEST(ConfigManagerTest, AddValidator) {
         mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoValidatorSubValidatorOption2 =
         mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
-                                                           mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
-                                                           mNoValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
     // Sub manager has validators of its own, as does the manager.
     ConfigManager mValidatorSubValidator;
@@ -1353,14 +1497,16 @@ TEST(ConfigManagerTest, AddValidator) {
         mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mValidatorSubValidatorOption2 =
         mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
-                                                           mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
-                                                           mValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
   };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
@@ -1382,15 +1528,19 @@ TEST(ConfigManagerTest, AddValidatorException) {
     /*
     @brief Check, if a call to the `addValidator` function behaves as wanted.
     */
-    auto checkAddValidatorBehavior = [&validatorDummyFunction](
-                                         ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                                         ConstConfigOptionProxy<T> notValidOption) {
-      ASSERT_NO_THROW(m.addValidator(validatorDummyFunction, "", validOption));
-      AD_EXPECT_THROW_WITH_MESSAGE(
-          m.addValidator(validatorDummyFunction, notValidOption.getConfigOption().getIdentifier(),
-                         notValidOption),
-          ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-    };
+    auto checkAddValidatorBehavior =
+        [&validatorDummyFunction](ConfigManager& m,
+                                  ConstConfigOptionProxy<T> validOption,
+                                  ConstConfigOptionProxy<T> notValidOption) {
+          ASSERT_NO_THROW(
+              m.addValidator(validatorDummyFunction, "", validOption));
+          AD_EXPECT_THROW_WITH_MESSAGE(
+              m.addValidator(validatorDummyFunction,
+                             notValidOption.getConfigOption().getIdentifier(),
+                             notValidOption),
+              ::testing::ContainsRegex(
+                  notValidOption.getConfigOption().getIdentifier()));
+        };
 
     // An outside configuration option.
     ConfigOption outsideOption("outside", "", &var);
@@ -1403,30 +1553,46 @@ TEST(ConfigManagerTest, AddValidatorException) {
 
     // With sub manager.
     ConfigManager mWithSub;
-    decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+    decltype(auto) mWithSubOption =
+        mWithSub.addOption("someTopOption", "", &var);
     ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+    decltype(auto) mWithSubSubOption =
+        mWithSubSub.addOption("someSubOption", "", &var);
     checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
     checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                              outsideOptionProxy);
     checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
     // With 2 sub manager.
     ConfigManager mWith2Sub;
-    decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
-    ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-    ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-    decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+    decltype(auto) mWith2SubOption =
+        mWith2Sub.addOption("someTopOption", "", &var);
+    ConfigManager& mWith2SubSub1 =
+        mWith2Sub.addSubManager({"Some"s, "manager"s});
+    decltype(auto) mWith2SubSub1Option =
+        mWith2SubSub1.addOption("someSubOption1", "", &var);
+    ConfigManager& mWith2SubSub2 =
+        mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+    decltype(auto) mWith2SubSub2Option =
+        mWith2SubSub2.addOption("someSubOption2", "", &var);
     checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                              mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                              mWith2SubSub2Option);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                              mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                              mWith2SubSub1Option);
   };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1435,11 +1601,13 @@ TEST(ConfigManagerTest, AddValidatorException) {
 TEST(ConfigManagerTest, AddOptionValidator) {
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
-    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
-      return ((options.getValueAsString() == wantedString) && ...);
-    };
-  };
+  auto generateValueAsStringComparison =
+      [](std::string_view valueStringRepresentation) {
+        return [wantedString = std::string(valueStringRepresentation)](
+                   const auto&... options) {
+          return ((options.getValueAsString() == wantedString) && ...);
+        };
+      };
 
   // Variables for configuration options.
   int firstVar;
@@ -1449,58 +1617,71 @@ TEST(ConfigManagerTest, AddOptionValidator) {
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "someOption1",
-                                             managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
+  managerWithNoSubManager.addOptionValidator(
+      generateValueAsStringComparison("10"), "someOption1",
+      managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
+                 "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "Both options",
-                                             managerWithNoSubManagerOption1,
-                                             managerWithNoSubManagerOption2);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-                 "Both options");
+  managerWithNoSubManager.addOptionValidator(
+      generateValueAsStringComparison("10"), "Both options",
+      managerWithNoSubManagerOption1, managerWithNoSubManagerOption2);
+  checkValidator(
+      managerWithNoSubManager,
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
+                                                        &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
+          "someOption", "", &secondVar, 4);
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(managerWithSubManagerWhoHasNoValidators,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+  checkValidator(
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Both options",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
       managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
+          "someOption", "", &firstVar, 4);
   managerHasNoValidatorsButSubManagerDoesSubManager.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(managerHasNoValidatorsButSubManagerDoes,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+  checkValidator(
+      managerHasNoValidatorsButSubManagerDoes,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1510,20 +1691,25 @@ TEST(ConfigManagerTest, AddOptionValidator) {
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"), "Top manager option",
+  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"),
+                                        "Top manager option",
                                         bothHaveValidatorsOption);
-  bothHaveValidatorsSubManager.addOptionValidator(generateValueAsStringComparison("20"),
-                                                  "Sub manager option",
-                                                  bothHaveValidatorsSubManagerOption);
+  bothHaveValidatorsSubManager.addOptionValidator(
+      generateValueAsStringComparison("20"), "Sub manager option",
+      bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
@@ -1539,13 +1725,18 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   wanted.
   */
   auto checkAddOptionValidatorBehavior =
-      [&validatorDummyFunction]<typename T>(ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                                            ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(m.addOptionValidator(validatorDummyFunction, "", validOption));
+      [&validatorDummyFunction]<typename T>(
+          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+          ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(
+            m.addOptionValidator(validatorDummyFunction, "", validOption));
         AD_EXPECT_THROW_WITH_MESSAGE(
-            m.addOptionValidator(validatorDummyFunction,
-                                 notValidOption.getConfigOption().getIdentifier(), notValidOption),
-            ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+            m.addOptionValidator(
+                validatorDummyFunction,
+                notValidOption.getConfigOption().getIdentifier(),
+                notValidOption),
+            ::testing::ContainsRegex(
+                notValidOption.getConfigOption().getIdentifier()));
       };
 
   // An outside configuration option.
@@ -1561,28 +1752,45 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption =
+      mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption =
+      mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option =
+      mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 =
+      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option =
+      mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, ContainsOption) {
@@ -1594,18 +1802,21 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus = [](const ConfigManager& m,
-                                   const ContainmentStatusVector& optionsAndWantedStatus) {
-    std::ranges::for_each(optionsAndWantedStatus,
-                          [&m](const ContainmentStatusVector::value_type& p) {
-                            if (p.second) {
-                              ASSERT_TRUE(m.containsOption(*p.first));
-                            } else {
-                              ASSERT_FALSE(m.containsOption(*p.first));
-                            }
-                          });
-  };
+  using ContainmentStatusVector =
+      std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus =
+      [](const ConfigManager& m,
+         const ContainmentStatusVector& optionsAndWantedStatus) {
+        std::ranges::for_each(
+            optionsAndWantedStatus,
+            [&m](const ContainmentStatusVector::value_type& p) {
+              if (p.second) {
+                ASSERT_TRUE(m.containsOption(*p.first));
+              } else {
+                ASSERT_FALSE(m.containsOption(*p.first));
+              }
+            });
+      };
 
   // Variable for the configuration options.
   int var;
@@ -1616,68 +1827,87 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
+      {&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 =
+      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option =
+      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -1698,7 +1928,8 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction =
+      decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -1708,65 +1939,87 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
+      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
+                                       std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
+                                       std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
-                                   int, int>);
+            !ad_utility::Validator<
+                decltype([](FirstParameter, SecondParameter) { return true; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility


### PR DESCRIPTION
Add the possibility to add a `ConfigManager` as a child to another `ConfigManager`. This makes it easier to manage configurations that have a nested structure. For example, the configuration for QLever's index builder takes settings for the Locale. These locale settings consist of multiple subsettings (the language, the country, etc.).