### PR TITLE
A subtle fix for the CONSTRUCT query parser

### DIFF
--- a/src/parser/data/Literal.h
+++ b/src/parser/data/Literal.h
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <string>
 
-#include "../../util/Concepts.h"
+#include "util/Concepts.h"
 
 class Literal {
   std::string _stringRepresentation;
@@ -25,9 +25,8 @@ class Literal {
 
  public:
   template <typename T>
-  requires(ad_utility::Streamable<T> &&
-           !std::same_as<std::remove_cvref_t<T>, Literal>)
-  explicit Literal(T&& t)
+  requires(!std::same_as<std::remove_cvref_t<T>, Literal> &&
+           ad_utility::Streamable<T>) explicit Literal(T&& t)
       : _stringRepresentation(toString(std::forward<T>(t))) {}
 
   explicit Literal(std::variant<int64_t, double> t) {

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -4,7 +4,7 @@
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <variant>
 
@@ -631,8 +631,8 @@ TEST(ParserTest, testParse) {
 
   // We currently only check, that the following two queries don't throw an
   // exception.
-  // TODO<RobinTF>  Also add checks for the correct semantics.
   {
+    namespace m = matchers;
     // Check Parse Construct (1)
     auto pq_1 = SparqlParser::parseQuery(
         "PREFIX foaf:   <http://xmlns.com/foaf/0.1/> \n"
@@ -640,12 +640,29 @@ TEST(ParserTest, testParse) {
         "CONSTRUCT { ?x foaf:name ?name } \n"
         "WHERE  { ?x org:employeeName ?name }");
 
+    EXPECT_THAT(pq_1,
+                m::ConstructQuery(
+                    {{Variable{"?x"}, Iri{"<http://xmlns.com/foaf/0.1/name>"},
+                      Variable{"?name"}}},
+                    m::GraphPattern(m::Triples({SparqlTriple{
+                        Variable{"?x"}, "<http://example.com/ns#employeeName>",
+                        Variable{"?name"}}}))));
+
     // Check Parse Construct (2)
     auto pq_2 = SparqlParser::parseQuery(
         "PREFIX foaf:    <http://xmlns.com/foaf/0.1/>\n"
         "PREFIX vcard:   <http://www.w3.org/2001/vcard-rdf/3.0#>\n"
         "CONSTRUCT   { <http://example.org/person#Alice> vcard:FN ?name }\n"
         "WHERE       { ?x foaf:name ?name } ");
+
+    EXPECT_THAT(pq_2,
+                m::ConstructQuery(
+                    {{Iri{"<http://example.org/person#Alice>"},
+                      Iri{"<http://www.w3.org/2001/vcard-rdf/3.0#FN>"},
+                      Variable{"?name"}}},
+                    m::GraphPattern(m::Triples({SparqlTriple{
+                        Variable{"?x"}, "<http://xmlns.com/foaf/0.1/name>",
+                        Variable{"?name"}}}))));
   }
 
   {

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -629,8 +629,6 @@ TEST(ParserTest, testParse) {
               sc_sub_subquery.getSelectedVariablesAsStrings());
   }
 
-  // We currently only check, that the following two queries don't throw an
-  // exception.
   {
     namespace m = matchers;
     // Check Parse Construct (1)


### PR DESCRIPTION
The templated constructor of the `Literal` class has to first check that it is not shadowing the copy constructor and only then may check for additional constraints to make the overload resolution work correctly.
Also add two tests for the parsing of construct queries that were missing so far.