### PR TITLE
Fix: `MemorySize` factory functions no longer ambigous

### DIFF
--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -256,7 +256,7 @@ constexpr MemorySize magicImplForDivAndMul(const MemorySize& m, const T c,
 
 // _____________________________________________________________________________
 constexpr MemorySize MemorySize::bytes(size_t numBytes) {
-  return MemorySize{numBytes};
+  return MemorySize{detail::convertMemoryUnitsToBytes(numBytes, "B")};
 }
 
 // _____________________________________________________________________________

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -59,7 +59,7 @@ class MemorySize {
   memory size saved internally. Always requries the exact memory size unit and
   size wanted.
   */
-  constexpr static MemorySize bytes(size_t numBytes);
+  constexpr static MemorySize bytes(std::integral auto numBytes);
   constexpr static MemorySize kilobytes(size_t numKilobytes);
   constexpr static MemorySize kilobytes(double numKilobytes);
   constexpr static MemorySize megabytes(size_t numMegabytes);
@@ -255,8 +255,11 @@ constexpr MemorySize magicImplForDivAndMul(const MemorySize& m, const T c,
 }  // namespace detail
 
 // _____________________________________________________________________________
-constexpr MemorySize MemorySize::bytes(size_t numBytes) {
-  return MemorySize{numBytes};
+constexpr MemorySize MemorySize::bytes(std::integral auto numBytes) {
+  // Doesn't make much sense to a negativ amount of memory.
+  AD_CONTRACT_CHECK(numBytes >= 0);
+
+  return MemorySize{static_cast<size_t>(numBytes)};
 }
 
 // _____________________________________________________________________________

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -256,7 +256,7 @@ constexpr MemorySize magicImplForDivAndMul(const MemorySize& m, const T c,
 
 // _____________________________________________________________________________
 constexpr MemorySize MemorySize::bytes(size_t numBytes) {
-  return MemorySize{detail::convertMemoryUnitsToBytes(numBytes, "B")};
+  return MemorySize{numBytes};
 }
 
 // _____________________________________________________________________________

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -174,6 +174,14 @@ constexpr static double sizeTDivision(const size_t dividend,
          static_cast<double>(dividend % divisor) / static_cast<double>(divisor);
 }
 
+// The maximal amount of a memory unit, that a `MemorySize` can remember.
+constexpr ConstexprMap<std::string_view, double, 5> maxAmountOfUnit(
+    {std::pair{"B", sizeTDivision(size_t_max, numBytesPerUnit.at("B"))},
+     std::pair{"kB", sizeTDivision(size_t_max, numBytesPerUnit.at("kB"))},
+     std::pair{"MB", sizeTDivision(size_t_max, numBytesPerUnit.at("MB"))},
+     std::pair{"GB", sizeTDivision(size_t_max, numBytesPerUnit.at("GB"))},
+     std::pair{"TB", sizeTDivision(size_t_max, numBytesPerUnit.at("TB"))}});
+
 // Converts a given number to `size_t`. Rounds up, if needed.
 template <Arithmetic T>
 constexpr size_t ceilAndCastToSizeT(const T d) {
@@ -210,7 +218,7 @@ constexpr size_t convertMemoryUnitsToBytes(const T amountOfUnits,
   than what can represented with `T`.
   */
   if (static_cast<T>(
-          std::min(sizeTDivision(size_t_max, numBytesPerUnit.at(unitName)),
+          std::min(maxAmountOfUnit.at(unitName),
                    static_cast<double>(std::numeric_limits<T>::max()))) <
       amountOfUnits) {
     throw std::runtime_error(

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -389,22 +389,22 @@ TEST(MemorySize, ArithmeticOperatorsOverAndUnderFlow) {
   // Floating point multiplication.
   ASSERT_THROW(ad_utility::MemorySize::bytes(ad_utility::size_t_max) * 1.5,
                std::overflow_error);
-  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(
-                      static_cast<float>(ad_utility::size_t_max) / 2.3) *
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(static_cast<size_t>(
+                      static_cast<float>(ad_utility::size_t_max) / 2.3)) *
                   2.3);
   ad_utility::MemorySize memFloatingPointMultiplication{
       ad_utility::MemorySize::bytes(ad_utility::size_t_max)};
   ASSERT_THROW(memFloatingPointMultiplication *= 1.487, std::overflow_error);
   memFloatingPointMultiplication = ad_utility::MemorySize::bytes(
-      static_cast<float>(ad_utility::size_t_max) / 4.73);
+      static_cast<size_t>(static_cast<float>(ad_utility::size_t_max) / 4.73));
   ASSERT_NO_THROW(memFloatingPointMultiplication *= 4.73);
 
   // Floating point division. We are checking for overflow via divisor, that
   // results in a quotient bigger than the dividend. For example: 1/(1/2) = 2
   ASSERT_THROW(100_GB / (1. / static_cast<float>(ad_utility::size_t_max)),
                std::overflow_error);
-  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(
-                      static_cast<float>(ad_utility::size_t_max) / 2.4) /
+  ASSERT_NO_THROW(ad_utility::MemorySize::bytes(static_cast<size_t>(
+                      static_cast<float>(ad_utility::size_t_max) / 2.4)) /
                   (1. / 2.4));
   ad_utility::MemorySize memFloatingPointDivision{12_MB};
   ASSERT_THROW(memFloatingPointDivision /=

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -118,6 +118,11 @@ TEST(MemorySize, MemorySizeConstructor) {
                            singleMemoryUnitSizes.at("TB"));
 
   // Negative numbers are not allowed.
+  ASSERT_ANY_THROW(ad_utility::MemorySize::bytes(-1));
+  ASSERT_ANY_THROW(ad_utility::MemorySize::kilobytes(-1));
+  ASSERT_ANY_THROW(ad_utility::MemorySize::megabytes(-1));
+  ASSERT_ANY_THROW(ad_utility::MemorySize::gigabytes(-1));
+  ASSERT_ANY_THROW(ad_utility::MemorySize::terabytes(-1));
   ASSERT_ANY_THROW(ad_utility::MemorySize::kilobytes(-1.0));
   ASSERT_ANY_THROW(ad_utility::MemorySize::megabytes(-1.0));
   ASSERT_ANY_THROW(ad_utility::MemorySize::gigabytes(-1.0));

--- a/test/MemorySizeTest.cpp
+++ b/test/MemorySizeTest.cpp
@@ -95,16 +95,16 @@ TEST(MemorySize, MemorySizeConstructor) {
   ad_utility::MemorySize m1;
   checkAllMemorySizeGetter(m1, AllMemoryUnitSizes{0uL, 0.0, 0.0, 0.0, 0.0});
 
-  // Factory functions for size_t overload.
-  checkAllMemorySizeGetter(ad_utility::MemorySize::bytes(1uL),
+  // Factory functions for integral overload.
+  checkAllMemorySizeGetter(ad_utility::MemorySize::bytes(1),
                            singleMemoryUnitSizes.at("B"));
-  checkAllMemorySizeGetter(ad_utility::MemorySize::kilobytes(1uL),
+  checkAllMemorySizeGetter(ad_utility::MemorySize::kilobytes(1),
                            singleMemoryUnitSizes.at("kB"));
-  checkAllMemorySizeGetter(ad_utility::MemorySize::megabytes(1uL),
+  checkAllMemorySizeGetter(ad_utility::MemorySize::megabytes(1),
                            singleMemoryUnitSizes.at("MB"));
-  checkAllMemorySizeGetter(ad_utility::MemorySize::gigabytes(1uL),
+  checkAllMemorySizeGetter(ad_utility::MemorySize::gigabytes(1),
                            singleMemoryUnitSizes.at("GB"));
-  checkAllMemorySizeGetter(ad_utility::MemorySize::terabytes(1uL),
+  checkAllMemorySizeGetter(ad_utility::MemorySize::terabytes(1),
                            singleMemoryUnitSizes.at("TB"));
 
   // Factory functions for double overload.


### PR DESCRIPTION
Before, a call of the kind `MemorySize::kilobytes(4)` was ambiguous, because the factory function overloads took `size_t` or `double`, which were both valid targets for implicit conversion. This has been fixed.