### PR TITLE
Simplify the generation of reproducible seeds

### DIFF
--- a/src/global/TypedIndex.h
+++ b/src/global/TypedIndex.h
@@ -2,8 +2,9 @@
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
-#ifndef QLEVER_TYPEDINDEX_H
-#define QLEVER_TYPEDINDEX_H
+#pragma once
+
+#include <ostream>
 
 #include "util/ConstexprSmallString.h"
 
@@ -61,5 +62,3 @@ struct TypedIndex {
   constexpr TypedIndex(Type value) noexcept : _value{value} {}
 };
 }  // namespace ad_utility
-
-#endif  // QLEVER_TYPEDINDEX_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -332,7 +332,7 @@ addLinkAndDiscoverTest(ConfigOptionProxyTest configManager)
 
 addLinkAndDiscoverTest(ConfigUtilTest configManager)
 
-addLinkAndDiscoverTest(RandomTest)
+addLinkAndDiscoverTest(RandomTest testUtil)
 
 addLinkAndDiscoverTest(BenchmarkMeasurementContainerTest benchmark)
 

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(testUtil IdTableHelpers.cpp ValidatorHelpers.cpp)
+add_library(testUtil IdTableHelpers.cpp ValidatorHelpers.cpp RandomTestHelpers.cpp)
 # TODO<c++20> Once there is more support for it, we should be able to do this cheaper with modules.
 qlever_target_link_libraries(testUtil engine)

--- a/test/util/RandomTestHelpers.cpp
+++ b/test/util/RandomTestHelpers.cpp
@@ -1,0 +1,13 @@
+// Copyright 2023, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Andre Schlegel (November of 2023,
+// schlegea@informatik.uni-freiburg.de)
+
+#include "../test/util/RandomTestHelpers.h"
+
+#include <functional>
+
+// ____________________________________________________________________________
+ad_utility::RandomSeed RandomSeedGenerator::operator()() {
+  return ad_utility::RandomSeed::make(std::invoke(numberGenerator_));
+}

--- a/test/util/RandomTestHelpers.cpp
+++ b/test/util/RandomTestHelpers.cpp
@@ -5,8 +5,6 @@
 
 #include "../test/util/RandomTestHelpers.h"
 
-#include <functional>
-
 // ____________________________________________________________________________
 ad_utility::RandomSeed RandomSeedGenerator::operator()() {
   return ad_utility::RandomSeed::make(std::invoke(numberGenerator_));

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -10,13 +10,15 @@
 
 #include "util/Random.h"
 
-// Create a array of non-deterministic random seeds for use with random number
-// generators.
+// Create a array of random seeds for use with random number generators.
 template <size_t NumSeeds>
-inline std::array<ad_utility::RandomSeed, NumSeeds> createArrayOfRandomSeeds() {
+inline std::array<ad_utility::RandomSeed, NumSeeds> createArrayOfRandomSeeds(
+    ad_utility::RandomSeed seed =
+        ad_utility::RandomSeed::make(std::random_device{}())) {
+  ad_utility::FastRandomIntGenerator<unsigned int> generator{std::move(seed)};
   std::array<ad_utility::RandomSeed, NumSeeds> seeds{};
-  std::ranges::generate(seeds, []() {
-    return ad_utility::RandomSeed::make(std::random_device{}());
+  std::ranges::generate(seeds, [&generator]() {
+    return ad_utility::RandomSeed::make(std::invoke(generator));
   });
   return seeds;
 }

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <functional>
 #include <random>
 
 #include "util/Random.h"

--- a/test/util/RandomTestHelpers.h
+++ b/test/util/RandomTestHelpers.h
@@ -10,15 +10,31 @@
 
 #include "util/Random.h"
 
+// A simple pseudo random generator for instances of `ad_utility::RandomSeed`.
+class RandomSeedGenerator {
+  // For generating the number, that will be transformed into a
+  // `ad_utility::RandomSeed`.
+  ad_utility::FastRandomIntGenerator<unsigned int> numberGenerator_;
+
+ public:
+  explicit RandomSeedGenerator(
+      ad_utility::RandomSeed seed =
+          ad_utility::RandomSeed::make(std::random_device{}()))
+      : numberGenerator_{ad_utility::FastRandomIntGenerator<unsigned int>{
+            std::move(seed)}} {}
+
+  // Generate a new `ad_utility::RandomSeed`.
+  ad_utility::RandomSeed operator()();
+};
+
 // Create a array of random seeds for use with random number generators.
 template <size_t NumSeeds>
 inline std::array<ad_utility::RandomSeed, NumSeeds> createArrayOfRandomSeeds(
     ad_utility::RandomSeed seed =
         ad_utility::RandomSeed::make(std::random_device{}())) {
-  ad_utility::FastRandomIntGenerator<unsigned int> generator{std::move(seed)};
+  RandomSeedGenerator generator{std::move(seed)};
   std::array<ad_utility::RandomSeed, NumSeeds> seeds{};
-  std::ranges::generate(seeds, [&generator]() {
-    return ad_utility::RandomSeed::make(std::invoke(generator));
-  });
+  std::ranges::generate(seeds,
+                        [&generator]() { return std::invoke(generator); });
   return seeds;
 }


### PR DESCRIPTION
This functionality helps when wanting to explicitly set a single random seed for a whole set of tests or benchmark to make those deterministically repeatable even if they work on randomly generated input.