### PR TITLE
Log the progress of benchmark runs

### DIFF
--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -16,7 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,11 +2,10 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
-
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
+#include <bits/ranges_algobase.h>
 
 #include <algorithm>
 #include <cstddef>
@@ -17,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"
@@ -57,7 +57,8 @@ ResultTable& ResultGroup::addTable(
     const std::string& descriptor, const std::vector<std::string>& rowNames,
     const std::vector<std::string>& columnNames) {
   resultTables_.push_back(ad_utility::make_copyable_unique<ResultTable>(
-      descriptor, rowNames, columnNames));
+      descriptor, absl::StrCat(descriptor, " of group ", descriptor_), rowNames,
+      columnNames));
   return (*resultTables_.back());
 }
 
@@ -107,12 +108,10 @@ void to_json(nlohmann::json& j, const ResultGroup& resultGroup) {
 }
 
 // ____________________________________________________________________________
-ResultTable::ResultTable(const std::string& descriptor,
-                         const std::vector<std::string>& rowNames,
-                         const std::vector<std::string>& columnNames)
-    : descriptor_{descriptor},
-      columnNames_{columnNames},
-      entries_(rowNames.size(), std::vector<EntryType>(columnNames.size())) {
+void ResultTable::init(const std::string& descriptor,
+                       std::string descriptorForLog,
+                       const std::vector<std::string>& rowNames,
+                       const std::vector<std::string>& columnNames) {
   // Having a table without any columns makes no sense.
   if (columnNames.empty()) {
     throw ad_utility::Exception(
@@ -121,10 +120,32 @@ ResultTable::ResultTable(const std::string& descriptor,
                      descriptor, "' has ", columnNames.size(), " columns"));
   }
 
+  // Setting the member variables.
+  descriptor_ = descriptor;
+  descriptorForLog_ = std::move(descriptorForLog);
+  columnNames_ = columnNames;
+  entries_.resize(rowNames.size());
+  std::ranges::fill(entries_, std::vector<EntryType>(columnNames.size()));
+
   // Setting the row names.
   for (size_t row = 0; row < rowNames.size(); row++) {
     setEntry(row, 0, rowNames.at(row));
   }
+}
+
+// ____________________________________________________________________________
+ResultTable::ResultTable(const std::string& descriptor,
+                         const std::vector<std::string>& rowNames,
+                         const std::vector<std::string>& columnNames) {
+  init(descriptor, descriptor, rowNames, columnNames);
+}
+
+// ____________________________________________________________________________
+ResultTable::ResultTable(const std::string& descriptor,
+                         std::string descriptorForLog,
+                         const std::vector<std::string>& rowNames,
+                         const std::vector<std::string>& columnNames) {
+  init(descriptor, std::move(descriptorForLog), rowNames, columnNames);
 }
 
 // ____________________________________________________________________________

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -7,7 +7,6 @@
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
-#include <bits/ranges_algobase.h>
 
 #include <algorithm>
 #include <cstddef>

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -35,8 +35,8 @@ template <std::invocable Function>
 static float measureTimeOfFunction(
     const Function& functionToMeasure,
     std::string_view measurementSubjectIdentifier) {
-  LOG(INFO) << "Running measurement \"" << measurementSubjectIdentifier << "\"."
-            << std::endl;
+  LOG(INFO) << "Running measurement \"" << measurementSubjectIdentifier
+            << "\" ..." << std::endl;
 
   // Measuring the time.
   ad_utility::timer::Timer benchmarkTimer(ad_utility::timer::Timer::Started);
@@ -47,8 +47,7 @@ static float measureTimeOfFunction(
   // precision.
   const auto measuredTime = static_cast<float>(
       ad_utility::timer::Timer::toSeconds(benchmarkTimer.value()));
-  LOG(INFO) << "Finished measurement \"" << measurementSubjectIdentifier
-            << "\" in " << measuredTime << " seconds." << std::endl;
+  LOG(INFO) << "Done in " << measuredTime << " seconds." << std::endl;
 
   return measuredTime;
 }

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -155,8 +155,8 @@ class ResultTable : public BenchmarkMetadataGetter {
     AD_CONTRACT_CHECK(row < numRows() && column < numColumns());
     entries_.at(row).at(column) = measureTimeOfFunction(
         functionToMeasure,
-        absl::StrCat("Entry at row ", row, ", column ", column, " of ",
-                     static_cast<std::string>(*this)));
+        absl::StrCat("Entry at row ", row, ", column ", column,
+                     " of ResultTable '", descriptor_, "'"));
   }
 
   /*


### PR DESCRIPTION
For each single measurement in a benchmark, the beginning and end of the measurement are now logged to the console. This makes it easier to track the progress of a long running benchmark that consists of multiple measurements.