### PR TITLE
Safe handling of over- and underflow in the `MemorySize` class

### DIFF
--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -396,6 +396,23 @@ constexpr MemorySize MemorySize::operator/(const T c) const {
   AD_CONTRACT_CHECK(c > static_cast<T>(0));
 
   /*
+  Check for overflow. Underflow isn't possible, because neither `MemorySize`,
+  nor `c`, can be negative.
+
+  Furthermore, overflow is only possible, if `T` is a floating point. Because
+  the quoutient, of the division between two natural numbers, is always smaller
+  than the dividend. Which is not always true, if the divisor is a floating
+  point number.
+  For example: 1/(1/2) = 2
+  */
+  if (std::floating_point<T> && static_cast<double>(memoryInBytes_) >
+                                    static_cast<double>(size_t_max) * c) {
+    throw std::overflow_error(
+        "Overflow error: Division of the given 'MemorySize' with the given "
+        "constant is not possible. Would result in size_t overflow.");
+  }
+
+  /*
   The default division for `size_t` doesn't always round up, which is the
   wanted behavior for the calculation of memory sizes. Instead, we calculate
   the division with as much precision as possible and leave the rounding to

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -331,8 +331,9 @@ constexpr MemorySize MemorySize::operator+(const MemorySize& m) const {
   // Check for overflow.
   if (memoryInBytes_ > size_t_max - m.memoryInBytes_) {
     throw std::overflow_error(
-        "Overflow error: Addition of the two given 'MemorySize' not possible. "
-        "Would result in size_t overflow.");
+        "Overflow error: Addition of the two given 'MemorySize's is not "
+        "possible. "
+        "It would result in a size_t overflow.");
   }
   return MemorySize::bytes(memoryInBytes_ + m.memoryInBytes_);
 }
@@ -348,8 +349,8 @@ constexpr MemorySize MemorySize::operator-(const MemorySize& m) const {
   // Check for underflow.
   if (memoryInBytes_ < m.memoryInBytes_) {
     throw std::underflow_error(
-        "Underflow error: Subtraction of the two given 'MemorySize' not "
-        "possible. Would result in size_t underflow.");
+        "Underflow error: Subtraction of the two given 'MemorySize's is not "
+        "possible. It would result in a size_t underflow.");
   }
   return MemorySize::bytes(memoryInBytes_ - m.memoryInBytes_);
 }
@@ -371,7 +372,8 @@ constexpr MemorySize MemorySize::operator*(const T c) const {
       detail::sizeTDivision(size_t_max, memoryInBytes_)) {
     throw std::overflow_error(
         "Overflow error: Multiplicaton of the given 'MemorySize' with the "
-        "given constant not possible. Would result in size_t overflow.");
+        "given constant is not possible. It would result in a size_t "
+        "overflow.");
   }
   return detail::magicImplForDivAndMul(*this, c, std::multiplies{});
 }
@@ -409,7 +411,7 @@ constexpr MemorySize MemorySize::operator/(const T c) const {
                                     static_cast<double>(size_t_max) * c) {
     throw std::overflow_error(
         "Overflow error: Division of the given 'MemorySize' with the given "
-        "constant is not possible. Would result in size_t overflow.");
+        "constant is not possible. It would result in a size_t overflow.");
   }
 
   /*

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -366,6 +366,13 @@ constexpr MemorySize MemorySize::operator*(const T c) const {
   // A negative amount of memory wouldn't make much sense.
   AD_CONTRACT_CHECK(c >= static_cast<T>(0));
 
+  // Check for overflow.
+  if (static_cast<double>(c) >
+      detail::sizeTDivision(size_t_max, memoryInBytes_)) {
+    throw std::overflow_error(
+        "Overflow error: Multiplicaton of the given 'MemorySize' with the "
+        "given constant not possible. Would result in size_t overflow.");
+  }
   return detail::magicImplForDivAndMul(*this, c, std::multiplies{});
 }
 

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -345,12 +345,18 @@ constexpr MemorySize& MemorySize::operator+=(const MemorySize& m) {
 
 // _____________________________________________________________________________
 constexpr MemorySize MemorySize::operator-(const MemorySize& m) const {
+  // Check for underflow.
+  if (memoryInBytes_ < m.memoryInBytes_) {
+    throw std::underflow_error(
+        "Underflow error: Subtraction of the two given 'MemorySize' not "
+        "possible. Would result in size_t underflow.");
+  }
   return MemorySize::bytes(memoryInBytes_ - m.memoryInBytes_);
 }
 
 // _____________________________________________________________________________
 constexpr MemorySize& MemorySize::operator-=(const MemorySize& m) {
-  memoryInBytes_ -= m.memoryInBytes_;
+  *this = *this - m;
   return *this;
 }
 

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -399,7 +399,6 @@ TEST(MemorySize, ArithmeticOperatorsOverAndUnderFlow) {
       static_cast<float>(ad_utility::size_t_max) / 4.73);
   ASSERT_NO_THROW(memFloatingPointMultiplication *= 4.73);
 
-  // TODO
   // Floating point division. We are checking for overflow via divisor, that
   // results in a quotient bigger than the dividend. For example: 1/(1/2) = 2
   ASSERT_THROW(100_GB / (1. / static_cast<float>(ad_utility::size_t_max)),

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <ranges>
 #include <sstream>
+#include <stdexcept>
 #include <vector>
 
 #include "./util/GTestHelpers.h"
@@ -342,6 +343,77 @@ TEST(MemorySize, ArithmeticOperators) {
   ASSERT_EQ((40_MB).getBytes(), memFloatingPointDivision.getBytes());
   ASSERT_ANY_THROW(1_GB / -2.48);
   ASSERT_ANY_THROW(1_GB / 0.);
+}
+
+// For checking, if the operators throw errors, when we have over-, or
+// underflow.
+TEST(MemorySize, ArithmeticOperatorsOverAndUnderFlow) {
+  // Addition.
+  ASSERT_THROW(
+      100_GB + ad_utility::MemorySize::bytes(ad_utility::size_t_max - 400),
+      std::overflow_error);
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(400) +
+                  ad_utility::MemorySize::bytes(ad_utility::size_t_max - 400));
+  ad_utility::MemorySize memAddition{4_MB};
+  ASSERT_THROW(memAddition +=
+               ad_utility::MemorySize::bytes(ad_utility::size_t_max - 400),
+               std::overflow_error);
+  memAddition = ad_utility::MemorySize::bytes(10);
+  ASSERT_NO_THROW(memAddition +=
+                  ad_utility::MemorySize::bytes(ad_utility::size_t_max - 10));
+
+  // Subtraction.
+  ASSERT_THROW(
+      100_GB - ad_utility::MemorySize::bytes(ad_utility::size_t_max - 400),
+      std::underflow_error);
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(400) -
+                  ad_utility::MemorySize::bytes(400));
+  ad_utility::MemorySize memSubtraction{40_MB};
+  ASSERT_THROW(memSubtraction -=
+               ad_utility::MemorySize::bytes(ad_utility::size_t_max - 400),
+               std::underflow_error);
+  memSubtraction = ad_utility::MemorySize::bytes(10);
+  ASSERT_NO_THROW(memSubtraction -= ad_utility::MemorySize::bytes(10));
+
+  // Whole number multiplication.
+  ASSERT_THROW(100_GB * ad_utility::size_t_max, std::overflow_error);
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(ad_utility::size_t_max / 2UL) *
+                  2UL);
+  ad_utility::MemorySize memWholeMultiplication{40_MB};
+  ASSERT_THROW(memWholeMultiplication *= ad_utility::size_t_max,
+               std::overflow_error);
+  memWholeMultiplication =
+      ad_utility::MemorySize::bytes(ad_utility::size_t_max);
+  ASSERT_NO_THROW(memWholeMultiplication *= 1);
+
+  // Floating point multiplication.
+  ASSERT_THROW(ad_utility::MemorySize::bytes(ad_utility::size_t_max) * 1.5,
+               std::overflow_error);
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(
+                      static_cast<float>(ad_utility::size_t_max) / 2.3) *
+                  2.3);
+  ad_utility::MemorySize memFloatingPointMultiplication{
+      ad_utility::MemorySize::bytes(ad_utility::size_t_max)};
+  ASSERT_THROW(memFloatingPointMultiplication *= 1.487, std::overflow_error);
+  memFloatingPointMultiplication = ad_utility::MemorySize::bytes(
+      static_cast<float>(ad_utility::size_t_max) / 4.73);
+  ASSERT_NO_THROW(memFloatingPointMultiplication *= 4.73);
+
+  // TODO
+  // Floating point division. We are checking for overflow via divisor, that
+  // results in a quotient bigger than the dividend. For example: 1/(1/2) = 2
+  ASSERT_THROW(100_GB / (1. / static_cast<float>(ad_utility::size_t_max)),
+               std::overflow_error);
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(
+                      static_cast<float>(ad_utility::size_t_max) / 2.4) /
+                  (1. / 2.4));
+  ad_utility::MemorySize memFloatingPointDivision{12_MB};
+  ASSERT_THROW(memFloatingPointDivision /=
+               (1. / static_cast<float>(ad_utility::size_t_max)),
+               std::overflow_error);
+  memFloatingPointDivision =
+      ad_utility::MemorySize::bytes(ad_utility::size_t_max);
+  ASSERT_NO_THROW(memFloatingPointDivision /= 7.80);
 }
 
 // Checks, if all the constexpr functions can actually be evaluated at compile


### PR DESCRIPTION
As of this commit, if an arithmetic operation on a `MemorySize` would overflow or underflow, an exception is thrown. For example `3_GB - 4_GB` now throws `std::underflow_error` because negative memory sizes are not useful.