### PR TITLE
Add explicit seeds to the random number generators

### DIFF
--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -79,7 +79,8 @@ class BMSingleMeasurements : public ConfigOptions {
     BenchmarkResults results{};
 
     // Setup.
-    const size_t number = SlowRandomIntGenerator<size_t>(10, 1'000)();
+    const size_t number =
+        ad_utility::SlowRandomIntGenerator<size_t>(10, 1'000)();
     auto exponentiate = [](const size_t numberToExponentiate) {
       return numberToExponentiate * numberToExponentiate;
     };

--- a/benchmark/IdTableCompressedWriterBenchmark.cpp
+++ b/benchmark/IdTableCompressedWriterBenchmark.cpp
@@ -30,7 +30,7 @@ class IdTableCompressedWriterBenchmarks : public BenchmarkInterface {
     BenchmarkResults results{};
 
     auto generateRandomRow =
-        [gen = FastRandomIntGenerator<uint64_t>{}]() mutable {
+        [gen = ad_utility::FastRandomIntGenerator<uint64_t>{}]() mutable {
           std::array<Id, numCols> arr;
           for (auto& id : arr) {
             id = Id::fromBits(gen() >> 40);

--- a/src/engine/SortPerformanceEstimator.cpp
+++ b/src/engine/SortPerformanceEstimator.cpp
@@ -21,7 +21,7 @@ IdTable createRandomIdTable(
   result.setNumColumns(numColumns);
   result.reserve(numRows);
 
-  FastRandomIntGenerator<uint32_t> generator;
+  ad_utility::FastRandomIntGenerator<uint32_t> generator;
 
   for (size_t i = 0; i < numRows; ++i) {
     result.emplace_back();

--- a/src/engine/sparqlExpressions/RandomExpression.h
+++ b/src/engine/sparqlExpressions/RandomExpression.h
@@ -13,7 +13,7 @@ namespace sparqlExpression {
 class RandomExpression : public SparqlExpression {
  private:
   // Unique random ID for this expression.
-  int64_t randId = FastRandomIntGenerator<int64_t>{}();
+  int64_t randId = ad_utility::FastRandomIntGenerator<int64_t>{}();
 
  public:
   // Evaluate a Sparql expression.
@@ -21,7 +21,7 @@ class RandomExpression : public SparqlExpression {
     VectorWithMemoryLimit<Id> result{context->_allocator};
     const size_t numElements = context->_endIndex - context->_beginIndex;
     result.reserve(numElements);
-    FastRandomIntGenerator<int64_t> randInt;
+    ad_utility::FastRandomIntGenerator<int64_t> randInt;
 
     // As part of a GROUP BY we only return one value per group.
     if (context->_isPartOfGroupBy) {

--- a/src/util/Random.h
+++ b/src/util/Random.h
@@ -26,7 +26,7 @@ template <typename Int>
 requires(std::is_integral_v<Int> && sizeof(Int) <= sizeof(uint64_t))
 class FastRandomIntGenerator {
  public:
-  FastRandomIntGenerator(unsigned int seed = std::random_device{}()) {
+  explicit FastRandomIntGenerator(unsigned int seed = std::random_device{}()) {
     // Randomly initialize the shuffleTable
     std::default_random_engine randomEngine{std::move(seed)};
     std::uniform_int_distribution<uint64_t> distribution;

--- a/src/util/Random.h
+++ b/src/util/Random.h
@@ -15,6 +15,7 @@
 
 #include "global/TypedIndex.h"
 
+namespace ad_utility {
 // The seed type for random number generators.
 using RandomSeed = ad_utility::TypedIndex<unsigned int, "Seed">;
 
@@ -110,3 +111,5 @@ void randomShuffle(RandomIt begin, RandomIt end,
   std::mt19937 g(seed.get());
   std::shuffle(begin, end, g);
 }
+
+}  // namespace ad_utility

--- a/src/util/Random.h
+++ b/src/util/Random.h
@@ -28,7 +28,7 @@ class FastRandomIntGenerator {
  public:
   explicit FastRandomIntGenerator(unsigned int seed = std::random_device{}()) {
     // Randomly initialize the shuffleTable
-    std::default_random_engine randomEngine{seed};
+    std::mt19937_64 randomEngine{seed};
     std::uniform_int_distribution<uint64_t> distribution;
     for (auto& el : _shuffleTable) {
       el = distribution(randomEngine);
@@ -73,7 +73,7 @@ class SlowRandomIntGenerator {
   Int operator()() { return _distribution(_randomEngine); }
 
  private:
-  std::default_random_engine _randomEngine;
+  std::mt19937_64 _randomEngine;
   std::uniform_int_distribution<Int> _distribution;
 };
 
@@ -91,7 +91,7 @@ class RandomDoubleGenerator {
   double operator()() { return _distribution(_randomEngine); }
 
  private:
-  std::default_random_engine _randomEngine;
+  std::mt19937_64 _randomEngine;
   std::uniform_real_distribution<double> _distribution;
 };
 

--- a/src/util/Random.h
+++ b/src/util/Random.h
@@ -16,7 +16,7 @@
 #include "global/TypedIndex.h"
 
 // The seed type for random number generators.
-using Seed = ad_utility::TypedIndex<unsigned int, "Seed">;
+using RandomSeed = ad_utility::TypedIndex<unsigned int, "Seed">;
 
 /**
  * A simple and fast Pseudo-Random-Number-Generator called Xoroshiro128+,
@@ -33,7 +33,7 @@ requires(std::is_integral_v<Int> && sizeof(Int) <= sizeof(uint64_t))
 class FastRandomIntGenerator {
  public:
   explicit FastRandomIntGenerator(
-      Seed seed = Seed::make(std::random_device{}())) {
+      RandomSeed seed = RandomSeed::make(std::random_device{}())) {
     // Randomly initialize the shuffleTable
     std::mt19937_64 randomEngine{seed.get()};
     std::uniform_int_distribution<uint64_t> distribution;
@@ -75,7 +75,7 @@ class SlowRandomIntGenerator {
   explicit SlowRandomIntGenerator(
       Int min = std::numeric_limits<Int>::min(),
       Int max = std::numeric_limits<Int>::max(),
-      Seed seed = Seed::make(std::random_device{}()))
+      RandomSeed seed = RandomSeed::make(std::random_device{}()))
       : _randomEngine{seed.get()}, _distribution{min, max} {}
 
   Int operator()() { return _distribution(_randomEngine); }
@@ -93,7 +93,7 @@ class RandomDoubleGenerator {
   explicit RandomDoubleGenerator(
       double min = std::numeric_limits<double>::min(),
       double max = std::numeric_limits<double>::max(),
-      Seed seed = Seed::make(std::random_device{}()))
+      RandomSeed seed = RandomSeed::make(std::random_device{}()))
       : _randomEngine{seed.get()}, _distribution{min, max} {}
 
   double operator()() { return _distribution(_randomEngine); }
@@ -106,7 +106,7 @@ class RandomDoubleGenerator {
 /// Randomly shuffle range denoted by `[begin, end)`
 template <typename RandomIt>
 void randomShuffle(RandomIt begin, RandomIt end,
-                   Seed seed = Seed::make(std::random_device{}())) {
+                   RandomSeed seed = RandomSeed::make(std::random_device{}())) {
   std::mt19937 g(seed.get());
   std::shuffle(begin, end, g);
 }

--- a/src/util/Random.h
+++ b/src/util/Random.h
@@ -28,7 +28,7 @@ class FastRandomIntGenerator {
  public:
   explicit FastRandomIntGenerator(unsigned int seed = std::random_device{}()) {
     // Randomly initialize the shuffleTable
-    std::default_random_engine randomEngine{std::move(seed)};
+    std::default_random_engine randomEngine{seed};
     std::uniform_int_distribution<uint64_t> distribution;
     for (auto& el : _shuffleTable) {
       el = distribution(randomEngine);
@@ -68,7 +68,7 @@ class SlowRandomIntGenerator {
   explicit SlowRandomIntGenerator(Int min = std::numeric_limits<Int>::min(),
                                   Int max = std::numeric_limits<Int>::max(),
                                   unsigned int seed = std::random_device{}())
-      : _randomEngine{std::move(seed)}, _distribution{min, max} {}
+      : _randomEngine{seed}, _distribution{min, max} {}
 
   Int operator()() { return _distribution(_randomEngine); }
 
@@ -86,7 +86,7 @@ class RandomDoubleGenerator {
       double min = std::numeric_limits<double>::min(),
       double max = std::numeric_limits<double>::max(),
       unsigned int seed = std::random_device{}())
-      : _randomEngine{std::move(seed)}, _distribution{min, max} {}
+      : _randomEngine{seed}, _distribution{min, max} {}
 
   double operator()() { return _distribution(_randomEngine); }
 

--- a/test/BackgroundStxxlSorterTest.cpp
+++ b/test/BackgroundStxxlSorterTest.cpp
@@ -45,7 +45,7 @@ TEST(StxxlUniqueSorter, uniqueInts) {
   std::vector<int> originalInts;
   const uint64_t numInts = 50'000;
   originalInts.reserve(numInts);
-  SlowRandomIntGenerator<int> r{-200'000, 200'000};
+  ad_utility::SlowRandomIntGenerator<int> r{-200'000, 200'000};
   for (size_t i = 0; i < numInts; ++i) {
     originalInts.push_back(r());
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -330,6 +330,8 @@ addLinkAndDiscoverTest(ConfigOptionProxyTest configManager)
 
 addLinkAndDiscoverTest(ConfigUtilTest configManager)
 
+addLinkAndDiscoverTest(RandomTest)
+
 addLinkAndDiscoverTest(BenchmarkMeasurementContainerTest benchmark)
 
 addLinkAndDiscoverTest(FindUndefRangesTest engine)

--- a/test/DateTest.cpp
+++ b/test/DateTest.cpp
@@ -15,13 +15,13 @@
 
 using ad_utility::source_location;
 
-SlowRandomIntGenerator yearGenerator{-9999, 9999};
-SlowRandomIntGenerator monthGenerator{1, 12};
-SlowRandomIntGenerator dayGenerator{1, 31};
-SlowRandomIntGenerator hourGenerator{0, 23};
-SlowRandomIntGenerator minuteGenerator{0, 59};
-RandomDoubleGenerator secondGenerator{0, 59.9999};
-SlowRandomIntGenerator timeZoneGenerator{-23, 23};
+ad_utility::SlowRandomIntGenerator yearGenerator{-9999, 9999};
+ad_utility::SlowRandomIntGenerator monthGenerator{1, 12};
+ad_utility::SlowRandomIntGenerator dayGenerator{1, 31};
+ad_utility::SlowRandomIntGenerator hourGenerator{0, 23};
+ad_utility::SlowRandomIntGenerator minuteGenerator{0, 59};
+ad_utility::RandomDoubleGenerator secondGenerator{0, 59.9999};
+ad_utility::SlowRandomIntGenerator timeZoneGenerator{-23, 23};
 
 TEST(Date, Size) {
   ASSERT_EQ(sizeof(Date), 8);

--- a/test/IdTableHelpersTest.cpp
+++ b/test/IdTableHelpersTest.cpp
@@ -217,12 +217,14 @@ TEST(IdTableHelpersTest, createRandomlyFilledIdTableWithGeneratos) {
   // Giving an empty function.
   ASSERT_ANY_THROW(createRandomlyFilledIdTable(
       10, 10, {{1, createCountUpGenerator()}, {1, {}}}));
-  ASSERT_ANY_THROW(createRandomlyFilledIdTable(10, 10, {1}, {}));
+  ASSERT_ANY_THROW(
+      createRandomlyFilledIdTable(10, 10, {1}, std::function<ValueId()>{}));
 
   // Creating an empty table of size (0,0).
   ASSERT_ANY_THROW(createRandomlyFilledIdTable(
       0, 0, std::vector<std::pair<size_t, std::function<ValueId()>>>{}));
-  ASSERT_ANY_THROW(createRandomlyFilledIdTable(0, 0, {}, {}));
+  ASSERT_ANY_THROW(
+      createRandomlyFilledIdTable(0, 0, {}, std::function<ValueId()>{}));
 
   // Exhaustive test, if the creation of a randomly filled table works,
   // regardless of the amount of join columns and their position.

--- a/test/IdTableHelpersTest.cpp
+++ b/test/IdTableHelpersTest.cpp
@@ -337,31 +337,35 @@ TEST(IdTableHelpersTest, randomSeed) {
   constexpr size_t NUM_ROWS = 100;
   constexpr size_t NUM_COLUMNS = 200;
 
-  std::ranges::for_each(createArrayOfRandomSeeds<5>(), [](const Seed seed) {
-    // Simply generate and compare.
-    ASSERT_EQ(
-        createRandomlyFilledIdTable(
-            NUM_ROWS, NUM_COLUMNS,
-            std::vector<std::pair<size_t, std::function<ValueId()>>>{}, seed),
-        createRandomlyFilledIdTable(
-            NUM_ROWS, NUM_COLUMNS,
-            std::vector<std::pair<size_t, std::function<ValueId()>>>{}, seed));
-    ASSERT_EQ(createRandomlyFilledIdTable(
-                  NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
-                  []() { return ad_utility::testing::VocabId(1); }, seed),
-              createRandomlyFilledIdTable(
-                  NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
-                  []() { return ad_utility::testing::VocabId(1); }, seed));
-    ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
-                                          JoinColumnAndBounds{}, seed),
-              createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
-                                          JoinColumnAndBounds{}, seed));
-    ASSERT_EQ(
-        createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
-                                    std::vector<JoinColumnAndBounds>{}, seed),
-        createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
-                                    std::vector<JoinColumnAndBounds>{}, seed));
-    ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed),
-              createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed));
-  });
+  std::ranges::for_each(
+      createArrayOfRandomSeeds<5>(), [](const RandomSeed seed) {
+        // Simply generate and compare.
+        ASSERT_EQ(
+            createRandomlyFilledIdTable(
+                NUM_ROWS, NUM_COLUMNS,
+                std::vector<std::pair<size_t, std::function<ValueId()>>>{},
+                seed),
+            createRandomlyFilledIdTable(
+                NUM_ROWS, NUM_COLUMNS,
+                std::vector<std::pair<size_t, std::function<ValueId()>>>{},
+                seed));
+        ASSERT_EQ(createRandomlyFilledIdTable(
+                      NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
+                      []() { return ad_utility::testing::VocabId(1); }, seed),
+                  createRandomlyFilledIdTable(
+                      NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
+                      []() { return ad_utility::testing::VocabId(1); }, seed));
+        ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
+                                              JoinColumnAndBounds{}, seed),
+                  createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
+                                              JoinColumnAndBounds{}, seed));
+        ASSERT_EQ(createRandomlyFilledIdTable(
+                      NUM_ROWS, NUM_COLUMNS, std::vector<JoinColumnAndBounds>{},
+                      seed),
+                  createRandomlyFilledIdTable(
+                      NUM_ROWS, NUM_COLUMNS, std::vector<JoinColumnAndBounds>{},
+                      seed));
+        ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed),
+                  createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed));
+      });
 }

--- a/test/IdTableHelpersTest.cpp
+++ b/test/IdTableHelpersTest.cpp
@@ -338,7 +338,7 @@ TEST(IdTableHelpersTest, randomSeed) {
   constexpr size_t NUM_COLUMNS = 200;
 
   std::ranges::for_each(
-      createArrayOfRandomSeeds<5>(), [](const RandomSeed seed) {
+      createArrayOfRandomSeeds<5>(), [](const ad_utility::RandomSeed seed) {
         // Simply generate and compare.
         ASSERT_EQ(
             createRandomlyFilledIdTable(

--- a/test/IdTableHelpersTest.cpp
+++ b/test/IdTableHelpersTest.cpp
@@ -337,35 +337,31 @@ TEST(IdTableHelpersTest, randomSeed) {
   constexpr size_t NUM_ROWS = 100;
   constexpr size_t NUM_COLUMNS = 200;
 
-  std::ranges::for_each(
-      createArrayOfRandomSeeds<5>(), [](const unsigned int seed) {
-        // Simply generate and compare.
-        ASSERT_EQ(
-            createRandomlyFilledIdTable(
-                NUM_ROWS, NUM_COLUMNS,
-                std::vector<std::pair<size_t, std::function<ValueId()>>>{},
-                seed),
-            createRandomlyFilledIdTable(
-                NUM_ROWS, NUM_COLUMNS,
-                std::vector<std::pair<size_t, std::function<ValueId()>>>{},
-                seed));
-        ASSERT_EQ(createRandomlyFilledIdTable(
-                      NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
-                      []() { return ad_utility::testing::VocabId(1); }, seed),
-                  createRandomlyFilledIdTable(
-                      NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
-                      []() { return ad_utility::testing::VocabId(1); }, seed));
-        ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
-                                              JoinColumnAndBounds{}, seed),
-                  createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
-                                              JoinColumnAndBounds{}, seed));
-        ASSERT_EQ(createRandomlyFilledIdTable(
-                      NUM_ROWS, NUM_COLUMNS, std::vector<JoinColumnAndBounds>{},
-                      seed),
-                  createRandomlyFilledIdTable(
-                      NUM_ROWS, NUM_COLUMNS, std::vector<JoinColumnAndBounds>{},
-                      seed));
-        ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed),
-                  createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed));
-      });
+  std::ranges::for_each(createArrayOfRandomSeeds<5>(), [](const Seed seed) {
+    // Simply generate and compare.
+    ASSERT_EQ(
+        createRandomlyFilledIdTable(
+            NUM_ROWS, NUM_COLUMNS,
+            std::vector<std::pair<size_t, std::function<ValueId()>>>{}, seed),
+        createRandomlyFilledIdTable(
+            NUM_ROWS, NUM_COLUMNS,
+            std::vector<std::pair<size_t, std::function<ValueId()>>>{}, seed));
+    ASSERT_EQ(createRandomlyFilledIdTable(
+                  NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
+                  []() { return ad_utility::testing::VocabId(1); }, seed),
+              createRandomlyFilledIdTable(
+                  NUM_ROWS, NUM_COLUMNS, std::vector<size_t>{},
+                  []() { return ad_utility::testing::VocabId(1); }, seed));
+    ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
+                                          JoinColumnAndBounds{}, seed),
+              createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
+                                          JoinColumnAndBounds{}, seed));
+    ASSERT_EQ(
+        createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
+                                    std::vector<JoinColumnAndBounds>{}, seed),
+        createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS,
+                                    std::vector<JoinColumnAndBounds>{}, seed));
+    ASSERT_EQ(createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed),
+              createRandomlyFilledIdTable(NUM_ROWS, NUM_COLUMNS, seed));
+  });
 }

--- a/test/LimitOffsetClauseTest.cpp
+++ b/test/LimitOffsetClauseTest.cpp
@@ -43,7 +43,7 @@ TEST(LimitOffsetClause, upperBound) {
 }
 
 TEST(LimitOffsetClause, randomTestingOfInvariants) {
-  FastRandomIntGenerator<uint64_t> r;
+  ad_utility::FastRandomIntGenerator<uint64_t> r;
   for (size_t i = 0; i < 10'000; ++i) {
     LimitOffsetClause l;
     l._limit = r();

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -87,7 +87,7 @@ struct NumericalRange {
   const T maximum_;
 
   NumericalRange(const T minimum, const T maximum)
-      : minimum_{std::move(minimum)}, maximum_{std::move(maximum)} {
+      : minimum_{minimum}, maximum_{maximum} {
     AD_CORRECTNESS_CHECK(minimum <= maximum);
   }
 };

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -11,20 +11,12 @@
 #include <ranges>
 #include <type_traits>
 
+#include "../test/util/RandomTestHelpers.h"
 #include "util/Exception.h"
 #include "util/GTestHelpers.h"
 #include "util/Random.h"
 #include "util/SourceLocation.h"
 #include "util/TypeTraits.h"
-
-// Create a array of non-deterministic random seeds for use with random number
-// generators.
-template <size_t NumSeeds>
-static std::array<unsigned int, NumSeeds> createArrayOfRandomSeeds() {
-  std::array<unsigned int, NumSeeds> seeds{};
-  std::ranges::generate(seeds, []() { return std::random_device{}(); });
-  return std::move(seeds);
-}
 
 /*
 @brief Test, if random number generators, that take a seed, produce the same

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -18,6 +18,8 @@
 #include "util/SourceLocation.h"
 #include "util/TypeTraits.h"
 
+namespace ad_utility {
+
 /*
 @brief Test, if random number generators, that take a seed, produce the same
 numbers for the same seed.
@@ -232,3 +234,5 @@ TEST(RandomShuffleTest, Seed) {
             });
       });
 }
+
+}  // namespace ad_utility

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -1,0 +1,244 @@
+// Copyright 2023, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Andre Schlegel (October of 2023, schlegea@informatik.uni-freiburg.de)
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <random>
+#include <ranges>
+#include <type_traits>
+
+#include "util/Exception.h"
+#include "util/GTestHelpers.h"
+#include "util/Random.h"
+#include "util/SourceLocation.h"
+#include "util/TypeTraits.h"
+
+// Create a array of non-deterministic random seeds for use with random number
+// generators.
+template <size_t NumSeeds>
+static std::array<unsigned int, NumSeeds> createArrayOfRandomSeeds() {
+  std::array<unsigned int, NumSeeds> seeds{};
+  std::ranges::generate(seeds, []() { return std::random_device{}(); });
+  return std::move(seeds);
+}
+
+/*
+@brief Test, if random number generators, that take a seed, produce the same
+numbers for the same seed.
+
+@param randomNumberGeneratorFactory An invocable object, that should return a
+random number generator, using the given seed.
+*/
+template <std::invocable<unsigned int> T>
+void testSeed(
+    T randomNumberGeneratorFactory,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
+  // For generating better messages, when failing a test.
+  auto trace{generateLocationTrace(l, "testSeed")};
+
+  // For how many random seeds should the test be done for?
+  constexpr size_t NUM_SEEDS = 5;
+  static_assert(NUM_SEEDS > 1);
+
+  // How many instances of the random number generator, with the given
+  // seed, should we compare?
+  constexpr size_t NUM_GENERATORS = 3;
+  static_assert(NUM_GENERATORS > 1);
+
+  // How many random numbers should be generated for comparison?
+  constexpr size_t NUM_RANDOM_NUMBER = 50;
+  static_assert(NUM_RANDOM_NUMBER > 1);
+
+  // For every seed test, if the random number generators return the same
+  // numbers.
+  std::ranges::for_each(
+      createArrayOfRandomSeeds<NUM_SEEDS>(),
+      [&randomNumberGeneratorFactory](const unsigned int seed) {
+        // What type of generator does the factory create?
+        using GeneratorType = std::invoke_result_t<T, unsigned int>;
+
+        // What kind of number does the generator return?
+        using NumberType = std::invoke_result_t<GeneratorType>;
+
+        // The generators, that should create the same numbers.
+        std::array<GeneratorType, NUM_GENERATORS> generators;
+        std::ranges::generate(
+            generators, [&randomNumberGeneratorFactory, &seed]() {
+              return std::invoke(randomNumberGeneratorFactory, seed);
+            });
+
+        // Do they generators create the same numbers?
+        for (size_t numCall = 0; numCall < NUM_RANDOM_NUMBER; numCall++) {
+          const NumberType expectedNumber = std::invoke(generators.front());
+
+          std::ranges::for_each(std::views::drop(generators, 1),
+                                [&expectedNumber](GeneratorType& g) {
+                                  ASSERT_EQ(std::invoke(g), expectedNumber);
+                                });
+        }
+      });
+}
+
+TEST(RandomNumberGeneratorTest, FastRandomIntGenerator) {
+  testSeed(
+      [](unsigned int seed) { return FastRandomIntGenerator<size_t>{seed}; });
+}
+
+// Describes an inclusive numerical range `[min, max]`.
+template <typename T>
+struct NumericalRange {
+  const T minimum_;
+  const T maximum_;
+
+  NumericalRange(const T minimum, const T maximum)
+      : minimum_{std::move(minimum)}, maximum_{std::move(maximum)} {
+    AD_CORRECTNESS_CHECK(minimum <= maximum);
+  }
+};
+
+/*
+@brief Test, if random number generators, that take a seed and a range, produce
+the same numbers for the same seed and range.
+
+@param randomNumberGeneratorFactory An invocable object, that should return a
+random number generator, using the given range and seed. Functionparameters
+should be `RangeNumberType rangeMin, RangeNumberType rangeMax, unsigned int
+seed`.
+@param ranges The ranges, that should be used.
+*/
+template <typename RangeNumberType,
+          std::invocable<RangeNumberType, RangeNumberType, unsigned int>
+              GeneratorFactory>
+void testSeedWithRange(
+    GeneratorFactory randomNumberGeneratorFactory,
+    const std::vector<NumericalRange<RangeNumberType>>& ranges,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
+  // For generating better messages, when failing a test.
+  auto trace{generateLocationTrace(l, "testSeedWithRange")};
+
+  std::ranges::for_each(ranges, [&randomNumberGeneratorFactory](
+                                    const NumericalRange<RangeNumberType>& r) {
+    testSeed([&r, &randomNumberGeneratorFactory](unsigned int seed) {
+      return std::invoke(randomNumberGeneratorFactory, r.minimum_, r.maximum_,
+                         seed);
+    });
+  });
+}
+
+/*
+@brief Test, if a given random number generator only creates numbers in a range.
+
+@tparam Generator The random number generator. Must have a constructor, whose
+first argument is the minimum of the range and the second argument the maximum
+of the range.
+
+@param ranges The ranges, for which should be tested for.
+*/
+template <typename Generator, typename RangeNumberType>
+requires std::constructible_from<Generator, RangeNumberType, RangeNumberType> &&
+         std::invocable<Generator> &&
+         ad_utility::isSimilar<std::invoke_result_t<Generator>, RangeNumberType>
+void testRange(
+    const std::vector<NumericalRange<RangeNumberType>>& ranges,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
+  // For generating better messages, when failing a test.
+  auto trace{generateLocationTrace(l, "testRange")};
+
+  // How many random numbers should be generated?
+  constexpr size_t NUM_RANDOM_NUMBER = 500;
+  static_assert(NUM_RANDOM_NUMBER > 1);
+
+  std::ranges::for_each(ranges, [](const NumericalRange<RangeNumberType>& r) {
+    Generator generator(r.minimum_, r.maximum_);
+    const auto& generatedNumber = std::invoke(generator);
+    ASSERT_LE(generatedNumber, r.maximum_);
+    ASSERT_GE(generatedNumber, r.minimum_);
+  });
+}
+
+TEST(RandomNumberGeneratorTest, SlowRandomIntGenerator) {
+  testSeed([](unsigned int seed) {
+    return SlowRandomIntGenerator<size_t>{std::numeric_limits<size_t>::min(),
+                                          std::numeric_limits<size_t>::max(),
+                                          seed};
+  });
+
+  // For use withing the range tests.
+  const std::vector<NumericalRange<size_t>> ranges{
+      {4ul, 7ul}, {200ul, 70171ul}, {71747ul, 1936556173ul}};
+
+  testSeedWithRange(
+      [](const auto rangeMin, const auto rangeMax, unsigned int seed) {
+        return SlowRandomIntGenerator{rangeMin, rangeMax, seed};
+      },
+      ranges);
+
+  testRange<SlowRandomIntGenerator<size_t>>(ranges);
+}
+
+TEST(RandomNumberGeneratorTest, RandomDoubleGenerator) {
+  testSeed([](unsigned int seed) {
+    return RandomDoubleGenerator{std::numeric_limits<double>::min(),
+                                 std::numeric_limits<double>::max(), seed};
+  });
+
+  // For use withing the range tests.
+  const std::vector<NumericalRange<double>> ranges{
+      {4.74717, 7.4}, {-200.0771370, -70.77713}, {-71747.6666, 1936556173.}};
+
+  // Repeat this test, but this time do it inside of a range.
+  testSeedWithRange(
+      [](const auto rangeMin, const auto rangeMax, unsigned int seed) {
+        return RandomDoubleGenerator{rangeMin, rangeMax, seed};
+      },
+      ranges);
+
+  testRange<RandomDoubleGenerator>(ranges);
+}
+
+// Small test, if `randomShuffle` shuffles things the same way, if given the
+// same seed.
+TEST(RandomShuffleTest, Seed) {
+  // For how many random seeds should the test be done for?
+  constexpr size_t NUM_SEEDS = 5;
+  static_assert(NUM_SEEDS > 1);
+
+  // How many shuffled `std::array` should we compare per seed? And how big
+  // should they be?
+  constexpr size_t NUM_SHUFFLED_ARRAY = 3;
+  constexpr size_t ARRAY_LENGTH = 100;
+  static_assert(NUM_SHUFFLED_ARRAY > 1 && ARRAY_LENGTH > 1);
+
+  /*
+  For every random seed test, if the shuffled array is the same, if given
+  identical input and seed.
+  */
+  std::ranges::for_each(
+      createArrayOfRandomSeeds<NUM_SEEDS>(), [](const unsigned int seed) {
+        std::array<std::array<unsigned int, ARRAY_LENGTH>, NUM_SHUFFLED_ARRAY>
+            inputArrays{};
+
+        // Fill the first input array with random values, then copy it into the
+        // other 'slots'.
+        inputArrays[0] = createArrayOfRandomSeeds<ARRAY_LENGTH>();
+        std::ranges::fill(std::views::drop(inputArrays, 1),
+                          inputArrays.front());
+
+        // Shuffle and compare, if they are all the same.
+        std::ranges::for_each(
+            inputArrays,
+            [&seed](std::array<unsigned int, ARRAY_LENGTH>& inputArray) {
+              randomShuffle(inputArray.begin(), inputArray.end(), seed);
+            });
+        std::ranges::for_each(
+            std::views::drop(inputArrays, 1),
+            [&inputArrays](
+                const std::array<unsigned int, ARRAY_LENGTH>& inputArray) {
+              ASSERT_EQ(inputArrays.front(), inputArray);
+            });
+      });
+}

--- a/test/SortPerformanceEstimatorTest.cpp
+++ b/test/SortPerformanceEstimatorTest.cpp
@@ -21,7 +21,7 @@ TEST(SortPerformanceEstimator, TestManyEstimates) {
   auto t =
       SortPerformanceEstimator{allocator, std::numeric_limits<size_t>::max()};
 
-  SlowRandomIntGenerator<int> dice(1, 6);
+  ad_utility::SlowRandomIntGenerator<int> dice(1, 6);
 
   for (size_t numColumns = 1; numColumns < 15; numColumns++) {
     bool isFirst = true;

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -115,7 +115,8 @@ TEST(ValueIdComparators, NumericTypes) {
         getRangeForDatatype(ids.begin(), ids.end(), datatype);
     auto numEntries = endOfDatatype - beginOfDatatype;
     AD_CONTRACT_CHECK(numEntries > 0);
-    auto getRandomIndex = SlowRandomIntGenerator<uint64_t>(0, numEntries - 1);
+    auto getRandomIndex =
+        ad_utility::SlowRandomIntGenerator<uint64_t>(0, numEntries - 1);
 
     for (size_t i = 0; i < 200; ++i) {
       auto randomId = *(beginOfDatatype + getRandomIndex());
@@ -222,7 +223,8 @@ TEST(ValueIdComparators, IndexTypes) {
         getRangeForDatatype(ids.begin(), ids.end(), datatype);
     auto numEntries = endOfDatatype - beginOfDatatype;
     AD_CONTRACT_CHECK(numEntries > 0);
-    auto getRandomIndex = SlowRandomIntGenerator<uint64_t>(0, numEntries - 1);
+    auto getRandomIndex =
+        ad_utility::SlowRandomIntGenerator<uint64_t>(0, numEntries - 1);
 
     auto isTypeMatching = [&](ValueId id) {
       return id.getDatatype() == datatype;

--- a/test/ValueIdTestHelpers.h
+++ b/test/ValueIdTestHelpers.h
@@ -15,23 +15,29 @@ static constexpr size_t numElements = 10'000;
 static constexpr size_t numElements = 10;
 #endif
 
-inline auto positiveRepresentableDoubleGenerator = RandomDoubleGenerator(
-    ValueId::minPositiveDouble, std::numeric_limits<double>::max());
-inline auto negativeRepresentableDoubleGenerator = RandomDoubleGenerator(
-    -std::numeric_limits<double>::max(), -ValueId::minPositiveDouble);
-inline auto nonRepresentableDoubleGenerator = RandomDoubleGenerator(
+inline auto positiveRepresentableDoubleGenerator =
+    ad_utility::RandomDoubleGenerator(ValueId::minPositiveDouble,
+                                      std::numeric_limits<double>::max());
+inline auto negativeRepresentableDoubleGenerator =
+    ad_utility::RandomDoubleGenerator(-std::numeric_limits<double>::max(),
+                                      -ValueId::minPositiveDouble);
+inline auto nonRepresentableDoubleGenerator = ad_utility::RandomDoubleGenerator(
     -ValueId::minPositiveDouble, ValueId::minPositiveDouble);
 inline auto indexGenerator =
-    SlowRandomIntGenerator<uint64_t>(0, ValueId::maxIndex);
-inline auto invalidIndexGenerator = SlowRandomIntGenerator<uint64_t>(
-    ValueId::maxIndex, std::numeric_limits<uint64_t>::max());
+    ad_utility::SlowRandomIntGenerator<uint64_t>(0, ValueId::maxIndex);
+inline auto invalidIndexGenerator =
+    ad_utility::SlowRandomIntGenerator<uint64_t>(
+        ValueId::maxIndex, std::numeric_limits<uint64_t>::max());
 
-inline auto nonOverflowingNBitGenerator = SlowRandomIntGenerator<int64_t>(
-    ValueId::IntegerType::min(), ValueId::IntegerType::max());
-inline auto overflowingNBitGenerator = SlowRandomIntGenerator<int64_t>(
-    ValueId::IntegerType::max() + 1, std::numeric_limits<int64_t>::max());
-inline auto underflowingNBitGenerator = SlowRandomIntGenerator<int64_t>(
-    std::numeric_limits<int64_t>::min(), ValueId::IntegerType::min() - 1);
+inline auto nonOverflowingNBitGenerator =
+    ad_utility::SlowRandomIntGenerator<int64_t>(ValueId::IntegerType::min(),
+                                                ValueId::IntegerType::max());
+inline auto overflowingNBitGenerator =
+    ad_utility::SlowRandomIntGenerator<int64_t>(
+        ValueId::IntegerType::max() + 1, std::numeric_limits<int64_t>::max());
+inline auto underflowingNBitGenerator =
+    ad_utility::SlowRandomIntGenerator<int64_t>(
+        std::numeric_limits<int64_t>::min(), ValueId::IntegerType::min() - 1);
 
 // Some helper functions to convert uint64_t values directly to and from index
 // type `ValueId`s.
@@ -61,7 +67,7 @@ inline uint64_t getWordVocabIndex(ValueId id) {
 
 inline auto addIdsFromGenerator = [](auto& generator, auto makeIds,
                                      std::vector<ValueId>& ids) {
-  SlowRandomIntGenerator<uint8_t> numRepetitionGenerator(1, 4);
+  ad_utility::SlowRandomIntGenerator<uint8_t> numRepetitionGenerator(1, 4);
   for (size_t i = 0; i < numElements; ++i) {
     auto randomValue = generator();
     auto numRepetitions = numRepetitionGenerator();
@@ -92,7 +98,7 @@ inline auto makeRandomDoubleIds = []() {
     ids.push_back(ValueId::makeFromDouble(max));
     ids.push_back(ValueId::makeFromDouble(min));
   }
-  randomShuffle(ids.begin(), ids.end());
+  ad_utility::randomShuffle(ids.begin(), ids.end());
   return ids;
 };
 inline auto makeRandomIds = []() {
@@ -109,7 +115,7 @@ inline auto makeRandomIds = []() {
     ids.push_back(ValueId::makeUndefined());
   }
 
-  randomShuffle(ids.begin(), ids.end());
+  ad_utility::randomShuffle(ids.begin(), ids.end());
   return ids;
 };
 

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -49,7 +49,7 @@ TEST(Views, UniqueView) {
   std::vector<int> ints;
   const uint64_t numInts = 50'000;
   ints.reserve(numInts);
-  SlowRandomIntGenerator<int> r;
+  ad_utility::SlowRandomIntGenerator<int> r;
   for (size_t i = 0; i < numInts; ++i) {
     ints.push_back(r());
   }

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -102,7 +102,7 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
-    const unsigned int randomNumberGeneratorSeed) {
+    const Seed randomSeed) {
   AD_CONTRACT_CHECK(numberRows > 0 && numberColumns > 0);
 
   // Views for clearer access.
@@ -125,8 +125,8 @@ IdTable createRandomlyFilledIdTable(
       joinColumnGeneratorView, [](auto func) { return func != nullptr; }));
 
   // The random number generators for normal entries.
-  SlowRandomIntGenerator<size_t> randomNumberGenerator(
-      0, ValueId::maxIndex, randomNumberGeneratorSeed);
+  SlowRandomIntGenerator<size_t> randomNumberGenerator(0, ValueId::maxIndex,
+                                                       randomSeed);
   std::function<ValueId()> normalEntryGenerator = [&randomNumberGenerator]() {
     // `IdTable`s don't take raw numbers, you have to transform them first.
     return ad_utility::testing::VocabId(randomNumberGenerator());
@@ -155,11 +155,11 @@ IdTable createRandomlyFilledIdTable(
 }
 
 // ____________________________________________________________________________
-IdTable createRandomlyFilledIdTable(
-    const size_t numberRows, const size_t numberColumns,
-    const std::vector<size_t>& joinColumns,
-    const std::function<ValueId()>& generator,
-    const unsigned int randomNumberGeneratorSeed) {
+IdTable createRandomlyFilledIdTable(const size_t numberRows,
+                                    const size_t numberColumns,
+                                    const std::vector<size_t>& joinColumns,
+                                    const std::function<ValueId()>& generator,
+                                    const Seed randomSeed) {
   // Is the generator not empty?
   AD_CONTRACT_CHECK(generator != nullptr);
 
@@ -178,14 +178,14 @@ IdTable createRandomlyFilledIdTable(
             return std::make_pair(
                 num, std::function{[&generator]() { return generator(); }});
           }),
-      randomNumberGeneratorSeed);
+      randomSeed);
 }
 
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
-    const unsigned int randomNumberGeneratorSeed) {
+    const Seed randomSeed) {
   // Entries in IdTables have a max size.
   constexpr size_t maxIdSize = ValueId::maxIndex;
 
@@ -207,36 +207,33 @@ IdTable createRandomlyFilledIdTable(
         return std::make_pair(
             j.joinColumn_,
             // Each column gets its own random generator.
-            std::function{[generator = SlowRandomIntGenerator<size_t>(
-                               j.lowerBound_, j.upperBound_,
-                               j.randomNumberGeneratorSeed_)]() mutable {
-              // `IdTable`s don't take raw numbers, you have to transform
-              // them first.
-              return ad_utility::testing::VocabId(generator());
-            }});
+            std::function{
+                [generator = SlowRandomIntGenerator<size_t>(
+                     j.lowerBound_, j.upperBound_, j.randomSeed_)]() mutable {
+                  // `IdTable`s don't take raw numbers, you have to transform
+                  // them first.
+                  return ad_utility::testing::VocabId(generator());
+                }});
       });
 
   return createRandomlyFilledIdTable(numberRows, numberColumns,
-                                     joinColumnAndGenerator,
-                                     randomNumberGeneratorSeed);
+                                     joinColumnAndGenerator, randomSeed);
 }
 
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const JoinColumnAndBounds& joinColumnAndBounds,
-    const unsigned int randomNumberGeneratorSeed) {
+    const JoinColumnAndBounds& joinColumnAndBounds, const Seed randomSeed) {
   // Just call the other overload.
-  return createRandomlyFilledIdTable(numberRows, numberColumns,
-                                     std::vector{joinColumnAndBounds},
-                                     randomNumberGeneratorSeed);
+  return createRandomlyFilledIdTable(
+      numberRows, numberColumns, std::vector{joinColumnAndBounds}, randomSeed);
 }
 
 // ____________________________________________________________________________
-IdTable createRandomlyFilledIdTable(
-    const size_t numberRows, const size_t numberColumns,
-    const unsigned int randomNumberGeneratorSeed) {
+IdTable createRandomlyFilledIdTable(const size_t numberRows,
+                                    const size_t numberColumns,
+                                    const Seed randomSeed) {
   return createRandomlyFilledIdTable(numberRows, numberColumns,
                                      std::vector<JoinColumnAndBounds>{},
-                                     randomNumberGeneratorSeed);
+                                     randomSeed);
 }

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -101,7 +101,8 @@ IdTable generateIdTable(
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
-        joinColumnWithGenerator) {
+        joinColumnWithGenerator,
+    const unsigned int randomNumberGeneratorSeed) {
   AD_CONTRACT_CHECK(numberRows > 0 && numberColumns > 0);
 
   // Views for clearer access.
@@ -124,7 +125,8 @@ IdTable createRandomlyFilledIdTable(
       joinColumnGeneratorView, [](auto func) { return func != nullptr; }));
 
   // The random number generators for normal entries.
-  SlowRandomIntGenerator<size_t> randomNumberGenerator(0, ValueId::maxIndex);
+  SlowRandomIntGenerator<size_t> randomNumberGenerator(
+      0, ValueId::maxIndex, randomNumberGeneratorSeed);
   std::function<ValueId()> normalEntryGenerator = [&randomNumberGenerator]() {
     // `IdTable`s don't take raw numbers, you have to transform them first.
     return ad_utility::testing::VocabId(randomNumberGenerator());
@@ -153,32 +155,37 @@ IdTable createRandomlyFilledIdTable(
 }
 
 // ____________________________________________________________________________
-IdTable createRandomlyFilledIdTable(const size_t numberRows,
-                                    const size_t numberColumns,
-                                    const std::vector<size_t>& joinColumns,
-                                    const std::function<ValueId()>& generator) {
+IdTable createRandomlyFilledIdTable(
+    const size_t numberRows, const size_t numberColumns,
+    const std::vector<size_t>& joinColumns,
+    const std::function<ValueId()>& generator,
+    const unsigned int randomNumberGeneratorSeed) {
   // Is the generator not empty?
   AD_CONTRACT_CHECK(generator != nullptr);
 
   // Creating the table.
   return createRandomlyFilledIdTable(
       numberRows, numberColumns,
-      ad_utility::transform(joinColumns, [&generator](const size_t num) {
-        /*
-        Simply passing `generator` doesn't work, because it would be copied,
-        which would lead to different behavior. After all, the columns would no
-        longer share a function with one internal state, but each have their own
-        separate function with its own internal state.
-        */
-        return std::make_pair(
-            num, std::function{[&generator]() { return generator(); }});
-      }));
+      ad_utility::transform(
+          joinColumns,
+          [&generator](const size_t num) {
+            /*
+            Simply passing `generator` doesn't work, because it would be copied,
+            which would lead to different behavior. After all, the columns would
+            no longer share a function with one internal state, but each have
+            their own separate function with its own internal state.
+            */
+            return std::make_pair(
+                num, std::function{[&generator]() { return generator(); }});
+          }),
+      randomNumberGeneratorSeed);
 }
 
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds) {
+    const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
+    const unsigned int randomNumberGeneratorSeed) {
   // Entries in IdTables have a max size.
   constexpr size_t maxIdSize = ValueId::maxIndex;
 
@@ -201,7 +208,8 @@ IdTable createRandomlyFilledIdTable(
             j.joinColumn_,
             // Each column gets its own random generator.
             std::function{[generator = SlowRandomIntGenerator<size_t>(
-                               j.lowerBound_, j.upperBound_)]() mutable {
+                               j.lowerBound_, j.upperBound_,
+                               j.randomNumberGeneratorSeed_)]() mutable {
               // `IdTable`s don't take raw numbers, you have to transform
               // them first.
               return ad_utility::testing::VocabId(generator());
@@ -209,14 +217,26 @@ IdTable createRandomlyFilledIdTable(
       });
 
   return createRandomlyFilledIdTable(numberRows, numberColumns,
-                                     joinColumnAndGenerator);
+                                     joinColumnAndGenerator,
+                                     randomNumberGeneratorSeed);
 }
 
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const JoinColumnAndBounds& joinColumnAndBounds) {
+    const JoinColumnAndBounds& joinColumnAndBounds,
+    const unsigned int randomNumberGeneratorSeed) {
   // Just call the other overload.
   return createRandomlyFilledIdTable(numberRows, numberColumns,
-                                     std::vector{joinColumnAndBounds});
+                                     std::vector{joinColumnAndBounds},
+                                     randomNumberGeneratorSeed);
+}
+
+// ____________________________________________________________________________
+IdTable createRandomlyFilledIdTable(
+    const size_t numberRows, const size_t numberColumns,
+    const unsigned int randomNumberGeneratorSeed) {
+  return createRandomlyFilledIdTable(numberRows, numberColumns,
+                                     std::vector<JoinColumnAndBounds>{},
+                                     randomNumberGeneratorSeed);
 }

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -2,13 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (Januar of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "../test/util/IdTableHelpers.h"
-
 #include <absl/strings/str_cat.h>
 
 #include <algorithm>
 #include <utility>
 
+#include "../test/util/IdTableHelpers.h"
 #include "engine/idTable/IdTable.h"
 #include "global/ValueId.h"
 #include "util/Algorithm.h"
@@ -102,7 +101,7 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
-    const Seed randomSeed) {
+    const RandomSeed randomSeed) {
   AD_CONTRACT_CHECK(numberRows > 0 && numberColumns > 0);
 
   // Views for clearer access.
@@ -159,7 +158,7 @@ IdTable createRandomlyFilledIdTable(const size_t numberRows,
                                     const size_t numberColumns,
                                     const std::vector<size_t>& joinColumns,
                                     const std::function<ValueId()>& generator,
-                                    const Seed randomSeed) {
+                                    const RandomSeed randomSeed) {
   // Is the generator not empty?
   AD_CONTRACT_CHECK(generator != nullptr);
 
@@ -185,7 +184,7 @@ IdTable createRandomlyFilledIdTable(const size_t numberRows,
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
-    const Seed randomSeed) {
+    const RandomSeed randomSeed) {
   // Entries in IdTables have a max size.
   constexpr size_t maxIdSize = ValueId::maxIndex;
 
@@ -223,7 +222,8 @@ IdTable createRandomlyFilledIdTable(
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const JoinColumnAndBounds& joinColumnAndBounds, const Seed randomSeed) {
+    const JoinColumnAndBounds& joinColumnAndBounds,
+    const RandomSeed randomSeed) {
   // Just call the other overload.
   return createRandomlyFilledIdTable(
       numberRows, numberColumns, std::vector{joinColumnAndBounds}, randomSeed);
@@ -232,7 +232,7 @@ IdTable createRandomlyFilledIdTable(
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(const size_t numberRows,
                                     const size_t numberColumns,
-                                    const Seed randomSeed) {
+                                    const RandomSeed randomSeed) {
   return createRandomlyFilledIdTable(numberRows, numberColumns,
                                      std::vector<JoinColumnAndBounds>{},
                                      randomSeed);

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -2,12 +2,13 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (Januar of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../test/util/IdTableHelpers.h"
+
 #include <absl/strings/str_cat.h>
 
 #include <algorithm>
 #include <utility>
 
-#include "../test/util/IdTableHelpers.h"
 #include "engine/idTable/IdTable.h"
 #include "global/ValueId.h"
 #include "util/Algorithm.h"
@@ -101,7 +102,7 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
-    const RandomSeed randomSeed) {
+    const ad_utility::RandomSeed randomSeed) {
   AD_CONTRACT_CHECK(numberRows > 0 && numberColumns > 0);
 
   // Views for clearer access.
@@ -124,8 +125,8 @@ IdTable createRandomlyFilledIdTable(
       joinColumnGeneratorView, [](auto func) { return func != nullptr; }));
 
   // The random number generators for normal entries.
-  SlowRandomIntGenerator<size_t> randomNumberGenerator(0, ValueId::maxIndex,
-                                                       randomSeed);
+  ad_utility::SlowRandomIntGenerator<size_t> randomNumberGenerator(
+      0, ValueId::maxIndex, randomSeed);
   std::function<ValueId()> normalEntryGenerator = [&randomNumberGenerator]() {
     // `IdTable`s don't take raw numbers, you have to transform them first.
     return ad_utility::testing::VocabId(randomNumberGenerator());
@@ -158,7 +159,7 @@ IdTable createRandomlyFilledIdTable(const size_t numberRows,
                                     const size_t numberColumns,
                                     const std::vector<size_t>& joinColumns,
                                     const std::function<ValueId()>& generator,
-                                    const RandomSeed randomSeed) {
+                                    const ad_utility::RandomSeed randomSeed) {
   // Is the generator not empty?
   AD_CONTRACT_CHECK(generator != nullptr);
 
@@ -184,7 +185,7 @@ IdTable createRandomlyFilledIdTable(const size_t numberRows,
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
-    const RandomSeed randomSeed) {
+    const ad_utility::RandomSeed randomSeed) {
   // Entries in IdTables have a max size.
   constexpr size_t maxIdSize = ValueId::maxIndex;
 
@@ -207,7 +208,7 @@ IdTable createRandomlyFilledIdTable(
             j.joinColumn_,
             // Each column gets its own random generator.
             std::function{
-                [generator = SlowRandomIntGenerator<size_t>(
+                [generator = ad_utility::SlowRandomIntGenerator<size_t>(
                      j.lowerBound_, j.upperBound_, j.randomSeed_)]() mutable {
                   // `IdTable`s don't take raw numbers, you have to transform
                   // them first.
@@ -223,7 +224,7 @@ IdTable createRandomlyFilledIdTable(
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const JoinColumnAndBounds& joinColumnAndBounds,
-    const RandomSeed randomSeed) {
+    const ad_utility::RandomSeed randomSeed) {
   // Just call the other overload.
   return createRandomlyFilledIdTable(
       numberRows, numberColumns, std::vector{joinColumnAndBounds}, randomSeed);
@@ -232,7 +233,7 @@ IdTable createRandomlyFilledIdTable(
 // ____________________________________________________________________________
 IdTable createRandomlyFilledIdTable(const size_t numberRows,
                                     const size_t numberColumns,
-                                    const RandomSeed randomSeed) {
+                                    const ad_utility::RandomSeed randomSeed) {
   return createRandomlyFilledIdTable(numberRows, numberColumns,
                                      std::vector<JoinColumnAndBounds>{},
                                      randomSeed);

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -120,8 +120,8 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
-    const Seed randomSeed =
-        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const RandomSeed randomSeed =
+        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Creates a `IdTable`, where the content of the join columns is given via
@@ -140,8 +140,8 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<size_t>& joinColumns,
     const std::function<ValueId()>& generator,
-    const Seed randomSeed =
-        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const RandomSeed randomSeed =
+        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 // Describes a join column together with an inclusive range of numbers, defined
 // as [lowerBound, upperBound], and the seed for the random number generator.
@@ -149,7 +149,8 @@ struct JoinColumnAndBounds {
   const size_t joinColumn_;
   const size_t lowerBound_;
   const size_t upperBound_;
-  const Seed randomSeed_ = Seed::make(FastRandomIntGenerator<unsigned int>{}());
+  const RandomSeed randomSeed_ =
+      RandomSeed::make(FastRandomIntGenerator<unsigned int>{}());
 };
 
 /*
@@ -166,8 +167,8 @@ generates the content for the non join column entries.
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const JoinColumnAndBounds& joinColumnAndBounds,
-    const Seed randomSeed =
-        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const RandomSeed randomSeed =
+        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Return a IdTable, that is randomly filled. The range of numbers
@@ -183,8 +184,8 @@ generates the content for the non join column entries.
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
-    const Seed randomSeed =
-        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const RandomSeed randomSeed =
+        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Return a IdTable, that is completly randomly filled.
@@ -196,5 +197,5 @@ generates the content.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const Seed randomSeed =
-        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const RandomSeed randomSeed =
+        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -120,8 +120,8 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
-    const RandomSeed randomSeed =
-        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const ad_utility::RandomSeed randomSeed = ad_utility::RandomSeed::make(
+        ad_utility::FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Creates a `IdTable`, where the content of the join columns is given via
@@ -140,8 +140,8 @@ IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<size_t>& joinColumns,
     const std::function<ValueId()>& generator,
-    const RandomSeed randomSeed =
-        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const ad_utility::RandomSeed randomSeed = ad_utility::RandomSeed::make(
+        ad_utility::FastRandomIntGenerator<unsigned int>{}()));
 
 // Describes a join column together with an inclusive range of numbers, defined
 // as [lowerBound, upperBound], and the seed for the random number generator.
@@ -149,8 +149,8 @@ struct JoinColumnAndBounds {
   const size_t joinColumn_;
   const size_t lowerBound_;
   const size_t upperBound_;
-  const RandomSeed randomSeed_ =
-      RandomSeed::make(FastRandomIntGenerator<unsigned int>{}());
+  const ad_utility::RandomSeed randomSeed_ = ad_utility::RandomSeed::make(
+      ad_utility::FastRandomIntGenerator<unsigned int>{}());
 };
 
 /*
@@ -167,8 +167,8 @@ generates the content for the non join column entries.
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const JoinColumnAndBounds& joinColumnAndBounds,
-    const RandomSeed randomSeed =
-        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const ad_utility::RandomSeed randomSeed = ad_utility::RandomSeed::make(
+        ad_utility::FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Return a IdTable, that is randomly filled. The range of numbers
@@ -184,8 +184,8 @@ generates the content for the non join column entries.
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
-    const RandomSeed randomSeed =
-        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const ad_utility::RandomSeed randomSeed = ad_utility::RandomSeed::make(
+        ad_utility::FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Return a IdTable, that is completly randomly filled.
@@ -197,5 +197,5 @@ generates the content.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const RandomSeed randomSeed =
-        RandomSeed::make(FastRandomIntGenerator<unsigned int>{}()));
+    const ad_utility::RandomSeed randomSeed = ad_utility::RandomSeed::make(
+        ad_utility::FastRandomIntGenerator<unsigned int>{}()));

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -106,17 +106,22 @@ IdTable generateIdTable(
 
 /*
 @brief Create an `IdTable`, where the content of the join columns are given via
-repeatedly called generator functions (one function per join column).
+repeatedly called generator functions (one function per join column) and other
+entries are random.
 
 @param numberRows numberColumns The number of rows and columns, the table should
 have.
 @param joinColumnWithGenerator Every pair describes the position of a join
 column and the function, which will be called, to generate it's entries.
+@param randomNumberGeneratorSeed The seed for the random number generator, that
+generates the content for the non join column entries.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
-        joinColumnWithGenerator);
+        joinColumnWithGenerator,
+    const unsigned int randomNumberGeneratorSeed =
+        FastRandomIntGenerator<unsigned int>{}());
 
 /*
 @brief Creates a `IdTable`, where the content of the join columns is given via
@@ -128,48 +133,69 @@ have.
 @param generator The generator for the join columns. Order of calls: Row per
 row, starting from row 0, and in a row for every join column, with the join
 columns ordered by their column. Starting from column 0.
+@param randomNumberGeneratorSeed The seed for the random number generator, that
+generates the content for the non join column entries.
 */
-IdTable createRandomlyFilledIdTable(const size_t numberRows,
-                                    const size_t numberColumns,
-                                    const std::vector<size_t>& joinColumns,
-                                    const std::function<ValueId()>& generator);
+IdTable createRandomlyFilledIdTable(
+    const size_t numberRows, const size_t numberColumns,
+    const std::vector<size_t>& joinColumns,
+    const std::function<ValueId()>& generator,
+    const unsigned int randomNumberGeneratorSeed =
+        FastRandomIntGenerator<unsigned int>{}());
 
 // Describes a join column together with an inclusive range of numbers, defined
-// as [lowerBound, upperBound];
+// as [lowerBound, upperBound], and the seed for the random number generator.
 struct JoinColumnAndBounds {
   const size_t joinColumn_;
   const size_t lowerBound_;
   const size_t upperBound_;
+  const unsigned int randomNumberGeneratorSeed_ =
+      FastRandomIntGenerator<unsigned int>{}();
 };
 
 /*
- * @brief Return a IdTable, that is randomly filled. The range of numbers
- *  being entered in the join column can be defined.
- *
- * @param numberRows, numberColumns The size of the IdTable, that is to be
- *  returned.
- * @param joinColumnAndBounds The given join column will be filled with random
- * number, that are all inside the given range.
- */
+@brief Return a IdTable, that is randomly filled. The range of numbers
+being entered in the join column can be defined.
+
+@param numberRows, numberColumns The size of the IdTable, that is to be
+returned.
+@param joinColumnAndBounds The given join column will be filled with random
+number, that are all inside the given range.
+@param randomNumberGeneratorSeed The seed for the random number generator, that
+generates the content for the non join column entries.
+*/
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const JoinColumnAndBounds& joinColumnAndBounds);
+    const JoinColumnAndBounds& joinColumnAndBounds,
+    const unsigned int randomNumberGeneratorSeed =
+        FastRandomIntGenerator<unsigned int>{}());
 
 /*
- * @brief Return a IdTable, that is randomly filled. The range of numbers
- *  being entered in the join columns can be defined.
- *
- * @param numberRows, numberColumns The size of the IdTable, that is to be
- *  returned.
- * @param joinColumnsAndBounds Every join columns will be filled with random
- * number, that are inside their corresponding range.
- */
+@brief Return a IdTable, that is randomly filled. The range of numbers
+being entered in the join columns can be defined.
+
+@param numberRows, numberColumns The size of the IdTable, that is to be
+returned.
+@param joinColumnsAndBounds Every join columns will be filled with random
+number, that are inside their corresponding range.
+@param randomNumberGeneratorSeed The seed for the random number generator, that
+generates the content for the non join column entries.
+*/
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds);
+    const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
+    const unsigned int randomNumberGeneratorSeed =
+        FastRandomIntGenerator<unsigned int>{}());
 
-inline IdTable createRandomlyFilledIdTable(const size_t numberRows,
-                                           const size_t numberColumns) {
-  return createRandomlyFilledIdTable(numberRows, numberColumns,
-                                     std::vector<JoinColumnAndBounds>{});
-}
+/*
+@brief Return a IdTable, that is completly randomly filled.
+
+@param numberRows, numberColumns The size of the IdTable, that is to be
+returned.
+@param randomNumberGeneratorSeed The seed for the random number generator, that
+generates the content.
+*/
+IdTable createRandomlyFilledIdTable(
+    const size_t numberRows, const size_t numberColumns,
+    const unsigned int randomNumberGeneratorSeed =
+        FastRandomIntGenerator<unsigned int>{}());

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -113,15 +113,15 @@ entries are random.
 have.
 @param joinColumnWithGenerator Every pair describes the position of a join
 column and the function, which will be called, to generate it's entries.
-@param randomNumberGeneratorSeed The seed for the random number generator, that
-generates the content for the non join column entries.
+@param randomSeed The seed for the random number generator, that generates the
+content for the non join column entries.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<std::pair<size_t, std::function<ValueId()>>>&
         joinColumnWithGenerator,
-    const unsigned int randomNumberGeneratorSeed =
-        FastRandomIntGenerator<unsigned int>{}());
+    const Seed randomSeed =
+        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Creates a `IdTable`, where the content of the join columns is given via
@@ -133,15 +133,15 @@ have.
 @param generator The generator for the join columns. Order of calls: Row per
 row, starting from row 0, and in a row for every join column, with the join
 columns ordered by their column. Starting from column 0.
-@param randomNumberGeneratorSeed The seed for the random number generator, that
-generates the content for the non join column entries.
+@param randomSeed The seed for the random number generator, that generates the
+content for the non join column entries.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<size_t>& joinColumns,
     const std::function<ValueId()>& generator,
-    const unsigned int randomNumberGeneratorSeed =
-        FastRandomIntGenerator<unsigned int>{}());
+    const Seed randomSeed =
+        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 // Describes a join column together with an inclusive range of numbers, defined
 // as [lowerBound, upperBound], and the seed for the random number generator.
@@ -149,8 +149,7 @@ struct JoinColumnAndBounds {
   const size_t joinColumn_;
   const size_t lowerBound_;
   const size_t upperBound_;
-  const unsigned int randomNumberGeneratorSeed_ =
-      FastRandomIntGenerator<unsigned int>{}();
+  const Seed randomSeed_ = Seed::make(FastRandomIntGenerator<unsigned int>{}());
 };
 
 /*
@@ -161,14 +160,14 @@ being entered in the join column can be defined.
 returned.
 @param joinColumnAndBounds The given join column will be filled with random
 number, that are all inside the given range.
-@param randomNumberGeneratorSeed The seed for the random number generator, that
+@param randomSeed The seed for the random number generator, that
 generates the content for the non join column entries.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const JoinColumnAndBounds& joinColumnAndBounds,
-    const unsigned int randomNumberGeneratorSeed =
-        FastRandomIntGenerator<unsigned int>{}());
+    const Seed randomSeed =
+        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Return a IdTable, that is randomly filled. The range of numbers
@@ -178,24 +177,24 @@ being entered in the join columns can be defined.
 returned.
 @param joinColumnsAndBounds Every join columns will be filled with random
 number, that are inside their corresponding range.
-@param randomNumberGeneratorSeed The seed for the random number generator, that
+@param randomSeed The seed for the random number generator, that
 generates the content for the non join column entries.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
     const std::vector<JoinColumnAndBounds>& joinColumnsAndBounds,
-    const unsigned int randomNumberGeneratorSeed =
-        FastRandomIntGenerator<unsigned int>{}());
+    const Seed randomSeed =
+        Seed::make(FastRandomIntGenerator<unsigned int>{}()));
 
 /*
 @brief Return a IdTable, that is completly randomly filled.
 
 @param numberRows, numberColumns The size of the IdTable, that is to be
 returned.
-@param randomNumberGeneratorSeed The seed for the random number generator, that
+@param randomSeed The seed for the random number generator, that
 generates the content.
 */
 IdTable createRandomlyFilledIdTable(
     const size_t numberRows, const size_t numberColumns,
-    const unsigned int randomNumberGeneratorSeed =
-        FastRandomIntGenerator<unsigned int>{}());
+    const Seed randomSeed =
+        Seed::make(FastRandomIntGenerator<unsigned int>{}()));

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -13,9 +13,9 @@
 // Create a array of non-deterministic random seeds for use with random number
 // generators.
 template <size_t NumSeeds>
-inline std::array<Seed, NumSeeds> createArrayOfRandomSeeds() {
-  std::array<Seed, NumSeeds> seeds{};
-  std::ranges::generate(seeds,
-                        []() { return Seed::make(std::random_device{}()); });
+inline std::array<RandomSeed, NumSeeds> createArrayOfRandomSeeds() {
+  std::array<RandomSeed, NumSeeds> seeds{};
+  std::ranges::generate(
+      seeds, []() { return RandomSeed::make(std::random_device{}()); });
   return seeds;
 }

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -1,0 +1,18 @@
+// Copyright 2023, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Andre Schlegel (October of 2023, schlegea@informatik.uni-freiburg.de)
+
+#pragma once
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <random>
+
+// Create a array of non-deterministic random seeds for use with random number
+// generators.
+template <size_t NumSeeds>
+static std::array<unsigned int, NumSeeds> createArrayOfRandomSeeds() {
+  std::array<unsigned int, NumSeeds> seeds{};
+  std::ranges::generate(seeds, []() { return std::random_device{}(); });
+  return std::move(seeds);
+}

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -13,9 +13,10 @@
 // Create a array of non-deterministic random seeds for use with random number
 // generators.
 template <size_t NumSeeds>
-inline std::array<RandomSeed, NumSeeds> createArrayOfRandomSeeds() {
-  std::array<RandomSeed, NumSeeds> seeds{};
-  std::ranges::generate(
-      seeds, []() { return RandomSeed::make(std::random_device{}()); });
+inline std::array<ad_utility::RandomSeed, NumSeeds> createArrayOfRandomSeeds() {
+  std::array<ad_utility::RandomSeed, NumSeeds> seeds{};
+  std::ranges::generate(seeds, []() {
+    return ad_utility::RandomSeed::make(std::random_device{}());
+  });
   return seeds;
 }

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -8,11 +8,14 @@
 #include <cstddef>
 #include <random>
 
+#include "util/Random.h"
+
 // Create a array of non-deterministic random seeds for use with random number
 // generators.
 template <size_t NumSeeds>
-static std::array<unsigned int, NumSeeds> createArrayOfRandomSeeds() {
-  std::array<unsigned int, NumSeeds> seeds{};
-  std::ranges::generate(seeds, []() { return std::random_device{}(); });
+static std::array<Seed, NumSeeds> createArrayOfRandomSeeds() {
+  std::array<Seed, NumSeeds> seeds{};
+  std::ranges::generate(seeds,
+                        []() { return Seed::make(std::random_device{}()); });
   return seeds;
 }

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -14,5 +14,5 @@ template <size_t NumSeeds>
 static std::array<unsigned int, NumSeeds> createArrayOfRandomSeeds() {
   std::array<unsigned int, NumSeeds> seeds{};
   std::ranges::generate(seeds, []() { return std::random_device{}(); });
-  return std::move(seeds);
+  return seeds;
 }

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -13,7 +13,7 @@
 // Create a array of non-deterministic random seeds for use with random number
 // generators.
 template <size_t NumSeeds>
-static std::array<Seed, NumSeeds> createArrayOfRandomSeeds() {
+inline std::array<Seed, NumSeeds> createArrayOfRandomSeeds() {
   std::array<Seed, NumSeeds> seeds{};
   std::ranges::generate(seeds,
                         []() { return Seed::make(std::random_device{}()); });


### PR DESCRIPTION
For the pseudorandom number generators in `util/Random.h`, add the possibility to explicitly specify the initial random seed. This is useful for deterministic unit tests and benchmark where we want to reproduce random numbers. The default value for the random seed is always generated via `std::default_random_engine` to get as close to "true" randomness as possible in the default case.
Also move the functions and types inside the `Random.h` file to the `ad_utility` namespace.