### PR TITLE
Implement builtin functions  `HOURS`, `MINUTES`, and `SECONDS` 

### DIFF
--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -52,17 +52,23 @@ inline auto extractTimeComponentImpl = [](std::optional<DateOrLargeYear> d) {
   return std::invoke(makeId, std::invoke(dateMember, date));
 };
 
-inline auto extractHours = extractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
-inline auto extractMinutes = extractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
-inline auto extractSeconds = extractTimeComponentImpl<&Date::getSecond, &Id::makeFromDouble>;
+inline auto extractHours =
+    extractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
+inline auto extractMinutes =
+    extractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
+inline auto extractSeconds =
+    extractTimeComponentImpl<&Date::getSecond, &Id::makeFromDouble>;
 
 NARY_EXPRESSION(YearExpression, 1, FV<decltype(extractYear), DateValueGetter>);
 NARY_EXPRESSION(MonthExpression, 1,
                 FV<decltype(extractMonth), DateValueGetter>);
 NARY_EXPRESSION(DayExpression, 1, FV<decltype(extractDay), DateValueGetter>);
-NARY_EXPRESSION(HoursExpression, 1, FV<decltype(extractHours), DateValueGetter>);
-NARY_EXPRESSION(MinutesExpression, 1, FV<decltype(extractMinutes), DateValueGetter>);
-NARY_EXPRESSION(SecondsExpression, 1, FV<decltype(extractSeconds), DateValueGetter>);
+NARY_EXPRESSION(HoursExpression, 1,
+                FV<decltype(extractHours), DateValueGetter>);
+NARY_EXPRESSION(MinutesExpression, 1,
+                FV<decltype(extractMinutes), DateValueGetter>);
+NARY_EXPRESSION(SecondsExpression, 1,
+                FV<decltype(extractSeconds), DateValueGetter>);
 
 }  // namespace detail
 using namespace detail;

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -40,10 +40,41 @@ inline auto extractDay = [](std::optional<DateOrLargeYear> d) {
   return Id::makeFromInt(optionalDay.value());
 };
 
+inline auto extractHours = [](std::optional<DateOrLargeYear> d) {
+  if (!d.has_value() || !d->isDate()) {
+    return Id::makeUndefined();
+  }
+  auto hours = d.value().getDate().getHour();
+  if (hours == -1 ) {
+    return Id::makeUndefined();
+  }
+  return Id::makeFromInt(hours);
+};
+
+inline auto extractMinutes = [](std::optional<DateOrLargeYear> d) {
+  if (!d.has_value() || !d->isDate()) {
+    return Id::makeUndefined();
+  }
+  auto minutes = d.value().getDate().getMinute();
+  return Id::makeFromInt(minutes);
+};
+
+inline auto extractSeconds = [](std::optional<DateOrLargeYear> d) {
+  if (!d.has_value() || !d->isDate()) {
+    return Id::makeUndefined();
+  }
+  auto seconds = d.value().getDate().getSecond();
+  return Id::makeFromDouble(seconds);
+};
+
 NARY_EXPRESSION(YearExpression, 1, FV<decltype(extractYear), DateValueGetter>);
 NARY_EXPRESSION(MonthExpression, 1,
                 FV<decltype(extractMonth), DateValueGetter>);
 NARY_EXPRESSION(DayExpression, 1, FV<decltype(extractDay), DateValueGetter>);
+NARY_EXPRESSION(HoursExpression, 1, FV<decltype(extractHours), DateValueGetter>);
+NARY_EXPRESSION(MinutesExpression, 1, FV<decltype(extractMinutes), DateValueGetter>);
+NARY_EXPRESSION(SecondsExpression, 1, FV<decltype(extractSeconds), DateValueGetter>);
+
 }  // namespace detail
 using namespace detail;
 SparqlExpression::Ptr makeYearExpression(SparqlExpression::Ptr child) {
@@ -56,5 +87,17 @@ SparqlExpression::Ptr makeDayExpression(SparqlExpression::Ptr child) {
 
 SparqlExpression::Ptr makeMonthExpression(SparqlExpression::Ptr child) {
   return std::make_unique<MonthExpression>(std::move(child));
+}
+
+SparqlExpression::Ptr makeHoursExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<HoursExpression>(std::move(child));
+}
+
+SparqlExpression::Ptr makeMinutesExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<MinutesExpression>(std::move(child));
+}
+
+SparqlExpression::Ptr makeSecondsExpression(SparqlExpression::Ptr child) {
+  return std::make_unique<SecondsExpression>(std::move(child));
 }
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -40,32 +40,21 @@ inline auto extractDay = [](std::optional<DateOrLargeYear> d) {
   return Id::makeFromInt(optionalDay.value());
 };
 
-inline auto extractHours = [](std::optional<DateOrLargeYear> d) {
-  if (!d.has_value() || d->getType() != DateOrLargeYear::Type::DateTime) {
+template <auto dateMember, auto makeId>
+inline auto extractTimeComponentImpl = [](std::optional<DateOrLargeYear> d) {
+  if (!d.has_value() || !d->isDate()) {
     return Id::makeUndefined();
   }
-  auto hours = d.value().getDate().getHour();
-  if (hours == -1 ) {
+  Date date = d.value().getDate();
+  if (!date.hasTime()) {
     return Id::makeUndefined();
   }
-  return Id::makeFromInt(hours);
+  return std::invoke(makeId, std::invoke(dateMember, date));
 };
 
-inline auto extractMinutes = [](std::optional<DateOrLargeYear> d) {
-  if (!d.has_value() || d->getType() != DateOrLargeYear::Type::DateTime) {
-    return Id::makeUndefined();
-  }
-  auto minutes = d.value().getDate().getMinute();
-  return Id::makeFromInt(minutes);
-};
-
-inline auto extractSeconds = [](std::optional<DateOrLargeYear> d) {
-  if (!d.has_value() || d->getType() != DateOrLargeYear::Type::DateTime) {
-    return Id::makeUndefined();
-  }
-  auto seconds = d.value().getDate().getSecond();
-  return Id::makeFromDouble(seconds);
-};
+inline auto extractHours = extractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
+inline auto extractMinutes = extractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
+inline auto extractSeconds = extractTimeComponentImpl<&Date::getSecond, &Id::makeFromDouble>;
 
 NARY_EXPRESSION(YearExpression, 1, FV<decltype(extractYear), DateValueGetter>);
 NARY_EXPRESSION(MonthExpression, 1,

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -52,11 +52,11 @@ inline auto extractTimeComponentImpl = [](std::optional<DateOrLargeYear> d) {
   return std::invoke(makeId, std::invoke(dateMember, date));
 };
 
-inline auto extractHours =
+constexpr auto extractHours =
     extractTimeComponentImpl<&Date::getHour, &Id::makeFromInt>;
-inline auto extractMinutes =
+constexpr auto extractMinutes =
     extractTimeComponentImpl<&Date::getMinute, &Id::makeFromInt>;
-inline auto extractSeconds =
+constexpr auto extractSeconds =
     extractTimeComponentImpl<&Date::getSecond, &Id::makeFromDouble>;
 
 NARY_EXPRESSION(YearExpression, 1, FV<decltype(extractYear), DateValueGetter>);

--- a/src/engine/sparqlExpressions/DateExpressions.cpp
+++ b/src/engine/sparqlExpressions/DateExpressions.cpp
@@ -41,7 +41,7 @@ inline auto extractDay = [](std::optional<DateOrLargeYear> d) {
 };
 
 inline auto extractHours = [](std::optional<DateOrLargeYear> d) {
-  if (!d.has_value() || !d->isDate()) {
+  if (!d.has_value() || d->getType() != DateOrLargeYear::Type::DateTime) {
     return Id::makeUndefined();
   }
   auto hours = d.value().getDate().getHour();
@@ -52,7 +52,7 @@ inline auto extractHours = [](std::optional<DateOrLargeYear> d) {
 };
 
 inline auto extractMinutes = [](std::optional<DateOrLargeYear> d) {
-  if (!d.has_value() || !d->isDate()) {
+  if (!d.has_value() || d->getType() != DateOrLargeYear::Type::DateTime) {
     return Id::makeUndefined();
   }
   auto minutes = d.value().getDate().getMinute();
@@ -60,7 +60,7 @@ inline auto extractMinutes = [](std::optional<DateOrLargeYear> d) {
 };
 
 inline auto extractSeconds = [](std::optional<DateOrLargeYear> d) {
-  if (!d.has_value() || !d->isDate()) {
+  if (!d.has_value() || d->getType() != DateOrLargeYear::Type::DateTime) {
     return Id::makeUndefined();
   }
   auto seconds = d.value().getDate().getSecond();

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -48,6 +48,9 @@ SparqlExpression::Ptr makeDistExpression(SparqlExpression::Ptr child1,
 SparqlExpression::Ptr makeLatitudeExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeLongitudeExpression(SparqlExpression::Ptr child);
 
+SparqlExpression::Ptr makeSecondsExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeMinutesExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeHoursExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeDayExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeMonthExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeYearExpression(SparqlExpression::Ptr child);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1674,6 +1674,12 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
     return createUnary(&makeMonthExpression);
   } else if (functionName == "day") {
     return createUnary(&makeDayExpression);
+  } else if(functionName == "hours") {
+    return createUnary(&makeHoursExpression);
+  } else if(functionName == "minutes") {
+    return createUnary(&makeMinutesExpression);
+  } else if(functionName == "seconds") {
+    return createUnary(&makeSecondsExpression);
   } else if (functionName == "rand") {
     AD_CONTRACT_CHECK(argList.empty());
     return std::make_unique<RandomExpression>();

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1674,11 +1674,11 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
     return createUnary(&makeMonthExpression);
   } else if (functionName == "day") {
     return createUnary(&makeDayExpression);
-  } else if(functionName == "hours") {
+  } else if (functionName == "hours") {
     return createUnary(&makeHoursExpression);
-  } else if(functionName == "minutes") {
+  } else if (functionName == "minutes") {
     return createUnary(&makeMinutesExpression);
-  } else if(functionName == "seconds") {
+  } else if (functionName == "seconds") {
     return createUnary(&makeSecondsExpression);
   } else if (functionName == "rand") {
     AD_CONTRACT_CHECK(argList.empty());

--- a/src/util/Date.cpp
+++ b/src/util/Date.cpp
@@ -35,7 +35,7 @@ std::pair<std::string, const char*> Date::toStringAndType() const {
     constexpr static std::string_view formatString = "%04d-%02d";
     dateString = absl::StrFormat(formatString, getYear(), getMonth());
     type = XSD_GYEARMONTH_TYPE;
-  } else if (getHour() == -1) {
+  } else if (!hasTime()) {
     constexpr static std::string_view formatString = "%04d-%02d-%02d";
     dateString = absl::StrFormat(formatString, getYear(), getMonth(), getDay());
     type = XSD_DATE_TYPE;

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -305,9 +305,7 @@ class Date {
 
   // True iff Date object has set time values (hours, minutes, seconds) (i.e
   //  "This is a `xsd:dateTime`")
-  [[nodiscard]] bool hasTime() const {
-    return getHour() != -1;
-  }
+  [[nodiscard]] bool hasTime() const { return getHour() != -1; }
 
   // Correctly format the time zone according to the `xsd` standard. This is a
   // helper function for `toStringAndType` below.

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -303,6 +303,12 @@ class Date {
     timeZone_ = static_cast<unsigned>(actualTimeZone - minTimeZoneActually);
   }
 
+  // True iff Date object has set time values (hours, minutes, seconds) (i.e
+  //  "This is a `xsd:dateTime`")
+  [[nodiscard]] bool hasTime() const {
+    return getHour() != -1;
+  }
+
   // Correctly format the time zone according to the `xsd` standard. This is a
   // helper function for `toStringAndType` below.
   std::string formatTimeZone() const;

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1279,6 +1279,9 @@ TEST(SparqlParser, builtInCall) {
   expectBuiltInCall("year(?x)", matchUnary(&makeYearExpression));
   expectBuiltInCall("month(?x)", matchUnary(&makeMonthExpression));
   expectBuiltInCall("day(?x)", matchUnary(&makeDayExpression));
+  expectBuiltInCall("hours(?x)", matchUnary(&makeHoursExpression));
+  expectBuiltInCall("minutes(?x)", matchUnary(&makeMinutesExpression));
+  expectBuiltInCall("seconds(?x)", matchUnary(&makeSecondsExpression));
   expectBuiltInCall("abs(?x)", matchUnary(&makeAbsExpression));
   expectBuiltInCall("ceil(?x)", matchUnary(&makeCeilExpression));
   expectBuiltInCall("floor(?x)", matchUnary(&makeFloorExpression));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -414,8 +414,8 @@ TEST(SparqlExpression, dateOperators) {
   auto check = [&checkYear, &checkMonth, &checkDay, &checkHours, &checkMinutes,
                 &checkSeconds](
                    const DateOrLargeYear& date, std::optional<int> expectedYear,
-                   std::optional<int> expectedMonth,
-                   std::optional<int> expectedDay,
+                   std::optional<int> expectedMonth = std::nullopt,
+                   std::optional<int> expectedDay = std::nullopt,
                    std::optional<int> expectedHours = std::nullopt,
                    std::optional<int> expectedMinutes = std::nullopt,
                    std::optional<double> expectedSeconds = std::nullopt,
@@ -458,9 +458,9 @@ TEST(SparqlExpression, dateOperators) {
 
   // Test behavior of the `largeYear` representation that doesn't store the
   // actual date.
-  check(D::parseGYear("123456"), 123456, std::nullopt, std::nullopt);
-  check(D::parseGYearMonth("-12345-01"), -12345, 1, std::nullopt);
-  check(D::parseGYearMonth("-12345-03"), -12345, 1, std::nullopt);
+  check(D::parseGYear("123456"), 123456);
+  check(D::parseGYearMonth("-12345-01"), -12345, 1);
+  check(D::parseGYearMonth("-12345-03"), -12345, 1);
   check(D::parseXsdDate("-12345-01-01"), -12345, 1, 1);
   check(D::parseXsdDate("-12345-03-04"), -12345, 1, 1);
 

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -420,7 +420,7 @@ TEST(SparqlExpression, dateOperators) {
                    std::optional<double> expectedSeconds,
                    std::source_location l = std::source_location::current()) {
     auto trace = generateLocationTrace(l);
-    auto optToId = [](const auto& opt) {
+    auto optToIdInt = [](const auto& opt) {
       if (opt.has_value()) {
         return Id::makeFromInt(opt.value());
       } else {
@@ -434,11 +434,11 @@ TEST(SparqlExpression, dateOperators) {
         return Id::makeUndefined();
       }
     };
-    checkYear(Ids{Id::makeFromDate(date)}, Ids{optToId(expectedYear)});
-    checkMonth(Ids{Id::makeFromDate(date)}, Ids{optToId(expectedMonth)});
-    checkDay(Ids{Id::makeFromDate(date)}, Ids{optToId(expectedDay)});
-    checkHours(Ids{Id::makeFromDate(date)}, Ids{optToId(expectedHours)});
-    checkMinutes(Ids{Id::makeFromDate(date)}, Ids{optToId(expectedMinutes)});
+    checkYear(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedYear)});
+    checkMonth(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedMonth)});
+    checkDay(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedDay)});
+    checkHours(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedHours)});
+    checkMinutes(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedMinutes)});
     checkSeconds(Ids{Id::makeFromDate(date)}, Ids{optToIdDouble(expectedSeconds)});
 
   };
@@ -448,7 +448,7 @@ TEST(SparqlExpression, dateOperators) {
   check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4,
         22, 11, 53, 42.25);
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22,
-        std::nullopt,std::nullopt,std::nullopt);
+        std::nullopt,0,0.0);
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22,
         std::nullopt,0,0.0);
   check(D::parseXsdDate("0042-12-24"), 42, 12, 24,

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -450,7 +450,7 @@ TEST(SparqlExpression, dateOperators) {
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
   check(D::parseXsdDate("0042-12-24"), 42, 12, 24);
-  check(D::parseXsdDate("-0099-07-01"), -99, 7,1);
+  check(D::parseXsdDate("-0099-07-01"), -99, 7, 1);
   check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt);
   check(D::parseXsdDate("0321-07-01"), 321, 7, 1);
   check(D::parseXsdDate("2321-07-01"), 2321, 7, 1);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -407,12 +407,13 @@ TEST(SparqlExpression, dateOperators) {
   auto checkMonth = std::bind_front(testUnaryExpression, &makeMonthExpression);
   auto checkDay = std::bind_front(testUnaryExpression, &makeDayExpression);
   auto checkHours = std::bind_front(testUnaryExpression, &makeHoursExpression);
-  auto checkMinutes = std::bind_front(testUnaryExpression, &makeMinutesExpression);
-  auto checkSeconds = std::bind_front(testUnaryExpression, &makeSecondsExpression);
-  auto check =
-      [&checkYear, &checkMonth, &checkDay, &checkHours, &checkMinutes, &checkSeconds](
-                   const DateOrLargeYear& date,
-                   std::optional<int> expectedYear,
+  auto checkMinutes =
+      std::bind_front(testUnaryExpression, &makeMinutesExpression);
+  auto checkSeconds =
+      std::bind_front(testUnaryExpression, &makeSecondsExpression);
+  auto check = [&checkYear, &checkMonth, &checkDay, &checkHours, &checkMinutes,
+                &checkSeconds](
+                   const DateOrLargeYear& date, std::optional<int> expectedYear,
                    std::optional<int> expectedMonth,
                    std::optional<int> expectedDay,
                    std::optional<int> expectedHours = std::nullopt,
@@ -439,14 +440,14 @@ TEST(SparqlExpression, dateOperators) {
     checkDay(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedDay)});
     checkHours(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedHours)});
     checkMinutes(Ids{Id::makeFromDate(date)}, Ids{optToIdInt(expectedMinutes)});
-    checkSeconds(Ids{Id::makeFromDate(date)}, Ids{optToIdDouble(expectedSeconds)});
-
+    checkSeconds(Ids{Id::makeFromDate(date)},
+                 Ids{optToIdDouble(expectedSeconds)});
   };
 
   using D = DateOrLargeYear;
   // Now the checks for dates with varying level of detail.
-  check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4,
-        22, 11, 53, 42.25);
+  check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4, 22, 11, 53,
+        42.25);
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
   check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
   check(D::parseXsdDate("0042-12-24"), 42, 12, 24);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -415,9 +415,9 @@ TEST(SparqlExpression, dateOperators) {
                    std::optional<int> expectedYear,
                    std::optional<int> expectedMonth,
                    std::optional<int> expectedDay,
-                   std::optional<int> expectedHours,
-                   std::optional<int> expectedMinutes,
-                   std::optional<double> expectedSeconds,
+                   std::optional<int> expectedHours = std::nullopt,
+                   std::optional<int> expectedMinutes = std::nullopt,
+                   std::optional<double> expectedSeconds = std::nullopt,
                    std::source_location l = std::source_location::current()) {
     auto trace = generateLocationTrace(l);
     auto optToIdInt = [](const auto& opt) {
@@ -447,28 +447,21 @@ TEST(SparqlExpression, dateOperators) {
   // Now the checks for dates with varying level of detail.
   check(D::parseXsdDatetime("1970-04-22T11:53:42.25"), 1970, 4,
         22, 11, 53, 42.25);
-  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22,
-        std::nullopt,0,0.0);
-  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22,
-        std::nullopt,0,0.0);
-  check(D::parseXsdDate("0042-12-24"), 42, 12, 24,
-        std::nullopt,0,0.0);
-  check(D::parseXsdDate("-0099-07-01"), -99, 7,1,
-        std::nullopt,0,0.0);
-  check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt,
-        std::nullopt,0,0.0);
-  check(D::parseXsdDate("0321-07-01"), 321, 7, 1,
-        std::nullopt,0,0.0);
-  check(D::parseXsdDate("2321-07-01"), 2321, 7, 1,
-        std::nullopt,0,0.0);
+  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
+  check(D::parseXsdDate("1970-04-22"), 1970, 4, 22);
+  check(D::parseXsdDate("0042-12-24"), 42, 12, 24);
+  check(D::parseXsdDate("-0099-07-01"), -99, 7,1);
+  check(D::parseGYear("-1234"), -1234, std::nullopt, std::nullopt);
+  check(D::parseXsdDate("0321-07-01"), 321, 7, 1);
+  check(D::parseXsdDate("2321-07-01"), 2321, 7, 1);
 
   // Test behavior of the `largeYear` representation that doesn't store the
   // actual date.
-  check(D::parseGYear("123456"), 123456, std::nullopt, std::nullopt, std::nullopt,std::nullopt,std::nullopt);
-  check(D::parseGYearMonth("-12345-01"), -12345, 1, std::nullopt, std::nullopt,std::nullopt,std::nullopt);
-  check(D::parseGYearMonth("-12345-03"), -12345, 1, std::nullopt, std::nullopt,std::nullopt,std::nullopt);
-  check(D::parseXsdDate("-12345-01-01"), -12345, 1, 1, std::nullopt,std::nullopt,std::nullopt);
-  check(D::parseXsdDate("-12345-03-04"), -12345, 1, 1, std::nullopt,std::nullopt,std::nullopt);
+  check(D::parseGYear("123456"), 123456, std::nullopt, std::nullopt);
+  check(D::parseGYearMonth("-12345-01"), -12345, 1, std::nullopt);
+  check(D::parseGYearMonth("-12345-03"), -12345, 1, std::nullopt);
+  check(D::parseXsdDate("-12345-01-01"), -12345, 1, 1);
+  check(D::parseXsdDate("-12345-03-04"), -12345, 1, 1);
 
   // Invalid inputs for date expressions.
   checkYear(Ids{Id::makeFromInt(42)}, Ids{Id::makeUndefined()});


### PR DESCRIPTION
These functions return the respective component of an `xsd:datetime` as a numeric value (integer for `HOURS` and `MINUTES`, decimal for `SECONDS`), and `UNDEF` for inputs of any other type.