### PR TITLE
Expose cancellation API via HTTP/Websocket

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -135,8 +135,9 @@ void Server::run(const string& indexBaseName, bool useText, bool usePatterns,
     auto queryHub =
         std::make_shared<ad_utility::websocket::QueryHub>(ioContext);
     // Make sure the `queryHub` does not outlive the ioContext it has a
-    // reference to, by only using a weak ptr here. Note: It must be only
-    // converted back to a shared_ptr inside a task running on the io_context.
+    // reference to, by only storing a `weak_ptr` in the `queryHub_`. Note: This
+    // `weak_ptr` may only be converted back to a `shared_ptr` inside a task
+    // running on the `io_context`.
     queryHub_ = queryHub;
     return [this, queryHub = std::move(queryHub)](
                const http::request<http::string_body>& request,

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -131,8 +131,9 @@ void Server::run(const string& indexBaseName, bool useText, bool usePatterns,
 
   // First set up the HTTP server, so that it binds to the socket, and
   // the "socket already in use" error appears quickly.
-  auto httpServer = HttpServer{port_, "0.0.0.0", static_cast<int>(numThreads_),
-                               std::move(httpSessionHandler)};
+  auto httpServer =
+      HttpServer{queryRegistry_, port_, "0.0.0.0",
+                 static_cast<int>(numThreads_), std::move(httpSessionHandler)};
   queryHub_ = &httpServer.getQueryHub();
 
   // Initialize the index
@@ -536,6 +537,7 @@ std::function<void()> Server::setupCancellationHandle(
     const std::shared_ptr<Operation>& rootOperation,
     std::optional<std::chrono::seconds> timeLimit) {
   auto cancellationHandle = queryRegistry_.getCancellationHandle(queryId);
+  AD_CORRECTNESS_CHECK(cancellationHandle);
   rootOperation->recursivelySetCancellationHandle(
       std::move(cancellationHandle));
   if (timeLimit.has_value()) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -293,7 +293,8 @@ Awaitable<void> Server::process(
   std::optional<http::response<http::string_body>> response;
 
   // Execute commands (URL parameter with key "cmd").
-  auto logCommand = [](std::optional<std::string>& cmd, std::string actionMsg) {
+  auto logCommand = [](const std::optional<std::string>& cmd,
+                       std::string_view actionMsg) {
     LOG(INFO) << "Processing command \"" << cmd.value() << "\""
               << ": " << actionMsg << std::endl;
   };

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -139,16 +139,12 @@ void Server::run(const string& indexBaseName, bool useText, bool usePatterns,
           *queryHub_, queryRegistry_, request, std::move(socket));
     };
   };
-  using WebSocketHandlerType =
-      std::invoke_result_t<decltype(webSocketSessionSupplier),
-                           net::io_context&>;
 
   // First set up the HTTP server, so that it binds to the socket, and
   // the "socket already in use" error appears quickly.
-  auto httpServer =
-      HttpServer<decltype(httpSessionHandler), WebSocketHandlerType>{
-          port_, "0.0.0.0", static_cast<int>(numThreads_),
-          std::move(httpSessionHandler), std::move(webSocketSessionSupplier)};
+  auto httpServer = HttpServer{port_, "0.0.0.0", static_cast<int>(numThreads_),
+                               std::move(httpSessionHandler),
+                               std::move(webSocketSessionSupplier)};
 
   // Initialize the index
   initialize(indexBaseName, useText, usePatterns, loadAllPermutations);

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -315,6 +315,10 @@ Awaitable<void> Server::process(
   } else if (auto cmd = checkParameter("cmd", "get-settings")) {
     logCommand(cmd, "get server settings");
     response = createJsonResponse(RuntimeParameters().toMap(), request);
+  } else if (auto cmd =
+                 checkParameter("cmd", "dump-active-queries", accessTokenOk)) {
+    logCommand(cmd, "dump active queries");
+    response = createJsonResponse(queryRegistry_.getActiveQueries(), request);
   }
 
   // Ping with or without messsage.

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -540,7 +540,7 @@ std::function<void()> Server::setupCancellationHandle(
     const net::any_io_executor& executor,
     const ad_utility::websocket::QueryId& queryId,
     const std::shared_ptr<Operation>& rootOperation,
-    std::optional<std::chrono::seconds> timeLimit) {
+    std::optional<std::chrono::seconds> timeLimit) const {
   auto cancellationHandle = queryRegistry_.getCancellationHandle(queryId);
   AD_CORRECTNESS_CHECK(cancellationHandle);
   rootOperation->recursivelySetCancellationHandle(

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -141,11 +141,13 @@ class Server {
       std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
       std::chrono::seconds timeLimit);
 
-  /// Create a cancellation handle, pass it to the operation and configure
-  /// it to get cancelled automatically if a time limit is passed by calling
-  /// `cancelAfterDeadline`. If `timeLimit` is empty, return a no-op lambda.
-  static std::function<void()> setupCancellationHandle(
+  /// Acquire the cancellation handle based on `queryId`, pass it to the
+  /// operation and configure it to get cancelled automatically if a time limit
+  /// is passed by calling `cancelAfterDeadline`. If `timeLimit` is empty,
+  /// return a no-op lambda.
+  std::function<void()> setupCancellationHandle(
       const net::any_io_executor& executor,
+      const ad_utility::websocket::QueryId& queryId,
       const std::shared_ptr<Operation>& rootOperation,
       std::optional<std::chrono::seconds> timeLimit);
 };

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -149,5 +149,5 @@ class Server {
       const net::any_io_executor& executor,
       const ad_utility::websocket::QueryId& queryId,
       const std::shared_ptr<Operation>& rootOperation,
-      std::optional<std::chrono::seconds> timeLimit);
+      std::optional<std::chrono::seconds> timeLimit) const;
 };

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -143,8 +143,9 @@ class Server {
 
   /// Acquire the cancellation handle based on `queryId`, pass it to the
   /// operation and configure it to get cancelled automatically if a time limit
-  /// is passed by calling `cancelAfterDeadline`. If `timeLimit` is empty,
-  /// return a no-op lambda.
+  /// is passed by calling `cancelAfterDeadline`. In this case the return value
+  /// can be used to cancel the timer. If `timeLimit` is empty, return a
+  /// no-op lambda.
   std::function<void()> setupCancellationHandle(
       const net::any_io_executor& executor,
       const ad_utility::websocket::QueryId& queryId,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -67,7 +67,7 @@ class Server {
   // Because HttpServer is not a member of this class, we need to assign
   // this pointer after HttpServer is instanced. It is also set back to
   // nullptr once the object is destroyed which only happens on shutdown.
-  ad_utility::websocket::QueryHub* queryHub_ = nullptr;
+  std::unique_ptr<ad_utility::websocket::QueryHub> queryHub_ = nullptr;
 
   mutable net::static_thread_pool threadPool_;
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -64,10 +64,9 @@ class Server {
 
   bool enablePatternTrick_;
 
-  // Because HttpServer is not a member of this class, we need to assign
-  // this pointer after HttpServer is instanced. It is also set back to
-  // nullptr once the object is destroyed which only happens on shutdown.
-  std::unique_ptr<ad_utility::websocket::QueryHub> queryHub_ = nullptr;
+  /// Non-owning reference to the `QueryHub` instance living inside
+  /// the `WebSocketHandler` created for `HttpServer`.
+  std::weak_ptr<ad_utility::websocket::QueryHub> queryHub_;
 
   mutable net::static_thread_pool threadPool_;
 

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -288,4 +288,10 @@ class HttpServer {
   }
 };
 
+template <typename HttpHandler, typename WebSocketHandlerSupplier>
+HttpServer(unsigned short, const std::string&, int, HttpHandler,
+           WebSocketHandlerSupplier)
+    -> HttpServer<HttpHandler, std::invoke_result_t<WebSocketHandlerSupplier,
+                                                    net::io_context&>>;
+
 #endif  // QLEVER_HTTPSERVER_H

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -41,6 +41,11 @@ using tcp = boost::asio::ip::tcp;  // from <boost/asio/ip/tcp.hpp>
  *
  * A very basic HttpHandler, which simply serves files from a directory, can be
  * obtained via `ad_utility::httpUtils::makeFileServer()`.
+ *
+ * \tparam WebSocketHandler A callable type that receives a `http::request<...>`
+ * and the underlying socket that was used to receive the request and returns
+ * a `net::awaitable<void>`. It is only called if the request is a valid
+ * websocket upgrade request and the URL represents a valid path.
  */
 template <typename HttpHandler,
           ad_utility::InvocableWithExactReturnType<
@@ -288,6 +293,8 @@ class HttpServer {
   }
 };
 
+/// Deduction guide, so you don't have to specify the types explicitly
+/// when creating an instance of this class.
 template <typename HttpHandler, typename WebSocketHandlerSupplier>
 HttpServer(unsigned short, const std::string&, int, HttpHandler,
            WebSocketHandlerSupplier)

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -72,7 +72,7 @@ class HttpServer {
   /// server will listen, as well as the HttpHandler. This constructor only
   /// initializes several member functions
   explicit HttpServer(
-      unsigned short port, const std::string& ipAddress = "0.0.0.0",
+      unsigned short port, std::string_view ipAddress = "0.0.0.0",
       int numServerThreads = 1, HttpHandler handler = HttpHandler{},
       ad_utility::InvocableWithConvertibleReturnType<WebSocketHandler,
                                                      net::io_context&> auto

--- a/src/util/http/websocket/MessageSender.h
+++ b/src/util/http/websocket/MessageSender.h
@@ -55,7 +55,9 @@ class MessageSender {
   /// Broadcast the string to all listeners of this query asynchronously.
   void operator()(std::string) const;
 
-  const QueryId& getQueryId() const noexcept { return distributor_->owningQueryId_.toQueryId(); }
+  const QueryId& getQueryId() const noexcept {
+    return distributor_->owningQueryId_.toQueryId();
+  }
 };
 
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/MessageSender.h
+++ b/src/util/http/websocket/MessageSender.h
@@ -55,6 +55,7 @@ class MessageSender {
   /// Broadcast the string to all listeners of this query asynchronously.
   void operator()(std::string) const;
 
+  /// Get read only view of underlying `QueryId`.
   const QueryId& getQueryId() const noexcept {
     return distributor_->owningQueryId_.toQueryId();
   }

--- a/src/util/http/websocket/MessageSender.h
+++ b/src/util/http/websocket/MessageSender.h
@@ -54,6 +54,8 @@ class MessageSender {
 
   /// Broadcast the string to all listeners of this query asynchronously.
   void operator()(std::string) const;
+
+  const QueryId& getQueryId() const noexcept { return distributor_->owningQueryId_.toQueryId(); }
 };
 
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/QueryId.h
+++ b/src/util/http/websocket/QueryId.h
@@ -24,7 +24,9 @@ class QueryId {
     AD_CONTRACT_CHECK(!id_.empty());
   }
 
-  friend void to_json(nlohmann::json&, const QueryId&);
+  friend void to_json(nlohmann::json& json, const QueryId& queryId) {
+    json = queryId.id_;
+  }
 
  public:
   /// Construct this object with the passed string
@@ -43,10 +45,6 @@ class QueryId {
   // Starting with gcc 12 and clang 15 this can be constexpr
   bool operator==(const QueryId&) const noexcept = default;
 };
-
-inline void to_json(nlohmann::json& json, const QueryId& queryId) {
-  json = queryId.id_;
-}
 
 /// This class is similar to QueryId, but it's instances are all unique within
 /// the registry it was created with. (It can not be created without a registry)

--- a/src/util/http/websocket/QueryId.h
+++ b/src/util/http/websocket/QueryId.h
@@ -132,8 +132,16 @@ class QueryRegistry {
     });
   }
 
+  /// Returns the cancellation handle from the registry if it exists, nullptr
+  /// otherwise.
   SharedCancellationHandle getCancellationHandle(const QueryId& queryId) const {
-    return registry_->rlock()->at(queryId);
+    return registry_->withReadLock(
+        [&queryId](const auto& map) -> SharedCancellationHandle {
+          if (map.contains(queryId)) {
+            return map.at(queryId);
+          }
+          return nullptr;
+        });
   }
 };
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -40,8 +40,8 @@ net::awaitable<void> WebSocketSession::handleClientCommands() {
         if (auto cancellationHandle =
                 queryRegistry_.getCancellationHandle(queryId_)) {
           cancellationHandle->cancel(CancellationState::MANUAL);
+          break;
         }
-        break;
       }
     }
     buffer.clear();

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -52,8 +52,6 @@ net::awaitable<void> WebSocketSession::handleClientCommands() {
       if (dataAsString == "cancel_on_close") {
         cancelOnClose_ = true;
       } else if (dataAsString == "cancel" && tryToCancelQuery()) {
-        co_await ws_.async_close(beast::websocket::close_code::normal,
-                                 net::use_awaitable);
         break;
       }
     }

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -33,9 +33,17 @@ net::awaitable<void> WebSocketSession::handleClientCommands() {
 
   while (ws_.is_open()) {
     co_await ws_.async_read(buffer, net::use_awaitable);
-    // TODO<RobinTF> replace with cancellation process
-    ws_.text(ws_.got_text());
-    co_await ws_.async_write(buffer.data(), net::use_awaitable);
+    if (ws_.got_text()) {
+      auto data = buffer.data();
+      if (std::string_view{static_cast<char*>(data.data()), data.size()} ==
+          "cancel") {
+        if (auto cancellationHandle =
+                queryRegistry_.getCancellationHandle(queryId_)) {
+          cancellationHandle->cancel(CancellationState::MANUAL);
+        }
+        break;
+      }
+    }
     buffer.clear();
   }
 }
@@ -89,8 +97,8 @@ net::awaitable<void> WebSocketSession::acceptAndWait(
 // _____________________________________________________________________________
 
 net::awaitable<void> WebSocketSession::handleSession(
-    QueryHub& queryHub, const http::request<http::string_body>& request,
-    tcp::socket socket) {
+    QueryHub& queryHub, const QueryRegistry& queryRegistry,
+    const http::request<http::string_body>& request, tcp::socket socket) {
   // Make sure access to new websocket is on a strand and therefore thread safe
   auto executor = co_await net::this_coro::executor;
   AD_CONTRACT_CHECK(
@@ -99,8 +107,10 @@ net::awaitable<void> WebSocketSession::handleSession(
 
   auto queryIdString = extractQueryId(request.target());
   AD_CORRECTNESS_CHECK(!queryIdString.empty());
-  UpdateFetcher fetcher{queryHub, QueryId::idFromString(queryIdString)};
-  WebSocketSession webSocketSession{std::move(fetcher), std::move(socket)};
+  auto queryId = QueryId::idFromString(queryIdString);
+  UpdateFetcher fetcher{queryHub, queryId};
+  WebSocketSession webSocketSession{std::move(fetcher), std::move(socket),
+                                    queryRegistry, std::move(queryId)};
   co_await webSocketSession.acceptAndWait(request);
 }
 // _____________________________________________________________________________

--- a/src/util/http/websocket/WebSocketSession.h
+++ b/src/util/http/websocket/WebSocketSession.h
@@ -28,8 +28,10 @@ class WebSocketSession {
   QueryId queryId_;
   bool cancelOnClose_ = false;
 
-  /// Wait for input from the client in a loop. Processing will happen in a
-  /// future version of Qlever.
+  /// Wait for input from the client in a loop. If the client sends the string
+  /// "cancel" this will attempt to cancel the current query. If the string is
+  /// "cancel_on_close", it will attempt to cancel it when the websocket closes
+  /// instead. Any other command will be ignored.
   net::awaitable<void> handleClientCommands();
 
   /// Wait for updates of the given query and send them to the client when they
@@ -40,6 +42,7 @@ class WebSocketSession {
   /// `waitForServerEvents` and `handleClientCommands`
   net::awaitable<void> acceptAndWait(const http::request<http::string_body>&);
 
+  /// If the query is active, trigger cancellation.
   bool tryToCancelQuery() const;
 
   /// Construct an instance of this class

--- a/src/util/http/websocket/WebSocketSession.h
+++ b/src/util/http/websocket/WebSocketSession.h
@@ -26,6 +26,7 @@ class WebSocketSession {
   websocket ws_;
   const QueryRegistry& queryRegistry_;
   QueryId queryId_;
+  bool cancelOnClose_ = false;
 
   /// Wait for input from the client in a loop. Processing will happen in a
   /// future version of Qlever.
@@ -38,6 +39,8 @@ class WebSocketSession {
   /// Accept the websocket handshake and delegate further handling to
   /// `waitForServerEvents` and `handleClientCommands`
   net::awaitable<void> acceptAndWait(const http::request<http::string_body>&);
+
+  bool tryToCancelQuery() const;
 
   /// Construct an instance of this class
   WebSocketSession(UpdateFetcher updateFetcher, tcp::socket socket,

--- a/src/util/http/websocket/WebSocketSession.h
+++ b/src/util/http/websocket/WebSocketSession.h
@@ -6,6 +6,7 @@
 
 #include <boost/beast/websocket.hpp>
 
+#include "util/CancellationHandle.h"
 #include "util/http/beast.h"
 #include "util/http/websocket/QueryHub.h"
 #include "util/http/websocket/QueryId.h"
@@ -23,6 +24,8 @@ using websocket = beast::websocket::stream<tcp::socket>;
 class WebSocketSession {
   UpdateFetcher updateFetcher_;
   websocket ws_;
+  const QueryRegistry& queryRegistry_;
+  QueryId queryId_;
 
   /// Wait for input from the client in a loop. Processing will happen in a
   /// future version of Qlever.
@@ -37,8 +40,12 @@ class WebSocketSession {
   net::awaitable<void> acceptAndWait(const http::request<http::string_body>&);
 
   /// Construct an instance of this class
-  WebSocketSession(UpdateFetcher updateFetcher, tcp::socket socket)
-      : updateFetcher_{std::move(updateFetcher)}, ws_{std::move(socket)} {}
+  WebSocketSession(UpdateFetcher updateFetcher, tcp::socket socket,
+                   const QueryRegistry& queryRegistry, QueryId queryId)
+      : updateFetcher_{std::move(updateFetcher)},
+        ws_{std::move(socket)},
+        queryRegistry_{queryRegistry},
+        queryId_{std::move(queryId)} {}
 
  public:
   /// The main interface for this class. The HTTP server is supposed to check
@@ -48,8 +55,8 @@ class WebSocketSession {
   /// coroutine on an explicit strand, and make sure the passed socket's
   /// executor is that same strand, otherwise there may be race conditions.
   static net::awaitable<void> handleSession(
-      QueryHub& queryHub, const http::request<http::string_body>& request,
-      tcp::socket socket);
+      QueryHub& queryHub, const QueryRegistry& queryRegistry,
+      const http::request<http::string_body>& request, tcp::socket socket);
   /// Helper function to provide a proper error response if the provided URL
   /// path is not accepted by the server.
   static std::optional<http::response<http::string_body>>

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -16,7 +16,7 @@ using namespace ad_utility::httpUtils;
 using namespace boost::beast::http;
 
 TEST(HttpServer, HttpTest) {
-  // Create and run a HTTP server, which replies to each request with three
+  // Create and run an HTTP server, which replies to each request with three
   // lines: the request method (GET, POST, or OTHER), a copy of the request
   // target (might be empty), and a copy of the request body (might be empty).
   TestHttpServer httpServer(

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -46,11 +46,10 @@ class TestHttpServer {
   explicit TestHttpServer(HttpHandler httpHandler) {
     const std::string& ipAddress = "0.0.0.0";
     int numServerThreads = 1;
-    auto webSocketSessionSupplier = [this](net::io_context& ioContext) {
+    auto webSocketSessionSupplier = [](net::io_context& ioContext) {
       ad_utility::websocket::QueryHub queryHub{ioContext};
       ad_utility::websocket::QueryRegistry registry;
-      return [this, queryHub = std::move(queryHub),
-              registry = std::move(registry)](
+      return [queryHub = std::move(queryHub), registry = std::move(registry)](
                  const http::request<http::string_body>& request,
                  tcp::socket socket) mutable {
         return ad_utility::websocket::WebSocketSession::handleSession(

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -14,6 +14,7 @@
 #include "util/http/HttpClient.h"
 #include "util/http/HttpServer.h"
 #include "util/http/HttpUtils.h"
+#include "util/http/websocket/QueryId.h"
 #include "util/jthread.h"
 
 using namespace std::literals;
@@ -35,6 +36,7 @@ class TestHttpServer {
   // Indicator whether the server has been shut down. We need this because
   // `HttpServer::shutDown` must only be called once.
   std::atomic<bool> hasBeenShutDown_ = false;
+  ad_utility::websocket::QueryRegistry registry_;
 
  public:
   // Create server on localhost. Port 0 instructs the operating system to choose
@@ -43,7 +45,7 @@ class TestHttpServer {
     const std::string& ipAddress = "0.0.0.0";
     int numServerThreads = 1;
     server_ = std::make_shared<HttpServer<HttpHandler>>(
-        0, ipAddress, numServerThreads, std::move(httpHandler));
+        registry_, 0, ipAddress, numServerThreads, std::move(httpHandler));
   }
 
   // Get port on which this server is running.

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -39,7 +39,6 @@ class TestHttpServer {
   // Indicator whether the server has been shut down. We need this because
   // `HttpServer::shutDown` must only be called once.
   std::atomic<bool> hasBeenShutDown_ = false;
-  ad_utility::websocket::QueryRegistry registry_;
 
  public:
   // Create server on localhost. Port 0 instructs the operating system to choose
@@ -49,11 +48,13 @@ class TestHttpServer {
     int numServerThreads = 1;
     auto webSocketSessionSupplier = [this](net::io_context& ioContext) {
       ad_utility::websocket::QueryHub queryHub{ioContext};
-      return [this, queryHub = std::move(queryHub)](
+      ad_utility::websocket::QueryRegistry registry;
+      return [this, queryHub = std::move(queryHub),
+              registry = std::move(registry)](
                  const http::request<http::string_body>& request,
                  tcp::socket socket) mutable {
         return ad_utility::websocket::WebSocketSession::handleSession(
-            queryHub, registry_, request, std::move(socket));
+            queryHub, registry, request, std::move(socket));
       };
     };
     server_ = std::make_shared<HttpServer<HttpHandler, WebSocketHandlerType>>(

--- a/test/HttpTestHelpers.h
+++ b/test/HttpTestHelpers.h
@@ -44,20 +44,17 @@ class TestHttpServer {
   // Create server on localhost. Port 0 instructs the operating system to choose
   // a free port of its choice.
   explicit TestHttpServer(HttpHandler httpHandler) {
-    const std::string& ipAddress = "0.0.0.0";
-    int numServerThreads = 1;
     auto webSocketSessionSupplier = [](net::io_context& ioContext) {
-      ad_utility::websocket::QueryHub queryHub{ioContext};
-      ad_utility::websocket::QueryRegistry registry;
-      return [queryHub = std::move(queryHub), registry = std::move(registry)](
+      using namespace ad_utility::websocket;
+      return [queryHub = QueryHub{ioContext}, registry = QueryRegistry{}](
                  const http::request<http::string_body>& request,
                  tcp::socket socket) mutable {
-        return ad_utility::websocket::WebSocketSession::handleSession(
-            queryHub, registry, request, std::move(socket));
+        return WebSocketSession::handleSession(queryHub, registry, request,
+                                               std::move(socket));
       };
     };
     server_ = std::make_shared<HttpServer<HttpHandler, WebSocketHandlerType>>(
-        0, ipAddress, numServerThreads, std::move(httpHandler),
+        0, "0.0.0.0", 1, std::move(httpHandler),
         std::move(webSocketSessionSupplier));
   }
 

--- a/test/MessageSenderTest.cpp
+++ b/test/MessageSenderTest.cpp
@@ -14,6 +14,7 @@
 using ad_utility::websocket::MessageSender;
 using ad_utility::websocket::OwningQueryId;
 using ad_utility::websocket::QueryHub;
+using ad_utility::websocket::QueryId;
 using ad_utility::websocket::QueryRegistry;
 
 using namespace boost::asio::experimental::awaitable_operators;
@@ -73,4 +74,17 @@ ASYNC_TEST(MessageSender, callingOperatorBroadcastsPayload) {
   using PayloadType = std::shared_ptr<const std::string>;
 
   EXPECT_THAT(result, VariantWith<PayloadType>(Pointee("Dre"s)));
+}
+
+// _____________________________________________________________________________
+
+ASYNC_TEST(MessageSender, testGetQueryIdGetterWorks) {
+  QueryRegistry queryRegistry;
+  OwningQueryId queryId = queryRegistry.uniqueId();
+  QueryId reference = queryId.toQueryId();
+  QueryHub queryHub{ioContext};
+
+  auto messageSender =
+      co_await MessageSender::create(std::move(queryId), queryHub);
+  EXPECT_EQ(reference, messageSender.getQueryId());
 }

--- a/test/MessageSenderTest.cpp
+++ b/test/MessageSenderTest.cpp
@@ -89,7 +89,13 @@ ASYNC_TEST(MessageSender, testGetQueryIdGetterWorks) {
   QueryId reference = queryId.toQueryId();
   QueryHub queryHub{ioContext};
 
-  auto messageSender =
-      co_await MessageSender::create(std::move(queryId), queryHub);
-  EXPECT_EQ(reference, messageSender.getQueryId());
+  {
+    auto messageSender =
+        co_await MessageSender::create(std::move(queryId), queryHub);
+    EXPECT_EQ(reference, messageSender.getQueryId());
+  }
+  // The destructor of `MessageSender` calls `signalEnd` on the underlying
+  // distributor instance asynchronously, so we need to wait for it to be
+  // executed before destroying the backing `QueryHub` instance.
+  co_await net::post(net::use_awaitable);
 }

--- a/test/QueryIdTest.cpp
+++ b/test/QueryIdTest.cpp
@@ -2,13 +2,16 @@
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "util/http/websocket/QueryId.h"
 
 using ad_utility::websocket::OwningQueryId;
 using ad_utility::websocket::QueryId;
 using ad_utility::websocket::QueryRegistry;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::UnorderedElementsAre;
 
 TEST(QueryId, checkIdEqualityRelation) {
   auto queryIdOne = QueryId::idFromString("some-id");
@@ -37,6 +40,13 @@ TEST(QueryId, checkEmptyAfterMove) {
   auto queryId = QueryId::idFromString("53.32794768794578, -2.230040905974742");
   { auto temporary = std::move(queryId); }
   EXPECT_TRUE(queryId.empty());
+}
+
+// _____________________________________________________________________________
+
+TEST(QueryId, veriyToJsonWorks) {
+  nlohmann::json json = QueryId::idFromString("test-id");
+  EXPECT_EQ(json.get<std::string_view>(), "test-id");
 }
 
 // _____________________________________________________________________________
@@ -88,6 +98,8 @@ TEST(QueryRegistry, demonstrateRegistryLocalUniqueness) {
   EXPECT_EQ(optQidOne->toQueryId(), optQidTwo->toQueryId());
 }
 
+// _____________________________________________________________________________
+
 // The code should guard against the case where the ids outlive their registries
 // so this should not segfault or raise any address sanitizer errors
 TEST(QueryRegistry, performCleanupFromDestroyedRegistry) {
@@ -96,4 +108,44 @@ TEST(QueryRegistry, performCleanupFromDestroyedRegistry) {
     QueryRegistry registry{};
     holder = std::make_unique<OwningQueryId>(registry.uniqueId());
   }
+}
+
+// _____________________________________________________________________________
+
+TEST(QueryRegistry, verifyCancellationHandleIsCreated) {
+  QueryRegistry registry{};
+  auto queryId = registry.uniqueId();
+
+  auto handle1 = registry.getCancellationHandle(queryId.toQueryId());
+  auto handle2 = registry.getCancellationHandle(queryId.toQueryId());
+
+  EXPECT_EQ(handle1, handle2);
+  EXPECT_NE(handle1, nullptr);
+  EXPECT_NE(handle2, nullptr);
+}
+
+// _____________________________________________________________________________
+
+TEST(QueryRegistry, verifyGetActiveQueriesReturnsAllActiveQueries) {
+  QueryRegistry registry{};
+
+  EXPECT_THAT(registry.getActiveQueries(), IsEmpty());
+
+  {
+    auto queryId1 = registry.uniqueId();
+
+    EXPECT_THAT(registry.getActiveQueries(), ElementsAre(queryId1.toQueryId()));
+
+    {
+      auto queryId2 = registry.uniqueId();
+
+      EXPECT_THAT(
+          registry.getActiveQueries(),
+          UnorderedElementsAre(queryId1.toQueryId(), queryId2.toQueryId()));
+    }
+
+    EXPECT_THAT(registry.getActiveQueries(), ElementsAre(queryId1.toQueryId()));
+  }
+
+  EXPECT_THAT(registry.getActiveQueries(), IsEmpty());
 }

--- a/test/QueryIdTest.cpp
+++ b/test/QueryIdTest.cpp
@@ -126,6 +126,17 @@ TEST(QueryRegistry, verifyCancellationHandleIsCreated) {
 
 // _____________________________________________________________________________
 
+TEST(QueryRegistry, verifyCancellationHandleIsNullptrIfNotPresent) {
+  QueryRegistry registry{};
+
+  auto handle =
+      registry.getCancellationHandle(QueryId::idFromString("does not exist"));
+
+  EXPECT_EQ(handle, nullptr);
+}
+
+// _____________________________________________________________________________
+
 TEST(QueryRegistry, verifyGetActiveQueriesReturnsAllActiveQueries) {
   QueryRegistry registry{};
 

--- a/test/WebSocketSessionTest.cpp
+++ b/test/WebSocketSessionTest.cpp
@@ -13,6 +13,7 @@
 
 using ad_utility::websocket::QueryHub;
 using ad_utility::websocket::QueryId;
+using ad_utility::websocket::QueryRegistry;
 using ad_utility::websocket::WebSocketSession;
 namespace net = boost::asio;
 namespace http = boost::beast::http;
@@ -53,6 +54,7 @@ TEST(WebSocketSession, EnsureCorrectPathAcceptAndRejectBehaviour) {
 
 ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientCloseWhileTransmitting) {
   QueryHub queryHub{ioContext};
+  QueryRegistry registry;
 
   auto distributor = co_await queryHub.createOrAcquireDistributorForSending(
       QueryId::idFromString("some-id"));
@@ -83,7 +85,7 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientCloseWhileTransmitting) {
     boost::beast::flat_buffer buffer;
     http::request<http::string_body> request;
     co_await http::async_read(stream, buffer, request, net::use_awaitable);
-    co_await WebSocketSession::handleSession(queryHub, request,
+    co_await WebSocketSession::handleSession(queryHub, registry, request,
                                              std::move(stream.socket()));
   };
 
@@ -94,6 +96,7 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientCloseWhileTransmitting) {
 
 ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientClose) {
   QueryHub queryHub{ioContext};
+  QueryRegistry registry;
 
   tcp::socket server{ioContext};
   tcp::socket client{ioContext};
@@ -114,7 +117,7 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientClose) {
     boost::beast::flat_buffer buffer;
     http::request<http::string_body> request;
     co_await http::async_read(stream, buffer, request, net::use_awaitable);
-    co_await WebSocketSession::handleSession(queryHub, request,
+    co_await WebSocketSession::handleSession(queryHub, registry, request,
                                              std::move(stream.socket()));
   };
 
@@ -125,6 +128,7 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientClose) {
 
 ASYNC_TEST(WebSocketSession, verifySessionEndsWhenServerIsDoneSending) {
   QueryHub queryHub{ioContext};
+  QueryRegistry registry;
 
   auto distributor = co_await queryHub.createOrAcquireDistributorForSending(
       QueryId::idFromString("some-id"));
@@ -157,7 +161,7 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsWhenServerIsDoneSending) {
     boost::beast::flat_buffer buffer;
     http::request<http::string_body> request;
     co_await http::async_read(stream, buffer, request, net::use_awaitable);
-    co_await WebSocketSession::handleSession(queryHub, request,
+    co_await WebSocketSession::handleSession(queryHub, registry, request,
                                              std::move(stream.socket()));
   };
 

--- a/test/WebSocketSessionTest.cpp
+++ b/test/WebSocketSessionTest.cpp
@@ -2,13 +2,14 @@
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <boost/asio/experimental/awaitable_operators.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 
 #include "util/AsyncTestHelpers.h"
 #include "util/BeastTestHelpers.h"
+#include "util/GTestHelpers.h"
 #include "util/http/websocket/WebSocketSession.h"
 
 using ad_utility::websocket::QueryHub;
@@ -19,12 +20,23 @@ namespace net = boost::asio;
 namespace http = boost::beast::http;
 using net::ip::tcp;
 using namespace boost::asio::experimental::awaitable_operators;
+using ::testing::HasSubstr;
+
+// _____________________________________________________________________________
 
 http::request<http::string_body> withPath(std::string_view path) {
   http::request<http::string_body> request{};
   request.target(path);
   return request;
 }
+
+// _____________________________________________________________________________
+
+auto toBuffer(std::string_view view) {
+  return net::const_buffer{view.data(), view.size()};
+}
+
+// _____________________________________________________________________________
 
 TEST(WebSocketSession, EnsureCorrectPathAcceptAndRejectBehaviour) {
   auto testFunc = WebSocketSession::getErrorResponseIfPathIsInvalid;
@@ -154,6 +166,53 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsWhenServerIsDoneSending) {
     co_await distributor->signalEnd();
     EXPECT_THROW(co_await webSocket.async_read(buffer, net::use_awaitable),
                  boost::system::system_error);
+  };
+
+  auto serverLogic = [&]() -> net::awaitable<void> {
+    boost::beast::tcp_stream stream{std::move(server)};
+    boost::beast::flat_buffer buffer;
+    http::request<http::string_body> request;
+    co_await http::async_read(stream, buffer, request, net::use_awaitable);
+    co_await WebSocketSession::handleSession(queryHub, registry, request,
+                                             std::move(stream.socket()));
+  };
+
+  co_await (serverLogic() && controllerActions());
+}
+
+// _____________________________________________________________________________
+
+ASYNC_TEST(WebSocketSession, verifyCancelStringTriggersCancellation) {
+  QueryHub queryHub{ioContext};
+  QueryRegistry registry;
+
+  auto queryId = registry.uniqueIdFromString("some-id");
+  auto cancellationHandle =
+      registry.getCancellationHandle(queryId->toQueryId());
+
+  tcp::socket server{ioContext};
+  tcp::socket client{ioContext};
+  co_await connect(server, client);
+
+  auto controllerActions = [&]() -> net::awaitable<void> {
+    boost::beast::websocket::stream<tcp::socket> webSocket{std::move(client)};
+    co_await webSocket.async_handshake("localhost", "/watch/some-id",
+                                       net::use_awaitable);
+    ASSERT_TRUE(webSocket.is_open());
+
+    EXPECT_FALSE(cancellationHandle->isCancelled());
+
+    // Wrong keyword should be ignored
+    co_await webSocket.async_write(toBuffer("other"), net::use_awaitable);
+
+    EXPECT_FALSE(cancellationHandle->isCancelled());
+
+    co_await webSocket.async_write(toBuffer("cancel"), net::use_awaitable);
+
+    EXPECT_TRUE(cancellationHandle->isCancelled());
+    AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+        cancellationHandle->throwIfCancelled(""),
+        HasSubstr("manual cancellation"), ad_utility::CancellationException);
   };
 
   auto serverLogic = [&]() -> net::awaitable<void> {

--- a/test/WebSocketSessionTest.cpp
+++ b/test/WebSocketSessionTest.cpp
@@ -65,6 +65,7 @@ TEST(WebSocketSession, EnsureCorrectPathAcceptAndRejectBehaviour) {
 #define return co_return
 
 ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientCloseWhileTransmitting) {
+  auto strand = net::make_strand(ioContext);
   QueryHub queryHub{ioContext};
   QueryRegistry registry;
 
@@ -73,8 +74,8 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientCloseWhileTransmitting) {
 
   co_await distributor->addQueryStatusUpdate("my-event");
 
-  tcp::socket server{ioContext};
-  tcp::socket client{ioContext};
+  tcp::socket server{strand};
+  tcp::socket client{strand};
   co_await connect(server, client);
 
   auto controllerActions = [&]() -> net::awaitable<void> {
@@ -101,17 +102,19 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientCloseWhileTransmitting) {
                                              std::move(stream.socket()));
   };
 
-  co_await (serverLogic() && controllerActions());
+  co_await net::co_spawn(strand, serverLogic() && controllerActions(),
+                         net::use_awaitable);
 }
 
 // _____________________________________________________________________________
 
 ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientClose) {
+  auto strand = net::make_strand(ioContext);
   QueryHub queryHub{ioContext};
   QueryRegistry registry;
 
-  tcp::socket server{ioContext};
-  tcp::socket client{ioContext};
+  tcp::socket server{strand};
+  tcp::socket client{strand};
   co_await connect(server, client);
 
   auto controllerActions = [&]() -> net::awaitable<void> {
@@ -133,12 +136,14 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsOnClientClose) {
                                              std::move(stream.socket()));
   };
 
-  co_await (serverLogic() && controllerActions());
+  co_await net::co_spawn(strand, serverLogic() && controllerActions(),
+                         net::use_awaitable);
 }
 
 // _____________________________________________________________________________
 
 ASYNC_TEST(WebSocketSession, verifySessionEndsWhenServerIsDoneSending) {
+  auto strand = net::make_strand(ioContext);
   QueryHub queryHub{ioContext};
   QueryRegistry registry;
 
@@ -147,8 +152,8 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsWhenServerIsDoneSending) {
 
   co_await distributor->addQueryStatusUpdate("my-event");
 
-  tcp::socket server{ioContext};
-  tcp::socket client{ioContext};
+  tcp::socket server{strand};
+  tcp::socket client{strand};
   co_await connect(server, client);
 
   auto controllerActions = [&]() -> net::awaitable<void> {
@@ -177,12 +182,14 @@ ASYNC_TEST(WebSocketSession, verifySessionEndsWhenServerIsDoneSending) {
                                              std::move(stream.socket()));
   };
 
-  co_await (serverLogic() && controllerActions());
+  co_await net::co_spawn(strand, serverLogic() && controllerActions(),
+                         net::use_awaitable);
 }
 
 // _____________________________________________________________________________
 
 ASYNC_TEST(WebSocketSession, verifyCancelStringTriggersCancellation) {
+  auto strand = net::make_strand(ioContext);
   QueryHub queryHub{ioContext};
   QueryRegistry registry;
 
@@ -190,8 +197,8 @@ ASYNC_TEST(WebSocketSession, verifyCancelStringTriggersCancellation) {
   auto cancellationHandle =
       registry.getCancellationHandle(queryId->toQueryId());
 
-  tcp::socket server{ioContext};
-  tcp::socket client{ioContext};
+  tcp::socket server{strand};
+  tcp::socket client{strand};
   co_await connect(server, client);
 
   auto controllerActions = [&]() -> net::awaitable<void> {
@@ -224,5 +231,6 @@ ASYNC_TEST(WebSocketSession, verifyCancelStringTriggersCancellation) {
                                              std::move(stream.socket()));
   };
 
-  co_await (serverLogic() && controllerActions());
+  co_await net::co_spawn(strand, serverLogic() && controllerActions(),
+                         net::use_awaitable);
 }

--- a/test/util/AsyncTestHelpers.h
+++ b/test/util/AsyncTestHelpers.h
@@ -43,6 +43,9 @@ void runCoroutine(Func innerRun, size_t numThreads) {
   AD_CORRECTNESS_CHECK(status != std::future_status::deferred);
   if (status == std::future_status::timeout) {
     FAIL() << "Timeout for awaitable reached!";
+  } else {
+    // Propagate exceptions
+    future.get();
   }
 }
 


### PR DESCRIPTION
* Allow users who know the `queryId` of a query to manually cancel this query via the Websocket API. Typically this is only the user who started the query and possibly administrators (see below).
* Allow all admins who know the access token of a QLever server to get a list of all `queryId`s of currently active queries.. Using these IDs they can get access to the runtime information of these queries and can also cancel them if necessary. 