### PR TITLE
Fix The GitHub MacOS build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -46,7 +46,7 @@ jobs:
         echo 'export LDFLAGS="-L/usr/local/opt/llvm@16/lib -L/usr/local/opt/llvm@16/lib/c++ -Wl,-rpath,/usr/local/opt/llvm@16/lib/c++"' >> ~/.bash_profile
         echo LDFLAGS="-L/usr/local/opt/llvm@16/lib -L/usr/local/opt/llvm@16/lib/c++ -Wl,-rpath,/usr/local/opt/llvm@16/lib/c++" >> $GITHUB_ENV 
         echo 'export CPPFLAGS="-I/usr/local/opt/llvm@16/include"' >> ~/.bash_profile
-        echo  >> CPPFLAGS="/usr/local/opt/llvm@16/include" >> $GITHUB_ENV 
+        echo  CPPFLAGS="/usr/local/opt/llvm@16/include" >> $GITHUB_ENV 
         source ~/.bash_profile
     - name: Print clang version
       run: clang++ --version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,10 +41,14 @@ jobs:
       run:  |
         brew install llvm@16
         brew install conan@2
-        echo 'export PATH="/usr/local/opt/llvm/bin:$PATH"' >> ~/.bash_profile
-        echo PATH="/usr/local/opt/llvm/bin:$PATH" >> $GITHUB_ENV 
+        echo 'export PATH="/usr/local/opt/llvm@16/bin:$PATH"' >> ~/.bash_profile
+        echo PATH="/usr/local/opt/llvm@16/bin:$PATH" >> $GITHUB_ENV 
+        echo 'export LDFLAGS="-L/usr/local/opt/llvm@16/lib -L/usr/local/opt/llvm@16/lib/c++ -Wl,-rpath,/usr/local/opt/llvm@16/lib/c++"' >> ~/.bash_profile
+        echo LDFLAGS="-L/usr/local/opt/llvm@16/lib -L/usr/local/opt/llvm@16/lib/c++ -Wl,-rpath,/usr/local/opt/llvm@16/lib/c++" >> $GITHUB_ENV 
+        echo 'export CPPFLAGS="-I/usr/local/opt/llvm@16/include"' >> ~/.bash_profile
+        echo  >> CPPFLAGS="/usr/local/opt/llvm@16/include" >> $GITHUB_ENV 
         source ~/.bash_profile
-    - name: Pring clang version
+    - name: Print clang version
       run: clang++ --version
 
     - name: Cache for conan


### PR DESCRIPTION
With the release of LLVM 17 on homebrew, our GitHub actions build (which uses LLVM 16) was broken, because several symlinks and environment variables were set to `...llvm...` (no explicit version, implicitly refer to the latest one available).
By changing this to  `...llvm@16...` in all those places these builds now work again.