### PR TITLE
Support more empty Transitive Paths

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,10 +41,14 @@ jobs:
       run:  |
         brew install llvm@16
         brew install conan@2
-        echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
-        echo PATH="/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_ENV 
+        echo 'export PATH="/usr/local/opt/llvm@16/bin:$PATH"' >> ~/.bash_profile
+        echo PATH="/usr/local/opt/llvm@16/bin:$PATH" >> $GITHUB_ENV 
+        echo 'export LDFLAGS="-L/usr/local/opt/llvm@16/lib -L/usr/local/opt/llvm@16/lib/c++ -Wl,-rpath,/usr/local/opt/llvm@16/lib/c++"' >> ~/.bash_profile
+        echo LDFLAGS="-L/usr/local/opt/llvm@16/lib -L/usr/local/opt/llvm@16/lib/c++ -Wl,-rpath,/usr/local/opt/llvm@16/lib/c++" >> $GITHUB_ENV 
+        echo 'export CPPFLAGS="-I/usr/local/opt/llvm@16/include"' >> ~/.bash_profile
+        echo  CPPFLAGS="/usr/local/opt/llvm@16/include" >> $GITHUB_ENV 
         source ~/.bash_profile
-    - name: Pring clang version
+    - name: Print clang version
       run: clang++ --version
 
     - name: Cache for conan

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -9,7 +9,7 @@ done <sourcelist
 
 ERROR=0
 for source in "${SOURCE_FILES[@]}" ;do
-	clang-format -output-replacements-xml $source | grep "<replacement " &> /dev/null
+	clang-format-16 -output-replacements-xml $source | grep "<replacement " &> /dev/null
 	HAS_WRONG_FILES=$?
 	if [ $HAS_WRONG_FILES -ne 1 ] ; then
 		# Print an error and exit

--- a/misc/format-check.sh
+++ b/misc/format-check.sh
@@ -9,7 +9,7 @@ done <sourcelist
 
 ERROR=0
 for source in "${SOURCE_FILES[@]}" ;do
-	clang-format-16 -output-replacements-xml $source | grep "<replacement " &> /dev/null
+	clang-format -output-replacements-xml $source | grep "<replacement " &> /dev/null
 	HAS_WRONG_FILES=$?
 	if [ $HAS_WRONG_FILES -ne 1 ] ; then
 		# Print an error and exit

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -80,6 +80,17 @@ class CartesianProductJoin : public Operation {
  private:
   //! Compute the result of the query-subtree rooted at this element..
   ResultTable computeResult() override;
+
+  // Copy each element from the `inputColumn` `groupSize` times to the
+  // `targetColumn`. Repeat until the `targetColumn` is copletely filled. Skip
+  // the first `offset` write operations to the `targetColumn`. Call
+  // `checkCancellation` after each write. If `StaticGroupSize != 0`, then the
+  // group size is known at compile time which allows for more efficient loop
+  // processing for very small group sizes.
+  template <size_t StaticGroupSize = 0>
+  void writeResultColumn(std::span<Id> targetColumn,
+                         std::span<const Id> inputColumn, size_t groupSize,
+                         size_t offset);
 };
 
 #endif  // QLEVER_CARTESIANPRODUCTJOIN_H

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -282,10 +282,9 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
     currentGroupBlock.push_back(std::pair<size_t, Id>(col, input(0, col)));
   }
   size_t blockStart = 0;
-  auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory(32000);
 
   for (size_t pos = 1; pos < input.size(); pos++) {
-    checkTimeoutAfterNCalls(currentGroupBlock.size());
+    checkCancellation();
     bool rowMatchesCurrentBlock =
         std::all_of(currentGroupBlock.begin(), currentGroupBlock.end(),
                     [&](const auto& columns) {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -121,10 +121,10 @@ ResultTable IndexScan::computeResult() {
   const auto permutedTriple = getPermutedTriple();
   if (numVariables_ == 2) {
     idTable = index.scan(*permutedTriple[0], std::nullopt, permutation_,
-                         _timeoutTimer);
+                         cancellationHandle_);
   } else if (numVariables_ == 1) {
     idTable = index.scan(*permutedTriple[0], *permutedTriple[1], permutation_,
-                         _timeoutTimer);
+                         cancellationHandle_);
   } else {
     AD_CORRECTNESS_CHECK(numVariables_ == 3);
     computeFullScan(&idTable, permutation_);
@@ -259,8 +259,8 @@ void IndexScan::computeFullScan(IdTable* result,
   size_t i = 0;
   const auto& permutationImpl =
       getExecutionContext()->getIndex().getImpl().getPermutation(permutation);
-  auto triplesView = TriplesView(permutationImpl, ignoredRanges,
-                                 isTripleIgnored, _timeoutTimer);
+  auto triplesView = TriplesView(permutationImpl, cancellationHandle_,
+                                 ignoredRanges, isTripleIgnored);
   for (const auto& triple : triplesView) {
     if (i >= resultSize) {
       break;
@@ -290,7 +290,7 @@ Permutation::IdTableGenerator IndexScan::getLazyScan(
     col1Id = s.getPermutedTriple()[1]->toValueId(index.getVocab()).value();
   }
   return index.getPermutation(s.permutation())
-      .lazyScan(col0Id, col1Id, std::move(blocks), s._timeoutTimer);
+      .lazyScan(col0Id, col1Id, std::move(blocks), s.cancellationHandle_);
 };
 
 // ________________________________________________________________

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -139,8 +139,6 @@ void Minus::computeMinus(
    */
   auto writeResult = [&result, &a](size_t ia) { result.push_back(a[ia]); };
 
-  auto checkTimeout = checkTimeoutAfterNCallsFactory();
-
   size_t ia = 0, ib = 0;
   while (ia < a.size() && ib < b.size()) {
     // Join columns 0 are the primary sort columns
@@ -148,14 +146,14 @@ void Minus::computeMinus(
       // Write a result
       writeResult(ia);
       ia++;
-      checkTimeout();
+      checkCancellation();
       if (ia >= a.size()) {
         goto finish;
       }
     }
     while (b(ib, joinColumns[0][1]) < a(ia, joinColumns[0][0])) {
       ib++;
-      checkTimeout();
+      checkCancellation();
       if (ib >= b.size()) {
         goto finish;
       }
@@ -189,7 +187,7 @@ void Minus::computeMinus(
         default:
           AD_FAIL();
       }
-      checkTimeout();
+      checkCancellation();
     }
   }
 finish:

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -71,15 +71,14 @@ ResultTable OrderBy::computeResult() {
   shared_ptr<const ResultTable> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
-  auto remainingTime = _timeoutTimer->wlock()->remainingTime();
   auto sortEstimateCancellationFactor =
       RuntimeParameters().get<"sort-estimate-cancellation-factor">();
   if (getExecutionContext()->getSortPerformanceEstimator().estimatedSortTime(
           subRes->size(), subRes->width()) >
-      remainingTime * sortEstimateCancellationFactor) {
+      remainingTime() * sortEstimateCancellationFactor) {
     // The estimated time for this sort is much larger than the actually
     // remaining time, cancel this operation
-    throw ad_utility::TimeoutException(
+    throw ad_utility::CancellationException(
         "OrderBy operation was canceled, because time estimate exceeded "
         "remaining time by a factor of " +
         std::to_string(sortEstimateCancellationFactor));

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -157,11 +157,6 @@ class QueryExecutionTree {
     return _rootOperation->collectWarnings();
   }
 
-  void recursivelySetTimeoutTimer(
-      ad_utility::SharedConcurrentTimeoutTimer timer) {
-    _rootOperation->recursivelySetTimeoutTimer(std::move(timer));
-  }
-
   template <typename F>
   void forAllDescendants(F f) {
     static_assert(

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1956,6 +1956,11 @@ auto QueryPlanner::createJoinWithTransitivePath(
   auto transPathOperation = std::dynamic_pointer_cast<TransitivePath>(
       transPathTree->getRootOperation());
 
+  // TODO: Handle the case of two or more common variables
+  if (jcs.size() > 1) {
+    AD_THROW("Transitive Path operation with more than"
+             " two common variables is not supported");
+  }
   const size_t otherCol = aIsTransPath ? jcs[0][1] : jcs[0][0];
   const size_t thisCol = aIsTransPath ? jcs[0][0] : jcs[0][1];
   // Do not bind the side of a path twice

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -402,7 +402,7 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           // TODO<joka921> Refactor the `TransitivePath` class s.t. we don't
           // have to specify a `Variable` that isn't used at all in the case of
           // a fixed subject or object.
-          auto getSideValue = [this](TripleComponent side) {
+          auto getSideValue = [this](TripleComponent& side) {
             std::variant<Id, Variable> value;
             if (isVariable(side)) {
               value = Variable{side.getVariable()};
@@ -418,12 +418,12 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
             return value;
           };
 
-          left.subCol =
+          left.subCol_ =
               sub._qet->getVariableColumn(arg._innerLeft.getVariable());
-          left.value = getSideValue(arg._left);
-          right.subCol =
+          left.value_ = getSideValue(arg._left);
+          right.subCol_ =
               sub._qet->getVariableColumn(arg._innerRight.getVariable());
-          right.value = getSideValue(arg._right);
+          right.value_ = getSideValue(arg._right);
           size_t min = arg._min;
           size_t max = arg._max;
           auto plan = makeSubtreePlan<TransitivePath>(_qec, sub._qet, left,

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -427,10 +427,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
               AD_THROW("No vocabulary entry for " + arg._right.toString());
             }
           }
-          LOG(DEBUG) << "Left:" << std::endl;
-          LOG(DEBUG) << std::get<Variable>(left.value)._name << std::endl;
-          LOG(DEBUG) << "Right:" << std::endl;
-          LOG(DEBUG) << std::get<Variable>(right.value)._name << std::endl;
           size_t min = arg._min;
           size_t max = arg._max;
           auto plan = makeSubtreePlan<TransitivePath>(
@@ -818,13 +814,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedWithScansAndText(
 // _____________________________________________________________________________
 vector<QueryPlanner::SubtreePlan> QueryPlanner::seedFromPropertyPathTriple(
     const SparqlTriple& triple) {
-  if (triple._p._can_be_null) {
-    std::stringstream buf;
-    buf << "The property path ";
-    triple._p.writeToStream(buf);
-    buf << " can evaluate to the empty path which is not yet supported.";
-    AD_THROW(std::move(buf).str());
-  }
   std::shared_ptr<ParsedQuery::GraphPattern> pattern =
       seedFromPropertyPath(triple._s, triple._p, triple._o);
 #if LOGLEVEL >= TRACE

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -402,7 +402,7 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           // TODO<joka921> Refactor the `TransitivePath` class s.t. we don't
           // have to specify a `Variable` that isn't used at all in the case of
           // a fixed subject or object.
-          auto getSideValue = [this](TripleComponent& side) {
+          auto getSideValue = [this](const TripleComponent& side) {
             std::variant<Id, Variable> value;
             if (isVariable(side)) {
               value = Variable{side.getVariable()};

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -836,9 +836,11 @@ std::shared_ptr<ParsedQuery::GraphPattern> QueryPlanner::seedFromPropertyPath(
     case PropertyPath::Operation::SEQUENCE:
       return seedFromSequence(left, path, right);
     case PropertyPath::Operation::ZERO_OR_MORE:
-      return seedFromTransitive(left, path, right, 0, std::numeric_limits<size_t>::max());
+      return seedFromTransitive(left, path, right, 0,
+                                std::numeric_limits<size_t>::max());
     case PropertyPath::Operation::ONE_OR_MORE:
-      return seedFromTransitive(left, path, right, 1, std::numeric_limits<size_t>::max());
+      return seedFromTransitive(left, path, right, 1,
+                                std::numeric_limits<size_t>::max());
     case PropertyPath::Operation::ZERO_OR_ONE:
       return seedFromTransitive(left, path, right, 0, 1);
   }
@@ -1958,8 +1960,9 @@ auto QueryPlanner::createJoinWithTransitivePath(
 
   // TODO: Handle the case of two or more common variables
   if (jcs.size() > 1) {
-    AD_THROW("Transitive Path operation with more than"
-             " two common variables is not supported");
+    AD_THROW(
+        "Transitive Path operation with more than"
+        " two common variables is not supported");
   }
   const size_t otherCol = aIsTransPath ? jcs[0][1] : jcs[0][0];
   const size_t thisCol = aIsTransPath ? jcs[0][0] : jcs[0][1];

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1959,9 +1959,7 @@ auto QueryPlanner::createJoinWithTransitivePath(
   const size_t otherCol = aIsTransPath ? jcs[0][1] : jcs[0][0];
   const size_t thisCol = aIsTransPath ? jcs[0][0] : jcs[0][1];
   // Do not bind the side of a path twice
-  if ((transPathOperation->isBound() ||
-       (transPathOperation->leftIsBound() && thisCol == 0) ||
-       (transPathOperation->rightIsBound() && thisCol == 1))) {
+  if (transPathOperation->isBound()) {
     return std::nullopt;
   }
   // An unbound transitive path has at most two columns.

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -402,7 +402,8 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           // TODO<joka921> Refactor the `TransitivePath` class s.t. we don't
           // have to specify a `Variable` that isn't used at all in the case of
           // a fixed subject or object.
-          left.subCol = sub._qet->getVariableColumn(arg._innerLeft.getVariable());
+          left.subCol =
+              sub._qet->getVariableColumn(arg._innerLeft.getVariable());
           if (isVariable(arg._left)) {
             left.value = Variable{arg._left.getVariable()};
           } else {
@@ -415,7 +416,8 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
             }
           }
           // TODO<joka921> This is really much code duplication, get rid of it!
-          right.subCol = sub._qet->getVariableColumn(arg._innerRight.getVariable());
+          right.subCol =
+              sub._qet->getVariableColumn(arg._innerRight.getVariable());
           if (isVariable(arg._right)) {
             right.value = Variable{arg._right.getVariable()};
           } else {
@@ -429,8 +431,8 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
           }
           size_t min = arg._min;
           size_t max = arg._max;
-          auto plan = makeSubtreePlan<TransitivePath>(
-              _qec, sub._qet, left, right, min, max);
+          auto plan = makeSubtreePlan<TransitivePath>(_qec, sub._qet, left,
+                                                      right, min, max);
           candidatesOut.push_back(std::move(plan));
         }
         joinCandidates(std::move(candidatesOut));
@@ -2016,8 +2018,8 @@ auto QueryPlanner::createJoinWithTransitivePath(
   const size_t thisCol = aIsTransPath ? jcs[0][0] : jcs[0][1];
   // Do not bind the side of a path twice
   if ((transPathOperation->isBound() ||
-      (transPathOperation->leftIsBound() && thisCol == 0) ||
-      (transPathOperation->rightIsBound() && thisCol == 1))) {
+       (transPathOperation->leftIsBound() && thisCol == 0) ||
+       (transPathOperation->rightIsBound() && thisCol == 1))) {
     return std::nullopt;
   }
   // An unbound transitive path has at most two columns.

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -271,15 +271,9 @@ class QueryPlanner {
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromAlternative(
       const TripleComponent& left, const PropertyPath& path,
       const TripleComponent& right);
-  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromZeroOrMore(
+  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromTransitive(
       const TripleComponent& left, const PropertyPath& path,
-      const TripleComponent& right);
-  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromZeroOrOne(
-      const TripleComponent& left, const PropertyPath& path,
-      const TripleComponent& right);
-  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromOneOrMore(
-      const TripleComponent& left, const PropertyPath& path,
-      const TripleComponent& right);
+      const TripleComponent& right, size_t min, size_t max);
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromInverse(
       const TripleComponent& left, const PropertyPath& path,
       const TripleComponent& right);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -54,8 +54,7 @@ class QueryPlanner {
             // TODO<joka921> What is this triple used for? If it is just a
             // dummy, then we can replace it by a `variant<Triple,
             // TextNodeData>`.
-            _triple(cvar,
-                    PropertyPath::fromIri(INTERNAL_TEXT_MATCH_PREDICATE),
+            _triple(cvar, PropertyPath::fromIri(INTERNAL_TEXT_MATCH_PREDICATE),
                     TripleComponent::UNDEF{}),
             _cvar(cvar),
             _wordPart(std::move(words)) {
@@ -275,12 +274,12 @@ class QueryPlanner {
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromZeroOrMore(
       const TripleComponent& left, const PropertyPath& path,
       const TripleComponent& right);
-  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern>
-  seedFromZeroOrOne(const TripleComponent& left, const PropertyPath& path,
-                        const TripleComponent& right);
-  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern>
-  seedFromOneOrMore(const TripleComponent& left, const PropertyPath& path,
-                        const TripleComponent& right);
+  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromZeroOrOne(
+      const TripleComponent& left, const PropertyPath& path,
+      const TripleComponent& right);
+  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromOneOrMore(
+      const TripleComponent& left, const PropertyPath& path,
+      const TripleComponent& right);
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromInverse(
       const TripleComponent& left, const PropertyPath& path,
       const TripleComponent& right);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -55,8 +55,7 @@ class QueryPlanner {
             // dummy, then we can replace it by a `variant<Triple,
             // TextNodeData>`.
             _triple(cvar,
-                    PropertyPath(PropertyPath::Operation::IRI, 0,
-                                 INTERNAL_TEXT_MATCH_PREDICATE, {}),
+                    PropertyPath::fromIri(INTERNAL_TEXT_MATCH_PREDICATE),
                     TripleComponent::UNDEF{}),
             _cvar(cvar),
             _wordPart(std::move(words)) {
@@ -273,14 +272,14 @@ class QueryPlanner {
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromAlternative(
       const TripleComponent& left, const PropertyPath& path,
       const TripleComponent& right);
-  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromTransitive(
+  [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromZeroOrMore(
       const TripleComponent& left, const PropertyPath& path,
       const TripleComponent& right);
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern>
-  seedFromTransitiveMin(const TripleComponent& left, const PropertyPath& path,
+  seedFromZeroOrOne(const TripleComponent& left, const PropertyPath& path,
                         const TripleComponent& right);
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern>
-  seedFromTransitiveMax(const TripleComponent& left, const PropertyPath& path,
+  seedFromOneOrMore(const TripleComponent& left, const PropertyPath& path,
                         const TripleComponent& right);
   [[nodiscard]] std::shared_ptr<ParsedQuery::GraphPattern> seedFromInverse(
       const TripleComponent& left, const PropertyPath& path,

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -503,6 +503,48 @@ ad_utility::websocket::OwningQueryId Server::getQueryId(
   return std::move(queryId.value());
 }
 
+// _____________________________________________________________________________
+
+auto Server::cancelAfterDeadline(
+    const net::any_io_executor& executor,
+    std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
+    std::chrono::seconds timeLimit) {
+  auto strand = net::make_strand(executor);
+  auto timer = std::make_shared<net::steady_timer>(strand, timeLimit);
+
+  auto cancelAfterTimeout =
+      [](std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
+         std::shared_ptr<net::steady_timer> timer) -> net::awaitable<void> {
+    // Ignore cancellation exceptions, they are normal
+    co_await timer->async_wait(net::as_tuple(net::use_awaitable));
+    if (auto pointer = cancellationHandle.lock()) {
+      pointer->cancel(ad_utility::CancellationState::TIMEOUT);
+    }
+  };
+  net::co_spawn(strand,
+                cancelAfterTimeout(std::move(cancellationHandle), timer),
+                net::detached);
+  return [strand, timer = std::move(timer)]() mutable {
+    net::post(strand, [timer = std::move(timer)]() { timer->cancel(); });
+  };
+}
+
+// ____________________________________________________________________________
+std::function<void()> Server::setupCancellationHandle(
+    const net::any_io_executor& executor,
+    const std::shared_ptr<Operation>& rootOperation,
+    std::optional<std::chrono::seconds> timeLimit) {
+  // TODO<RobinTF> register cancellation handle to allow manual cancellation
+  auto cancellationHandle = std::make_shared<ad_utility::CancellationHandle>();
+  rootOperation->recursivelySetCancellationHandle(
+      std::move(cancellationHandle));
+  if (timeLimit.has_value()) {
+    rootOperation->recursivelySetTimeConstraint(timeLimit.value());
+    return cancelAfterDeadline(executor, cancellationHandle, timeLimit.value());
+  }
+  return []() { /* Do nothing when no timeout is given */ };
+}
+
 // ____________________________________________________________________________
 boost::asio::awaitable<void> Server::processQuery(
     const ParamValueMap& params, ad_utility::Timer& requestTimer,
@@ -532,14 +574,10 @@ boost::asio::awaitable<void> Server::processQuery(
   // access to the runtimeInformation in the case of an error.
   std::optional<QueryExecutionTree> queryExecutionTree;
   try {
-    ad_utility::SharedConcurrentTimeoutTimer timeoutTimer = [&]() {
-      auto t = ad_utility::TimeoutTimer::unlimited();
-      if (params.contains("timeout")) {
-        ad_utility::Timer::Seconds timeout{std::stof(params.at("timeout"))};
-        t = ad_utility::TimeoutTimer{timeout, ad_utility::Timer::Started};
-      }
-      return std::make_shared<ad_utility::ConcurrentTimeoutTimer>(std::move(t));
-    }();
+    std::optional<std::chrono::seconds> timeLimit =
+        params.contains("timeout") ? std::optional{std::chrono::seconds(
+                                         std::stoi(params.at("timeout")))}
+                                   : std::nullopt;
 
     auto containsParam = [&params](const std::string& param,
                                    const std::string& expected) {
@@ -615,8 +653,7 @@ boost::asio::awaitable<void> Server::processQuery(
     auto messageSender = co_await ad_utility::websocket::MessageSender::create(
         getQueryId(request), *queryHub_);
     // Do the query planning. This creates a `QueryExecutionTree`, which will
-    // then be used to process the query. Start the shared `timeoutTimer` here
-    // to also include the query planning.
+    // then be used to process the query.
     //
     // NOTE: This should come after determining the media type. Otherwise, it
     // might happen that the query planner runs for a while (recall that it many
@@ -630,7 +667,8 @@ boost::asio::awaitable<void> Server::processQuery(
     queryExecutionTree = qp.createExecutionTree(pq);
     auto& qet = queryExecutionTree.value();
     qet.isRoot() = true;  // allow pinning of the final result
-    qet.recursivelySetTimeoutTimer(timeoutTimer);
+    absl::Cleanup cancelCancellationHandle{setupCancellationHandle(
+        co_await net::this_coro::executor, qet.getRootOperation(), timeLimit)};
     size_t timeForQueryPlanning = requestTimer.msecs();
     auto& runtimeInfoWholeQuery =
         qet.getRootOperation()->getRuntimeInfoWholeQuery();

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -18,7 +18,6 @@
 #include "util/AllocatorWithLimit.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/ParseException.h"
-#include "util/Timer.h"
 #include "util/http/HttpServer.h"
 #include "util/http/streamable_body.h"
 #include "util/http/websocket/QueryHub.h"
@@ -132,4 +131,21 @@ class Server {
   ///         on destruction.
   ad_utility::websocket::OwningQueryId getQueryId(
       const ad_utility::httpUtils::HttpRequest auto& request);
+
+  /// Schedule a task to trigger the timeout after the `timeLimit`.
+  /// The returned callback can be used to prevent this task from executing
+  /// either because the `cancellationHandle` has been aborted by some other
+  /// means or because the task has been completed successfully.
+  static auto cancelAfterDeadline(
+      const net::any_io_executor& executor,
+      std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
+      std::chrono::seconds timeLimit);
+
+  /// Create a cancellation handle, pass it to the operation and configure
+  /// it to get cancelled automatically if a time limit is passed by calling
+  /// `cancelAfterDeadline`. If `timeLimit` is empty, return a no-op lambda.
+  static std::function<void()> setupCancellationHandle(
+      const net::any_io_executor& executor,
+      const std::shared_ptr<Operation>& rootOperation,
+      std::optional<std::chrono::seconds> timeLimit);
 };

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -60,15 +60,14 @@ ResultTable Sort::computeResult() {
   shared_ptr<const ResultTable> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
-  auto remainingTime = _timeoutTimer->wlock()->remainingTime();
   auto sortEstimateCancellationFactor =
       RuntimeParameters().get<"sort-estimate-cancellation-factor">();
   if (getExecutionContext()->getSortPerformanceEstimator().estimatedSortTime(
           subRes->size(), subRes->width()) >
-      remainingTime * sortEstimateCancellationFactor) {
+      remainingTime() * sortEstimateCancellationFactor) {
     // The estimated time for this sort is much larger than the actually
     // remaining time, cancel this operation
-    throw ad_utility::TimeoutException(
+    throw ad_utility::CancellationException(
         "Sort operation was canceled, because time estimate exceeded "
         "remaining time by a factor of " +
         std::to_string(sortEstimateCancellationFactor));

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -275,11 +275,6 @@ void TransitivePath::computeTransitivePath(IdTable* dynRes,
   // All nodes on the graph from which an edge leads to another node
   std::vector<Id> nodes;
 
-  auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory();
-  auto checkTimeoutHashSet = [&checkTimeoutAfterNCalls]() {
-    checkTimeoutAfterNCalls(NUM_OPERATIONS_HASHSET_LOOKUP);
-  };
-
   // initialize the map from the subresult
   if constexpr (rightIsVar) {
     (void)rightValue;
@@ -287,7 +282,7 @@ void TransitivePath::computeTransitivePath(IdTable* dynRes,
       nodes.push_back(leftValue);
     }
     for (size_t i = 0; i < sub.size(); i++) {
-      checkTimeoutHashSet();
+      checkCancellation();
       Id l = sub(i, leftSubCol);
       Id r = sub(i, rightSubCol);
       MapIt it = edges.find(l);
@@ -308,7 +303,7 @@ void TransitivePath::computeTransitivePath(IdTable* dynRes,
     (void)leftValue;
     nodes.push_back(rightValue);
     for (size_t i = 0; i < sub.size(); i++) {
-      checkTimeoutHashSet();
+      checkCancellation();
       // Use the inverted edges
       Id l = sub(i, leftSubCol);
       Id r = sub(i, rightSubCol);
@@ -411,13 +406,9 @@ void TransitivePath::computeTransitivePathLeftBound(
   // Used to map entries in the left column to entries they have connection with
   Map edges;
 
-  auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory();
-  auto checkTimeoutHashSet = [&checkTimeoutAfterNCalls]() {
-    checkTimeoutAfterNCalls(NUM_OPERATIONS_HASHSET_LOOKUP);
-  };
   // initialize the map from the subresult
   for (size_t i = 0; i < sub.size(); i++) {
-    checkTimeoutHashSet();
+    checkCancellation();
     Id l = sub(i, leftSubCol);
     Id r = sub(i, rightSubCol);
     MapIt it = edges.find(l);
@@ -448,13 +439,13 @@ void TransitivePath::computeTransitivePathLeftBound(
   size_t last_result_begin = 0;
   size_t last_result_end = 0;
   for (size_t i = 0; i < left.size(); i++) {
-    checkTimeoutHashSet();
+    checkCancellation();
     if (left[i][leftSideCol] == last_elem) {
       // We can repeat the last output
       size_t num_new = last_result_end - last_result_begin;
       size_t res_row = res.size();
       res.resize(res.size() + num_new);
-      checkTimeoutAfterNCalls(num_new * resWidth);
+      checkCancellation();
       for (size_t j = 0; j < num_new; j++) {
         for (size_t c = 0; c < resWidth; c++) {
           res(res_row + j, c) = res(last_result_begin + j, c);
@@ -548,14 +539,10 @@ void TransitivePath::computeTransitivePathRightBound(
 
   // Used to map entries in the left column to entries they have connection with
   Map edges;
-  auto checkTimeoutAfterNCalls = checkTimeoutAfterNCallsFactory();
-  auto checkTimeoutHashSet = [&checkTimeoutAfterNCalls]() {
-    checkTimeoutAfterNCalls(NUM_OPERATIONS_HASHSET_LOOKUP);
-  };
 
   // initialize the map from the subresult
   for (size_t i = 0; i < sub.size(); i++) {
-    checkTimeoutHashSet();
+    checkCancellation();
     Id l = sub(i, leftSubCol);
     Id r = sub(i, rightSubCol);
     MapIt it = edges.find(r);
@@ -586,7 +573,7 @@ void TransitivePath::computeTransitivePathRightBound(
   size_t last_result_begin = 0;
   size_t last_result_end = 0;
   for (size_t i = 0; i < right.size(); i++) {
-    checkTimeoutHashSet();
+    checkCancellation();
     if (right[i][rightSideCol] == last_elem) {
       // We can repeat the last output
       size_t num_new = last_result_end - last_result_begin;
@@ -597,7 +584,7 @@ void TransitivePath::computeTransitivePathRightBound(
           res(res_row + j, c) = res(last_result_begin + j, c);
         }
       }
-      checkTimeoutAfterNCalls(num_new * resWidth);
+      checkCancellation();
       continue;
     }
     last_elem = right(i, rightSideCol);

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -19,17 +19,17 @@ TransitivePath::TransitivePath(QueryExecutionContext* qec,
                                size_t maxDist)
     : Operation(qec),
       _subtree(std::move(child)),
-      _lhs(leftSide),
-      _rhs(rightSide),
+      _lhs(std::move(leftSide)),
+      _rhs(std::move(rightSide)),
       _resultWidth(2),
       _minDist(minDist),
       _maxDist(maxDist) {
-  if (leftSide.isVariable()) {
-    _variableColumns[std::get<Variable>(leftSide.value)] =
+  if (_lhs.isVariable()) {
+    _variableColumns[std::get<Variable>(_lhs.value)] =
         makeAlwaysDefinedColumn(0);
   }
-  if (rightSide.isVariable()) {
-    _variableColumns[std::get<Variable>(rightSide.value)] =
+  if (_rhs.isVariable()) {
+    _variableColumns[std::get<Variable>(_rhs.value)] =
         makeAlwaysDefinedColumn(1);
   }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -43,25 +43,20 @@ std::string TransitivePath::asStringImpl(size_t indent) const {
   for (size_t i = 0; i < indent; ++i) {
     os << " ";
   }
-  os << "TransitivePath leftCol " << _lhs.subCol << " rightCol " << _rhs.subCol;
-
-  if (std::holds_alternative<Id>(_lhs.value)) {
-    os << " leftValue " << std::get<Id>(_lhs.value);
-  }
-  if (std::holds_alternative<Id>(_rhs.value)) {
-    os << " rightValue " << std::get<Id>(_rhs.value);
-  }
   os << " minDist " << _minDist << " maxDist " << _maxDist << "\n";
-  os << _subtree->asString(indent) << "\n";
-  if (_lhs.treeAndCol.has_value()) {
-    os << "Left subtree:\n";
-    os << _lhs.treeAndCol.value().first->asString(indent) << "\n";
+
+  for (size_t i = 0; i < indent; ++i) {
+    os << " ";
   }
-  os << _subtree->asString(indent) << "\n";
-  if (_rhs.treeAndCol.has_value()) {
-    os << "Right subtree:\n";
-    os << _rhs.treeAndCol.value().first->asString(indent) << "\n";
+  os << "Left side:\n";
+  os << _lhs.asString(indent + 1);
+
+  for (size_t i = 0; i < indent; ++i) {
+    os << " ";
   }
+  os << "Right side:\n";
+  os << _rhs.asString(indent + 1);
+
   return std::move(os).str();
 }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -238,7 +238,8 @@ void TransitivePath::computeTransitivePath(
 
 // _____________________________________________________________________________
 ResultTable TransitivePath::computeResult() {
-  if (_minDist == 0 && !isBound() && _lhs.isVariable() && _rhs.isVariable()) {
+  if (_minDist == 0 && !isBoundOrId() && _lhs.isVariable() &&
+      _rhs.isVariable()) {
     AD_THROW(
         "This query might have to evalute the empty path, which is currently "
         "not supported");
@@ -252,7 +253,8 @@ ResultTable TransitivePath::computeResult() {
   size_t subWidth = subRes->idTable().numColumns();
 
   auto computeForOneSide = [this, &idTable, subRes, subWidth](
-                               auto boundSide, auto otherSide) -> ResultTable {
+                               auto& boundSide,
+                               auto& otherSide) -> ResultTable {
     shared_ptr<const ResultTable> sideRes =
         boundSide.treeAndCol.value().first->getResult();
     size_t sideWidth = sideRes->idTable().numColumns();
@@ -263,8 +265,7 @@ ResultTable TransitivePath::computeResult() {
                     sideRes->idTable());
 
     return {std::move(idTable), resultSortedOn(),
-            subRes->getSharedLocalVocabFromNonEmptyOf(*sideRes,
-                                                      *subRes)};
+            subRes->getSharedLocalVocabFromNonEmptyOf(*sideRes, *subRes)};
   };
 
   if (_lhs.isBoundVariable()) {
@@ -344,8 +345,9 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftOrRightSide(
 }
 
 // _____________________________________________________________________________
-bool TransitivePath::isBound() const {
-  return _lhs.isBoundVariable() || _rhs.isBoundVariable();
+bool TransitivePath::isBoundOrId() const {
+  return _lhs.isBoundVariable() || _rhs.isBoundVariable() ||
+         !_lhs.isVariable() || !_rhs.isVariable();
 }
 
 // _____________________________________________________________________________

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -263,8 +263,8 @@ ResultTable TransitivePath::computeResult() {
                     sideRes->idTable());
 
     return {std::move(idTable), resultSortedOn(),
-            subRes->getSharedLocalVocabFromNonEmptyOf(*sideRes.get(),
-                                                      *subRes.get())};
+            subRes->getSharedLocalVocabFromNonEmptyOf(*sideRes,
+                                                      *subRes)};
   };
 
   if (_lhs.isBoundVariable()) {

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -170,7 +170,8 @@ uint64_t TransitivePath::getSizeEstimateBeforeLimit() {
   }
   // TODO(Florian): this is not necessarily a good estimator
   if (lhs_.isVariable()) {
-    return subtree_->getSizeEstimate() / subtree_->getMultiplicity(lhs_.subCol_);
+    return subtree_->getSizeEstimate() /
+           subtree_->getMultiplicity(lhs_.subCol_);
   }
   return subtree_->getSizeEstimate();
 }

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -383,7 +383,7 @@ TransitivePath::Map TransitivePath::transitiveHull(
       positions.push_back(rootEdges->second.begin());
       edgeCache.push_back(&rootEdges->second);
     }
-    if (_minDist == 0) {
+    if (_minDist == 0 && (!target.has_value() || currentStartNode == target.value())) {
       hull[currentStartNode].insert(currentStartNode);
     }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -383,7 +383,8 @@ TransitivePath::Map TransitivePath::transitiveHull(
       positions.push_back(rootEdges->second.begin());
       edgeCache.push_back(&rootEdges->second);
     }
-    if (_minDist == 0 && (!target.has_value() || currentStartNode == target.value())) {
+    if (_minDist == 0 &&
+        (!target.has_value() || currentStartNode == target.value())) {
       hull[currentStartNode].insert(currentStartNode);
     }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -106,13 +106,6 @@ size_t TransitivePath::getResultWidth() const { return _resultWidth; }
 
 // _____________________________________________________________________________
 vector<ColumnIndex> TransitivePath::resultSortedOn() const {
-  const std::vector<ColumnIndex>& subSortedOn =
-      _subtree->getRootOperation()->getResultSortedOn();
-  if (!_lhs.isBoundVariable() && !_rhs.isBoundVariable() && subSortedOn.size() > 0 &&
-      subSortedOn[0] == _lhs.subCol) {
-    // This operation preserves the order of the _leftCol of the subtree.
-    return {0};
-  }
   if (_lhs.isSortedOnInputCol()) {
     return {0};
   }

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -238,6 +238,11 @@ void TransitivePath::computeTransitivePath(
 
 // _____________________________________________________________________________
 ResultTable TransitivePath::computeResult() {
+  if (_minDist == 0 && !isBound() && _lhs.isVariable() && _rhs.isVariable()) {
+    AD_THROW(
+        "This query might have to evalute the empty path, which is currently "
+        "not supported");
+  }
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -169,7 +169,7 @@ uint64_t TransitivePath::getSizeEstimateBeforeLimit() {
   }
   // TODO(Florian): this is not necessarily a good estimator
   if (lhs_.isVariable()) {
-    size_t multiplicity = static_cast<size_t>(getMultiplicity(lhs_.subCol_));
+    auto multiplicity = static_cast<size_t>(getMultiplicity(lhs_.subCol_));
     return subtree_->getSizeEstimate() / multiplicity;
   }
   return subtree_->getSizeEstimate();

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -388,10 +388,7 @@ TransitivePath::Map TransitivePath::transitiveHull(
     // While we have not found the entire transitive hull and have not reached
     // the max step limit
     while (!positions.empty()) {
-<<<<<<< HEAD
       checkCancellation();
-=======
->>>>>>> f3ef5a1abc9be5fb8621fbcdc2ca21de4eaa6274
       size_t stackIndex = positions.size() - 1;
       // Process the next child of the node at the top of the stack
       ad_utility::HashSet<Id>::const_iterator& pos = positions[stackIndex];
@@ -533,7 +530,10 @@ TransitivePath::Map TransitivePath::setupEdgesMap(
 
   for (size_t i = 0; i < sub.size(); i++) {
     checkCancellation();
+    Id startId = startCol[i];
     Id targetId = targetCol[i];
+    MapIt it = edges.find(startId);
+    if (it == edges.end()) {
       edges[startId].insert(targetId);
     } else {
       // If r is not in the vector insert it

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -12,10 +12,11 @@
 #include "util/Exception.h"
 
 // _____________________________________________________________________________
-TransitivePath::TransitivePath(
-    QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> child,
-    TransitivePathSide leftSide, TransitivePathSide rightSide,
-    size_t minDist, size_t maxDist)
+TransitivePath::TransitivePath(QueryExecutionContext* qec,
+                               std::shared_ptr<QueryExecutionTree> child,
+                               TransitivePathSide leftSide,
+                               TransitivePathSide rightSide, size_t minDist,
+                               size_t maxDist)
     : Operation(qec),
       _subtree(std::move(child)),
       _lhs(leftSide),
@@ -25,11 +26,11 @@ TransitivePath::TransitivePath(
       _maxDist(maxDist) {
   if (leftSide.isVariable()) {
     _variableColumns[std::get<Variable>(leftSide.value)] =
-      makeAlwaysDefinedColumn(0);
+        makeAlwaysDefinedColumn(0);
   }
   if (rightSide.isVariable()) {
     _variableColumns[std::get<Variable>(rightSide.value)] =
-      makeAlwaysDefinedColumn(1);
+        makeAlwaysDefinedColumn(1);
   }
 
   _lhs.outputCol = 0;
@@ -42,8 +43,7 @@ std::string TransitivePath::asStringImpl(size_t indent) const {
   for (size_t i = 0; i < indent; ++i) {
     os << " ";
   }
-  os << "TransitivePath leftCol " << _lhs.subCol << " rightCol "
-     << _rhs.subCol;
+  os << "TransitivePath leftCol " << _lhs.subCol << " rightCol " << _rhs.subCol;
 
   if (std::holds_alternative<Id>(_lhs.value)) {
     os << " leftValue " << std::get<Id>(_lhs.value);
@@ -224,40 +224,37 @@ size_t TransitivePath::getCostEstimate() {
 
 // _____________________________________________________________________________
 template <size_t RES_WIDTH, size_t SUB_WIDTH, size_t OTHER_WIDTH>
-void TransitivePath::computeTransitivePathBound(IdTable* dynRes,
-    const IdTable& dynSub, const TransitivePathSide& startSide,
-    const TransitivePathSide& targetSide,
-    const IdTable& otherTable) const {
-    
+void TransitivePath::computeTransitivePathBound(
+    IdTable* dynRes, const IdTable& dynSub, const TransitivePathSide& startSide,
+    const TransitivePathSide& targetSide, const IdTable& otherTable) const {
   IdTableStatic<RES_WIDTH> res = std::move(*dynRes).toStatic<RES_WIDTH>();
 
   auto [edges, nodes] = setupMapAndNodes<SUB_WIDTH, OTHER_WIDTH>(
-    dynSub, startSide, targetSide, otherTable);
+      dynSub, startSide, targetSide, otherTable);
 
   Map hull = transitiveHull(edges, nodes);
 
   TransitivePath::fillTableWithHull<RES_WIDTH, OTHER_WIDTH>(
-    res, hull, nodes, startSide.outputCol, targetSide.outputCol,
-    otherTable, startSide.treeAndCol.value().second);
-  
+      res, hull, nodes, startSide.outputCol, targetSide.outputCol, otherTable,
+      startSide.treeAndCol.value().second);
+
   *dynRes = std::move(res).toDynamic();
 }
 
 // _____________________________________________________________________________
 template <size_t RES_WIDTH, size_t SUB_WIDTH>
-void TransitivePath::computeTransitivePath(IdTable* dynRes,
-    const IdTable& dynSub, const TransitivePathSide& startSide,
+void TransitivePath::computeTransitivePath(
+    IdTable* dynRes, const IdTable& dynSub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
-
   IdTableStatic<RES_WIDTH> res = std::move(*dynRes).toStatic<RES_WIDTH>();
 
-  auto [edges, nodes] = setupMapAndNodes<SUB_WIDTH>(
-    dynSub, startSide, targetSide);
+  auto [edges, nodes] =
+      setupMapAndNodes<SUB_WIDTH>(dynSub, startSide, targetSide);
 
   Map hull = transitiveHull(edges, nodes);
 
-  TransitivePath::fillTableWithHull<RES_WIDTH>(
-    res, hull, startSide.outputCol, targetSide.outputCol);
+  TransitivePath::fillTableWithHull<RES_WIDTH>(res, hull, startSide.outputCol,
+                                               targetSide.outputCol);
 
   *dynRes = std::move(res).toDynamic();
 }
@@ -275,7 +272,8 @@ ResultTable TransitivePath::computeResult() {
   size_t subWidth = subRes->idTable().numColumns();
   if (_lhs.treeAndCol.has_value()) {
     LOG(DEBUG) << "TransitivePath left result computation..." << std::endl;
-    shared_ptr<const ResultTable> leftRes = _lhs.treeAndCol.value().first->getResult();
+    shared_ptr<const ResultTable> leftRes =
+        _lhs.treeAndCol.value().first->getResult();
     LOG(DEBUG) << "TransitivePath left result computation done." << std::endl;
     size_t leftWidth = leftRes->idTable().numColumns();
 
@@ -286,7 +284,8 @@ ResultTable TransitivePath::computeResult() {
 
   } else if (_rhs.treeAndCol.has_value()) {
     LOG(DEBUG) << "TransitivePath right result computation..." << std::endl;
-    shared_ptr<const ResultTable> rightRes = _rhs.treeAndCol.value().first->getResult();
+    shared_ptr<const ResultTable> rightRes =
+        _rhs.treeAndCol.value().first->getResult();
     LOG(DEBUG) << "TransitivePath right result computation done." << std::endl;
     size_t rightWidth = rightRes->idTable().numColumns();
 
@@ -370,18 +369,14 @@ bool TransitivePath::isBound() const {
 }
 
 // _____________________________________________________________________________
-bool TransitivePath::leftIsBound() const {
-  return _lhs.isBound();
-}
+bool TransitivePath::leftIsBound() const { return _lhs.isBound(); }
 
 // _____________________________________________________________________________
-bool TransitivePath::rightIsBound() const {
-  return _rhs.isBound();
-}
+bool TransitivePath::rightIsBound() const { return _rhs.isBound(); }
 
 // _____________________________________________________________________________
-TransitivePath::Map TransitivePath::transitiveHull(const Map& edges,
-    const std::vector<Id>& nodes) const {
+TransitivePath::Map TransitivePath::transitiveHull(
+    const Map& edges, const std::vector<Id>& nodes) const {
   using MapIt = TransitivePath::Map::const_iterator;
   // For every node do a dfs on the graph
   Map hull;
@@ -437,10 +432,12 @@ TransitivePath::Map TransitivePath::transitiveHull(const Map& edges,
         if (childDepth >= _minDist) {
           marks.insert(child);
           if (_rhs.isVariable() || child == std::get<Id>(_rhs.value)) {
-            hull.try_emplace(nodes[i], std::make_shared<ad_utility::HashSet<Id>>());
+            hull.try_emplace(nodes[i],
+                             std::make_shared<ad_utility::HashSet<Id>>());
             hull[nodes[i]]->insert(child);
           } else if (_lhs.isVariable() || child == std::get<Id>(_lhs.value)) {
-            hull.try_emplace(child, std::make_shared<ad_utility::HashSet<Id>>());
+            hull.try_emplace(child,
+                             std::make_shared<ad_utility::HashSet<Id>>());
             hull[child]->insert(nodes[i]);
           }
         }
@@ -464,10 +461,13 @@ TransitivePath::Map TransitivePath::transitiveHull(const Map& edges,
 // _____________________________________________________________________________
 template <size_t WIDTH, size_t TEMP_WIDTH>
 void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
-    std::vector<Id>& nodes, size_t startSideCol, size_t targetSideCol,
-    const IdTable& tableTemplate, size_t skipCol) {
-
-  IdTableView<TEMP_WIDTH> templateView = tableTemplate.asStaticView<TEMP_WIDTH>();
+                                       std::vector<Id>& nodes,
+                                       size_t startSideCol,
+                                       size_t targetSideCol,
+                                       const IdTable& tableTemplate,
+                                       size_t skipCol) {
+  IdTableView<TEMP_WIDTH> templateView =
+      tableTemplate.asStaticView<TEMP_WIDTH>();
 
   size_t rowIndex = 0;
   for (size_t i = 0; i < nodes.size(); i++) {
@@ -481,7 +481,8 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
       table(rowIndex, startSideCol) = node;
       table(rowIndex, targetSideCol) = otherNode;
 
-      TransitivePath::copyColumns<TEMP_WIDTH, WIDTH>(templateView, table, i, rowIndex, skipCol);
+      TransitivePath::copyColumns<TEMP_WIDTH, WIDTH>(templateView, table, i,
+                                                     rowIndex, skipCol);
 
       rowIndex++;
     }
@@ -491,8 +492,8 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
 // _____________________________________________________________________________
 template <size_t WIDTH>
 void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
-    size_t startSideCol, size_t targetSideCol) {
-
+                                       size_t startSideCol,
+                                       size_t targetSideCol) {
   size_t rowIndex = 0;
   for (auto const& [node, linkedNodes] : hull) {
     for (Id linkedNode : *linkedNodes) {
@@ -507,36 +508,39 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
 
 // _____________________________________________________________________________
 template <size_t SUB_WIDTH, size_t SIDE_WIDTH>
-std::pair<TransitivePath::Map, std::vector<Id>> TransitivePath::setupMapAndNodes(
-    const IdTable& sub, const TransitivePathSide& startSide,
-    const TransitivePathSide& targetSide,
-    const IdTable& startSideTable) const {
+std::pair<TransitivePath::Map, std::vector<Id>>
+TransitivePath::setupMapAndNodes(const IdTable& sub,
+                                 const TransitivePathSide& startSide,
+                                 const TransitivePathSide& targetSide,
+                                 const IdTable& startSideTable) const {
   std::vector<Id> nodes;
   Map edges = setupEdgesMap<SUB_WIDTH>(sub, startSide, targetSide);
 
   // Bound -> var|id
   nodes = setupNodesVector<SIDE_WIDTH>(startSideTable,
-                                        startSide.treeAndCol.value().second);
+                                       startSide.treeAndCol.value().second);
 
   return std::make_pair(edges, nodes);
 }
 
 // _____________________________________________________________________________
 template <size_t SUB_WIDTH>
-std::pair<TransitivePath::Map, std::vector<Id>> TransitivePath::setupMapAndNodes(
-    const IdTable& sub, const TransitivePathSide& startSide,
-    const TransitivePathSide& targetSide) const {
+std::pair<TransitivePath::Map, std::vector<Id>>
+TransitivePath::setupMapAndNodes(const IdTable& sub,
+                                 const TransitivePathSide& startSide,
+                                 const TransitivePathSide& targetSide) const {
   std::vector<Id> nodes;
   Map edges = setupEdgesMap<SUB_WIDTH>(sub, startSide, targetSide);
 
   // id -> var|id
-   if (startSide.isBound()) {
+  if (startSide.isBound()) {
     nodes.push_back(std::get<Id>(startSide.value));
-  // var -> var
+    // var -> var
   } else {
     nodes = setupNodesVector<SUB_WIDTH>(sub, startSide.subCol);
     if (_minDist == 0) {
-      std::vector<Id> targetNodes = setupNodesVector<SUB_WIDTH>(sub, targetSide.subCol);
+      std::vector<Id> targetNodes =
+          setupNodesVector<SUB_WIDTH>(sub, targetSide.subCol);
       nodes.insert(nodes.end(), targetNodes.begin(), targetNodes.end());
     }
   }
@@ -546,10 +550,9 @@ std::pair<TransitivePath::Map, std::vector<Id>> TransitivePath::setupMapAndNodes
 
 // _____________________________________________________________________________
 template <size_t SUB_WIDTH>
-TransitivePath::Map TransitivePath::setupEdgesMap(const IdTable& dynSub,
-    const TransitivePathSide& startSide,
+TransitivePath::Map TransitivePath::setupEdgesMap(
+    const IdTable& dynSub, const TransitivePathSide& startSide,
     const TransitivePathSide& targetSide) const {
-
   const IdTableView<SUB_WIDTH> sub = dynSub.asStaticView<SUB_WIDTH>();
   Map edges;
 
@@ -573,7 +576,8 @@ TransitivePath::Map TransitivePath::setupEdgesMap(const IdTable& dynSub,
 
 // _____________________________________________________________________________
 template <size_t WIDTH>
-std::vector<Id> TransitivePath::setupNodesVector(const IdTable& table, size_t col) {
+std::vector<Id> TransitivePath::setupNodesVector(const IdTable& table,
+                                                 size_t col) {
   std::vector<Id> nodes;
   const IdTableView<WIDTH> tableView = table.asStaticView<WIDTH>();
   for (size_t i = 0; i < tableView.size(); i++) {
@@ -583,12 +587,11 @@ std::vector<Id> TransitivePath::setupNodesVector(const IdTable& table, size_t co
 }
 
 // _____________________________________________________________________________
-template<size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
-void TransitivePath::copyColumns(
-    const IdTableView<INPUT_WIDTH>& inputTable,
-    IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow, size_t outputRow,
-    size_t skipCol) {
-
+template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
+void TransitivePath::copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
+                                 IdTableStatic<OUTPUT_WIDTH>& outputTable,
+                                 size_t inputRow, size_t outputRow,
+                                 size_t skipCol) {
   size_t inCol = 0;
   size_t outCol = 2;
   while (inCol < inputTable.numColumns() && outCol < outputTable.numColumns()) {

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -207,8 +207,8 @@ void TransitivePath::computeTransitivePathBound(
   }
 
   TransitivePath::fillTableWithHull<RES_WIDTH, SIDE_WIDTH>(
-      res, hull, nodes, startSide.outputCol, targetSide.outputCol, startSideTable,
-      startSide.treeAndCol.value().second);
+      res, hull, nodes, startSide.outputCol, targetSide.outputCol,
+      startSideTable, startSide.treeAndCol.value().second);
 
   *dynRes = std::move(res).toDynamic();
 }
@@ -246,29 +246,33 @@ ResultTable TransitivePath::computeResult() {
 
   size_t subWidth = subRes->idTable().numColumns();
 
-  auto computeForOneSide = [this, &idTable, subRes, subWidth](auto boundSide, auto otherSide) -> ResultTable {
+  auto computeForOneSide = [this, &idTable, subRes, subWidth](
+                               auto boundSide, auto otherSide) -> ResultTable {
     shared_ptr<const ResultTable> sideRes =
         boundSide.treeAndCol.value().first->getResult();
     size_t sideWidth = sideRes->idTable().numColumns();
 
     CALL_FIXED_SIZE((std::array{_resultWidth, subWidth, sideWidth}),
                     &TransitivePath::computeTransitivePathBound, this, &idTable,
-                    subRes->idTable(), boundSide, otherSide, sideRes->idTable());
+                    subRes->idTable(), boundSide, otherSide,
+                    sideRes->idTable());
 
-    return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocabFromNonEmptyOf(*sideRes.get(), *subRes.get())};
+    return {std::move(idTable), resultSortedOn(),
+            subRes->getSharedLocalVocabFromNonEmptyOf(*sideRes.get(),
+                                                      *subRes.get())};
   };
 
   if (_lhs.isBoundVariable()) {
     return computeForOneSide(_lhs, _rhs);
   } else if (_rhs.isBoundVariable()) {
     return computeForOneSide(_rhs, _lhs);
-  // Right side is an Id
+    // Right side is an Id
   } else if (!_rhs.isVariable()) {
     CALL_FIXED_SIZE((std::array{_resultWidth, subWidth}),
                     &TransitivePath::computeTransitivePath, this, &idTable,
                     subRes->idTable(), _rhs, _lhs);
-  // No side is a bound variable, the right side is an unbound variable
-  // and the left side is either an unbound Variable or an ID.
+    // No side is a bound variable, the right side is an unbound variable
+    // and the left side is either an unbound Variable or an ID.
   } else {
     CALL_FIXED_SIZE((std::array{_resultWidth, subWidth}),
                     &TransitivePath::computeTransitivePath, this, &idTable,
@@ -322,9 +326,11 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftOrRightSide(
   for (auto [variable, columnIndexWithType] :
        leftOrRightOp->getVariableColumns()) {
     ColumnIndex columnIndex = columnIndexWithType.columnIndex_;
-    if (columnIndex == inputCol) { continue; }
+    if (columnIndex == inputCol) {
+      continue;
+    }
 
-    columnIndexWithType.columnIndex_ += columnIndex > inputCol ? 1: 2;
+    columnIndexWithType.columnIndex_ += columnIndex > inputCol ? 1 : 2;
 
     p->_variableColumns[variable] = columnIndexWithType;
     p->_resultWidth++;
@@ -339,7 +345,8 @@ bool TransitivePath::isBound() const {
 
 // _____________________________________________________________________________
 TransitivePath::Map TransitivePath::transitiveHull(
-    const Map& edges, const std::vector<Id>& startNodes, std::optional<Id> target) const {
+    const Map& edges, const std::vector<Id>& startNodes,
+    std::optional<Id> target) const {
   using MapIt = TransitivePath::Map::const_iterator;
   // For every node do a dfs on the graph
   Map hull;
@@ -437,7 +444,7 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
       table(rowIndex, targetSideCol) = otherNode;
 
       TransitivePath::copyColumns<START_WIDTH, WIDTH>(startView, table, i,
-                                                     rowIndex, skipCol);
+                                                      rowIndex, skipCol);
 
       rowIndex++;
     }
@@ -472,8 +479,8 @@ TransitivePath::setupMapAndNodes(const IdTable& sub,
   Map edges = setupEdgesMap<SUB_WIDTH>(sub, startSide, targetSide);
 
   // Bound -> var|id
-  std::span<const Id> startNodes = setupNodes<SIDE_WIDTH>(startSideTable,
-                                       startSide.treeAndCol.value().second);
+  std::span<const Id> startNodes = setupNodes<SIDE_WIDTH>(
+      startSideTable, startSide.treeAndCol.value().second);
   nodes.insert(nodes.end(), startNodes.begin(), startNodes.end());
 
   return {std::move(edges), std::move(nodes)};
@@ -493,7 +500,8 @@ TransitivePath::setupMapAndNodes(const IdTable& sub,
     nodes.push_back(std::get<Id>(startSide.value));
     // var -> var
   } else {
-    std::span<const Id> startNodes = setupNodes<SUB_WIDTH>(sub, startSide.subCol);
+    std::span<const Id> startNodes =
+        setupNodes<SUB_WIDTH>(sub, startSide.subCol);
     nodes.insert(nodes.end(), startNodes.begin(), startNodes.end());
     if (_minDist == 0) {
       std::span<const Id> targetNodes =
@@ -512,8 +520,8 @@ TransitivePath::Map TransitivePath::setupEdgesMap(
     const TransitivePathSide& targetSide) const {
   const IdTableView<SUB_WIDTH> sub = dynSub.asStaticView<SUB_WIDTH>();
   Map edges;
-  decltype (auto) startCol = sub.getColumn(startSide.subCol);
-  decltype (auto) targetCol = sub.getColumn(targetSide.subCol);
+  decltype(auto) startCol = sub.getColumn(startSide.subCol);
+  decltype(auto) targetCol = sub.getColumn(targetSide.subCol);
 
   for (size_t i = 0; i < sub.size(); i++) {
     checkCancellation();
@@ -533,7 +541,7 @@ TransitivePath::Map TransitivePath::setupEdgesMap(
 // _____________________________________________________________________________
 template <size_t WIDTH>
 std::span<const Id> TransitivePath::setupNodes(const IdTable& table,
-                                                 size_t col) {
+                                               size_t col) {
   return table.getColumn(col);
 }
 

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -114,23 +114,11 @@ vector<ColumnIndex> TransitivePath::resultSortedOn() const {
     // This operation preserves the order of the _leftCol of the subtree.
     return {0};
   }
-  if (_lhs.treeAndCol.has_value()) {
-    auto tree = _lhs.treeAndCol.value().first;
-    auto col = _lhs.treeAndCol.value().second;
-    const std::vector<ColumnIndex>& leftSortedOn =
-        tree->getRootOperation()->getResultSortedOn();
-    if (leftSortedOn.size() > 0 && leftSortedOn[0] == col) {
-      return {0};
-    }
+  if (_lhs.isSortedOnInputCol()) {
+    return {0};
   }
-  if (_rhs.treeAndCol.has_value()) {
-    auto tree = _rhs.treeAndCol.value().first;
-    auto col = _rhs.treeAndCol.value().second;
-    const std::vector<ColumnIndex>& rightSortedOn =
-        tree->getRootOperation()->getResultSortedOn();
-    if (rightSortedOn.size() > 0 && rightSortedOn[0] == col) {
-      return {1};
-    }
+  if (_rhs.isSortedOnInputCol()) {
+    return {1};
   }
   return {};
 }
@@ -143,11 +131,8 @@ VariableToColumnMap TransitivePath::computeVariableToColumnMap() const {
 // _____________________________________________________________________________
 void TransitivePath::setTextLimit(size_t limit) {
   _subtree->setTextLimit(limit);
-  if (_lhs.treeAndCol.has_value()) {
-    _lhs.treeAndCol.value().first->setTextLimit(limit);
-  }
-  if (_rhs.treeAndCol.has_value()) {
-    _rhs.treeAndCol.value().first->setTextLimit(limit);
+  for (auto child : getChildren()) {
+    child->setTextLimit(limit);
   }
 }
 
@@ -322,9 +307,9 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftOrRightSide(
   std::shared_ptr<TransitivePath> p = std::make_shared<TransitivePath>(
       getExecutionContext(), _subtree, _lhs, _rhs, _minDist, _maxDist);
   if (isLeft) {
-    p->_lhs.treeAndCol = std::make_pair(leftOrRightOp, inputCol);
+    p->_lhs.treeAndCol = {leftOrRightOp, inputCol};
   } else {
-    p->_rhs.treeAndCol = std::make_pair(leftOrRightOp, inputCol);
+    p->_rhs.treeAndCol = {leftOrRightOp, inputCol};
   }
 
   // Note: The `variable` in the following structured binding is `const`, even
@@ -336,11 +321,10 @@ std::shared_ptr<TransitivePath> TransitivePath::bindLeftOrRightSide(
     if (columnIndex != inputCol) {
       if (columnIndex > inputCol) {
         columnIndexWithType.columnIndex_++;
-        p->_variableColumns[variable] = columnIndexWithType;
       } else {
         columnIndexWithType.columnIndex_ += 2;
-        p->_variableColumns[variable] = columnIndexWithType;
       }
+      p->_variableColumns[variable] = columnIndexWithType;
       p->_resultWidth++;
     }
   }
@@ -376,20 +360,23 @@ TransitivePath::Map TransitivePath::transitiveHull(
   // be modified after this point.
   std::vector<std::shared_ptr<const ad_utility::HashSet<Id>>> edgeCache;
 
-  for (size_t i = 0; i < startNodes.size(); i++) {
-    if (hull.contains(startNodes[i])) {
+  for (Id currentStartNode : startNodes) {
+    if (hull.contains(currentStartNode)) {
       // We have already computed the hull for this node
       continue;
     }
 
-    MapIt rootEdges = edges.find(startNodes[i]);
+    // Reset for this iteration
+    marks.clear();
+
+    MapIt rootEdges = edges.find(currentStartNode);
     if (rootEdges != edges.end()) {
       positions.push_back(rootEdges->second->begin());
       edgeCache.push_back(rootEdges->second);
     }
     if (_minDist == 0) {
-      hull.try_emplace(startNodes[i], std::make_shared<ad_utility::HashSet<Id>>());
-      hull[startNodes[i]]->insert(startNodes[i]);
+      hull.try_emplace(currentStartNode, std::make_shared<ad_utility::HashSet<Id>>());
+      hull[currentStartNode]->insert(currentStartNode);
     }
 
     // While we have not found the entire transitive hull and have not reached
@@ -416,13 +403,13 @@ TransitivePath::Map TransitivePath::transitiveHull(
         if (childDepth >= _minDist) {
           marks.insert(child);
           if (_rhs.isVariable() || child == std::get<Id>(_rhs.value)) {
-            hull.try_emplace(startNodes[i],
+            hull.try_emplace(currentStartNode,
                              std::make_shared<ad_utility::HashSet<Id>>());
-            hull[startNodes[i]]->insert(child);
+            hull[currentStartNode]->insert(child);
           } else if (_lhs.isVariable() || child == std::get<Id>(_lhs.value)) {
             hull.try_emplace(child,
                              std::make_shared<ad_utility::HashSet<Id>>());
-            hull[child]->insert(startNodes[i]);
+            hull[child]->insert(currentStartNode);
           }
         }
         // Add the child to the stack
@@ -432,11 +419,6 @@ TransitivePath::Map TransitivePath::transitiveHull(
           edgeCache.push_back(it->second);
         }
       }
-    }
-
-    if (i + 1 < startNodes.size()) {
-      // reset everything for the next iteration
-      marks.clear();
     }
   }
   return hull;
@@ -456,11 +438,12 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
   size_t rowIndex = 0;
   for (size_t i = 0; i < nodes.size(); i++) {
     Id node = nodes[i];
-    if (!hull.contains(node)) {
+    auto it = hull.find(node);
+    if (it == hull.end()) {
       continue;
     }
 
-    for (Id otherNode : *hull[node]) {
+    for (Id otherNode : *it->second) {
       table.emplace_back();
       table(rowIndex, startSideCol) = node;
       table(rowIndex, targetSideCol) = otherNode;
@@ -501,10 +484,11 @@ TransitivePath::setupMapAndNodes(const IdTable& sub,
   Map edges = setupEdgesMap<SUB_WIDTH>(sub, startSide, targetSide);
 
   // Bound -> var|id
-  nodes = setupNodesVector<SIDE_WIDTH>(startSideTable,
+  std::span<const Id> startNodes = setupNodes<SIDE_WIDTH>(startSideTable,
                                        startSide.treeAndCol.value().second);
+  nodes.insert(nodes.end(), startNodes.begin(), startNodes.end());
 
-  return std::make_pair(edges, nodes);
+  return {std::move(edges), std::move(nodes)};
 }
 
 // _____________________________________________________________________________
@@ -521,15 +505,16 @@ TransitivePath::setupMapAndNodes(const IdTable& sub,
     nodes.push_back(std::get<Id>(startSide.value));
     // var -> var
   } else {
-    nodes = setupNodesVector<SUB_WIDTH>(sub, startSide.subCol);
+    std::span<const Id> startNodes = setupNodes<SUB_WIDTH>(sub, startSide.subCol);
+    nodes.insert(nodes.end(), startNodes.begin(), startNodes.end());
     if (_minDist == 0) {
-      std::vector<Id> targetNodes =
-          setupNodesVector<SUB_WIDTH>(sub, targetSide.subCol);
+      std::span<const Id> targetNodes =
+          setupNodes<SUB_WIDTH>(sub, targetSide.subCol);
       nodes.insert(nodes.end(), targetNodes.begin(), targetNodes.end());
     }
   }
 
-  return std::make_pair(edges, nodes);
+  return {std::move(edges), std::move(nodes)};
 }
 
 // _____________________________________________________________________________
@@ -539,11 +524,13 @@ TransitivePath::Map TransitivePath::setupEdgesMap(
     const TransitivePathSide& targetSide) const {
   const IdTableView<SUB_WIDTH> sub = dynSub.asStaticView<SUB_WIDTH>();
   Map edges;
+  decltype (auto) startCol = sub.getColumn(startSide.subCol);
+  decltype (auto) targetCol = sub.getColumn(targetSide.subCol);
 
   for (size_t i = 0; i < sub.size(); i++) {
     checkCancellation();
-    Id startId = sub(i, startSide.subCol);
-    Id targetId = sub(i, targetSide.subCol);
+    Id startId = startCol[i];
+    Id targetId = targetCol[i];
     MapIt it = edges.find(startId);
     if (it == edges.end()) {
       std::shared_ptr<ad_utility::HashSet<Id>> edgeTargets =
@@ -560,14 +547,9 @@ TransitivePath::Map TransitivePath::setupEdgesMap(
 
 // _____________________________________________________________________________
 template <size_t WIDTH>
-std::vector<Id> TransitivePath::setupNodesVector(const IdTable& table,
+std::span<const Id> TransitivePath::setupNodes(const IdTable& table,
                                                  size_t col) {
-  std::vector<Id> nodes;
-  const IdTableView<WIDTH> tableView = table.asStaticView<WIDTH>();
-  for (size_t i = 0; i < tableView.size(); i++) {
-    nodes.push_back(tableView(i, col));
-  }
-  return nodes;
+  return table.getColumn(col);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -409,10 +409,8 @@ TransitivePath::Map TransitivePath::transitiveHull(const Map& edges,
       edgeCache.push_back(rootEdges->second);
     }
     if (_minDist == 0) {
-      // res.push_back({nodes[i], nodes[i]});
-      AD_THROW(
-          "The TransitivePath operation does not support a minimum "
-          "distance of 0 (use at least one instead).");
+      hull.try_emplace(nodes[i], std::make_shared<ad_utility::HashSet<Id>>());
+      hull[nodes[i]]->insert(nodes[i]);
     }
 
     // While we have not found the entire transitive hull and have not reached
@@ -474,6 +472,10 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
   size_t rowIndex = 0;
   for (size_t i = 0; i < nodes.size(); i++) {
     Id node = nodes[i];
+    if (!hull.contains(node)) {
+      continue;
+    }
+
     for (Id otherNode : *hull[node]) {
       table.emplace_back();
       table(rowIndex, startSideCol) = node;
@@ -533,6 +535,10 @@ std::pair<TransitivePath::Map, std::vector<Id>> TransitivePath::setupMapAndNodes
   // var -> var
   } else {
     nodes = setupNodesVector<SUB_WIDTH>(sub, startSide.subCol);
+    if (_minDist == 0) {
+      std::vector<Id> targetNodes = setupNodesVector<SUB_WIDTH>(sub, targetSide.subCol);
+      nodes.insert(nodes.end(), targetNodes.begin(), targetNodes.end());
+    }
   }
 
   return std::make_pair(edges, nodes);
@@ -581,12 +587,18 @@ template<size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
 void TransitivePath::copyColumns(
     const IdTableView<INPUT_WIDTH>& inputTable,
     IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow, size_t outputRow,
-    size_t tableCol) {
-  for (size_t i = 2; i < outputTable.numColumns() + 1; i++) {
-    if (i - 2 < tableCol) {
-      outputTable(outputRow, i) = inputTable(inputRow, i - 2);
-    } else if (i - 2 > tableCol) {
-      outputTable(outputRow, i - 1) = inputTable(inputRow, i - 2);
+    size_t skipCol) {
+
+  size_t inCol = 0;
+  size_t outCol = 2;
+  while (inCol < inputTable.numColumns() && outCol < outputTable.numColumns()) {
+    if (skipCol == inCol) {
+      inCol++;
+      continue;
     }
+
+    outputTable(outputRow, outCol) = inputTable(inputRow, inCol);
+    inCol++;
+    outCol++;
   }
 }

--- a/src/engine/TransitivePath.cpp
+++ b/src/engine/TransitivePath.cpp
@@ -21,7 +21,6 @@ TransitivePath::TransitivePath(QueryExecutionContext* qec,
       subtree_(std::move(child)),
       lhs_(std::move(leftSide)),
       rhs_(std::move(rightSide)),
-      resultWidth_(2),
       minDist_(minDist),
       maxDist_(maxDist) {
   if (lhs_.isVariable()) {
@@ -170,8 +169,8 @@ uint64_t TransitivePath::getSizeEstimateBeforeLimit() {
   }
   // TODO(Florian): this is not necessarily a good estimator
   if (lhs_.isVariable()) {
-    return subtree_->getSizeEstimate() /
-           subtree_->getMultiplicity(lhs_.subCol_);
+    size_t multiplicity = static_cast<size_t>(getMultiplicity(lhs_.subCol_));
+    return subtree_->getSizeEstimate() / multiplicity;
   }
   return subtree_->getSizeEstimate();
 }
@@ -430,8 +429,8 @@ TransitivePath::Map TransitivePath::transitiveHull(
 
 // _____________________________________________________________________________
 template <size_t WIDTH, size_t START_WIDTH>
-void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map& hull,
-                                       std::vector<Id>& nodes,
+void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table,
+                                       const Map& hull, std::vector<Id>& nodes,
                                        size_t startSideCol,
                                        size_t targetSideCol,
                                        const IdTable& startSideTable,
@@ -462,8 +461,8 @@ void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map& hull,
 
 // _____________________________________________________________________________
 template <size_t WIDTH>
-void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table, Map& hull,
-                                       size_t startSideCol,
+void TransitivePath::fillTableWithHull(IdTableStatic<WIDTH>& table,
+                                       const Map& hull, size_t startSideCol,
                                        size_t targetSideCol) {
   size_t rowIndex = 0;
   for (auto const& [node, linkedNodes] : hull) {

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -10,141 +10,228 @@
 #include "engine/QueryExecutionTree.h"
 #include "engine/idTable/IdTable.h"
 
-class TransitivePath : public Operation {
- private:
-  // If this is not nullptr then the left side of all paths is within the result
+using TreeAndCol = std::pair<std::shared_ptr<QueryExecutionTree>, size_t>;
+struct TransitivePathSide {
+  // If this is not nullptr then this side of all paths is within the result
   // of this tree.
-  std::shared_ptr<QueryExecutionTree> _leftSideTree;
-  size_t _leftSideCol;
+  std::optional<TreeAndCol> treeAndCol;
+  size_t subCol;
+  std::variant<Id, Variable> value;
+  // This member is set by the TransitivePath class
+  size_t outputCol = 0;
 
-  // If this is not nullptr then the right side of all paths is within the
-  // result of this tree.
-  std::shared_ptr<QueryExecutionTree> _rightSideTree;
-  size_t _rightSideCol;
+  bool isVariable() const {
+    return std::holds_alternative<Variable>(value);
+  };
 
-  size_t _resultWidth;
-  VariableToColumnMap _variableColumns;
+  bool isBound() const {
+    return treeAndCol.has_value() || std::holds_alternative<Id>(value);
+  };
+};
+
+class TransitivePath : public Operation {
+  using Map = ad_utility::HashMap<Id, std::shared_ptr<ad_utility::HashSet<Id>>>;
+  using MapIt = Map::iterator;
 
   std::shared_ptr<QueryExecutionTree> _subtree;
-  bool _leftIsVar;
-  bool _rightIsVar;
-  size_t _leftSubCol;
-  size_t _rightSubCol;
-  Id _leftValue;
-  Id _rightValue;
-  std::string _leftColName;
-  std::string _rightColName;
+  TransitivePathSide _lhs;
+  TransitivePathSide _rhs;
+  size_t _resultWidth;
   size_t _minDist;
   size_t _maxDist;
+  VariableToColumnMap _variableColumns;
 
- public:
-  // TODO<joka921> Understand this interface and refactor it to
-  // `std::variant<Variable, ID>` or something similar for the `left...` and
-  // `right...` parameters0.
-  TransitivePath(QueryExecutionContext* qec,
-                 std::shared_ptr<QueryExecutionTree> child, bool leftIsVar,
-                 bool rightIsVar, size_t leftSubCol, size_t rightSubCol,
-                 Id leftValue, Id rightValue, const Variable& leftColName,
-                 const Variable& rightColName, size_t minDist, size_t maxDist);
+  public:
+    TransitivePath(QueryExecutionContext* qec,
+                   std::shared_ptr<QueryExecutionTree> child,
+                   TransitivePathSide leftSide, TransitivePathSide rightSide,
+                   size_t minDist, size_t maxDist);
 
-  /**
-   * Returns a new TransitivePath operation that uses the fact that leftop
-   * generates all possible values for the left side of the paths. If the
-   * results of leftop is smaller than all possible values this will result in a
-   * faster transitive path operation (as the transitive paths has to be
-   * computed for fewer elements).
-   */
-  std::shared_ptr<TransitivePath> bindLeftSide(
-      std::shared_ptr<QueryExecutionTree> leftop, size_t inputCol) const;
+    /**
+     * Returns a new TransitivePath operation that uses the fact that leftop
+     * generates all possible values for the left side of the paths. If the
+     * results of leftop is smaller than all possible values this will result in a
+     * faster transitive path operation (as the transitive paths has to be
+     * computed for fewer elements).
+     */
+    std::shared_ptr<TransitivePath> bindLeftSide(
+        std::shared_ptr<QueryExecutionTree> leftop, size_t inputCol) const;
 
-  /**
-   * Returns a new TransitivePath operation that uses the fact that rightop
-   * generates all possible values for the right side of the paths. If the
-   * results of rightop is smaller than all possible values this will result in
-   * a faster transitive path operation (as the transitive paths has to be
-   * computed for fewer elements).
-   */
-  std::shared_ptr<TransitivePath> bindRightSide(
-      std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
+    /**
+     * Returns a new TransitivePath operation that uses the fact that rightop
+     * generates all possible values for the right side of the paths. If the
+     * results of rightop is smaller than all possible values this will result in
+     * a faster transitive path operation (as the transitive paths has to be
+     * computed for fewer elements).
+     */
+    std::shared_ptr<TransitivePath> bindRightSide(
+        std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
 
-  /**
-   * Returns true if this tree was created using the bindLeftSide method.
-   * Neither side of a tree may be bound twice
-   */
-  bool isBound() const;
+    /**
+     * Neither side of a tree may be bound twice
+     */
+    bool isBound() const;
 
- protected:
-  virtual std::string asStringImpl(size_t indent = 0) const override;
+    bool leftIsBound() const;
 
- public:
-  virtual std::string getDescriptor() const override;
+    bool rightIsBound() const;
 
-  virtual size_t getResultWidth() const override;
+  protected:
+    virtual std::string asStringImpl(size_t indent = 0) const override;
 
-  virtual vector<ColumnIndex> resultSortedOn() const override;
+  public:
+    virtual std::string getDescriptor() const override;
 
-  virtual void setTextLimit(size_t limit) override;
+    virtual size_t getResultWidth() const override;
 
-  virtual bool knownEmptyResult() override;
+    virtual vector<ColumnIndex> resultSortedOn() const override;
 
-  virtual float getMultiplicity(size_t col) override;
+    virtual void setTextLimit(size_t limit) override;
 
- private:
-  uint64_t getSizeEstimateBeforeLimit() override;
+    virtual bool knownEmptyResult() override;
 
- public:
-  virtual size_t getCostEstimate() override;
+    virtual float getMultiplicity(size_t col) override;
 
-  vector<QueryExecutionTree*> getChildren() override {
-    std::vector<QueryExecutionTree*> res;
-    if (_leftSideTree) {
-      res.push_back(_leftSideTree.get());
+  private:
+    uint64_t getSizeEstimateBeforeLimit() override;
+
+  public:
+    virtual size_t getCostEstimate() override;
+
+    vector<QueryExecutionTree*> getChildren() override {
+      std::vector<QueryExecutionTree*> res;
+      if (_lhs.treeAndCol.has_value()) {
+        res.push_back(_lhs.treeAndCol.value().first.get());
+      }
+      res.push_back(_subtree.get());
+      if (_rhs.treeAndCol.has_value()) {
+        res.push_back(_rhs.treeAndCol.value().first.get());
+      }
+      return res;
     }
-    res.push_back(_subtree.get());
-    if (_rightSideTree) {
-      res.push_back(_rightSideTree.get());
-    }
-    return res;
-  }
 
-  // The method is declared here to make it unit testable
+    /**
+     * @brief Compute the transitive hull with a bound side.
+     * 
+     * @tparam RES_WIDTH 
+     * @tparam SUB_WIDTH 
+     * @tparam OTHER_WIDTH 
+     * @param res 
+     * @param sub 
+     * @param startSide 
+     * @param targetSide 
+     * @param other 
+     */
+    template <size_t RES_WIDTH, size_t SUB_WIDTH, size_t OTHER_WIDTH>
+    void computeTransitivePathBound(IdTable* res, const IdTable& sub,
+        const TransitivePathSide& startSide, const TransitivePathSide& targetSide,
+        const IdTable& other) const;
 
-  template <size_t SUB_WIDTH, bool leftIsVar, bool rightIsVar>
-  void computeTransitivePath(IdTable* res, const IdTable& sub,
-                             size_t leftSubCol, size_t rightSubCol,
-                             Id leftValue, Id rightValue, size_t minDist,
-                             size_t maxDist);
+    template <size_t RES_WIDTH, size_t SUB_WIDTH>
+    void computeTransitivePath(IdTable* res, const IdTable& sub,
+        const TransitivePathSide& startSide, const TransitivePathSide& targetSide) const;
 
-  template <size_t SUB_WIDTH>
-  void computeTransitivePath(IdTable* res, const IdTable& sub, bool leftIsVar,
-                             bool rightIsVar, size_t leftSubCol,
-                             size_t rightSubCol, Id leftValue, Id rightValue,
-                             size_t minDist, size_t maxDist);
+  private:
+    virtual ResultTable computeResult() override;
 
-  template <size_t SUB_WIDTH, size_t LEFT_WIDTH, size_t RES_WIDTH>
-  void computeTransitivePathLeftBound(IdTable* res, const IdTable& sub,
-                                      const IdTable& left, size_t leftSideCol,
-                                      bool rightIsVar, size_t leftSubCol,
-                                      size_t rightSubCol, Id rightValue,
-                                      size_t minDist, size_t maxDist,
-                                      size_t resWidth);
+    VariableToColumnMap computeVariableToColumnMap() const override;
 
-  template <int SUB_WIDTH, int LEFT_WIDTH, int RES_WIDTH>
-  void computeTransitivePathRightBound(IdTable* res, const IdTable& sub,
-                                       const IdTable& dynRight,
-                                       size_t rightSideCol, bool leftIsVar,
-                                       size_t leftSubCol, size_t rightSubCol,
-                                       Id leftValue, size_t minDist,
-                                       size_t maxDist, size_t resWidth);
+    // The internal implementation of `bindLeftSide` and `bindRightSide` which
+    // share a lot of code.
+    std::shared_ptr<TransitivePath> bindLeftOrRightSide(
+        std::shared_ptr<QueryExecutionTree> leftOrRightOp, size_t inputCol,
+        bool isLeft) const;
 
- private:
-  virtual ResultTable computeResult() override;
+    /**
+     * @brief Compute the transitive hull starting at the given nodes,
+     * using the given Map.
+     * 
+     * @param edges An adjacency matrix, mapping Ids (nodes) to their connected Ids.
+     * @param nodes A list of Ids. These Ids are used as starting points for the transitive
+     * hull. Thus, this parameter guides the performance of this algorithm. 
+     * @return Map Maps each Id to its connected Ids in the transitive hull
+     */
+    Map transitiveHull(const Map& edges, const std::vector<Id>& nodes) const;
+  
+    /**
+     * @brief Fill the given table with the transitive hull and use the tableTemplate
+     * to fill in the rest of the columns.
+     * 
+     * @tparam WIDTH The number of columns of the result table.
+     * @tparam TEMP_WIDTH The number of columns of the template table.
+     * @param table The result table which will be filled.
+     * @param hull The transitive hull.
+     * @param nodes The start nodes of the transitive hull. These need to be in the
+     * same order and amount as the starting side nodes in the tableTemplate.
+     * @param startSideCol The column of the result table for the startSide of the hull
+     * @param targetSideCol The column of the result table for the targetSide of the hull
+     * @param tableTemplate An IdTable that holds other results. The other results will be
+     * transferred to the new result table.
+     * @param skipCol This column contains the Ids of the start side in the templateTable
+     * and will be skipped.
+     */
+    template<size_t WIDTH, size_t TEMP_WIDTH>
+    static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
+        std::vector<Id>& nodes, size_t startSideCol, size_t targetSideCol,
+        const IdTable& tableTemplate, size_t skipCol);
 
-  VariableToColumnMap computeVariableToColumnMap() const override;
+    /**
+     * @brief Fill the given table with the transitive hull.
+     * 
+     * @tparam WIDTH The number of columns of the result table.
+     * @param table The result table which will be filled.
+     * @param hull The transitive hull.
+     * @param startSideCol The column of the result table for the startSide of the hull
+     * @param targetSideCol The column of the result table for the targetSide of the hull
+     */
+    template<size_t WIDTH>
+    static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
+        size_t startSideCol, size_t targetSideCol);
 
-  // The internal implementation of `bindLeftSide` and `bindRightSide` which
-  // share a lot of code.
-  std::shared_ptr<TransitivePath> bindLeftOrRightSide(
-      std::shared_ptr<QueryExecutionTree> leftOrRightOp, size_t inputCol,
-      bool isLeft) const;
+    /**
+     * @brief Prepare a Map and a nodes vector for the transitive hull computation.
+     * 
+     * @tparam SUB_WIDTH Number of columns of the sub table
+     * @tparam SIDE_WIDTH Number of columns of the startSideTable
+     * @param sub The sub table result
+     * @param startSide The TransitivePathSide where the edges start
+     * @param targetSide The TransitivePathSide where the edges end
+     * @param startSideTable An IdTable containing the Ids for the startSide
+     * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
+     * transitive hull computation
+     */
+    template <size_t SUB_WIDTH, size_t SIDE_WIDTH>
+    std::pair<Map, std::vector<Id>> setupMapAndNodes(const IdTable& sub,
+      const TransitivePathSide& startSide, const TransitivePathSide& targetSide,
+      const IdTable& startSideTable) const;
+
+    /**
+     * @brief Prepare a Map and a nodes vector for the transitive hull computation.
+     * 
+     * @tparam SUB_WIDTH Number of columns of the sub table
+     * @param sub The sub table result
+     * @param startSide The TransitivePathSide where the edges start
+     * @param targetSide The TransitivePathSide where the edges end
+     * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
+     * transitive hull computation
+     */
+    template <size_t SUB_WIDTH>
+    std::pair<Map, std::vector<Id>> setupMapAndNodes(const IdTable& sub,
+      const TransitivePathSide& startSide, const TransitivePathSide& targetSide) const;
+
+    // initialize the map from the subresult
+    template <size_t SUB_WIDTH>
+    Map setupEdgesMap(const IdTable& dynSub, const TransitivePathSide& startSide,
+        const TransitivePathSide& targetSide) const;
+
+    // initialize a vector for the starting nodes (Ids)
+    template <size_t WIDTH>
+    static std::vector<Id> setupNodesVector(const IdTable& table, size_t col);
+
+    // Copy the columns from the input table to the output table
+    template<size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
+    static void copyColumns(
+        const IdTableView<INPUT_WIDTH>& inputTable,
+        IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow, size_t outputRow,
+        size_t inputTableCol);
 };

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -10,7 +10,7 @@
 #include "engine/QueryExecutionTree.h"
 #include "engine/idTable/IdTable.h"
 
-using TreeAndCol = std::pair<std::shared_ptr<QueryExecutionTree>, size_t>;
+using TreeAndCol = std::pair<QueryExecutionTree*, size_t>;
 struct TransitivePathSide {
   // treeAndCol contains the QueryExecutionTree of this side and the column
   // where the Ids of this side are located. This member only has a value if
@@ -62,7 +62,7 @@ struct TransitivePathSide {
 };
 
 class TransitivePath : public Operation {
-  using Map = ad_utility::HashMap<Id, std::shared_ptr<ad_utility::HashSet<Id>>>;
+  using Map = ad_utility::HashMap<Id, ad_utility::HashSet<Id>>;
   using MapIt = Map::iterator;
 
   std::shared_ptr<QueryExecutionTree> _subtree;
@@ -132,13 +132,14 @@ class TransitivePath : public Operation {
 
   vector<QueryExecutionTree*> getChildren() override {
     std::vector<QueryExecutionTree*> res;
-    if (_lhs.treeAndCol.has_value()) {
-      res.push_back(_lhs.treeAndCol.value().first.get());
-    }
+    auto addChildren = [](std::vector<QueryExecutionTree*>& res, TransitivePathSide side) {
+      if (side.treeAndCol.has_value()) {
+        res.push_back(side.treeAndCol.value().first);
+      }
+    };
+    addChildren(res, _lhs);
+    addChildren(res, _rhs);
     res.push_back(_subtree.get());
-    if (_rhs.treeAndCol.has_value()) {
-      res.push_back(_rhs.treeAndCol.value().first.get());
-    }
     return res;
   }
 

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -28,6 +28,26 @@ struct TransitivePathSide {
   bool isBound() const {
     return treeAndCol.has_value() || std::holds_alternative<Id>(value);
   };
+
+  std::string asString(size_t indent) const {
+    std::ostringstream os;
+    for (size_t i = 0; i < indent; i++) {
+      os << " ";
+    }
+    if (isVariable()) {
+      os << "Variable name: " << std::get<Variable>(value)._name;
+    } else if (isBound()) {
+      os << "Id: " << std::get<Id>(value);
+    }
+
+    os << ", Column: " << subCol;
+    
+    if (treeAndCol.has_value()) {
+      os << ", Subtree:\n";
+      os << treeAndCol.value().first->asString(indent) << "\n";
+    }
+    return std::move(os).str();
+  }
 };
 
 class TransitivePath : public Operation {

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -100,6 +100,14 @@ class TransitivePath : public Operation {
    * Neither side of a tree may be bound twice
    */
   bool isBound() const;
+  
+  /**
+   * Getters, mainly necessary for testing 
+   */
+  size_t getMinDist() const { return _minDist; }
+  size_t getMaxDist() const { return _maxDist; }
+  const TransitivePathSide& getLeft() const {return _lhs; }
+  const TransitivePathSide& getRight() const {return _rhs; }
 
  protected:
   virtual std::string asStringImpl(size_t indent = 0) const override;

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -98,20 +98,7 @@ class TransitivePath : public Operation {
   std::shared_ptr<TransitivePath> bindRightSide(
       std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
 
-  /**
-   * @brief Return true if one of the sides was bound.
-   * Bound does **not** refer to a TransitivePath which has an Id on one side.
-   * Instead, a TransitivePath is only called "bound", iff. it has been bound
-   * by using the bindLeftOrRightSide function. This is important for the
-   * QueryPlanner, as it needs the isBound function to decide whether to bind
-   * a TransitivePath or not. If one side of the TransitivePath is an Id, then
-   * the other side may be bound. Also, it is not possible to bind a side
-   * which has an Id.
-   *
-   * @return true The TransitivePath has a bound side
-   * @return false The TransitivePath does not have a bound side
-   */
-  bool isBound() const;
+  bool isBoundOrId() const;
 
   /**
    * Getters, mainly necessary for testing

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -26,7 +26,7 @@ struct TransitivePathSide {
   bool isVariable() const { return std::holds_alternative<Variable>(value); };
 
   bool isBound() const {
-    return treeAndCol.has_value() || std::holds_alternative<Id>(value);
+    return treeAndCol.has_value();
   };
 
   std::string asString(size_t indent) const {
@@ -103,10 +103,6 @@ class TransitivePath : public Operation {
    * Neither side of a tree may be bound twice
    */
   bool isBound() const;
-
-  bool leftIsBound() const;
-
-  bool rightIsBound() const;
 
  protected:
   virtual std::string asStringImpl(size_t indent = 0) const override;

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -67,7 +67,7 @@ class TransitivePath : public Operation {
   std::shared_ptr<QueryExecutionTree> subtree_;
   TransitivePathSide lhs_;
   TransitivePathSide rhs_;
-  size_t resultWidth_;
+  size_t resultWidth_ = 2;
   size_t minDist_;
   size_t maxDist_;
   VariableToColumnMap variableColumns_;
@@ -238,7 +238,7 @@ class TransitivePath : public Operation {
    * startSideTable and will be skipped.
    */
   template <size_t WIDTH, size_t START_WIDTH>
-  static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map& hull,
+  static void fillTableWithHull(IdTableStatic<WIDTH>& table, const Map& hull,
                                 std::vector<Id>& nodes, size_t startSideCol,
                                 size_t targetSideCol,
                                 const IdTable& startSideTable, size_t skipCol);
@@ -256,7 +256,7 @@ class TransitivePath : public Operation {
    * the hull
    */
   template <size_t WIDTH>
-  static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map& hull,
+  static void fillTableWithHull(IdTableStatic<WIDTH>& table, const Map& hull,
                                 size_t startSideCol, size_t targetSideCol);
 
   /**

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -54,6 +54,7 @@ struct TransitivePathSide {
 
     auto [tree, col] = treeAndCol.value();
     const std::vector<ColumnIndex>& sortedOn = tree->getRootOperation()->getResultSortedOn();
+    // TODO<C++23> use std::ranges::starts_with
     return (!sortedOn.empty() && sortedOn[0] == col);
   }
 };
@@ -97,7 +98,17 @@ class TransitivePath : public Operation {
       std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
 
   /**
-   * Neither side of a tree may be bound twice
+   * @brief Return true if one of the sides was bound.
+   * Bound does **not** refer to a TransitivePath which has an Id on one side.
+   * Instead, a TransitivePath is only called "bound", iff. it has been bound
+   * by using the bindLeftOrRightSide function. This is important for the
+   * QueryPlanner, as it needs the isBound function to decide whether to bind
+   * a TransitivePath or not. If one side of the TransitivePath is an Id, then
+   * the other side may be bound. Also, it is not possible to bind a side
+   * which has an Id.
+   * 
+   * @return true The TransitivePath has a bound side
+   * @return false The TransitivePath does not have a bound side
    */
   bool isBound() const;
   

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -210,9 +210,12 @@ class TransitivePath : public Operation {
    * @param nodes A list of Ids. These Ids are used as starting points for the
    * transitive hull. Thus, this parameter guides the performance of this
    * algorithm.
+   * @param target Optional target Id. If supplied, only paths which end
+   * in this Id are added to the hull.
    * @return Map Maps each Id to its connected Ids in the transitive hull
    */
-  Map transitiveHull(const Map& edges, const std::vector<Id>& startNodes) const;
+  Map transitiveHull(const Map& edges, const std::vector<Id>& startNodes,
+                     std::optional<Id> target) const;
 
   /**
    * @brief Fill the given table with the transitive hull and use the

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -20,9 +20,7 @@ struct TransitivePathSide {
   // This member is set by the TransitivePath class
   size_t outputCol = 0;
 
-  bool isVariable() const {
-    return std::holds_alternative<Variable>(value);
-  };
+  bool isVariable() const { return std::holds_alternative<Variable>(value); };
 
   bool isBound() const {
     return treeAndCol.has_value() || std::holds_alternative<Id>(value);
@@ -41,197 +39,209 @@ class TransitivePath : public Operation {
   size_t _maxDist;
   VariableToColumnMap _variableColumns;
 
-  public:
-    TransitivePath(QueryExecutionContext* qec,
-                   std::shared_ptr<QueryExecutionTree> child,
-                   TransitivePathSide leftSide, TransitivePathSide rightSide,
-                   size_t minDist, size_t maxDist);
+ public:
+  TransitivePath(QueryExecutionContext* qec,
+                 std::shared_ptr<QueryExecutionTree> child,
+                 TransitivePathSide leftSide, TransitivePathSide rightSide,
+                 size_t minDist, size_t maxDist);
 
-    /**
-     * Returns a new TransitivePath operation that uses the fact that leftop
-     * generates all possible values for the left side of the paths. If the
-     * results of leftop is smaller than all possible values this will result in a
-     * faster transitive path operation (as the transitive paths has to be
-     * computed for fewer elements).
-     */
-    std::shared_ptr<TransitivePath> bindLeftSide(
-        std::shared_ptr<QueryExecutionTree> leftop, size_t inputCol) const;
+  /**
+   * Returns a new TransitivePath operation that uses the fact that leftop
+   * generates all possible values for the left side of the paths. If the
+   * results of leftop is smaller than all possible values this will result in a
+   * faster transitive path operation (as the transitive paths has to be
+   * computed for fewer elements).
+   */
+  std::shared_ptr<TransitivePath> bindLeftSide(
+      std::shared_ptr<QueryExecutionTree> leftop, size_t inputCol) const;
 
-    /**
-     * Returns a new TransitivePath operation that uses the fact that rightop
-     * generates all possible values for the right side of the paths. If the
-     * results of rightop is smaller than all possible values this will result in
-     * a faster transitive path operation (as the transitive paths has to be
-     * computed for fewer elements).
-     */
-    std::shared_ptr<TransitivePath> bindRightSide(
-        std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
+  /**
+   * Returns a new TransitivePath operation that uses the fact that rightop
+   * generates all possible values for the right side of the paths. If the
+   * results of rightop is smaller than all possible values this will result in
+   * a faster transitive path operation (as the transitive paths has to be
+   * computed for fewer elements).
+   */
+  std::shared_ptr<TransitivePath> bindRightSide(
+      std::shared_ptr<QueryExecutionTree> rightop, size_t inputCol) const;
 
-    /**
-     * Neither side of a tree may be bound twice
-     */
-    bool isBound() const;
+  /**
+   * Neither side of a tree may be bound twice
+   */
+  bool isBound() const;
 
-    bool leftIsBound() const;
+  bool leftIsBound() const;
 
-    bool rightIsBound() const;
+  bool rightIsBound() const;
 
-  protected:
-    virtual std::string asStringImpl(size_t indent = 0) const override;
+ protected:
+  virtual std::string asStringImpl(size_t indent = 0) const override;
 
-  public:
-    virtual std::string getDescriptor() const override;
+ public:
+  virtual std::string getDescriptor() const override;
 
-    virtual size_t getResultWidth() const override;
+  virtual size_t getResultWidth() const override;
 
-    virtual vector<ColumnIndex> resultSortedOn() const override;
+  virtual vector<ColumnIndex> resultSortedOn() const override;
 
-    virtual void setTextLimit(size_t limit) override;
+  virtual void setTextLimit(size_t limit) override;
 
-    virtual bool knownEmptyResult() override;
+  virtual bool knownEmptyResult() override;
 
-    virtual float getMultiplicity(size_t col) override;
+  virtual float getMultiplicity(size_t col) override;
 
-  private:
-    uint64_t getSizeEstimateBeforeLimit() override;
+ private:
+  uint64_t getSizeEstimateBeforeLimit() override;
 
-  public:
-    virtual size_t getCostEstimate() override;
+ public:
+  virtual size_t getCostEstimate() override;
 
-    vector<QueryExecutionTree*> getChildren() override {
-      std::vector<QueryExecutionTree*> res;
-      if (_lhs.treeAndCol.has_value()) {
-        res.push_back(_lhs.treeAndCol.value().first.get());
-      }
-      res.push_back(_subtree.get());
-      if (_rhs.treeAndCol.has_value()) {
-        res.push_back(_rhs.treeAndCol.value().first.get());
-      }
-      return res;
+  vector<QueryExecutionTree*> getChildren() override {
+    std::vector<QueryExecutionTree*> res;
+    if (_lhs.treeAndCol.has_value()) {
+      res.push_back(_lhs.treeAndCol.value().first.get());
     }
+    res.push_back(_subtree.get());
+    if (_rhs.treeAndCol.has_value()) {
+      res.push_back(_rhs.treeAndCol.value().first.get());
+    }
+    return res;
+  }
 
-    /**
-     * @brief Compute the transitive hull with a bound side.
-     * 
-     * @tparam RES_WIDTH 
-     * @tparam SUB_WIDTH 
-     * @tparam OTHER_WIDTH 
-     * @param res 
-     * @param sub 
-     * @param startSide 
-     * @param targetSide 
-     * @param other 
-     */
-    template <size_t RES_WIDTH, size_t SUB_WIDTH, size_t OTHER_WIDTH>
-    void computeTransitivePathBound(IdTable* res, const IdTable& sub,
-        const TransitivePathSide& startSide, const TransitivePathSide& targetSide,
-        const IdTable& other) const;
+  /**
+   * @brief Compute the transitive hull with a bound side.
+   *
+   * @tparam RES_WIDTH
+   * @tparam SUB_WIDTH
+   * @tparam OTHER_WIDTH
+   * @param res
+   * @param sub
+   * @param startSide
+   * @param targetSide
+   * @param other
+   */
+  template <size_t RES_WIDTH, size_t SUB_WIDTH, size_t OTHER_WIDTH>
+  void computeTransitivePathBound(IdTable* res, const IdTable& sub,
+                                  const TransitivePathSide& startSide,
+                                  const TransitivePathSide& targetSide,
+                                  const IdTable& other) const;
 
-    template <size_t RES_WIDTH, size_t SUB_WIDTH>
-    void computeTransitivePath(IdTable* res, const IdTable& sub,
-        const TransitivePathSide& startSide, const TransitivePathSide& targetSide) const;
+  template <size_t RES_WIDTH, size_t SUB_WIDTH>
+  void computeTransitivePath(IdTable* res, const IdTable& sub,
+                             const TransitivePathSide& startSide,
+                             const TransitivePathSide& targetSide) const;
 
-  private:
-    virtual ResultTable computeResult() override;
+ private:
+  virtual ResultTable computeResult() override;
 
-    VariableToColumnMap computeVariableToColumnMap() const override;
+  VariableToColumnMap computeVariableToColumnMap() const override;
 
-    // The internal implementation of `bindLeftSide` and `bindRightSide` which
-    // share a lot of code.
-    std::shared_ptr<TransitivePath> bindLeftOrRightSide(
-        std::shared_ptr<QueryExecutionTree> leftOrRightOp, size_t inputCol,
-        bool isLeft) const;
+  // The internal implementation of `bindLeftSide` and `bindRightSide` which
+  // share a lot of code.
+  std::shared_ptr<TransitivePath> bindLeftOrRightSide(
+      std::shared_ptr<QueryExecutionTree> leftOrRightOp, size_t inputCol,
+      bool isLeft) const;
 
-    /**
-     * @brief Compute the transitive hull starting at the given nodes,
-     * using the given Map.
-     * 
-     * @param edges An adjacency matrix, mapping Ids (nodes) to their connected Ids.
-     * @param nodes A list of Ids. These Ids are used as starting points for the transitive
-     * hull. Thus, this parameter guides the performance of this algorithm. 
-     * @return Map Maps each Id to its connected Ids in the transitive hull
-     */
-    Map transitiveHull(const Map& edges, const std::vector<Id>& nodes) const;
-  
-    /**
-     * @brief Fill the given table with the transitive hull and use the tableTemplate
-     * to fill in the rest of the columns.
-     * 
-     * @tparam WIDTH The number of columns of the result table.
-     * @tparam TEMP_WIDTH The number of columns of the template table.
-     * @param table The result table which will be filled.
-     * @param hull The transitive hull.
-     * @param nodes The start nodes of the transitive hull. These need to be in the
-     * same order and amount as the starting side nodes in the tableTemplate.
-     * @param startSideCol The column of the result table for the startSide of the hull
-     * @param targetSideCol The column of the result table for the targetSide of the hull
-     * @param tableTemplate An IdTable that holds other results. The other results will be
-     * transferred to the new result table.
-     * @param skipCol This column contains the Ids of the start side in the templateTable
-     * and will be skipped.
-     */
-    template<size_t WIDTH, size_t TEMP_WIDTH>
-    static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
-        std::vector<Id>& nodes, size_t startSideCol, size_t targetSideCol,
-        const IdTable& tableTemplate, size_t skipCol);
+  /**
+   * @brief Compute the transitive hull starting at the given nodes,
+   * using the given Map.
+   *
+   * @param edges An adjacency matrix, mapping Ids (nodes) to their connected
+   * Ids.
+   * @param nodes A list of Ids. These Ids are used as starting points for the
+   * transitive hull. Thus, this parameter guides the performance of this
+   * algorithm.
+   * @return Map Maps each Id to its connected Ids in the transitive hull
+   */
+  Map transitiveHull(const Map& edges, const std::vector<Id>& nodes) const;
 
-    /**
-     * @brief Fill the given table with the transitive hull.
-     * 
-     * @tparam WIDTH The number of columns of the result table.
-     * @param table The result table which will be filled.
-     * @param hull The transitive hull.
-     * @param startSideCol The column of the result table for the startSide of the hull
-     * @param targetSideCol The column of the result table for the targetSide of the hull
-     */
-    template<size_t WIDTH>
-    static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
-        size_t startSideCol, size_t targetSideCol);
+  /**
+   * @brief Fill the given table with the transitive hull and use the
+   * tableTemplate to fill in the rest of the columns.
+   *
+   * @tparam WIDTH The number of columns of the result table.
+   * @tparam TEMP_WIDTH The number of columns of the template table.
+   * @param table The result table which will be filled.
+   * @param hull The transitive hull.
+   * @param nodes The start nodes of the transitive hull. These need to be in
+   * the same order and amount as the starting side nodes in the tableTemplate.
+   * @param startSideCol The column of the result table for the startSide of the
+   * hull
+   * @param targetSideCol The column of the result table for the targetSide of
+   * the hull
+   * @param tableTemplate An IdTable that holds other results. The other results
+   * will be transferred to the new result table.
+   * @param skipCol This column contains the Ids of the start side in the
+   * templateTable and will be skipped.
+   */
+  template <size_t WIDTH, size_t TEMP_WIDTH>
+  static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
+                                std::vector<Id>& nodes, size_t startSideCol,
+                                size_t targetSideCol,
+                                const IdTable& tableTemplate, size_t skipCol);
 
-    /**
-     * @brief Prepare a Map and a nodes vector for the transitive hull computation.
-     * 
-     * @tparam SUB_WIDTH Number of columns of the sub table
-     * @tparam SIDE_WIDTH Number of columns of the startSideTable
-     * @param sub The sub table result
-     * @param startSide The TransitivePathSide where the edges start
-     * @param targetSide The TransitivePathSide where the edges end
-     * @param startSideTable An IdTable containing the Ids for the startSide
-     * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
-     * transitive hull computation
-     */
-    template <size_t SUB_WIDTH, size_t SIDE_WIDTH>
-    std::pair<Map, std::vector<Id>> setupMapAndNodes(const IdTable& sub,
-      const TransitivePathSide& startSide, const TransitivePathSide& targetSide,
+  /**
+   * @brief Fill the given table with the transitive hull.
+   *
+   * @tparam WIDTH The number of columns of the result table.
+   * @param table The result table which will be filled.
+   * @param hull The transitive hull.
+   * @param startSideCol The column of the result table for the startSide of the
+   * hull
+   * @param targetSideCol The column of the result table for the targetSide of
+   * the hull
+   */
+  template <size_t WIDTH>
+  static void fillTableWithHull(IdTableStatic<WIDTH>& table, Map hull,
+                                size_t startSideCol, size_t targetSideCol);
+
+  /**
+   * @brief Prepare a Map and a nodes vector for the transitive hull
+   * computation.
+   *
+   * @tparam SUB_WIDTH Number of columns of the sub table
+   * @tparam SIDE_WIDTH Number of columns of the startSideTable
+   * @param sub The sub table result
+   * @param startSide The TransitivePathSide where the edges start
+   * @param targetSide The TransitivePathSide where the edges end
+   * @param startSideTable An IdTable containing the Ids for the startSide
+   * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
+   * transitive hull computation
+   */
+  template <size_t SUB_WIDTH, size_t SIDE_WIDTH>
+  std::pair<Map, std::vector<Id>> setupMapAndNodes(
+      const IdTable& sub, const TransitivePathSide& startSide,
+      const TransitivePathSide& targetSide,
       const IdTable& startSideTable) const;
 
-    /**
-     * @brief Prepare a Map and a nodes vector for the transitive hull computation.
-     * 
-     * @tparam SUB_WIDTH Number of columns of the sub table
-     * @param sub The sub table result
-     * @param startSide The TransitivePathSide where the edges start
-     * @param targetSide The TransitivePathSide where the edges end
-     * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
-     * transitive hull computation
-     */
-    template <size_t SUB_WIDTH>
-    std::pair<Map, std::vector<Id>> setupMapAndNodes(const IdTable& sub,
-      const TransitivePathSide& startSide, const TransitivePathSide& targetSide) const;
+  /**
+   * @brief Prepare a Map and a nodes vector for the transitive hull
+   * computation.
+   *
+   * @tparam SUB_WIDTH Number of columns of the sub table
+   * @param sub The sub table result
+   * @param startSide The TransitivePathSide where the edges start
+   * @param targetSide The TransitivePathSide where the edges end
+   * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
+   * transitive hull computation
+   */
+  template <size_t SUB_WIDTH>
+  std::pair<Map, std::vector<Id>> setupMapAndNodes(
+      const IdTable& sub, const TransitivePathSide& startSide,
+      const TransitivePathSide& targetSide) const;
 
-    // initialize the map from the subresult
-    template <size_t SUB_WIDTH>
-    Map setupEdgesMap(const IdTable& dynSub, const TransitivePathSide& startSide,
-        const TransitivePathSide& targetSide) const;
+  // initialize the map from the subresult
+  template <size_t SUB_WIDTH>
+  Map setupEdgesMap(const IdTable& dynSub, const TransitivePathSide& startSide,
+                    const TransitivePathSide& targetSide) const;
 
-    // initialize a vector for the starting nodes (Ids)
-    template <size_t WIDTH>
-    static std::vector<Id> setupNodesVector(const IdTable& table, size_t col);
+  // initialize a vector for the starting nodes (Ids)
+  template <size_t WIDTH>
+  static std::vector<Id> setupNodesVector(const IdTable& table, size_t col);
 
-    // Copy the columns from the input table to the output table
-    template<size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
-    static void copyColumns(
-        const IdTableView<INPUT_WIDTH>& inputTable,
-        IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow, size_t outputRow,
-        size_t skipCol);
+  // Copy the columns from the input table to the output table
+  template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
+  static void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
+                          IdTableStatic<OUTPUT_WIDTH>& outputTable,
+                          size_t inputRow, size_t outputRow, size_t skipCol);
 };

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -12,11 +12,14 @@
 
 using TreeAndCol = std::pair<std::shared_ptr<QueryExecutionTree>, size_t>;
 struct TransitivePathSide {
-  // If this is not nullptr then this side of all paths is within the result
-  // of this tree.
+  // treeAndCol contains the QueryExecutionTree of this side and the column
+  // where the Ids of this side are located. This member only has a value if
+  // this side was bound.
   std::optional<TreeAndCol> treeAndCol;
+  // Column of the sub table where the Ids of this side are located
   size_t subCol;
   std::variant<Id, Variable> value;
+  // The column in the ouput table where this side Ids are written to.
   // This member is set by the TransitivePath class
   size_t outputCol = 0;
 

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -233,5 +233,5 @@ class TransitivePath : public Operation {
     static void copyColumns(
         const IdTableView<INPUT_WIDTH>& inputTable,
         IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow, size_t outputRow,
-        size_t inputTableCol);
+        size_t skipCol);
 };

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -25,9 +25,7 @@ struct TransitivePathSide {
 
   bool isVariable() const { return std::holds_alternative<Variable>(value); };
 
-  bool isBoundVariable() const {
-    return treeAndCol.has_value();
-  };
+  bool isBoundVariable() const { return treeAndCol.has_value(); };
 
   std::string asString(size_t indent) const {
     std::ostringstream os;
@@ -41,7 +39,7 @@ struct TransitivePathSide {
     }
 
     os << ", Column: " << subCol;
-    
+
     if (treeAndCol.has_value()) {
       os << ", Subtree:\n";
       os << treeAndCol.value().first->asString(indent) << "\n";
@@ -50,10 +48,13 @@ struct TransitivePathSide {
   }
 
   bool isSortedOnInputCol() const {
-    if (!treeAndCol.has_value()) { return false; };
+    if (!treeAndCol.has_value()) {
+      return false;
+    };
 
     auto [tree, col] = treeAndCol.value();
-    const std::vector<ColumnIndex>& sortedOn = tree->getRootOperation()->getResultSortedOn();
+    const std::vector<ColumnIndex>& sortedOn =
+        tree->getRootOperation()->getResultSortedOn();
     // TODO<C++23> use std::ranges::starts_with
     return (!sortedOn.empty() && sortedOn[0] == col);
   }
@@ -106,19 +107,19 @@ class TransitivePath : public Operation {
    * a TransitivePath or not. If one side of the TransitivePath is an Id, then
    * the other side may be bound. Also, it is not possible to bind a side
    * which has an Id.
-   * 
+   *
    * @return true The TransitivePath has a bound side
    * @return false The TransitivePath does not have a bound side
    */
   bool isBound() const;
-  
+
   /**
-   * Getters, mainly necessary for testing 
+   * Getters, mainly necessary for testing
    */
   size_t getMinDist() const { return _minDist; }
   size_t getMaxDist() const { return _maxDist; }
-  const TransitivePathSide& getLeft() const {return _lhs; }
-  const TransitivePathSide& getRight() const {return _rhs; }
+  const TransitivePathSide& getLeft() const { return _lhs; }
+  const TransitivePathSide& getRight() const { return _rhs; }
 
  protected:
   virtual std::string asStringImpl(size_t indent = 0) const override;
@@ -144,7 +145,8 @@ class TransitivePath : public Operation {
 
   vector<QueryExecutionTree*> getChildren() override {
     std::vector<QueryExecutionTree*> res;
-    auto addChildren = [](std::vector<QueryExecutionTree*>& res, TransitivePathSide side) {
+    auto addChildren = [](std::vector<QueryExecutionTree*>& res,
+                          TransitivePathSide side) {
       if (side.treeAndCol.has_value()) {
         res.push_back(side.treeAndCol.value().first.get());
       }
@@ -163,7 +165,7 @@ class TransitivePath : public Operation {
    *
    * @tparam RES_WIDTH Number of columns of the result table
    * @tparam SUB_WIDTH Number of columns of the sub table
-   * @tparam SIDE_WIDTH Number of columns of the 
+   * @tparam SIDE_WIDTH Number of columns of the
    * @param res The result table which will be filled in-place
    * @param sub The IdTable for the sub result
    * @param startSide The start side for the transitive hull
@@ -179,7 +181,7 @@ class TransitivePath : public Operation {
   /**
    * @brief Compute the transitive hull.
    * This function is called when no side is bound (or an id).
-   * 
+   *
    * @tparam RES_WIDTH Number of columns of the result table
    * @tparam SUB_WIDTH Number of columns of the sub table
    * @param res The result table which will be filled in-place
@@ -199,7 +201,7 @@ class TransitivePath : public Operation {
    * hull computation. This choice of the start side has a large impact
    * on the time it takes to compute the hull. The set of nodes on the
    * start side should be as small as possible.
-   * 
+   *
    * @return ResultTable The result of the TransitivePath operation
    */
   virtual ResultTable computeResult() override;
@@ -243,8 +245,8 @@ class TransitivePath : public Operation {
    * hull
    * @param targetSideCol The column of the result table for the targetSide of
    * the hull
-   * @param startSideTable An IdTable that holds other results. The other results
-   * will be transferred to the new result table.
+   * @param startSideTable An IdTable that holds other results. The other
+   * results will be transferred to the new result table.
    * @param skipCol This column contains the Ids of the start side in the
    * startSideTable and will be skipped.
    */

--- a/src/engine/TransitivePath.h
+++ b/src/engine/TransitivePath.h
@@ -48,6 +48,17 @@ struct TransitivePathSide {
     }
     return std::move(os).str();
   }
+
+  bool isSortedOnInputCol() const {
+    if (treeAndCol.has_value()) {
+      auto [tree, col] = treeAndCol.value();
+      const std::vector<ColumnIndex>& sortedOn = tree->getRootOperation()->getResultSortedOn();
+      if (sortedOn.size() > 0 && sortedOn[0] == col) {
+        return true;
+      }
+    }
+    return false;
+  }
 };
 
 class TransitivePath : public Operation {
@@ -285,7 +296,7 @@ class TransitivePath : public Operation {
 
   // initialize a vector for the starting nodes (Ids)
   template <size_t WIDTH>
-  static std::vector<Id> setupNodesVector(const IdTable& table, size_t col);
+  static std::span<const Id> setupNodes(const IdTable& table, size_t col);
 
   // Copy the columns from the input table to the output table
   template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -199,7 +199,7 @@ void Union::computeUnion(
   auto copyChunked = [this](auto beg, auto end, auto target) {
     size_t total = end - beg;
     for (size_t i = 0; i < total; i += chunkSize) {
-      checkTimeout();
+      checkCancellation();
       size_t actualEnd = std::min(i + chunkSize, total);
       std::copy(beg + i, beg + actualEnd, target + i);
     }
@@ -209,7 +209,7 @@ void Union::computeUnion(
   auto fillChunked = [this](auto beg, auto end, const auto& value) {
     size_t total = end - beg;
     for (size_t i = 0; i < total; i += chunkSize) {
-      checkTimeout();
+      checkCancellation();
       size_t actualEnd = std::min(i + chunkSize, total);
       std::fill(beg + i, beg + actualEnd, value);
     }

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -158,12 +158,6 @@ static constexpr uint8_t NUM_COMPRESSION_PREFIXES = 126;
 static const uint8_t NO_PREFIX_CHAR =
     MIN_COMPRESSION_PREFIX + NUM_COMPRESSION_PREFIXES;
 
-// After performing this many "basic operations", we check for timeouts
-static constexpr size_t NUM_OPERATIONS_BETWEEN_TIMEOUT_CHECKS = 32000;
-// How many "basic operations" (see above) do we assume for a hashset or hashmap
-// operation
-static constexpr size_t NUM_OPERATIONS_HASHSET_LOOKUP = 32;
-
 // When initializing a sort performance estimator, at most this percentage of
 // the number of triples in the index is being sorted at once.
 static constexpr size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -13,6 +13,7 @@
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
 #include "util/OverloadCallOperator.h"
 #include "util/ThreadSafeQueue.h"
+#include "util/Timer.h"
 #include "util/TypeTraits.h"
 #include "util/jthread.h"
 
@@ -22,7 +23,8 @@ using namespace std::chrono_literals;
 IdTable CompressedRelationReader::scan(
     const CompressedRelationMetadata& metadata,
     std::span<const CompressedBlockMetadata> blockMetadata,
-    ad_utility::File& file, const TimeoutTimer& timer) const {
+    ad_utility::File& file,
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   IdTable result(2, allocator_);
 
   auto relevantBlocks =
@@ -59,7 +61,7 @@ IdTable CompressedRelationReader::scan(
   // Read the first block (it might be incomplete).
   readIncompleteBlock(*beginBlock);
   ++beginBlock;
-  checkTimeout(timer);
+  checkCancellation(cancellationHandle);
 
   // Read all the other (complete!) blocks in parallel
   if (beginBlock < endBlock) {
@@ -87,9 +89,9 @@ IdTable CompressedRelationReader::scan(
         // The `decompressLambda` can now run in parallel
 #pragma omp task
         {
-          if (!timer || !timer->wlock()->hasTimedOut()) {
+          if (!cancellationHandle->isCancelled()) {
             decompressLambda();
-          };
+          }
         }
 
         // this is again serial code, set up the correct pointers
@@ -100,6 +102,7 @@ IdTable CompressedRelationReader::scan(
       AD_CORRECTNESS_CHECK(spaceLeft == 0);
     }  // End of omp parallel region, all the decompression was handled now.
   }
+  checkCancellation(cancellationHandle);
   return result;
 }
 
@@ -108,7 +111,7 @@ CompressedRelationReader::IdTableGenerator
 CompressedRelationReader::asyncParallelBlockGenerator(
     auto beginBlock, auto endBlock, ad_utility::File& file,
     std::optional<std::vector<size_t>> columnIndices,
-    TimeoutTimer timer) const {
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   LazyScanMetadata& details = co_await cppcoro::getDetails;
   if (beginBlock == endBlock) {
     co_return;
@@ -119,7 +122,7 @@ CompressedRelationReader::asyncParallelBlockGenerator(
   std::mutex blockIteratorMutex;
   auto readAndDecompressBlock =
       [&]() -> std::optional<std::pair<size_t, DecompressedBlock>> {
-    checkTimeout(timer);
+    checkCancellation(cancellationHandle);
     std::unique_lock lock{blockIteratorMutex};
     if (blockIterator == endBlock) {
       return std::nullopt;
@@ -160,7 +163,7 @@ CompressedRelationReader::asyncParallelBlockGenerator(
       queueSize, numThreads, readAndDecompressBlock);
   for (IdTable& block : queue) {
     popTimer.stop();
-    checkTimeout(timer);
+    checkCancellation(cancellationHandle);
     ++details.numBlocksRead_;
     details.numElementsRead_ += block.numRows();
     co_yield block;
@@ -175,7 +178,7 @@ CompressedRelationReader::asyncParallelBlockGenerator(
 CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
     CompressedRelationMetadata metadata,
     std::vector<CompressedBlockMetadata> blockMetadata, ad_utility::File& file,
-    TimeoutTimer timer) const {
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   auto relevantBlocks =
       getBlocksFromMetadata(metadata, std::nullopt, blockMetadata);
   const auto beginBlock = relevantBlocks.begin();
@@ -192,10 +195,10 @@ CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
   auto firstBlock = readPossiblyIncompleteBlock(metadata, std::nullopt, file,
                                                 *beginBlock, std::ref(details));
   co_yield firstBlock;
-  checkTimeout(timer);
+  checkCancellation(cancellationHandle);
 
-  auto blockGenerator = asyncParallelBlockGenerator(beginBlock + 1, endBlock,
-                                                    file, std::nullopt, timer);
+  auto blockGenerator = asyncParallelBlockGenerator(
+      beginBlock + 1, endBlock, file, std::nullopt, cancellationHandle);
   blockGenerator.setDetailsPointer(&details);
   for (auto& block : blockGenerator) {
     co_yield block;
@@ -207,7 +210,8 @@ CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
 CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
     CompressedRelationMetadata metadata, Id col1Id,
     std::vector<CompressedBlockMetadata> blockMetadata, ad_utility::File& file,
-    TimeoutTimer timer) const {
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+  AD_CONTRACT_CHECK(cancellationHandle);
   auto relevantBlocks = getBlocksFromMetadata(metadata, col1Id, blockMetadata);
   auto beginBlock = relevantBlocks.begin();
   auto endBlock = relevantBlocks.end();
@@ -228,11 +232,11 @@ CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
     AD_CORRECTNESS_CHECK(endBlock - beginBlock <= 1);
   }
 
-  auto getIncompleteBlock = [&](auto it) {
+  auto getIncompleteBlock = [&, cancellationHandle](auto it) {
     auto result = readPossiblyIncompleteBlock(metadata, col1Id, file, *it,
                                               std::ref(details));
     result.setColumnSubset(std::array<ColumnIndex, 1>{1});
-    checkTimeout(timer);
+    checkCancellation(cancellationHandle);
     return result;
   };
 
@@ -243,7 +247,8 @@ CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
 
   if (beginBlock + 1 < endBlock) {
     auto blockGenerator = asyncParallelBlockGenerator(
-        beginBlock + 1, endBlock - 1, file, std::vector{1UL}, timer);
+        beginBlock + 1, endBlock - 1, file, std::vector{1UL},
+        std::move(cancellationHandle));
     blockGenerator.setDetailsPointer(&details);
     for (auto& block : blockGenerator) {
       co_yield block;
@@ -411,7 +416,7 @@ CompressedRelationReader::getBlocksForJoin(
 IdTable CompressedRelationReader::scan(
     const CompressedRelationMetadata& metadata, Id col1Id,
     std::span<const CompressedBlockMetadata> blocks, ad_utility::File& file,
-    const TimeoutTimer& timer) const {
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   IdTable result(1, allocator_);
 
   // Get all the blocks  that possibly might contain our pair of col0Id and
@@ -447,13 +452,13 @@ IdTable CompressedRelationReader::scan(
     firstBlockResult = readIncompleteBlock(*beginBlock);
     totalResultSize += firstBlockResult.value().size();
     ++beginBlock;
-    checkTimeout(timer);
+    checkCancellation(cancellationHandle);
   }
   if (beginBlock < endBlock) {
     lastBlockResult = readIncompleteBlock(*(endBlock - 1));
     totalResultSize += lastBlockResult.value().size();
     endBlock--;
-    checkTimeout(timer);
+    checkCancellation(cancellationHandle);
   }
 
   // Determine the total size of the result.
@@ -499,7 +504,7 @@ IdTable CompressedRelationReader::scan(
       // block in parallel
 #pragma omp task
       {
-        if (!timer || !timer->wlock()->hasTimedOut()) {
+        if (!cancellationHandle->isCancelled()) {
           decompressLambda();
         }
       }
@@ -515,6 +520,7 @@ IdTable CompressedRelationReader::scan(
     rowIndexOfNextBlockStart += lastBlockResult.value().size();
   }
   AD_CORRECTNESS_CHECK(rowIndexOfNextBlockStart == result.size());
+  checkCancellation(cancellationHandle);
   return result;
 }
 

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -311,14 +311,16 @@ vector<float> Index::getMultiplicities(const TripleComponent& key,
 IdTable Index::scan(
     const TripleComponent& col0String,
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
-    Permutation::Enum p, ad_utility::SharedConcurrentTimeoutTimer timer) const {
-  return pimpl_->scan(col0String, col1String, p, std::move(timer));
+    Permutation::Enum p,
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+  return pimpl_->scan(col0String, col1String, p, std::move(cancellationHandle));
 }
 
 // ____________________________________________________________________________
-IdTable Index::scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-                    ad_utility::SharedConcurrentTimeoutTimer timer) const {
-  return pimpl_->scan(col0Id, col1Id, p, std::move(timer));
+IdTable Index::scan(
+    Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+  return pimpl_->scan(col0Id, col1Id, p, std::move(cancellationHandle));
 }
 
 // ____________________________________________________________________________

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -16,6 +16,7 @@
 #include "index/StringSortComparator.h"
 #include "index/Vocabulary.h"
 #include "parser/TripleComponent.h"
+#include "util/CancellationHandle.h"
 
 // Forward declarations.
 class IdTable;
@@ -265,11 +266,12 @@ class Index {
       const TripleComponent& col0String,
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       Permutation::Enum p,
-      ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
-  IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-               ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+  IdTable scan(
+      Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
   // the scan result.

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1331,7 +1331,7 @@ IdTable IndexImpl::scan(
     const TripleComponent& col0String,
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     const Permutation::Enum& permutation,
-    ad_utility::SharedConcurrentTimeoutTimer timer) const {
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   std::optional<Id> col0Id = col0String.toValueId(getVocab());
   std::optional<Id> col1Id =
       col1String.has_value() ? col1String.value().get().toValueId(getVocab())
@@ -1340,13 +1340,14 @@ IdTable IndexImpl::scan(
     size_t numColumns = col1String.has_value() ? 1 : 2;
     return IdTable{numColumns, allocator_};
   }
-  return scan(col0Id.value(), col1Id, permutation, timer);
+  return scan(col0Id.value(), col1Id, permutation,
+              std::move(cancellationHandle));
 }
 // _____________________________________________________________________________
-IdTable IndexImpl::scan(Id col0Id, std::optional<Id> col1Id,
-                        Permutation::Enum p,
-                        ad_utility::SharedConcurrentTimeoutTimer timer) const {
-  return getPermutation(p).scan(col0Id, col1Id, timer);
+IdTable IndexImpl::scan(
+    Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+  return getPermutation(p).scan(col0Id, col1Id, std::move(cancellationHandle));
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -29,7 +29,6 @@
 #include <util/Forward.h>
 #include <util/HashMap.h>
 #include <util/MmapVector.h>
-#include <util/Timer.h>
 #include <util/json.h>
 
 #include <array>
@@ -43,6 +42,7 @@
 #include <vector>
 
 #include "engine/idTable/CompressedExternalIdTable.h"
+#include "util/CancellationHandle.h"
 #include "util/MemorySize/MemorySize.h"
 
 using ad_utility::BufferedVector;
@@ -399,11 +399,12 @@ class IndexImpl {
       const TripleComponent& col0String,
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       const Permutation::Enum& permutation,
-      ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
 
   // _____________________________________________________________________________
-  IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-               ad_utility::SharedConcurrentTimeoutTimer timer = nullptr) const;
+  IdTable scan(
+      Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
 
   // _____________________________________________________________________________
   size_t getResultSizeOfScan(const TripleComponent& col0,

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -37,8 +37,9 @@ void Permutation::loadFromDisk(const std::string& onDiskBase) {
 }
 
 // _____________________________________________________________________
-IdTable Permutation::scan(Id col0Id, std::optional<Id> col1Id,
-                          const TimeoutTimer& timer) const {
+IdTable Permutation::scan(
+    Id col0Id, std::optional<Id> col1Id,
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   if (!isLoaded_) {
     throw std::runtime_error("This query requires the permutation " +
                              readableName_ + ", which was not loaded");
@@ -52,9 +53,9 @@ IdTable Permutation::scan(Id col0Id, std::optional<Id> col1Id,
 
   if (col1Id.has_value()) {
     return reader_.scan(metaData, col1Id.value(), meta_.blockData(), file_,
-                        timer);
+                        cancellationHandle);
   } else {
-    return reader_.scan(metaData, meta_.blockData(), file_, timer);
+    return reader_.scan(metaData, meta_.blockData(), file_, cancellationHandle);
   }
 }
 
@@ -131,7 +132,7 @@ std::optional<Permutation::MetadataAndBlocks> Permutation::getMetadataAndBlocks(
 Permutation::IdTableGenerator Permutation::lazyScan(
     Id col0Id, std::optional<Id> col1Id,
     std::optional<std::vector<CompressedBlockMetadata>> blocks,
-    const TimeoutTimer& timer) const {
+    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
   if (!meta_.col0IdExists(col0Id)) {
     return {};
   }
@@ -143,9 +144,11 @@ Permutation::IdTableGenerator Permutation::lazyScan(
   }
   if (col1Id.has_value()) {
     return reader_.lazyScan(meta_.getMetaData(col0Id), col1Id.value(),
-                            std::move(blocks.value()), file_, timer);
+                            std::move(blocks.value()), file_,
+                            cancellationHandle);
   } else {
     return reader_.lazyScan(meta_.getMetaData(col0Id),
-                            std::move(blocks.value()), file_, timer);
+                            std::move(blocks.value()), file_,
+                            cancellationHandle);
   }
 }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -8,6 +8,7 @@
 
 #include "global/Constants.h"
 #include "index/IndexMetaData.h"
+#include "util/CancellationHandle.h"
 #include "util/File.h"
 #include "util/Log.h"
 
@@ -32,7 +33,6 @@ class Permutation {
 
   using MetaData = IndexMetaDataMmapView;
   using Allocator = ad_utility::AllocatorWithLimit<Id>;
-  using TimeoutTimer = ad_utility::SharedConcurrentTimeoutTimer;
 
   // Convert a permutation to the corresponding string, etc. `PSO` is converted
   // to "PSO".
@@ -51,8 +51,9 @@ class Permutation {
   // If `col1Id` is specified, only the col2 is returned for triples that
   // additionally have the specified col1. .This is just a thin wrapper around
   // `CompressedRelationMetaData::scan`.
-  IdTable scan(Id col0Id, std::optional<Id> col1Id,
-               const TimeoutTimer& timer = nullptr) const;
+  IdTable scan(
+      Id col0Id, std::optional<Id> col1Id,
+      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks = CompressedRelationReader::MetadataAndBlocks;
@@ -74,7 +75,7 @@ class Permutation {
   IdTableGenerator lazyScan(
       Id col0Id, std::optional<Id> col1Id,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
-      const TimeoutTimer& timer = nullptr) const;
+      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
 
   // Return the metadata for the relation specified by the `col0Id`
   // along with the metadata for all the blocks that contain this relation (also

--- a/src/index/PermutationExporterMain.cpp
+++ b/src/index/PermutationExporterMain.cpp
@@ -13,7 +13,8 @@ void dumpToStdout(const Permutation& permutation) {
   ad_utility::AllocatorWithLimit<Id> allocator{
       ad_utility::makeAllocationMemoryLeftThreadsafeObject(
           ad_utility::MemorySize::max())};
-  auto triples = TriplesView(permutation);
+  auto triples = TriplesView(
+      permutation, std::make_shared<ad_utility::CancellationHandle>());
   size_t i = 0;
   for (auto triple : triples) {
     std::cout << triple[0] << " " << triple[1] << " " << triple[2] << std::endl;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -70,7 +70,7 @@ class SparqlTriple {
 
   SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
       : _s(std::move(s)),
-        _p(PropertyPath::Operation::IRI, 0, p_iri, {}),
+        _p(PropertyPath::fromIri(p_iri)),
         _o(std::move(o)) {}
 
   bool operator==(const SparqlTriple& other) const {

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -69,9 +69,7 @@ class SparqlTriple {
       : _s(std::move(s)), _p(std::move(p)), _o(std::move(o)) {}
 
   SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
-      : _s(std::move(s)),
-        _p(PropertyPath::fromIri(p_iri)),
-        _o(std::move(o)) {}
+      : _s(std::move(s)), _p(PropertyPath::fromIri(p_iri)), _o(std::move(o)) {}
 
   bool operator==(const SparqlTriple& other) const {
     return _s == other._s && _p == other._p && _o == other._o;

--- a/src/parser/PropertyPath.cpp
+++ b/src/parser/PropertyPath.cpp
@@ -105,15 +105,15 @@ std::string PropertyPath::asString() const {
 
 // _____________________________________________________________________________
 void PropertyPath::computeCanBeNull() {
-  _can_be_null = !_children.empty();
+  can_be_null_ = !_children.empty();
   for (PropertyPath& p : _children) {
     p.computeCanBeNull();
-    _can_be_null &= p._can_be_null;
+    can_be_null_ &= p.can_be_null_;
   }
 
   if (_operation == Operation::ZERO_OR_MORE ||
       _operation == Operation::ZERO_OR_ONE) {
-    _can_be_null = true;
+    can_be_null_ = true;
   }
 }
 

--- a/src/parser/PropertyPath.cpp
+++ b/src/parser/PropertyPath.cpp
@@ -13,7 +13,7 @@ PropertyPath::PropertyPath(Operation op, std::string iri,
 
 // _____________________________________________________________________________
 PropertyPath PropertyPath::makeModified(PropertyPath child,
-                                        std::string modifier) {
+                                        std::string_view modifier) {
   if (modifier == "+") {
     return makeWithChildren({std::move(child)}, Operation::ONE_OR_MORE);
   } else if (modifier == "*") {

--- a/src/parser/PropertyPath.cpp
+++ b/src/parser/PropertyPath.cpp
@@ -6,10 +6,7 @@
 // _____________________________________________________________________________
 PropertyPath::PropertyPath(Operation op, std::string iri,
                            std::initializer_list<PropertyPath> children)
-    : _operation(op),
-      _iri(std::move(iri)),
-      _children(children),
-      _can_be_null(false) {}
+    : _operation(op), _iri(std::move(iri)), _children(children) {}
 
 // _____________________________________________________________________________
 PropertyPath PropertyPath::makeModified(PropertyPath child,

--- a/src/parser/PropertyPath.cpp
+++ b/src/parser/PropertyPath.cpp
@@ -12,7 +12,8 @@ PropertyPath::PropertyPath(Operation op, std::string iri,
       _can_be_null(false) {}
 
 // _____________________________________________________________________________
-PropertyPath PropertyPath::makeModified(PropertyPath child, std::string modifier) {
+PropertyPath PropertyPath::makeModified(PropertyPath child,
+                                        std::string modifier) {
   if (modifier == "+") {
     return makeWithChildren({std::move(child)}, Operation::ONE_OR_MORE);
   } else if (modifier == "*") {

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -24,8 +24,7 @@ class PropertyPath {
     ZERO_OR_ONE
   };
 
-  PropertyPath()
-      : _operation(Operation::IRI) {}
+  PropertyPath() : _operation(Operation::IRI) {}
   explicit PropertyPath(Operation op)
       : _operation(op), _iri(), _can_be_null(false) {
     if (op == Operation::ZERO_OR_MORE || op == Operation::ZERO_OR_ONE) {

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -25,8 +25,7 @@ class PropertyPath {
   };
 
   PropertyPath() : _operation(Operation::IRI) {}
-  explicit PropertyPath(Operation op)
-      : _operation(op), _iri(), _can_be_null(false) {
+  explicit PropertyPath(Operation op) : _operation(op) {
     if (op == Operation::ZERO_OR_MORE || op == Operation::ZERO_OR_ONE) {
       _can_be_null = true;
     }
@@ -118,5 +117,5 @@ class PropertyPath {
    * True iff this property path is either a transitive path with minimum length
    * of 0, or if all of this transitive path's children can be null.
    */
-  bool _can_be_null;
+  bool _can_be_null = false;
 };

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -77,12 +77,13 @@ class PropertyPath {
   /**
    * @brief Make a PropertyPath based on the given child and apply the path
    * modifier. The path modifier may be one of: ? + *
-   * 
+   *
    * @param child The PropertyPath child
    * @param modifier A PropertyPath modifier (? + *)
    * @return PropertyPath With given modifier as Operation and given child
    */
-  static PropertyPath makeModified(PropertyPath child, std::string_view modifier);
+  static PropertyPath makeModified(PropertyPath child,
+                                   std::string_view modifier);
 
   static PropertyPath makeZeroOrMore(PropertyPath child) {
     return makeWithChildren({std::move(child)}, Operation::ZERO_OR_MORE);

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -25,9 +25,9 @@ class PropertyPath {
   };
 
   PropertyPath()
-      : _operation(Operation::IRI), _iri(), _children(), _can_be_null(false) {}
+      : _operation(Operation::IRI) {}
   explicit PropertyPath(Operation op)
-      : _operation(op), _iri(), _children(), _can_be_null(false) {
+      : _operation(op), _iri(), _can_be_null(false) {
     if (op == Operation::ZERO_OR_MORE || op == Operation::ZERO_OR_ONE) {
       _can_be_null = true;
     }

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -74,7 +74,15 @@ class PropertyPath {
     return makeWithChildren({std::move(child)}, Operation::INVERSE);
   }
 
-  static PropertyPath makeModified(PropertyPath child, std::string modifier);
+  /**
+   * @brief Make a PropertyPath based on the given child and apply the path
+   * modifier. The path modifier may be one of: ? + *
+   * 
+   * @param child The PropertyPath child
+   * @param modifier A PropertyPath modifier (? + *)
+   * @return PropertyPath With given modifier as Operation and given child
+   */
+  static PropertyPath makeModified(PropertyPath child, std::string_view modifier);
 
   static PropertyPath makeZeroOrMore(PropertyPath child) {
     return makeWithChildren({std::move(child)}, Operation::ZERO_OR_MORE);

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -117,5 +117,5 @@ class PropertyPath {
    * True iff this property path is either a transitive path with minimum length
    * of 0, or if all of this transitive path's children can be null.
    */
-  bool _can_be_null = false;
+  bool can_be_null_ = false;
 };

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -25,16 +25,13 @@ class PropertyPath {
   };
 
   PropertyPath()
-      : _operation(Operation::IRI),
-        _iri(),
-        _children(),
-        _can_be_null(false) {}
+      : _operation(Operation::IRI), _iri(), _children(), _can_be_null(false) {}
   explicit PropertyPath(Operation op)
       : _operation(op), _iri(), _children(), _can_be_null(false) {
-        if (op == Operation::ZERO_OR_MORE || op == Operation::ZERO_OR_ONE) {
-          _can_be_null = true;
-        }
-      }
+    if (op == Operation::ZERO_OR_MORE || op == Operation::ZERO_OR_ONE) {
+      _can_be_null = true;
+    }
+  }
   PropertyPath(Operation op, std::string iri,
                std::initializer_list<PropertyPath> children);
 

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -27,7 +27,7 @@ class PropertyPath {
   PropertyPath() : _operation(Operation::IRI) {}
   explicit PropertyPath(Operation op) : _operation(op) {
     if (op == Operation::ZERO_OR_MORE || op == Operation::ZERO_OR_ONE) {
-      _can_be_null = true;
+      can_be_null_ = true;
     }
   }
   PropertyPath(Operation op, std::string iri,

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1161,15 +1161,8 @@ PropertyPath Visitor::visit(Parser::PathEltContext* ctx) {
   PropertyPath p = visit(ctx->pathPrimary());
 
   if (ctx->pathMod()) {
-    // TODO move case distinction +/*/? into PropertyPath.
-    if (ctx->pathMod()->getText() == "+") {
-      p = PropertyPath::makeTransitiveMin(p, 1);
-    } else if (ctx->pathMod()->getText() == "?") {
-      p = PropertyPath::makeTransitiveMax(p, 1);
-    } else {
-      AD_CORRECTNESS_CHECK(ctx->pathMod()->getText() == "*");
-      p = PropertyPath::makeTransitive(p);
-    }
+    std::string modifier = ctx->pathMod()->getText();
+    p = PropertyPath::makeModified(p, modifier);
   }
   return p;
 }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,5 +2,6 @@ add_subdirectory(ConfigManager)
 add_subdirectory(MemorySize)
 add_subdirectory(http)
 add_library(util GeoSparqlHelpers.cpp
-        antlr/ANTLRErrorHandling.cpp ParseException.cpp Conversions.cpp Date.cpp antlr/GenerateAntlrExceptionMetadata.cpp)
+        antlr/ANTLRErrorHandling.cpp ParseException.cpp Conversions.cpp Date.cpp antlr/GenerateAntlrExceptionMetadata.cpp
+        CancellationHandle.cpp)
 qlever_target_link_libraries(util)

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -1,0 +1,18 @@
+//   Copyright 2023, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#include "CancellationHandle.h"
+
+#include "util/Exception.h"
+
+namespace ad_utility {
+
+void CancellationHandle::cancel(CancellationState reason) {
+  AD_CONTRACT_CHECK(reason != CancellationState::NOT_CANCELLED);
+
+  CancellationState notAborted = CancellationState::NOT_CANCELLED;
+  cancellationState_.compare_exchange_strong(notAborted, reason,
+                                             std::memory_order_relaxed);
+}
+}  // namespace ad_utility

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -1,0 +1,84 @@
+//   Copyright 2023, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#ifndef QLEVER_CANCELLATIONHANDLE_H
+#define QLEVER_CANCELLATIONHANDLE_H
+
+#include <absl/strings/str_cat.h>
+
+#include <atomic>
+#include <type_traits>
+
+#include "util/CompilerExtensions.h"
+#include "util/Exception.h"
+#include "util/TypeTraits.h"
+
+namespace ad_utility {
+/// Enum to represent possible states of cancellation
+enum class CancellationState { NOT_CANCELLED, MANUAL, TIMEOUT };
+
+/// An exception signalling an cancellation
+class CancellationException : public std::runtime_error {
+ public:
+  using std::runtime_error::runtime_error;
+  CancellationException(CancellationState reason, std::string_view details)
+      : std::runtime_error{absl::StrCat("Cancelled due to ",
+                                        reason == CancellationState::TIMEOUT
+                                            ? "timeout"
+                                            : "manual cancellation",
+                                        ". Stage: ", details)} {
+    AD_CONTRACT_CHECK(reason != CancellationState::NOT_CANCELLED);
+  }
+};
+
+// Ensure no locks are used
+static_assert(std::atomic<CancellationState>::is_always_lock_free);
+
+/// Thread safe wrapper around an atomic variable, providing efficient
+/// checks for cancellation across threads.
+class CancellationHandle {
+  std::atomic<CancellationState> cancellationState_ =
+      CancellationState::NOT_CANCELLED;
+
+ public:
+  /// Sets the cancellation flag so the next call to throwIfCancelled will throw
+  void cancel(CancellationState reason);
+
+  /// Overload for static exception messages, make sure the string is a constant
+  /// expression, or computed in advance. If that's not the case do not use
+  /// this overload and use the overload that takes a callable that creates
+  /// the exception message (see below).
+  AD_ALWAYS_INLINE void throwIfCancelled(std::string_view detail) const {
+    throwIfCancelled(std::identity{}, detail);
+  }
+
+  /// Throw an `CancellationException` when this handle has been cancelled. Do
+  /// nothing otherwise. The arg types are passed to the `detailSupplier` only
+  /// if an exception is about to be thrown. If no exception is thrown,
+  /// `detailSupplier` will not be evaluated.
+  template <typename... ArgTypes>
+  AD_ALWAYS_INLINE void throwIfCancelled(
+      const InvocableWithReturnType<std::string_view, ArgTypes...> auto&
+          detailSupplier,
+      ArgTypes&&... argTypes) const {
+    auto state = cancellationState_.load(std::memory_order_relaxed);
+    if (state == CancellationState::NOT_CANCELLED) [[likely]] {
+      return;
+    }
+    throw CancellationException{
+        state, std::invoke(detailSupplier, AD_FWD(argTypes)...)};
+  }
+
+  /// Return true if this cancellation handle has been cancelled, false
+  /// otherwise. Note: Make sure to not use this value to set any other atomic
+  /// value with relaxed memory ordering, as this may lead to out-of-thin-air
+  /// values.
+  AD_ALWAYS_INLINE bool isCancelled() const {
+    return cancellationState_.load(std::memory_order_relaxed) !=
+           CancellationState::NOT_CANCELLED;
+  }
+};
+}  // namespace ad_utility
+
+#endif  // QLEVER_CANCELLATIONHANDLE_H

--- a/src/util/CompilerExtensions.h
+++ b/src/util/CompilerExtensions.h
@@ -1,0 +1,20 @@
+//   Copyright 2023, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#ifndef QLEVER_COMPILEREXTENSIONS_H
+#define QLEVER_COMPILEREXTENSIONS_H
+
+// A generic macro that forces inlining during compilation across compilers
+#ifdef __CLANG__
+#define AD_ALWAYS_INLINE [[clang::always_inline]]
+#elif __GNUC__
+#define AD_ALWAYS_INLINE [[gnu::always_inline]]
+#else
+#warning \
+    "For this compiler we don't know how to force the inlining of functions. \
+There might be some performance degradations."
+#define AD_ALWAYS_INLINE
+#endif
+
+#endif  // QLEVER_COMPILEREXTENSIONS_H

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -133,80 +133,6 @@ class Timer {
   }
 };
 
-/// An exception signalling a timeout
-class TimeoutException : public std::exception {
- public:
-  TimeoutException(std::string message) : message_{std::move(message)} {}
-  const char* what() const noexcept override { return message_.c_str(); }
-
- private:
-  std::string message_;
-};
-
-/// A timer which also can be given a timeout value and queried whether it
-/// has timed out
-class TimeoutTimer : public Timer {
- public:
-  /// Factory function for a timer that never times out
-  static TimeoutTimer unlimited() { return TimeoutTimer(UnlimitedTag{}); }
-
-  template <ad_utility::isInstantiation<chr::duration> T>
-  TimeoutTimer(T timeLimit, Timer::InitialStatus status)
-      : Timer{status}, timeLimit_{toDuration(timeLimit)} {}
-
-  /// Did this timer already timeout
-  /// Can't be const because of the internals of the Timer class.
-  bool hasTimedOut() {
-    if (isUnlimited_) {
-      return false;
-    } else {
-      return value() > timeLimit_;
-    }
-  }
-
-  // Check if this timer has timed out. If the timer has timed out, throws a
-  // TimeoutException. Else, nothing happens.
-  void checkTimeoutAndThrow(std::string_view additionalMessage = {}) {
-    if (hasTimedOut()) {
-      double seconds =
-          std::chrono::duration_cast<Timer::Seconds>(timeLimit_).count();
-      std::stringstream numberStream;
-      // Seconds with three digits after the decimal point.
-      // TODO<C++20> : Use std::format for formatting, it is much more readable.
-      numberStream << std::setprecision(3) << std::fixed << seconds;
-      throw TimeoutException{absl::StrCat(
-          additionalMessage, "A Timeout occured. The time limit was "s,
-          std::move(numberStream).str(), " seconds"s)};
-    }
-  }
-
-  // Overload that does not take an error message directly, but a callable that
-  // creates the error message lazily when the timeout occurs. This can be used
-  // to make calling this function cheaper in the typical "no timeout" case.
-  template <typename F>
-  requires std::is_invocable_r_v<std::string_view, F>
-  void checkTimeoutAndThrow(F&& f) {
-    if (hasTimedOut()) {
-      checkTimeoutAndThrow(f());
-    }
-  }
-
-  Duration remainingTime() const {
-    if (isUnlimited_) {
-      return Duration::max();
-    }
-    auto passedTime = value();
-    return passedTime < timeLimit_ ? timeLimit_ - passedTime : Duration::zero();
-  }
-
- private:
-  Timer::Duration timeLimit_ = Timer::Duration::zero();
-  bool isUnlimited_ = false;  // never times out
-  class UnlimitedTag {};
-  explicit TimeoutTimer(UnlimitedTag)
-      : Timer{Timer::Started}, isUnlimited_{true} {}
-};
-
 namespace detail {
 // A helper struct that measures the time from its creation until its
 // destruction and logs the time together with a specified message
@@ -249,14 +175,5 @@ using detail::TimeBlockAndLog;
 
 }  // namespace timer
 using timer::TimeBlockAndLog;
-using timer::TimeoutException;
-using timer::TimeoutTimer;
 using timer::Timer;
-
-/// A threadsafe timeout timer
-using ConcurrentTimeoutTimer =
-    ad_utility::Synchronized<TimeoutTimer, std::mutex>;
-
-/// A shared ptr to a threadsafe timeout timer
-using SharedConcurrentTimeoutTimer = std::shared_ptr<ConcurrentTimeoutTimer>;
 }  // namespace ad_utility

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -215,6 +215,10 @@ template <typename... Ts>
 requires(sizeof...(Ts) > 0)
 using First = typename detail::FirstWrapper<Ts...>::type;
 
+/// Concept for `std::is_invocable_r_v`.
+template <typename Func, typename R, typename... ArgTypes>
+concept InvocableWithReturnType = std::is_invocable_r_v<R, Func, ArgTypes...>;
+
 /*
 The following concepts are similar to `std::is_invocable_r_v` with the following
 difference: `std::is_invocable_r_v` only checks that the return type of a

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -371,3 +371,5 @@ addLinkAndDiscoverTest(QueryToSocketDistributorTest http)
 addLinkAndDiscoverTest(UpdateFetcherTest http)
 
 addLinkAndDiscoverTest(MessageSenderTest http)
+
+addLinkAndDiscoverTest(CancellationHandleTest util)

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -1,0 +1,108 @@
+//   Copyright 2023, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "util/CancellationHandle.h"
+#include "util/GTestHelpers.h"
+#include "util/jthread.h"
+
+using ad_utility::CancellationException;
+using ad_utility::CancellationHandle;
+using ad_utility::CancellationState;
+using ::testing::HasSubstr;
+
+using namespace std::chrono_literals;
+
+TEST(CancellationException, verifyConstructorMessageIsPassed) {
+  auto message = "Message";
+  CancellationException exception{message};
+  EXPECT_STREQ(message, exception.what());
+}
+
+// _____________________________________________________________________________
+
+TEST(CancellationException, verifyConstructorDoesNotAcceptNoReason) {
+  EXPECT_THROW(
+      CancellationException exception(CancellationState::NOT_CANCELLED, ""),
+      ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
+
+TEST(CancellationHandle, verifyNotCancelledByDefault) {
+  CancellationHandle handle;
+
+  EXPECT_FALSE(handle.isCancelled());
+  EXPECT_NO_THROW(handle.throwIfCancelled(""));
+  EXPECT_NO_THROW(handle.throwIfCancelled([]() { return ""; }));
+}
+
+// _____________________________________________________________________________
+
+TEST(CancellationHandle, verifyCancelWithWrongReasonThrows) {
+  CancellationHandle handle;
+
+  EXPECT_THROW(handle.cancel(CancellationState::NOT_CANCELLED),
+               ad_utility::Exception);
+}
+
+// _____________________________________________________________________________
+
+auto detail = "Some Detail";
+
+TEST(CancellationHandle, verifyTimeoutCancellationWorks) {
+  CancellationHandle handle;
+
+  handle.cancel(CancellationState::TIMEOUT);
+
+  auto timeoutMessageMatcher = AllOf(HasSubstr(detail), HasSubstr("timeout"));
+  EXPECT_TRUE(handle.isCancelled());
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(handle.throwIfCancelled(detail),
+                                        timeoutMessageMatcher,
+                                        CancellationException);
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      handle.throwIfCancelled([]() { return detail; }), timeoutMessageMatcher,
+      CancellationException);
+}
+
+// _____________________________________________________________________________
+
+TEST(CancellationHandle, verifyManualCancellationWorks) {
+  CancellationHandle handle;
+
+  handle.cancel(CancellationState::MANUAL);
+
+  auto cancellationMessageMatcher =
+      AllOf(HasSubstr(detail), HasSubstr("manual cancellation"));
+  EXPECT_TRUE(handle.isCancelled());
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(handle.throwIfCancelled(detail),
+                                        cancellationMessageMatcher,
+                                        CancellationException);
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      handle.throwIfCancelled([]() { return detail; }),
+      cancellationMessageMatcher, CancellationException);
+}
+
+// _____________________________________________________________________________
+
+TEST(CancellationHandle, verifyCancellationWorksWithMultipleThreads) {
+  CancellationHandle handle;
+
+  ad_utility::JThread thread{[&]() {
+    std::this_thread::sleep_for(5ms);
+    handle.cancel(CancellationState::TIMEOUT);
+  }};
+
+  EXPECT_THROW(
+      {
+        auto end = std::chrono::steady_clock::now() + 100ms;
+        while (std::chrono::steady_clock::now() < end) {
+          handle.throwIfCancelled("Some Detail");
+        }
+      },
+      CancellationException);
+  EXPECT_TRUE(handle.isCancelled());
+}

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -32,7 +32,9 @@ auto makeTestScanWidthOne = [](const IndexImpl& index) {
                       ad_utility::source_location::current()) {
     auto t = generateLocationTrace(l);
     TripleComponent c1Tc{c1};
-    IdTable result = index.scan(c0, std::cref(c1Tc), permutation);
+    IdTable result =
+        index.scan(c0, std::cref(c1Tc), permutation,
+                   std::make_shared<ad_utility::CancellationHandle>());
     ASSERT_EQ(result, makeIdTableFromVector(expected));
   };
 };
@@ -47,7 +49,9 @@ auto makeTestScanWidthTwo = [](const IndexImpl& index) {
                   ad_utility::source_location l =
                       ad_utility::source_location::current()) {
     auto t = generateLocationTrace(l);
-    IdTable wol = index.scan(c0, std::nullopt, permutation);
+    IdTable wol =
+        index.scan(c0, std::nullopt, permutation,
+                   std::make_shared<ad_utility::CancellationHandle>());
     ASSERT_EQ(wol, makeIdTableFromVector(expected));
   };
 };

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -293,8 +293,9 @@ TEST(LocalVocab, propagation) {
   // NOTE: As part of an actual query, the child of a transitive path
   // operation is always an index scan, which has a non-empty
   // local-vocabulary. Still, it doesn't harm to test this.
-  TransitivePath transitivePath(testQec, qet(values1), true, true, 0, 1, {}, {},
-                                Variable{"?x"}, Variable{"?y"}, 1, 1);
+  TransitivePathSide left(std::nullopt, 0, Variable{"?x"});
+  TransitivePathSide right(std::nullopt, 1, Variable{"?y"});
+  TransitivePath transitivePath(testQec, qet(values1), left, right, 1, 1);
   checkLocalVocab(transitivePath, std::vector<std::string>{"x", "y1", "y2"});
 
   // PATTERN TRICK operations.

--- a/test/OrderByTest.cpp
+++ b/test/OrderByTest.cpp
@@ -13,6 +13,7 @@
 #include "global/ValueIdComparators.h"
 
 using namespace std::string_literals;
+using namespace std::chrono_literals;
 using ad_utility::source_location;
 
 namespace {
@@ -234,4 +235,25 @@ TEST(OrderBy, simpleMemberFunctions) {
     EXPECT_EQ(42.0, s.getMultiplicity(0));
     EXPECT_EQ(84.0, s.getMultiplicity(1));
   }
+}
+
+TEST(OrderBy, verifyOperationIsPreemptivelyAbortedWithNoRemainingTime) {
+  VectorTable input;
+  // Make sure the estimator estimates a couple of ms to sort this
+  for (int64_t i = 0; i < 1000; i++) {
+    input.push_back({0, i});
+  }
+  auto inputTable = makeIdTableFromVector(input, &Id::makeFromInt);
+  OrderBy orderBy = makeOrderBy(std::move(inputTable), {{1, false}, {0, true}});
+  // Safe to do, because we know the underlying estimator is mutable
+  const_cast<SortPerformanceEstimator&>(
+      orderBy.getExecutionContext()->getSortPerformanceEstimator())
+      .computeEstimatesExpensively(
+          ad_utility::makeUnlimitedAllocator<ValueId>(), 1'000'000);
+
+  orderBy.recursivelySetTimeConstraint(0ms);
+
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      orderBy.getResult(true), ::testing::HasSubstr("time estimate exceeded"),
+      ad_utility::AbortException);
 }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -693,8 +693,7 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
       "SELECT ?s ?p ?o WHERE {"
       "?s ?p ?o . ?s ?p <x> }",
       h::MultiColumnJoin(h::IndexScan(Var{"?s"}, Var{"?p"}, Var{"?o"}),
-                         h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")),
-      qec);
+                         h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")));
 }
 
 TEST(QueryPlannerTest, threeVarXthreeVarException) {
@@ -1193,44 +1192,6 @@ TEST(QueryPlannerTest, TransitivePathBindRight) {
           scan("?y", "<p>", "<o>"),
           scan("?_qlever_internal_variable_query_planner_0", "<p>",
                "?_qlever_internal_variable_query_planner_1")));
-}
-
-TEST(QueryPlannerTest, TransitivePathLeftBoundRightId) {
-  auto scan = h::IndexScanFromStrings;
-  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
-
-  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
-  TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
-  TransitivePathSide right{std::nullopt, 1, getId("<o>"), 1};
-  h::expect(
-      "SELECT ?x ?y WHERE {"
-      "<s> <p> ?x."
-      "?x <p>* <o> }",
-      h::TransitivePath(
-          left, right, 0, std::numeric_limits<size_t>::max(),
-          scan("<s>", "<p>", "?x"),
-          scan("?_qlever_internal_variable_query_planner_0", "<p>",
-               "?_qlever_internal_variable_query_planner_1")),
-      qec);
-}
-
-TEST(QueryPlannerTest, TransitivePathRightBoundLeftId) {
-  auto scan = h::IndexScanFromStrings;
-  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
-
-  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
-  TransitivePathSide left{std::nullopt, 0, getId("<s>"), 0};
-  TransitivePathSide right{std::nullopt, 1, Variable("?x"), 1};
-  h::expect(
-      "SELECT ?x ?y WHERE {"
-      "<s> <p>* ?x."
-      "?x <p> <o> }",
-      h::TransitivePath(
-          left, right, 0, std::numeric_limits<size_t>::max(),
-          scan("?x", "<p>", "<o>"),
-          scan("?_qlever_internal_variable_query_planner_0", "<p>",
-               "?_qlever_internal_variable_query_planner_1")),
-      qec);
 }
 
 // __________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -681,7 +681,7 @@ TEST(QueryPlannerTest, threeVarTriples) {
 }
 
 TEST(QueryPlannerTest, threeVarTriplesTCJ) {
-  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
+  auto qec = ad_utility::testing::getQec("<s> <p> <x>");
   h::expect(
       "SELECT ?x ?p ?o WHERE {"
       "<s> ?p ?x . ?x ?p ?o }",
@@ -693,7 +693,8 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
       "SELECT ?s ?p ?o WHERE {"
       "?s ?p ?o . ?s ?p <x> }",
       h::MultiColumnJoin(h::IndexScan(Var{"?s"}, Var{"?p"}, Var{"?o"}),
-                         h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")));
+                         h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")),
+    qec);
 }
 
 TEST(QueryPlannerTest, threeVarXthreeVarException) {

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1138,16 +1138,13 @@ TEST(QueryPlannerTest, TransitivePathLeftId) {
   TransitivePathSide left{std::nullopt, 0, getId("<s>"), 0};
   TransitivePathSide right{std::nullopt, 1, Variable("?y"), 1};
   h::expect(
-    "SELECT ?y WHERE {"
-    "<s> <p>+ ?y }",
-    h::TransitivePath(
-      left, right, 1, std::numeric_limits<size_t>::max(),
-      scan("?_qlever_internal_variable_query_planner_0",
-           "<p>",
-           "?_qlever_internal_variable_query_planner_1")
-    ),
-    qec
-  );
+      "SELECT ?y WHERE {"
+      "<s> <p>+ ?y }",
+      h::TransitivePath(
+          left, right, 1, std::numeric_limits<size_t>::max(),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")),
+      qec);
 }
 
 TEST(QueryPlannerTest, TransitivePathRightId) {
@@ -1159,16 +1156,13 @@ TEST(QueryPlannerTest, TransitivePathRightId) {
   TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
   TransitivePathSide right{std::nullopt, 1, getId("<o>"), 1};
   h::expect(
-    "SELECT ?y WHERE {"
-    "?x <p>+ <o> }",
-    h::TransitivePath(
-      left, right, 1, std::numeric_limits<size_t>::max(),
-      scan("?_qlever_internal_variable_query_planner_0",
-           "<p>",
-           "?_qlever_internal_variable_query_planner_1")
-    ),
-    qec
-  );
+      "SELECT ?y WHERE {"
+      "?x <p>+ <o> }",
+      h::TransitivePath(
+          left, right, 1, std::numeric_limits<size_t>::max(),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")),
+      qec);
 }
 
 TEST(QueryPlannerTest, TransitivePathBindLeft) {
@@ -1199,6 +1193,44 @@ TEST(QueryPlannerTest, TransitivePathBindRight) {
           scan("?y", "<p>", "<o>"),
           scan("?_qlever_internal_variable_query_planner_0", "<p>",
                "?_qlever_internal_variable_query_planner_1")));
+}
+
+TEST(QueryPlannerTest, TransitivePathLeftBoundRightId) {
+  auto scan = h::IndexScanFromStrings;
+  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
+
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+  TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
+  TransitivePathSide right{std::nullopt, 1, getId("<o>"), 1};
+  h::expect(
+      "SELECT ?x ?y WHERE {"
+      "<s> <p> ?x."
+      "?x <p>* <o> }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          scan("<s>", "<p>", "?x"),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")),
+      qec);
+}
+
+TEST(QueryPlannerTest, TransitivePathRightBoundLeftId) {
+  auto scan = h::IndexScanFromStrings;
+  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
+
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+  TransitivePathSide left{std::nullopt, 0, getId("<s>"), 0};
+  TransitivePathSide right{std::nullopt, 1, Variable("?x"), 1};
+  h::expect(
+      "SELECT ?x ?y WHERE {"
+      "<s> <p>* ?x."
+      "?x <p> <o> }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          scan("?x", "<p>", "<o>"),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")),
+      qec);
 }
 
 // __________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1110,15 +1110,12 @@ TEST(QueryPlannerTest, TransitivePathUnbound) {
   TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
   TransitivePathSide right{std::nullopt, 1, Variable("?y"), 1};
   h::expect(
-    "SELECT ?x ?y WHERE {"
-    "?x <p>+ ?y }",
-    h::TransitivePath(
-      left, right, 1, std::numeric_limits<size_t>::max(),
-      scan("?_qlever_internal_variable_query_planner_0",
-           "<p>",
-           "?_qlever_internal_variable_query_planner_1")
-    )
-  );
+      "SELECT ?x ?y WHERE {"
+      "?x <p>+ ?y }",
+      h::TransitivePath(
+          left, right, 1, std::numeric_limits<size_t>::max(),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")));
 }
 
 TEST(QueryPlannerTest, TransitivePathBindLeft) {
@@ -1126,17 +1123,14 @@ TEST(QueryPlannerTest, TransitivePathBindLeft) {
   TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
   TransitivePathSide right{std::nullopt, 1, Variable("?y"), 1};
   h::expect(
-    "SELECT ?x ?y WHERE {"
-    "<s> <p> ?x."
-    "?x <p>* ?y }",
-    h::TransitivePath(
-      left, right, 0, std::numeric_limits<size_t>::max(),
-      scan("<s>", "<p>", "?x"),
-      scan("?_qlever_internal_variable_query_planner_0",
-           "<p>",
-           "?_qlever_internal_variable_query_planner_1")
-    )
-  );
+      "SELECT ?x ?y WHERE {"
+      "<s> <p> ?x."
+      "?x <p>* ?y }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          scan("<s>", "<p>", "?x"),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")));
 }
 
 TEST(QueryPlannerTest, TransitivePathBindRight) {
@@ -1144,17 +1138,14 @@ TEST(QueryPlannerTest, TransitivePathBindRight) {
   TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
   TransitivePathSide right{std::nullopt, 1, Variable("?y"), 1};
   h::expect(
-    "SELECT ?x ?y WHERE {"
-    "?x <p>* ?y."
-    "?y <p> <o> }",
-    h::TransitivePath(
-      left, right, 0, std::numeric_limits<size_t>::max(),
-      scan("?y", "<p>", "<o>"),
-      scan("?_qlever_internal_variable_query_planner_0",
-           "<p>",
-           "?_qlever_internal_variable_query_planner_1")
-    )
-  );
+      "SELECT ?x ?y WHERE {"
+      "?x <p>* ?y."
+      "?y <p> <o> }",
+      h::TransitivePath(
+          left, right, 0, std::numeric_limits<size_t>::max(),
+          scan("?y", "<p>", "<o>"),
+          scan("?_qlever_internal_variable_query_planner_0", "<p>",
+               "?_qlever_internal_variable_query_planner_1")));
 }
 
 // __________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1129,6 +1129,48 @@ TEST(QueryPlannerTest, TransitivePathUnbound) {
                "?_qlever_internal_variable_query_planner_1")));
 }
 
+TEST(QueryPlannerTest, TransitivePathLeftId) {
+  auto scan = h::IndexScanFromStrings;
+  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
+
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+
+  TransitivePathSide left{std::nullopt, 0, getId("<s>"), 0};
+  TransitivePathSide right{std::nullopt, 1, Variable("?y"), 1};
+  h::expect(
+    "SELECT ?y WHERE {"
+    "<s> <p>+ ?y }",
+    h::TransitivePath(
+      left, right, 1, std::numeric_limits<size_t>::max(),
+      scan("?_qlever_internal_variable_query_planner_0",
+           "<p>",
+           "?_qlever_internal_variable_query_planner_1")
+    ),
+    qec
+  );
+}
+
+TEST(QueryPlannerTest, TransitivePathRightId) {
+  auto scan = h::IndexScanFromStrings;
+  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
+
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+
+  TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};
+  TransitivePathSide right{std::nullopt, 1, getId("<o>"), 1};
+  h::expect(
+    "SELECT ?y WHERE {"
+    "?x <p>+ <o> }",
+    h::TransitivePath(
+      left, right, 1, std::numeric_limits<size_t>::max(),
+      scan("?_qlever_internal_variable_query_planner_0",
+           "<p>",
+           "?_qlever_internal_variable_query_planner_1")
+    ),
+    qec
+  );
+}
+
 TEST(QueryPlannerTest, TransitivePathBindLeft) {
   auto scan = h::IndexScanFromStrings;
   TransitivePathSide left{std::nullopt, 0, Variable("?x"), 0};

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -694,7 +694,7 @@ TEST(QueryPlannerTest, threeVarTriplesTCJ) {
       "?s ?p ?o . ?s ?p <x> }",
       h::MultiColumnJoin(h::IndexScan(Var{"?s"}, Var{"?p"}, Var{"?o"}),
                          h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")),
-    qec);
+      qec);
 }
 
 TEST(QueryPlannerTest, threeVarXthreeVarException) {

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -6,6 +6,7 @@
 
 #include "./util/GTestHelpers.h"
 #include "engine/Bind.h"
+#include "engine/TransitivePath.h"
 #include "engine/CartesianProductJoin.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
@@ -124,6 +125,29 @@ inline auto MultiColumnJoin = MatchTypeAndUnorderedChildren<::MultiColumnJoin>;
 inline auto Join = MatchTypeAndUnorderedChildren<::Join>;
 inline auto CartesianProductJoin =
     MatchTypeAndUnorderedChildren<::CartesianProductJoin>;
+
+inline auto TransitivePathSideMatcher = [](TransitivePathSide side){
+    return AllOf(
+      AD_FIELD(TransitivePathSide, value, Eq(side.value)),
+      AD_FIELD(TransitivePathSide, subCol, Eq(side.subCol)),
+      AD_FIELD(TransitivePathSide, outputCol, Eq(side.outputCol))
+    );
+};
+
+// Match a TransitivePath operation
+inline auto TransitivePath = [](TransitivePathSide left,
+  TransitivePathSide right, size_t minDist, size_t maxDist,
+  const std::same_as<QetMatcher> auto&... childMatchers){
+    return RootOperation<::TransitivePath>(AllOf(
+      Property("getChildren", &Operation::getChildren,
+                         ElementsAre(Pointee(childMatchers)...)),
+      AD_PROPERTY(TransitivePath, getMinDist, Eq(minDist)),
+      AD_PROPERTY(TransitivePath, getMaxDist, Eq(maxDist)),
+      AD_PROPERTY(TransitivePath, getLeft, TransitivePathSideMatcher(left)),
+      AD_PROPERTY(TransitivePath, getRight, TransitivePathSideMatcher(right))
+    )
+  );
+};
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -128,9 +128,9 @@ inline auto CartesianProductJoin =
     MatchTypeAndUnorderedChildren<::CartesianProductJoin>;
 
 inline auto TransitivePathSideMatcher = [](TransitivePathSide side) {
-  return AllOf(AD_FIELD(TransitivePathSide, value, Eq(side.value)),
-               AD_FIELD(TransitivePathSide, subCol, Eq(side.subCol)),
-               AD_FIELD(TransitivePathSide, outputCol, Eq(side.outputCol)));
+  return AllOf(AD_FIELD(TransitivePathSide, value_, Eq(side.value_)),
+               AD_FIELD(TransitivePathSide, subCol_, Eq(side.subCol_)),
+               AD_FIELD(TransitivePathSide, outputCol_, Eq(side.outputCol_)));
 };
 
 // Match a TransitivePath operation

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -6,7 +6,6 @@
 
 #include "./util/GTestHelpers.h"
 #include "engine/Bind.h"
-#include "engine/TransitivePath.h"
 #include "engine/CartesianProductJoin.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
@@ -14,6 +13,7 @@
 #include "engine/NeutralElementOperation.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/QueryPlanner.h"
+#include "engine/TransitivePath.h"
 #include "gmock/gmock-matchers.h"
 #include "gmock/gmock.h"
 #include "parser/SparqlParser.h"
@@ -126,28 +126,25 @@ inline auto Join = MatchTypeAndUnorderedChildren<::Join>;
 inline auto CartesianProductJoin =
     MatchTypeAndUnorderedChildren<::CartesianProductJoin>;
 
-inline auto TransitivePathSideMatcher = [](TransitivePathSide side){
-    return AllOf(
-      AD_FIELD(TransitivePathSide, value, Eq(side.value)),
-      AD_FIELD(TransitivePathSide, subCol, Eq(side.subCol)),
-      AD_FIELD(TransitivePathSide, outputCol, Eq(side.outputCol))
-    );
+inline auto TransitivePathSideMatcher = [](TransitivePathSide side) {
+  return AllOf(AD_FIELD(TransitivePathSide, value, Eq(side.value)),
+               AD_FIELD(TransitivePathSide, subCol, Eq(side.subCol)),
+               AD_FIELD(TransitivePathSide, outputCol, Eq(side.outputCol)));
 };
 
 // Match a TransitivePath operation
-inline auto TransitivePath = [](TransitivePathSide left,
-  TransitivePathSide right, size_t minDist, size_t maxDist,
-  const std::same_as<QetMatcher> auto&... childMatchers){
-    return RootOperation<::TransitivePath>(AllOf(
-      Property("getChildren", &Operation::getChildren,
-                         ElementsAre(Pointee(childMatchers)...)),
-      AD_PROPERTY(TransitivePath, getMinDist, Eq(minDist)),
-      AD_PROPERTY(TransitivePath, getMaxDist, Eq(maxDist)),
-      AD_PROPERTY(TransitivePath, getLeft, TransitivePathSideMatcher(left)),
-      AD_PROPERTY(TransitivePath, getRight, TransitivePathSideMatcher(right))
-    )
-  );
-};
+inline auto TransitivePath =
+    [](TransitivePathSide left, TransitivePathSide right, size_t minDist,
+       size_t maxDist, const std::same_as<QetMatcher> auto&... childMatchers) {
+      return RootOperation<::TransitivePath>(AllOf(
+          Property("getChildren", &Operation::getChildren,
+                   ElementsAre(Pointee(childMatchers)...)),
+          AD_PROPERTY(TransitivePath, getMinDist, Eq(minDist)),
+          AD_PROPERTY(TransitivePath, getMaxDist, Eq(maxDist)),
+          AD_PROPERTY(TransitivePath, getLeft, TransitivePathSideMatcher(left)),
+          AD_PROPERTY(TransitivePath, getRight,
+                      TransitivePathSideMatcher(right))));
+    };
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`

--- a/test/SortTest.cpp
+++ b/test/SortTest.cpp
@@ -12,6 +12,7 @@
 #include "global/ValueIdComparators.h"
 
 using namespace std::string_literals;
+using namespace std::chrono_literals;
 using ad_utility::source_location;
 
 namespace {
@@ -171,4 +172,27 @@ TEST(Sort, SimpleMemberFunctions) {
     EXPECT_EQ(42.0, s.getMultiplicity(0));
     EXPECT_EQ(84.0, s.getMultiplicity(1));
   }
+}
+
+// _____________________________________________________________________________
+
+TEST(Sort, verifyOperationIsPreemptivelyAbortedWithNoRemainingTime) {
+  VectorTable input;
+  // Make sure the estimator estimates a couple of ms to sort this
+  for (int64_t i = 0; i < 1000; i++) {
+    input.push_back({0, i});
+  }
+  auto inputTable = makeIdTableFromVector(input, &Id::makeFromInt);
+  Sort sort = makeSort(std::move(inputTable), {1, 0});
+  // Safe to do, because we know the underlying estimator is mutable
+  const_cast<SortPerformanceEstimator&>(
+      sort.getExecutionContext()->getSortPerformanceEstimator())
+      .computeEstimatesExpensively(
+          ad_utility::makeUnlimitedAllocator<ValueId>(), 1'000'000);
+
+  sort.recursivelySetTimeConstraint(0ms);
+
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      sort.getResult(true), ::testing::HasSubstr("time estimate exceeded"),
+      ad_utility::AbortException);
 }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -629,9 +629,9 @@ TEST(SparqlParser, propertyPaths) {
   auto Iri = &PropertyPath::fromIri;
   auto Sequence = &PropertyPath::makeSequence;
   auto Alternative = &PropertyPath::makeAlternative;
-  auto Transitive = &PropertyPath::makeTransitive;
-  auto TransitiveMin = &PropertyPath::makeTransitiveMin;
-  auto TransitiveMax = &PropertyPath::makeTransitiveMax;
+  auto ZeroOrMore = &PropertyPath::makeZeroOrMore;
+  auto OneOrMore = &PropertyPath::makeOneOrMore;
+  auto ZeroOrOne = &PropertyPath::makeZeroOrOne;
   using PrefixMap = SparqlQleverVisitor::PrefixMap;
   // Test all the base cases.
   // "a" is a special case. It is a valid PropertyPath.
@@ -660,16 +660,16 @@ TEST(SparqlParser, propertyPaths) {
                   {{"a", "<http://www.example.com/>"}});
   expectPathOrVar("(a:a)", Iri("<http://www.example.com/a>"),
                   {{"a", "<http://www.example.com/>"}});
-  expectPathOrVar("a:a+", TransitiveMin({Iri("<http://www.example.com/a>")}, 1),
+  expectPathOrVar("a:a+", OneOrMore({Iri("<http://www.example.com/a>")}),
                   {{"a", "<http://www.example.com/>"}});
   {
     PropertyPath expected =
-        TransitiveMax({Iri("<http://www.example.com/a>")}, 1);
+        ZeroOrOne({Iri("<http://www.example.com/a>")});
     expected._can_be_null = true;
     expectPathOrVar("a:a?", expected, {{"a", "<http://www.example.com/>"}});
   }
   {
-    PropertyPath expected = Transitive({Iri("<http://www.example.com/a>")});
+    PropertyPath expected = ZeroOrMore({Iri("<http://www.example.com/a>")});
     expected._can_be_null = true;
     expectPathOrVar("a:a*", expected, {{"a", "<http://www.example.com/>"}});
   }
@@ -678,13 +678,13 @@ TEST(SparqlParser, propertyPaths) {
     PropertyPath expected = Alternative(
         {Sequence({
              Iri("<http://www.example.com/a/a>"),
-             Transitive({Iri("<http://www.example.com/b/b>")}),
+             ZeroOrMore({Iri("<http://www.example.com/b/b>")}),
          }),
          Iri("<http://www.example.com/c/c>"),
-         TransitiveMin(
+         OneOrMore(
              {Sequence({Iri("<http://www.example.com/a/a>"),
-                        Iri("<http://www.example.com/b/b>"), Iri("<a/b/c>")})},
-             1)});
+                        Iri("<http://www.example.com/b/b>"), Iri("<a/b/c>")})}
+             )});
     expected.computeCanBeNull();
     expected._can_be_null = false;
     expectPathOrVar("a:a/b:b*|c:c|(a:a/b:b/<a/b/c>)+", expected,

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -663,8 +663,7 @@ TEST(SparqlParser, propertyPaths) {
   expectPathOrVar("a:a+", OneOrMore({Iri("<http://www.example.com/a>")}),
                   {{"a", "<http://www.example.com/>"}});
   {
-    PropertyPath expected =
-        ZeroOrOne({Iri("<http://www.example.com/a>")});
+    PropertyPath expected = ZeroOrOne({Iri("<http://www.example.com/a>")});
     expected._can_be_null = true;
     expectPathOrVar("a:a?", expected, {{"a", "<http://www.example.com/>"}});
   }
@@ -675,16 +674,15 @@ TEST(SparqlParser, propertyPaths) {
   }
   // Test a bigger example that contains everything.
   {
-    PropertyPath expected = Alternative(
-        {Sequence({
-             Iri("<http://www.example.com/a/a>"),
-             ZeroOrMore({Iri("<http://www.example.com/b/b>")}),
-         }),
-         Iri("<http://www.example.com/c/c>"),
-         OneOrMore(
-             {Sequence({Iri("<http://www.example.com/a/a>"),
-                        Iri("<http://www.example.com/b/b>"), Iri("<a/b/c>")})}
-             )});
+    PropertyPath expected =
+        Alternative({Sequence({
+                         Iri("<http://www.example.com/a/a>"),
+                         ZeroOrMore({Iri("<http://www.example.com/b/b>")}),
+                     }),
+                     Iri("<http://www.example.com/c/c>"),
+                     OneOrMore({Sequence({Iri("<http://www.example.com/a/a>"),
+                                          Iri("<http://www.example.com/b/b>"),
+                                          Iri("<a/b/c>")})})});
     expected.computeCanBeNull();
     expected._can_be_null = false;
     expectPathOrVar("a:a/b:b*|c:c|(a:a/b:b/<a/b/c>)+", expected,

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -664,12 +664,12 @@ TEST(SparqlParser, propertyPaths) {
                   {{"a", "<http://www.example.com/>"}});
   {
     PropertyPath expected = ZeroOrOne({Iri("<http://www.example.com/a>")});
-    expected._can_be_null = true;
+    expected.can_be_null_ = true;
     expectPathOrVar("a:a?", expected, {{"a", "<http://www.example.com/>"}});
   }
   {
     PropertyPath expected = ZeroOrMore({Iri("<http://www.example.com/a>")});
-    expected._can_be_null = true;
+    expected.can_be_null_ = true;
     expectPathOrVar("a:a*", expected, {{"a", "<http://www.example.com/>"}});
   }
   // Test a bigger example that contains everything.
@@ -684,7 +684,7 @@ TEST(SparqlParser, propertyPaths) {
                                           Iri("<http://www.example.com/b/b>"),
                                           Iri("<a/b/c>")})})});
     expected.computeCanBeNull();
-    expected._can_be_null = false;
+    expected.can_be_null_ = false;
     expectPathOrVar("a:a/b:b*|c:c|(a:a/b:b/<a/b/c>)+", expected,
                     {{"a", "<http://www.example.com/a/>"},
                      {"b", "<http://www.example.com/b/>"},

--- a/test/TimerTest.cpp
+++ b/test/TimerTest.cpp
@@ -9,7 +9,6 @@
 
 #include "util/Timer.h"
 
-using ad_utility::TimeoutTimer;
 using ad_utility::Timer;
 using namespace std::chrono_literals;
 
@@ -97,38 +96,6 @@ TEST(Timer, InitiallyStopped) {
   t.cont();
   std::this_thread::sleep_for(15ms);
   testTime(t, 15ms);
-}
-
-TEST(TimeoutTimer, Unlimited) {
-  auto timer = TimeoutTimer::unlimited();
-  for (size_t i = 0; i < 10; ++i) {
-    std::this_thread::sleep_for(1ms);
-    ASSERT_FALSE(timer.hasTimedOut());
-    ASSERT_NO_THROW(timer.checkTimeoutAndThrow("error1"));
-    // When no timeout occurs, the lambda is not executed.
-    ASSERT_NO_THROW(
-        timer.checkTimeoutAndThrow([]() -> std::string { throw 42; }));
-  }
-}
-
-TEST(TimeoutTimer, Limited) {
-  auto timer = TimeoutTimer{10ms, Timer::Started};
-  std::this_thread::sleep_for(5ms);
-  ASSERT_FALSE(timer.hasTimedOut());
-  ASSERT_NO_THROW(timer.checkTimeoutAndThrow("error1"));
-  ASSERT_NO_THROW(timer.checkTimeoutAndThrow([]() { return "error2"; }));
-  std::this_thread::sleep_for(7ms);
-
-  ASSERT_TRUE(timer.hasTimedOut());
-  ASSERT_THROW(timer.checkTimeoutAndThrow("hi"), ad_utility::TimeoutException);
-  try {
-    timer.checkTimeoutAndThrow([]() { return "Testing. "; });
-    FAIL() << "Expected a timeout exception, but no exception was thrown";
-  } catch (const ad_utility::TimeoutException& ex) {
-    ASSERT_STREQ(
-        ex.what(),
-        "Testing. A Timeout occured. The time limit was 0.010 seconds");
-  }
 }
 
 TEST(TimeBlockAndLog, TimeBlockAndLog) {

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -53,7 +53,8 @@ TEST(TransitivePathTest, idToId) {
 
   TransitivePathSide left(std::nullopt, 0, V(0), 0);
   TransitivePathSide right(std::nullopt, 1, V(3), 1);
-  TransitivePath T(nullptr, nullptr, left, right, 1, std::numeric_limits<size_t>::max());
+  TransitivePath T(nullptr, nullptr, left, right, 1,
+                   std::numeric_limits<size_t>::max());
 
   T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
@@ -75,7 +76,8 @@ TEST(TransitivePathTest, idToVar) {
 
   TransitivePathSide left(std::nullopt, 0, V(0), 0);
   TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
-  TransitivePath T(nullptr, nullptr, left, right, 1, std::numeric_limits<size_t>::max());
+  TransitivePath T(nullptr, nullptr, left, right, 1,
+                   std::numeric_limits<size_t>::max());
 
   T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
@@ -100,7 +102,8 @@ TEST(TransitivePathTest, varTovar) {
 
   TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
   TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
-  TransitivePath T(nullptr, nullptr, right, left, 1, std::numeric_limits<size_t>::max());
+  TransitivePath T(nullptr, nullptr, right, left, 1,
+                   std::numeric_limits<size_t>::max());
 
   T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
@@ -141,12 +144,12 @@ TEST(TransitivePathTest, unlimitedMaxLength) {
 
   TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
   TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
-  TransitivePath T(nullptr, nullptr, left, right, 1, std::numeric_limits<size_t>::max());
+  TransitivePath T(nullptr, nullptr, left, right, 1,
+                   std::numeric_limits<size_t>::max());
 
   T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
 }
-
 
 TEST(TransitivePathTest, maxLength2) {
   IdTable sub(2, makeAllocator());

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -39,7 +39,74 @@ void assertSameUnorderedContent(const IdTable& a, const IdTable& b) {
 }
 }  // namespace
 
-TEST(TransitivePathTest, computeTransitivePath) {
+TEST(TransitivePathTest, idToId) {
+  IdTable sub(2, makeAllocator());
+  sub.push_back({V(0), V(1)});
+  sub.push_back({V(1), V(2)});
+  sub.push_back({V(1), V(3)});
+  sub.push_back({V(2), V(3)});
+
+  IdTable result(2, makeAllocator());
+
+  IdTable expected(2, makeAllocator());
+  expected.push_back({V(0), V(3)});
+
+  TransitivePathSide left(std::nullopt, 0, V(0), 0);
+  TransitivePathSide right(std::nullopt, 1, V(3), 1);
+  TransitivePath T(nullptr, nullptr, left, right, 1, std::numeric_limits<size_t>::max());
+
+  T.computeTransitivePath<2, 2>(&result, sub, left, right);
+  assertSameUnorderedContent(expected, result);
+}
+
+TEST(TransitivePathTest, idToVar) {
+  IdTable sub(2, makeAllocator());
+  sub.push_back({V(0), V(1)});
+  sub.push_back({V(1), V(2)});
+  sub.push_back({V(1), V(3)});
+  sub.push_back({V(2), V(3)});
+
+  IdTable result(2, makeAllocator());
+
+  IdTable expected(2, makeAllocator());
+  expected.push_back({V(0), V(1)});
+  expected.push_back({V(0), V(2)});
+  expected.push_back({V(0), V(3)});
+
+  TransitivePathSide left(std::nullopt, 0, V(0), 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  TransitivePath T(nullptr, nullptr, left, right, 1, std::numeric_limits<size_t>::max());
+
+  T.computeTransitivePath<2, 2>(&result, sub, left, right);
+  assertSameUnorderedContent(expected, result);
+}
+
+TEST(TransitivePathTest, varTovar) {
+  IdTable sub(2, makeAllocator());
+  sub.push_back({V(0), V(1)});
+  sub.push_back({V(1), V(2)});
+  sub.push_back({V(1), V(3)});
+  sub.push_back({V(2), V(3)});
+
+  IdTable result(2, makeAllocator());
+
+  IdTable expected(2, makeAllocator());
+  expected.push_back({V(0), V(1)});
+  expected.push_back({V(0), V(2)});
+  expected.push_back({V(0), V(3)});
+  expected.push_back({V(1), V(2)});
+  expected.push_back({V(1), V(3)});
+  expected.push_back({V(2), V(3)});
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  TransitivePath T(nullptr, nullptr, right, left, 1, std::numeric_limits<size_t>::max());
+
+  T.computeTransitivePath<2, 2>(&result, sub, left, right);
+  assertSameUnorderedContent(expected, result);
+}
+
+TEST(TransitivePathTest, unlimitedMaxLength) {
   IdTable sub(2, makeAllocator());
   sub.push_back({V(0), V(2)});
   sub.push_back({V(2), V(4)});
@@ -72,15 +139,30 @@ TEST(TransitivePathTest, computeTransitivePath) {
   expected.push_back({V(7), V(7)});
   expected.push_back({V(10), V(11)});
 
-  TransitivePath T(nullptr, nullptr, false, false, 0, 0, V(0), V(0),
-                   Variable{"?bim"}, Variable{"?bam"}, 0, 0);
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  TransitivePath T(nullptr, nullptr, left, right, 1, std::numeric_limits<size_t>::max());
 
-  T.computeTransitivePath<2>(&result, sub, true, true, 0, 1, V(0), V(0), 1,
-                             std::numeric_limits<size_t>::max());
+  T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
+}
 
-  result.clear();
-  expected.clear();
+
+TEST(TransitivePathTest, maxLength2) {
+  IdTable sub(2, makeAllocator());
+  sub.push_back({V(0), V(2)});
+  sub.push_back({V(2), V(4)});
+  sub.push_back({V(4), V(7)});
+  sub.push_back({V(0), V(7)});
+  sub.push_back({V(3), V(3)});
+  sub.push_back({V(7), V(0)});
+  // Disconnected component.
+  sub.push_back({V(10), V(11)});
+
+  IdTable result(2, makeAllocator());
+
+  IdTable expected(2, makeAllocator());
+
   expected.push_back({V(0), V(2)});
   expected.push_back({V(0), V(4)});
   expected.push_back({V(0), V(7)});
@@ -95,7 +177,10 @@ TEST(TransitivePathTest, computeTransitivePath) {
   expected.push_back({V(7), V(7)});
   expected.push_back({V(10), V(11)});
 
-  T.computeTransitivePath<2>(&result, sub, true, true, 0, 1, V(0), V(0), 1, 2);
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  TransitivePath T(nullptr, nullptr, left, right, 1, 2);
+  T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
 
   result.clear();
@@ -104,7 +189,9 @@ TEST(TransitivePathTest, computeTransitivePath) {
   expected.push_back({V(7), V(2)});
   expected.push_back({V(7), V(7)});
 
-  T.computeTransitivePath<2>(&result, sub, false, true, 0, 1, V(7), V(0), 1, 2);
+  left.value = V(7);
+  right.value = Variable{"?target"};
+  T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
 
   result.clear();
@@ -112,6 +199,8 @@ TEST(TransitivePathTest, computeTransitivePath) {
   expected.push_back({V(0), V(2)});
   expected.push_back({V(7), V(2)});
 
-  T.computeTransitivePath<2>(&result, sub, true, false, 0, 1, V(0), V(2), 1, 2);
+  left.value = Variable{"?start"};
+  right.value = V(2);
+  T.computeTransitivePath<2, 2>(&result, sub, right, left);
   assertSameUnorderedContent(expected, result);
 }

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -192,8 +192,8 @@ TEST(TransitivePathTest, maxLength2) {
   expected.push_back({V(7), V(2)});
   expected.push_back({V(7), V(7)});
 
-  left.value = V(7);
-  right.value = Variable{"?target"};
+  left.value_ = V(7);
+  right.value_ = Variable{"?target"};
   T.computeTransitivePath<2, 2>(&result, sub, left, right);
   assertSameUnorderedContent(expected, result);
 
@@ -202,8 +202,8 @@ TEST(TransitivePathTest, maxLength2) {
   expected.push_back({V(0), V(2)});
   expected.push_back({V(7), V(2)});
 
-  left.value = Variable{"?start"};
-  right.value = V(2);
+  left.value_ = Variable{"?start"};
+  right.value_ = V(2);
   T.computeTransitivePath<2, 2>(&result, sub, right, left);
   assertSameUnorderedContent(expected, result);
 }

--- a/test/TriplesViewTest.cpp
+++ b/test/TriplesViewTest.cpp
@@ -67,7 +67,9 @@ std::vector<std::array<Id, 3>> expectedResult() {
 
 TEST(TriplesView, AllTriples) {
   std::vector<std::array<Id, 3>> result;
-  for (auto triple : TriplesView(DummyPermutation{})) {
+  for (auto triple :
+       TriplesView(DummyPermutation{},
+                   std::make_shared<ad_utility::CancellationHandle>())) {
     result.push_back(triple);
   }
   ASSERT_EQ(result, expectedResult());
@@ -82,7 +84,9 @@ TEST(TriplesView, IgnoreRanges) {
   });
   std::vector<std::pair<Id, Id>> ignoredRanges{
       {V(0), V(4)}, {V(7), V(8)}, {V(13), V(87593)}};
-  for (auto triple : TriplesView(DummyPermutation{}, ignoredRanges)) {
+  for (auto triple : TriplesView(
+           DummyPermutation{},
+           std::make_shared<ad_utility::CancellationHandle>(), ignoredRanges)) {
     result.push_back(triple);
   }
   ASSERT_EQ(result, expected);
@@ -95,7 +99,10 @@ TEST(TriplesView, IgnoreTriples) {
     return triple[1].getVocabIndex().get() % 2 == 0;
   };
   std::erase_if(expected, isTripleIgnored);
-  for (auto triple : TriplesView(DummyPermutation{}, {}, isTripleIgnored)) {
+  for (auto triple :
+       TriplesView(DummyPermutation{},
+                   std::make_shared<ad_utility::CancellationHandle>(), {},
+                   isTripleIgnored)) {
     result.push_back(triple);
   }
   ASSERT_EQ(result, expected);

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -1,0 +1,98 @@
+//   Copyright 2023, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#ifndef QLEVER_OPERATIONTESTHELPERS_H
+#define QLEVER_OPERATIONTESTHELPERS_H
+
+#include <chrono>
+#include <vector>
+
+#include "engine/Operation.h"
+#include "engine/QueryExecutionTree.h"
+
+using namespace std::chrono_literals;
+
+class StallForeverOperation : public Operation {
+  std::vector<QueryExecutionTree*> getChildren() override { return {}; }
+  string asStringImpl([[maybe_unused]] size_t) const override {
+    return "StallForEverOperation";
+  }
+  string getDescriptor() const override {
+    return "StallForEverOperationDescriptor";
+  }
+  size_t getResultWidth() const override { return 0; }
+  size_t getCostEstimate() override { return 0; }
+  uint64_t getSizeEstimateBeforeLimit() override { return 0; }
+  float getMultiplicity([[maybe_unused]] size_t) override { return 0; }
+  bool knownEmptyResult() override { return false; }
+  vector<ColumnIndex> resultSortedOn() const override { return {}; }
+  VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
+
+ public:
+  using Operation::Operation;
+  // Do-nothing operation that runs for 100ms without computing anything, but
+  // which can be cancelled.
+  ResultTable computeResult() override {
+    auto end = std::chrono::steady_clock::now() + 100ms;
+    while (std::chrono::steady_clock::now() < end) {
+      checkCancellation();
+    }
+    throw std::runtime_error{"Loop was not interrupted for 100ms, aborting"};
+  }
+
+  // Provide public view of remainingTime for tests
+  std::chrono::milliseconds publicRemainingTime() const {
+    return remainingTime();
+  }
+};
+// _____________________________________________________________________________
+
+// Dummy parent to test recursive application of a function
+class ShallowParentOperation : public Operation {
+  std::shared_ptr<QueryExecutionTree> child_;
+
+  explicit ShallowParentOperation(std::shared_ptr<QueryExecutionTree> child)
+      : child_{std::move(child)} {}
+  string asStringImpl([[maybe_unused]] size_t) const override {
+    return "ParentOperation";
+  }
+  string getDescriptor() const override { return "ParentOperationDescriptor"; }
+  size_t getResultWidth() const override { return 0; }
+  size_t getCostEstimate() override { return 0; }
+  uint64_t getSizeEstimateBeforeLimit() override { return 0; }
+  float getMultiplicity([[maybe_unused]] size_t) override { return 0; }
+  bool knownEmptyResult() override { return false; }
+  vector<ColumnIndex> resultSortedOn() const override { return {}; }
+  VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
+
+ public:
+  template <typename ChildOperation, typename... Args>
+  static ShallowParentOperation of(QueryExecutionContext* qec, Args&&... args) {
+    return ShallowParentOperation{
+        ad_utility::makeExecutionTree<ChildOperation>(qec, args...)};
+  }
+
+  std::vector<QueryExecutionTree*> getChildren() override {
+    return {child_.get()};
+  }
+
+  ResultTable computeResult() override {
+    auto childResult = child_->getResult();
+    return {childResult->idTable().clone(), resultSortedOn(),
+            childResult->getSharedLocalVocab()};
+  }
+
+  // Provide public view of remainingTime for tests
+  std::chrono::milliseconds publicRemainingTime() const {
+    return remainingTime();
+  }
+};
+
+template <>
+void QueryExecutionTree::setOperation<StallForeverOperation>(
+    std::shared_ptr<StallForeverOperation> operation) {
+  _rootOperation = std::move(operation);
+}
+
+#endif  // QLEVER_OPERATIONTESTHELPERS_H

--- a/toolchains/gcc13.cmake
+++ b/toolchains/gcc13.cmake
@@ -3,3 +3,4 @@ set(CMAKE_C_COMPILER gcc-13)
 set(CMAKE_CXX_COMPILER g++-13)
 # Disable errors for known false-positive warnings
 set(CMAKE_CXX_FLAGS "-Wno-error=array-bounds")
+set(CMAKE_CXX_FLAGS "-Wno-error=nonnull")

--- a/toolchains/gcc13.cmake
+++ b/toolchains/gcc13.cmake
@@ -2,5 +2,4 @@
 set(CMAKE_C_COMPILER gcc-13)
 set(CMAKE_CXX_COMPILER g++-13)
 # Disable errors for known false-positive warnings
-set(CMAKE_CXX_FLAGS "-Wno-error=array-bounds")
-set(CMAKE_CXX_FLAGS "-Wno-error=nonnull")
+set(CMAKE_CXX_FLAGS "-Wno-error=array-bounds -Wno-error=nonnull")


### PR DESCRIPTION
QLever now supports patterns like `?x <is_a> ?y. ?y <subtype>* ?z` where the transitive path `<subtype>*` can be empty, but is constrained by the join on `?y`.  For cases like this where the connection between the empty path and its neighbors in the tree is made via explicit variables (as oppsed to the short hand `?x <is_a>/<subtype>* ?y` the query planner now can optimize the join order for such queries. Consider for example :
```
?x <profession> <astronaut> . # very few instances
?x <type>     ?type .  # very many instances without the previous restriction.
?type <subtype>* ?subtype
```
The query planner now first joins the first two triples (which yields very few bindings for `?type` and then uses this small subresult to compute the transitive path.

Note that this optimization does currently not work for the follwing pattern:
```
?x <profession> <astronaut>
?x <type>/<subtype>* ?subtype
```
Here QLever first materializes the transitive path for all types of all entities. This restriction will be lifted in an upcoming commit.

This commit also completely refactor the `TransitivePath` class to get rid of a lot of duplicate code.