### PR TITLE
Fix a small bug in the config manager

### DIFF
--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -33,8 +33,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
-                 const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
+                 const bool wasSet, const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -51,14 +51,16 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(
+      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -67,14 +69,18 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
+                                &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
+          &notUsed, 42),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -93,7 +99,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
+                        "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -104,7 +111,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -121,20 +129,22 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
-Cases, that caused exceptions with `addOption` in the past, even though they shouldn't have.
+Cases, that caused exceptions with `addOption` in the past, even though they
+shouldn't have.
 */
 TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
   /*
   First of, a short explanation, of what a path collision is.
 
-  A path collisions is, when the path for a new config option, or sub manager, would cause problems
-  with the path of an already added config option, or manager.
-  More specifically, we call the following cases path collisions:
+  A path collisions is, when the path for a new config option, or sub manager,
+  would cause problems with the path of an already added config option, or
+  manager. More specifically, we call the following cases path collisions:
   - Same path. Makes it impossible for the user to later identify the correct
   one.
   - Prefix of the path of an already exiting option/manager. This would mean,
@@ -146,43 +156,52 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
   - The path of an already exiting option/manager is a prefix of the new path.
   The reasons, why it's not allowed, are basically the same.
 
-  In the past, it was possible to cause path collisions even though there weren't any, by having
-  paths, which json pointer representation fullfilled the conditions for one of the cases.
-  For example: It should be possible, to have one option under `[prefixes]` and one under
-  `[prefixes-eternal]`. But, because `/prefixes` is a prefix of `/prefixes-eternal` a false
-  exception was thrown.
+  In the past, it was possible to cause path collisions even though there
+  weren't any, by having paths, which json pointer representation fullfilled the
+  conditions for one of the cases. For example: It should be possible, to have
+  one option under `[prefixes]` and one under
+  `[prefixes-eternal]`. But, because `/prefixes` is a prefix of
+  `/prefixes-eternal` a false exception was thrown.
 
-  Which is why, we are testing the second and third case for path collisions with such cases here.
+  Which is why, we are testing the second and third case for path collisions
+  with such cases here.
   */
   ad_utility::ConfigManager config{};
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
-  Adding a config option, where the json pointer version of the path is a prefix of the json pointer
-  version of a config option path, that is is already in use.
+  Adding a config option, where the json pointer version of the path is a prefix
+  of the json pointer version of a config option path, that is is already in
+  use.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(
+      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
-  Adding a config option and there exists an already in use config option path, whose json
-  pointer version is a prefix of the json pointer version of the new path.
+  Adding a config option and there exists an already in use config option path,
+  whose json pointer version is a prefix of the json pointer version of the new
+  path.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-                                   &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption(
+      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+      &notUsed, 42));
 
   /*
-  Adding a config option, where the json pointer version of the path is a prefix of the json pointer
-  version of a sub manager path, that is is already in use.
+  Adding a config option, where the json pointer version of the path is a prefix
+  of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
-  Adding a config option and there exists an already in use sub manager path, whose json
-  pointer version is a prefix of the json pointer version of the new path.
+  Adding a config option and there exists an already in use sub manager path,
+  whose json pointer version is a prefix of the json pointer version of the new
+  path.
   */
   ASSERT_NO_THROW(config.addOption({"sub"s, "manager4"s}, "", &notUsed, 42));
 }
@@ -195,7 +214,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -213,16 +233,19 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -230,8 +253,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
+                            "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -250,27 +273,30 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s, "manager"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
-Cases, that caused exceptions with `addSubManager` in the past, even though they shouldn't have.
+Cases, that caused exceptions with `addSubManager` in the past, even though they
+shouldn't have.
 */
 TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   /*
   First of, a short explanation, of what a path collision is.
 
-  A path collisions is, when the path for a new config option, or sub manager, would cause problems
-  with the path of an already added config option, or manager.
-  More specifically, we call the following cases path collisions:
+  A path collisions is, when the path for a new config option, or sub manager,
+  would cause problems with the path of an already added config option, or
+  manager. More specifically, we call the following cases path collisions:
   - Same path. Makes it impossible for the user to later identify the correct
   one.
   - Prefix of the path of an already exiting option/manager. This would mean,
@@ -282,47 +308,57 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   - The path of an already exiting option/manager is a prefix of the new path.
   The reasons, why it's not allowed, are basically the same.
 
-  In the past, it was possible to cause path collisions even though there weren't any, by having
-  paths, which json pointer representation fullfilled the conditions for one of the cases.
-  For example: It should be possible, to have one sub manager under `[prefixes]` and one under
-  `[prefixes-eternal]`. But, because `/prefixes` is a prefix of `/prefixes-eternal` a false
-  exception was thrown.
+  In the past, it was possible to cause path collisions even though there
+  weren't any, by having paths, which json pointer representation fullfilled the
+  conditions for one of the cases. For example: It should be possible, to have
+  one sub manager under `[prefixes]` and one under
+  `[prefixes-eternal]`. But, because `/prefixes` is a prefix of
+  `/prefixes-eternal` a false exception was thrown.
 
-  Which is why, we are testing the second and third case for path collisions with such cases here.
+  Which is why, we are testing the second and third case for path collisions
+  with such cases here.
   */
   ad_utility::ConfigManager config{};
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
-  Adding a sub manager, where the json pointer version of the path is a prefix of the json pointer
-  version of a sub manager path, that is is already in use.
+  Adding a sub manager, where the json pointer version of the path is a prefix
+  of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(
-      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
-
-  /*
-  Adding a sub manager and there exists an already in use sub manager path, whose json
-  pointer version is a prefix of the json pointer version of the new path.
-  */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
-  Adding a sub manager, where the json pointer version of the path is a prefix of the json pointer
-  version of a config option path, that is is already in use.
+  Adding a sub manager and there exists an already in use sub manager path,
+  whose json pointer version is a prefix of the json pointer version of the new
+  path.
   */
-  config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config
+                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
+                                      "Sense_of_existence_42"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
-  Adding a sub manager and there exists an already in use config option path, whose json
-  pointer version is a prefix of the json pointer version of the new path.
+  Adding a sub manager, where the json pointer version of the path is a prefix
+  of the json pointer version of a config option path, that is is already in
+  use.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
+  config.addOption({"some"s, "option"s}, "", &notUsed);
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
+                      .addOption("ignore", "", &notUsed));
+
+  /*
+  Adding a sub manager and there exists an already in use config option path,
+  whose json pointer version is a prefix of the json pointer version of the new
+  path.
+  */
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
+                      .addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -334,10 +370,13 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                                              "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s},
+                       "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne =
+      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                       "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo =
+      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -370,14 +409,16 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
-                          const std::vector<std::pair<int*, int>>& wantedValues) {
-    m.parseConfig(j);
+  auto parseAndCheck =
+      [](const nlohmann::json& j, ConfigManager& m,
+         const std::vector<std::pair<int*, int>>& wantedValues) {
+        m.parseConfig(j);
 
-    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-      ASSERT_EQ(*wantedValue.first, wantedValue.second);
-    });
-  };
+        std::ranges::for_each(
+            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+              ASSERT_EQ(*wantedValue.first, wantedValue.second);
+            });
+      };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -395,13 +436,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion,
+                {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
+                                         &amountOfPersonal, 0);
 
-  parseAndCheck(nlohmann::json::parse(R"--({
+  parseAndCheck(
+      nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -409,8 +453,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+      managerWithOneSubNoRecursion,
+      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -438,10 +482,14 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+                {{&daveId, 4},
+                 {&daveInfractions, 0},
+                 {&janiceId, 0},
+                 {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
+                                              &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -463,16 +511,20 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 =
+      managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 =
+      managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex =
+      managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter =
+      managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -493,7 +545,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+                {{&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -589,10 +644,11 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                   &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                   &notUsedVector, {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s},
+                   "Must be set. Has no default value.", &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s},
+                   "Must not be set. Has default value.", &notUsedVector,
+                   {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -619,20 +675,27 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_integer)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -640,32 +703,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
+                   41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
-               {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s},
+               "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s},
+               "Must not be set. Has default value.", &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -676,29 +745,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 =
+      config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 =
+      config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.",
+                    &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.",
+                      &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                      &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                      &notUsedVector, {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s},
+                      "Must be set. Has no default value.", &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s},
+                      "Must not be set. Has default value.", &notUsedVector,
+                      {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -709,13 +787,15 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -727,7 +807,8 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -736,59 +817,65 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.",
+      &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.",
+      &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist = config.addOption(
-      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist =
+      config.addOption("someIntegerlist", "Must be set. Has no default value.",
+                       &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint =
-      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
-                       &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint = config.addOption(
+      "somePositiveFloatingPoint", "Must be set. Has no default value.",
+      &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint =
-      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
-                       &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint = config.addOption(
+      "someNegativFloatingPoint", "Must be set. Has no default value.",
+      &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList =
-      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
-                       &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList = config.addOption(
+      "someFloatingPointList", "Must be set. Has no default value.",
+      &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue =
-      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue = config.addOption(
+      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse =
-      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse = config.addOption(
+      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList = config.addOption(
-      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
+  decltype(auto) someBooleanList =
+      config.addOption("someBooleanList", "Must be set. Has no default value.",
+                       &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName =
-      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName = config.addOption(
+      "myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList = config.addOption(
-      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
+  decltype(auto) someStringList =
+      config.addOption("someStringList", "Must be set. Has no default value.",
+                       &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption = config.addOption(
-      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption =
+      config.addOption({"depth"s, "here"s, "list"s},
+                       "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -802,17 +889,22 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true,
+              std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
+              4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
+              -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
+              {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true,
+              std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -825,13 +917,15 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
-      , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
+                                   R"(complicatedKey:42, complicatedKey:43)");
+                               , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
+      R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(
+      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -848,7 +942,8 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan =
+      config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -858,10 +953,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -873,12 +970,14 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager,
+                    const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
-                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.parseConfig(jsonWithNonValidValues),
+      ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator`.
@@ -888,11 +987,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
-                 numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
-                 numberInRangeOption);
+  decltype(auto) numberInRangeOption =
+      m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; },
+                 "'numberInRange' must be <=100.", numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; },
+                 "'numberInRange' must be >=50.", numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -906,12 +1006,15 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption =
+      m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) ||
+               (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
+      boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -926,12 +1029,16 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-                                     "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption =
+      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator(
+      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+      "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
+      nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption =
+      mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -942,19 +1049,25 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter =
+      mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
+      [](const ConfigOption& opt) {
+        return opt.getIdentifier().starts_with('d');
+      },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') &&
+               opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter, wrongLetter);
-  ASSERT_ANY_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter,
+      wrongLetter);
+  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
+      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -974,7 +1087,8 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> ||
+                       std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1009,8 +1123,10 @@ what the exact difference is, see the code.
 */
 template <typename ParameterType>
 auto generateSingleParameterValidatorFunction(size_t variant) {
-  if constexpr (std::is_same_v<ParameterType, bool> || std::is_same_v<ParameterType, std::string> ||
-                std::is_same_v<ParameterType, int> || std::is_same_v<ParameterType, size_t> ||
+  if constexpr (std::is_same_v<ParameterType, bool> ||
+                std::is_same_v<ParameterType, std::string> ||
+                std::is_same_v<ParameterType, int> ||
+                std::is_same_v<ParameterType, size_t> ||
                 std::is_same_v<ParameterType, float>) {
     return [compareTo = createDummyValueForValidator<ParameterType>(variant)](
                const ParameterType& n) { return n != compareTo; };
@@ -1026,8 +1142,8 @@ auto generateSingleParameterValidatorFunction(size_t variant) {
       }
 
       for (size_t i = 0; i < variant + 1; i++) {
-        if (generateSingleParameterValidatorFunction<typename ParameterType::value_type>(i)(
-                v.at(i))) {
+        if (generateSingleParameterValidatorFunction<
+                typename ParameterType::value_type>(i)(v.at(i))) {
           return true;
         }
       }
@@ -1059,10 +1175,12 @@ TEST(ConfigManagerTest, AddValidator) {
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes,
+               &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func),
+                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1078,7 +1196,8 @@ TEST(ConfigManagerTest, AddValidator) {
   @tparam T Same `T` as for `createDummyValueForValidator` and
   `generateSingleParameterValidatorFunction`.
   */
-  auto adjustVariantArgument = []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
+  auto adjustVariantArgument =
+      []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
     if constexpr (std::is_same_v<T, bool>) {
       /*
       Even numbers for `variant` always result in true, regardless if
@@ -1104,7 +1223,9 @@ TEST(ConfigManagerTest, AddValidator) {
   auto generateValidatorName = []<typename... Ts>(size_t id) {
     return absl::StrCat(
         "Config manager validator<",
-        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), "> ", id);
+        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
+                    ", "),
+        "> ", id);
   };
 
   /*
@@ -1122,16 +1243,19 @@ TEST(ConfigManagerTest, AddValidator) {
   */
   auto addValidatorToConfigManager =
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
-          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m,
+          ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
     m.addValidator(
         [variant, &adjustVariantArgument](const Ts&... args) {
           return (generateSingleParameterValidatorFunction<Ts>(
-                      adjustVariantArgument.template operator()<Ts>(variant))(args) ||
+                      adjustVariantArgument.template operator()<Ts>(variant))(
+                      args) ||
                   ...);
         },
-        generateValidatorName.template operator()<Ts...>(variant), validatorArguments...);
+        generateValidatorName.template operator()<Ts...>(variant),
+        validatorArguments...);
   };
 
   /*
@@ -1156,11 +1280,13 @@ TEST(ConfigManagerTest, AddValidator) {
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
           size_t variantStart, size_t variantEnd, ConfigManager & m,
           const nlohmann::json& defaultValues,
-          const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
+          const std::same_as<
+              nlohmann::json::json_pointer> auto&... configOptionPaths)
           requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
+         validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1182,8 +1308,9 @@ TEST(ConfigManagerTest, AddValidator) {
         checkValidator(m, validJson, invalidJson,
                        generateValidatorName.template operator()<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName.template operator()<Ts...>(validatorNumber));
+        checkValidator(
+            m, validJson, invalidJson,
+            generateValidatorName.template operator()<Ts...>(validatorNumber));
       }
     }
   };
@@ -1207,7 +1334,8 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1217,7 +1345,8 @@ TEST(ConfigManagerTest, AddValidator) {
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1248,8 +1377,10 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM,
+          const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1260,7 +1391,8 @@ TEST(ConfigManagerTest, AddValidator) {
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1270,7 +1402,8 @@ TEST(ConfigManagerTest, AddValidator) {
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1279,97 +1412,116 @@ TEST(ConfigManagerTest, AddValidator) {
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
-    // Variables needed for configuration options.
-    Type firstVar;
+  auto doSingleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type>() {
+        // Variables needed for configuration options.
+        Type firstVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption =
+            mNoSub.addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue"),
+                           mNoSubOption));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    decltype(auto) mSubNoValidatorOption =
-        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubNoValidatorOption));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        decltype(auto) mSubNoValidatorOption =
+            mSubNoValidator.addSubManager({"some"s, "manager"s})
+                .addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubNoValidatorOption));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption =
-        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubWithValidatorOption));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption =
+            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubWithValidatorOption));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
-                                                                     typename Type2>() {
-    // Variables needed for configuration options.
-    Type1 firstVar;
-    Type2 secondVar;
+  auto doDoubleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
+        // Variables needed for configuration options.
+        Type1 firstVar;
+        Type2 secondVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 =
+            mNoSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mNoSubOption2 =
+            mNoSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
+                           mNoSubOption1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
+                           mNoSubOption2));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubNoValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubNoValidatorOption2));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub =
+            mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubNoValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubNoValidatorOption2));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption1 =
-        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubWithValidatorOption2 =
-        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubWithValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubWithValidatorOption2));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption1 =
+            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubWithValidatorOption2 =
+            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubWithValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubWithValidatorOption2));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1377,7 +1529,8 @@ TEST(ConfigManagerTest, AddValidator) {
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
   auto doDifferentParameterTests = [&addValidatorToConfigManager,
-                                    &generateValidatorName]<typename Type1, typename Type2>() {
+                                    &generateValidatorName]<typename Type1,
+                                                            typename Type2>() {
     // Variables for config options.
     Type1 var1;
     Type2 var2;
@@ -1397,7 +1550,8 @@ TEST(ConfigManagerTest, AddValidator) {
     */
     auto checkAllValidAndInvalidValueCombinations =
         [&generateValidatorName]<typename T1, typename T2>(
-            ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            ConfigManager& m,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
             const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
           /*
           Input for `parseConfig`. One contains values, that are valid for all
@@ -1419,7 +1573,8 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second + 1);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type1>(validator1.second));
+                         generateValidatorName.template operator()<Type1>(
+                             validator1.second));
 
           // Value for `validator1` is valid. Value for `validator2` is invalid.
           invalidValueJson[validator1.first] =
@@ -1427,32 +1582,40 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type2>(validator2.second));
+                         generateValidatorName.template operator()<Type2>(
+                             validator2.second));
         };
 
     // No sub manager.
     ConfigManager mNoSub;
     decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
+                                                           mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
+                                                           mNoSubOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
         std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
     // With sub manager. Sub manager has no validators of its own.
     ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 = mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 = mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
-                                                           mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
-                                                           mSubNoValidatorOption2);
+    ConfigManager& mSubNoValidatorSub =
+        mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mSubNoValidator, mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mSubNoValidator, mSubNoValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
     // Sub manager has validators of its own, however the manager does not.
     ConfigManager mNoValidatorSubValidator;
@@ -1462,14 +1625,16 @@ TEST(ConfigManagerTest, AddValidator) {
         mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoValidatorSubValidatorOption2 =
         mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
-                                                           mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
-                                                           mNoValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
     // Sub manager has validators of its own, as does the manager.
     ConfigManager mValidatorSubValidator;
@@ -1479,14 +1644,16 @@ TEST(ConfigManagerTest, AddValidator) {
         mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mValidatorSubValidatorOption2 =
         mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
-                                                           mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
-                                                           mValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
   };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
@@ -1508,15 +1675,19 @@ TEST(ConfigManagerTest, AddValidatorException) {
     /*
     @brief Check, if a call to the `addValidator` function behaves as wanted.
     */
-    auto checkAddValidatorBehavior = [&validatorDummyFunction](
-                                         ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                                         ConstConfigOptionProxy<T> notValidOption) {
-      ASSERT_NO_THROW(m.addValidator(validatorDummyFunction, "", validOption));
-      AD_EXPECT_THROW_WITH_MESSAGE(
-          m.addValidator(validatorDummyFunction, notValidOption.getConfigOption().getIdentifier(),
-                         notValidOption),
-          ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-    };
+    auto checkAddValidatorBehavior =
+        [&validatorDummyFunction](ConfigManager& m,
+                                  ConstConfigOptionProxy<T> validOption,
+                                  ConstConfigOptionProxy<T> notValidOption) {
+          ASSERT_NO_THROW(
+              m.addValidator(validatorDummyFunction, "", validOption));
+          AD_EXPECT_THROW_WITH_MESSAGE(
+              m.addValidator(validatorDummyFunction,
+                             notValidOption.getConfigOption().getIdentifier(),
+                             notValidOption),
+              ::testing::ContainsRegex(
+                  notValidOption.getConfigOption().getIdentifier()));
+        };
 
     // An outside configuration option.
     ConfigOption outsideOption("outside", "", &var);
@@ -1529,30 +1700,46 @@ TEST(ConfigManagerTest, AddValidatorException) {
 
     // With sub manager.
     ConfigManager mWithSub;
-    decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+    decltype(auto) mWithSubOption =
+        mWithSub.addOption("someTopOption", "", &var);
     ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+    decltype(auto) mWithSubSubOption =
+        mWithSubSub.addOption("someSubOption", "", &var);
     checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
     checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                              outsideOptionProxy);
     checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
     // With 2 sub manager.
     ConfigManager mWith2Sub;
-    decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
-    ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-    ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-    decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+    decltype(auto) mWith2SubOption =
+        mWith2Sub.addOption("someTopOption", "", &var);
+    ConfigManager& mWith2SubSub1 =
+        mWith2Sub.addSubManager({"Some"s, "manager"s});
+    decltype(auto) mWith2SubSub1Option =
+        mWith2SubSub1.addOption("someSubOption1", "", &var);
+    ConfigManager& mWith2SubSub2 =
+        mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+    decltype(auto) mWith2SubSub2Option =
+        mWith2SubSub2.addOption("someSubOption2", "", &var);
     checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                              mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                              mWith2SubSub2Option);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                              mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                              mWith2SubSub1Option);
   };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1561,11 +1748,13 @@ TEST(ConfigManagerTest, AddValidatorException) {
 TEST(ConfigManagerTest, AddOptionValidator) {
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
-    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
-      return ((options.getValueAsString() == wantedString) && ...);
-    };
-  };
+  auto generateValueAsStringComparison =
+      [](std::string_view valueStringRepresentation) {
+        return [wantedString = std::string(valueStringRepresentation)](
+                   const auto&... options) {
+          return ((options.getValueAsString() == wantedString) && ...);
+        };
+      };
 
   // Variables for configuration options.
   int firstVar;
@@ -1575,58 +1764,71 @@ TEST(ConfigManagerTest, AddOptionValidator) {
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "someOption1",
-                                             managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
+  managerWithNoSubManager.addOptionValidator(
+      generateValueAsStringComparison("10"), "someOption1",
+      managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
+                 "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "Both options",
-                                             managerWithNoSubManagerOption1,
-                                             managerWithNoSubManagerOption2);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-                 "Both options");
+  managerWithNoSubManager.addOptionValidator(
+      generateValueAsStringComparison("10"), "Both options",
+      managerWithNoSubManagerOption1, managerWithNoSubManagerOption2);
+  checkValidator(
+      managerWithNoSubManager,
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
+                                                        &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
+          "someOption", "", &secondVar, 4);
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(managerWithSubManagerWhoHasNoValidators,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+  checkValidator(
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Both options",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
       managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
+          "someOption", "", &firstVar, 4);
   managerHasNoValidatorsButSubManagerDoesSubManager.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(managerHasNoValidatorsButSubManagerDoes,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+  checkValidator(
+      managerHasNoValidatorsButSubManagerDoes,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1636,20 +1838,25 @@ TEST(ConfigManagerTest, AddOptionValidator) {
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"), "Top manager option",
+  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"),
+                                        "Top manager option",
                                         bothHaveValidatorsOption);
-  bothHaveValidatorsSubManager.addOptionValidator(generateValueAsStringComparison("20"),
-                                                  "Sub manager option",
-                                                  bothHaveValidatorsSubManagerOption);
+  bothHaveValidatorsSubManager.addOptionValidator(
+      generateValueAsStringComparison("20"), "Sub manager option",
+      bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
@@ -1665,13 +1872,18 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   wanted.
   */
   auto checkAddOptionValidatorBehavior =
-      [&validatorDummyFunction]<typename T>(ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                                            ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(m.addOptionValidator(validatorDummyFunction, "", validOption));
+      [&validatorDummyFunction]<typename T>(
+          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+          ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(
+            m.addOptionValidator(validatorDummyFunction, "", validOption));
         AD_EXPECT_THROW_WITH_MESSAGE(
-            m.addOptionValidator(validatorDummyFunction,
-                                 notValidOption.getConfigOption().getIdentifier(), notValidOption),
-            ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+            m.addOptionValidator(
+                validatorDummyFunction,
+                notValidOption.getConfigOption().getIdentifier(),
+                notValidOption),
+            ::testing::ContainsRegex(
+                notValidOption.getConfigOption().getIdentifier()));
       };
 
   // An outside configuration option.
@@ -1687,28 +1899,45 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption =
+      mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption =
+      mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option =
+      mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 =
+      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option =
+      mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, ContainsOption) {
@@ -1720,18 +1949,21 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus = [](const ConfigManager& m,
-                                   const ContainmentStatusVector& optionsAndWantedStatus) {
-    std::ranges::for_each(optionsAndWantedStatus,
-                          [&m](const ContainmentStatusVector::value_type& p) {
-                            if (p.second) {
-                              ASSERT_TRUE(m.containsOption(*p.first));
-                            } else {
-                              ASSERT_FALSE(m.containsOption(*p.first));
-                            }
-                          });
-  };
+  using ContainmentStatusVector =
+      std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus =
+      [](const ConfigManager& m,
+         const ContainmentStatusVector& optionsAndWantedStatus) {
+        std::ranges::for_each(
+            optionsAndWantedStatus,
+            [&m](const ContainmentStatusVector::value_type& p) {
+              if (p.second) {
+                ASSERT_TRUE(m.containsOption(*p.first));
+              } else {
+                ASSERT_FALSE(m.containsOption(*p.first));
+              }
+            });
+      };
 
   // Variable for the configuration options.
   int var;
@@ -1742,68 +1974,87 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
+      {&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 =
+      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option =
+      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -1824,7 +2075,8 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction =
+      decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -1834,65 +2086,87 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
+      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
+                                       std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
+                                       std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
-                                   int, int>);
+            !ad_utility::Validator<
+                decltype([](FirstParameter, SecondParameter) { return true; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -33,8 +33,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
-                 const bool wasSet, const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
+                 const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -51,16 +51,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(
-      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -69,18 +67,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
-                                &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
-          &notUsed, 42),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -99,8 +93,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
-                        "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -111,8 +104,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -129,9 +121,70 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+}
+
+/*
+Cases, that caused exceptions with `addOption` in the past, even though they shouldn't have.
+*/
+TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
+  /*
+  First of, a short explanation, of what a path collision is.
+
+  A path collisions is, when the path for a new config option, or sub manager, would cause problems
+  with the path of an already added config option, or manager.
+  More specifically, we call the following cases path collisions:
+  - Same path. Makes it impossible for the user to later identify the correct
+  one.
+  - Prefix of the path of an already exiting option/manager. This would mean,
+  that the old config option, or sub manager, are part of the new config option,
+  or sub manager from the view of json. This is not allowed for a new config
+  option, because there is currently no support to put config options, or sub
+  managers, inside config options. For a new sub manager it's not allowed,
+  because nesting should be done on the `C++` level, not on the json path level.
+  - The path of an already exiting option/manager is a prefix of the new path.
+  The reasons, why it's not allowed, are basically the same.
+
+  In the past, it was possible to cause path collisions even though there weren't any, by having
+  paths, which json pointer representation fullfilled the conditions for one of the cases.
+  For example: It should be possible, to have one option under `[prefixes]` and one under
+  `[prefixes-eternal]`. But, because `/prefixes` is a prefix of `/prefixes-eternal` a false
+  exception was thrown.
+
+  Which is why, we are testing the second and third case for path collisions with such cases here.
+  */
+  ad_utility::ConfigManager config{};
+
+  // Configuration options for testing.
+  int notUsed;
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+
+  /*
+  Adding a config option, where the json pointer version of the path is a prefix of the json pointer
+  version of a config option path, that is is already in use.
+  */
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+
+  /*
+  Adding a config option and there exists an already in use config option path, whose json
+  pointer version is a prefix of the json pointer version of the new path.
+  */
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+                                   &notUsed, 42));
+
+  /*
+  Adding a config option, where the json pointer version of the path is a prefix of the json pointer
+  version of a sub manager path, that is is already in use.
+  */
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
+
+  /*
+  Adding a config option and there exists an already in use sub manager path, whose json
+  pointer version is a prefix of the json pointer version of the new path.
+  */
+  ASSERT_NO_THROW(config.addOption({"sub"s, "manager4"s}, "", &notUsed, 42));
 }
 
 /*
@@ -142,8 +195,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -161,19 +213,16 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -181,8 +230,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
-                            "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -201,17 +250,79 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s, "manager"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+}
+
+/*
+Cases, that caused exceptions with `addSubManager` in the past, even though they shouldn't have.
+*/
+TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
+  /*
+  First of, a short explanation, of what a path collision is.
+
+  A path collisions is, when the path for a new config option, or sub manager, would cause problems
+  with the path of an already added config option, or manager.
+  More specifically, we call the following cases path collisions:
+  - Same path. Makes it impossible for the user to later identify the correct
+  one.
+  - Prefix of the path of an already exiting option/manager. This would mean,
+  that the old config option, or sub manager, are part of the new config option,
+  or sub manager from the view of json. This is not allowed for a new config
+  option, because there is currently no support to put config options, or sub
+  managers, inside config options. For a new sub manager it's not allowed,
+  because nesting should be done on the `C++` level, not on the json path level.
+  - The path of an already exiting option/manager is a prefix of the new path.
+  The reasons, why it's not allowed, are basically the same.
+
+  In the past, it was possible to cause path collisions even though there weren't any, by having
+  paths, which json pointer representation fullfilled the conditions for one of the cases.
+  For example: It should be possible, to have one sub manager under `[prefixes]` and one under
+  `[prefixes-eternal]`. But, because `/prefixes` is a prefix of `/prefixes-eternal` a false
+  exception was thrown.
+
+  Which is why, we are testing the second and third case for path collisions with such cases here.
+  */
+  ad_utility::ConfigManager config{};
+
+  // Sub manager for testing. Empty sub manager are not allowed.
+  int notUsed;
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+      .addOption("ignore", "", &notUsed);
+
+  /*
+  Adding a sub manager, where the json pointer version of the path is a prefix of the json pointer
+  version of a sub manager path, that is is already in use.
+  */
+  ASSERT_NO_THROW(
+      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
+
+  /*
+  Adding a sub manager and there exists an already in use sub manager path, whose json
+  pointer version is a prefix of the json pointer version of the new path.
+  */
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
+                      .addOption("ignore", "", &notUsed));
+
+  /*
+  Adding a sub manager, where the json pointer version of the path is a prefix of the json pointer
+  version of a config option path, that is is already in use.
+  */
+  config.addOption({"some"s, "option"s}, "", &notUsed);
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
+
+  /*
+  Adding a sub manager and there exists an already in use config option path, whose json
+  pointer version is a prefix of the json pointer version of the new path.
+  */
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -223,13 +334,10 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s},
-                       "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne =
-      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                       "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo =
-      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                                              "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -262,16 +370,14 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck =
-      [](const nlohmann::json& j, ConfigManager& m,
-         const std::vector<std::pair<int*, int>>& wantedValues) {
-        m.parseConfig(j);
+  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
+                          const std::vector<std::pair<int*, int>>& wantedValues) {
+    m.parseConfig(j);
 
-        std::ranges::for_each(
-            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-              ASSERT_EQ(*wantedValue.first, wantedValue.second);
-            });
-      };
+    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+      ASSERT_EQ(*wantedValue.first, wantedValue.second);
+    });
+  };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -289,16 +395,13 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
-                                         &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
-  parseAndCheck(
-      nlohmann::json::parse(R"--({
+  parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -306,8 +409,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-      managerWithOneSubNoRecursion,
-      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+                managerWithOneSubNoRecursion,
+                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -335,14 +438,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4},
-                 {&daveInfractions, 0},
-                 {&janiceId, 0},
-                 {&janiceInfractions, 6}});
+                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
-                                              &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -364,20 +463,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 =
-      managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 =
-      managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex =
-      managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter =
-      managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -398,10 +493,7 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4},
-                 {&alexInfractions, 0},
-                 {&peterId, 0},
-                 {&peterInfractions, 6}});
+                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -497,11 +589,10 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s},
-                   "Must be set. Has no default value.", &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s},
-                   "Must not be set. Has default value.", &notUsedVector,
-                   {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                   &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                   &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -528,27 +619,20 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_integer)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -556,38 +640,32 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
-                   41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s},
-               "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s},
-               "Must not be set. Has default value.", &notUsedVector, {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
+               {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -598,38 +676,29 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 =
-      config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 =
-      config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.",
-                    &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.",
-                      &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s},
-                      "Must be set. Has no default value.", &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s},
-                      "Must not be set. Has default value.", &notUsedVector,
-                      {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                      &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                      &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -640,15 +709,13 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -660,8 +727,7 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -670,65 +736,59 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.",
-      &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.",
-      &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist =
-      config.addOption("someIntegerlist", "Must be set. Has no default value.",
-                       &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist = config.addOption(
+      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint = config.addOption(
-      "somePositiveFloatingPoint", "Must be set. Has no default value.",
-      &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint =
+      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
+                       &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint = config.addOption(
-      "someNegativFloatingPoint", "Must be set. Has no default value.",
-      &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint =
+      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
+                       &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList = config.addOption(
-      "someFloatingPointList", "Must be set. Has no default value.",
-      &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList =
+      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
+                       &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue = config.addOption(
-      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue =
+      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse = config.addOption(
-      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse =
+      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList =
-      config.addOption("someBooleanList", "Must be set. Has no default value.",
-                       &someBooleanListBoolVector);
+  decltype(auto) someBooleanList = config.addOption(
+      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName = config.addOption(
-      "myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName =
+      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList =
-      config.addOption("someStringList", "Must be set. Has no default value.",
-                       &someStringListStringVector);
+  decltype(auto) someStringList = config.addOption(
+      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption =
-      config.addOption({"depth"s, "here"s, "list"s},
-                       "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption = config.addOption(
+      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -742,22 +802,17 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true,
-              std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
-              4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
-              -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
-              {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true,
-              std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -770,15 +825,13 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
-                                   R"(complicatedKey:42, complicatedKey:43)");
-                               , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
+      , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
-      R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(
-      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -795,8 +848,7 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan =
-      config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -806,12 +858,10 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -823,14 +873,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager,
-                    const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      manager.parseConfig(jsonWithNonValidValues),
-      ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
+                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator`.
@@ -840,12 +888,11 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption =
-      m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; },
-                 "'numberInRange' must be <=100.", numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; },
-                 "'numberInRange' must be >=50.", numberInRangeOption);
+  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
+                 numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
+                 numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -859,15 +906,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption =
-      m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) ||
-               (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
-      boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -882,16 +926,12 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption =
-      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-      "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
-      nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+                                     "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption =
-      mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -902,25 +942,19 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter =
-      mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) {
-        return opt.getIdentifier().starts_with('d');
-      },
+      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') &&
-               opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter,
-      wrongLetter);
-  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
-      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter, wrongLetter);
+  ASSERT_ANY_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -940,8 +974,7 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> ||
-                       std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -976,10 +1009,8 @@ what the exact difference is, see the code.
 */
 template <typename ParameterType>
 auto generateSingleParameterValidatorFunction(size_t variant) {
-  if constexpr (std::is_same_v<ParameterType, bool> ||
-                std::is_same_v<ParameterType, std::string> ||
-                std::is_same_v<ParameterType, int> ||
-                std::is_same_v<ParameterType, size_t> ||
+  if constexpr (std::is_same_v<ParameterType, bool> || std::is_same_v<ParameterType, std::string> ||
+                std::is_same_v<ParameterType, int> || std::is_same_v<ParameterType, size_t> ||
                 std::is_same_v<ParameterType, float>) {
     return [compareTo = createDummyValueForValidator<ParameterType>(variant)](
                const ParameterType& n) { return n != compareTo; };
@@ -995,8 +1026,8 @@ auto generateSingleParameterValidatorFunction(size_t variant) {
       }
 
       for (size_t i = 0; i < variant + 1; i++) {
-        if (generateSingleParameterValidatorFunction<
-                typename ParameterType::value_type>(i)(v.at(i))) {
+        if (generateSingleParameterValidatorFunction<typename ParameterType::value_type>(i)(
+                v.at(i))) {
           return true;
         }
       }
@@ -1028,12 +1059,10 @@ TEST(ConfigManagerTest, AddValidator) {
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes,
-               &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func),
-                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1049,8 +1078,7 @@ TEST(ConfigManagerTest, AddValidator) {
   @tparam T Same `T` as for `createDummyValueForValidator` and
   `generateSingleParameterValidatorFunction`.
   */
-  auto adjustVariantArgument =
-      []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
+  auto adjustVariantArgument = []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
     if constexpr (std::is_same_v<T, bool>) {
       /*
       Even numbers for `variant` always result in true, regardless if
@@ -1076,9 +1104,7 @@ TEST(ConfigManagerTest, AddValidator) {
   auto generateValidatorName = []<typename... Ts>(size_t id) {
     return absl::StrCat(
         "Config manager validator<",
-        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
-                    ", "),
-        "> ", id);
+        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), "> ", id);
   };
 
   /*
@@ -1096,19 +1122,16 @@ TEST(ConfigManagerTest, AddValidator) {
   */
   auto addValidatorToConfigManager =
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
-          size_t variant, ConfigManager & m,
-          ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
     m.addValidator(
         [variant, &adjustVariantArgument](const Ts&... args) {
           return (generateSingleParameterValidatorFunction<Ts>(
-                      adjustVariantArgument.template operator()<Ts>(variant))(
-                      args) ||
+                      adjustVariantArgument.template operator()<Ts>(variant))(args) ||
                   ...);
         },
-        generateValidatorName.template operator()<Ts...>(variant),
-        validatorArguments...);
+        generateValidatorName.template operator()<Ts...>(variant), validatorArguments...);
   };
 
   /*
@@ -1133,13 +1156,11 @@ TEST(ConfigManagerTest, AddValidator) {
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
           size_t variantStart, size_t variantEnd, ConfigManager & m,
           const nlohmann::json& defaultValues,
-          const std::same_as<
-              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
           requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
-         validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1161,9 +1182,8 @@ TEST(ConfigManagerTest, AddValidator) {
         checkValidator(m, validJson, invalidJson,
                        generateValidatorName.template operator()<Ts...>(0));
       } else {
-        checkValidator(
-            m, validJson, invalidJson,
-            generateValidatorName.template operator()<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName.template operator()<Ts...>(validatorNumber));
       }
     }
   };
@@ -1187,8 +1207,7 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1198,8 +1217,7 @@ TEST(ConfigManagerTest, AddValidator) {
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1230,10 +1248,8 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM,
-          const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1244,8 +1260,7 @@ TEST(ConfigManagerTest, AddValidator) {
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1255,8 +1270,7 @@ TEST(ConfigManagerTest, AddValidator) {
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1265,116 +1279,97 @@ TEST(ConfigManagerTest, AddValidator) {
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type>() {
-        // Variables needed for configuration options.
-        Type firstVar;
+  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
+    // Variables needed for configuration options.
+    Type firstVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption =
-            mNoSub.addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue"),
-                           mNoSubOption));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        decltype(auto) mSubNoValidatorOption =
-            mSubNoValidator.addSubManager({"some"s, "manager"s})
-                .addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubNoValidatorOption));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    decltype(auto) mSubNoValidatorOption =
+        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubNoValidatorOption));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption =
-            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubWithValidatorOption));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption =
+        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubWithValidatorOption));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
-        // Variables needed for configuration options.
-        Type1 firstVar;
-        Type2 secondVar;
+  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
+                                                                     typename Type2>() {
+    // Variables needed for configuration options.
+    Type1 firstVar;
+    Type2 secondVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 =
-            mNoSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mNoSubOption2 =
-            mNoSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
-                           mNoSubOption1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
-                           mNoSubOption2));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub =
-            mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubNoValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubNoValidatorOption2));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubNoValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubNoValidatorOption2));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption1 =
-            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubWithValidatorOption2 =
-            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubWithValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubWithValidatorOption2));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption1 =
+        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubWithValidatorOption2 =
+        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubWithValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubWithValidatorOption2));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1382,8 +1377,7 @@ TEST(ConfigManagerTest, AddValidator) {
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
   auto doDifferentParameterTests = [&addValidatorToConfigManager,
-                                    &generateValidatorName]<typename Type1,
-                                                            typename Type2>() {
+                                    &generateValidatorName]<typename Type1, typename Type2>() {
     // Variables for config options.
     Type1 var1;
     Type2 var2;
@@ -1403,8 +1397,7 @@ TEST(ConfigManagerTest, AddValidator) {
     */
     auto checkAllValidAndInvalidValueCombinations =
         [&generateValidatorName]<typename T1, typename T2>(
-            ConfigManager& m,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
             const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
           /*
           Input for `parseConfig`. One contains values, that are valid for all
@@ -1426,8 +1419,7 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second + 1);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type1>(
-                             validator1.second));
+                         generateValidatorName.template operator()<Type1>(validator1.second));
 
           // Value for `validator1` is valid. Value for `validator2` is invalid.
           invalidValueJson[validator1.first] =
@@ -1435,40 +1427,32 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type2>(
-                             validator2.second));
+                         generateValidatorName.template operator()<Type2>(validator2.second));
         };
 
     // No sub manager.
     ConfigManager mNoSub;
     decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
-                                                           mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
-                                                           mNoSubOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
         std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
     // With sub manager. Sub manager has no validators of its own.
     ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub =
-        mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mSubNoValidator, mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mSubNoValidator, mSubNoValidatorOption2);
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 = mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 = mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
+                                                           mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
+                                                           mSubNoValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
     // Sub manager has validators of its own, however the manager does not.
     ConfigManager mNoValidatorSubValidator;
@@ -1478,16 +1462,14 @@ TEST(ConfigManagerTest, AddValidator) {
         mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoValidatorSubValidatorOption2 =
         mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
+                                                           mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
+                                                           mNoValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
     // Sub manager has validators of its own, as does the manager.
     ConfigManager mValidatorSubValidator;
@@ -1497,16 +1479,14 @@ TEST(ConfigManagerTest, AddValidator) {
         mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mValidatorSubValidatorOption2 =
         mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
+                                                           mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
+                                                           mValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
   };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
@@ -1528,19 +1508,15 @@ TEST(ConfigManagerTest, AddValidatorException) {
     /*
     @brief Check, if a call to the `addValidator` function behaves as wanted.
     */
-    auto checkAddValidatorBehavior =
-        [&validatorDummyFunction](ConfigManager& m,
-                                  ConstConfigOptionProxy<T> validOption,
-                                  ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(
-              m.addValidator(validatorDummyFunction, "", validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              m.addValidator(validatorDummyFunction,
-                             notValidOption.getConfigOption().getIdentifier(),
-                             notValidOption),
-              ::testing::ContainsRegex(
-                  notValidOption.getConfigOption().getIdentifier()));
-        };
+    auto checkAddValidatorBehavior = [&validatorDummyFunction](
+                                         ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                                         ConstConfigOptionProxy<T> notValidOption) {
+      ASSERT_NO_THROW(m.addValidator(validatorDummyFunction, "", validOption));
+      AD_EXPECT_THROW_WITH_MESSAGE(
+          m.addValidator(validatorDummyFunction, notValidOption.getConfigOption().getIdentifier(),
+                         notValidOption),
+          ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+    };
 
     // An outside configuration option.
     ConfigOption outsideOption("outside", "", &var);
@@ -1553,46 +1529,30 @@ TEST(ConfigManagerTest, AddValidatorException) {
 
     // With sub manager.
     ConfigManager mWithSub;
-    decltype(auto) mWithSubOption =
-        mWithSub.addOption("someTopOption", "", &var);
+    decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
     ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWithSubSubOption =
-        mWithSubSub.addOption("someSubOption", "", &var);
+    decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
     checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
     checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
     checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
     // With 2 sub manager.
     ConfigManager mWith2Sub;
-    decltype(auto) mWith2SubOption =
-        mWith2Sub.addOption("someTopOption", "", &var);
-    ConfigManager& mWith2SubSub1 =
-        mWith2Sub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWith2SubSub1Option =
-        mWith2SubSub1.addOption("someSubOption1", "", &var);
-    ConfigManager& mWith2SubSub2 =
-        mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-    decltype(auto) mWith2SubSub2Option =
-        mWith2SubSub2.addOption("someSubOption2", "", &var);
+    decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+    ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+    decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+    ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+    decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
     checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                              mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                              mWith2SubSub2Option);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                              mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                              mWith2SubSub1Option);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
   };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1601,13 +1561,11 @@ TEST(ConfigManagerTest, AddValidatorException) {
 TEST(ConfigManagerTest, AddOptionValidator) {
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison =
-      [](std::string_view valueStringRepresentation) {
-        return [wantedString = std::string(valueStringRepresentation)](
-                   const auto&... options) {
-          return ((options.getValueAsString() == wantedString) && ...);
-        };
-      };
+  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
+    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
+      return ((options.getValueAsString() == wantedString) && ...);
+    };
+  };
 
   // Variables for configuration options.
   int firstVar;
@@ -1617,71 +1575,58 @@ TEST(ConfigManagerTest, AddOptionValidator) {
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  managerWithNoSubManager.addOptionValidator(
-      generateValueAsStringComparison("10"), "someOption1",
-      managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
-                 "someOption1");
+  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "someOption1",
+                                             managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  managerWithNoSubManager.addOptionValidator(
-      generateValueAsStringComparison("10"), "Both options",
-      managerWithNoSubManagerOption1, managerWithNoSubManagerOption2);
-  checkValidator(
-      managerWithNoSubManager,
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-      "Both options");
+  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "Both options",
+                                             managerWithNoSubManagerOption1,
+                                             managerWithNoSubManagerOption2);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+                 "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
-                                                        &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager(
-          {"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
-          "someOption", "", &secondVar, 4);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(
-      managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+  checkValidator(managerWithSubManagerWhoHasNoValidators,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Both options",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
       managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager(
-          {"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
-          "someOption", "", &firstVar, 4);
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
   managerHasNoValidatorsButSubManagerDoesSubManager.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(
-      managerHasNoValidatorsButSubManagerDoes,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+  checkValidator(managerHasNoValidatorsButSubManagerDoes,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1691,25 +1636,20 @@ TEST(ConfigManagerTest, AddOptionValidator) {
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"),
-                                        "Top manager option",
+  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"), "Top manager option",
                                         bothHaveValidatorsOption);
-  bothHaveValidatorsSubManager.addOptionValidator(
-      generateValueAsStringComparison("20"), "Sub manager option",
-      bothHaveValidatorsSubManagerOption);
+  bothHaveValidatorsSubManager.addOptionValidator(generateValueAsStringComparison("20"),
+                                                  "Sub manager option",
+                                                  bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
@@ -1725,18 +1665,13 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   wanted.
   */
   auto checkAddOptionValidatorBehavior =
-      [&validatorDummyFunction]<typename T>(
-          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-          ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(
-            m.addOptionValidator(validatorDummyFunction, "", validOption));
+      [&validatorDummyFunction]<typename T>(ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                                            ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(m.addOptionValidator(validatorDummyFunction, "", validOption));
         AD_EXPECT_THROW_WITH_MESSAGE(
-            m.addOptionValidator(
-                validatorDummyFunction,
-                notValidOption.getConfigOption().getIdentifier(),
-                notValidOption),
-            ::testing::ContainsRegex(
-                notValidOption.getConfigOption().getIdentifier()));
+            m.addOptionValidator(validatorDummyFunction,
+                                 notValidOption.getConfigOption().getIdentifier(), notValidOption),
+            ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
       };
 
   // An outside configuration option.
@@ -1752,45 +1687,28 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption =
-      mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption =
-      mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option =
-      mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 =
-      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option =
-      mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, ContainsOption) {
@@ -1802,21 +1720,18 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector =
-      std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus =
-      [](const ConfigManager& m,
-         const ContainmentStatusVector& optionsAndWantedStatus) {
-        std::ranges::for_each(
-            optionsAndWantedStatus,
-            [&m](const ContainmentStatusVector::value_type& p) {
-              if (p.second) {
-                ASSERT_TRUE(m.containsOption(*p.first));
-              } else {
-                ASSERT_FALSE(m.containsOption(*p.first));
-              }
-            });
-      };
+  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus = [](const ConfigManager& m,
+                                   const ContainmentStatusVector& optionsAndWantedStatus) {
+    std::ranges::for_each(optionsAndWantedStatus,
+                          [&m](const ContainmentStatusVector::value_type& p) {
+                            if (p.second) {
+                              ASSERT_TRUE(m.containsOption(*p.first));
+                            } else {
+                              ASSERT_FALSE(m.containsOption(*p.first));
+                            }
+                          });
+  };
 
   // Variable for the configuration options.
   int var;
@@ -1827,87 +1742,68 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
-      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 =
-      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option =
-      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -1928,8 +1824,7 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction =
-      decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -1939,87 +1834,65 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
-                                       std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
-                                       std::string>);
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(
-      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<
-                decltype([](FirstParameter, SecondParameter) { return true; }),
-                int, int>);
+            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
+                                   int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility


### PR DESCRIPTION
We had a small problem, where using paths, that weren't hindering each other, were recognized as hindering each other.

For example: `["prefix"]` was recognized as hindering `["prefixes-external"]`.