### PR TITLE
Allow multiline comments when parsing Turtle

### DIFF
--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -9,15 +9,13 @@ void Tokenizer::skipWhitespaceAndComments() {
   // Call `skipWhitespace` and `skipComments` in a loop until no more input was
   // consumed. This is necessary because we might have multiple lines of
   // comments that are spearated by whitespace.
-  auto ptr = _data.begin();
+
   while (true) {
-    skipWhitespace();
-    skipComments();
-    auto newPtr = _data.begin();
-    if (ptr == newPtr) {
+    bool a = skipWhitespace();
+    bool b = skipComments();
+    if (!(a || b)) {
       return;
     }
-    ptr = newPtr;
   }
 }
 

--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -6,9 +6,19 @@
 
 // ______________________________________________________
 void Tokenizer::skipWhitespaceAndComments() {
-  skipWhitespace();
-  skipComments();
-  skipWhitespace();
+  // Call `skipWhitespace` and `skipComments` in a loop until no more input was
+  // consumed. This is necessary because we might have multiple lines of
+  // comments that are spearated by whitespace.
+  auto ptr = _data.begin();
+  while (true) {
+    skipWhitespace();
+    skipComments();
+    auto newPtr = _data.begin();
+    if (ptr == newPtr) {
+      return;
+    }
+    ptr = newPtr;
+  }
 }
 
 // _______________________________________________________

--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -4,21 +4,6 @@
 
 #include "./Tokenizer.h"
 
-// ______________________________________________________
-void Tokenizer::skipWhitespaceAndComments() {
-  // Call `skipWhitespace` and `skipComments` in a loop until no more input was
-  // consumed. This is necessary because we might have multiple lines of
-  // comments that are spearated by whitespace.
-
-  while (true) {
-    bool a = skipWhitespace();
-    bool b = skipComments();
-    if (!(a || b)) {
-      return;
-    }
-  }
-}
-
 // _______________________________________________________
 std::pair<bool, std::string> Tokenizer::getNextToken(const RE2& reg) {
   std::string match = "";
@@ -62,61 +47,62 @@ std::tuple<bool, size_t, std::string> Tokenizer::getNextToken(
 // ______________________________________________________________________________________________________
 const RE2& Tokenizer::idToRegex(const TurtleTokenId reg) {
   switch (reg) {
-    case TurtleTokenId::TurtlePrefix:
+    using enum TurtleTokenId;
+    case TurtlePrefix:
       return _tokens.TurtlePrefix;
-    case TurtleTokenId::SparqlPrefix:
+    case SparqlPrefix:
       return _tokens.SparqlPrefix;
-    case TurtleTokenId::TurtleBase:
+    case TurtleBase:
       return _tokens.TurtleBase;
-    case TurtleTokenId::SparqlBase:
+    case SparqlBase:
       return _tokens.SparqlBase;
-    case TurtleTokenId::Dot:
+    case Dot:
       return _tokens.Dot;
-    case TurtleTokenId::Comma:
+    case Comma:
       return _tokens.Comma;
-    case TurtleTokenId::Semicolon:
+    case Semicolon:
       return _tokens.Semicolon;
-    case TurtleTokenId::OpenSquared:
+    case OpenSquared:
       return _tokens.OpenSquared;
-    case TurtleTokenId::CloseSquared:
+    case CloseSquared:
       return _tokens.CloseSquared;
-    case TurtleTokenId::OpenRound:
+    case OpenRound:
       return _tokens.OpenRound;
-    case TurtleTokenId::CloseRound:
+    case CloseRound:
       return _tokens.CloseRound;
-    case TurtleTokenId::A:
+    case A:
       return _tokens.A;
-    case TurtleTokenId::DoubleCircumflex:
+    case DoubleCircumflex:
       return _tokens.DoubleCircumflex;
-    case TurtleTokenId::True:
+    case True:
       return _tokens.True;
-    case TurtleTokenId::False:
+    case False:
       return _tokens.False;
-    case TurtleTokenId::Langtag:
+    case Langtag:
       return _tokens.Langtag;
-    case TurtleTokenId::Decimal:
+    case Decimal:
       return _tokens.Decimal;
-    case TurtleTokenId::Exponent:
+    case Exponent:
       return _tokens.Exponent;
-    case TurtleTokenId::Double:
+    case Double:
       return _tokens.Double;
-    case TurtleTokenId::Iriref:
+    case Iriref:
       return _tokens.Iriref;
-    case TurtleTokenId::PnameNS:
+    case PnameNS:
       return _tokens.PnameNS;
-    case TurtleTokenId::PnameLN:
+    case PnameLN:
       return _tokens.PnameLN;
-    case TurtleTokenId::PnLocal:
+    case PnLocal:
       return _tokens.PnLocal;
-    case TurtleTokenId::BlankNodeLabel:
+    case BlankNodeLabel:
       return _tokens.BlankNodeLabel;
-    case TurtleTokenId::WsMultiple:
+    case WsMultiple:
       return _tokens.WsMultiple;
-    case TurtleTokenId::Anon:
+    case Anon:
       return _tokens.Anon;
-    case TurtleTokenId::Comment:
+    case Comment:
       return _tokens.Comment;
-    case TurtleTokenId::Integer:
+    case Integer:
       return _tokens.Integer;
   }
   throw std::runtime_error(

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -308,16 +308,14 @@ class Tokenizer {
   // ________________________________________________________________
   bool skipWhitespace() {
     auto v = view();
-    auto pos = v.find_first_not_of("\x20\x09\x0D\x0A");
-    pos = std::min(pos, v.size());
-    _data.remove_prefix(pos);
-    return pos != 0;
+    auto numLeadingWhitespace = v.find_first_not_of("\x20\x09\x0D\x0A");
+    numLeadingWhitespace = std::min(numLeadingWhitespace, v.size());
+    _data.remove_prefix(numLeadingWhitespace);
+    return numLeadingWhitespace > 0;
   }
 
   // ___________________________________________________________________________________
   bool skipComments() {
-    // if not successful, then there was no comment, but this does not matter to
-    // us
     auto v = view();
     if (v.starts_with('#')) {
       auto pos = v.find('\n');

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -9,9 +9,9 @@
 
 #include <regex>
 
-#include "../util/Exception.h"
-#include "../util/Log.h"
-#include "./TurtleTokenId.h"
+#include "parser/TurtleTokenId.h"
+#include "util/Exception.h"
+#include "util/Log.h"
 
 using re2::RE2;
 using namespace std::string_literals;
@@ -199,6 +199,57 @@ struct TurtleToken {
   static string cls(const string& s) { return '[' + s + ']'; }
 };
 
+// A CRTP-style Mixin that factors out the common implementation of
+// `skipWhitespaceAndComments` of the `Tokenizer` and `TokenizerCtre` classes.
+template <typename Self>
+struct SkipWhitespaceAndCommentsMixin {
+ private:
+  Self& self() { return static_cast<Self&>(*this); }
+
+ public:
+  /// Skip any whitespace or comments at the beginning of the held characters
+  void skipWhitespaceAndComments() {
+    // Call `skipWhitespace` and `skipComments` in a loop until no more input
+    // was consumed. This is necessary because we might have multiple lines of
+    // comments that are spearated by whitespace.
+    while (true) {
+      bool a = skipWhitespace();
+      bool b = skipComments();
+      if (!(a || b)) {
+        return;
+      }
+    }
+  }
+
+ private:
+  // ________________________________________________________________
+  bool skipWhitespace() {
+    auto v = self().view();
+    auto numLeadingWhitespace = v.find_first_not_of("\x20\x09\x0D\x0A");
+    numLeadingWhitespace = std::min(numLeadingWhitespace, v.size());
+    self()._data.remove_prefix(numLeadingWhitespace);
+    return numLeadingWhitespace > 0;
+  }
+
+  // ___________________________________________________________________________________
+  bool skipComments() {
+    auto v = self().view();
+    if (v.starts_with('#')) {
+      auto pos = v.find('\n');
+      if (pos == string::npos) {
+        // TODO<joka921>: This should rather yield an error.
+        LOG(INFO) << "Warning, unfinished comment found while parsing"
+                  << std::endl;
+      } else {
+        self()._data.remove_prefix(pos + 1);
+      }
+      return true;
+    }
+    return false;
+  }
+  FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
+};
+
 /**
  * @brief Tokenizer that uses the Ctre library
  *
@@ -209,7 +260,8 @@ struct TurtleToken {
 
 // The currently used hand-written tokenizer
 // for this for correctness and efficiency
-class Tokenizer {
+class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
+  friend struct SkipWhitespaceAndCommentsMixin<Tokenizer>;
   FRIEND_TEST(TokenizerTest, Compilation);
 
  public:
@@ -271,9 +323,6 @@ class Tokenizer {
                       curBetter ? res : content);
   }
 
-  // _______________________________________________________________________________
-  void skipWhitespaceAndComments();
-
   // If there is a prefix match with the argument, move forward the input stream
   // and return true. Can be used if we are not interested in the actual value
   // of the match
@@ -305,31 +354,6 @@ class Tokenizer {
   // convert the (external) TurtleTokenId to the internally used google-regex
   const RE2& idToRegex(const TurtleTokenId reg);
 
-  // ________________________________________________________________
-  bool skipWhitespace() {
-    auto v = view();
-    auto numLeadingWhitespace = v.find_first_not_of("\x20\x09\x0D\x0A");
-    numLeadingWhitespace = std::min(numLeadingWhitespace, v.size());
-    _data.remove_prefix(numLeadingWhitespace);
-    return numLeadingWhitespace > 0;
-  }
-
-  // ___________________________________________________________________________________
-  bool skipComments() {
-    auto v = view();
-    if (v.starts_with('#')) {
-      auto pos = v.find('\n');
-      if (pos == string::npos) {
-        // TODO: this actually should yield a n error
-        LOG(INFO) << "Warning, unfinished comment found while parsing"
-                  << std::endl;
-      } else {
-        _data.remove_prefix(pos + 1);
-      }
-      return true;
-    }
-    return false;
-  }
   FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
   re2::StringPiece _data;
 };

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -222,7 +222,7 @@ struct SkipWhitespaceAndCommentsMixin {
   }
 
  private:
-  // ________________________________________________________________
+  // _________________________________________________________________________
   bool skipWhitespace() {
     auto v = self().view();
     auto numLeadingWhitespace = v.find_first_not_of("\x20\x09\x0D\x0A");
@@ -231,7 +231,7 @@ struct SkipWhitespaceAndCommentsMixin {
     return numLeadingWhitespace > 0;
   }
 
-  // ___________________________________________________________________________________
+  // _________________________________________________________________________
   bool skipComments() {
     auto v = self().view();
     if (v.starts_with('#')) {

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -306,16 +306,16 @@ class Tokenizer {
   const RE2& idToRegex(const TurtleTokenId reg);
 
   // ________________________________________________________________
-  void skipWhitespace() {
+  bool skipWhitespace() {
     auto v = view();
     auto pos = v.find_first_not_of("\x20\x09\x0D\x0A");
     pos = std::min(pos, v.size());
     _data.remove_prefix(pos);
-    return;
+    return pos != 0;
   }
 
   // ___________________________________________________________________________________
-  void skipComments() {
+  bool skipComments() {
     // if not successful, then there was no comment, but this does not matter to
     // us
     auto v = view();
@@ -328,7 +328,9 @@ class Tokenizer {
       } else {
         _data.remove_prefix(pos + 1);
       }
+      return true;
     }
+    return false;
   }
   FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
   re2::StringPiece _data;

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -198,9 +198,19 @@ class TokenizerCtre {
 
   /// Skip any whitespace or comments at the beginning of the held characters
   void skipWhitespaceAndComments() {
-    skipWhitespace();
-    skipComments();
-    skipWhitespace();
+    // Call `skipWhitespace` and `skipComments` in a loop until no more input
+    // was consumed. This is necessary because we might have multiple lines of
+    // comments that are spearated by whitespace.
+    auto ptr = _data.begin();
+    while (true) {
+      skipWhitespace();
+      skipComments();
+      auto newPtr = _data.begin();
+      if (ptr == newPtr) {
+        return;
+      }
+      ptr = newPtr;
+    }
   }
 
   /**

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -240,10 +240,10 @@ class TokenizerCtre {
   // ________________________________________________________________
   bool skipWhitespace() {
     auto v = view();
-    auto pos = v.find_first_not_of("\x20\x09\x0D\x0A");
-    pos = std::min(pos, v.size());
-    _data.remove_prefix(pos);
-    return pos != 0;
+    auto numLeadingWhitespace = v.find_first_not_of("\x20\x09\x0D\x0A");
+    numLeadingWhitespace = std::min(numLeadingWhitespace, v.size());
+    _data.remove_prefix(numLeadingWhitespace);
+    return numLeadingWhitespace > 0;
   }
 
   // ___________________________________________________________________________________

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -198,22 +198,6 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
     return innerResult;
   }
 
-  /*
-  /// Skip any whitespace or comments at the beginning of the held characters
-  void skipWhitespaceAndComments() {
-    // Call `skipWhitespace` and `skipComments` in a loop until no more input
-    // was consumed. This is necessary because we might have multiple lines of
-    // comments that are spearated by whitespace.
-    while (true) {
-      bool a = skipWhitespace();
-      bool b = skipComments();
-      if (!(a || b)) {
-        return;
-      }
-    }
-  }
-   */
-
   /**
    * If there is a prefix match with the argument, move forward the beginning
    * of _data and return true. Else return false.Can be used if we are not
@@ -241,34 +225,6 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
   /// string_view of the characters we are parsing from.
   std::string_view _data;
 
-  /*
-  // ________________________________________________________________
-  bool skipWhitespace() {
-    auto v = view();
-    auto numLeadingWhitespace = v.find_first_not_of("\x20\x09\x0D\x0A");
-    numLeadingWhitespace = std::min(numLeadingWhitespace, v.size());
-    _data.remove_prefix(numLeadingWhitespace);
-    return numLeadingWhitespace > 0;
-  }
-
-  //
-  ___________________________________________________________________________________
-  bool skipComments() {
-    auto v = view();
-    if (v.starts_with('#')) {
-      auto pos = v.find('\n');
-      if (pos == string::npos) {
-        // TODO<joka921>: This should rather yield an error.
-        LOG(INFO) << "Warning, unfinished comment found while parsing"
-                  << std::endl;
-      } else {
-        _data.remove_prefix(pos + 1);
-      }
-      return true;
-    }
-    return false;
-  }
-   */
   FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
 
   /*

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -10,6 +10,7 @@
 #include <cstdlib>
 #include <string>
 
+#include "parser/Tokenizer.h"
 #include "parser/TurtleTokenId.h"
 #include "util/CtreHelpers.h"
 #include "util/Log.h"
@@ -140,7 +141,8 @@ struct TurtleTokenCtre {
   static constexpr fixed_string Comment = grp(CommentString);
 };
 
-class TokenizerCtre {
+class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
+  friend struct SkipWhitespaceAndCommentsMixin<TokenizerCtre>;
   FRIEND_TEST(TokenizerTest, Compilation);
   using string = std::string;
 
@@ -196,6 +198,7 @@ class TokenizerCtre {
     return innerResult;
   }
 
+  /*
   /// Skip any whitespace or comments at the beginning of the held characters
   void skipWhitespaceAndComments() {
     // Call `skipWhitespace` and `skipComments` in a loop until no more input
@@ -209,6 +212,7 @@ class TokenizerCtre {
       }
     }
   }
+   */
 
   /**
    * If there is a prefix match with the argument, move forward the beginning
@@ -237,6 +241,7 @@ class TokenizerCtre {
   /// string_view of the characters we are parsing from.
   std::string_view _data;
 
+  /*
   // ________________________________________________________________
   bool skipWhitespace() {
     auto v = view();
@@ -246,7 +251,8 @@ class TokenizerCtre {
     return numLeadingWhitespace > 0;
   }
 
-  // ___________________________________________________________________________________
+  //
+  ___________________________________________________________________________________
   bool skipComments() {
     auto v = view();
     if (v.starts_with('#')) {
@@ -262,6 +268,7 @@ class TokenizerCtre {
     }
     return false;
   }
+   */
   FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
 
   /*

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -201,15 +201,12 @@ class TokenizerCtre {
     // Call `skipWhitespace` and `skipComments` in a loop until no more input
     // was consumed. This is necessary because we might have multiple lines of
     // comments that are spearated by whitespace.
-    auto ptr = _data.begin();
     while (true) {
-      skipWhitespace();
-      skipComments();
-      auto newPtr = _data.begin();
-      if (ptr == newPtr) {
+      bool a = skipWhitespace();
+      bool b = skipComments();
+      if (!(a || b)) {
         return;
       }
-      ptr = newPtr;
     }
   }
 
@@ -241,15 +238,16 @@ class TokenizerCtre {
   std::string_view _data;
 
   // ________________________________________________________________
-  void skipWhitespace() {
+  bool skipWhitespace() {
     auto v = view();
     auto pos = v.find_first_not_of("\x20\x09\x0D\x0A");
     pos = std::min(pos, v.size());
     _data.remove_prefix(pos);
+    return pos != 0;
   }
 
   // ___________________________________________________________________________________
-  void skipComments() {
+  bool skipComments() {
     auto v = view();
     if (v.starts_with('#')) {
       auto pos = v.find('\n');
@@ -260,7 +258,9 @@ class TokenizerCtre {
       } else {
         _data.remove_prefix(pos + 1);
       }
+      return true;
     }
+    return false;
   }
   FRIEND_TEST(TokenizerTest, WhitespaceAndComments);
 


### PR DESCRIPTION
Multiple adjacent lines that started with a `#` (indicating a comment) previously caused the Turtle parser to crash. This is now fixed.