### PR TITLE
Implement REPLACE

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1697,15 +1697,15 @@ queries:
   - query: REPLACE
     type: no-text
     sparql: |
-      SELECT ?x (REPLACE(STR(?x), "e.", "-") as ?f) WHERE {
+      SELECT ?x (REPLACE(STR(?x), "e.", "-") as ?f) (REPLACE(STR(?x), "(?i)r", "") as ?g) WHERE {
           ?x <is-a> <Scientist> .
           ?x <Gender> <Female>  .
           ?x <Date_of_birth> ?date
           FILTER (?x > <Yzz>) .
       }
     checks:
-      - num_cols: 2
-      - selected: [ "?x", "?f" ]
-      - contains_row: [ "<Zelda_Rubinstein>", "Z-da_Rubinst-n" ]
-      - contains_row: [ "<Zhang_Peili>", "Zhang_P-li"]
-      - contains_row: [ "<Zlata_Bartl>", "Zlata_Bartl"]
+      - num_cols: 3
+      - selected: [ "?x", "?f", "?g" ]
+      - contains_row: [ "<Zelda_Rubinstein>", "Z-da_Rubinst-n", "Zelda_ubinstein" ]
+      - contains_row: [ "<Zhang_Peili>", "Zhang_P-li", "Zhang_Peili"]
+      - contains_row: [ "<Zlata_Bartl>", "Zlata_Bartl", "Zlata_Batl"]

--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1693,3 +1693,19 @@ queries:
       - contains_row: [ "<Zelda_Rubinstein>", "Name: Zelda_Rubinstein Year: 1933" ]
       - contains_row: [ "<Zhang_Peili>", "Name: Zhang_Peili Year: 1941"]
       - contains_row: [ "<Zlata_Bartl>", "Name: Zlata_Bartl Year: 1920"]
+
+  - query: REPLACE
+    type: no-text
+    sparql: |
+      SELECT ?x (REPLACE(STR(?x), "e.", "-") as ?f) WHERE {
+          ?x <is-a> <Scientist> .
+          ?x <Gender> <Female>  .
+          ?x <Date_of_birth> ?date
+          FILTER (?x > <Yzz>) .
+      }
+    checks:
+      - num_cols: 2
+      - selected: [ "?x", "?f" ]
+      - contains_row: [ "<Zelda_Rubinstein>", "Z-da_Rubinst-n" ]
+      - contains_row: [ "<Zhang_Peili>", "Zhang_P-li"]
+      - contains_row: [ "<Zlata_Bartl>", "Zlata_Bartl"]

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -68,6 +68,10 @@ SparqlExpression::Ptr makeContainsExpression(SparqlExpression::Ptr child1,
                                              SparqlExpression::Ptr child2);
 SparqlExpression::Ptr makeStrAfterExpression(SparqlExpression::Ptr child1,
                                              SparqlExpression::Ptr child2);
+
+SparqlExpression::Ptr makeReplaceExpression(SparqlExpression::Ptr input,
+                                            SparqlExpression::Ptr pattern,
+                                            SparqlExpression::Ptr replacement);
 SparqlExpression::Ptr makeStrBeforeExpression(SparqlExpression::Ptr child1,
                                               SparqlExpression::Ptr child2);
 

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -170,10 +170,13 @@ struct LiteralFromIdGetter {
   }
 };
 
+// Convert the input into a `unique_ptr<RE2>`. Return nullptr if the input is
+// not convertible to a string.
 struct RegexValueGetter {
-  std::unique_ptr<re2::RE2> operator()(SingleExpressionResult auto&& input,
-                                       const EvaluationContext* context) const
-      requires requires { StringValueGetter{}(AD_FWD(input), context); } {
+  template <SingleExpressionResult S>
+  requires std::invocable<StringValueGetter, S&&, const EvaluationContext*>
+  std::unique_ptr<re2::RE2> operator()(S&& input,
+                                       const EvaluationContext* context) const {
     auto str = StringValueGetter{}(AD_FWD(input), context);
     if (!str.has_value()) {
       return nullptr;

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -171,8 +171,9 @@ struct LiteralFromIdGetter {
 };
 
 struct RegexValueGetter {
-  std::unique_ptr<re2::RE2> operator()(auto&& input,
-                                       const EvaluationContext* context) const {
+  std::unique_ptr<re2::RE2> operator()(SingleExpressionResult auto&& input,
+                                       const EvaluationContext* context) const
+      requires requires { StringValueGetter{}(AD_FWD(input), context); } {
     auto str = StringValueGetter{}(AD_FWD(input), context);
     if (!str.has_value()) {
       return nullptr;

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -5,6 +5,8 @@
 #ifndef QLEVER_SPARQLEXPRESSIONVALUEGETTERS_H
 #define QLEVER_SPARQLEXPRESSIONVALUEGETTERS_H
 
+#include <re2/re2.h>
+
 #include "../../global/Id.h"
 #include "../ResultTable.h"
 #include "./SparqlExpressionTypes.h"
@@ -165,6 +167,17 @@ struct LiteralFromIdGetter {
                                    const EvaluationContext* ctx) const {
     return std::visit([this, ctx](auto el) { return operator()(el, ctx); },
                       std::move(s));
+  }
+};
+
+struct RegexValueGetter {
+  std::unique_ptr<re2::RE2> operator()(auto&& input,
+                                       const EvaluationContext* context) const {
+    auto str = StringValueGetter{}(AD_FWD(input), context);
+    if (!str.has_value()) {
+      return nullptr;
+    }
+    return std::make_unique<re2::RE2>(str.value(), re2::RE2::Quiet);
   }
 };
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -253,8 +253,9 @@ using StrBeforeExpression =
                          StringValueGetter>;
 
 [[maybe_unused]] auto replaceImpl =
-    [](std::optional<std::string> input, std::unique_ptr<re2::RE2> pattern,
-       std::optional<std::string> replacement) -> IdOrString {
+    [](std::optional<std::string> input,
+       const std::unique_ptr<re2::RE2>& pattern,
+       const std::optional<std::string>& replacement) -> IdOrString {
   if (!input.has_value() || !pattern || !replacement.has_value()) {
     return Id::makeUndefined();
   }
@@ -401,7 +402,7 @@ Expr makeStrBeforeExpression(Expr child1, Expr child2) {
 }
 
 Expr makeReplaceExpression(Expr input, Expr pattern, Expr repl) {
-  //return make<ReplaceExpression>(input, pattern, repl);
+  return make<ReplaceExpression>(input, pattern, repl);
 }
 Expr makeContainsExpression(Expr child1, Expr child2) {
   return make<ContainsExpression>(child1, child2);

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -252,6 +252,27 @@ using StrBeforeExpression =
     StringExpressionImpl<2, LiftStringFunction<decltype(strBefore)>,
                          StringValueGetter>;
 
+[[maybe_unused]] auto replaceImpl =
+    [](std::optional<std::string> input, std::unique_ptr<re2::RE2> pattern,
+       std::optional<std::string> replacement) -> IdOrString {
+  if (!input.has_value() || !pattern || !replacement.has_value()) {
+    return Id::makeUndefined();
+  }
+  auto& in = input.value();
+  const auto& pat = *pattern;
+  // Check for invalid regexes.
+  if (!pat.ok()) {
+    return Id::makeUndefined();
+  }
+  const auto& repl = replacement.value();
+  re2::RE2::GlobalReplace(&in, pat, repl);
+  return std::move(in);
+};
+
+using ReplaceExpression =
+    StringExpressionImpl<3, decltype(replaceImpl), RegexValueGetter,
+                         StringValueGetter>;
+
 // CONCAT
 class ConcatExpression : public detail::VariadicExpression {
  public:
@@ -377,6 +398,10 @@ Expr makeStrAfterExpression(Expr child1, Expr child2) {
 }
 Expr makeStrBeforeExpression(Expr child1, Expr child2) {
   return make<StrBeforeExpression>(child1, child2);
+}
+
+Expr makeReplaceExpression(Expr input, Expr pattern, Expr repl) {
+  //return make<ReplaceExpression>(input, pattern, repl);
 }
 Expr makeContainsExpression(Expr child1, Expr child2) {
   return make<ContainsExpression>(child1, child2);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1619,6 +1619,8 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
     return visit(ctx->langExpression());
   } else if (ctx->substringExpression()) {
     return visit(ctx->substringExpression());
+  } else if (ctx->strReplaceExpression()) {
+    return visit(ctx->strReplaceExpression());
   }
   // Get the function name and the arguments. Note that we do not have to check
   // the number of arguments like for `processIriFunctionCall`, since the number
@@ -1630,24 +1632,28 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
   using namespace sparqlExpression;
   // Create the expression using the matching factory function from
   // `NaryExpression.h`.
-  auto createUnary = [&argList]<typename Function>(Function function)
-      requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr> {
+  auto createUnary =
+      [&argList]<typename Function>(Function function)
+          requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr>
+  {
     AD_CORRECTNESS_CHECK(argList.size() == 1);
     return function(std::move(argList[0]));
   };
-  auto createBinary = [&argList]<typename Function>(Function function)
-      requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
-                                     ExpressionPtr> {
-    AD_CORRECTNESS_CHECK(argList.size() == 2);
-    return function(std::move(argList[0]), std::move(argList[1]));
-  };
-  auto createTernary = [&argList]<typename Function>(Function function)
-      requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
-                                     ExpressionPtr, ExpressionPtr> {
-    AD_CORRECTNESS_CHECK(argList.size() == 3);
-    return function(std::move(argList[0]), std::move(argList[1]),
-                    std::move(argList[2]));
-  };
+  auto createBinary =
+      [&argList]<typename Function>(Function function)
+          requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
+                                         ExpressionPtr> {
+            AD_CORRECTNESS_CHECK(argList.size() == 2);
+            return function(std::move(argList[0]), std::move(argList[1]));
+          };
+  auto createTernary =
+      [&argList]<typename Function>(Function function)
+          requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
+                                         ExpressionPtr, ExpressionPtr> {
+            AD_CORRECTNESS_CHECK(argList.size() == 3);
+            return function(std::move(argList[0]), std::move(argList[1]),
+                            std::move(argList[2]));
+          };
   if (functionName == "str") {
     return createUnary(&makeStrExpression);
   } else if (functionName == "strlen") {
@@ -1743,8 +1749,19 @@ SparqlExpression::Ptr Visitor::visit(Parser::SubstringExpressionContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(const Parser::StrReplaceExpressionContext* ctx) {
-  reportNotSupported(ctx, "The REPLACE function is");
+SparqlExpression::Ptr Visitor::visit(Parser::StrReplaceExpressionContext* ctx) {
+  auto children = visitVector(ctx->expression());
+  AD_CORRECTNESS_CHECK(children.size() == 3 || children.size() == 4);
+  if (children.size() == 4) {
+    reportError(ctx,
+        "REPLACE expressions with four arguments (including regex flags) are "
+        "currently not supported by QLever. You can however incorporate flags "
+        "directly into a regex by prepending `?(<flags>)` to your regex. For "
+        "example `?(i)[ei]` will match the regex `[ei]` in a case-insensitive "
+        "way."
+        );
+  }
+  return sparqlExpression::makeReplaceExpression(std::move(children.at(0)), std::move(children.at(1)), std::move(children.at(2)));
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1632,28 +1632,24 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
   using namespace sparqlExpression;
   // Create the expression using the matching factory function from
   // `NaryExpression.h`.
-  auto createUnary =
-      [&argList]<typename Function>(Function function)
-          requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr>
-  {
+  auto createUnary = [&argList]<typename Function>(Function function)
+      requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr> {
     AD_CORRECTNESS_CHECK(argList.size() == 1);
     return function(std::move(argList[0]));
   };
-  auto createBinary =
-      [&argList]<typename Function>(Function function)
-          requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
-                                         ExpressionPtr> {
-            AD_CORRECTNESS_CHECK(argList.size() == 2);
-            return function(std::move(argList[0]), std::move(argList[1]));
-          };
-  auto createTernary =
-      [&argList]<typename Function>(Function function)
-          requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
-                                         ExpressionPtr, ExpressionPtr> {
-            AD_CORRECTNESS_CHECK(argList.size() == 3);
-            return function(std::move(argList[0]), std::move(argList[1]),
-                            std::move(argList[2]));
-          };
+  auto createBinary = [&argList]<typename Function>(Function function)
+      requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
+                                     ExpressionPtr> {
+    AD_CORRECTNESS_CHECK(argList.size() == 2);
+    return function(std::move(argList[0]), std::move(argList[1]));
+  };
+  auto createTernary = [&argList]<typename Function>(Function function)
+      requires std::is_invocable_r_v<ExpressionPtr, Function, ExpressionPtr,
+                                     ExpressionPtr, ExpressionPtr> {
+    AD_CORRECTNESS_CHECK(argList.size() == 3);
+    return function(std::move(argList[0]), std::move(argList[1]),
+                    std::move(argList[2]));
+  };
   if (functionName == "str") {
     return createUnary(&makeStrExpression);
   } else if (functionName == "strlen") {
@@ -1753,15 +1749,17 @@ SparqlExpression::Ptr Visitor::visit(Parser::StrReplaceExpressionContext* ctx) {
   auto children = visitVector(ctx->expression());
   AD_CORRECTNESS_CHECK(children.size() == 3 || children.size() == 4);
   if (children.size() == 4) {
-    reportError(ctx,
+    reportError(
+        ctx,
         "REPLACE expressions with four arguments (including regex flags) are "
         "currently not supported by QLever. You can however incorporate flags "
         "directly into a regex by prepending `?(<flags>)` to your regex. For "
         "example `?(i)[ei]` will match the regex `[ei]` in a case-insensitive "
-        "way."
-        );
+        "way.");
   }
-  return sparqlExpression::makeReplaceExpression(std::move(children.at(0)), std::move(children.at(1)), std::move(children.at(2)));
+  return sparqlExpression::makeReplaceExpression(std::move(children.at(0)),
+                                                 std::move(children.at(1)),
+                                                 std::move(children.at(2)));
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1753,8 +1753,8 @@ SparqlExpression::Ptr Visitor::visit(Parser::StrReplaceExpressionContext* ctx) {
         ctx,
         "REPLACE expressions with four arguments (including regex flags) are "
         "currently not supported by QLever. You can however incorporate flags "
-        "directly into a regex by prepending `?(<flags>)` to your regex. For "
-        "example `?(i)[ei]` will match the regex `[ei]` in a case-insensitive "
+        "directly into a regex by prepending `(?<flags>)` to your regex. For "
+        "example `(?i)[ei]` will match the regex `[ei]` in a case-insensitive "
         "way.");
   }
   return sparqlExpression::makeReplaceExpression(std::move(children.at(0)),

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -388,8 +388,7 @@ class SparqlQleverVisitor {
 
   ExpressionPtr visit(Parser::SubstringExpressionContext* ctx);
 
-  [[noreturn]] static void visit(
-      const Parser::StrReplaceExpressionContext* ctx);
+  ExpressionPtr visit(Parser::StrReplaceExpressionContext* ctx);
 
   [[noreturn]] static void visit(const Parser::ExistsFuncContext* ctx);
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1294,6 +1294,11 @@ TEST(SparqlParser, builtInCall) {
   expectBuiltInCall(
       "concat(?x, ?y, ?z)",
       matchNary(makeConcatExpressionVariadic, Var{"?x"}, Var{"?y"}, Var{"?z"}));
+
+  expectBuiltInCall(
+      "replace(?x, ?y, ?z)",
+      matchNary(&makeReplaceExpression, Var{"?x"}, Var{"?y"}, Var{"?z"}));
+  expectFails("replace(?x, ?y, ?z, \"i\")", ::testing::AllOf(::testing::ContainsRegex("regex"), ::testing::ContainsRegex("flags")));
   expectBuiltInCall("IF(?a, ?h, ?c)", matchNary(&makeIfExpression, Var{"?a"},
                                                 Var{"?h"}, Var{"?c"}));
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1298,7 +1298,9 @@ TEST(SparqlParser, builtInCall) {
   expectBuiltInCall(
       "replace(?x, ?y, ?z)",
       matchNary(&makeReplaceExpression, Var{"?x"}, Var{"?y"}, Var{"?z"}));
-  expectFails("replace(?x, ?y, ?z, \"i\")", ::testing::AllOf(::testing::ContainsRegex("regex"), ::testing::ContainsRegex("flags")));
+  expectFails("replace(?x, ?y, ?z, \"i\")",
+              ::testing::AllOf(::testing::ContainsRegex("regex"),
+                               ::testing::ContainsRegex("flags")));
   expectBuiltInCall("IF(?a, ?h, ?c)", matchNary(&makeIfExpression, Var{"?a"},
                                                 Var{"?h"}, Var{"?c"}));
 

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -790,10 +790,9 @@ TEST(SparqlExpression, ReplaceExpression) {
                           IdOrString{"e.[a-z]"}, IdOrString{"X"}});
 
   // Case-insensitive matching using the hack for google regex:
-    checkReplace(IdOrStrings{"null", "xxns", "zwxx", "drxx"},
-                 std::tuple{IdOrStrings{"null", "eIns", "zwEi", "drei"},
-                            IdOrString{"(?i)[ei]"}, IdOrString{"x"}});
-
+  checkReplace(IdOrStrings{"null", "xxns", "zwxx", "drxx"},
+               std::tuple{IdOrStrings{"null", "eIns", "zwEi", "drei"},
+                          IdOrString{"(?i)[ei]"}, IdOrString{"x"}});
 
   // Multiple matches withing the same string
   checkReplace(
@@ -809,7 +808,6 @@ TEST(SparqlExpression, ReplaceExpression) {
   checkReplace(IdOrStrings{U, U, U, U, U, U},
                std::tuple{IdOrStrings{"null", "Xs", "zwei", "drei", U, U},
                           IdOrString{"e"}, Id::makeUndefined()});
-
 }
 
 TEST(SparqlExpression, literalExpression) {

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -777,6 +777,41 @@ TEST(SparqlExpression, concatExpression) {
                              ::testing::ContainsRegex("<bim>, <bam>)")));
 }
 
+TEST(SparqlExpression, ReplaceExpression) {
+  auto checkReplace =
+      std::bind_front(testNaryExpressionVec, makeReplaceExpression);
+  // A simple replace( no regexes involved).
+  checkReplace(IdOrStrings{"null", "Eins", "zwEi", "drEi", U, U},
+               std::tuple{IdOrStrings{"null", "eins", "zwei", "drei", U, U},
+                          IdOrString{"e"}, IdOrString{"E"}});
+  // A somewhat more involved regex
+  checkReplace(IdOrStrings{"null", "Xs", "zwei", "drei", U, U},
+               std::tuple{IdOrStrings{"null", "eins", "zwei", "drei", U, U},
+                          IdOrString{"e.[a-z]"}, IdOrString{"X"}});
+
+  // Case-insensitive matching using the hack for google regex:
+    checkReplace(IdOrStrings{"null", "xxns", "zwxx", "drxx"},
+                 std::tuple{IdOrStrings{"null", "eIns", "zwEi", "drei"},
+                            IdOrString{"(?i)[ei]"}, IdOrString{"x"}});
+
+
+  // Multiple matches withing the same string
+  checkReplace(
+      IdOrString{"wEeDEflE"},
+      std::tuple{IdOrString{"weeeDeeflee"}, IdOrString{"ee"}, IdOrString{"E"}});
+
+  // Illegal regex.
+  checkReplace(IdOrStrings{U, U, U, U, U, U},
+               std::tuple{IdOrStrings{"null", "Xs", "zwei", "drei", U, U},
+                          IdOrString{"e.[a-z"}, IdOrString{"X"}});
+
+  // Illegal replacement.
+  checkReplace(IdOrStrings{U, U, U, U, U, U},
+               std::tuple{IdOrStrings{"null", "Xs", "zwei", "drei", U, U},
+                          IdOrString{"e"}, Id::makeUndefined()});
+
+}
+
 TEST(SparqlExpression, literalExpression) {
   TestContext ctx;
   StringLiteralExpression expr{TripleComponent::Literal{

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -803,7 +803,10 @@ TEST(SparqlExpression, ReplaceExpression) {
   checkReplace(IdOrStrings{U, U, U, U, U, U},
                std::tuple{IdOrStrings{"null", "Xs", "zwei", "drei", U, U},
                           IdOrString{"e.[a-z"}, IdOrString{"X"}});
-
+  // Undefined regex
+  checkReplace(IdOrStrings{U, U, U, U, U, U},
+               std::tuple{IdOrStrings{"null", "Xs", "zwei", "drei", U, U}, U,
+                          IdOrString{"X"}});
   // Illegal replacement.
   checkReplace(IdOrStrings{U, U, U, U, U, U},
                std::tuple{IdOrStrings{"null", "Xs", "zwei", "drei", U, U},


### PR DESCRIPTION
The `REPLACE` function is now implemented. Note the following details:

1. According to the standard, `REPLACE` takes an optional fourth argument for the flags. This is not yet supported. However, the flags can equivalently be prepended to the regular expression. For example, to get a case-insensitive regular expression, prepend `(?i)`. The new `RegexValueGetter` is not yet used in `FILTER` clauses, where prefix regular expressions are treated specially for efficiency reasons.

2. For constant values that are repeated multiple times (for each result row), the value is now evaluated only once and then repeated. In particular, in a `REPLACE` with a constant regular expression (the typical case), the regular expression is now compiled only once. This also avoids copying a constant string (for example, in a call to `CONCAT`) many times.