### PR TITLE
Make it possible to pass and explicit execution context to the query …

### DIFF
--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -681,17 +681,20 @@ TEST(QueryPlannerTest, threeVarTriples) {
 }
 
 TEST(QueryPlannerTest, threeVarTriplesTCJ) {
+  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
   h::expect(
       "SELECT ?x ?p ?o WHERE {"
       "<s> ?p ?x . ?x ?p ?o }",
       h::MultiColumnJoin(h::IndexScan("<s>", Var{"?p"}, Var{"?x"}),
-                         h::IndexScan(Var{"?x"}, Var{"?p"}, Var{"?o"})));
+                         h::IndexScan(Var{"?x"}, Var{"?p"}, Var{"?o"})),
+      qec);
 
   h::expect(
       "SELECT ?s ?p ?o WHERE {"
       "?s ?p ?o . ?s ?p <x> }",
       h::MultiColumnJoin(h::IndexScan(Var{"?s"}, Var{"?p"}, Var{"?o"}),
-                         h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")));
+                         h::IndexScan(Var{"?s"}, Var{"?p"}, "<x>")),
+      qec);
 }
 
 TEST(QueryPlannerTest, threeVarXthreeVarException) {
@@ -1025,32 +1028,40 @@ TEST(QueryPlannerTest, SimpleTripleOneVariable) {
 TEST(QueryPlannerTest, SimpleTripleTwoVariables) {
   using enum Permutation::Enum;
 
+  // In the following tests we need the query planner to be aware that the index
+  // contains the entities `<s> <p> <o>` that are used below, otherwise it will
+  // estimate that and Index scan has the same cost as an Index scan followed by
+  // a sort (because both plans have a cost of zero if the index scan is known
+  // to be empty).
+
+  auto qec = ad_utility::testing::getQec("<s> <p> <o>");
+
   // Fixed predicate.
 
   // Without `Order By`, two orderings are possible, both are fine.
   h::expect("SELECT * WHERE { ?s <p> ?o }",
-            h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {POS, PSO}));
+            h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {POS, PSO}), qec);
   // Must always be a single index scan, never index scan + sorting.
   h::expect("SELECT * WHERE { ?s <p> ?o } INTERNAL SORT BY ?o",
-            h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {POS}));
+            h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {POS}), qec);
   h::expect("SELECT * WHERE { ?s <p> ?o } INTERNAL SORT BY ?s",
-            h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {PSO}));
+            h::IndexScan(Var{"?s"}, "<p>", Var{"?o"}, {PSO}), qec);
 
   // Fixed subject.
   h::expect("SELECT * WHERE { <s> ?p ?o }",
-            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP, SPO}));
+            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP, SPO}), qec);
   h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?o",
-            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP}));
+            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP}), qec);
   h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?p",
-            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SPO}));
+            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SPO}), qec);
 
   // Fixed object.
   h::expect("SELECT * WHERE { <s> ?p ?o }",
-            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP, SPO}));
+            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP, SPO}), qec);
   h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?o",
-            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP}));
+            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SOP}), qec);
   h::expect("SELECT * WHERE { <s> ?p ?o } INTERNAL SORT BY ?p",
-            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SPO}));
+            h::IndexScan("<s>", Var{"?p"}, Var{"?o"}, {SPO}), qec);
 }
 
 TEST(QueryPlannerTest, SimpleTripleThreeVariables) {

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "./IndexTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "engine/Bind.h"
 #include "engine/CartesianProductJoin.h"
@@ -127,19 +128,21 @@ inline auto CartesianProductJoin =
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`
-QueryExecutionTree parseAndPlan(std::string query) {
+QueryExecutionTree parseAndPlan(std::string query, QueryExecutionContext* qec) {
   ParsedQuery pq = SparqlParser::parseQuery(std::move(query));
   // TODO<joka921> make it impossible to pass `nullptr` here, properly mock a
   // queryExecutionContext.
-  return QueryPlanner{nullptr}.createExecutionTree(pq);
+  return QueryPlanner{qec}.createExecutionTree(pq);
 }
 
 // Check that the `QueryExecutionTree` that is obtained by parsing and planning
 // the `query` matches the `matcher`.
 void expect(std::string query, auto matcher,
+            std::optional<QueryExecutionContext*> optQec = std::nullopt,
             source_location l = source_location::current()) {
   auto trace = generateLocationTrace(l, "expect");
-  auto qet = parseAndPlan(std::move(query));
+  QueryExecutionContext* qec = optQec.value_or(ad_utility::testing::getQec());
+  auto qet = parseAndPlan(std::move(query), qec);
   EXPECT_THAT(qet, matcher);
 }
 }  // namespace queryPlannerTestHelpers


### PR DESCRIPTION
…planner tests.