### PR TITLE
Actually spawn queries on new thread

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -760,7 +760,7 @@ boost::asio::awaitable<void> Server::processQuery(
 template <typename Function, typename T>
 Awaitable<T> Server::computeInNewThread(Function function) const {
   auto runOnExecutor = [](auto executor, Function func) -> net::awaitable<T> {
-    co_await net::post(executor, net::use_awaitable);
+    co_await net::post(net::bind_executor(executor, net::use_awaitable));
     co_return std::invoke(func);
   };
   return ad_utility::sameExecutor(


### PR DESCRIPTION
Fix a regression introduced in #1103, that caused the query processing to actually happen on the server threads instead of the threads dedicated to query processing.