### PR TITLE
Decrease the block size of `CompressedExternalIdTable` to 500 kB

### DIFF
--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -24,6 +24,10 @@
 namespace ad_utility {
 
 using namespace ad_utility::memory_literals;
+
+// The default size for compressed blocks in the following classes.
+static constexpr ad_utility::MemorySize DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE =
+    500_kB;
 // A class that stores a sequence of `IdTable`s in a file. Each `IdTable` is
 // compressed blockwise. Typically, the blocksize is much smaller than the size
 // of a single IdTable, such that there are multiple blocks per IdTable. This is
@@ -62,7 +66,8 @@ class CompressedExternalIdTableWriter {
   // then separately compressed and stored. Has to be chosen s.t. it is much
   // smaller than the size of the single `IdTables` and  large enough to make
   // the used compression algorithm work well.
-  ad_utility::MemorySize blockSizeUncompressed_ = 4_MB;
+  ad_utility::MemorySize blockSizeUncompressed_ =
+      DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE;
 
   // Keep track of the number of active output generators to detect whether we
   // are currently reading from the file and it is thus unsafe to add to the
@@ -75,7 +80,8 @@ class CompressedExternalIdTableWriter {
   explicit CompressedExternalIdTableWriter(
       std::string filename, size_t numCols,
       ad_utility::AllocatorWithLimit<Id> allocator,
-      ad_utility::MemorySize blockSizeUncompressed = 4_MB)
+      ad_utility::MemorySize blockSizeUncompressed =
+          DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE)
       : filename_{std::move(filename)},
         blocksPerColumn_(numCols),
         allocator_{std::move(allocator)},
@@ -316,7 +322,7 @@ class CompressedExternalIdTableBase {
   explicit CompressedExternalIdTableBase(
       std::string filename, size_t numCols, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
-      MemorySize blocksizeCompression = 4_MB,
+      MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE,
       BlockTransformation blockTransformation = {})
       : currentBlock_{numCols, allocator},
         numColumns_{numCols},
@@ -436,7 +442,7 @@ class CompressedExternalIdTable
   explicit CompressedExternalIdTable(
       std::string filename, size_t numCols, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
-      MemorySize blocksizeCompression = 4_MB)
+      MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE)
       : Base{std::move(filename), numCols, memory, std::move(allocator),
              blocksizeCompression} {}
 
@@ -445,7 +451,8 @@ class CompressedExternalIdTable
   explicit CompressedExternalIdTable(
       std::string filename, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
-      MemorySize blocksizeCompression = 4_MB) requires(NumStaticCols > 0)
+      MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE)
+      requires(NumStaticCols > 0)
       : CompressedExternalIdTable(std::move(filename), NumStaticCols, memory,
                                   std::move(allocator), blocksizeCompression) {}
 
@@ -531,7 +538,8 @@ class CompressedExternalIdTableSorter
   explicit CompressedExternalIdTableSorter(
       std::string filename, size_t numCols, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
-      MemorySize blocksizeCompression = 4_MB, Comparator comparator = {})
+      MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE,
+      Comparator comparator = {})
       : Base{std::move(filename),
              numCols,
              memory,
@@ -545,8 +553,8 @@ class CompressedExternalIdTableSorter
   explicit CompressedExternalIdTableSorter(
       std::string filename, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
-      MemorySize blocksizeCompression = 4_MB, Comparator comp = {})
-      requires(NumStaticCols > 0)
+      MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE,
+      Comparator comp = {}) requires(NumStaticCols > 0)
       : CompressedExternalIdTableSorter(std::move(filename), NumStaticCols,
                                         memory, std::move(allocator),
                                         blocksizeCompression, comp) {}


### PR DESCRIPTION
The block size for a single column of a compressed `IdTable` used to be `4 MB` and is now `500 kB`. This is still large enough so that a single block is well compressible and the space for the metadata is negligible compared to the space for the compressed blocks.

The index build needs RAM for `6 k` such blocks when sorting the permutations, where `k` is the number of runs of the merge sort. For an index build of OSM planet with 44 B input triples, the merge sort had 421 runs, which with a block size of `4 MB` leads to a RAM requirement of `10.1 GB`. With the new block size of `500 kB`, one fourth of this is sufficient. 