### PR TITLE
Code improvements for the Websocket module

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -757,6 +757,6 @@ Awaitable<T> Server::computeInNewThread(Function function) const {
     co_await net::post(net::bind_executor(executor, net::use_awaitable));
     co_return std::invoke(func);
   };
-  return ad_utility::originalExecutor(
+  return ad_utility::resumeOnOriginalExecutor(
       runOnExecutor(threadPool_.get_executor(), std::move(function)));
 }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -757,6 +757,6 @@ Awaitable<T> Server::computeInNewThread(Function function) const {
     co_await net::post(net::bind_executor(executor, net::use_awaitable));
     co_return std::invoke(func);
   };
-  return ad_utility::sameExecutor(
+  return ad_utility::originalExecutor(
       runOnExecutor(threadPool_.get_executor(), std::move(function)));
 }

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -15,24 +15,23 @@ namespace ad_utility {
 
 namespace net = boost::asio;
 
-/// Helper function that ensures that co_await resumes on the same
-/// executor it started with.
+/// Helper function that ensures that co_await resumes on the executor
+/// this coroutine was started on.
 /// IMPORTANT: If the coroutine is cancelled, no guarantees are given. Make
 /// sure to keep that in mind when handling cancellation errors!
 template <typename T>
 inline net::awaitable<T> sameExecutor(net::awaitable<T> awaitable) {
-  auto initialExecutor = co_await net::this_coro::executor;
   std::exception_ptr exceptionPtr;
   try {
     T result = co_await std::move(awaitable);
-    co_await net::dispatch(initialExecutor, net::use_awaitable);
+    co_await net::dispatch(net::use_awaitable);
     co_return result;
   } catch (...) {
     exceptionPtr = std::current_exception();
   }
   auto cancellationState = co_await net::this_coro::cancellation_state;
   if (cancellationState.cancelled() == net::cancellation_type::none) {
-    co_await net::dispatch(initialExecutor, net::use_awaitable);
+    co_await net::dispatch(net::use_awaitable);
   }
   AD_CORRECTNESS_CHECK(exceptionPtr);
   std::rethrow_exception(exceptionPtr);
@@ -40,10 +39,9 @@ inline net::awaitable<T> sameExecutor(net::awaitable<T> awaitable) {
 
 // _____________________________________________________________________________
 
-/// Helper function that ensures that co_await resumes on the same
-/// executor it started with. Overload for void.
+/// Helper function that ensures that co_await resumes on the executor
+/// this coroutine was started on. Overload for void.
 inline net::awaitable<void> sameExecutor(net::awaitable<void> awaitable) {
-  auto initialExecutor = co_await net::this_coro::executor;
   std::exception_ptr exceptionPtr;
   try {
     co_await std::move(awaitable);
@@ -52,7 +50,7 @@ inline net::awaitable<void> sameExecutor(net::awaitable<void> awaitable) {
   }
   if ((co_await net::this_coro::cancellation_state).cancelled() ==
       net::cancellation_type::none) {
-    co_await net::dispatch(initialExecutor, net::use_awaitable);
+    co_await net::dispatch(net::use_awaitable);
   }
   if (exceptionPtr) {
     std::rethrow_exception(exceptionPtr);

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -16,11 +16,11 @@ namespace ad_utility {
 namespace net = boost::asio;
 
 /// Helper function that ensures that co_await resumes on the executor
-/// this coroutine was started on.
+/// this coroutine was co_spawned on.
 /// IMPORTANT: If the coroutine is cancelled, no guarantees are given. Make
 /// sure to keep that in mind when handling cancellation errors!
 template <typename T>
-inline net::awaitable<T> originalExecutor(net::awaitable<T> awaitable) {
+inline net::awaitable<T> resumeOnOriginalExecutor(net::awaitable<T> awaitable) {
   std::exception_ptr exceptionPtr;
   try {
     T result = co_await std::move(awaitable);
@@ -31,6 +31,8 @@ inline net::awaitable<T> originalExecutor(net::awaitable<T> awaitable) {
   }
   auto cancellationState = co_await net::this_coro::cancellation_state;
   if (cancellationState.cancelled() == net::cancellation_type::none) {
+    // use_awaitable always resumes the coroutine on the executor the coroutine
+    // was co_spawned on
     co_await net::dispatch(net::use_awaitable);
   }
   AD_CORRECTNESS_CHECK(exceptionPtr);
@@ -40,8 +42,9 @@ inline net::awaitable<T> originalExecutor(net::awaitable<T> awaitable) {
 // _____________________________________________________________________________
 
 /// Helper function that ensures that co_await resumes on the executor
-/// this coroutine was started on. Overload for void.
-inline net::awaitable<void> originalExecutor(net::awaitable<void> awaitable) {
+/// this coroutine was co_spawned on. Overload for void.
+inline net::awaitable<void> resumeOnOriginalExecutor(
+    net::awaitable<void> awaitable) {
   std::exception_ptr exceptionPtr;
   try {
     co_await std::move(awaitable);
@@ -50,6 +53,8 @@ inline net::awaitable<void> originalExecutor(net::awaitable<void> awaitable) {
   }
   if ((co_await net::this_coro::cancellation_state).cancelled() ==
       net::cancellation_type::none) {
+    // use_awaitable always resumes the coroutine on the executor the coroutine
+    // was co_spawned on
     co_await net::dispatch(net::use_awaitable);
   }
   if (exceptionPtr) {

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -20,7 +20,7 @@ namespace net = boost::asio;
 /// IMPORTANT: If the coroutine is cancelled, no guarantees are given. Make
 /// sure to keep that in mind when handling cancellation errors!
 template <typename T>
-inline net::awaitable<T> sameExecutor(net::awaitable<T> awaitable) {
+inline net::awaitable<T> originalExecutor(net::awaitable<T> awaitable) {
   std::exception_ptr exceptionPtr;
   try {
     T result = co_await std::move(awaitable);
@@ -41,7 +41,7 @@ inline net::awaitable<T> sameExecutor(net::awaitable<T> awaitable) {
 
 /// Helper function that ensures that co_await resumes on the executor
 /// this coroutine was started on. Overload for void.
-inline net::awaitable<void> sameExecutor(net::awaitable<void> awaitable) {
+inline net::awaitable<void> originalExecutor(net::awaitable<void> awaitable) {
   std::exception_ptr exceptionPtr;
   try {
     co_await std::move(awaitable);

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -54,7 +54,7 @@ QueryHub::createOrAcquireDistributorInternal(QueryId queryId) {
 
 net::awaitable<std::shared_ptr<QueryToSocketDistributor>>
 QueryHub::createOrAcquireDistributorForSending(QueryId queryId) {
-  return sameExecutor(
+  return originalExecutor(
       createOrAcquireDistributorInternal<true>(std::move(queryId)));
 }
 
@@ -62,7 +62,7 @@ QueryHub::createOrAcquireDistributorForSending(QueryId queryId) {
 
 net::awaitable<std::shared_ptr<const QueryToSocketDistributor>>
 QueryHub::createOrAcquireDistributorForReceiving(QueryId queryId) {
-  return sameExecutor(
+  return originalExecutor(
       createOrAcquireDistributorInternal<false>(std::move(queryId)));
 }
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -54,7 +54,7 @@ QueryHub::createOrAcquireDistributorInternal(QueryId queryId) {
 
 net::awaitable<std::shared_ptr<QueryToSocketDistributor>>
 QueryHub::createOrAcquireDistributorForSending(QueryId queryId) {
-  return originalExecutor(
+  return resumeOnOriginalExecutor(
       createOrAcquireDistributorInternal<true>(std::move(queryId)));
 }
 
@@ -62,7 +62,7 @@ QueryHub::createOrAcquireDistributorForSending(QueryId queryId) {
 
 net::awaitable<std::shared_ptr<const QueryToSocketDistributor>>
 QueryHub::createOrAcquireDistributorForReceiving(QueryId queryId) {
-  return originalExecutor(
+  return resumeOnOriginalExecutor(
       createOrAcquireDistributorInternal<false>(std::move(queryId)));
 }
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/QueryToSocketDistributor.cpp
+++ b/src/util/http/websocket/QueryToSocketDistributor.cpp
@@ -12,19 +12,20 @@
 
 namespace ad_utility::websocket {
 
+auto QueryToSocketDistributor::useStrandedAwaitable() const {
+  return net::bind_executor(strand_, net::use_awaitable);
+}
+
 net::awaitable<void> QueryToSocketDistributor::waitForUpdate() const {
-  try {
-    co_await infiniteTimer_.async_wait(net::use_awaitable);
-    AD_THROW("Infinite timer expired. This should not happen");
-  } catch (boost::system::system_error& error) {
-    if (error.code() != net::error::operation_aborted) {
-      throw;
-    }
-  }
+  auto [error] =
+      co_await infiniteTimer_.async_wait(net::as_tuple(useStrandedAwaitable()));
+  // If this fails this means the infinite timer expired or aborted with an
+  // unexpected error code. This should not happen at all
+  AD_CORRECTNESS_CHECK(error == net::error::operation_aborted);
+  AD_CORRECTNESS_CHECK(strand_.running_in_this_thread());
   // Clear cancellation flag if set, and wake up to allow the caller
   // to return no-data and gracefully end this
   co_await net::this_coro::reset_cancellation_state();
-  co_await net::dispatch(net::bind_executor(strand_, net::use_awaitable));
 }
 
 // _____________________________________________________________________________
@@ -39,7 +40,7 @@ void QueryToSocketDistributor::wakeUpWaitingListeners() {
 net::awaitable<void> QueryToSocketDistributor::addQueryStatusUpdate(
     std::string payload) {
   auto sharedPayload = std::make_shared<const std::string>(std::move(payload));
-  co_await net::dispatch(net::bind_executor(strand_, net::use_awaitable));
+  co_await net::dispatch(useStrandedAwaitable());
   AD_CONTRACT_CHECK(!finished_);
   data_.push_back(std::move(sharedPayload));
   wakeUpWaitingListeners();
@@ -48,7 +49,7 @@ net::awaitable<void> QueryToSocketDistributor::addQueryStatusUpdate(
 // _____________________________________________________________________________
 
 net::awaitable<void> QueryToSocketDistributor::signalEnd() {
-  co_await net::dispatch(net::bind_executor(strand_, net::use_awaitable));
+  co_await net::dispatch(useStrandedAwaitable());
   AD_CONTRACT_CHECK(!finished_);
   finished_ = true;
   wakeUpWaitingListeners();
@@ -60,7 +61,7 @@ net::awaitable<void> QueryToSocketDistributor::signalEnd() {
 
 net::awaitable<std::shared_ptr<const std::string>>
 QueryToSocketDistributor::waitForNextDataPiece(size_t index) const {
-  co_await net::dispatch(net::bind_executor(strand_, net::use_awaitable));
+  co_await net::dispatch(useStrandedAwaitable());
 
   if (index < data_.size()) {
     co_return data_.at(index);

--- a/src/util/http/websocket/QueryToSocketDistributor.h
+++ b/src/util/http/websocket/QueryToSocketDistributor.h
@@ -23,7 +23,7 @@ namespace net = boost::asio;
 /// It also provides its own strand so operations on this class do not need
 /// to be synchronized globally. The public API is thread-safe, but you
 /// will end up on a different executor when awaiting it, so make sure
-/// to use a wrapper like `sameExecutor()` to stay on your executor!
+/// to use a wrapper like `originalExecutor()` to stay on your executor!
 class QueryToSocketDistributor {
   /// Strand to synchronize all operations on this class
   net::strand<net::any_io_executor> strand_;

--- a/src/util/http/websocket/QueryToSocketDistributor.h
+++ b/src/util/http/websocket/QueryToSocketDistributor.h
@@ -47,6 +47,8 @@ class QueryToSocketDistributor {
   /// update to the data.
   net::awaitable<void> waitForUpdate() const;
 
+  auto useStrandedAwaitable() const;
+
  public:
   /// Constructor that builds a new strand from the provided io context.
   explicit QueryToSocketDistributor(net::io_context& ioContext,

--- a/src/util/http/websocket/QueryToSocketDistributor.h
+++ b/src/util/http/websocket/QueryToSocketDistributor.h
@@ -47,7 +47,9 @@ class QueryToSocketDistributor {
   /// update to the data.
   net::awaitable<void> waitForUpdate() const;
 
-  auto useStrandedAwaitable() const;
+  /// Schedule a coroutine onto the strand of this instance.
+  /// Make sure to co_await this before accessing any member of this class.
+  net::awaitable<void> dispatchToStrand() const;
 
  public:
   /// Constructor that builds a new strand from the provided io context.

--- a/src/util/http/websocket/QueryToSocketDistributor.h
+++ b/src/util/http/websocket/QueryToSocketDistributor.h
@@ -23,7 +23,7 @@ namespace net = boost::asio;
 /// It also provides its own strand so operations on this class do not need
 /// to be synchronized globally. The public API is thread-safe, but you
 /// will end up on a different executor when awaiting it, so make sure
-/// to use a wrapper like `originalExecutor()` to stay on your executor!
+/// to use a wrapper like `resumeOnOriginalExecutor()` to stay on your executor!
 class QueryToSocketDistributor {
   /// Strand to synchronize all operations on this class
   net::strand<net::any_io_executor> strand_;

--- a/src/util/http/websocket/UpdateFetcher.cpp
+++ b/src/util/http/websocket/UpdateFetcher.cpp
@@ -15,7 +15,7 @@ net::awaitable<UpdateFetcher::PayloadType> UpdateFetcher::waitForEvent() {
   }
 
   auto data =
-      co_await sameExecutor(distributor_->waitForNextDataPiece(nextIndex_));
+      co_await originalExecutor(distributor_->waitForNextDataPiece(nextIndex_));
   if (data) {
     nextIndex_++;
   }

--- a/src/util/http/websocket/UpdateFetcher.cpp
+++ b/src/util/http/websocket/UpdateFetcher.cpp
@@ -14,8 +14,8 @@ net::awaitable<UpdateFetcher::PayloadType> UpdateFetcher::waitForEvent() {
         co_await queryHub_.createOrAcquireDistributorForReceiving(queryId_);
   }
 
-  auto data =
-      co_await originalExecutor(distributor_->waitForNextDataPiece(nextIndex_));
+  auto data = co_await resumeOnOriginalExecutor(
+      distributor_->waitForNextDataPiece(nextIndex_));
   if (data) {
     nextIndex_++;
   }

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -70,10 +70,6 @@ net::awaitable<void> WebSocketSession::acceptAndWait(
 
     co_await ws_.async_accept(request, boost::asio::use_awaitable);
 
-    auto strand = net::make_strand(ws_.get_executor());
-
-    co_await net::dispatch(strand, net::use_awaitable);
-
     // Experimental operators, see
     // https://www.boost.org/doc/libs/1_81_0/doc/html/boost_asio/overview/composition/cpp20_coroutines.html
     // for more information

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -68,7 +68,7 @@ net::awaitable<void> WebSocketSession::acceptAndWait(
     ws_.set_option(beast::websocket::stream_base::timeout::suggested(
         beast::role_type::server));
 
-    co_await ws_.async_accept(request, boost::asio::use_awaitable);
+    co_await ws_.async_accept(request, net::use_awaitable);
 
     // Experimental operators, see
     // https://www.boost.org/doc/libs/1_81_0/doc/html/boost_asio/overview/composition/cpp20_coroutines.html
@@ -91,6 +91,12 @@ net::awaitable<void> WebSocketSession::acceptAndWait(
 net::awaitable<void> WebSocketSession::handleSession(
     QueryHub& queryHub, const http::request<http::string_body>& request,
     tcp::socket socket) {
+  // Make sure access to new websocket is on a strand and therefore thread safe
+  auto executor = co_await net::this_coro::executor;
+  AD_CONTRACT_CHECK(
+      executor.target<net::strand<net::io_context::executor_type>>());
+  co_await net::dispatch(net::use_awaitable);
+
   auto queryIdString = extractQueryId(request.target());
   AD_CORRECTNESS_CHECK(!queryIdString.empty());
   UpdateFetcher fetcher{queryHub, QueryId::idFromString(queryIdString)};

--- a/src/util/http/websocket/WebSocketSession.h
+++ b/src/util/http/websocket/WebSocketSession.h
@@ -44,7 +44,9 @@ class WebSocketSession {
   /// The main interface for this class. The HTTP server is supposed to check
   /// if an HTTP request is a websocket upgrade request and delegate further
   /// handling to this method if it is the case. It then accepts the websocket
-  /// connection and "blocks" for the lifetime of it.
+  /// connection and "blocks" for the lifetime of it. Make sure to call this
+  /// coroutine on an explicit strand, and make sure the passed socket's
+  /// executor is that same strand, otherwise there may be race conditions.
   static net::awaitable<void> handleSession(
       QueryHub& queryHub, const http::request<http::string_body>& request,
       tcp::socket socket);

--- a/test/AsioHelpersTest.cpp
+++ b/test/AsioHelpersTest.cpp
@@ -16,10 +16,10 @@
 
 namespace net = boost::asio;
 
-using ad_utility::originalExecutor;
+using ad_utility::resumeOnOriginalExecutor;
 using namespace boost::asio::experimental::awaitable_operators;
 
-TEST(AsioHelpers, originalExecutor) {
+TEST(AsioHelpers, resumeOnOriginalExecutor) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -38,7 +38,7 @@ TEST(AsioHelpers, originalExecutor) {
                          strand1]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    auto value = co_await originalExecutor(innerAwaitable());
+    auto value = co_await resumeOnOriginalExecutor(innerAwaitable());
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
     EXPECT_EQ(value, 1337);
@@ -54,7 +54,7 @@ TEST(AsioHelpers, originalExecutor) {
 
 // _____________________________________________________________________________
 
-TEST(AsioHelpers, originalExecutorVoidOverload) {
+TEST(AsioHelpers, resumeOnOriginalExecutorVoidOverload) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -65,7 +65,7 @@ TEST(AsioHelpers, originalExecutorVoidOverload) {
                          strand2]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    co_await originalExecutor(net::post(strand2, net::use_awaitable));
+    co_await resumeOnOriginalExecutor(net::post(strand2, net::use_awaitable));
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
     sanityFlag = true;
@@ -80,7 +80,7 @@ TEST(AsioHelpers, originalExecutorVoidOverload) {
 
 // _____________________________________________________________________________
 
-TEST(AsioHelpers, originalExecutorWhenException) {
+TEST(AsioHelpers, resumeOnOriginalExecutorWhenException) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -99,7 +99,7 @@ TEST(AsioHelpers, originalExecutorWhenException) {
                          strand1]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
+    EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  std::runtime_error);
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
@@ -115,7 +115,7 @@ TEST(AsioHelpers, originalExecutorWhenException) {
 
 // _____________________________________________________________________________
 
-TEST(AsioHelpers, originalExecutorVoidOverloadWhenException) {
+TEST(AsioHelpers, resumeOnOriginalExecutorVoidOverloadWhenException) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -134,7 +134,7 @@ TEST(AsioHelpers, originalExecutorVoidOverloadWhenException) {
                          strand1]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
+    EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  std::runtime_error);
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
@@ -159,7 +159,7 @@ net::awaitable<T> cancelAfter(net::awaitable<T> coroutine,
 // _____________________________________________________________________________
 
 // Checks that behavior is consistent for cancellation case
-TEST(AsioHelpers, originalExecutorWhenCancelled) {
+TEST(AsioHelpers, resumeOnOriginalExecutorWhenCancelled) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -184,7 +184,7 @@ TEST(AsioHelpers, originalExecutorWhenCancelled) {
     co_await net::post(strand1, net::use_awaitable);
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
+    EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  boost::system::system_error);
     // Verify we're on the strand the cancellation happened
     EXPECT_TRUE(strand3.running_in_this_thread());
@@ -203,7 +203,7 @@ TEST(AsioHelpers, originalExecutorWhenCancelled) {
 // _____________________________________________________________________________
 
 // Checks that behavior is consistent for cancellation case
-TEST(AsioHelpers, originalExecutorVoidOverloadWhenCancelled) {
+TEST(AsioHelpers, resumeOnOriginalExecutorVoidOverloadWhenCancelled) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -228,7 +228,7 @@ TEST(AsioHelpers, originalExecutorVoidOverloadWhenCancelled) {
     co_await net::post(strand1, net::use_awaitable);
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
+    EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  boost::system::system_error);
     // Verify we're on the strand the cancellation happened
     EXPECT_TRUE(strand3.running_in_this_thread());

--- a/test/AsioHelpersTest.cpp
+++ b/test/AsioHelpersTest.cpp
@@ -16,10 +16,10 @@
 
 namespace net = boost::asio;
 
-using ad_utility::sameExecutor;
+using ad_utility::originalExecutor;
 using namespace boost::asio::experimental::awaitable_operators;
 
-TEST(AsioHelpers, sameExecutor) {
+TEST(AsioHelpers, originalExecutor) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -38,7 +38,7 @@ TEST(AsioHelpers, sameExecutor) {
                          strand1]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    auto value = co_await sameExecutor(innerAwaitable());
+    auto value = co_await originalExecutor(innerAwaitable());
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
     EXPECT_EQ(value, 1337);
@@ -54,7 +54,7 @@ TEST(AsioHelpers, sameExecutor) {
 
 // _____________________________________________________________________________
 
-TEST(AsioHelpers, sameExecutorVoidOverload) {
+TEST(AsioHelpers, originalExecutorVoidOverload) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -65,7 +65,7 @@ TEST(AsioHelpers, sameExecutorVoidOverload) {
                          strand2]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    co_await sameExecutor(net::post(strand2, net::use_awaitable));
+    co_await originalExecutor(net::post(strand2, net::use_awaitable));
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
     sanityFlag = true;
@@ -80,7 +80,7 @@ TEST(AsioHelpers, sameExecutorVoidOverload) {
 
 // _____________________________________________________________________________
 
-TEST(AsioHelpers, sameExecutorWhenException) {
+TEST(AsioHelpers, originalExecutorWhenException) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -99,7 +99,8 @@ TEST(AsioHelpers, sameExecutorWhenException) {
                          strand1]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await sameExecutor(innerAwaitable()), std::runtime_error);
+    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
+                 std::runtime_error);
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
     sanityCounter++;
@@ -114,7 +115,7 @@ TEST(AsioHelpers, sameExecutorWhenException) {
 
 // _____________________________________________________________________________
 
-TEST(AsioHelpers, sameExecutorVoidOverloadWhenException) {
+TEST(AsioHelpers, originalExecutorVoidOverloadWhenException) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -133,7 +134,8 @@ TEST(AsioHelpers, sameExecutorVoidOverloadWhenException) {
                          strand1]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await sameExecutor(innerAwaitable()), std::runtime_error);
+    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
+                 std::runtime_error);
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
     sanityCounter++;
@@ -157,7 +159,7 @@ net::awaitable<T> cancelAfter(net::awaitable<T> coroutine,
 // _____________________________________________________________________________
 
 // Checks that behavior is consistent for cancellation case
-TEST(AsioHelpers, sameExecutorWhenCancelled) {
+TEST(AsioHelpers, originalExecutorWhenCancelled) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -182,7 +184,7 @@ TEST(AsioHelpers, sameExecutorWhenCancelled) {
     co_await net::post(strand1, net::use_awaitable);
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await sameExecutor(innerAwaitable()),
+    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
                  boost::system::system_error);
     // Verify we're on the strand the cancellation happened
     EXPECT_TRUE(strand3.running_in_this_thread());
@@ -201,7 +203,7 @@ TEST(AsioHelpers, sameExecutorWhenCancelled) {
 // _____________________________________________________________________________
 
 // Checks that behavior is consistent for cancellation case
-TEST(AsioHelpers, sameExecutorVoidOverloadWhenCancelled) {
+TEST(AsioHelpers, originalExecutorVoidOverloadWhenCancelled) {
   net::io_context ioContext{};
   auto strand1 = net::make_strand(ioContext);
   auto strand2 = net::make_strand(ioContext);
@@ -226,7 +228,7 @@ TEST(AsioHelpers, sameExecutorVoidOverloadWhenCancelled) {
     co_await net::post(strand1, net::use_awaitable);
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    EXPECT_THROW(co_await sameExecutor(innerAwaitable()),
+    EXPECT_THROW(co_await originalExecutor(innerAwaitable()),
                  boost::system::system_error);
     // Verify we're on the strand the cancellation happened
     EXPECT_TRUE(strand3.running_in_this_thread());

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -153,6 +153,7 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
       co_await queryHub.createOrAcquireDistributorForReceiving(queryId);
   EXPECT_FALSE(!comparison.owner_before(distributor) &&
                !distributor.owner_before(comparison));
+  co_await net::post(net::use_awaitable);
   future.wait();
 }
 

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -117,7 +117,7 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnSignalEnd, 3) {
       net::co_spawn(ioContext, distributor1->signalEnd(), net::use_future);
 
   // Wait until signalEnd() blocks, increase time if tests sporadically fail
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
 
   auto distributor2 =
       co_await queryHub.createOrAcquireDistributorForSending(queryId);
@@ -138,18 +138,22 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
 
   co_await net::dispatch(
       net::bind_executor(queryHub.getStrand(), net::use_awaitable));
-  net::post(ioContext, [distributor = std::move(distributor)]() mutable {
-    // Invoke destructor while the strand of queryHub is still in use
-    distributor.reset();
-  });
+  auto future = net::post(ioContext,
+                          std::packaged_task<void()>(
+                              [distributor = std::move(distributor)]() mutable {
+                                // Invoke destructor while the strand of
+                                // queryHub is still in use
+                                distributor.reset();
+                              }));
 
   // Wait until destructor of distributor blocks, increase time if tests
   // sporadically fail
-  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));
   distributor =
       co_await queryHub.createOrAcquireDistributorForReceiving(queryId);
   EXPECT_FALSE(!comparison.owner_before(distributor) &&
                !distributor.owner_before(comparison));
+  future.wait();
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
With our increased understanding of `Boost::ASIO`'s scheduling mechanisms we have now cleaned up the synchronization within the websocket module. Most notably the usage of strands for synchronization is now unified and documented, and several helper functions have been renamed to better reflect their actual functionality.