### PR TITLE
More flexible error messages for the validators in the `ConfigManager`

### DIFF
--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "util/ConfigManager/ConfigManager.h"
+
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -22,7 +24,6 @@
 
 #include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigExceptions.h"
-#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "util/ConfigManager/ConfigManager.h"
-
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -24,6 +22,7 @@
 
 #include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigExceptions.h"
+#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"
@@ -576,4 +575,7 @@ bool ConfigManager::containsOption(const ConfigOption& opt) const {
               [](const ConfigOption& option) { return &option; }),
       &opt);
 }
+
+// ____________________________________________________________________________
+const std::string& ErrorMessage::getMessage() const { return message_; }
 }  // namespace ad_utility

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -46,6 +46,25 @@ concept Validator =
     std::regular_invocable<Func, const ParameterTypes&...> &&
     std::same_as<std::invoke_result_t<Func, const ParameterTypes&...>, bool>;
 
+// Simple struct, that holds an error message. For use as the return type of
+// invocable object, that fullfill `ExceptionValidator`.
+struct ErrorMessage {
+  const std::string message;
+};
+
+/*
+An exception validator function is any invocable object, who takes the given
+parameter types, in the same order and transformed to `const type&`, and returns
+an instance of `std::optional<ErrorMessage>`.
+
+This concept is used for `ConfigManager::addValidator`.
+*/
+template <typename Func, typename... ParameterTypes>
+concept ExceptionValidator =
+    std::regular_invocable<Func, const ParameterTypes&...> &&
+    std::same_as<std::invoke_result_t<Func, const ParameterTypes&...>,
+                 std::optional<ErrorMessage>>;
+
 /*
 Manages a bunch of `ConfigOption`s.
 */

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -508,13 +508,14 @@ class ConfigManager {
       Validator<ValidatorParameterTypes...> auto validatorFunction,
       std::string errorMessage) {
     // The whole 'transformation' is simply a wrapper.
-    return [validatorFunction, errorMessage = std::move(errorMessage)](
+    return [validatorFunction,
+            errorMessage = ErrorMessage{std::move(errorMessage)}](
                const ValidatorParameterTypes&... args)
                -> std::optional<ErrorMessage> {
       if (std::invoke(validatorFunction, args...)) {
         return std::nullopt;
       } else {
-        return std::make_optional<ErrorMessage>(errorMessage);
+        return errorMessage;
       }
     };
   }

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -53,10 +53,6 @@ struct ErrorMessage {
 
   // Constructor.
   ErrorMessage(std::string message) : message_{std::move(message)} {}
-
-  // Move constructor. A move assignment operator is not possible, because
-  // `message_` is const.
-  ErrorMessage(ErrorMessage&&) = default;
 };
 
 /*

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -49,17 +49,21 @@ concept Validator =
 // Simple struct, that holds an error message. For use as the return type of
 // invocable object, that fullfill `ExceptionValidator`.
 struct ErrorMessage {
-  const std::string message_;
+ private:
+  std::string message_;
 
+ public:
   // Constructor.
   explicit ErrorMessage(std::string message) : message_{std::move(message)} {}
 
-  // Copy constructor
+  // Default copy and move semantics.
   ErrorMessage(const ErrorMessage&) = default;
+  ErrorMessage(ErrorMessage&&) = default;
+  ErrorMessage& operator=(const ErrorMessage&) = default;
+  ErrorMessage& operator=(ErrorMessage&&) = default;
 
-  // No move schemantics.
-  ErrorMessage(ErrorMessage&&) = delete;
-  ErrorMessage& operator=(ErrorMessage&&) = delete;
+  // Getter for the message.
+  const std::string& getMessage() const;
 };
 
 /*
@@ -599,7 +603,7 @@ class ConfigManager {
               std::invoke(translationFunction, configOptionsToBeChecked)...);
           errorMessage.has_value()) {
         throw std::runtime_error(
-            absl::StrCat(errorMessagePre, errorMessage.value().message_));
+            absl::StrCat(errorMessagePre, errorMessage.value().getMessage()));
       }
     });
   }

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -248,7 +248,7 @@ class ConfigManager {
   after parsing.
 
   @tparam ValidatorParameterTypes The types of the values in the
-  `validatorParameter`. Can be left up to type deduction.
+  `configOptionsToBeChecked`. Can be left up to type deduction.
 
   @param validatorFunction Checks, if the values of the given configuration
   options are valid. Should return true, if they are valid.
@@ -273,6 +273,37 @@ class ConfigManager {
         transformValidatorIntoExceptionValidator<ValidatorParameterTypes...>(
             validatorFunction, errorMessage),
         configOptionsToBeChecked...);
+  }
+
+  /*
+  @brief Add a function to the configuration manager for verifying, that the
+  values of the given configuration options are valid. Will always be called
+  after parsing.
+
+  @tparam ValidatorParameterTypes The types of the values in the
+  `configOptionsToBeChecked`. Can be left up to type deduction.
+
+  @param exceptionValidatorFunction Checks, if the values of the given
+  configuration options are valid. Return an empty instance of
+  `std::optional<ErrorMessage>` if valid. Otherwise, the `ErrorMessage` should
+  contain the reason, why the values are none valid.
+  @param configOptionsToBeChecked Proxies for the configuration options, whos
+  values will be passed to the exception validator function as function
+  arguments. Will keep the same order.
+  */
+  template <typename... ExceptionValidatorParameterTypes>
+  void addValidator(
+      ExceptionValidator<ExceptionValidatorParameterTypes...> auto
+          exceptionValidatorFunction,
+      ConstConfigOptionProxy<
+          ExceptionValidatorParameterTypes>... configOptionsToBeChecked)
+      requires(sizeof...(configOptionsToBeChecked) > 0) {
+    addValidatorImpl(
+        "addValidator",
+        []<typename T>(ConstConfigOptionProxy<T> opt) {
+          return opt.getConfigOption().template getValue<std::decay_t<T>>();
+        },
+        exceptionValidatorFunction, configOptionsToBeChecked...);
   }
 
   /*

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -560,12 +560,22 @@ class ConfigManager {
     (checkIfContainOption(configOptionsToBeChecked), ...);
 
     // Create the error message prefix for inside the function.
-    const std::array optionNames{absl::StrCat(
-        "'", configOptionsToBeChecked.getConfigOption().getIdentifier(),
-        "'")...};
+    auto generateConfigOptionIdentifierWithValueString =
+        [](const ConfigOption& c) {
+          // Is there a value, we can show together with the identifier?
+          const bool wasSet = c.wasSet();
+          return absl::StrCat(
+              "'", c.getIdentifier(), "' (With ",
+              wasSet ? absl::StrCat("value '", c.getValueAsString(), "'")
+                     : "no value",
+              ".)");
+        };
+    const std::array optionNamesWithValues{
+        generateConfigOptionIdentifierWithValueString(
+            configOptionsToBeChecked.getConfigOption())...};
     std::string errorMessagePrefix =
         absl::StrCat("Validity check of configuration options ",
-                     lazyStrJoin(optionNames, ", "), " failed: ");
+                     lazyStrJoin(optionNamesWithValues, ", "), " failed: ");
 
     /*
     Add a function wrapper to our list of validators, that calls the

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -54,6 +54,9 @@ struct ErrorMessage {
   // Constructor.
   explicit ErrorMessage(std::string message) : message_{std::move(message)} {}
 
+  // Copy constructor
+  ErrorMessage(const ErrorMessage&) = default;
+
   // No move schemantics.
   ErrorMessage(ErrorMessage&&) = delete;
   ErrorMessage& operator=(ErrorMessage&&) = delete;
@@ -513,7 +516,7 @@ class ConfigManager {
       if (std::invoke(validatorFunction, args...)) {
         return std::nullopt;
       } else {
-        return ErrorMessage{errorMessage};
+        return std::make_optional<ErrorMessage>(errorMessage);
       }
     };
   }

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -56,12 +56,6 @@ struct ErrorMessage {
   // Constructor.
   explicit ErrorMessage(std::string message) : message_{std::move(message)} {}
 
-  // Default copy and move semantics.
-  ErrorMessage(const ErrorMessage&) = default;
-  ErrorMessage(ErrorMessage&&) = default;
-  ErrorMessage& operator=(const ErrorMessage&) = default;
-  ErrorMessage& operator=(ErrorMessage&&) = default;
-
   // Getter for the message.
   const std::string& getMessage() const;
 };

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -52,7 +52,7 @@ struct ErrorMessage {
   const std::string message_;
 
   // Constructor.
-  ErrorMessage(std::string_view message) : message_{message} {}
+  ErrorMessage(std::string message) : message_{std::move(message)} {}
 
   // Move constructor. A move assignment operator is not possible, because
   // `message_` is const.

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -295,8 +295,8 @@ class ConfigManager {
   configuration options are valid. Return an empty instance of
   `std::optional<ErrorMessage>` if valid. Otherwise, the `ErrorMessage` should
   contain the reason, why the values are none valid.
-  @param configOptionsToBeChecked Proxies for the configuration options, whos
-  values will be passed to the exception validator function as function
+  @param configOptionsToBeChecked Proxies for the configuration options, the
+  values of which will be passed to the exception validator function as function
   arguments. Will keep the same order.
   */
   template <typename... ExceptionValidatorParameterTypes>

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -337,6 +337,34 @@ class ConfigManager {
         configOptionsToBeChecked...);
   }
 
+  /*
+  @brief Add a function to the configuration manager for verifying, that the
+  given configuration options are valid. Will always be called after parsing.
+
+  @param exceptionValidatorFunction Checks, if the given configuration options
+  are valid. Return an empty instance of `std::optional<ErrorMessage>` if valid.
+  Otherwise, the `ErrorMessage` should contain the reason, why the options are
+  none valid.
+  @param configOptionsToBeChecked Proxies for the configuration options, who
+  will be passed to the validator function as function arguments. Will keep the
+  same order.
+  */
+  template <typename ExceptionValidatorT>
+  void addOptionValidator(
+      ExceptionValidatorT exceptionValidatorFunction,
+      isInstantiation<ConstConfigOptionProxy> auto... configOptionsToBeChecked)
+      requires(sizeof...(configOptionsToBeChecked) > 0 &&
+               ExceptionValidator<
+                   ExceptionValidatorT,
+                   decltype(configOptionsToBeChecked.getConfigOption())...>) {
+    addValidatorImpl(
+        "addOptionValidator",
+        []<typename T>(ConstConfigOptionProxy<T> opt) {
+          return opt.getConfigOption();
+        },
+        exceptionValidatorFunction, configOptionsToBeChecked...);
+  }
+
  private:
   FRIEND_TEST(ConfigManagerTest, ParseConfig);
   FRIEND_TEST(ConfigManagerTest, ParseConfigExceptionTest);

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -52,7 +52,7 @@ struct ErrorMessage {
   const std::string message_;
 
   // Constructor.
-  ErrorMessage(std::string message) : message_{std::move(message)} {}
+  explicit ErrorMessage(std::string message) : message_{std::move(message)} {}
 };
 
 /*

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -53,6 +53,10 @@ struct ErrorMessage {
 
   // Constructor.
   explicit ErrorMessage(std::string message) : message_{std::move(message)} {}
+
+  // No move schemantics.
+  ErrorMessage(ErrorMessage&&) = delete;
+  ErrorMessage& operator=(ErrorMessage&&) = delete;
 };
 
 /*

--- a/src/util/ConfigManager/ConfigOption.h
+++ b/src/util/ConfigManager/ConfigOption.h
@@ -249,9 +249,12 @@ class ConfigOption {
   }
 
  private:
-  FRIEND_TEST(ConfigOptionTest, AddValidator);
-  FRIEND_TEST(ConfigOptionTest, AddValidatorExceptions);
-  FRIEND_TEST(ConfigManagerTest, AddValidator);
+  // Needed for testing.
+  FRIEND_TEST(ConfigManagerTest, AddNonExceptionValidator);
+
+  // This is a test helper function.
+  template <typename... Ts>
+  friend std::string generateValidatorName(size_t id);
 
   /*
   @brief Return the string representation/name of the type, of the currently

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -3,6 +3,7 @@
 // Author: Andre Schlegel (April of 2023,
 // schlegea@informatik.uni-freiburg.de)
 
+#include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 
 #include <concepts>
@@ -37,8 +38,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
-                 const bool wasSet, const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
+                 const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -55,16 +56,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(
-      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -73,18 +72,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
-                                &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
-          &notUsed, 42),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -103,8 +98,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
-                        "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -115,8 +109,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -133,9 +126,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -174,32 +166,28 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(
-      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption(
-      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-      &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+                                   &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -218,8 +206,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -237,19 +224,16 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -257,8 +241,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
-                            "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -277,17 +261,15 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s, "manager"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -326,25 +308,22 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(
+      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config
-                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
-                                      "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -353,16 +332,14 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -374,13 +351,10 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s},
-                       "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne =
-      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                       "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo =
-      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                                              "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -413,16 +387,14 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck =
-      [](const nlohmann::json& j, ConfigManager& m,
-         const std::vector<std::pair<int*, int>>& wantedValues) {
-        m.parseConfig(j);
+  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
+                          const std::vector<std::pair<int*, int>>& wantedValues) {
+    m.parseConfig(j);
 
-        std::ranges::for_each(
-            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-              ASSERT_EQ(*wantedValue.first, wantedValue.second);
-            });
-      };
+    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+      ASSERT_EQ(*wantedValue.first, wantedValue.second);
+    });
+  };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -440,16 +412,13 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
-                                         &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
-  parseAndCheck(
-      nlohmann::json::parse(R"--({
+  parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -457,8 +426,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-      managerWithOneSubNoRecursion,
-      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+                managerWithOneSubNoRecursion,
+                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -486,14 +455,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4},
-                 {&daveInfractions, 0},
-                 {&janiceId, 0},
-                 {&janiceInfractions, 6}});
+                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
-                                              &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -515,20 +480,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 =
-      managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 =
-      managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex =
-      managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter =
-      managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -549,10 +510,7 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4},
-                 {&alexInfractions, 0},
-                 {&peterId, 0},
-                 {&peterInfractions, 6}});
+                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -648,11 +606,10 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s},
-                   "Must be set. Has no default value.", &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s},
-                   "Must not be set. Has default value.", &notUsedVector,
-                   {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                   &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                   &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -679,27 +636,20 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_integer)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -707,38 +657,32 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
-                   41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s},
-               "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s},
-               "Must not be set. Has default value.", &notUsedVector, {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
+               {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -749,38 +693,29 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 =
-      config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 =
-      config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.",
-                    &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.",
-                      &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s},
-                      "Must be set. Has no default value.", &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s},
-                      "Must not be set. Has default value.", &notUsedVector,
-                      {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                      &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                      &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -791,15 +726,13 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -811,8 +744,7 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -821,65 +753,59 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.",
-      &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.",
-      &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist =
-      config.addOption("someIntegerlist", "Must be set. Has no default value.",
-                       &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist = config.addOption(
+      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint = config.addOption(
-      "somePositiveFloatingPoint", "Must be set. Has no default value.",
-      &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint =
+      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
+                       &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint = config.addOption(
-      "someNegativFloatingPoint", "Must be set. Has no default value.",
-      &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint =
+      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
+                       &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList = config.addOption(
-      "someFloatingPointList", "Must be set. Has no default value.",
-      &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList =
+      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
+                       &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue = config.addOption(
-      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue =
+      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse = config.addOption(
-      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse =
+      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList =
-      config.addOption("someBooleanList", "Must be set. Has no default value.",
-                       &someBooleanListBoolVector);
+  decltype(auto) someBooleanList = config.addOption(
+      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName = config.addOption(
-      "myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName =
+      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList =
-      config.addOption("someStringList", "Must be set. Has no default value.",
-                       &someStringListStringVector);
+  decltype(auto) someStringList = config.addOption(
+      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption =
-      config.addOption({"depth"s, "here"s, "list"s},
-                       "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption = config.addOption(
+      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -893,22 +819,17 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true,
-              std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
-              4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
-              -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
-              {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true,
-              std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -921,15 +842,13 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
-                                   R"(complicatedKey:42, complicatedKey:43)");
-                               , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
+      , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
-      R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(
-      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -946,8 +865,7 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan =
-      config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -957,12 +875,10 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -974,14 +890,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager,
-                    const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      manager.parseConfig(jsonWithNonValidValues),
-      ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
+                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -991,12 +905,11 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption =
-      m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; },
-                 "'numberInRange' must be <=100.", numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; },
-                 "'numberInRange' must be >=50.", numberInRangeOption);
+  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
+                 numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
+                 numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -1010,15 +923,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption =
-      m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) ||
-               (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
-      boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -1033,16 +943,12 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption =
-      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-      "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
-      nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+                                     "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption =
-      mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -1053,25 +959,19 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter =
-      mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) {
-        return opt.getIdentifier().starts_with('d');
-      },
+      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') &&
-               opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter,
-      wrongLetter);
-  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
-      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter, wrongLetter);
+  ASSERT_ANY_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -1091,8 +991,7 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> ||
-                       std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1133,13 +1032,11 @@ what the exact difference is, see the code in `createDummyValueForValidator`.
 */
 template <typename... ParameterTypes>
 auto generateDummyNonExceptionValidatorFunction(size_t variant) {
-  return [... dummyValuesToCompareTo =
-              createDummyValueForValidator<ParameterTypes>(variant)](
+  return [... dummyValuesToCompareTo = createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {
     // Special handeling for `args` of type bool is needed. For the reasoning:
     // See the doc string.
-    auto compare = []<typename T>(const T& arg,
-                                  const T& dummyValueToCompareTo) {
+    auto compare = []<typename T>(const T& arg, const T& dummyValueToCompareTo) {
       if constexpr (std::is_same_v<T, bool>) {
         return arg == false;
       } else {
@@ -1162,11 +1059,9 @@ functions.
 */
 template <typename... Ts>
 std::string generateValidatorName(size_t id) {
-  return absl::StrCat(
-      "Config manager validator<",
-      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
-                  ", "),
-      "> ", id);
+  return absl::StrCat("Config manager validator<",
+                      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "),
+                      "> ", id);
 };
 
 /*
@@ -1178,19 +1073,16 @@ That is, instead of returning `bool`, it now returns
 */
 template <typename... ValidatorParameterTypes>
 auto transformNonExceptionValidatorIntoExceptionValidator(
-    Validator<ValidatorParameterTypes...> auto validatorFunction,
-    std::string_view errorMessage) {
+    Validator<ValidatorParameterTypes...> auto validatorFunction, std::string_view errorMessage) {
   // The whole 'transformation' is simply a wrapper.
-  return
-      [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
-          const ValidatorParameterTypes&... args)
-          -> std::optional<ErrorMessage> {
-        if (std::invoke(validatorFunction, args...)) {
-          return std::nullopt;
-        } else {
-          return std::make_optional<ErrorMessage>(errorMessage);
-        }
-      };
+  return [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
+             const ValidatorParameterTypes&... args) -> std::optional<ErrorMessage> {
+    if (std::invoke(validatorFunction, args...)) {
+      return std::nullopt;
+    } else {
+      return std::make_optional<ErrorMessage>(errorMessage);
+    }
+  };
 }
 /*
 @brief The test for adding a validator to a config manager.
@@ -1203,9 +1095,8 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(
-    auto addValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(auto addValidatorFunction,
+                     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1230,12 +1121,10 @@ void doValidatorTest(
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes,
-               &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func),
-                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1282,13 +1171,11 @@ void doValidatorTest(
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m,
-          ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(
-        adjustVariantArgument.template operator()<Ts...>(variant),
-        generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
+                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1309,17 +1196,14 @@ void doValidatorTest(
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager =
-      [&adjustVariantArgument]<typename... Ts>(
-          size_t variantStart, size_t variantEnd, ConfigManager & m,
-          const nlohmann::json& defaultValues,
-          const std::same_as<
-              nlohmann::json::json_pointer> auto&... configOptionPaths)
-          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
+      size_t variantStart, size_t variantEnd, ConfigManager & m,
+      const nlohmann::json& defaultValues,
+      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
+      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
-         validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1338,11 +1222,9 @@ void doValidatorTest(
       are all identical.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName<Ts...>(0));
+        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1366,8 +1248,7 @@ void doValidatorTest(
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1377,8 +1258,7 @@ void doValidatorTest(
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1409,10 +1289,8 @@ void doValidatorTest(
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM,
-          const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1423,8 +1301,7 @@ void doValidatorTest(
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1434,8 +1311,7 @@ void doValidatorTest(
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1444,270 +1320,307 @@ void doValidatorTest(
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type>() {
-        // Variables needed for configuration options.
-        Type firstVar;
+  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
+    // Variables needed for configuration options.
+    Type firstVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption =
-            mNoSub.addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue"),
-                           mNoSubOption));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        decltype(auto) mSubNoValidatorOption =
-            mSubNoValidator.addSubManager({"some"s, "manager"s})
-                .addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubNoValidatorOption));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    decltype(auto) mSubNoValidatorOption =
+        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubNoValidatorOption));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption =
-            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubWithValidatorOption));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption =
+        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubWithValidatorOption));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
-        // Variables needed for configuration options.
-        Type1 firstVar;
-        Type2 secondVar;
+  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
+                                                                     typename Type2>() {
+    // Variables needed for configuration options.
+    Type1 firstVar;
+    Type2 secondVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 =
-            mNoSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mNoSubOption2 =
-            mNoSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
-                           mNoSubOption1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
-                           mNoSubOption2));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub =
-            mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubNoValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubNoValidatorOption2));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubNoValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubNoValidatorOption2));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption1 =
-            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubWithValidatorOption2 =
-            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubWithValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubWithValidatorOption2));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption1 =
+        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubWithValidatorOption2 =
+        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubWithValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubWithValidatorOption2));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
-                                       typename Type1, typename Type2>() {
-    // Variables for config options.
-    Type1 var1;
-    Type2 var2;
+  auto doDifferentParameterTests =
+      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
+        // Variables for config options.
+        Type1 var1;
+        Type2 var2;
 
-    /*
-    @brief Helper function, that checks all combinations of valid/invalid values
-    for two single argument parameter validator functions.
+        /*
+        @brief Helper function, that checks all combinations of valid/invalid values
+        for two single argument parameter validator functions.
 
-    @tparam T1, T2 Function parameter type for the first and the second
-    validator.
+        @tparam T1, T2 Function parameter type for the first and the second
+        validator.
 
-    @param m The config manager, on which `parseConfig` will be called on.
-    @param validator1, validator2 A pair consisting of the path to the
-    configuration option, that the validator is looking at, and the `variant`
-    value, that was used to generate the validator function with
-    `addValidatorToConfigManager`.
-    */
-    auto checkAllValidAndInvalidValueCombinations =
-        []<typename T1, typename T2>(
-            ConfigManager& m,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-          /*
-          Input for `parseConfig`. One contains values, that are valid for all
-          validators, the other contains values, that are valid for all
-          validators except one.
-          */
-          nlohmann::json validValueJson(nlohmann::json::value_t::object);
-          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+        @param m The config manager, on which `parseConfig` will be called on.
+        @param validator1, validator2 A pair consisting of the path to the
+        configuration option, that the validator is looking at, and the `variant`
+        value, that was used to generate the validator function with
+        `addValidatorToConfigManager`.
+        */
+        auto checkAllValidAndInvalidValueCombinations =
+            []<typename T1, typename T2>(
+                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+              /*
+              Input for `parseConfig`. One contains values, that are valid for all
+              validators, the other contains values, that are valid for all
+              validators except one.
+              */
+              nlohmann::json validValueJson(nlohmann::json::value_t::object);
+              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-          // Add the valid values.
-          validValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second + 1);
-          validValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second + 1);
+              // Add the valid values.
+              validValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second + 1);
+              validValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second + 1);
 
-          // Value for `validator1` is invalid. Value for `validator2` is valid.
-          invalidValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second);
-          invalidValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second + 1);
-          checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName<Type1>(validator1.second));
+              // Value for `validator1` is invalid. Value for `validator2` is valid.
+              invalidValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second);
+              invalidValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second + 1);
+              checkValidator(m, validValueJson, invalidValueJson,
+                             generateValidatorName<Type1>(validator1.second));
 
-          // Value for `validator1` is valid. Value for `validator2` is invalid.
-          invalidValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second + 1);
-          invalidValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second);
-          checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName<Type2>(validator2.second));
-        };
+              // Value for `validator1` is valid. Value for `validator2` is invalid.
+              invalidValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second + 1);
+              invalidValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second);
+              checkValidator(m, validValueJson, invalidValueJson,
+                             generateValidatorName<Type2>(validator2.second));
+            };
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
-                                                           mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
-                                                           mNoSubOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub =
-        mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mSubNoValidator, mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mSubNoValidator, mSubNoValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
+                                                               mSubNoValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
+                                                               mSubNoValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mSubNoValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
-    // Sub manager has validators of its own, however the manager does not.
-    ConfigManager mNoValidatorSubValidator;
-    ConfigManager& mNoValidatorSubValidatorSub =
-        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mNoValidatorSubValidatorOption1 =
-        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mNoValidatorSubValidatorOption2 =
-        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        // Sub manager has validators of its own, however the manager does not.
+        ConfigManager mNoValidatorSubValidator;
+        ConfigManager& mNoValidatorSubValidatorSub =
+            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mNoValidatorSubValidatorOption1 =
+            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mNoValidatorSubValidatorOption2 =
+            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
+                                                               mNoValidatorSubValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
+                                                               mNoValidatorSubValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mNoValidatorSubValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
-    // Sub manager has validators of its own, as does the manager.
-    ConfigManager mValidatorSubValidator;
-    ConfigManager& mValidatorSubValidatorSub =
-        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mValidatorSubValidatorOption1 =
-        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mValidatorSubValidatorOption2 =
-        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
-  };
+        // Sub manager has validators of its own, as does the manager.
+        ConfigManager mValidatorSubValidator;
+        ConfigManager& mValidatorSubValidatorSub =
+            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mValidatorSubValidatorOption1 =
+            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mValidatorSubValidatorOption2 =
+            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
+                                                               mValidatorSubValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
+                                                               mValidatorSubValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mValidatorSubValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
+
+  // Quick test, if the exception message generated for failed validators include up to date
+  // information about all used configuration options.
+
+  // Variables for the options.
+  std::string string0;
+  std::string string1;
+
+  // Default values.
+  const std::string defaultValue = "This is the default value.";
+  constexpr std::string_view defaultExceptionMessage = "Default exception message";
+
+  // Add the validator and check, if the configuration option with it's current value is in the
+  // exception message for failing the validator.
+  auto doExceptionMessageTest = [&addValidatorFunction, &defaultExceptionMessage](
+                                    size_t variantNumber, ConfigManager& managerToRunParseOn,
+                                    ConfigManager& managerToAddValidatorTo,
+                                    ConstConfigOptionProxy<std::string> option,
+                                    const nlohmann::json::json_pointer& pathToOption) {
+    // The value, which causes the automaticly generated validator with the given variant to fail.
+    const std::string& failValue = createDummyValueForValidator<std::string>(variantNumber);
+
+    nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
+    jsonForParsing[pathToOption] = failValue;
+
+    // Adding the validator and checking.
+    std::invoke(addValidatorFunction, variantNumber, defaultExceptionMessage,
+                managerToAddValidatorTo, option);
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        managerToRunParseOn.parseConfig(jsonForParsing),
+        ::testing::ContainsRegex(absl::StrCat("value '\"", failValue, "\"'")));
+  };
+
+  // No sub manager.
+  ConfigManager mNoSub;
+  decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &string0, defaultValue);
+  doExceptionMessageTest(10, mNoSub, mNoSub, mNoSubOption1,
+                         nlohmann::json::json_pointer("/someValue1"));
+
+  // With sub manager. Sub manager has no validators of its own.
+  ConfigManager mSubNoValidator;
+  ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+  decltype(auto) mSubNoValidatorOption1 =
+      mSubNoValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+  doExceptionMessageTest(10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+
+  // Sub manager has validators of its own, however the manager does not.
+  ConfigManager mNoValidatorSubValidator;
+  ConfigManager& mNoValidatorSubValidatorSub =
+      mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+  decltype(auto) mNoValidatorSubValidatorOption1 =
+      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+  doExceptionMessageTest(10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
+                         mNoValidatorSubValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+
+  // Sub manager has validators of its own, as does the manager.
+  ConfigManager mValidatorSubValidator;
+  ConfigManager& mValidatorSubValidatorSub =
+      mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+  decltype(auto) mValidatorSubValidatorOption1 =
+      mValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+  decltype(auto) mValidatorSubValidatorOption2 =
+      mValidatorSubValidatorSub.addOption("someValue2", "", &string1, defaultValue);
+  doExceptionMessageTest(4, mValidatorSubValidator, mValidatorSubValidator,
+                         mValidatorSubValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(5, mValidatorSubValidator, mValidatorSubValidatorSub,
+                         mValidatorSubValidatorOption2,
+                         nlohmann::json::json_pointer("/some/manager/someValue2"));
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant,
-                                     std::string_view validatorExceptionMessage,
-                                     ConfigManager& m,
-                                     ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
+                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
                    validatorExceptionMessage, optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant,
-                                     std::string_view validatorExceptionMessage,
-                                     ConfigManager& m,
-                                     ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
+                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(
         transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
-            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
-            validatorExceptionMessage),
+            generateDummyNonExceptionValidatorFunction<Ts...>(variant), validatorExceptionMessage),
         optProxy...);
   });
 }
@@ -1740,16 +1653,15 @@ void doValidatorExceptionTest(
         @brief Check, if a call to the `addValidator` function behaves as
         wanted.
         */
-        auto checkAddValidatorBehavior =
-            [&addAlwaysValidValidatorFunction](
-                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                ConstConfigOptionProxy<T> notValidOption) {
-              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-              AD_EXPECT_THROW_WITH_MESSAGE(
-                  addAlwaysValidValidatorFunction(m, notValidOption),
-                  ::testing::ContainsRegex(
-                      notValidOption.getConfigOption().getIdentifier()));
-            };
+        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
+                                             ConfigManager& m,
+                                             ConstConfigOptionProxy<T> validOption,
+                                             ConstConfigOptionProxy<T> notValidOption) {
+          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+          AD_EXPECT_THROW_WITH_MESSAGE(
+              addAlwaysValidValidatorFunction(m, notValidOption),
+              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+        };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1762,50 +1674,30 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption =
-            mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub =
-            mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption =
-            mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption =
-            mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 =
-            mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option =
-            mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 =
-            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option =
-            mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1813,22 +1705,16 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m,
-                         ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "",
-                       validatorArguments...);
+      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "", validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m,
-                         ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator(
-            [](const Ts&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
-            validatorArguments...);
+      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
+                       validatorArguments...);
       });
 }
 
@@ -1849,13 +1735,11 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison =
-      [](std::string_view valueStringRepresentation) {
-        return [wantedString = std::string(valueStringRepresentation)](
-                   const auto&... options) {
-          return ((options.getValueAsString() == wantedString) && ...);
-        };
-      };
+  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
+    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
+      return ((options.getValueAsString() == wantedString) && ...);
+    };
+  };
 
   // Variables for configuration options.
   int firstVar;
@@ -1865,75 +1749,58 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "someOption1", managerWithNoSubManager,
-                                   managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
-                 "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
+                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "Both options", managerWithNoSubManager,
-                                   managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
+                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(
-      managerWithNoSubManager,
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-      "Both options");
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+                 "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
-                                                        &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager(
-          {"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
-          "someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Sub manager option",
-      managerWithSubManagerWhoHasNoValidators,
-      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
+                                   managerWithSubManagerWhoHasNoValidators,
+                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+  checkValidator(managerWithSubManagerWhoHasNoValidators,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
+                                   managerWithSubManagerWhoHasNoValidators,
+                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+                                   managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Both options",
-      managerWithSubManagerWhoHasNoValidators,
-      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-      managerWithSubManagerWhoHasNoValidatorsOption);
-  checkValidator(
-      managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager(
-          {"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
-          "someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Sub manager option",
-      managerHasNoValidatorsButSubManagerDoesSubManager,
-      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(
-      managerHasNoValidatorsButSubManagerDoes,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
+                                   managerHasNoValidatorsButSubManagerDoesSubManager,
+                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(managerHasNoValidatorsButSubManagerDoes,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1943,49 +1810,40 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "Top manager option", bothHaveValidators,
-                                   bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("20"), "Sub manager option",
-      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
+                                   bothHaveValidators, bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
+                                   bothHaveValidatorsSubManager,
+                                   bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction,
-                         std::string_view validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction, std::string_view validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage,
-                             args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage, args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
-  doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction,
-                         std::string_view validatorExceptionMessage,
-                         ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(
-            transformNonExceptionValidatorIntoExceptionValidator<
-                decltype(args.getConfigOption())...>(validatorFunction,
-                                                     validatorExceptionMessage),
-            args...);
-      });
+  doAddOptionValidatorTest([]<typename... Ts>(
+                               auto validatorFunction, std::string_view validatorExceptionMessage,
+                               ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
+    m.addOptionValidator(
+        transformNonExceptionValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
+            validatorFunction, validatorExceptionMessage),
+        args...);
+  });
 }
 
 /*
@@ -2010,16 +1868,15 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior =
-      [&addAlwaysValidValidatorFunction]<typename T>(
-          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-          ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            addAlwaysValidValidatorFunction(m, notValidOption),
-            ::testing::ContainsRegex(
-                notValidOption.getConfigOption().getIdentifier()));
-      };
+  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
+                                             ConfigManager& m,
+                                             ConstConfigOptionProxy<T> validOption,
+                                             ConstConfigOptionProxy<T> notValidOption) {
+    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        addAlwaysValidValidatorFunction(m, notValidOption),
+        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+  };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -2034,53 +1891,35 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption =
-      mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption =
-      mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option =
-      mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 =
-      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option =
-      mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) { return true; }, "",
-            args...);
+        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
+                             args...);
       });
 }
 
@@ -2088,8 +1927,9 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...)
-                -> std::optional<ErrorMessage> { return {std::nullopt}; },
+            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
             args...);
       });
 }
@@ -2103,21 +1943,18 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector =
-      std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus =
-      [](const ConfigManager& m,
-         const ContainmentStatusVector& optionsAndWantedStatus) {
-        std::ranges::for_each(
-            optionsAndWantedStatus,
-            [&m](const ContainmentStatusVector::value_type& p) {
-              if (p.second) {
-                ASSERT_TRUE(m.containsOption(*p.first));
-              } else {
-                ASSERT_FALSE(m.containsOption(*p.first));
-              }
-            });
-      };
+  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus = [](const ConfigManager& m,
+                                   const ContainmentStatusVector& optionsAndWantedStatus) {
+    std::ranges::for_each(optionsAndWantedStatus,
+                          [&m](const ContainmentStatusVector::value_type& p) {
+                            if (p.second) {
+                              ASSERT_TRUE(m.containsOption(*p.first));
+                            } else {
+                              ASSERT_FALSE(m.containsOption(*p.first));
+                            }
+                          });
+  };
 
   // Variable for the configuration options.
   int var;
@@ -2128,87 +1965,68 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
-      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 =
-      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option =
-      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -2229,8 +2047,7 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction =
-      decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -2240,88 +2057,66 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
-                                       std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
-                                       std::string>);
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(
-      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<
-                decltype([](FirstParameter, SecondParameter) { return true; }),
-                int, int>);
+            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
+                                   int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 
 TEST(ConfigManagerTest, ExceptionValidatorConcept) {
@@ -2329,126 +2124,87 @@ TEST(ConfigManagerTest, ExceptionValidatorConcept) {
   using SingleIntExceptionValidatorFunction =
       decltype([](const int&) { return std::optional<ErrorMessage>{}; });
   using DoubleIntExceptionValidatorFunction =
-      decltype([](const int&, const int&) {
-        return std::optional<ErrorMessage>{};
-      });
+      decltype([](const int&, const int&) { return std::optional<ErrorMessage>{}; });
 
   // Valid function.
-  static_assert(
-      ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
-  static_assert(
-      ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                     int>);
+  static_assert(ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
+  static_assert(ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int>);
 
   // The number of parameter types is wrong.
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int, int>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
-  static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int,
-                                      int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                      int, int, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
-                                      std::vector<bool>>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::string>);
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
-                                      std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::vector<bool>, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::vector<bool>, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::vector<bool>>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                                std::vector<bool>, std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                      std::vector<bool>>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::vector<bool>, std::vector<bool>>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::string, int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                      std::string>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::string, std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string,
+                                                std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
   static_assert(
-      !ad_utility::ExceptionValidator<
-          decltype([](int&) { return std::optional<ErrorMessage>{}; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<
-          decltype([](int&&) { return std::optional<ErrorMessage>{}; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int&&) {
-                                        return std::optional<ErrorMessage>{};
-                                      }),
+      !ad_utility::ExceptionValidator<decltype([](int&) { return std::optional<ErrorMessage>{}; }),
                                       int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int&&) { return std::optional<ErrorMessage>{}; }),
+                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<
+                decltype([](const int&&) { return std::optional<ErrorMessage>{}; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<
-                      decltype([](FirstParameter, SecondParameter) {
-                        return std::optional<ErrorMessage>{};
-                      }),
-                      int, int>);
+        static_assert(!ad_utility::ExceptionValidator<decltype([](FirstParameter, SecondParameter) {
+                                                        return std::optional<ErrorMessage>{};
+                                                      }),
+                                                      int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int n) { return n; }),
-                                      int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }),
-                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(
-            !ad_utility::ExceptionValidator<
-                decltype([](FirstParameter n, SecondParameter) { return n; }),
-                int, int>);
+        static_assert(!ad_utility::ExceptionValidator<
+                      decltype([](FirstParameter n, SecondParameter) { return n; }), int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }),
-                                      int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }),
-                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -38,8 +38,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
-                 const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
+                 const bool wasSet, const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -56,14 +56,16 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(
+      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -72,14 +74,18 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
+                                &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
+          &notUsed, 42),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -98,7 +104,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
+                        "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -109,7 +116,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -126,8 +134,9 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -166,28 +175,32 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(
+      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-                                   &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption(
+      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+      &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -206,7 +219,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -224,16 +238,19 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -241,8 +258,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
+                            "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -261,15 +278,17 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s, "manager"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -308,22 +327,25 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(
-      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config
+                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
+                                      "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -332,14 +354,16 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
+                      .addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -351,10 +375,13 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                                              "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s},
+                       "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne =
+      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                       "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo =
+      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -387,14 +414,16 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
-                          const std::vector<std::pair<int*, int>>& wantedValues) {
-    m.parseConfig(j);
+  auto parseAndCheck =
+      [](const nlohmann::json& j, ConfigManager& m,
+         const std::vector<std::pair<int*, int>>& wantedValues) {
+        m.parseConfig(j);
 
-    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-      ASSERT_EQ(*wantedValue.first, wantedValue.second);
-    });
-  };
+        std::ranges::for_each(
+            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+              ASSERT_EQ(*wantedValue.first, wantedValue.second);
+            });
+      };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -412,13 +441,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion,
+                {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
+                                         &amountOfPersonal, 0);
 
-  parseAndCheck(nlohmann::json::parse(R"--({
+  parseAndCheck(
+      nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -426,8 +458,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+      managerWithOneSubNoRecursion,
+      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -455,10 +487,14 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+                {{&daveId, 4},
+                 {&daveInfractions, 0},
+                 {&janiceId, 0},
+                 {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
+                                              &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -480,16 +516,20 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 =
+      managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 =
+      managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex =
+      managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter =
+      managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -510,7 +550,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+                {{&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -606,10 +649,11 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                   &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                   &notUsedVector, {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s},
+                   "Must be set. Has no default value.", &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s},
+                   "Must not be set. Has default value.", &notUsedVector,
+                   {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -636,20 +680,27 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_integer)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -657,32 +708,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
+                   41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
-               {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s},
+               "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s},
+               "Must not be set. Has default value.", &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -693,29 +750,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 =
+      config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 =
+      config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.",
+                    &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.",
+                      &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                      &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                      &notUsedVector, {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s},
+                      "Must be set. Has no default value.", &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s},
+                      "Must not be set. Has default value.", &notUsedVector,
+                      {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -726,13 +792,15 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -744,7 +812,8 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -753,59 +822,65 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.",
+      &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.",
+      &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist = config.addOption(
-      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist =
+      config.addOption("someIntegerlist", "Must be set. Has no default value.",
+                       &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint =
-      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
-                       &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint = config.addOption(
+      "somePositiveFloatingPoint", "Must be set. Has no default value.",
+      &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint =
-      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
-                       &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint = config.addOption(
+      "someNegativFloatingPoint", "Must be set. Has no default value.",
+      &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList =
-      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
-                       &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList = config.addOption(
+      "someFloatingPointList", "Must be set. Has no default value.",
+      &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue =
-      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue = config.addOption(
+      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse =
-      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse = config.addOption(
+      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList = config.addOption(
-      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
+  decltype(auto) someBooleanList =
+      config.addOption("someBooleanList", "Must be set. Has no default value.",
+                       &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName =
-      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName = config.addOption(
+      "myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList = config.addOption(
-      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
+  decltype(auto) someStringList =
+      config.addOption("someStringList", "Must be set. Has no default value.",
+                       &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption = config.addOption(
-      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption =
+      config.addOption({"depth"s, "here"s, "list"s},
+                       "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -819,17 +894,22 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true,
+              std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
+              4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
+              -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
+              {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true,
+              std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -842,13 +922,15 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
-      , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
+                                   R"(complicatedKey:42, complicatedKey:43)");
+                               , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
+      R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(
+      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -865,7 +947,8 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan =
+      config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -875,10 +958,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -890,12 +975,14 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager,
+                    const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
-                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.parseConfig(jsonWithNonValidValues),
+      ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -905,11 +992,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
-                 numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
-                 numberInRangeOption);
+  decltype(auto) numberInRangeOption =
+      m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; },
+                 "'numberInRange' must be <=100.", numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; },
+                 "'numberInRange' must be >=50.", numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -923,12 +1011,15 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption =
+      m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) ||
+               (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
+      boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -943,12 +1034,16 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-                                     "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption =
+      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator(
+      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+      "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
+      nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption =
+      mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -959,19 +1054,25 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter =
+      mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
+      [](const ConfigOption& opt) {
+        return opt.getIdentifier().starts_with('d');
+      },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') &&
+               opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter, wrongLetter);
-  ASSERT_ANY_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter,
+      wrongLetter);
+  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
+      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -991,7 +1092,8 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> ||
+                       std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1032,11 +1134,13 @@ what the exact difference is, see the code in `createDummyValueForValidator`.
 */
 template <typename... ParameterTypes>
 auto generateDummyNonExceptionValidatorFunction(size_t variant) {
-  return [... dummyValuesToCompareTo = createDummyValueForValidator<ParameterTypes>(variant)](
+  return [... dummyValuesToCompareTo =
+              createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {
     // Special handeling for `args` of type bool is needed. For the reasoning:
     // See the doc string.
-    auto compare = []<typename T>(const T& arg, const T& dummyValueToCompareTo) {
+    auto compare = []<typename T>(const T& arg,
+                                  const T& dummyValueToCompareTo) {
       if constexpr (std::is_same_v<T, bool>) {
         return arg == false;
       } else {
@@ -1059,9 +1163,11 @@ functions.
 */
 template <typename... Ts>
 std::string generateValidatorName(size_t id) {
-  return absl::StrCat("Config manager validator<",
-                      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "),
-                      "> ", id);
+  return absl::StrCat(
+      "Config manager validator<",
+      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
+                  ", "),
+      "> ", id);
 };
 
 /*
@@ -1073,16 +1179,19 @@ That is, instead of returning `bool`, it now returns
 */
 template <typename... ValidatorParameterTypes>
 auto transformNonExceptionValidatorIntoExceptionValidator(
-    Validator<ValidatorParameterTypes...> auto validatorFunction, std::string_view errorMessage) {
+    Validator<ValidatorParameterTypes...> auto validatorFunction,
+    std::string_view errorMessage) {
   // The whole 'transformation' is simply a wrapper.
-  return [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
-             const ValidatorParameterTypes&... args) -> std::optional<ErrorMessage> {
-    if (std::invoke(validatorFunction, args...)) {
-      return std::nullopt;
-    } else {
-      return std::make_optional<ErrorMessage>(errorMessage);
-    }
-  };
+  return
+      [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
+          const ValidatorParameterTypes&... args)
+          -> std::optional<ErrorMessage> {
+        if (std::invoke(validatorFunction, args...)) {
+          return std::nullopt;
+        } else {
+          return std::make_optional<ErrorMessage>(errorMessage);
+        }
+      };
 }
 /*
 @brief The test for adding a validator to a config manager.
@@ -1095,8 +1204,9 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(auto addValidatorFunction,
-                     ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(
+    auto addValidatorFunction,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1121,10 +1231,12 @@ void doValidatorTest(auto addValidatorFunction,
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes,
+               &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func),
+                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1171,11 +1283,13 @@ void doValidatorTest(auto addValidatorFunction,
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m,
+          ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
-                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(
+        adjustVariantArgument.template operator()<Ts...>(variant),
+        generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1196,14 +1310,17 @@ void doValidatorTest(auto addValidatorFunction,
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
-      size_t variantStart, size_t variantEnd, ConfigManager & m,
-      const nlohmann::json& defaultValues,
-      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
-      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager =
+      [&adjustVariantArgument]<typename... Ts>(
+          size_t variantStart, size_t variantEnd, ConfigManager & m,
+          const nlohmann::json& defaultValues,
+          const std::same_as<
+              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
+         validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1222,9 +1339,11 @@ void doValidatorTest(auto addValidatorFunction,
       are all identical.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(0));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1248,7 +1367,8 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1258,7 +1378,8 @@ void doValidatorTest(auto addValidatorFunction,
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1289,8 +1410,10 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM,
+          const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1301,7 +1424,8 @@ void doValidatorTest(auto addValidatorFunction,
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1311,7 +1435,8 @@ void doValidatorTest(auto addValidatorFunction,
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1320,223 +1445,252 @@ void doValidatorTest(auto addValidatorFunction,
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
-    // Variables needed for configuration options.
-    Type firstVar;
+  auto doSingleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type>() {
+        // Variables needed for configuration options.
+        Type firstVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption =
+            mNoSub.addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue"),
+                           mNoSubOption));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    decltype(auto) mSubNoValidatorOption =
-        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubNoValidatorOption));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        decltype(auto) mSubNoValidatorOption =
+            mSubNoValidator.addSubManager({"some"s, "manager"s})
+                .addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubNoValidatorOption));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption =
-        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubWithValidatorOption));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption =
+            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubWithValidatorOption));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
-                                                                     typename Type2>() {
-    // Variables needed for configuration options.
-    Type1 firstVar;
-    Type2 secondVar;
+  auto doDoubleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
+        // Variables needed for configuration options.
+        Type1 firstVar;
+        Type2 secondVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 =
+            mNoSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mNoSubOption2 =
+            mNoSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
+                           mNoSubOption1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
+                           mNoSubOption2));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubNoValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubNoValidatorOption2));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub =
+            mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubNoValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubNoValidatorOption2));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption1 =
-        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubWithValidatorOption2 =
-        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubWithValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubWithValidatorOption2));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption1 =
+            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubWithValidatorOption2 =
+            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubWithValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubWithValidatorOption2));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests =
-      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
-        // Variables for config options.
-        Type1 var1;
-        Type2 var2;
+  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
+                                       typename Type1, typename Type2>() {
+    // Variables for config options.
+    Type1 var1;
+    Type2 var2;
 
-        /*
-        @brief Helper function, that checks all combinations of valid/invalid values
-        for two single argument parameter validator functions.
+    /*
+    @brief Helper function, that checks all combinations of valid/invalid values
+    for two single argument parameter validator functions.
 
-        @tparam T1, T2 Function parameter type for the first and the second
-        validator.
+    @tparam T1, T2 Function parameter type for the first and the second
+    validator.
 
-        @param m The config manager, on which `parseConfig` will be called on.
-        @param validator1, validator2 A pair consisting of the path to the
-        configuration option, that the validator is looking at, and the `variant`
-        value, that was used to generate the validator function with
-        `addValidatorToConfigManager`.
-        */
-        auto checkAllValidAndInvalidValueCombinations =
-            []<typename T1, typename T2>(
-                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-              /*
-              Input for `parseConfig`. One contains values, that are valid for all
-              validators, the other contains values, that are valid for all
-              validators except one.
-              */
-              nlohmann::json validValueJson(nlohmann::json::value_t::object);
-              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+    @param m The config manager, on which `parseConfig` will be called on.
+    @param validator1, validator2 A pair consisting of the path to the
+    configuration option, that the validator is looking at, and the `variant`
+    value, that was used to generate the validator function with
+    `addValidatorToConfigManager`.
+    */
+    auto checkAllValidAndInvalidValueCombinations =
+        []<typename T1, typename T2>(
+            ConfigManager& m,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+          /*
+          Input for `parseConfig`. One contains values, that are valid for all
+          validators, the other contains values, that are valid for all
+          validators except one.
+          */
+          nlohmann::json validValueJson(nlohmann::json::value_t::object);
+          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-              // Add the valid values.
-              validValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              validValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
+          // Add the valid values.
+          validValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          validValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
 
-              // Value for `validator1` is invalid. Value for `validator2` is valid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type1>(validator1.second));
+          // Value for `validator1` is invalid. Value for `validator2` is valid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type1>(validator1.second));
 
-              // Value for `validator1` is valid. Value for `validator2` is invalid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type2>(validator2.second));
-            };
+          // Value for `validator1` is valid. Value for `validator2` is invalid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type2>(validator2.second));
+        };
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
+                                                           mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
+                                                           mNoSubOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mSubNoValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub =
+        mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mSubNoValidator, mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mSubNoValidator, mSubNoValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mSubNoValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, however the manager does not.
-        ConfigManager mNoValidatorSubValidator;
-        ConfigManager& mNoValidatorSubValidatorSub =
-            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mNoValidatorSubValidatorOption1 =
-            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoValidatorSubValidatorOption2 =
-            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // Sub manager has validators of its own, however the manager does not.
+    ConfigManager mNoValidatorSubValidator;
+    ConfigManager& mNoValidatorSubValidatorSub =
+        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mNoValidatorSubValidatorOption1 =
+        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoValidatorSubValidatorOption2 =
+        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, as does the manager.
-        ConfigManager mValidatorSubValidator;
-        ConfigManager& mValidatorSubValidatorSub =
-            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mValidatorSubValidatorOption1 =
-            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mValidatorSubValidatorOption2 =
-            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
-                                                               mValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
-                                                               mValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
-      };
+    // Sub manager has validators of its own, as does the manager.
+    ConfigManager mValidatorSubValidator;
+    ConfigManager& mValidatorSubValidatorSub =
+        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mValidatorSubValidatorOption1 =
+        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mValidatorSubValidatorOption2 =
+        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
-  // Quick test, if the exception message generated for failed validators include up to date
-  // information about all used configuration options.
+  // Quick test, if the exception message generated for failed validators
+  // include up to date information about all used configuration options.
 
   // Variables for the options.
   std::string string0;
@@ -1544,83 +1698,102 @@ void doValidatorTest(auto addValidatorFunction,
 
   // Default values.
   const std::string defaultValue = "This is the default value.";
-  constexpr std::string_view defaultExceptionMessage = "Default exception message";
+  constexpr std::string_view defaultExceptionMessage =
+      "Default exception message";
 
-  // Add the validator and check, if the configuration option with it's current value is in the
-  // exception message for failing the validator.
-  auto doExceptionMessageTest = [&addValidatorFunction, &defaultExceptionMessage](
-                                    size_t variantNumber, ConfigManager& managerToRunParseOn,
-                                    ConfigManager& managerToAddValidatorTo,
-                                    ConstConfigOptionProxy<std::string> option,
-                                    const nlohmann::json::json_pointer& pathToOption) {
-    // The value, which causes the automaticly generated validator with the given variant to fail.
-    const std::string& failValue = createDummyValueForValidator<std::string>(variantNumber);
+  // Add the validator and check, if the configuration option with it's current
+  // value is in the exception message for failing the validator.
+  auto doExceptionMessageTest =
+      [&addValidatorFunction, &defaultExceptionMessage](
+          size_t variantNumber, ConfigManager& managerToRunParseOn,
+          ConfigManager& managerToAddValidatorTo,
+          ConstConfigOptionProxy<std::string> option,
+          const nlohmann::json::json_pointer& pathToOption) {
+        // The value, which causes the automaticly generated validator with the
+        // given variant to fail.
+        const std::string& failValue =
+            createDummyValueForValidator<std::string>(variantNumber);
 
-    nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
-    jsonForParsing[pathToOption] = failValue;
+        nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
+        jsonForParsing[pathToOption] = failValue;
 
-    // Adding the validator and checking.
-    std::invoke(addValidatorFunction, variantNumber, defaultExceptionMessage,
-                managerToAddValidatorTo, option);
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        managerToRunParseOn.parseConfig(jsonForParsing),
-        ::testing::ContainsRegex(absl::StrCat("value '\"", failValue, "\"'")));
-  };
+        // Adding the validator and checking.
+        std::invoke(addValidatorFunction, variantNumber,
+                    defaultExceptionMessage, managerToAddValidatorTo, option);
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            managerToRunParseOn.parseConfig(jsonForParsing),
+            ::testing::ContainsRegex(
+                absl::StrCat("value '\"", failValue, "\"'")));
+      };
 
   // No sub manager.
   ConfigManager mNoSub;
-  decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &string0, defaultValue);
+  decltype(auto) mNoSubOption1 =
+      mNoSub.addOption("someValue1", "", &string0, defaultValue);
   doExceptionMessageTest(10, mNoSub, mNoSub, mNoSubOption1,
                          nlohmann::json::json_pointer("/someValue1"));
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager mSubNoValidator;
-  ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+  ConfigManager& mSubNoValidatorSub =
+      mSubNoValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mSubNoValidatorOption1 =
       mSubNoValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(
+      10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager mNoValidatorSubValidator;
   ConfigManager& mNoValidatorSubValidatorSub =
       mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mNoValidatorSubValidatorOption1 =
-      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
-                         mNoValidatorSubValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0,
+                                            defaultValue);
+  doExceptionMessageTest(
+      10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
+      mNoValidatorSubValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager mValidatorSubValidator;
   ConfigManager& mValidatorSubValidatorSub =
       mValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mValidatorSubValidatorOption1 =
-      mValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+      mValidatorSubValidatorSub.addOption("someValue1", "", &string0,
+                                          defaultValue);
   decltype(auto) mValidatorSubValidatorOption2 =
-      mValidatorSubValidatorSub.addOption("someValue2", "", &string1, defaultValue);
-  doExceptionMessageTest(4, mValidatorSubValidator, mValidatorSubValidator,
-                         mValidatorSubValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
-  doExceptionMessageTest(5, mValidatorSubValidator, mValidatorSubValidatorSub,
-                         mValidatorSubValidatorOption2,
-                         nlohmann::json::json_pointer("/some/manager/someValue2"));
+      mValidatorSubValidatorSub.addOption("someValue2", "", &string1,
+                                          defaultValue);
+  doExceptionMessageTest(
+      4, mValidatorSubValidator, mValidatorSubValidator,
+      mValidatorSubValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(
+      5, mValidatorSubValidator, mValidatorSubValidatorSub,
+      mValidatorSubValidatorOption2,
+      nlohmann::json::json_pointer("/some/manager/someValue2"));
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string_view validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
                    validatorExceptionMessage, optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string_view validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(
         transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
-            generateDummyNonExceptionValidatorFunction<Ts...>(variant), validatorExceptionMessage),
+            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
+            validatorExceptionMessage),
         optProxy...);
   });
 }
@@ -1653,15 +1826,16 @@ void doValidatorExceptionTest(
         @brief Check, if a call to the `addValidator` function behaves as
         wanted.
         */
-        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              addAlwaysValidValidatorFunction(m, notValidOption),
-              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-        };
+        auto checkAddValidatorBehavior =
+            [&addAlwaysValidValidatorFunction](
+                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                ConstConfigOptionProxy<T> notValidOption) {
+              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+              AD_EXPECT_THROW_WITH_MESSAGE(
+                  addAlwaysValidValidatorFunction(m, notValidOption),
+                  ::testing::ContainsRegex(
+                      notValidOption.getConfigOption().getIdentifier()));
+            };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1674,30 +1848,50 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption =
+            mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub =
+            mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption =
+            mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption =
+            mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 =
+            mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option =
+            mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 =
+            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option =
+            mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1705,16 +1899,22 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "", validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "",
+                       validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
-                       validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator(
+            [](const Ts&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
+            validatorArguments...);
       });
 }
 
@@ -1735,11 +1935,13 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
-    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
-      return ((options.getValueAsString() == wantedString) && ...);
-    };
-  };
+  auto generateValueAsStringComparison =
+      [](std::string_view valueStringRepresentation) {
+        return [wantedString = std::string(valueStringRepresentation)](
+                   const auto&... options) {
+          return ((options.getValueAsString() == wantedString) && ...);
+        };
+      };
 
   // Variables for configuration options.
   int firstVar;
@@ -1749,58 +1951,75 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "someOption1", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
+                 "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Both options", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-                 "Both options");
+  checkValidator(
+      managerWithNoSubManager,
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
+                                                        &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(managerWithSubManagerWhoHasNoValidators,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-                                   managerWithSubManagerWhoHasNoValidatorsOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
+          "someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Both options",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+      managerWithSubManagerWhoHasNoValidatorsOption);
+  checkValidator(
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerHasNoValidatorsButSubManagerDoesSubManager,
-                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(managerHasNoValidatorsButSubManagerDoes,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
+          "someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerHasNoValidatorsButSubManagerDoesSubManager,
+      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(
+      managerHasNoValidatorsButSubManagerDoes,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1810,40 +2029,49 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
-                                   bothHaveValidators, bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
-                                   bothHaveValidatorsSubManager,
-                                   bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Top manager option", bothHaveValidators,
+                                   bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("20"), "Sub manager option",
+      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction, std::string_view validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction,
+                         std::string_view validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage, args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage,
+                             args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
-  doAddOptionValidatorTest([]<typename... Ts>(
-                               auto validatorFunction, std::string_view validatorExceptionMessage,
-                               ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-    m.addOptionValidator(
-        transformNonExceptionValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
-            validatorFunction, validatorExceptionMessage),
-        args...);
-  });
+  doAddOptionValidatorTest(
+      []<typename... Ts>(auto validatorFunction,
+                         std::string_view validatorExceptionMessage,
+                         ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
+        m.addOptionValidator(
+            transformNonExceptionValidatorIntoExceptionValidator<
+                decltype(args.getConfigOption())...>(validatorFunction,
+                                                     validatorExceptionMessage),
+            args...);
+      });
 }
 
 /*
@@ -1868,15 +2096,16 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        addAlwaysValidValidatorFunction(m, notValidOption),
-        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-  };
+  auto checkAddOptionValidatorBehavior =
+      [&addAlwaysValidValidatorFunction]<typename T>(
+          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+          ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            addAlwaysValidValidatorFunction(m, notValidOption),
+            ::testing::ContainsRegex(
+                notValidOption.getConfigOption().getIdentifier()));
+      };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -1891,35 +2120,53 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption =
+      mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption =
+      mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option =
+      mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 =
+      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option =
+      mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
-                             args...);
+        m.addOptionValidator(
+            [](const decltype(args.getConfigOption())&...) { return true; }, "",
+            args...);
       });
 }
 
@@ -1927,9 +2174,8 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
+            [](const decltype(args.getConfigOption())&...)
+                -> std::optional<ErrorMessage> { return {std::nullopt}; },
             args...);
       });
 }
@@ -1943,18 +2189,21 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus = [](const ConfigManager& m,
-                                   const ContainmentStatusVector& optionsAndWantedStatus) {
-    std::ranges::for_each(optionsAndWantedStatus,
-                          [&m](const ContainmentStatusVector::value_type& p) {
-                            if (p.second) {
-                              ASSERT_TRUE(m.containsOption(*p.first));
-                            } else {
-                              ASSERT_FALSE(m.containsOption(*p.first));
-                            }
-                          });
-  };
+  using ContainmentStatusVector =
+      std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus =
+      [](const ConfigManager& m,
+         const ContainmentStatusVector& optionsAndWantedStatus) {
+        std::ranges::for_each(
+            optionsAndWantedStatus,
+            [&m](const ContainmentStatusVector::value_type& p) {
+              if (p.second) {
+                ASSERT_TRUE(m.containsOption(*p.first));
+              } else {
+                ASSERT_FALSE(m.containsOption(*p.first));
+              }
+            });
+      };
 
   // Variable for the configuration options.
   int var;
@@ -1965,68 +2214,87 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
+      {&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 =
+      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option =
+      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -2047,7 +2315,8 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction =
+      decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -2057,66 +2326,88 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
+      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
+                                       std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
+                                       std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
-                                   int, int>);
+            !ad_utility::Validator<
+                decltype([](FirstParameter, SecondParameter) { return true; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 
 TEST(ConfigManagerTest, ExceptionValidatorConcept) {
@@ -2124,87 +2415,126 @@ TEST(ConfigManagerTest, ExceptionValidatorConcept) {
   using SingleIntExceptionValidatorFunction =
       decltype([](const int&) { return std::optional<ErrorMessage>{}; });
   using DoubleIntExceptionValidatorFunction =
-      decltype([](const int&, const int&) { return std::optional<ErrorMessage>{}; });
+      decltype([](const int&, const int&) {
+        return std::optional<ErrorMessage>{};
+      });
 
   // Valid function.
-  static_assert(ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
-  static_assert(ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int>);
+  static_assert(
+      ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
+  static_assert(
+      ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                     int>);
 
   // The number of parameter types is wrong.
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int, int>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int, int, int>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int,
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::string>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
+                                      std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::vector<bool>, int>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
+                                      std::string>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::vector<bool>>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                                std::vector<bool>, std::vector<bool>>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::vector<bool>, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string,
-                                                std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::string, int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      std::string>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
   static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&) { return std::optional<ErrorMessage>{}; }),
-                                      int>);
+      !ad_utility::ExceptionValidator<
+          decltype([](int&) { return std::optional<ErrorMessage>{}; }), int>);
   static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&&) { return std::optional<ErrorMessage>{}; }),
+      !ad_utility::ExceptionValidator<
+          decltype([](int&&) { return std::optional<ErrorMessage>{}; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int&&) {
+                                        return std::optional<ErrorMessage>{};
+                                      }),
                                       int>);
-  static_assert(!ad_utility::ExceptionValidator<
-                decltype([](const int&&) { return std::optional<ErrorMessage>{}; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<decltype([](FirstParameter, SecondParameter) {
-                                                        return std::optional<ErrorMessage>{};
-                                                      }),
-                                                      int, int>);
+        static_assert(!ad_utility::ExceptionValidator<
+                      decltype([](FirstParameter, SecondParameter) {
+                        return std::optional<ErrorMessage>{};
+                      }),
+                      int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int n) { return n; }),
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }),
+                                      int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<
-                      decltype([](FirstParameter n, SecondParameter) { return n; }), int, int>);
+        static_assert(
+            !ad_utility::ExceptionValidator<
+                decltype([](FirstParameter n, SecondParameter) { return n; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }),
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }),
+                                      int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -38,8 +38,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
-                 const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
+                 const bool wasSet, const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -56,14 +56,16 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(
+      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -72,14 +74,18 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
+                                &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
+          &notUsed, 42),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -98,7 +104,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
+                        "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -109,7 +116,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -126,8 +134,9 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -166,28 +175,32 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(
+      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-                                   &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption(
+      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+      &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -206,7 +219,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -224,16 +238,19 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -241,8 +258,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
+                            "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -261,15 +278,17 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s, "manager"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -308,22 +327,25 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(
-      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config
+                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
+                                      "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -332,14 +354,16 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
+                      .addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -351,10 +375,13 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                                              "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s},
+                       "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne =
+      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                       "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo =
+      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -387,14 +414,16 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
-                          const std::vector<std::pair<int*, int>>& wantedValues) {
-    m.parseConfig(j);
+  auto parseAndCheck =
+      [](const nlohmann::json& j, ConfigManager& m,
+         const std::vector<std::pair<int*, int>>& wantedValues) {
+        m.parseConfig(j);
 
-    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-      ASSERT_EQ(*wantedValue.first, wantedValue.second);
-    });
-  };
+        std::ranges::for_each(
+            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+              ASSERT_EQ(*wantedValue.first, wantedValue.second);
+            });
+      };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -412,13 +441,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion,
+                {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
+                                         &amountOfPersonal, 0);
 
-  parseAndCheck(nlohmann::json::parse(R"--({
+  parseAndCheck(
+      nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -426,8 +458,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+      managerWithOneSubNoRecursion,
+      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -455,10 +487,14 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+                {{&daveId, 4},
+                 {&daveInfractions, 0},
+                 {&janiceId, 0},
+                 {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
+                                              &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -480,16 +516,20 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 =
+      managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 =
+      managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex =
+      managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter =
+      managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -510,7 +550,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+                {{&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -606,10 +649,11 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                   &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                   &notUsedVector, {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s},
+                   "Must be set. Has no default value.", &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s},
+                   "Must not be set. Has default value.", &notUsedVector,
+                   {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -636,20 +680,27 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_integer)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -657,32 +708,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
+                   41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
-               {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s},
+               "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s},
+               "Must not be set. Has default value.", &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -693,29 +750,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 =
+      config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 =
+      config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.",
+                    &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.",
+                      &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                      &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                      &notUsedVector, {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s},
+                      "Must be set. Has no default value.", &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s},
+                      "Must not be set. Has default value.", &notUsedVector,
+                      {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -726,13 +792,15 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -744,7 +812,8 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -753,59 +822,65 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.",
+      &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.",
+      &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist = config.addOption(
-      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist =
+      config.addOption("someIntegerlist", "Must be set. Has no default value.",
+                       &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint =
-      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
-                       &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint = config.addOption(
+      "somePositiveFloatingPoint", "Must be set. Has no default value.",
+      &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint =
-      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
-                       &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint = config.addOption(
+      "someNegativFloatingPoint", "Must be set. Has no default value.",
+      &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList =
-      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
-                       &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList = config.addOption(
+      "someFloatingPointList", "Must be set. Has no default value.",
+      &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue =
-      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue = config.addOption(
+      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse =
-      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse = config.addOption(
+      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList = config.addOption(
-      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
+  decltype(auto) someBooleanList =
+      config.addOption("someBooleanList", "Must be set. Has no default value.",
+                       &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName =
-      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName = config.addOption(
+      "myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList = config.addOption(
-      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
+  decltype(auto) someStringList =
+      config.addOption("someStringList", "Must be set. Has no default value.",
+                       &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption = config.addOption(
-      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption =
+      config.addOption({"depth"s, "here"s, "list"s},
+                       "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -819,17 +894,22 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true,
+              std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
+              4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
+              -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
+              {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true,
+              std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -842,13 +922,15 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
-      , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
+                                   R"(complicatedKey:42, complicatedKey:43)");
+                               , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
+      R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(
+      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -865,7 +947,8 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan =
+      config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -875,10 +958,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -890,12 +975,14 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager,
+                    const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
-                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.parseConfig(jsonWithNonValidValues),
+      ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -905,11 +992,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
-                 numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
-                 numberInRangeOption);
+  decltype(auto) numberInRangeOption =
+      m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; },
+                 "'numberInRange' must be <=100.", numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; },
+                 "'numberInRange' must be >=50.", numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -923,12 +1011,15 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption =
+      m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) ||
+               (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
+      boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -943,12 +1034,16 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-                                     "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption =
+      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator(
+      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+      "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
+      nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption =
+      mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -959,19 +1054,25 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter =
+      mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
+      [](const ConfigOption& opt) {
+        return opt.getIdentifier().starts_with('d');
+      },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') &&
+               opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter, wrongLetter);
-  ASSERT_ANY_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter,
+      wrongLetter);
+  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
+      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -991,7 +1092,8 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> ||
+                       std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1032,11 +1134,13 @@ what the exact difference is, see the code in `createDummyValueForValidator`.
 */
 template <typename... ParameterTypes>
 auto generateDummyNonExceptionValidatorFunction(size_t variant) {
-  return [... dummyValuesToCompareTo = createDummyValueForValidator<ParameterTypes>(variant)](
+  return [... dummyValuesToCompareTo =
+              createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {
     // Special handeling for `args` of type bool is needed. For the reasoning:
     // See the doc string.
-    auto compare = []<typename T>(const T& arg, const T& dummyValueToCompareTo) {
+    auto compare = []<typename T>(const T& arg,
+                                  const T& dummyValueToCompareTo) {
       if constexpr (std::is_same_v<T, bool>) {
         return arg == false;
       } else {
@@ -1059,9 +1163,11 @@ functions.
 */
 template <typename... Ts>
 std::string generateValidatorName(size_t id) {
-  return absl::StrCat("Config manager validator<",
-                      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "),
-                      "> ", id);
+  return absl::StrCat(
+      "Config manager validator<",
+      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
+                  ", "),
+      "> ", id);
 };
 
 /*
@@ -1073,10 +1179,12 @@ That is, instead of returning `bool`, it now returns
 */
 template <typename... ValidatorParameterTypes>
 auto transformNonExceptionValidatorIntoExceptionValidator(
-    Validator<ValidatorParameterTypes...> auto validatorFunction, std::string errorMessage) {
+    Validator<ValidatorParameterTypes...> auto validatorFunction,
+    std::string errorMessage) {
   // The whole 'transformation' is simply a wrapper.
   return [validatorFunction, errorMessage = std::move(errorMessage)](
-             const ValidatorParameterTypes&... args) -> std::optional<ErrorMessage> {
+             const ValidatorParameterTypes&... args)
+             -> std::optional<ErrorMessage> {
     if (std::invoke(validatorFunction, args...)) {
       return std::nullopt;
     } else {
@@ -1095,8 +1203,9 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(auto addValidatorFunction,
-                     ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(
+    auto addValidatorFunction,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1121,10 +1230,12 @@ void doValidatorTest(auto addValidatorFunction,
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes,
+               &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func),
+                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1171,11 +1282,13 @@ void doValidatorTest(auto addValidatorFunction,
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m,
+          ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
-                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(
+        adjustVariantArgument.template operator()<Ts...>(variant),
+        generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1196,14 +1309,17 @@ void doValidatorTest(auto addValidatorFunction,
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
-      size_t variantStart, size_t variantEnd, ConfigManager & m,
-      const nlohmann::json& defaultValues,
-      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
-      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager =
+      [&adjustVariantArgument]<typename... Ts>(
+          size_t variantStart, size_t variantEnd, ConfigManager & m,
+          const nlohmann::json& defaultValues,
+          const std::same_as<
+              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
+         validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1222,9 +1338,11 @@ void doValidatorTest(auto addValidatorFunction,
       are all identical.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(0));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1248,7 +1366,8 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1258,7 +1377,8 @@ void doValidatorTest(auto addValidatorFunction,
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1289,8 +1409,10 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM,
+          const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1301,7 +1423,8 @@ void doValidatorTest(auto addValidatorFunction,
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1311,7 +1434,8 @@ void doValidatorTest(auto addValidatorFunction,
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1320,217 +1444,246 @@ void doValidatorTest(auto addValidatorFunction,
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
-    // Variables needed for configuration options.
-    Type firstVar;
+  auto doSingleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type>() {
+        // Variables needed for configuration options.
+        Type firstVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption =
+            mNoSub.addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue"),
+                           mNoSubOption));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    decltype(auto) mSubNoValidatorOption =
-        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubNoValidatorOption));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        decltype(auto) mSubNoValidatorOption =
+            mSubNoValidator.addSubManager({"some"s, "manager"s})
+                .addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubNoValidatorOption));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption =
-        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubWithValidatorOption));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption =
+            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubWithValidatorOption));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
-                                                                     typename Type2>() {
-    // Variables needed for configuration options.
-    Type1 firstVar;
-    Type2 secondVar;
+  auto doDoubleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
+        // Variables needed for configuration options.
+        Type1 firstVar;
+        Type2 secondVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 =
+            mNoSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mNoSubOption2 =
+            mNoSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
+                           mNoSubOption1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
+                           mNoSubOption2));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubNoValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubNoValidatorOption2));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub =
+            mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubNoValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubNoValidatorOption2));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption1 =
-        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubWithValidatorOption2 =
-        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubWithValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubWithValidatorOption2));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption1 =
+            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubWithValidatorOption2 =
+            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubWithValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubWithValidatorOption2));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests =
-      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
-        // Variables for config options.
-        Type1 var1;
-        Type2 var2;
+  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
+                                       typename Type1, typename Type2>() {
+    // Variables for config options.
+    Type1 var1;
+    Type2 var2;
 
-        /*
-        @brief Helper function, that checks all combinations of valid/invalid values
-        for two single argument parameter validator functions.
+    /*
+    @brief Helper function, that checks all combinations of valid/invalid values
+    for two single argument parameter validator functions.
 
-        @tparam T1, T2 Function parameter type for the first and the second
-        validator.
+    @tparam T1, T2 Function parameter type for the first and the second
+    validator.
 
-        @param m The config manager, on which `parseConfig` will be called on.
-        @param validator1, validator2 A pair consisting of the path to the
-        configuration option, that the validator is looking at, and the `variant`
-        value, that was used to generate the validator function with
-        `addValidatorToConfigManager`.
-        */
-        auto checkAllValidAndInvalidValueCombinations =
-            []<typename T1, typename T2>(
-                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-              /*
-              Input for `parseConfig`. One contains values, that are valid for all
-              validators, the other contains values, that are valid for all
-              validators except one.
-              */
-              nlohmann::json validValueJson(nlohmann::json::value_t::object);
-              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+    @param m The config manager, on which `parseConfig` will be called on.
+    @param validator1, validator2 A pair consisting of the path to the
+    configuration option, that the validator is looking at, and the `variant`
+    value, that was used to generate the validator function with
+    `addValidatorToConfigManager`.
+    */
+    auto checkAllValidAndInvalidValueCombinations =
+        []<typename T1, typename T2>(
+            ConfigManager& m,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+          /*
+          Input for `parseConfig`. One contains values, that are valid for all
+          validators, the other contains values, that are valid for all
+          validators except one.
+          */
+          nlohmann::json validValueJson(nlohmann::json::value_t::object);
+          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-              // Add the valid values.
-              validValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              validValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
+          // Add the valid values.
+          validValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          validValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
 
-              // Value for `validator1` is invalid. Value for `validator2` is valid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type1>(validator1.second));
+          // Value for `validator1` is invalid. Value for `validator2` is valid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type1>(validator1.second));
 
-              // Value for `validator1` is valid. Value for `validator2` is invalid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type2>(validator2.second));
-            };
+          // Value for `validator1` is valid. Value for `validator2` is invalid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type2>(validator2.second));
+        };
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
+                                                           mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
+                                                           mNoSubOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mSubNoValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub =
+        mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mSubNoValidator, mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mSubNoValidator, mSubNoValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mSubNoValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, however the manager does not.
-        ConfigManager mNoValidatorSubValidator;
-        ConfigManager& mNoValidatorSubValidatorSub =
-            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mNoValidatorSubValidatorOption1 =
-            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoValidatorSubValidatorOption2 =
-            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // Sub manager has validators of its own, however the manager does not.
+    ConfigManager mNoValidatorSubValidator;
+    ConfigManager& mNoValidatorSubValidatorSub =
+        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mNoValidatorSubValidatorOption1 =
+        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoValidatorSubValidatorOption2 =
+        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, as does the manager.
-        ConfigManager mValidatorSubValidator;
-        ConfigManager& mValidatorSubValidatorSub =
-            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mValidatorSubValidatorOption1 =
-            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mValidatorSubValidatorOption2 =
-            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
-                                                               mValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
-                                                               mValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
-      };
+    // Sub manager has validators of its own, as does the manager.
+    ConfigManager mValidatorSubValidator;
+    ConfigManager& mValidatorSubValidatorSub =
+        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mValidatorSubValidatorOption1 =
+        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mValidatorSubValidatorOption2 =
+        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1548,81 +1701,98 @@ void doValidatorTest(auto addValidatorFunction,
 
   // Add the validator and check, if the configuration option with it's current
   // value is in the exception message for failing the validator.
-  auto doExceptionMessageTest = [&addValidatorFunction, &defaultExceptionMessage](
-                                    size_t variantNumber, ConfigManager& managerToRunParseOn,
-                                    ConfigManager& managerToAddValidatorTo,
-                                    ConstConfigOptionProxy<std::string> option,
-                                    const nlohmann::json::json_pointer& pathToOption) {
-    // The value, which causes the automaticly generated validator with the
-    // given variant to fail.
-    const std::string& failValue = createDummyValueForValidator<std::string>(variantNumber);
+  auto doExceptionMessageTest =
+      [&addValidatorFunction, &defaultExceptionMessage](
+          size_t variantNumber, ConfigManager& managerToRunParseOn,
+          ConfigManager& managerToAddValidatorTo,
+          ConstConfigOptionProxy<std::string> option,
+          const nlohmann::json::json_pointer& pathToOption) {
+        // The value, which causes the automaticly generated validator with the
+        // given variant to fail.
+        const std::string& failValue =
+            createDummyValueForValidator<std::string>(variantNumber);
 
-    nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
-    jsonForParsing[pathToOption] = failValue;
+        nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
+        jsonForParsing[pathToOption] = failValue;
 
-    // Adding the validator and checking.
-    std::invoke(addValidatorFunction, variantNumber, defaultExceptionMessage,
-                managerToAddValidatorTo, option);
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        managerToRunParseOn.parseConfig(jsonForParsing),
-        ::testing::ContainsRegex(absl::StrCat("value '\"", failValue, "\"'")));
-  };
+        // Adding the validator and checking.
+        std::invoke(addValidatorFunction, variantNumber,
+                    defaultExceptionMessage, managerToAddValidatorTo, option);
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            managerToRunParseOn.parseConfig(jsonForParsing),
+            ::testing::ContainsRegex(
+                absl::StrCat("value '\"", failValue, "\"'")));
+      };
 
   // No sub manager.
   ConfigManager mNoSub;
-  decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &string0, defaultValue);
+  decltype(auto) mNoSubOption1 =
+      mNoSub.addOption("someValue1", "", &string0, defaultValue);
   doExceptionMessageTest(10, mNoSub, mNoSub, mNoSubOption1,
                          nlohmann::json::json_pointer("/someValue1"));
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager mSubNoValidator;
-  ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+  ConfigManager& mSubNoValidatorSub =
+      mSubNoValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mSubNoValidatorOption1 =
       mSubNoValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(
+      10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager mNoValidatorSubValidator;
   ConfigManager& mNoValidatorSubValidatorSub =
       mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mNoValidatorSubValidatorOption1 =
-      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
-                         mNoValidatorSubValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0,
+                                            defaultValue);
+  doExceptionMessageTest(
+      10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
+      mNoValidatorSubValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager mValidatorSubValidator;
   ConfigManager& mValidatorSubValidatorSub =
       mValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mValidatorSubValidatorOption1 =
-      mValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+      mValidatorSubValidatorSub.addOption("someValue1", "", &string0,
+                                          defaultValue);
   decltype(auto) mValidatorSubValidatorOption2 =
-      mValidatorSubValidatorSub.addOption("someValue2", "", &string1, defaultValue);
-  doExceptionMessageTest(4, mValidatorSubValidator, mValidatorSubValidator,
-                         mValidatorSubValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
-  doExceptionMessageTest(5, mValidatorSubValidator, mValidatorSubValidatorSub,
-                         mValidatorSubValidatorOption2,
-                         nlohmann::json::json_pointer("/some/manager/someValue2"));
+      mValidatorSubValidatorSub.addOption("someValue2", "", &string1,
+                                          defaultValue);
+  doExceptionMessageTest(
+      4, mValidatorSubValidator, mValidatorSubValidator,
+      mValidatorSubValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(
+      5, mValidatorSubValidator, mValidatorSubValidatorSub,
+      mValidatorSubValidatorOption2,
+      nlohmann::json::json_pointer("/some/manager/someValue2"));
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string_view validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
                    std::string(validatorExceptionMessage), optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
-    m.addValidator(transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
-                       generateDummyNonExceptionValidatorFunction<Ts...>(variant),
-                       std::move(validatorExceptionMessage)),
-                   optProxy...);
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
+    m.addValidator(
+        transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
+            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
+            std::move(validatorExceptionMessage)),
+        optProxy...);
   });
 }
 
@@ -1654,15 +1824,16 @@ void doValidatorExceptionTest(
         @brief Check, if a call to the `addValidator` function behaves as
         wanted.
         */
-        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              addAlwaysValidValidatorFunction(m, notValidOption),
-              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-        };
+        auto checkAddValidatorBehavior =
+            [&addAlwaysValidValidatorFunction](
+                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                ConstConfigOptionProxy<T> notValidOption) {
+              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+              AD_EXPECT_THROW_WITH_MESSAGE(
+                  addAlwaysValidValidatorFunction(m, notValidOption),
+                  ::testing::ContainsRegex(
+                      notValidOption.getConfigOption().getIdentifier()));
+            };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1675,30 +1846,50 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption =
+            mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub =
+            mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption =
+            mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption =
+            mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 =
+            mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option =
+            mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 =
+            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option =
+            mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1706,16 +1897,22 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "", validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "",
+                       validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
-                       validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator(
+            [](const Ts&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
+            validatorArguments...);
       });
 }
 
@@ -1736,11 +1933,13 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
-    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
-      return ((options.getValueAsString() == wantedString) && ...);
-    };
-  };
+  auto generateValueAsStringComparison =
+      [](std::string_view valueStringRepresentation) {
+        return [wantedString = std::string(valueStringRepresentation)](
+                   const auto&... options) {
+          return ((options.getValueAsString() == wantedString) && ...);
+        };
+      };
 
   // Variables for configuration options.
   int firstVar;
@@ -1750,58 +1949,75 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "someOption1", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
+                 "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Both options", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-                 "Both options");
+  checkValidator(
+      managerWithNoSubManager,
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
+                                                        &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(managerWithSubManagerWhoHasNoValidators,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-                                   managerWithSubManagerWhoHasNoValidatorsOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
+          "someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Both options",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+      managerWithSubManagerWhoHasNoValidatorsOption);
+  checkValidator(
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerHasNoValidatorsButSubManagerDoesSubManager,
-                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(managerHasNoValidatorsButSubManagerDoes,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
+          "someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerHasNoValidatorsButSubManagerDoesSubManager,
+      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(
+      managerHasNoValidatorsButSubManagerDoes,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1811,40 +2027,49 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
-                                   bothHaveValidators, bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
-                                   bothHaveValidatorsSubManager,
-                                   bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Top manager option", bothHaveValidators,
+                                   bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("20"), "Sub manager option",
+      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction, std::string validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction,
+                         std::string validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage, args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage,
+                             args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
-  doAddOptionValidatorTest([]<typename... Ts>(
-                               auto validatorFunction, std::string validatorExceptionMessage,
-                               ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-    m.addOptionValidator(
-        transformNonExceptionValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
-            validatorFunction, std::move(validatorExceptionMessage)),
-        args...);
-  });
+  doAddOptionValidatorTest(
+      []<typename... Ts>(auto validatorFunction,
+                         std::string validatorExceptionMessage,
+                         ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
+        m.addOptionValidator(
+            transformNonExceptionValidatorIntoExceptionValidator<
+                decltype(args.getConfigOption())...>(
+                validatorFunction, std::move(validatorExceptionMessage)),
+            args...);
+      });
 }
 
 /*
@@ -1869,15 +2094,16 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        addAlwaysValidValidatorFunction(m, notValidOption),
-        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-  };
+  auto checkAddOptionValidatorBehavior =
+      [&addAlwaysValidValidatorFunction]<typename T>(
+          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+          ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            addAlwaysValidValidatorFunction(m, notValidOption),
+            ::testing::ContainsRegex(
+                notValidOption.getConfigOption().getIdentifier()));
+      };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -1892,35 +2118,53 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption =
+      mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption =
+      mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option =
+      mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 =
+      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option =
+      mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
-                             args...);
+        m.addOptionValidator(
+            [](const decltype(args.getConfigOption())&...) { return true; }, "",
+            args...);
       });
 }
 
@@ -1928,9 +2172,8 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
+            [](const decltype(args.getConfigOption())&...)
+                -> std::optional<ErrorMessage> { return {std::nullopt}; },
             args...);
       });
 }
@@ -1944,18 +2187,21 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus = [](const ConfigManager& m,
-                                   const ContainmentStatusVector& optionsAndWantedStatus) {
-    std::ranges::for_each(optionsAndWantedStatus,
-                          [&m](const ContainmentStatusVector::value_type& p) {
-                            if (p.second) {
-                              ASSERT_TRUE(m.containsOption(*p.first));
-                            } else {
-                              ASSERT_FALSE(m.containsOption(*p.first));
-                            }
-                          });
-  };
+  using ContainmentStatusVector =
+      std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus =
+      [](const ConfigManager& m,
+         const ContainmentStatusVector& optionsAndWantedStatus) {
+        std::ranges::for_each(
+            optionsAndWantedStatus,
+            [&m](const ContainmentStatusVector::value_type& p) {
+              if (p.second) {
+                ASSERT_TRUE(m.containsOption(*p.first));
+              } else {
+                ASSERT_FALSE(m.containsOption(*p.first));
+              }
+            });
+      };
 
   // Variable for the configuration options.
   int var;
@@ -1966,68 +2212,87 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
+      {&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 =
+      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option =
+      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -2048,7 +2313,8 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction =
+      decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -2058,66 +2324,88 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
+      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
+                                       std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
+                                       std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
-                                   int, int>);
+            !ad_utility::Validator<
+                decltype([](FirstParameter, SecondParameter) { return true; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 
 TEST(ConfigManagerTest, ExceptionValidatorConcept) {
@@ -2125,87 +2413,126 @@ TEST(ConfigManagerTest, ExceptionValidatorConcept) {
   using SingleIntExceptionValidatorFunction =
       decltype([](const int&) { return std::optional<ErrorMessage>{}; });
   using DoubleIntExceptionValidatorFunction =
-      decltype([](const int&, const int&) { return std::optional<ErrorMessage>{}; });
+      decltype([](const int&, const int&) {
+        return std::optional<ErrorMessage>{};
+      });
 
   // Valid function.
-  static_assert(ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
-  static_assert(ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int>);
+  static_assert(
+      ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
+  static_assert(
+      ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                     int>);
 
   // The number of parameter types is wrong.
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int, int>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int, int, int>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int,
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::string>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
+                                      std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::vector<bool>, int>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
+                                      std::string>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::vector<bool>>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                                std::vector<bool>, std::vector<bool>>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::vector<bool>, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string,
-                                                std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::string, int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      std::string>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
   static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&) { return std::optional<ErrorMessage>{}; }),
-                                      int>);
+      !ad_utility::ExceptionValidator<
+          decltype([](int&) { return std::optional<ErrorMessage>{}; }), int>);
   static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&&) { return std::optional<ErrorMessage>{}; }),
+      !ad_utility::ExceptionValidator<
+          decltype([](int&&) { return std::optional<ErrorMessage>{}; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int&&) {
+                                        return std::optional<ErrorMessage>{};
+                                      }),
                                       int>);
-  static_assert(!ad_utility::ExceptionValidator<
-                decltype([](const int&&) { return std::optional<ErrorMessage>{}; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<decltype([](FirstParameter, SecondParameter) {
-                                                        return std::optional<ErrorMessage>{};
-                                                      }),
-                                                      int, int>);
+        static_assert(!ad_utility::ExceptionValidator<
+                      decltype([](FirstParameter, SecondParameter) {
+                        return std::optional<ErrorMessage>{};
+                      }),
+                      int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int n) { return n; }),
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }),
+                                      int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<
-                      decltype([](FirstParameter n, SecondParameter) { return n; }), int, int>);
+        static_assert(
+            !ad_utility::ExceptionValidator<
+                decltype([](FirstParameter n, SecondParameter) { return n; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }),
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }),
+                                      int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -38,8 +38,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
-                 const bool wasSet, const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
+                 const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -56,16 +56,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(
-      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -74,18 +72,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
-                                &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
-          &notUsed, 42),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -104,8 +98,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
-                        "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -116,8 +109,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -134,9 +126,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -175,32 +166,28 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(
-      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption(
-      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-      &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+                                   &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -219,8 +206,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -238,19 +224,16 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -258,8 +241,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
-                            "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -278,17 +261,15 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s, "manager"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -327,25 +308,22 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(
+      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config
-                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
-                                      "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -354,16 +332,14 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -375,13 +351,10 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s},
-                       "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne =
-      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                       "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo =
-      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                                              "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -414,16 +387,14 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck =
-      [](const nlohmann::json& j, ConfigManager& m,
-         const std::vector<std::pair<int*, int>>& wantedValues) {
-        m.parseConfig(j);
+  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
+                          const std::vector<std::pair<int*, int>>& wantedValues) {
+    m.parseConfig(j);
 
-        std::ranges::for_each(
-            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-              ASSERT_EQ(*wantedValue.first, wantedValue.second);
-            });
-      };
+    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+      ASSERT_EQ(*wantedValue.first, wantedValue.second);
+    });
+  };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -441,16 +412,13 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
-                                         &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
-  parseAndCheck(
-      nlohmann::json::parse(R"--({
+  parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -458,8 +426,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-      managerWithOneSubNoRecursion,
-      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+                managerWithOneSubNoRecursion,
+                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -487,14 +455,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4},
-                 {&daveInfractions, 0},
-                 {&janiceId, 0},
-                 {&janiceInfractions, 6}});
+                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
-                                              &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -516,20 +480,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 =
-      managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 =
-      managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex =
-      managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter =
-      managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -550,10 +510,7 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4},
-                 {&alexInfractions, 0},
-                 {&peterId, 0},
-                 {&peterInfractions, 6}});
+                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -649,11 +606,10 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s},
-                   "Must be set. Has no default value.", &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s},
-                   "Must not be set. Has default value.", &notUsedVector,
-                   {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                   &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                   &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -680,27 +636,20 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_integer)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -708,38 +657,32 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
-                   41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s},
-               "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s},
-               "Must not be set. Has default value.", &notUsedVector, {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
+               {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -750,38 +693,29 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 =
-      config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 =
-      config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.",
-                    &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.",
-                      &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s},
-                      "Must be set. Has no default value.", &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s},
-                      "Must not be set. Has default value.", &notUsedVector,
-                      {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                      &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                      &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -792,15 +726,13 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -812,8 +744,7 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -822,65 +753,59 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.",
-      &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.",
-      &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist =
-      config.addOption("someIntegerlist", "Must be set. Has no default value.",
-                       &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist = config.addOption(
+      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint = config.addOption(
-      "somePositiveFloatingPoint", "Must be set. Has no default value.",
-      &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint =
+      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
+                       &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint = config.addOption(
-      "someNegativFloatingPoint", "Must be set. Has no default value.",
-      &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint =
+      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
+                       &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList = config.addOption(
-      "someFloatingPointList", "Must be set. Has no default value.",
-      &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList =
+      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
+                       &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue = config.addOption(
-      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue =
+      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse = config.addOption(
-      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse =
+      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList =
-      config.addOption("someBooleanList", "Must be set. Has no default value.",
-                       &someBooleanListBoolVector);
+  decltype(auto) someBooleanList = config.addOption(
+      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName = config.addOption(
-      "myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName =
+      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList =
-      config.addOption("someStringList", "Must be set. Has no default value.",
-                       &someStringListStringVector);
+  decltype(auto) someStringList = config.addOption(
+      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption =
-      config.addOption({"depth"s, "here"s, "list"s},
-                       "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption = config.addOption(
+      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -894,22 +819,17 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true,
-              std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
-              4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
-              -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
-              {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true,
-              std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -922,15 +842,13 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
-                                   R"(complicatedKey:42, complicatedKey:43)");
-                               , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
+      , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
-      R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(
-      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -947,8 +865,7 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan =
-      config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -958,12 +875,10 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -975,14 +890,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager,
-                    const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      manager.parseConfig(jsonWithNonValidValues),
-      ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
+                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -992,12 +905,11 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption =
-      m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; },
-                 "'numberInRange' must be <=100.", numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; },
-                 "'numberInRange' must be >=50.", numberInRangeOption);
+  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
+                 numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
+                 numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -1011,15 +923,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption =
-      m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) ||
-               (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
-      boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -1034,16 +943,12 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption =
-      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-      "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
-      nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+                                     "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption =
-      mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -1054,25 +959,19 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter =
-      mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) {
-        return opt.getIdentifier().starts_with('d');
-      },
+      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') &&
-               opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter,
-      wrongLetter);
-  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
-      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter, wrongLetter);
+  ASSERT_ANY_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -1092,8 +991,7 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> ||
-                       std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1134,13 +1032,11 @@ what the exact difference is, see the code in `createDummyValueForValidator`.
 */
 template <typename... ParameterTypes>
 auto generateDummyNonExceptionValidatorFunction(size_t variant) {
-  return [... dummyValuesToCompareTo =
-              createDummyValueForValidator<ParameterTypes>(variant)](
+  return [... dummyValuesToCompareTo = createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {
     // Special handeling for `args` of type bool is needed. For the reasoning:
     // See the doc string.
-    auto compare = []<typename T>(const T& arg,
-                                  const T& dummyValueToCompareTo) {
+    auto compare = []<typename T>(const T& arg, const T& dummyValueToCompareTo) {
       if constexpr (std::is_same_v<T, bool>) {
         return arg == false;
       } else {
@@ -1163,11 +1059,9 @@ functions.
 */
 template <typename... Ts>
 std::string generateValidatorName(size_t id) {
-  return absl::StrCat(
-      "Config manager validator<",
-      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
-                  ", "),
-      "> ", id);
+  return absl::StrCat("Config manager validator<",
+                      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "),
+                      "> ", id);
 };
 
 /*
@@ -1179,19 +1073,16 @@ That is, instead of returning `bool`, it now returns
 */
 template <typename... ValidatorParameterTypes>
 auto transformNonExceptionValidatorIntoExceptionValidator(
-    Validator<ValidatorParameterTypes...> auto validatorFunction,
-    std::string_view errorMessage) {
+    Validator<ValidatorParameterTypes...> auto validatorFunction, std::string errorMessage) {
   // The whole 'transformation' is simply a wrapper.
-  return
-      [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
-          const ValidatorParameterTypes&... args)
-          -> std::optional<ErrorMessage> {
-        if (std::invoke(validatorFunction, args...)) {
-          return std::nullopt;
-        } else {
-          return std::make_optional<ErrorMessage>(errorMessage);
-        }
-      };
+  return [validatorFunction, errorMessage = std::move(errorMessage)](
+             const ValidatorParameterTypes&... args) -> std::optional<ErrorMessage> {
+    if (std::invoke(validatorFunction, args...)) {
+      return std::nullopt;
+    } else {
+      return std::make_optional<ErrorMessage>(errorMessage);
+    }
+  };
 }
 /*
 @brief The test for adding a validator to a config manager.
@@ -1204,9 +1095,8 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(
-    auto addValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(auto addValidatorFunction,
+                     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1231,12 +1121,10 @@ void doValidatorTest(
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes,
-               &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func),
-                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1283,13 +1171,11 @@ void doValidatorTest(
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m,
-          ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(
-        adjustVariantArgument.template operator()<Ts...>(variant),
-        generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
+                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1310,17 +1196,14 @@ void doValidatorTest(
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager =
-      [&adjustVariantArgument]<typename... Ts>(
-          size_t variantStart, size_t variantEnd, ConfigManager & m,
-          const nlohmann::json& defaultValues,
-          const std::same_as<
-              nlohmann::json::json_pointer> auto&... configOptionPaths)
-          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
+      size_t variantStart, size_t variantEnd, ConfigManager & m,
+      const nlohmann::json& defaultValues,
+      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
+      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
-         validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1339,11 +1222,9 @@ void doValidatorTest(
       are all identical.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName<Ts...>(0));
+        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1367,8 +1248,7 @@ void doValidatorTest(
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1378,8 +1258,7 @@ void doValidatorTest(
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1410,10 +1289,8 @@ void doValidatorTest(
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM,
-          const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1424,8 +1301,7 @@ void doValidatorTest(
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1435,8 +1311,7 @@ void doValidatorTest(
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1445,246 +1320,217 @@ void doValidatorTest(
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type>() {
-        // Variables needed for configuration options.
-        Type firstVar;
+  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
+    // Variables needed for configuration options.
+    Type firstVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption =
-            mNoSub.addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue"),
-                           mNoSubOption));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        decltype(auto) mSubNoValidatorOption =
-            mSubNoValidator.addSubManager({"some"s, "manager"s})
-                .addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubNoValidatorOption));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    decltype(auto) mSubNoValidatorOption =
+        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubNoValidatorOption));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption =
-            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubWithValidatorOption));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption =
+        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubWithValidatorOption));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
-        // Variables needed for configuration options.
-        Type1 firstVar;
-        Type2 secondVar;
+  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
+                                                                     typename Type2>() {
+    // Variables needed for configuration options.
+    Type1 firstVar;
+    Type2 secondVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 =
-            mNoSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mNoSubOption2 =
-            mNoSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
-                           mNoSubOption1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
-                           mNoSubOption2));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub =
-            mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubNoValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubNoValidatorOption2));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubNoValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubNoValidatorOption2));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption1 =
-            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubWithValidatorOption2 =
-            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubWithValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubWithValidatorOption2));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption1 =
+        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubWithValidatorOption2 =
+        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubWithValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubWithValidatorOption2));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
-                                       typename Type1, typename Type2>() {
-    // Variables for config options.
-    Type1 var1;
-    Type2 var2;
+  auto doDifferentParameterTests =
+      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
+        // Variables for config options.
+        Type1 var1;
+        Type2 var2;
 
-    /*
-    @brief Helper function, that checks all combinations of valid/invalid values
-    for two single argument parameter validator functions.
+        /*
+        @brief Helper function, that checks all combinations of valid/invalid values
+        for two single argument parameter validator functions.
 
-    @tparam T1, T2 Function parameter type for the first and the second
-    validator.
+        @tparam T1, T2 Function parameter type for the first and the second
+        validator.
 
-    @param m The config manager, on which `parseConfig` will be called on.
-    @param validator1, validator2 A pair consisting of the path to the
-    configuration option, that the validator is looking at, and the `variant`
-    value, that was used to generate the validator function with
-    `addValidatorToConfigManager`.
-    */
-    auto checkAllValidAndInvalidValueCombinations =
-        []<typename T1, typename T2>(
-            ConfigManager& m,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-          /*
-          Input for `parseConfig`. One contains values, that are valid for all
-          validators, the other contains values, that are valid for all
-          validators except one.
-          */
-          nlohmann::json validValueJson(nlohmann::json::value_t::object);
-          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+        @param m The config manager, on which `parseConfig` will be called on.
+        @param validator1, validator2 A pair consisting of the path to the
+        configuration option, that the validator is looking at, and the `variant`
+        value, that was used to generate the validator function with
+        `addValidatorToConfigManager`.
+        */
+        auto checkAllValidAndInvalidValueCombinations =
+            []<typename T1, typename T2>(
+                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+              /*
+              Input for `parseConfig`. One contains values, that are valid for all
+              validators, the other contains values, that are valid for all
+              validators except one.
+              */
+              nlohmann::json validValueJson(nlohmann::json::value_t::object);
+              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-          // Add the valid values.
-          validValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second + 1);
-          validValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second + 1);
+              // Add the valid values.
+              validValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second + 1);
+              validValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second + 1);
 
-          // Value for `validator1` is invalid. Value for `validator2` is valid.
-          invalidValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second);
-          invalidValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second + 1);
-          checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName<Type1>(validator1.second));
+              // Value for `validator1` is invalid. Value for `validator2` is valid.
+              invalidValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second);
+              invalidValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second + 1);
+              checkValidator(m, validValueJson, invalidValueJson,
+                             generateValidatorName<Type1>(validator1.second));
 
-          // Value for `validator1` is valid. Value for `validator2` is invalid.
-          invalidValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second + 1);
-          invalidValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second);
-          checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName<Type2>(validator2.second));
-        };
+              // Value for `validator1` is valid. Value for `validator2` is invalid.
+              invalidValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second + 1);
+              invalidValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second);
+              checkValidator(m, validValueJson, invalidValueJson,
+                             generateValidatorName<Type2>(validator2.second));
+            };
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
-                                                           mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
-                                                           mNoSubOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub =
-        mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mSubNoValidator, mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mSubNoValidator, mSubNoValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
+                                                               mSubNoValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
+                                                               mSubNoValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mSubNoValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
-    // Sub manager has validators of its own, however the manager does not.
-    ConfigManager mNoValidatorSubValidator;
-    ConfigManager& mNoValidatorSubValidatorSub =
-        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mNoValidatorSubValidatorOption1 =
-        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mNoValidatorSubValidatorOption2 =
-        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        // Sub manager has validators of its own, however the manager does not.
+        ConfigManager mNoValidatorSubValidator;
+        ConfigManager& mNoValidatorSubValidatorSub =
+            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mNoValidatorSubValidatorOption1 =
+            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mNoValidatorSubValidatorOption2 =
+            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
+                                                               mNoValidatorSubValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
+                                                               mNoValidatorSubValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mNoValidatorSubValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
-    // Sub manager has validators of its own, as does the manager.
-    ConfigManager mValidatorSubValidator;
-    ConfigManager& mValidatorSubValidatorSub =
-        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mValidatorSubValidatorOption1 =
-        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mValidatorSubValidatorOption2 =
-        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
-  };
+        // Sub manager has validators of its own, as does the manager.
+        ConfigManager mValidatorSubValidator;
+        ConfigManager& mValidatorSubValidatorSub =
+            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mValidatorSubValidatorOption1 =
+            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mValidatorSubValidatorOption2 =
+            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
+                                                               mValidatorSubValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
+                                                               mValidatorSubValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mValidatorSubValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1698,103 +1544,85 @@ void doValidatorTest(
 
   // Default values.
   const std::string defaultValue = "This is the default value.";
-  constexpr std::string_view defaultExceptionMessage =
-      "Default exception message";
+  const std::string defaultExceptionMessage = "Default exception message";
 
   // Add the validator and check, if the configuration option with it's current
   // value is in the exception message for failing the validator.
-  auto doExceptionMessageTest =
-      [&addValidatorFunction, &defaultExceptionMessage](
-          size_t variantNumber, ConfigManager& managerToRunParseOn,
-          ConfigManager& managerToAddValidatorTo,
-          ConstConfigOptionProxy<std::string> option,
-          const nlohmann::json::json_pointer& pathToOption) {
-        // The value, which causes the automaticly generated validator with the
-        // given variant to fail.
-        const std::string& failValue =
-            createDummyValueForValidator<std::string>(variantNumber);
+  auto doExceptionMessageTest = [&addValidatorFunction, &defaultExceptionMessage](
+                                    size_t variantNumber, ConfigManager& managerToRunParseOn,
+                                    ConfigManager& managerToAddValidatorTo,
+                                    ConstConfigOptionProxy<std::string> option,
+                                    const nlohmann::json::json_pointer& pathToOption) {
+    // The value, which causes the automaticly generated validator with the
+    // given variant to fail.
+    const std::string& failValue = createDummyValueForValidator<std::string>(variantNumber);
 
-        nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
-        jsonForParsing[pathToOption] = failValue;
+    nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
+    jsonForParsing[pathToOption] = failValue;
 
-        // Adding the validator and checking.
-        std::invoke(addValidatorFunction, variantNumber,
-                    defaultExceptionMessage, managerToAddValidatorTo, option);
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            managerToRunParseOn.parseConfig(jsonForParsing),
-            ::testing::ContainsRegex(
-                absl::StrCat("value '\"", failValue, "\"'")));
-      };
+    // Adding the validator and checking.
+    std::invoke(addValidatorFunction, variantNumber, defaultExceptionMessage,
+                managerToAddValidatorTo, option);
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        managerToRunParseOn.parseConfig(jsonForParsing),
+        ::testing::ContainsRegex(absl::StrCat("value '\"", failValue, "\"'")));
+  };
 
   // No sub manager.
   ConfigManager mNoSub;
-  decltype(auto) mNoSubOption1 =
-      mNoSub.addOption("someValue1", "", &string0, defaultValue);
+  decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &string0, defaultValue);
   doExceptionMessageTest(10, mNoSub, mNoSub, mNoSubOption1,
                          nlohmann::json::json_pointer("/someValue1"));
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager mSubNoValidator;
-  ConfigManager& mSubNoValidatorSub =
-      mSubNoValidator.addSubManager({"some"s, "manager"s});
+  ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mSubNoValidatorOption1 =
       mSubNoValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(
-      10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
-      nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager mNoValidatorSubValidator;
   ConfigManager& mNoValidatorSubValidatorSub =
       mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mNoValidatorSubValidatorOption1 =
-      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0,
-                                            defaultValue);
-  doExceptionMessageTest(
-      10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
-      mNoValidatorSubValidatorOption1,
-      nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+  doExceptionMessageTest(10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
+                         mNoValidatorSubValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager mValidatorSubValidator;
   ConfigManager& mValidatorSubValidatorSub =
       mValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mValidatorSubValidatorOption1 =
-      mValidatorSubValidatorSub.addOption("someValue1", "", &string0,
-                                          defaultValue);
+      mValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
   decltype(auto) mValidatorSubValidatorOption2 =
-      mValidatorSubValidatorSub.addOption("someValue2", "", &string1,
-                                          defaultValue);
-  doExceptionMessageTest(
-      4, mValidatorSubValidator, mValidatorSubValidator,
-      mValidatorSubValidatorOption1,
-      nlohmann::json::json_pointer("/some/manager/someValue1"));
-  doExceptionMessageTest(
-      5, mValidatorSubValidator, mValidatorSubValidatorSub,
-      mValidatorSubValidatorOption2,
-      nlohmann::json::json_pointer("/some/manager/someValue2"));
+      mValidatorSubValidatorSub.addOption("someValue2", "", &string1, defaultValue);
+  doExceptionMessageTest(4, mValidatorSubValidator, mValidatorSubValidator,
+                         mValidatorSubValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(5, mValidatorSubValidator, mValidatorSubValidatorSub,
+                         mValidatorSubValidatorOption2,
+                         nlohmann::json::json_pointer("/some/manager/someValue2"));
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant,
-                                     std::string_view validatorExceptionMessage,
-                                     ConfigManager& m,
-                                     ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
+                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
-                   validatorExceptionMessage, optProxy...);
+                   std::string(validatorExceptionMessage), optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant,
-                                     std::string_view validatorExceptionMessage,
-                                     ConfigManager& m,
-                                     ConstConfigOptionProxy<Ts>... optProxy) {
-    m.addValidator(
-        transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
-            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
-            validatorExceptionMessage),
-        optProxy...);
+  doValidatorTest([]<typename... Ts>(size_t variant, std::string validatorExceptionMessage,
+                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+    m.addValidator(transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
+                       generateDummyNonExceptionValidatorFunction<Ts...>(variant),
+                       std::move(validatorExceptionMessage)),
+                   optProxy...);
   });
 }
 
@@ -1826,16 +1654,15 @@ void doValidatorExceptionTest(
         @brief Check, if a call to the `addValidator` function behaves as
         wanted.
         */
-        auto checkAddValidatorBehavior =
-            [&addAlwaysValidValidatorFunction](
-                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                ConstConfigOptionProxy<T> notValidOption) {
-              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-              AD_EXPECT_THROW_WITH_MESSAGE(
-                  addAlwaysValidValidatorFunction(m, notValidOption),
-                  ::testing::ContainsRegex(
-                      notValidOption.getConfigOption().getIdentifier()));
-            };
+        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
+                                             ConfigManager& m,
+                                             ConstConfigOptionProxy<T> validOption,
+                                             ConstConfigOptionProxy<T> notValidOption) {
+          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+          AD_EXPECT_THROW_WITH_MESSAGE(
+              addAlwaysValidValidatorFunction(m, notValidOption),
+              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+        };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1848,50 +1675,30 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption =
-            mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub =
-            mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption =
-            mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption =
-            mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 =
-            mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option =
-            mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 =
-            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option =
-            mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1899,22 +1706,16 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m,
-                         ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "",
-                       validatorArguments...);
+      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "", validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m,
-                         ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator(
-            [](const Ts&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
-            validatorArguments...);
+      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
+                       validatorArguments...);
       });
 }
 
@@ -1935,13 +1736,11 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison =
-      [](std::string_view valueStringRepresentation) {
-        return [wantedString = std::string(valueStringRepresentation)](
-                   const auto&... options) {
-          return ((options.getValueAsString() == wantedString) && ...);
-        };
-      };
+  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
+    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
+      return ((options.getValueAsString() == wantedString) && ...);
+    };
+  };
 
   // Variables for configuration options.
   int firstVar;
@@ -1951,75 +1750,58 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "someOption1", managerWithNoSubManager,
-                                   managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
-                 "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
+                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "Both options", managerWithNoSubManager,
-                                   managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
+                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(
-      managerWithNoSubManager,
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-      "Both options");
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+                 "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
-                                                        &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager(
-          {"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
-          "someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Sub manager option",
-      managerWithSubManagerWhoHasNoValidators,
-      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
+                                   managerWithSubManagerWhoHasNoValidators,
+                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+  checkValidator(managerWithSubManagerWhoHasNoValidators,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
+                                   managerWithSubManagerWhoHasNoValidators,
+                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+                                   managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Both options",
-      managerWithSubManagerWhoHasNoValidators,
-      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-      managerWithSubManagerWhoHasNoValidatorsOption);
-  checkValidator(
-      managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager(
-          {"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
-          "someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Sub manager option",
-      managerHasNoValidatorsButSubManagerDoesSubManager,
-      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(
-      managerHasNoValidatorsButSubManagerDoes,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
+                                   managerHasNoValidatorsButSubManagerDoesSubManager,
+                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(managerHasNoValidatorsButSubManagerDoes,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -2029,49 +1811,40 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "Top manager option", bothHaveValidators,
-                                   bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("20"), "Sub manager option",
-      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
+                                   bothHaveValidators, bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
+                                   bothHaveValidatorsSubManager,
+                                   bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction,
-                         std::string_view validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction, std::string validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage,
-                             args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage, args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
-  doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction,
-                         std::string_view validatorExceptionMessage,
-                         ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(
-            transformNonExceptionValidatorIntoExceptionValidator<
-                decltype(args.getConfigOption())...>(validatorFunction,
-                                                     validatorExceptionMessage),
-            args...);
-      });
+  doAddOptionValidatorTest([]<typename... Ts>(
+                               auto validatorFunction, std::string validatorExceptionMessage,
+                               ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
+    m.addOptionValidator(
+        transformNonExceptionValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
+            validatorFunction, std::move(validatorExceptionMessage)),
+        args...);
+  });
 }
 
 /*
@@ -2096,16 +1869,15 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior =
-      [&addAlwaysValidValidatorFunction]<typename T>(
-          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-          ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            addAlwaysValidValidatorFunction(m, notValidOption),
-            ::testing::ContainsRegex(
-                notValidOption.getConfigOption().getIdentifier()));
-      };
+  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
+                                             ConfigManager& m,
+                                             ConstConfigOptionProxy<T> validOption,
+                                             ConstConfigOptionProxy<T> notValidOption) {
+    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        addAlwaysValidValidatorFunction(m, notValidOption),
+        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+  };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -2120,53 +1892,35 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption =
-      mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption =
-      mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option =
-      mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 =
-      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option =
-      mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) { return true; }, "",
-            args...);
+        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
+                             args...);
       });
 }
 
@@ -2174,8 +1928,9 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...)
-                -> std::optional<ErrorMessage> { return {std::nullopt}; },
+            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
             args...);
       });
 }
@@ -2189,21 +1944,18 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector =
-      std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus =
-      [](const ConfigManager& m,
-         const ContainmentStatusVector& optionsAndWantedStatus) {
-        std::ranges::for_each(
-            optionsAndWantedStatus,
-            [&m](const ContainmentStatusVector::value_type& p) {
-              if (p.second) {
-                ASSERT_TRUE(m.containsOption(*p.first));
-              } else {
-                ASSERT_FALSE(m.containsOption(*p.first));
-              }
-            });
-      };
+  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus = [](const ConfigManager& m,
+                                   const ContainmentStatusVector& optionsAndWantedStatus) {
+    std::ranges::for_each(optionsAndWantedStatus,
+                          [&m](const ContainmentStatusVector::value_type& p) {
+                            if (p.second) {
+                              ASSERT_TRUE(m.containsOption(*p.first));
+                            } else {
+                              ASSERT_FALSE(m.containsOption(*p.first));
+                            }
+                          });
+  };
 
   // Variable for the configuration options.
   int var;
@@ -2214,87 +1966,68 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
-      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 =
-      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option =
-      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -2315,8 +2048,7 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction =
-      decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -2326,88 +2058,66 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
-                                       std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, std::vector<bool>>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
-                                       std::string>);
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(
-      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<
-                decltype([](FirstParameter, SecondParameter) { return true; }),
-                int, int>);
+            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
+                                   int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 
 TEST(ConfigManagerTest, ExceptionValidatorConcept) {
@@ -2415,126 +2125,87 @@ TEST(ConfigManagerTest, ExceptionValidatorConcept) {
   using SingleIntExceptionValidatorFunction =
       decltype([](const int&) { return std::optional<ErrorMessage>{}; });
   using DoubleIntExceptionValidatorFunction =
-      decltype([](const int&, const int&) {
-        return std::optional<ErrorMessage>{};
-      });
+      decltype([](const int&, const int&) { return std::optional<ErrorMessage>{}; });
 
   // Valid function.
-  static_assert(
-      ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
-  static_assert(
-      ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                     int>);
+  static_assert(ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
+  static_assert(ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int>);
 
   // The number of parameter types is wrong.
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int, int>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
-  static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int,
-                                      int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                      int, int, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
-                                      std::vector<bool>>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::string>);
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
-                                      std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::vector<bool>, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::vector<bool>, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::vector<bool>>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                                std::vector<bool>, std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                      std::vector<bool>>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::vector<bool>, std::vector<bool>>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::string, int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
-                                      std::string>);
-  static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                      std::string, std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string,
+                                                std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
   static_assert(
-      !ad_utility::ExceptionValidator<
-          decltype([](int&) { return std::optional<ErrorMessage>{}; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<
-          decltype([](int&&) { return std::optional<ErrorMessage>{}; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int&&) {
-                                        return std::optional<ErrorMessage>{};
-                                      }),
+      !ad_utility::ExceptionValidator<decltype([](int&) { return std::optional<ErrorMessage>{}; }),
                                       int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int&&) { return std::optional<ErrorMessage>{}; }),
+                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<
+                decltype([](const int&&) { return std::optional<ErrorMessage>{}; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<
-                      decltype([](FirstParameter, SecondParameter) {
-                        return std::optional<ErrorMessage>{};
-                      }),
-                      int, int>);
+        static_assert(!ad_utility::ExceptionValidator<decltype([](FirstParameter, SecondParameter) {
+                                                        return std::optional<ErrorMessage>{};
+                                                      }),
+                                                      int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int n) { return n; }),
-                                      int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }),
-                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(
-            !ad_utility::ExceptionValidator<
-                decltype([](FirstParameter n, SecondParameter) { return n; }),
-                int, int>);
+        static_assert(!ad_utility::ExceptionValidator<
+                      decltype([](FirstParameter n, SecondParameter) { return n; }), int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }),
-                                      int>);
-  static_assert(
-      !ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }),
-                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1188,7 +1188,7 @@ auto transformNonExceptionValidatorIntoExceptionValidator(
         if (std::invoke(validatorFunction, args...)) {
           return std::nullopt;
         } else {
-          return ErrorMessage{errorMessage};
+          return std::make_optional<ErrorMessage>(errorMessage);
         }
       };
 }

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -33,8 +33,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
-                 const bool wasSet, const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
+                 const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -51,16 +51,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(
-      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -69,18 +67,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
-                                &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
-          &notUsed, 42),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -99,8 +93,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
-                        "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -111,8 +104,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -129,9 +121,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -170,32 +161,28 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(
-      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption(
-      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-      &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+                                   &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -214,8 +201,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -233,19 +219,16 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -253,8 +236,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
-                            "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -273,17 +256,15 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s, "manager"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -322,25 +303,22 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(
+      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config
-                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
-                                      "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -349,16 +327,14 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -370,13 +346,10 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s},
-                       "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne =
-      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                       "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo =
-      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                                              "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -409,16 +382,14 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck =
-      [](const nlohmann::json& j, ConfigManager& m,
-         const std::vector<std::pair<int*, int>>& wantedValues) {
-        m.parseConfig(j);
+  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
+                          const std::vector<std::pair<int*, int>>& wantedValues) {
+    m.parseConfig(j);
 
-        std::ranges::for_each(
-            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-              ASSERT_EQ(*wantedValue.first, wantedValue.second);
-            });
-      };
+    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+      ASSERT_EQ(*wantedValue.first, wantedValue.second);
+    });
+  };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -436,16 +407,13 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
-                                         &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
-  parseAndCheck(
-      nlohmann::json::parse(R"--({
+  parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -453,8 +421,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-      managerWithOneSubNoRecursion,
-      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+                managerWithOneSubNoRecursion,
+                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -482,14 +450,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4},
-                 {&daveInfractions, 0},
-                 {&janiceId, 0},
-                 {&janiceInfractions, 6}});
+                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
-                                              &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -511,20 +475,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 =
-      managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 =
-      managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex =
-      managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter =
-      managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -545,10 +505,7 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4},
-                 {&alexInfractions, 0},
-                 {&peterId, 0},
-                 {&peterInfractions, 6}});
+                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -644,11 +601,10 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s},
-                   "Must be set. Has no default value.", &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s},
-                   "Must not be set. Has default value.", &notUsedVector,
-                   {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                   &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                   &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -675,27 +631,20 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_integer)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -703,38 +652,32 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
-                   41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s},
-               "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s},
-               "Must not be set. Has default value.", &notUsedVector, {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
+               {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -745,38 +688,29 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 =
-      config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 =
-      config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.",
-                    &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.",
-                      &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s},
-                      "Must be set. Has no default value.", &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s},
-                      "Must not be set. Has default value.", &notUsedVector,
-                      {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                      &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                      &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -787,15 +721,13 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -807,8 +739,7 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -817,65 +748,59 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.",
-      &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.",
-      &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist =
-      config.addOption("someIntegerlist", "Must be set. Has no default value.",
-                       &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist = config.addOption(
+      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint = config.addOption(
-      "somePositiveFloatingPoint", "Must be set. Has no default value.",
-      &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint =
+      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
+                       &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint = config.addOption(
-      "someNegativFloatingPoint", "Must be set. Has no default value.",
-      &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint =
+      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
+                       &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList = config.addOption(
-      "someFloatingPointList", "Must be set. Has no default value.",
-      &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList =
+      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
+                       &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue = config.addOption(
-      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue =
+      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse = config.addOption(
-      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse =
+      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList =
-      config.addOption("someBooleanList", "Must be set. Has no default value.",
-                       &someBooleanListBoolVector);
+  decltype(auto) someBooleanList = config.addOption(
+      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName = config.addOption(
-      "myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName =
+      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList =
-      config.addOption("someStringList", "Must be set. Has no default value.",
-                       &someStringListStringVector);
+  decltype(auto) someStringList = config.addOption(
+      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption =
-      config.addOption({"depth"s, "here"s, "list"s},
-                       "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption = config.addOption(
+      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -889,22 +814,17 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true,
-              std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
-              4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
-              -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
-              {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true,
-              std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -917,15 +837,13 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
-                                   R"(complicatedKey:42, complicatedKey:43)");
-                               , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
+      , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
-      R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(
-      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -942,8 +860,7 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan =
-      config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -953,12 +870,10 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -970,14 +885,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager,
-                    const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      manager.parseConfig(jsonWithNonValidValues),
-      ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
+                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator`.
@@ -987,12 +900,11 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption =
-      m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; },
-                 "'numberInRange' must be <=100.", numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; },
-                 "'numberInRange' must be >=50.", numberInRangeOption);
+  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
+                 numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
+                 numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -1006,15 +918,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption =
-      m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) ||
-               (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
-      boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -1029,16 +938,12 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption =
-      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-      "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
-      nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+                                     "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption =
-      mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -1049,25 +954,19 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter =
-      mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) {
-        return opt.getIdentifier().starts_with('d');
-      },
+      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') &&
-               opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter,
-      wrongLetter);
-  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
-      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter, wrongLetter);
+  ASSERT_ANY_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -1087,8 +986,7 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> ||
-                       std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1123,10 +1021,8 @@ what the exact difference is, see the code.
 */
 template <typename ParameterType>
 auto generateSingleParameterValidatorFunction(size_t variant) {
-  if constexpr (std::is_same_v<ParameterType, bool> ||
-                std::is_same_v<ParameterType, std::string> ||
-                std::is_same_v<ParameterType, int> ||
-                std::is_same_v<ParameterType, size_t> ||
+  if constexpr (std::is_same_v<ParameterType, bool> || std::is_same_v<ParameterType, std::string> ||
+                std::is_same_v<ParameterType, int> || std::is_same_v<ParameterType, size_t> ||
                 std::is_same_v<ParameterType, float>) {
     return [compareTo = createDummyValueForValidator<ParameterType>(variant)](
                const ParameterType& n) { return n != compareTo; };
@@ -1142,8 +1038,8 @@ auto generateSingleParameterValidatorFunction(size_t variant) {
       }
 
       for (size_t i = 0; i < variant + 1; i++) {
-        if (generateSingleParameterValidatorFunction<
-                typename ParameterType::value_type>(i)(v.at(i))) {
+        if (generateSingleParameterValidatorFunction<typename ParameterType::value_type>(i)(
+                v.at(i))) {
           return true;
         }
       }
@@ -1175,12 +1071,10 @@ TEST(ConfigManagerTest, AddValidator) {
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes,
-               &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func),
-                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1196,8 +1090,7 @@ TEST(ConfigManagerTest, AddValidator) {
   @tparam T Same `T` as for `createDummyValueForValidator` and
   `generateSingleParameterValidatorFunction`.
   */
-  auto adjustVariantArgument =
-      []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
+  auto adjustVariantArgument = []<typename T>(size_t variantThatNeedsPossibleAdjustment) -> size_t {
     if constexpr (std::is_same_v<T, bool>) {
       /*
       Even numbers for `variant` always result in true, regardless if
@@ -1223,9 +1116,7 @@ TEST(ConfigManagerTest, AddValidator) {
   auto generateValidatorName = []<typename... Ts>(size_t id) {
     return absl::StrCat(
         "Config manager validator<",
-        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
-                    ", "),
-        "> ", id);
+        lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), "> ", id);
   };
 
   /*
@@ -1243,19 +1134,16 @@ TEST(ConfigManagerTest, AddValidator) {
   */
   auto addValidatorToConfigManager =
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
-          size_t variant, ConfigManager & m,
-          ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
     m.addValidator(
         [variant, &adjustVariantArgument](const Ts&... args) {
           return (generateSingleParameterValidatorFunction<Ts>(
-                      adjustVariantArgument.template operator()<Ts>(variant))(
-                      args) ||
+                      adjustVariantArgument.template operator()<Ts>(variant))(args) ||
                   ...);
         },
-        generateValidatorName.template operator()<Ts...>(variant),
-        validatorArguments...);
+        generateValidatorName.template operator()<Ts...>(variant), validatorArguments...);
   };
 
   /*
@@ -1280,13 +1168,11 @@ TEST(ConfigManagerTest, AddValidator) {
       [&generateValidatorName, &adjustVariantArgument ]<typename... Ts>(
           size_t variantStart, size_t variantEnd, ConfigManager & m,
           const nlohmann::json& defaultValues,
-          const std::same_as<
-              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
           requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
-         validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1308,9 +1194,8 @@ TEST(ConfigManagerTest, AddValidator) {
         checkValidator(m, validJson, invalidJson,
                        generateValidatorName.template operator()<Ts...>(0));
       } else {
-        checkValidator(
-            m, validJson, invalidJson,
-            generateValidatorName.template operator()<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName.template operator()<Ts...>(validatorNumber));
       }
     }
   };
@@ -1334,8 +1219,7 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1345,8 +1229,7 @@ TEST(ConfigManagerTest, AddValidator) {
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1377,10 +1260,8 @@ TEST(ConfigManagerTest, AddValidator) {
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM,
-          const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1391,8 +1272,7 @@ TEST(ConfigManagerTest, AddValidator) {
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1402,8 +1282,7 @@ TEST(ConfigManagerTest, AddValidator) {
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1412,116 +1291,97 @@ TEST(ConfigManagerTest, AddValidator) {
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type>() {
-        // Variables needed for configuration options.
-        Type firstVar;
+  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
+    // Variables needed for configuration options.
+    Type firstVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption =
-            mNoSub.addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue"),
-                           mNoSubOption));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        decltype(auto) mSubNoValidatorOption =
-            mSubNoValidator.addSubManager({"some"s, "manager"s})
-                .addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubNoValidatorOption));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    decltype(auto) mSubNoValidatorOption =
+        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubNoValidatorOption));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption =
-            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubWithValidatorOption));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption =
+        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubWithValidatorOption));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
-        // Variables needed for configuration options.
-        Type1 firstVar;
-        Type2 secondVar;
+  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
+                                                                     typename Type2>() {
+    // Variables needed for configuration options.
+    Type1 firstVar;
+    Type2 secondVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 =
-            mNoSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mNoSubOption2 =
-            mNoSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
-                           mNoSubOption1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
-                           mNoSubOption2));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub =
-            mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubNoValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubNoValidatorOption2));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubNoValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubNoValidatorOption2));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption1 =
-            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubWithValidatorOption2 =
-            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubWithValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubWithValidatorOption2));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption1 =
+        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubWithValidatorOption2 =
+        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubWithValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubWithValidatorOption2));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1529,8 +1389,7 @@ TEST(ConfigManagerTest, AddValidator) {
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
   auto doDifferentParameterTests = [&addValidatorToConfigManager,
-                                    &generateValidatorName]<typename Type1,
-                                                            typename Type2>() {
+                                    &generateValidatorName]<typename Type1, typename Type2>() {
     // Variables for config options.
     Type1 var1;
     Type2 var2;
@@ -1550,8 +1409,7 @@ TEST(ConfigManagerTest, AddValidator) {
     */
     auto checkAllValidAndInvalidValueCombinations =
         [&generateValidatorName]<typename T1, typename T2>(
-            ConfigManager& m,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
             const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
           /*
           Input for `parseConfig`. One contains values, that are valid for all
@@ -1573,8 +1431,7 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second + 1);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type1>(
-                             validator1.second));
+                         generateValidatorName.template operator()<Type1>(validator1.second));
 
           // Value for `validator1` is valid. Value for `validator2` is invalid.
           invalidValueJson[validator1.first] =
@@ -1582,40 +1439,32 @@ TEST(ConfigManagerTest, AddValidator) {
           invalidValueJson[validator2.first] =
               createDummyValueForValidator<Type2>(validator2.second);
           checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName.template operator()<Type2>(
-                             validator2.second));
+                         generateValidatorName.template operator()<Type2>(validator2.second));
         };
 
     // No sub manager.
     ConfigManager mNoSub;
     decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
-                                                           mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
-                                                           mNoSubOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
         std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
     // With sub manager. Sub manager has no validators of its own.
     ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub =
-        mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mSubNoValidator, mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mSubNoValidator, mSubNoValidatorOption2);
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 = mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 = mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
+                                                           mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
+                                                           mSubNoValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
     // Sub manager has validators of its own, however the manager does not.
     ConfigManager mNoValidatorSubValidator;
@@ -1625,16 +1474,14 @@ TEST(ConfigManagerTest, AddValidator) {
         mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mNoValidatorSubValidatorOption2 =
         mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
+                                                           mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
+                                                           mNoValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
     // Sub manager has validators of its own, as does the manager.
     ConfigManager mValidatorSubValidator;
@@ -1644,16 +1491,14 @@ TEST(ConfigManagerTest, AddValidator) {
         mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
     decltype(auto) mValidatorSubValidatorOption2 =
         mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
+                                                           mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
+                                                           mValidatorSubValidatorOption2);
     checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
         mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
   };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
@@ -1675,19 +1520,15 @@ TEST(ConfigManagerTest, AddValidatorException) {
     /*
     @brief Check, if a call to the `addValidator` function behaves as wanted.
     */
-    auto checkAddValidatorBehavior =
-        [&validatorDummyFunction](ConfigManager& m,
-                                  ConstConfigOptionProxy<T> validOption,
-                                  ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(
-              m.addValidator(validatorDummyFunction, "", validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              m.addValidator(validatorDummyFunction,
-                             notValidOption.getConfigOption().getIdentifier(),
-                             notValidOption),
-              ::testing::ContainsRegex(
-                  notValidOption.getConfigOption().getIdentifier()));
-        };
+    auto checkAddValidatorBehavior = [&validatorDummyFunction](
+                                         ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                                         ConstConfigOptionProxy<T> notValidOption) {
+      ASSERT_NO_THROW(m.addValidator(validatorDummyFunction, "", validOption));
+      AD_EXPECT_THROW_WITH_MESSAGE(
+          m.addValidator(validatorDummyFunction, notValidOption.getConfigOption().getIdentifier(),
+                         notValidOption),
+          ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+    };
 
     // An outside configuration option.
     ConfigOption outsideOption("outside", "", &var);
@@ -1700,46 +1541,30 @@ TEST(ConfigManagerTest, AddValidatorException) {
 
     // With sub manager.
     ConfigManager mWithSub;
-    decltype(auto) mWithSubOption =
-        mWithSub.addOption("someTopOption", "", &var);
+    decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
     ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWithSubSubOption =
-        mWithSubSub.addOption("someSubOption", "", &var);
+    decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
     checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
     checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                              outsideOptionProxy);
+    checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
     checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
     // With 2 sub manager.
     ConfigManager mWith2Sub;
-    decltype(auto) mWith2SubOption =
-        mWith2Sub.addOption("someTopOption", "", &var);
-    ConfigManager& mWith2SubSub1 =
-        mWith2Sub.addSubManager({"Some"s, "manager"s});
-    decltype(auto) mWith2SubSub1Option =
-        mWith2SubSub1.addOption("someSubOption1", "", &var);
-    ConfigManager& mWith2SubSub2 =
-        mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-    decltype(auto) mWith2SubSub2Option =
-        mWith2SubSub2.addOption("someSubOption2", "", &var);
+    decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+    ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+    decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+    ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+    decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
     checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                              mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                              mWith2SubSub2Option);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                              outsideOptionProxy);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                              mWith2SubOption);
-    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                              mWith2SubSub1Option);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+    checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
   };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1748,13 +1573,11 @@ TEST(ConfigManagerTest, AddValidatorException) {
 TEST(ConfigManagerTest, AddOptionValidator) {
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison =
-      [](std::string_view valueStringRepresentation) {
-        return [wantedString = std::string(valueStringRepresentation)](
-                   const auto&... options) {
-          return ((options.getValueAsString() == wantedString) && ...);
-        };
-      };
+  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
+    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
+      return ((options.getValueAsString() == wantedString) && ...);
+    };
+  };
 
   // Variables for configuration options.
   int firstVar;
@@ -1764,71 +1587,58 @@ TEST(ConfigManagerTest, AddOptionValidator) {
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  managerWithNoSubManager.addOptionValidator(
-      generateValueAsStringComparison("10"), "someOption1",
-      managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
-                 "someOption1");
+  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "someOption1",
+                                             managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  managerWithNoSubManager.addOptionValidator(
-      generateValueAsStringComparison("10"), "Both options",
-      managerWithNoSubManagerOption1, managerWithNoSubManagerOption2);
-  checkValidator(
-      managerWithNoSubManager,
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-      "Both options");
+  managerWithNoSubManager.addOptionValidator(generateValueAsStringComparison("10"), "Both options",
+                                             managerWithNoSubManagerOption1,
+                                             managerWithNoSubManagerOption2);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+                 "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
-                                                        &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager(
-          {"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
-          "someOption", "", &secondVar, 4);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(
-      managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+  checkValidator(managerWithSubManagerWhoHasNoValidators,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
   managerWithSubManagerWhoHasNoValidators.addOptionValidator(
       generateValueAsStringComparison("10"), "Both options",
       managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
       managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager(
-          {"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
-          "someOption", "", &firstVar, 4);
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
   managerHasNoValidatorsButSubManagerDoesSubManager.addOptionValidator(
       generateValueAsStringComparison("10"), "Sub manager option",
       managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(
-      managerHasNoValidatorsButSubManagerDoes,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+  checkValidator(managerHasNoValidatorsButSubManagerDoes,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1838,25 +1648,20 @@ TEST(ConfigManagerTest, AddOptionValidator) {
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"),
-                                        "Top manager option",
+  bothHaveValidators.addOptionValidator(generateValueAsStringComparison("10"), "Top manager option",
                                         bothHaveValidatorsOption);
-  bothHaveValidatorsSubManager.addOptionValidator(
-      generateValueAsStringComparison("20"), "Sub manager option",
-      bothHaveValidatorsSubManagerOption);
+  bothHaveValidatorsSubManager.addOptionValidator(generateValueAsStringComparison("20"),
+                                                  "Sub manager option",
+                                                  bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
@@ -1872,18 +1677,13 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   wanted.
   */
   auto checkAddOptionValidatorBehavior =
-      [&validatorDummyFunction]<typename T>(
-          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-          ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(
-            m.addOptionValidator(validatorDummyFunction, "", validOption));
+      [&validatorDummyFunction]<typename T>(ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                                            ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(m.addOptionValidator(validatorDummyFunction, "", validOption));
         AD_EXPECT_THROW_WITH_MESSAGE(
-            m.addOptionValidator(
-                validatorDummyFunction,
-                notValidOption.getConfigOption().getIdentifier(),
-                notValidOption),
-            ::testing::ContainsRegex(
-                notValidOption.getConfigOption().getIdentifier()));
+            m.addOptionValidator(validatorDummyFunction,
+                                 notValidOption.getConfigOption().getIdentifier(), notValidOption),
+            ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
       };
 
   // An outside configuration option.
@@ -1899,45 +1699,28 @@ TEST(ConfigManagerTest, AddOptionValidatorException) {
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption =
-      mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption =
-      mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option =
-      mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 =
-      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option =
-      mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, ContainsOption) {
@@ -1949,21 +1732,18 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector =
-      std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus =
-      [](const ConfigManager& m,
-         const ContainmentStatusVector& optionsAndWantedStatus) {
-        std::ranges::for_each(
-            optionsAndWantedStatus,
-            [&m](const ContainmentStatusVector::value_type& p) {
-              if (p.second) {
-                ASSERT_TRUE(m.containsOption(*p.first));
-              } else {
-                ASSERT_FALSE(m.containsOption(*p.first));
-              }
-            });
-      };
+  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus = [](const ConfigManager& m,
+                                   const ContainmentStatusVector& optionsAndWantedStatus) {
+    std::ranges::for_each(optionsAndWantedStatus,
+                          [&m](const ContainmentStatusVector::value_type& p) {
+                            if (p.second) {
+                              ASSERT_TRUE(m.containsOption(*p.first));
+                            } else {
+                              ASSERT_FALSE(m.containsOption(*p.first));
+                            }
+                          });
+  };
 
   // Variable for the configuration options.
   int var;
@@ -1974,87 +1754,68 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
-      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 =
-      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option =
-      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -2075,8 +1836,7 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction =
-      decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -2086,87 +1846,154 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+
+  // Function is valid, but the parameter types are of the wrong object type.
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
+
+  // The given function is not valid.
+
+  // The parameter types of the function are wrong, but the return type is
+  // correct.
+  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+
+  auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
+      []<typename FirstParameter, typename SecondParameter>() {
+        static_assert(
+            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
+                                   int, int>);
+      };
+  passCartesianPorductToLambda<
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+
+  // Parameter types are correct, but return type is wrong.
+  static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+
+  auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
+      []<typename FirstParameter, typename SecondParameter>() {
+        static_assert(
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+                                   int, int>);
+      };
+  passCartesianPorductToLambda<
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+
+  // Both the parameter types and the return type is wrong.
+  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+
+  auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
+      []<typename FirstParameter, typename SecondParameter>() {
+        static_assert(
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+                                   int, int>);
+      };
+  passCartesianPorductToLambda<
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+}
+
+TEST(ConfigManagerTest, ExceptionValidatorConcept) {
+  // Lambda function types for easier test creation.
+  using SingleIntExceptionValidatorFunction =
+      decltype([](const int&) { return std::optional<ErrorMessage>{}; });
+  using DoubleIntExceptionValidatorFunction =
+      decltype([](const int&, const int&) { return std::optional<ErrorMessage>{}; });
+
+  // Valid function.
+  static_assert(ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
+  static_assert(ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int>);
+
+  // The number of parameter types is wrong.
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int, int>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
   static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::vector<bool>>);
+  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::string>);
   static_assert(
-      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
-                                       std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
-                                       std::vector<bool>, std::vector<bool>>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::vector<bool>, int>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::vector<bool>>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                                std::vector<bool>, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
-                                       std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string, int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string,
+                                                std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
   static_assert(
-      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
+      !ad_utility::ExceptionValidator<decltype([](int&) { return std::optional<ErrorMessage>{}; }),
+                                      int>);
   static_assert(
-      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+      !ad_utility::ExceptionValidator<decltype([](int&&) { return std::optional<ErrorMessage>{}; }),
+                                      int>);
+  static_assert(!ad_utility::ExceptionValidator<
+                decltype([](const int&&) { return std::optional<ErrorMessage>{}; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(
-            !ad_utility::Validator<
-                decltype([](FirstParameter, SecondParameter) { return true; }),
-                int, int>);
+        static_assert(!ad_utility::ExceptionValidator<decltype([](FirstParameter, SecondParameter) {
+                                                        return std::optional<ErrorMessage>{};
+                                                      }),
+                                                      int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
-  static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
-                                   int, int>);
+        static_assert(!ad_utility::ExceptionValidator<
+                      decltype([](FirstParameter n, SecondParameter) { return n; }), int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
-      int, const int, const int&>(
-      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
+      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(
-      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(
-      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }), int>);
+  static_assert(!ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n,
-                                               SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
-      int&, int&&, const int&&>(
-      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
+      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -37,8 +37,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
-                 const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
+                 const bool wasSet, const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -55,14 +55,16 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(
+      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -71,14 +73,18 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
+                                &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
+          &notUsed, 42),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -97,7 +103,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
+                        "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -108,7 +115,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -125,8 +133,9 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -165,28 +174,32 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(
+      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-                                   &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption(
+      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+      &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -205,7 +218,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -223,16 +237,19 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -240,8 +257,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
+                            "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -260,15 +277,17 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s, "manager"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -307,22 +326,25 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(
-      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config
+                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
+                                      "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -331,14 +353,16 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
+                      .addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -350,10 +374,13 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                                              "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s},
+                       "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne =
+      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                       "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo =
+      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -386,14 +413,16 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
-                          const std::vector<std::pair<int*, int>>& wantedValues) {
-    m.parseConfig(j);
+  auto parseAndCheck =
+      [](const nlohmann::json& j, ConfigManager& m,
+         const std::vector<std::pair<int*, int>>& wantedValues) {
+        m.parseConfig(j);
 
-    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-      ASSERT_EQ(*wantedValue.first, wantedValue.second);
-    });
-  };
+        std::ranges::for_each(
+            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+              ASSERT_EQ(*wantedValue.first, wantedValue.second);
+            });
+      };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -411,13 +440,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion,
+                {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
+                                         &amountOfPersonal, 0);
 
-  parseAndCheck(nlohmann::json::parse(R"--({
+  parseAndCheck(
+      nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -425,8 +457,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+      managerWithOneSubNoRecursion,
+      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -454,10 +486,14 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+                {{&daveId, 4},
+                 {&daveInfractions, 0},
+                 {&janiceId, 0},
+                 {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
+                                              &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -479,16 +515,20 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 =
+      managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 =
+      managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex =
+      managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter =
+      managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -509,7 +549,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+                {{&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -605,10 +648,11 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                   &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                   &notUsedVector, {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s},
+                   "Must be set. Has no default value.", &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s},
+                   "Must not be set. Has default value.", &notUsedVector,
+                   {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -635,20 +679,27 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_integer)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -656,32 +707,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
+                   41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
-               {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s},
+               "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s},
+               "Must not be set. Has default value.", &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -692,29 +749,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 =
+      config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 =
+      config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.",
+                    &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.",
+                      &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                      &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                      &notUsedVector, {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s},
+                      "Must be set. Has no default value.", &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s},
+                      "Must not be set. Has default value.", &notUsedVector,
+                      {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -725,13 +791,15 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -743,7 +811,8 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -752,59 +821,65 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.",
+      &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.",
+      &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist = config.addOption(
-      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist =
+      config.addOption("someIntegerlist", "Must be set. Has no default value.",
+                       &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint =
-      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
-                       &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint = config.addOption(
+      "somePositiveFloatingPoint", "Must be set. Has no default value.",
+      &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint =
-      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
-                       &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint = config.addOption(
+      "someNegativFloatingPoint", "Must be set. Has no default value.",
+      &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList =
-      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
-                       &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList = config.addOption(
+      "someFloatingPointList", "Must be set. Has no default value.",
+      &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue =
-      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue = config.addOption(
+      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse =
-      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse = config.addOption(
+      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList = config.addOption(
-      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
+  decltype(auto) someBooleanList =
+      config.addOption("someBooleanList", "Must be set. Has no default value.",
+                       &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName =
-      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName = config.addOption(
+      "myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList = config.addOption(
-      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
+  decltype(auto) someStringList =
+      config.addOption("someStringList", "Must be set. Has no default value.",
+                       &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption = config.addOption(
-      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption =
+      config.addOption({"depth"s, "here"s, "list"s},
+                       "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -818,17 +893,22 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true,
+              std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
+              4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
+              -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
+              {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true,
+              std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -841,13 +921,15 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
-      , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
+                                   R"(complicatedKey:42, complicatedKey:43)");
+                               , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
+      R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(
+      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -864,7 +946,8 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan =
+      config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -874,10 +957,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -889,12 +974,14 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager,
+                    const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
-                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.parseConfig(jsonWithNonValidValues),
+      ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -904,11 +991,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.",
-                 numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.",
-                 numberInRangeOption);
+  decltype(auto) numberInRangeOption =
+      m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; },
+                 "'numberInRange' must be <=100.", numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; },
+                 "'numberInRange' must be >=50.", numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -922,12 +1010,15 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption =
+      m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) ||
+               (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption, boolThreeOption);
+      "Exactly one bool must be choosen.", boolOneOption, boolTwoOption,
+      boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -942,12 +1033,16 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-                                     "Every option must have a default value.", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption =
+      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator(
+      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+      "Every option must have a default value.", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
+      nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption =
+      mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -958,19 +1053,25 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter =
+      mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
+      [](const ConfigOption& opt) {
+        return opt.getIdentifier().starts_with('d');
+      },
       "Every option name must start with the letter d.", correctLetter);
-  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') &&
+               opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", correctLetter, wrongLetter);
-  ASSERT_ANY_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", correctLetter,
+      wrongLetter);
+  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
+      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -990,7 +1091,8 @@ Type createDummyValueForValidator(size_t variant) {
       stream << i;
     }
     return stream.str();
-  } else if constexpr (std::is_same_v<Type, int> || std::is_same_v<Type, size_t>) {
+  } else if constexpr (std::is_same_v<Type, int> ||
+                       std::is_same_v<Type, size_t>) {
     // Return uneven numbers.
     return static_cast<Type>(variant) * 2 + 1;
   } else if constexpr (std::is_same_v<Type, float>) {
@@ -1008,17 +1110,19 @@ Type createDummyValueForValidator(size_t variant) {
 };
 
 /*
-@brief For easily creating `Validator` functions, that compare given values to values created using
-the `createDummyValueForValidator` function.
+@brief For easily creating `Validator` functions, that compare given values to
+values created using the `createDummyValueForValidator` function.
 
-The following invariant should always be true, except for when `bool` is one of the types in
-`ParameterTypes`: A validator function, that was generated with `variant` number $x$, returns false,
-when given `createDummyValueForValidator<ParameterTypes>(x)...`. Otherwise, it always returns true.
+The following invariant should always be true, except for when `bool` is one of
+the types in `ParameterTypes`: A validator function, that was generated with
+`variant` number $x$, returns false, when given
+`createDummyValueForValidator<ParameterTypes>(x)...`. Otherwise, it always
+returns true.
 
-Special behavior for `bool` types: Because we only have 2 values for `bool`, I decided, that the
-comparison for any `bool` argument `b` is always `b == false`. In other words, when only looking at
-the `bool` arguments given to the generated validator, than the given arguments are valid, as long
-as they are all `false`.
+Special behavior for `bool` types: Because we only have 2 values for `bool`, I
+decided, that the comparison for any `bool` argument `b` is always `b == false`.
+In other words, when only looking at the `bool` arguments given to the generated
+validator, than the given arguments are valid, as long as they are all `false`.
 
 @tparam ParameterType The parameter type for the parameter of the
 function.
@@ -1029,10 +1133,13 @@ what the exact difference is, see the code in `createDummyValueForValidator`.
 */
 template <typename... ParameterTypes>
 auto generateDummyNonExceptionValidatorFunction(size_t variant) {
-  return [... dummyValuesToCompareTo = createDummyValueForValidator<ParameterTypes>(variant)](
+  return [... dummyValuesToCompareTo =
+              createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {
-    // Special handeling for `args` of type bool is needed. For the reasoning: See the doc string.
-    auto compare = []<typename T>(const T& arg, const T& dummyValueToCompareTo) {
+    // Special handeling for `args` of type bool is needed. For the reasoning:
+    // See the doc string.
+    auto compare = []<typename T>(const T& arg,
+                                  const T& dummyValueToCompareTo) {
       if constexpr (std::is_same_v<T, bool>) {
         return arg == false;
       } else {
@@ -1055,9 +1162,11 @@ functions.
 */
 template <typename... Ts>
 std::string generateValidatorName(size_t id) {
-  return absl::StrCat("Config manager validator<",
-                      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "),
-                      "> ", id);
+  return absl::StrCat(
+      "Config manager validator<",
+      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
+                  ", "),
+      "> ", id);
 };
 
 /*
@@ -1069,29 +1178,34 @@ That is, instead of returning `bool`, it now returns
 */
 template <typename... ValidatorParameterTypes>
 auto transformNonExceptionValidatorIntoExceptionValidator(
-    Validator<ValidatorParameterTypes...> auto validatorFunction, std::string_view errorMessage) {
+    Validator<ValidatorParameterTypes...> auto validatorFunction,
+    std::string_view errorMessage) {
   // The whole 'transformation' is simply a wrapper.
-  return [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
-             const ValidatorParameterTypes&... args) -> std::optional<ErrorMessage> {
-    if (std::invoke(validatorFunction, args...)) {
-      return std::nullopt;
-    } else {
-      return ErrorMessage{errorMessage};
-    }
-  };
+  return
+      [validatorFunction, errorMessage = std::string(std::move(errorMessage))](
+          const ValidatorParameterTypes&... args)
+          -> std::optional<ErrorMessage> {
+        if (std::invoke(validatorFunction, args...)) {
+          return std::nullopt;
+        } else {
+          return ErrorMessage{errorMessage};
+        }
+      };
 }
 /*
 @brief The test for adding a validator to a config manager.
 
-@param addValidatorFunction A function, that adds a validator function to a config manager. The
-function signature should look like this: `void func(size_t variant, std::string_view
-validatorExceptionMessage, ConfigManager& m, ConstConfigOptionProxy...)`.
-With `variant` being for the invariant of `generateDummyNonExceptionValidatorFunction` and the rest
-for the generation, as well as adding, of a new validator function.
+@param addValidatorFunction A function, that adds a validator function to a
+config manager. The function signature should look like this: `void func(size_t
+variant, std::string_view validatorExceptionMessage, ConfigManager& m,
+ConstConfigOptionProxy...)`. With `variant` being for the invariant of
+`generateDummyNonExceptionValidatorFunction` and the rest for the generation, as
+well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(auto addValidatorFunction,
-                     ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(
+    auto addValidatorFunction,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1116,10 +1230,12 @@ void doValidatorTest(auto addValidatorFunction,
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes,
+               &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func),
+                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1129,8 +1245,8 @@ void doValidatorTest(auto addValidatorFunction,
   `generateDummyNonExceptionValidatorFunction`.
   The bool type in those helper functions needs special handeling, because it
   only has two values and can't fulfill the invariant, that
-  `createDummyValueForValidator` and `generateDummyNonExceptionValidatorFunction`
-  should fulfill.
+  `createDummyValueForValidator` and
+  `generateDummyNonExceptionValidatorFunction` should fulfill.
 
   @tparam T Same `T` as for `createDummyValueForValidator` and
   `generateDummyNonExceptionValidatorFunction`.
@@ -1157,8 +1273,8 @@ void doValidatorTest(auto addValidatorFunction,
   @tparam Ts The parameter types for the validator functions.
 
   @param variant See `generateDummyNonExceptionValidatorFunction`.
-  @param validatorExceptionMessage The message, that will be thrown, if the validator gets non valid
-  input.
+  @param validatorExceptionMessage The message, that will be thrown, if the
+  validator gets non valid input.
   @param m The config manager, to which the validator will be added.
   @param validatorArguments The values of the configuration options will be
   passed as arguments to the validator function, in the same order as given
@@ -1166,11 +1282,13 @@ void doValidatorTest(auto addValidatorFunction,
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m,
+          ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
-                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(
+        adjustVariantArgument.template operator()<Ts...>(variant),
+        generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1191,14 +1309,17 @@ void doValidatorTest(auto addValidatorFunction,
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
-      size_t variantStart, size_t variantEnd, ConfigManager & m,
-      const nlohmann::json& defaultValues,
-      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
-      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager =
+      [&adjustVariantArgument]<typename... Ts>(
+          size_t variantStart, size_t variantEnd, ConfigManager & m,
+          const nlohmann::json& defaultValues,
+          const std::same_as<
+              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
+         validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1217,9 +1338,11 @@ void doValidatorTest(auto addValidatorFunction,
       are all identical.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(0));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(0));
       } else {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1243,7 +1366,8 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1253,7 +1377,8 @@ void doValidatorTest(auto addValidatorFunction,
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1284,8 +1409,10 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM,
+          const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1296,7 +1423,8 @@ void doValidatorTest(auto addValidatorFunction,
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1306,7 +1434,8 @@ void doValidatorTest(auto addValidatorFunction,
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1315,236 +1444,270 @@ void doValidatorTest(auto addValidatorFunction,
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
-    // Variables needed for configuration options.
-    Type firstVar;
+  auto doSingleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type>() {
+        // Variables needed for configuration options.
+        Type firstVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption =
+            mNoSub.addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue"),
+                           mNoSubOption));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    decltype(auto) mSubNoValidatorOption =
-        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubNoValidatorOption));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        decltype(auto) mSubNoValidatorOption =
+            mSubNoValidator.addSubManager({"some"s, "manager"s})
+                .addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubNoValidatorOption));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption =
-        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubWithValidatorOption));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption =
+            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubWithValidatorOption));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
-                                                                     typename Type2>() {
-    // Variables needed for configuration options.
-    Type1 firstVar;
-    Type2 secondVar;
+  auto doDoubleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
+        // Variables needed for configuration options.
+        Type1 firstVar;
+        Type2 secondVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 =
+            mNoSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mNoSubOption2 =
+            mNoSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
+                           mNoSubOption1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
+                           mNoSubOption2));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubNoValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubNoValidatorOption2));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub =
+            mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubNoValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubNoValidatorOption2));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption1 =
-        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubWithValidatorOption2 =
-        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubWithValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubWithValidatorOption2));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption1 =
+            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubWithValidatorOption2 =
+            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubWithValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubWithValidatorOption2));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests =
-      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
-        // Variables for config options.
-        Type1 var1;
-        Type2 var2;
+  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
+                                       typename Type1, typename Type2>() {
+    // Variables for config options.
+    Type1 var1;
+    Type2 var2;
 
-        /*
-        @brief Helper function, that checks all combinations of valid/invalid values
-        for two single argument parameter validator functions.
+    /*
+    @brief Helper function, that checks all combinations of valid/invalid values
+    for two single argument parameter validator functions.
 
-        @tparam T1, T2 Function parameter type for the first and the second
-        validator.
+    @tparam T1, T2 Function parameter type for the first and the second
+    validator.
 
-        @param m The config manager, on which `parseConfig` will be called on.
-        @param validator1, validator2 A pair consisting of the path to the
-        configuration option, that the validator is looking at, and the `variant`
-        value, that was used to generate the validator function with
-        `addValidatorToConfigManager`.
-        */
-        auto checkAllValidAndInvalidValueCombinations =
-            []<typename T1, typename T2>(
-                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-              /*
-              Input for `parseConfig`. One contains values, that are valid for all
-              validators, the other contains values, that are valid for all
-              validators except one.
-              */
-              nlohmann::json validValueJson(nlohmann::json::value_t::object);
-              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+    @param m The config manager, on which `parseConfig` will be called on.
+    @param validator1, validator2 A pair consisting of the path to the
+    configuration option, that the validator is looking at, and the `variant`
+    value, that was used to generate the validator function with
+    `addValidatorToConfigManager`.
+    */
+    auto checkAllValidAndInvalidValueCombinations =
+        []<typename T1, typename T2>(
+            ConfigManager& m,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+          /*
+          Input for `parseConfig`. One contains values, that are valid for all
+          validators, the other contains values, that are valid for all
+          validators except one.
+          */
+          nlohmann::json validValueJson(nlohmann::json::value_t::object);
+          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-              // Add the valid values.
-              validValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              validValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
+          // Add the valid values.
+          validValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          validValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
 
-              // Value for `validator1` is invalid. Value for `validator2` is valid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type1>(validator1.second));
+          // Value for `validator1` is invalid. Value for `validator2` is valid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type1>(validator1.second));
 
-              // Value for `validator1` is valid. Value for `validator2` is invalid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type2>(validator2.second));
-            };
+          // Value for `validator1` is valid. Value for `validator2` is invalid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type2>(validator2.second));
+        };
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
+                                                           mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
+                                                           mNoSubOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mSubNoValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub =
+        mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mSubNoValidator, mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mSubNoValidator, mSubNoValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mSubNoValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, however the manager does not.
-        ConfigManager mNoValidatorSubValidator;
-        ConfigManager& mNoValidatorSubValidatorSub =
-            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mNoValidatorSubValidatorOption1 =
-            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoValidatorSubValidatorOption2 =
-            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // Sub manager has validators of its own, however the manager does not.
+    ConfigManager mNoValidatorSubValidator;
+    ConfigManager& mNoValidatorSubValidatorSub =
+        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mNoValidatorSubValidatorOption1 =
+        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoValidatorSubValidatorOption2 =
+        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, as does the manager.
-        ConfigManager mValidatorSubValidator;
-        ConfigManager& mValidatorSubValidatorSub =
-            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mValidatorSubValidatorOption1 =
-            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mValidatorSubValidatorOption2 =
-            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
-                                                               mValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
-                                                               mValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
-      };
+    // Sub manager has validators of its own, as does the manager.
+    ConfigManager mValidatorSubValidator;
+    ConfigManager& mValidatorSubValidatorSub =
+        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mValidatorSubValidatorOption1 =
+        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mValidatorSubValidatorOption2 =
+        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string_view validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
                    validatorExceptionMessage, optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string_view validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(
         transformNonExceptionValidatorIntoExceptionValidator<Ts...>(
-            generateDummyNonExceptionValidatorFunction<Ts...>(variant), validatorExceptionMessage),
+            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
+            validatorExceptionMessage),
         optProxy...);
   });
 }
@@ -1552,9 +1715,10 @@ TEST(ConfigManagerTest, AddExceptionValidator) {
 /*
 @brief The test for checking, if `addValidator` throws exceptions as wanted.
 
-@param addAlwaysValidValidatorFunction A function, that adds a validator function, which recognizes
-any input as valid, to a config manager. The function signature should look like this: `void
-func(ConfigManager& m, ConstConfigOptionProxy... validatorArguments)`.
+@param addAlwaysValidValidatorFunction A function, that adds a validator
+function, which recognizes any input as valid, to a config manager. The function
+signature should look like this: `void func(ConfigManager& m,
+ConstConfigOptionProxy... validatorArguments)`.
 @param l For better error messages, when the tests fail.
 */
 void doValidatorExceptionTest(
@@ -1573,17 +1737,19 @@ void doValidatorExceptionTest(
         T var{};
 
         /*
-        @brief Check, if a call to the `addValidator` function behaves as wanted.
+        @brief Check, if a call to the `addValidator` function behaves as
+        wanted.
         */
-        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              addAlwaysValidValidatorFunction(m, notValidOption),
-              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-        };
+        auto checkAddValidatorBehavior =
+            [&addAlwaysValidValidatorFunction](
+                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                ConstConfigOptionProxy<T> notValidOption) {
+              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+              AD_EXPECT_THROW_WITH_MESSAGE(
+                  addAlwaysValidValidatorFunction(m, notValidOption),
+                  ::testing::ContainsRegex(
+                      notValidOption.getConfigOption().getIdentifier()));
+            };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1596,30 +1762,50 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption =
+            mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub =
+            mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption =
+            mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption =
+            mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 =
+            mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option =
+            mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 =
+            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option =
+            mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1627,26 +1813,32 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "", validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "",
+                       validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
-                       validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator(
+            [](const Ts&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
+            validatorArguments...);
       });
 }
 
 /*
 @brief The test for `addOptionValidator`.
 
-@param addNonExceptionValidatorFunction A function, that adds a non exception validator function to
-a config manager. The function signature should look like this: `void func(Validator
-validatorFunction, std::string_view validatorExceptionMessage, ConfigManager& m,
-ConstConfigOptionProxy...)`.
+@param addNonExceptionValidatorFunction A function, that adds a non exception
+validator function to a config manager. The function signature should look like
+this: `void func(Validator validatorFunction, std::string_view
+validatorExceptionMessage, ConfigManager& m, ConstConfigOptionProxy...)`.
 @param l For better error messages, when the tests fail.
 */
 void doAddOptionValidatorTest(
@@ -1657,11 +1849,13 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
-    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
-      return ((options.getValueAsString() == wantedString) && ...);
-    };
-  };
+  auto generateValueAsStringComparison =
+      [](std::string_view valueStringRepresentation) {
+        return [wantedString = std::string(valueStringRepresentation)](
+                   const auto&... options) {
+          return ((options.getValueAsString() == wantedString) && ...);
+        };
+      };
 
   // Variables for configuration options.
   int firstVar;
@@ -1671,58 +1865,75 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "someOption1", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
+                 "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Both options", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-                 "Both options");
+  checkValidator(
+      managerWithNoSubManager,
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
+                                                        &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(managerWithSubManagerWhoHasNoValidators,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-                                   managerWithSubManagerWhoHasNoValidatorsOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
+          "someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Both options",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+      managerWithSubManagerWhoHasNoValidatorsOption);
+  checkValidator(
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerHasNoValidatorsButSubManagerDoesSubManager,
-                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(managerHasNoValidatorsButSubManagerDoes,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
+          "someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerHasNoValidatorsButSubManagerDoesSubManager,
+      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(
+      managerHasNoValidatorsButSubManagerDoes,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1732,48 +1943,59 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
-                                   bothHaveValidators, bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
-                                   bothHaveValidatorsSubManager,
-                                   bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Top manager option", bothHaveValidators,
+                                   bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("20"), "Sub manager option",
+      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction, std::string_view validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction,
+                         std::string_view validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage, args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage,
+                             args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
-  doAddOptionValidatorTest([]<typename... Ts>(
-                               auto validatorFunction, std::string_view validatorExceptionMessage,
-                               ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-    m.addOptionValidator(
-        transformNonExceptionValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
-            validatorFunction, validatorExceptionMessage),
-        args...);
-  });
+  doAddOptionValidatorTest(
+      []<typename... Ts>(auto validatorFunction,
+                         std::string_view validatorExceptionMessage,
+                         ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
+        m.addOptionValidator(
+            transformNonExceptionValidatorIntoExceptionValidator<
+                decltype(args.getConfigOption())...>(validatorFunction,
+                                                     validatorExceptionMessage),
+            args...);
+      });
 }
 
 /*
-@brief The test for checking, if `addOptionValidator` throws exceptions as wanted.
+@brief The test for checking, if `addOptionValidator` throws exceptions as
+wanted.
 
-@param addAlwaysValidValidatorFunction A function, that adds a validator function, which recognizes
-any input as valid, to a config manager. The function signature should look like this: `void
-func(ConfigManager& m, ConstConfigOptionProxy... validatorArguments)`.
+@param addAlwaysValidValidatorFunction A function, that adds a validator
+function, which recognizes any input as valid, to a config manager. The function
+signature should look like this: `void func(ConfigManager& m,
+ConstConfigOptionProxy... validatorArguments)`.
 @param l For better error messages, when the tests fail.
 */
 void doAddOptionValidatorExceptionTest(
@@ -1788,15 +2010,16 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        addAlwaysValidValidatorFunction(m, notValidOption),
-        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-  };
+  auto checkAddOptionValidatorBehavior =
+      [&addAlwaysValidValidatorFunction]<typename T>(
+          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+          ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            addAlwaysValidValidatorFunction(m, notValidOption),
+            ::testing::ContainsRegex(
+                notValidOption.getConfigOption().getIdentifier()));
+      };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -1811,35 +2034,53 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption =
+      mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption =
+      mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option =
+      mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 =
+      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option =
+      mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
-                             args...);
+        m.addOptionValidator(
+            [](const decltype(args.getConfigOption())&...) { return true; }, "",
+            args...);
       });
 }
 
@@ -1847,9 +2088,8 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
+            [](const decltype(args.getConfigOption())&...)
+                -> std::optional<ErrorMessage> { return {std::nullopt}; },
             args...);
       });
 }
@@ -1863,18 +2103,21 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus = [](const ConfigManager& m,
-                                   const ContainmentStatusVector& optionsAndWantedStatus) {
-    std::ranges::for_each(optionsAndWantedStatus,
-                          [&m](const ContainmentStatusVector::value_type& p) {
-                            if (p.second) {
-                              ASSERT_TRUE(m.containsOption(*p.first));
-                            } else {
-                              ASSERT_FALSE(m.containsOption(*p.first));
-                            }
-                          });
-  };
+  using ContainmentStatusVector =
+      std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus =
+      [](const ConfigManager& m,
+         const ContainmentStatusVector& optionsAndWantedStatus) {
+        std::ranges::for_each(
+            optionsAndWantedStatus,
+            [&m](const ContainmentStatusVector::value_type& p) {
+              if (p.second) {
+                ASSERT_TRUE(m.containsOption(*p.first));
+              } else {
+                ASSERT_FALSE(m.containsOption(*p.first));
+              }
+            });
+      };
 
   // Variable for the configuration options.
   int var;
@@ -1885,68 +2128,87 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
+      {&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 =
+      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option =
+      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
 }
 
 /*
@@ -1967,7 +2229,8 @@ constexpr void passCartesianPorductToLambda(Func func) {
 TEST(ConfigManagerTest, ValidatorConcept) {
   // Lambda function types for easier test creation.
   using SingleIntValidatorFunction = decltype([](const int&) { return true; });
-  using DoubleIntValidatorFunction = decltype([](const int&, const int&) { return true; });
+  using DoubleIntValidatorFunction =
+      decltype([](const int&, const int&) { return true; });
 
   // Valid function.
   static_assert(ad_utility::Validator<SingleIntValidatorFunction, int>);
@@ -1977,66 +2240,88 @@ TEST(ConfigManagerTest, ValidatorConcept) {
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction>);
   static_assert(!ad_utility::Validator<SingleIntValidatorFunction, int, int>);
   static_assert(!ad_utility::Validator<DoubleIntValidatorFunction>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<SingleIntValidatorFunction, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::vector<bool>>);
   static_assert(
-      !ad_utility::Validator<DoubleIntValidatorFunction, std::vector<bool>, std::vector<bool>>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string, std::string>);
+      !ad_utility::Validator<SingleIntValidatorFunction, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<SingleIntValidatorFunction, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, int>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, int,
+                                       std::vector<bool>>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction,
+                                       std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, std::string, int>);
+  static_assert(
+      !ad_utility::Validator<DoubleIntValidatorFunction, int, std::string>);
+  static_assert(!ad_utility::Validator<DoubleIntValidatorFunction, std::string,
+                                       std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
-  static_assert(!ad_utility::Validator<decltype([](int&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&&) { return true; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&&) { return true; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&&) { return true; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter, SecondParameter) { return true; }),
-                                   int, int>);
+            !ad_utility::Validator<
+                decltype([](FirstParameter, SecondParameter) { return true; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
   static_assert(!ad_utility::Validator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::Validator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::Validator<decltype([](const int&& n) { return n; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 
 TEST(ConfigManagerTest, ExceptionValidatorConcept) {
@@ -2044,87 +2329,126 @@ TEST(ConfigManagerTest, ExceptionValidatorConcept) {
   using SingleIntExceptionValidatorFunction =
       decltype([](const int&) { return std::optional<ErrorMessage>{}; });
   using DoubleIntExceptionValidatorFunction =
-      decltype([](const int&, const int&) { return std::optional<ErrorMessage>{}; });
+      decltype([](const int&, const int&) {
+        return std::optional<ErrorMessage>{};
+      });
 
   // Valid function.
-  static_assert(ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
-  static_assert(ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int>);
+  static_assert(
+      ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int>);
+  static_assert(
+      ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                     int>);
 
   // The number of parameter types is wrong.
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int, int>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, int, int, int>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, int,
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      int, int, int>);
 
   // Function is valid, but the parameter types are of the wrong object type.
   static_assert(
-      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::vector<bool>>);
-  static_assert(!ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction, std::string>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
+                                      std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::vector<bool>, int>);
+      !ad_utility::ExceptionValidator<SingleIntExceptionValidatorFunction,
+                                      std::string>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::vector<bool>>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
-                                                std::vector<bool>, std::vector<bool>>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::vector<bool>, int>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string, int>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      std::vector<bool>>);
   static_assert(
-      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int, std::string>);
-  static_assert(!ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, std::string,
-                                                std::string>);
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::vector<bool>, std::vector<bool>>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::string, int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction, int,
+                                      std::string>);
+  static_assert(
+      !ad_utility::ExceptionValidator<DoubleIntExceptionValidatorFunction,
+                                      std::string, std::string>);
 
   // The given function is not valid.
 
   // The parameter types of the function are wrong, but the return type is
   // correct.
   static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&) { return std::optional<ErrorMessage>{}; }),
-                                      int>);
+      !ad_utility::ExceptionValidator<
+          decltype([](int&) { return std::optional<ErrorMessage>{}; }), int>);
   static_assert(
-      !ad_utility::ExceptionValidator<decltype([](int&&) { return std::optional<ErrorMessage>{}; }),
+      !ad_utility::ExceptionValidator<
+          decltype([](int&&) { return std::optional<ErrorMessage>{}; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int&&) {
+                                        return std::optional<ErrorMessage>{};
+                                      }),
                                       int>);
-  static_assert(!ad_utility::ExceptionValidator<
-                decltype([](const int&&) { return std::optional<ErrorMessage>{}; }), int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<decltype([](FirstParameter, SecondParameter) {
-                                                        return std::optional<ErrorMessage>{};
-                                                      }),
-                                                      int, int>);
+        static_assert(!ad_utility::ExceptionValidator<
+                      decltype([](FirstParameter, SecondParameter) {
+                        return std::optional<ErrorMessage>{};
+                      }),
+                      int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeRightTestHelper);
 
   // Parameter types are correct, but return type is wrong.
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int n) { return n; }),
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int& n) { return n; }),
+                                      int>);
 
   auto validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
-        static_assert(!ad_utility::ExceptionValidator<
-                      decltype([](FirstParameter n, SecondParameter) { return n; }), int, int>);
+        static_assert(
+            !ad_utility::ExceptionValidator<
+                decltype([](FirstParameter n, SecondParameter) { return n; }),
+                int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper), int, const int,
-      const int&>(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper),
+      int, const int, const int&>(
+      validParameterButFunctionParameterRightAndReturnTypeWrongTestHelper);
 
   // Both the parameter types and the return type is wrong.
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }), int>);
-  static_assert(!ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int& n) { return n; }), int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](int&& n) { return n; }),
+                                      int>);
+  static_assert(
+      !ad_utility::ExceptionValidator<decltype([](const int&& n) { return n; }),
+                                      int>);
 
   auto validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper =
       []<typename FirstParameter, typename SecondParameter>() {
         static_assert(
-            !ad_utility::Validator<decltype([](FirstParameter n, SecondParameter) { return n; }),
+            !ad_utility::Validator<decltype([](FirstParameter n,
+                                               SecondParameter) { return n; }),
                                    int, int>);
       };
   passCartesianPorductToLambda<
-      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper), int&, int&&,
-      const int&&>(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
+      decltype(validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper),
+      int&, int&&, const int&&>(
+      validParameterButFunctionParameterWrongAndReturnTypeWrongTestHelper);
 }
 }  // namespace ad_utility


### PR DESCRIPTION
This commit adds new overloads for `ConfigManager::addValidator` and  `ConfigManager::addOptionValidator`. These take a validation function which doesn't return a bool, but a `std::optional<ErrorMessage>` (`std::nullopt` means no error).
Using these overloads, validators can now generate non-static messages for invalid input. In particular the error messages can include the invalid values and more details for complex conditions. 