### PR TITLE
Add more possible types for the entries of `Benchmark::ResultTable`

### DIFF
--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -65,8 +65,8 @@ BenchmarkResults runAllBenchmarks(){
   results.addMeasurement(identifier, dummyFunctionToMeasure);
 
   /*
-  Create an empty table with a set number of rows and columns. Doesn't
-  measure anything.
+  Create an empty table with a number of rows and columns. Doesn't measure anything.
+  The number of columns can not be changed after creation, but the number of rows can.
   Important: The row names aren't saved in a seperate container, but INSIDE the
   first column of the table.
   */
@@ -76,7 +76,7 @@ BenchmarkResults runAllBenchmarks(){
   // You can add measurements to the table as entries, but you can also
   // read and set entries.
   table.addMeasurement(0, 2, dummyFunctionToMeasure); // Row 0, column 1.
-  table.setEntry(0, 1, "A custom entry can be a float, or a string.");
+  table.setEntry(0, 1, "A custom entry can be any type in 'ad_benchmark::ResultTable::EntryType', except 'std::monostate'.");
   table.getEntry(0, 2); // The measured time of the dummy function.
 
   // Replacing a row name.
@@ -119,11 +119,11 @@ Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata i
 
 You can find instances of `BenchmarkMetadata` for your usage at 4 locations:
 
-- At `metadata_` of created `ResultEntry` objects, in order to give metadata information about the benchmark measurement.
+- At `metadata()` of created `ResultEntry` objects, in order to give metadata information about the benchmark measurement.
 
-- At `metadata_` of created `ResultGroup` objects, in order to give metadata information about the group.
+- At `metadata()` of created `ResultGroup` objects, in order to give metadata information about the group.
 
-- At `metadata_` of created `ResultTable` objects, in order to give metadata information about the table.
+- At `metadata()` of created `ResultTable` objects, in order to give metadata information about the table.
 
 - Writing a `getMetadata` function, like in the `BenchmarkInterface`, in order to give more general metadata information about your benchmark class. This is mostly, so that you don't have to constantly repeat metadata information, that are true for all the things you are measuring, in other places. For example, this would be a good place to give the name of an algorithm, if your whole benchmark class is about measuring the runtimes of one. Or you could give the time, at which those benchmark measurements were taken.
 

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+
 #include <absl/strings/str_cat.h>
 #include <absl/strings/str_format.h>
 #include <absl/strings/string_view.h>
@@ -17,9 +19,6 @@
 #include <variant>
 #include <vector>
 
-using namespace std::string_literals;
-
-#include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "../benchmark/infrastructure/BenchmarkToString.h"
 #include "BenchmarkMetadata.h"
 #include "util/Algorithm.h"
@@ -27,6 +26,8 @@ using namespace std::string_literals;
 #include "util/Forward.h"
 #include "util/Iterators.h"
 #include "util/StringUtils.h"
+
+using namespace std::string_literals;
 
 namespace ad_benchmark {
 

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -184,6 +184,9 @@ ResultTable::operator std::string() const {
       return absl::StrFormat(floatFormatSpecifier, entry);
     } else if constexpr (std::is_same_v<T, std::string>) {
       return entry;
+    } else if constexpr (std::is_same_v<T, bool>) {
+      // Simple conversion.
+      return entry ? "true"s : "false"s;
     } else {
       // Unsupported type.
       AD_CONTRACT_CHECK(false);

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <ranges>
 #include <sstream>
+#include <string>
 #include <string_view>
 #include <utility>
 #include <variant>
@@ -182,6 +183,9 @@ ResultTable::operator std::string() const {
     } else if constexpr (std::is_same_v<T, float>) {
       // There is a value, format it as specified.
       return absl::StrFormat(floatFormatSpecifier, entry);
+    } else if constexpr (std::is_same_v<T, size_t> || std::is_same_v<T, int>) {
+      // There is already a `std` function for this.
+      return std::to_string(entry);
     } else if constexpr (std::is_same_v<T, std::string>) {
       return entry;
     } else if constexpr (std::is_same_v<T, bool>) {

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -194,7 +194,7 @@ ResultTable::operator std::string() const {
       return entry ? "true"s : "false"s;
     } else {
       // Unsupported type.
-      AD_CONTRACT_CHECK(false);
+      AD_FAIL();
     }
   };
   auto entryToString = [&entryToStringVisitor](const EntryType& entry) {

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -10,6 +10,7 @@
 #include <concepts>
 #include <memory>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "../benchmark/infrastructure/BenchmarkMetadata.h"
@@ -17,6 +18,7 @@
 #include "util/Exception.h"
 #include "util/Log.h"
 #include "util/Timer.h"
+#include "util/TypeTraits.h"
 #include "util/json.h"
 
 namespace ad_benchmark {
@@ -125,6 +127,15 @@ class ResultEntry : public BenchmarkMetadataGetter {
 
 // Describes a table of measured execution times of functions.
 class ResultTable : public BenchmarkMetadataGetter {
+ public:
+  /*
+  What type of entry a `ResultTable` can hold. The float is for the measured
+  time in seconds, the `monostate` for empty entries, and the rest for custom
+  entries by the user for better readability.
+  */
+  using EntryType = std::variant<std::monostate, float, std::string>;
+
+ private:
   // For identification.
   std::string descriptor_;
   /*
@@ -137,7 +148,6 @@ class ResultTable : public BenchmarkMetadataGetter {
   std::vector<std::string> columnNames_;
   // The entries in the table. Access is [row, column]. Can be the time in
   // seconds, a string, or empty.
-  using EntryType = std::variant<std::monostate, float, std::string>;
   std::vector<std::vector<EntryType>> entries_;
 
   // Needed for testing purposes.
@@ -210,16 +220,17 @@ class ResultTable : public BenchmarkMetadataGetter {
   @brief Returns the content of a table entry, if the the correct type was
   given. Otherwise, causes an error.
 
-  @tparam T What type the entry has. Must be either `float`, or `string`. If
+  @tparam T What type the entry has. Must be contained in `EntryType`. If
    you give the wrong one, or the entry was never set/added, then this
    function will cause an exception.
 
   @param row, column Which table entry to read. Starts with `(0,0)`.
   */
   template <typename T>
-  requires std::is_same_v<T, float> || std::is_same_v<T, std::string>
+  requires ad_utility::isTypeContainedIn<T, EntryType>
   T getEntry(const size_t row, const size_t column) const {
     AD_CONTRACT_CHECK(row < numRows() && column < numColumns());
+    static_assert(!ad_utility::isSimilar<T, std::monostate>);
 
     // There is a chance, that the entry of the table does NOT have type T,
     // in which case this will cause an error. As this is a mistake on the

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -133,7 +133,7 @@ class ResultTable : public BenchmarkMetadataGetter {
   time in seconds, the `monostate` for empty entries, and the rest for custom
   entries by the user for better readability.
   */
-  using EntryType = std::variant<std::monostate, float, std::string>;
+  using EntryType = std::variant<std::monostate, float, std::string, bool>;
 
  private:
   // For identification.

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -133,7 +133,8 @@ class ResultTable : public BenchmarkMetadataGetter {
   time in seconds, the `monostate` for empty entries, and the rest for custom
   entries by the user for better readability.
   */
-  using EntryType = std::variant<std::monostate, float, std::string, bool>;
+  using EntryType =
+      std::variant<std::monostate, float, std::string, bool, size_t, int>;
 
  private:
   // For identification.

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -3,14 +3,19 @@
 // Author: Andre Schlegel (April of 2023,
 // schlegea@informatik.uni-freiburg.de)
 
+#include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <string>
 #include <type_traits>
 #include <variant>
+using namespace std::string_literals;
 
 #include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
+#include "util/Exception.h"
 #include "util/Timer.h"
+#include "util/TypeTraits.h"
 #include "util/json.h"
 
 namespace ad_benchmark {
@@ -84,6 +89,43 @@ TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
   ASSERT_EQ(table.getEntry<std::string>(1, 0), rowNames.at(1));
 }
 
+/*
+@brief Call the function with each of the alternatives in
+`ad_benchmark::ResultTable::EntryType`, except `std::monostate`, as template
+parameter.
+
+@tparam Function The loop body should be a templated function, with one
+`typename` template argument and no more. It also shouldn't take any function
+arguments. Should be passed per deduction.
+*/
+template <typename Function>
+static void doForTypeInResultTableEntryType(Function function) {
+  ad_utility::ConstexprForLoop(
+      std::make_index_sequence<std::variant_size_v<ResultTable::EntryType>>{},
+      [&function]<size_t index, typename IndexType = std::variant_alternative_t<
+                                    index, ResultTable::EntryType>>() {
+        // `std::monostate` is not important for these kinds of tests.
+        if constexpr (!ad_utility::isSimilar<IndexType, std::monostate>) {
+          function.template operator()<IndexType>();
+        }
+      });
+}
+
+// Helper function for creating `ad_benchmark::ResultTable::EntryType` dummy
+// values.
+template <typename Type>
+requires ad_utility::isTypeContainedIn<Type, ResultTable::EntryType>
+static Type createDummyValueEntryType() {
+  if constexpr (ad_utility::isSimilar<Type, float>) {
+    return 4.2f;
+  } else if (ad_utility::isSimilar<Type, std::string>) {
+    return "test"s;
+  } else {
+    // Not a supported type.
+    AD_CORRECTNESS_CHECK(false);
+  }
+}
+
 TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   // Looks, if the general form is correct.
   auto checkForm = [](const ResultTable& table, const std::string& name,
@@ -119,8 +161,9 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
         table.entries_.at(row).at(column)));
 
     // Does trying to access it anyway cause an error?
-    ASSERT_ANY_THROW(table.getEntry<std::string>(row, column));
-    ASSERT_ANY_THROW(table.getEntry<float>(row, column));
+    doForTypeInResultTableEntryType([&table, &row, &column]<typename T>() {
+      ASSERT_ANY_THROW(table.getEntry<T>(row, column));
+    });
   };
 
   /*
@@ -131,10 +174,20 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
                                  const auto&... wantedContent) {
     size_t column = 0;
     auto check = [&table, &rowNumber, &column,
-                  &assertEqual](const auto& wantedContent) mutable {
-      assertEqual(wantedContent,
-                  table.getEntry<std::decay_t<decltype(wantedContent)>>(
-                      rowNumber, column++));
+                  &assertEqual]<typename T>(const T& wantedContent) mutable {
+      // `getEntry` should ONLY work with `T`
+      doForTypeInResultTableEntryType(
+          [&table, &rowNumber, &column, &assertEqual,
+           &wantedContent]<typename PossiblyWrongType>() {
+            if constexpr (ad_utility::isSimilar<PossiblyWrongType, T>) {
+              assertEqual(wantedContent,
+                          table.getEntry<std::decay_t<T>>(rowNumber, column));
+            } else {
+              ASSERT_ANY_THROW(
+                  table.getEntry<PossiblyWrongType>(rowNumber, column));
+            }
+          });
+      column++;
     };
     ((check(wantedContent)), ...);
   };
@@ -160,44 +213,59 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   // Was it created correctly?
   checkForm(table, "My table", "My table", rowNames, columnNames);
 
-  // Add measured function to it.
-  table.addMeasurement(0, 1, createWaitLambda(100));
-
-  // Set custom entries.
-  table.setEntry(0, 2, (float)4.9);
-  table.setEntry(1, 1, "Custom entry");
-
-  // Check the entries.
-  checkRow(table, 0, std::string{"row1"}, static_cast<float>(0.1),
-           static_cast<float>(4.9));
-  checkRow(table, 1, std::string{"row2"}, std::string{"Custom entry"});
-  checkNeverSet(table, 1, 2);
-
-  // Trying to get entries with the wrong type, should cause an error.
-  ASSERT_ANY_THROW(table.getEntry<std::string>(0, 2));
-  ASSERT_ANY_THROW(table.getEntry<float>(1, 1));
-
-  // Can we add a new row, without changing things?
-  table.addRow();
-  table.setEntry(2, 0, std::string{"row3"});
-  checkForm(table, "My table", "My table", {"row1", "row2", "row3"},
-            columnNames);
-  checkRow(table, 0, std::string{"row1"}, static_cast<float>(0.1),
-           static_cast<float>(4.9));
-  checkRow(table, 1, std::string{"row2"}, std::string{"Custom entry"});
-
-  // Are the entries of the new row empty?
-  checkNeverSet(table, 2, 1);
-  checkNeverSet(table, 2, 2);
-
-  // To those new fields work like the old ones?
-  table.addMeasurement(2, 1, createWaitLambda(290));
-  table.setEntry(2, 2, "Custom entry #2");
-  checkRow(table, 2, std::string{"row3"}, static_cast<float>(0.29),
-           std::string{"Custom entry #2"});
-
   // Does the constructor for the custom log name work?
   checkForm(ResultTable("My table", "T", rowNames, columnNames), "My table",
             "T", rowNames, columnNames);
+
+  // Add measured function to it.
+  table.addMeasurement(0, 1, createWaitLambda(100));
+
+  // Check, if it works with custom entries.
+  doForTypeInResultTableEntryType(
+      [&table, &checkNeverSet, &checkRow]<typename T1>() {
+        doForTypeInResultTableEntryType([&table, &checkNeverSet,
+                                         &checkRow]<typename T2>() {
+          // Set custom entries.
+          table.setEntry(0, 2, createDummyValueEntryType<T1>());
+          table.setEntry(1, 1, createDummyValueEntryType<T2>());
+
+          // Check the entries.
+          checkRow(table, 0, "row1"s, 0.1f, createDummyValueEntryType<T1>());
+          checkRow(table, 1, "row2"s, createDummyValueEntryType<T2>());
+          checkNeverSet(table, 1, 2);
+        });
+      });
+
+  // For keeping track of the new row names.
+  std::vector<std::string> addRowRowNames(rowNames);
+  // Testing `addRow`.
+  doForTypeInResultTableEntryType([&table, &checkNeverSet, &checkRow,
+                                   &checkForm, &columnNames,
+                                   &addRowRowNames]<typename T>() {
+    // What is the index of the new row?
+    const size_t indexNewRow = table.numRows();
+
+    // Can we add a new row, without changing things?
+    table.addRow();
+    addRowRowNames.emplace_back(absl::StrCat("row", indexNewRow + 1));
+    table.setEntry(indexNewRow, 0, addRowRowNames.back());
+    checkForm(table, "My table", "My table", addRowRowNames, columnNames);
+    checkRow(table, 0, "row1"s, 0.1f);
+    checkRow(table, 1, "row2"s);
+    checkNeverSet(table, 1, 2);
+
+    // Are the entries of the new row empty?
+    checkNeverSet(table, indexNewRow, 1);
+    checkNeverSet(table, indexNewRow, 2);
+
+    // To those new fields work like the old ones?
+    table.addMeasurement(indexNewRow, 1, createWaitLambda(290));
+    table.setEntry(indexNewRow, 2, createDummyValueEntryType<T>());
+    checkRow(table, indexNewRow, addRowRowNames.back(), 0.29f,
+             createDummyValueEntryType<T>());
+  });
+
+  // Just a simple existence test for printing.
+  const auto tableAsString = static_cast<std::string>(table);
 }
 }  // namespace ad_benchmark

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -10,13 +10,14 @@
 #include <string>
 #include <type_traits>
 #include <variant>
-using namespace std::string_literals;
 
 #include "../benchmark/infrastructure/BenchmarkMeasurementContainer.h"
 #include "util/Exception.h"
 #include "util/Timer.h"
 #include "util/TypeTraits.h"
 #include "util/json.h"
+
+using namespace std::string_literals;
 
 namespace ad_benchmark {
 /*

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -41,18 +41,22 @@ TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
   constexpr size_t waitTimeinMillieseconds = 100;
 
   // The normal constructor.
-  ResultEntry entryNormalConstructor(entryDescriptor, createWaitLambda(waitTimeinMillieseconds));
+  ResultEntry entryNormalConstructor(entryDescriptor,
+                                     createWaitLambda(waitTimeinMillieseconds));
 
   ASSERT_EQ(entryNormalConstructor.descriptor_, entryDescriptor);
 
   // The time measurements can't be 100% accurat, so we give it a 'window'.
-  ASSERT_NEAR(waitTimeinMillieseconds / 1000.0, entryNormalConstructor.measuredTime_, 0.01);
+  ASSERT_NEAR(waitTimeinMillieseconds / 1000.0,
+              entryNormalConstructor.measuredTime_, 0.01);
 
   // The constructor with custom log descriptor.
-  ResultEntry entryLogConstructor(entryDescriptor, "t", createWaitLambda(waitTimeinMillieseconds));
+  ResultEntry entryLogConstructor(entryDescriptor, "t",
+                                  createWaitLambda(waitTimeinMillieseconds));
 
   // The time measurements can't be 100% accurat, so we give it a 'window'.
-  ASSERT_NEAR(waitTimeinMillieseconds / 1000.0, entryLogConstructor.measuredTime_, 0.01);
+  ASSERT_NEAR(waitTimeinMillieseconds / 1000.0,
+              entryLogConstructor.measuredTime_, 0.01);
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
@@ -98,8 +102,8 @@ template <typename Function>
 static void doForTypeInResultTableEntryType(Function function) {
   ad_utility::ConstexprForLoop(
       std::make_index_sequence<std::variant_size_v<ResultTable::EntryType>>{},
-      [&function]<size_t index, typename IndexType =
-                                    std::variant_alternative_t<index, ResultTable::EntryType>>() {
+      [&function]<size_t index, typename IndexType = std::variant_alternative_t<
+                                    index, ResultTable::EntryType>>() {
         // `std::monostate` is not important for these kinds of tests.
         if constexpr (!ad_utility::isSimilar<IndexType, std::monostate>) {
           function.template operator()<IndexType>();
@@ -131,7 +135,8 @@ static Type createDummyValueEntryType() {
 TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   // Looks, if the general form is correct.
   auto checkForm = [](const ResultTable& table, const std::string& name,
-                      const std::string& descriptorForLog, const std::vector<std::string>& rowNames,
+                      const std::string& descriptorForLog,
+                      const std::vector<std::string>& rowNames,
                       const std::vector<std::string>& columnNames) {
     ASSERT_EQ(name, table.descriptor_);
     ASSERT_EQ(descriptorForLog, table.descriptorForLog_);
@@ -155,9 +160,11 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   };
 
   // Checks, if a table entry was never set.
-  auto checkNeverSet = [](const ResultTable& table, const size_t& row, const size_t& column) {
+  auto checkNeverSet = [](const ResultTable& table, const size_t& row,
+                          const size_t& column) {
     // Is it empty?
-    ASSERT_TRUE(std::holds_alternative<std::monostate>(table.entries_.at(row).at(column)));
+    ASSERT_TRUE(std::holds_alternative<std::monostate>(
+        table.entries_.at(row).at(column)));
 
     // Does trying to access it anyway cause an error?
     doForTypeInResultTableEntryType([&table, &row, &column]<typename T>() {
@@ -168,20 +175,24 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   /*
   Check the content of a tables row.
   */
-  auto checkRow = [&assertEqual](const ResultTable& table, const size_t& rowNumber,
+  auto checkRow = [&assertEqual](const ResultTable& table,
+                                 const size_t& rowNumber,
                                  const auto&... wantedContent) {
     size_t column = 0;
     auto check = [&table, &rowNumber, &column,
                   &assertEqual]<typename T>(const T& wantedContent) mutable {
       // `getEntry` should ONLY work with `T`
-      doForTypeInResultTableEntryType([&table, &rowNumber, &column, &assertEqual,
-                                       &wantedContent]<typename PossiblyWrongType>() {
-        if constexpr (ad_utility::isSimilar<PossiblyWrongType, T>) {
-          assertEqual(wantedContent, table.getEntry<std::decay_t<T>>(rowNumber, column));
-        } else {
-          ASSERT_ANY_THROW(table.getEntry<PossiblyWrongType>(rowNumber, column));
-        }
-      });
+      doForTypeInResultTableEntryType(
+          [&table, &rowNumber, &column, &assertEqual,
+           &wantedContent]<typename PossiblyWrongType>() {
+            if constexpr (ad_utility::isSimilar<PossiblyWrongType, T>) {
+              assertEqual(wantedContent,
+                          table.getEntry<std::decay_t<T>>(rowNumber, column));
+            } else {
+              ASSERT_ANY_THROW(
+                  table.getEntry<PossiblyWrongType>(rowNumber, column));
+            }
+          });
       column++;
     };
     ((check(wantedContent)), ...);
@@ -209,52 +220,56 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   checkForm(table, "My table", "My table", rowNames, columnNames);
 
   // Does the constructor for the custom log name work?
-  checkForm(ResultTable("My table", "T", rowNames, columnNames), "My table", "T", rowNames,
-            columnNames);
+  checkForm(ResultTable("My table", "T", rowNames, columnNames), "My table",
+            "T", rowNames, columnNames);
 
   // Add measured function to it.
   table.addMeasurement(0, 1, createWaitLambda(100));
 
   // Check, if it works with custom entries.
-  doForTypeInResultTableEntryType([&table, &checkNeverSet, &checkRow]<typename T1>() {
-    doForTypeInResultTableEntryType([&table, &checkNeverSet, &checkRow]<typename T2>() {
-      // Set custom entries.
-      table.setEntry(0, 2, createDummyValueEntryType<T1>());
-      table.setEntry(1, 1, createDummyValueEntryType<T2>());
+  doForTypeInResultTableEntryType(
+      [&table, &checkNeverSet, &checkRow]<typename T1>() {
+        doForTypeInResultTableEntryType([&table, &checkNeverSet,
+                                         &checkRow]<typename T2>() {
+          // Set custom entries.
+          table.setEntry(0, 2, createDummyValueEntryType<T1>());
+          table.setEntry(1, 1, createDummyValueEntryType<T2>());
 
-      // Check the entries.
-      checkRow(table, 0, "row1"s, 0.1f, createDummyValueEntryType<T1>());
-      checkRow(table, 1, "row2"s, createDummyValueEntryType<T2>());
-      checkNeverSet(table, 1, 2);
-    });
-  });
+          // Check the entries.
+          checkRow(table, 0, "row1"s, 0.1f, createDummyValueEntryType<T1>());
+          checkRow(table, 1, "row2"s, createDummyValueEntryType<T2>());
+          checkNeverSet(table, 1, 2);
+        });
+      });
 
   // For keeping track of the new row names.
   std::vector<std::string> addRowRowNames(rowNames);
   // Testing `addRow`.
-  doForTypeInResultTableEntryType(
-      [&table, &checkNeverSet, &checkRow, &checkForm, &columnNames, &addRowRowNames]<typename T>() {
-        // What is the index of the new row?
-        const size_t indexNewRow = table.numRows();
+  doForTypeInResultTableEntryType([&table, &checkNeverSet, &checkRow,
+                                   &checkForm, &columnNames,
+                                   &addRowRowNames]<typename T>() {
+    // What is the index of the new row?
+    const size_t indexNewRow = table.numRows();
 
-        // Can we add a new row, without changing things?
-        table.addRow();
-        addRowRowNames.emplace_back(absl::StrCat("row", indexNewRow + 1));
-        table.setEntry(indexNewRow, 0, addRowRowNames.back());
-        checkForm(table, "My table", "My table", addRowRowNames, columnNames);
-        checkRow(table, 0, "row1"s, 0.1f);
-        checkRow(table, 1, "row2"s);
-        checkNeverSet(table, 1, 2);
+    // Can we add a new row, without changing things?
+    table.addRow();
+    addRowRowNames.emplace_back(absl::StrCat("row", indexNewRow + 1));
+    table.setEntry(indexNewRow, 0, addRowRowNames.back());
+    checkForm(table, "My table", "My table", addRowRowNames, columnNames);
+    checkRow(table, 0, "row1"s, 0.1f);
+    checkRow(table, 1, "row2"s);
+    checkNeverSet(table, 1, 2);
 
-        // Are the entries of the new row empty?
-        checkNeverSet(table, indexNewRow, 1);
-        checkNeverSet(table, indexNewRow, 2);
+    // Are the entries of the new row empty?
+    checkNeverSet(table, indexNewRow, 1);
+    checkNeverSet(table, indexNewRow, 2);
 
-        // To those new fields work like the old ones?
-        table.addMeasurement(indexNewRow, 1, createWaitLambda(290));
-        table.setEntry(indexNewRow, 2, createDummyValueEntryType<T>());
-        checkRow(table, indexNewRow, addRowRowNames.back(), 0.29f, createDummyValueEntryType<T>());
-      });
+    // To those new fields work like the old ones?
+    table.addMeasurement(indexNewRow, 1, createWaitLambda(290));
+    table.setEntry(indexNewRow, 2, createDummyValueEntryType<T>());
+    checkRow(table, indexNewRow, addRowRowNames.back(), 0.29f,
+             createDummyValueEntryType<T>());
+  });
 
   // Just a simple existence test for printing.
   const auto tableAsString = static_cast<std::string>(table);

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -28,8 +28,8 @@ static auto createWaitLambda(std::chrono::milliseconds waitDuration) {
 TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
   // There's really no special cases.
   const std::string entryDescriptor{"entry"};
-  // The function should just wait 0.01 seconds.
-  constexpr auto waitTime = 10ms;
+  // The function should just wait 0.1 seconds.
+  constexpr auto waitTime = 100ms;
 
   // The normal constructor.
   ResultEntry entryNormalConstructor(entryDescriptor,
@@ -51,8 +51,8 @@ TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
-  // The function should just wait 0.01 seconds.
-  constexpr auto waitTime = 10ms;
+  // The function should just wait 0.1 seconds.
+  constexpr auto waitTime = 100ms;
   // There's really no special cases.
   ResultGroup group("group");
 
@@ -218,7 +218,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
             "T", rowNames, columnNames);
 
   // Add measured function to it.
-  table.addMeasurement(0, 1, createWaitLambda(10ms));
+  table.addMeasurement(0, 1, createWaitLambda(100ms));
 
   // Check, if it works with custom entries.
   doForTypeInResultTableEntryType(
@@ -230,7 +230,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
           table.setEntry(1, 1, createDummyValueEntryType<T2>());
 
           // Check the entries.
-          checkRow(table, 0, "row1"s, 0.01f, createDummyValueEntryType<T1>());
+          checkRow(table, 0, "row1"s, 0.1f, createDummyValueEntryType<T1>());
           checkRow(table, 1, "row2"s, createDummyValueEntryType<T2>());
           checkNeverSet(table, 1, 2);
         });
@@ -250,7 +250,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
     addRowRowNames.emplace_back(absl::StrCat("row", indexNewRow + 1));
     table.setEntry(indexNewRow, 0, addRowRowNames.back());
     checkForm(table, "My table", "My table", addRowRowNames, columnNames);
-    checkRow(table, 0, "row1"s, 0.01f);
+    checkRow(table, 0, "row1"s, 0.1f);
     checkRow(table, 1, "row2"s);
     checkNeverSet(table, 1, 2);
 
@@ -259,9 +259,9 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
     checkNeverSet(table, indexNewRow, 2);
 
     // To those new fields work like the old ones?
-    table.addMeasurement(indexNewRow, 1, createWaitLambda(29ms));
+    table.addMeasurement(indexNewRow, 1, createWaitLambda(290ms));
     table.setEntry(indexNewRow, 2, createDummyValueEntryType<T>());
-    checkRow(table, indexNewRow, addRowRowNames.back(), 0.029f,
+    checkRow(table, indexNewRow, addRowRowNames.back(), 0.29f,
              createDummyValueEntryType<T>());
   });
 

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -118,6 +118,10 @@ static Type createDummyValueEntryType() {
     return "test"s;
   } else if constexpr (ad_utility::isSimilar<Type, bool>) {
     return true;
+  } else if constexpr (ad_utility::isSimilar<Type, size_t>) {
+    return 17361644613946UL;
+  } else if constexpr (ad_utility::isSimilar<Type, int>) {
+    return -42;
   } else {
     // Not a supported type.
     AD_CORRECTNESS_CHECK(false);

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -28,8 +28,8 @@ static auto createWaitLambda(std::chrono::milliseconds waitDuration) {
 TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
   // There's really no special cases.
   const std::string entryDescriptor{"entry"};
-  // The function should just wait 0.1 seconds.
-  constexpr auto waitTime = 100ms;
+  // The function should just wait 0.01 seconds.
+  constexpr auto waitTime = 10ms;
 
   // The normal constructor.
   ResultEntry entryNormalConstructor(entryDescriptor,
@@ -51,8 +51,8 @@ TEST(BenchmarkMeasurementContainerTest, ResultEntry) {
 }
 
 TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
-  // The function should just wait 0.1 seconds.
-  constexpr auto waitTime = 100ms;
+  // The function should just wait 0.01 seconds.
+  constexpr auto waitTime = 10ms;
   // There's really no special cases.
   ResultGroup group("group");
 
@@ -218,7 +218,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
             "T", rowNames, columnNames);
 
   // Add measured function to it.
-  table.addMeasurement(0, 1, createWaitLambda(100ms));
+  table.addMeasurement(0, 1, createWaitLambda(10ms));
 
   // Check, if it works with custom entries.
   doForTypeInResultTableEntryType(
@@ -230,7 +230,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
           table.setEntry(1, 1, createDummyValueEntryType<T2>());
 
           // Check the entries.
-          checkRow(table, 0, "row1"s, 0.1f, createDummyValueEntryType<T1>());
+          checkRow(table, 0, "row1"s, 0.01f, createDummyValueEntryType<T1>());
           checkRow(table, 1, "row2"s, createDummyValueEntryType<T2>());
           checkNeverSet(table, 1, 2);
         });
@@ -250,7 +250,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
     addRowRowNames.emplace_back(absl::StrCat("row", indexNewRow + 1));
     table.setEntry(indexNewRow, 0, addRowRowNames.back());
     checkForm(table, "My table", "My table", addRowRowNames, columnNames);
-    checkRow(table, 0, "row1"s, 0.1f);
+    checkRow(table, 0, "row1"s, 0.01f);
     checkRow(table, 1, "row2"s);
     checkNeverSet(table, 1, 2);
 
@@ -259,9 +259,9 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
     checkNeverSet(table, indexNewRow, 2);
 
     // To those new fields work like the old ones?
-    table.addMeasurement(indexNewRow, 1, createWaitLambda(290ms));
+    table.addMeasurement(indexNewRow, 1, createWaitLambda(29ms));
     table.setEntry(indexNewRow, 2, createDummyValueEntryType<T>());
-    checkRow(table, indexNewRow, addRowRowNames.back(), 0.29f,
+    checkRow(table, indexNewRow, addRowRowNames.back(), 0.029f,
              createDummyValueEntryType<T>());
   });
 

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -129,7 +129,7 @@ static Type createDummyValueEntryType() {
     return -42;
   } else {
     // Not a supported type.
-    AD_CORRECTNESS_CHECK(false);
+    AD_FAIL();
   }
 }
 


### PR DESCRIPTION
When using a table as the result of a benchmark run, each entry of the table now can be any of the following: `int, float, string, bool`.