### PR TITLE
Add "in progress" state to RuntimeInformation

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -649,7 +649,8 @@ nlohmann::json ExportQueryExecutionTrees::computeQueryResultAsQLeverJSON(
   j["runtimeInformation"]["meta"] = nlohmann::ordered_json(
       qet.getRootOperation()->getRuntimeInfoWholeQuery());
   RuntimeInformation runtimeInformation = qet.getRootOperation()->runtimeInfo();
-  runtimeInformation.addLimitOffsetRow(query._limitOffset, 0, false);
+  runtimeInformation.addLimitOffsetRow(
+      query._limitOffset, std::chrono::milliseconds::zero(), false);
   runtimeInformation.addDetail("executed-implicitly-during-query-export", true);
   j["runtimeInformation"]["query_execution_tree"] =
       nlohmann::ordered_json(runtimeInformation);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -691,7 +691,7 @@ void updateRuntimeInfoForLazyScan(
       RuntimeInformation::Status::lazilyMaterialized);
   auto& rti = scanTree.runtimeInfo();
   rti.numRows_ = metadata.numElementsRead_;
-  rti.totalTime_ = static_cast<double>(metadata.blockingTimeMs_);
+  rti.totalTime_ = std::chrono::milliseconds{metadata.blockingTimeMs_};
   rti.addDetail("num-blocks-read", metadata.numBlocksRead_);
   rti.addDetail("num-blocks-all", metadata.numBlocksAll_);
 }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -691,7 +691,7 @@ void updateRuntimeInfoForLazyScan(
       RuntimeInformation::Status::lazilyMaterialized);
   auto& rti = scanTree.runtimeInfo();
   rti.numRows_ = metadata.numElementsRead_;
-  rti.totalTime_ = std::chrono::milliseconds{metadata.blockingTimeMs_};
+  rti.totalTime_ = metadata.blockingTime_;
   rti.addDetail("num-blocks-read", metadata.numBlocksRead_);
   rti.addDetail("num-blocks-all", metadata.numBlocksAll_);
 }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -115,6 +115,8 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
             "functionality, before " +
             getDescriptor());
       }
+      runtimeInfo().status_ = RuntimeInformation::Status::inProgress;
+      signalQueryUpdate();
       ResultTable result = computeResult();
 
       // Compute the datatypes that occur in each column of the result.

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -218,8 +218,8 @@ void Operation::checkTimeout() const {
 // _______________________________________________________________________
 void Operation::updateRuntimeInformationOnSuccess(
     const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
-    millis timeInMilliseconds, std::optional<RuntimeInformation> runtimeInfo) {
-  _runtimeInfo->totalTime_ = timeInMilliseconds;
+    millis duration, std::optional<RuntimeInformation> runtimeInfo) {
+  _runtimeInfo->totalTime_ = duration;
   _runtimeInfo->numRows_ = resultTable.size();
   _runtimeInfo->cacheStatus_ = cacheStatus;
 
@@ -256,10 +256,10 @@ void Operation::updateRuntimeInformationOnSuccess(
 // ____________________________________________________________________________________________________________________
 void Operation::updateRuntimeInformationOnSuccess(
     const ConcurrentLruCache ::ResultAndCacheStatus& resultAndCacheStatus,
-    millis timeInMilliseconds) {
+    millis duration) {
   updateRuntimeInformationOnSuccess(
       *resultAndCacheStatus._resultPointer->resultTable(),
-      resultAndCacheStatus._cacheStatus, timeInMilliseconds,
+      resultAndCacheStatus._cacheStatus, duration,
       resultAndCacheStatus._resultPointer->runtimeInfo());
 }
 
@@ -298,13 +298,13 @@ void Operation::updateRuntimeInformationWhenOptimizedOut(
 }
 
 // _______________________________________________________________________
-void Operation::updateRuntimeInformationOnFailure(millis timeInMilliseconds) {
+void Operation::updateRuntimeInformationOnFailure(millis duration) {
   _runtimeInfo->children_.clear();
   for (auto child : getChildren()) {
     _runtimeInfo->children_.push_back(child->getRootOperation()->_runtimeInfo);
   }
 
-  _runtimeInfo->totalTime_ = timeInMilliseconds;
+  _runtimeInfo->totalTime_ = duration;
   _runtimeInfo->status_ = RuntimeInformation::Status::failed;
 
   signalQueryUpdate();

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -25,7 +25,7 @@
 class QueryExecutionTree;
 
 class Operation {
-  using millis = std::chrono::milliseconds;
+  using Milliseconds = std::chrono::milliseconds;
 
  public:
   // Default Constructor.
@@ -243,7 +243,7 @@ class Operation {
   // it has either been succesfully computed or read from the cache.
   virtual void updateRuntimeInformationOnSuccess(
       const ConcurrentLruCache::ResultAndCacheStatus& resultAndCacheStatus,
-      millis duration) final;
+      Milliseconds duration) final;
 
   // Similar to the function above, but the components are specified manually.
   // If nullopt is specified for the last argument, then the `_runtimeInfo` is
@@ -252,7 +252,8 @@ class Operation {
   // otherwise a runtime check will fail.
   virtual void updateRuntimeInformationOnSuccess(
       const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
-      millis duration, std::optional<RuntimeInformation> runtimeInfo) final;
+      Milliseconds duration,
+      std::optional<RuntimeInformation> runtimeInfo) final;
 
  public:
   // This function has to be called when this `Operation` was not executed,
@@ -280,7 +281,7 @@ class Operation {
  private:
   // Create the runtime information in case the evaluation of this operation has
   // failed.
-  void updateRuntimeInformationOnFailure(millis duration);
+  void updateRuntimeInformationOnFailure(Milliseconds duration);
 
   // Compute the variable to column index mapping. Is used internally by
   // `getInternallyVisibleVariableColumns`.

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -241,7 +241,7 @@ class Operation {
   // it has either been succesfully computed or read from the cache.
   virtual void updateRuntimeInformationOnSuccess(
       const ConcurrentLruCache::ResultAndCacheStatus& resultAndCacheStatus,
-      size_t timeInMilliseconds) final;
+      std::chrono::milliseconds timeInMilliseconds) final;
 
   // Similar to the function above, but the components are specified manually.
   // If nullopt is specified for the last argument, then the `_runtimeInfo` is
@@ -250,7 +250,7 @@ class Operation {
   // otherwise a runtime check will fail.
   virtual void updateRuntimeInformationOnSuccess(
       const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
-      size_t timeInMilliseconds,
+      std::chrono::milliseconds timeInMilliseconds,
       std::optional<RuntimeInformation> runtimeInfo) final;
 
  public:
@@ -279,7 +279,8 @@ class Operation {
  private:
   // Create the runtime information in case the evaluation of this operation has
   // failed.
-  void updateRuntimeInformationOnFailure(size_t timeInMilliseconds);
+  void updateRuntimeInformationOnFailure(
+      std::chrono::milliseconds timeInMilliseconds);
 
   // Compute the variable to column index mapping. Is used internally by
   // `getInternallyVisibleVariableColumns`.

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -25,6 +25,8 @@
 class QueryExecutionTree;
 
 class Operation {
+  using millis = std::chrono::milliseconds;
+
  public:
   // Default Constructor.
   Operation() : _executionContext(nullptr) {}
@@ -241,7 +243,7 @@ class Operation {
   // it has either been succesfully computed or read from the cache.
   virtual void updateRuntimeInformationOnSuccess(
       const ConcurrentLruCache::ResultAndCacheStatus& resultAndCacheStatus,
-      std::chrono::milliseconds timeInMilliseconds) final;
+      millis timeInMilliseconds) final;
 
   // Similar to the function above, but the components are specified manually.
   // If nullopt is specified for the last argument, then the `_runtimeInfo` is
@@ -250,7 +252,7 @@ class Operation {
   // otherwise a runtime check will fail.
   virtual void updateRuntimeInformationOnSuccess(
       const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
-      std::chrono::milliseconds timeInMilliseconds,
+      millis timeInMilliseconds,
       std::optional<RuntimeInformation> runtimeInfo) final;
 
  public:
@@ -279,8 +281,7 @@ class Operation {
  private:
   // Create the runtime information in case the evaluation of this operation has
   // failed.
-  void updateRuntimeInformationOnFailure(
-      std::chrono::milliseconds timeInMilliseconds);
+  void updateRuntimeInformationOnFailure(millis timeInMilliseconds);
 
   // Compute the variable to column index mapping. Is used internally by
   // `getInternallyVisibleVariableColumns`.

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -243,7 +243,7 @@ class Operation {
   // it has either been succesfully computed or read from the cache.
   virtual void updateRuntimeInformationOnSuccess(
       const ConcurrentLruCache::ResultAndCacheStatus& resultAndCacheStatus,
-      millis timeInMilliseconds) final;
+      millis duration) final;
 
   // Similar to the function above, but the components are specified manually.
   // If nullopt is specified for the last argument, then the `_runtimeInfo` is
@@ -252,8 +252,7 @@ class Operation {
   // otherwise a runtime check will fail.
   virtual void updateRuntimeInformationOnSuccess(
       const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
-      millis timeInMilliseconds,
-      std::optional<RuntimeInformation> runtimeInfo) final;
+      millis duration, std::optional<RuntimeInformation> runtimeInfo) final;
 
  public:
   // This function has to be called when this `Operation` was not executed,
@@ -281,7 +280,7 @@ class Operation {
  private:
   // Create the runtime information in case the evaluation of this operation has
   // failed.
-  void updateRuntimeInformationOnFailure(millis timeInMilliseconds);
+  void updateRuntimeInformationOnFailure(millis duration);
 
   // Compute the variable to column index mapping. Is used internally by
   // `getInternallyVisibleVariableColumns`.

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -143,6 +143,8 @@ std::string_view RuntimeInformation::toString(Status status) {
       return "fully materialized";
     case lazilyMaterialized:
       return "lazily materialized";
+    case inProgress:
+      return "in progress";
     case notStarted:
       return "not started";
     case optimizedOut:

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -127,9 +127,8 @@ std::chrono::milliseconds RuntimeInformation::getOperationTime() const {
     // Prevent "negative" computation times in case totalTime_ was not
     // computed for this yet.
     constexpr auto zero = std::chrono::milliseconds::zero();
-    return std::max(zero,
-                    totalTime_ - std::reduce(timesOfChildren.begin(),
-                                             timesOfChildren.end(), zero));
+    return std::max(zero, -std::reduce(timesOfChildren.begin(),
+                                       timesOfChildren.end(), -totalTime_));
   }
 }
 

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -115,8 +115,7 @@ class RuntimeInformation {
   // The details of the LIMIT/OFFSET, the time (in ms) that was spent computing
   // it, and the information whether the `actual` operation (the old root of the
   // runtime information) is written to the cache, are passed in as arguments.
-  void addLimitOffsetRow(const LimitOffsetClause& l,
-                         Milliseconds timeForLimit,
+  void addLimitOffsetRow(const LimitOffsetClause& l, Milliseconds timeForLimit,
                          bool fullResultIsNotCached);
 
   static std::string_view toString(Status status);

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -39,12 +39,14 @@ class RuntimeInformation {
 
   /// The total time spent computing this operation. This includes the
   /// computation of the children.
-  double totalTime_ = 0.0;
+  std::chrono::milliseconds totalTime_ = std::chrono::milliseconds::zero();
 
   /// In case this operation was read from the cache, we will store the time
   /// information about the original computation in the following two members.
-  double originalTotalTime_ = 0.0;
-  double originalOperationTime_ = 0.0;
+  std::chrono::milliseconds originalTotalTime_ =
+      std::chrono::milliseconds::zero();
+  std::chrono::milliseconds originalOperationTime_ =
+      std::chrono::milliseconds::zero();
 
   /// The estimated cost, size, and column multiplicities of the operation.
   size_t costEstimate_ = 0;
@@ -91,10 +93,10 @@ class RuntimeInformation {
 
   /// Get the time spent computing the operation. This is the total time minus
   /// the time spent computing the children.
-  [[nodiscard]] double getOperationTime() const;
+  [[nodiscard]] std::chrono::milliseconds getOperationTime() const;
 
   /// Get the cost estimate for this operation. This is the total cost estimate
-  /// minus the sum of the cost estimates of all children.
+  /// minus the sum of the cost estimates of all children, but always positive.
   [[nodiscard]] size_t getOperationCostEstimate() const;
 
   /// Add a key-value pair to the `details` section of the output. `value` may
@@ -109,7 +111,8 @@ class RuntimeInformation {
   // The details of the LIMIT/OFFSET, the time (in ms) that was spent computing
   // it, and the information whether the `actual` operation (the old root of the
   // runtime information) is written to the cache, are passed in as arguments.
-  void addLimitOffsetRow(const LimitOffsetClause& l, size_t timeForLimit,
+  void addLimitOffsetRow(const LimitOffsetClause& l,
+                         std::chrono::milliseconds timeForLimit,
                          bool fullResultIsNotCached);
 
   static std::string_view toString(Status status);

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -22,6 +22,12 @@
 /// time to compute, status, etc.). Also contains the functionality to print
 /// that information nicely formatted and to export it to JSON.
 class RuntimeInformation {
+  using Milliseconds = std::chrono::milliseconds;
+  // Ideally we'd use `using namespace std::chrono_literals;` here,
+  // but C++ forbids using this within a class, and we don't want
+  // to clutter the global namespace.
+  static constexpr auto ZERO = Milliseconds::zero();
+
  public:
   /// The computation status of an operation.
   enum struct Status {
@@ -39,14 +45,12 @@ class RuntimeInformation {
 
   /// The total time spent computing this operation. This includes the
   /// computation of the children.
-  std::chrono::milliseconds totalTime_ = std::chrono::milliseconds::zero();
+  Milliseconds totalTime_ = ZERO;
 
   /// In case this operation was read from the cache, we will store the time
   /// information about the original computation in the following two members.
-  std::chrono::milliseconds originalTotalTime_ =
-      std::chrono::milliseconds::zero();
-  std::chrono::milliseconds originalOperationTime_ =
-      std::chrono::milliseconds::zero();
+  Milliseconds originalTotalTime_ = ZERO;
+  Milliseconds originalOperationTime_ = ZERO;
 
   /// The estimated cost, size, and column multiplicities of the operation.
   size_t costEstimate_ = 0;
@@ -92,11 +96,11 @@ class RuntimeInformation {
   void setColumnNames(const VariableToColumnMap& columnMap);
 
   /// Get the time spent computing the operation. This is the total time minus
-  /// the time spent computing the children.
-  [[nodiscard]] std::chrono::milliseconds getOperationTime() const;
+  /// the time spent computing the children, but always positive.
+  [[nodiscard]] Milliseconds getOperationTime() const;
 
   /// Get the cost estimate for this operation. This is the total cost estimate
-  /// minus the sum of the cost estimates of all children, but always positive.
+  /// minus the sum of the cost estimates of all children.
   [[nodiscard]] size_t getOperationCostEstimate() const;
 
   /// Add a key-value pair to the `details` section of the output. `value` may
@@ -112,7 +116,7 @@ class RuntimeInformation {
   // it, and the information whether the `actual` operation (the old root of the
   // runtime information) is written to the cache, are passed in as arguments.
   void addLimitOffsetRow(const LimitOffsetClause& l,
-                         std::chrono::milliseconds timeForLimit,
+                         Milliseconds timeForLimit,
                          bool fullResultIsNotCached);
 
   static std::string_view toString(Status status);

--- a/src/engine/RuntimeInformation.h
+++ b/src/engine/RuntimeInformation.h
@@ -26,6 +26,7 @@ class RuntimeInformation {
   /// The computation status of an operation.
   enum struct Status {
     notStarted,
+    inProgress,
     fullyMaterialized,
     lazilyMaterialized,
     optimizedOut,

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -259,7 +259,7 @@ class CompressedRelationReader {
     size_t numBlocksRead_ = 0;
     size_t numBlocksAll_ = 0;
     size_t numElementsRead_ = 0;
-    size_t blockingTimeMs_ = 0;
+    std::chrono::milliseconds blockingTime_ = std::chrono::milliseconds::zero();
   };
 
   using IdTableGenerator = cppcoro::generator<IdTable, LazyScanMetadata>;

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -7,55 +7,54 @@
 
 #include "engine/RuntimeInformation.h"
 
-using std::chrono::milliseconds;
+using namespace std::chrono_literals;
 
 // ________________________________________________________________
 TEST(RuntimeInformation, addLimitOffsetRow) {
   RuntimeInformation rti;
   rti.descriptor_ = "BaseOperation";
-  rti.totalTime_ = milliseconds{4};
+  rti.totalTime_ = 4ms;
   rti.sizeEstimate_ = 34;
 
-  rti.addLimitOffsetRow(LimitOffsetClause{23, 1, 4}, milliseconds{20}, true);
+  rti.addLimitOffsetRow(LimitOffsetClause{23, 1, 4}, 20ms, true);
   EXPECT_EQ(rti.descriptor_, "LIMIT 23 OFFSET 4");
-  EXPECT_EQ(rti.totalTime_, milliseconds{24});
-  EXPECT_EQ(rti.getOperationTime(), milliseconds{20});
+  EXPECT_EQ(rti.totalTime_, 24ms);
+  EXPECT_EQ(rti.getOperationTime(), 20ms);
 
   ASSERT_EQ(rti.children_.size(), 1u);
   auto& child = *rti.children_.at(0);
   EXPECT_EQ(child.descriptor_, "BaseOperation");
-  EXPECT_EQ(child.totalTime_, milliseconds{4});
-  EXPECT_EQ(child.getOperationTime(), milliseconds{4});
+  EXPECT_EQ(child.totalTime_, 4ms);
+  EXPECT_EQ(child.getOperationTime(), 4ms);
   EXPECT_TRUE(child.details_.at("not-written-to-cache-because-child-of-limit"));
 
-  rti.addLimitOffsetRow(LimitOffsetClause{std::nullopt, 1, 17},
-                        milliseconds{15}, false);
+  rti.addLimitOffsetRow(LimitOffsetClause{std::nullopt, 1, 17}, 15ms, false);
   EXPECT_FALSE(rti.children_.at(0)->details_.at(
       "not-written-to-cache-because-child-of-limit"));
   EXPECT_EQ(rti.descriptor_, "OFFSET 17");
 
-  rti.addLimitOffsetRow(LimitOffsetClause{42, 1, 0}, milliseconds{15}, true);
+  rti.addLimitOffsetRow(LimitOffsetClause{42, 1, 0}, 15ms, true);
   EXPECT_EQ(rti.descriptor_, "LIMIT 42");
 }
 
 // ________________________________________________________________
 TEST(RuntimeInformation, getOperationTimeAndCostEstimate) {
   RuntimeInformation child1;
-  child1.totalTime_ = milliseconds{3};
+  child1.totalTime_ = 3ms;
   child1.costEstimate_ = 12;
   RuntimeInformation child2;
-  child2.totalTime_ = milliseconds{4};
+  child2.totalTime_ = 4ms;
   child2.costEstimate_ = 43;
 
   RuntimeInformation parent;
-  parent.totalTime_ = milliseconds{10};
+  parent.totalTime_ = 10ms;
   parent.costEstimate_ = 100;
 
   parent.children_.push_back(std::make_shared<RuntimeInformation>(child1));
   parent.children_.push_back(std::make_shared<RuntimeInformation>(child2));
 
   // 3 == 10 - 4 - 3
-  ASSERT_EQ(parent.getOperationTime(), milliseconds{3});
+  ASSERT_EQ(parent.getOperationTime(), 3ms);
 
   // 45 == 100 - 43 - 12
   ASSERT_EQ(parent.getOperationCostEstimate(), 45);
@@ -127,7 +126,7 @@ TEST(RuntimeInformation, toStringAndJson) {
   child.numRows_ = 7;
   child.columnNames_.emplace_back("?x");
   child.columnNames_.emplace_back("?y");
-  child.totalTime_ = milliseconds{3};
+  child.totalTime_ = 3ms;
   child.cacheStatus_ = ad_utility::CacheStatus::cachedPinned;
   child.status_ = RuntimeInformation::Status::optimizedOut;
   child.addDetail("minor detail", 42);
@@ -137,7 +136,7 @@ TEST(RuntimeInformation, toStringAndJson) {
   parent.numCols_ = 6;
   parent.numRows_ = 4;
   parent.columnNames_.push_back("?alpha");
-  parent.totalTime_ = milliseconds{6};
+  parent.totalTime_ = 6ms;
   parent.cacheStatus_ = ad_utility::CacheStatus::computed;
   parent.status_ = RuntimeInformation::Status::fullyMaterialized;
 

--- a/test/RuntimeInformationTest.cpp
+++ b/test/RuntimeInformationTest.cpp
@@ -7,52 +7,55 @@
 
 #include "engine/RuntimeInformation.h"
 
+using std::chrono::milliseconds;
+
 // ________________________________________________________________
 TEST(RuntimeInformation, addLimitOffsetRow) {
   RuntimeInformation rti;
   rti.descriptor_ = "BaseOperation";
-  rti.totalTime_ = 4.0;
+  rti.totalTime_ = milliseconds{4};
   rti.sizeEstimate_ = 34;
 
-  rti.addLimitOffsetRow(LimitOffsetClause{23, 1, 4}, 20, true);
+  rti.addLimitOffsetRow(LimitOffsetClause{23, 1, 4}, milliseconds{20}, true);
   EXPECT_EQ(rti.descriptor_, "LIMIT 23 OFFSET 4");
-  EXPECT_EQ(rti.totalTime_, 24.0);
-  EXPECT_EQ(rti.getOperationTime(), 20.0);
+  EXPECT_EQ(rti.totalTime_, milliseconds{24});
+  EXPECT_EQ(rti.getOperationTime(), milliseconds{20});
 
   ASSERT_EQ(rti.children_.size(), 1u);
   auto& child = *rti.children_.at(0);
   EXPECT_EQ(child.descriptor_, "BaseOperation");
-  EXPECT_EQ(child.totalTime_, 4.0);
-  EXPECT_EQ(child.getOperationTime(), 4.0);
+  EXPECT_EQ(child.totalTime_, milliseconds{4});
+  EXPECT_EQ(child.getOperationTime(), milliseconds{4});
   EXPECT_TRUE(child.details_.at("not-written-to-cache-because-child-of-limit"));
 
-  rti.addLimitOffsetRow(LimitOffsetClause{std::nullopt, 1, 17}, 15, false);
+  rti.addLimitOffsetRow(LimitOffsetClause{std::nullopt, 1, 17},
+                        milliseconds{15}, false);
   EXPECT_FALSE(rti.children_.at(0)->details_.at(
       "not-written-to-cache-because-child-of-limit"));
   EXPECT_EQ(rti.descriptor_, "OFFSET 17");
 
-  rti.addLimitOffsetRow(LimitOffsetClause{42, 1, 0}, 15, true);
+  rti.addLimitOffsetRow(LimitOffsetClause{42, 1, 0}, milliseconds{15}, true);
   EXPECT_EQ(rti.descriptor_, "LIMIT 42");
 }
 
 // ________________________________________________________________
 TEST(RuntimeInformation, getOperationTimeAndCostEstimate) {
   RuntimeInformation child1;
-  child1.totalTime_ = 3.0;
+  child1.totalTime_ = milliseconds{3};
   child1.costEstimate_ = 12;
   RuntimeInformation child2;
-  child2.totalTime_ = 4.5;
+  child2.totalTime_ = milliseconds{4};
   child2.costEstimate_ = 43;
 
   RuntimeInformation parent;
-  parent.totalTime_ = 10.0;
+  parent.totalTime_ = milliseconds{10};
   parent.costEstimate_ = 100;
 
   parent.children_.push_back(std::make_shared<RuntimeInformation>(child1));
   parent.children_.push_back(std::make_shared<RuntimeInformation>(child2));
 
-  // 2.5 == 10.0 - 4.5 - 3.0
-  ASSERT_DOUBLE_EQ(parent.getOperationTime(), 2.5);
+  // 3 == 10 - 4 - 3
+  ASSERT_EQ(parent.getOperationTime(), milliseconds{3});
 
   // 45 == 100 - 43 - 12
   ASSERT_EQ(parent.getOperationCostEstimate(), 45);
@@ -124,7 +127,7 @@ TEST(RuntimeInformation, toStringAndJson) {
   child.numRows_ = 7;
   child.columnNames_.emplace_back("?x");
   child.columnNames_.emplace_back("?y");
-  child.totalTime_ = 3.4;
+  child.totalTime_ = milliseconds{3};
   child.cacheStatus_ = ad_utility::CacheStatus::cachedPinned;
   child.status_ = RuntimeInformation::Status::optimizedOut;
   child.addDetail("minor detail", 42);
@@ -134,7 +137,7 @@ TEST(RuntimeInformation, toStringAndJson) {
   parent.numCols_ = 6;
   parent.numRows_ = 4;
   parent.columnNames_.push_back("?alpha");
-  parent.totalTime_ = 6.2;
+  parent.totalTime_ = milliseconds{6};
   parent.cacheStatus_ = ad_utility::CacheStatus::computed;
   parent.status_ = RuntimeInformation::Status::fullyMaterialized;
 
@@ -146,8 +149,8 @@ TEST(RuntimeInformation, toStringAndJson) {
             R"(├─ parent
 │  result_size: 4 x 6
 │  columns: ?alpha
-│  total_time: 6.20 ms
-│  operation_time: 2.80 ms
+│  total_time: 6 ms
+│  operation_time: 3 ms
 │  status: fully materialized
 │  cache_status: computed
 │  ┬
@@ -155,12 +158,12 @@ TEST(RuntimeInformation, toStringAndJson) {
 │  ├─ child
 │  │  result_size: 7 x 2
 │  │  columns: ?x, ?y
-│  │  total_time: 3.40 ms
-│  │  operation_time: 3.40 ms
+│  │  total_time: 3 ms
+│  │  operation_time: 3 ms
 │  │  status: optimized out
 │  │  cache_status: cached_pinned
-│  │  original_total_time: 0.00 ms
-│  │  original_operation_time: 0.00 ms
+│  │  original_total_time: 0 ms
+│  │  original_operation_time: 0 ms
 │  │    minor detail: 42
 )");
   nlohmann::ordered_json j = parent;
@@ -172,10 +175,10 @@ TEST(RuntimeInformation, toStringAndJson) {
 "column_names": [
     "?alpha"
 ],
-"total_time": 6.2,
-"operation_time": 2.8000000000000003,
-"original_total_time": 0.0,
-"original_operation_time": 0.0,
+"total_time": 6,
+"operation_time": 3,
+"original_total_time": 0,
+"original_operation_time": 0,
 "cache_status": "computed",
 "details": null,
 "estimated_total_cost": 0,
@@ -192,10 +195,10 @@ TEST(RuntimeInformation, toStringAndJson) {
             "?x",
             "?y"
         ],
-        "total_time": 3.4,
-        "operation_time": 3.4,
-        "original_total_time": 0.0,
-        "original_operation_time": 0.0,
+        "total_time": 3,
+        "operation_time": 3,
+        "original_total_time": 0,
+        "original_operation_time": 0,
         "cache_status": "cached_pinned",
         "details": {
             "minor detail": 42


### PR DESCRIPTION
* Mark the currently running operation as well as all its ancestors in the runtime tree as `in progress` (previously they were shown as `not started`. Note that it is easy to filter out the "actually" running operation by traversing the runtime information.
* Fix a bug in the runtime information that the time of the currently running operation was negative. It is now zero.\
* Also refactor the `RuntimeInformation` and `Operation` class to consistently use types from `std::chrono` for durations.