### PR TITLE
Simplify test port selection

### DIFF
--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -113,9 +113,7 @@ class HttpServer {
   }
 
   // Get the server port.
-  [[nodiscard]] auto getPort() const {
-    return acceptor_.local_endpoint().port();
-  }
+  auto getPort() const { return acceptor_.local_endpoint().port(); }
 
   // Is the server ready yet? We need this in `test/HttpTest.cpp` so that our
   // test can wait for the server to be ready and continue with its test

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -45,8 +45,6 @@ using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
 template <typename HttpHandler>
 class HttpServer {
  private:
-  const net::ip::address ipAddress_;
-  const unsigned short port_;
   HttpHandler httpHandler_;
   int numServerThreads_;
   net::io_context ioContext_;
@@ -68,15 +66,13 @@ class HttpServer {
                       const std::string& ipAddress = "0.0.0.0",
                       int numServerThreads = 1,
                       HttpHandler handler = HttpHandler{})
-      : ipAddress_{net::ip::make_address(ipAddress)},
-        port_{port},
-        httpHandler_{std::move(handler)},
+      : httpHandler_{std::move(handler)},
         // We need at least two threads to avoid blocking.
         // TODO<joka921> why is that?
         numServerThreads_{std::max(2, numServerThreads)},
         ioContext_{numServerThreads_} {
     try {
-      tcp::endpoint endpoint{ipAddress_, port_};
+      tcp::endpoint endpoint{net::ip::make_address(ipAddress), port};
       // Open the acceptor.
       acceptor_.open(endpoint.protocol());
       boost::asio::socket_base::reuse_address option{true};
@@ -117,7 +113,9 @@ class HttpServer {
   }
 
   // Get the server port.
-  [[nodiscard]] unsigned short getPort() const { return port_; }
+  [[nodiscard]] auto getPort() const {
+    return acceptor_.local_endpoint().port();
+  }
 
   // Is the server ready yet? We need this in `test/HttpTest.cpp` so that our
   // test can wait for the server to be ready and continue with its test

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -47,7 +47,7 @@ class TestHttpServer {
   }
 
   // Get port on which this server is running.
-  [[nodiscard]] auto getPort() const { return server_->getPort(); }
+  auto getPort() const { return server_->getPort(); }
 
   // Run the server in its own thread. Wait for 100ms until the server is up and
   // throw `std::runtime_error` if it's not (it should be up immediately).

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -37,33 +37,17 @@ class TestHttpServer {
   std::atomic<bool> hasBeenShutDown_ = false;
 
  public:
-  // Create server on localhost. Try out 10 different ports, if connection
-  // to all of them fail, throw `std::runtime_error`.
-  //
-  // TODO: Is there a more robust way to find a free port?
-  TestHttpServer(HttpHandler httpHandler) {
-    std::vector<short unsigned int> ports(10);
-    std::generate(ports.begin(), ports.end(),
-                  []() { return 1024 + std::rand() % (65535 - 1024); });
+  // Create server on localhost. Port 0 instructs the operating system to choose
+  // a free port of its choice.
+  explicit TestHttpServer(HttpHandler httpHandler) {
     const std::string& ipAddress = "0.0.0.0";
     int numServerThreads = 1;
-    for (const short unsigned int port : ports) {
-      try {
-        server_ = std::make_shared<HttpServer<HttpHandler>>(
-            port, ipAddress, numServerThreads, std::move(httpHandler));
-        return;
-      } catch (const boost::system::system_error& b) {
-        LOG(INFO) << "Starting test HTTP server on port " << port
-                  << " failed, trying next port ..." << std::endl;
-      }
-    }
-    AD_THROW(
-        absl::StrCat("Could not start test HTTP server on any of these ports: ",
-                     absl::StrJoin(ports, ", ")));
+    server_ = std::make_shared<HttpServer<HttpHandler>>(
+        0, ipAddress, numServerThreads, std::move(httpHandler));
   }
 
-  // Get the port on which this server is running.
-  short unsigned int getPort() const { return server_->getPort(); }
+  // Get port on which this server is running.
+  [[nodiscard]] auto getPort() const { return server_->getPort(); }
 
   // Run the server in its own thread. Wait for 100ms until the server is up and
   // throw `std::runtime_error` if it's not (it should be up immediately).


### PR DESCRIPTION
The test code that needs to start a Server on an available port (and we don't care about the exact port number) now asks the operating system for such a port. This is done by specifying the special port `0` when constructing the server. After the construction we can then query the server which port is actually used. This simple code replaces a manually implemented random sampling of ports.