### PR TITLE
Fix for subtraction bug with `MemorySize`

### DIFF
--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -338,12 +338,16 @@ constexpr MemorySize& MemorySize::operator+=(const MemorySize& m) {
 
 // _____________________________________________________________________________
 constexpr MemorySize MemorySize::operator-(const MemorySize& m) const {
-  return MemorySize::bytes(memoryInBytes_ - m.memoryInBytes_);
+  // Subtracting a bigger `MemorySize` from a smaller one, could end in
+  // underflow.
+  return MemorySize::bytes(memoryInBytes_ >= m.memoryInBytes_
+                               ? memoryInBytes_ - m.memoryInBytes_
+                               : 0UL);
 }
 
 // _____________________________________________________________________________
 constexpr MemorySize& MemorySize::operator-=(const MemorySize& m) {
-  memoryInBytes_ -= m.memoryInBytes_;
+  *this = *this - m;
   return *this;
 }
 

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -301,6 +301,11 @@ TEST(MemorySize, ArithmeticOperators) {
   memSubtraction -= 11000_kB;
   ASSERT_EQ((22_MB).getBytes(), memSubtraction.getBytes());
 
+  // Subtraction, so that the resulting `MemorySize` is smaller than `0` should
+  // be impossible. Instead, we stop at `0`.
+  ASSERT_EQ((0_GB).getBytes(), (3_GB - 10_GB).getBytes());
+  ASSERT_EQ((0_GB).getBytes(), (3_GB -= 10_GB).getBytes());
+
   // Whole number multiplication.
   ASSERT_EQ((2_GB).getBytes(), (1_GB * 2).getBytes());
   ASSERT_EQ((20_TB).getBytes(), (2 * 1_TB * 10).getBytes());


### PR DESCRIPTION
I just now noticed, that subtracting a bigger `MemorySize` from a smaller one, results in underflow. I fixed that, so that it now results in a `MemorySize` with size `0`.