### PR TITLE
Make Codecov run again by using less disk space

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -82,18 +82,15 @@ jobs:
       working-directory: ${{github.workspace}}/build/test
       env:
         LLVM_PROFILE_FILE: "default%p.profraw"
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: env CTEST_OUTPUT_ON_FAILURE=1 ASAN_OPTIONS="alloc_dealloc_mismatch=0" ctest -C ${{env.build-type}} .
+      # We have to manually run the test executable to only get a single `.profraw` file.
+      # Otherwise, the GitHub runner goes out of memory.
+      run: env ASAN_OPTIONS="alloc_dealloc_mismatch=0" ./QLeverAllUnitTestsMain
 
-    - name: GetListOfExecutablesForCoverageInfo
-      working-directory: ${{github.workspace}}/build/test
-      run: ctest --show-only=json-v1 > tests.json && python3 ${{github.workspace}}/misc/ctest-output-to-executables.py tests.json tests.txt
     - name: Process coverage info
       working-directory: ${{github.workspace}}/build/test
       run:  >
         llvm-profdata-16 merge -sparse *.profraw -o default.profdata;
-        xargs -a tests.txt llvm-cov-16 export --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" --ignore-filename-regex="/benchmark/" > ./coverage.lcov
+        llvm-cov-16 export ./QLeverAllUnitTestsMain --dump --format=lcov --instr-profile ./default.profdata --ignore-filename-regex="/third_party/" --ignore-filename-regex="/generated/"  --ignore-filename-regex="/nlohmann/" --ignore-filename-regex="/ctre/"  --ignore-filename-regex="/test/" --ignore-filename-regex="/benchmark/" > ./coverage.lcov
 
 # Only upload the coverage directly if this is not a pull request. In this
 # case we are on the master branch and have access to the Codecov token.

--- a/test/ExceptionHandlingTest.cpp
+++ b/test/ExceptionHandlingTest.cpp
@@ -8,6 +8,8 @@
 
 // ________________________________________________________________
 TEST(OnDestruction, terminateIfThrows) {
+  // Avoid warnings and crashes when running all tests at once.
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   int numCallsToMockedTerminate = 0;
   auto mockedTerminate = [&numCallsToMockedTerminate]() noexcept {
     ++numCallsToMockedTerminate;

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -115,9 +115,22 @@ inline QueryExecutionContext* getQec(
   // Similar to `absl::Cleanup`. Calls the `callback_` in the destructor, but
   // the callback is stored as a `std::function`, which allows to store
   // different types of callbacks in the same wrapper type.
+  // TODO<joka921> RobinTF has a similar tool in the pipeline that can be used
+  // here.
   struct TypeErasedCleanup {
     std::function<void()> callback_;
     ~TypeErasedCleanup() { callback_(); }
+    TypeErasedCleanup(std::function<void()> callback)
+        : callback_{std::move(callback)} {}
+    TypeErasedCleanup(const TypeErasedCleanup& rhs) = delete;
+    TypeErasedCleanup& operator=(const TypeErasedCleanup&) = delete;
+    // When being moved from, then the callback is disabled.
+    TypeErasedCleanup(TypeErasedCleanup&& rhs)
+        : callback_(std::exchange(rhs.callback_, [] {})) {}
+    TypeErasedCleanup& operator=(TypeErasedCleanup&& rhs) {
+      callback_ = std::exchange(rhs.callback_, [] {});
+      return *this;
+    }
   };
 
   // A `QueryExecutionContext` together with all data structures that it


### PR DESCRIPTION
Manually run `QLeverAllUnitTestsMain` so that only a single file with profiling data is produced. Otherwise, one such file per unit test is produced. Due to our (by now) very large number of tests, this caused the GitHub runner to run out of  disk space.