### PR TITLE
Add a `constexpr` function for iterating over nested types

### DIFF
--- a/src/util/ConfigManager/ConfigOption.cpp
+++ b/src/util/ConfigManager/ConfigOption.cpp
@@ -118,12 +118,8 @@ void ConfigOption::setValueWithJson(const nlohmann::json& json) {
           data_)) {
     // Does the json represent one of the types in our `AvailableTypes`? If yes,
     // we can create a better exception message.
-    ad_utility::ConstexprForLoop(
-        std::make_index_sequence<std::variant_size_v<AvailableTypes>>{},
-        [&isValueTypeSubType, &json,
-         this ]<size_t TypeIndex,
-                typename AlternativeType =
-                    std::variant_alternative_t<TypeIndex, AvailableTypes>>() {
+    forEachTypeInTemplateType<AvailableTypes>(
+        [&isValueTypeSubType, &json, this]<typename AlternativeType>() {
           if (isValueTypeSubType.template operator()<AlternativeType>(
                   json, isValueTypeSubType)) {
             throw ConfigOptionSetWrongJsonTypeException(

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -206,7 +206,7 @@ auto cartesianPowerAsIntegerArray() {
 explicit template parameter, keeping the same order.
 */
 template <typename... Ts>
-constexpr void constExprForEachType(const auto& lambda) {
+constexpr void forEachTypeInParameterPack(const auto& lambda) {
   (lambda.template operator()<Ts>(), ...);
 }
 
@@ -222,7 +222,9 @@ struct forEachTypeInTemplateTypeImpl;
 
 template <template <typename...> typename Template, typename... Ts>
 struct forEachTypeInTemplateTypeImpl<Template<Ts...>> {
-  void operator()(const auto& lambda) { constExprForEachType<Ts...>(lambda); }
+  void operator()(const auto& lambda) {
+    forEachTypeInParameterPack<Ts...>(lambda);
+  }
 };
 }  // namespace detail
 

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -215,4 +215,13 @@ requires isVariant<VariantType> constexpr void constExprForEachTypeInVariant(con
       });
 }
 
+/*
+@brief Call the given lambda function with each type in the given `std::tuple` type as explicit
+template parameter, keeping the same order.
+*/
+template <typename TupleType>
+requires isTuple<TupleType> constexpr void constExprForEachTypeInTuple(const auto& lambda) {
+  constExprForEachTypeInVariant<TupleToVariant<TupleType>>(lambda);
+}
+
 }  // namespace ad_utility

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <ranges>
 
 #include "util/Exception.h"
@@ -197,6 +198,15 @@ constexpr auto cartesianPowerAsArray() {
 template <std::integral auto Upper, size_t Num>
 auto cartesianPowerAsIntegerArray() {
   return toIntegerSequence<cartesianPowerAsArray<Upper, Num>()>();
+}
+
+/*
+@brief Call the given lambda function with each of the given types `Ts` as
+explicit template parameter, keeping the same order.
+*/
+template <typename... Ts>
+constexpr void constExprForEachType(const auto& lambda) {
+  (lambda.template operator()<Ts>(), ...);
 }
 
 }  // namespace ad_utility

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -222,7 +222,7 @@ struct forEachTypeInTemplateTypeImpl;
 
 template <template <typename...> typename Template, typename... Ts>
 struct forEachTypeInTemplateTypeImpl<Template<Ts...>> {
-  void operator()(const auto& lambda) {
+  void operator()(const auto& lambda) const {
     forEachTypeInParameterPack<Ts...>(lambda);
   }
 };

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -94,10 +94,8 @@ arguments. Should be passed per deduction.
 */
 template <typename Function>
 static void doForTypeInResultTableEntryType(Function function) {
-  ad_utility::ConstexprForLoop(
-      std::make_index_sequence<std::variant_size_v<ResultTable::EntryType>>{},
-      [&function]<size_t index, typename IndexType = std::variant_alternative_t<
-                                    index, ResultTable::EntryType>>() {
+  ad_utility::forEachTypeInTemplateType<ResultTable::EntryType>(
+      [&function]<typename IndexType>() {
         // `std::monostate` is not important for these kinds of tests.
         if constexpr (!ad_utility::isSimilar<IndexType, std::monostate>) {
           function.template operator()<IndexType>();

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -6,6 +6,8 @@
 
 #include "gtest/gtest.h"
 #include "util/ConstexprUtils.h"
+#include "util/Exception.h"
+#include "util/TypeTraits.h"
 
 using namespace ad_utility;
 
@@ -169,4 +171,39 @@ TEST(ConstexprUtils, ConstexprSwitch) {
   // F1 can only be called with 0 and 1 as template arguments.
   static_assert(std::invocable<decltype(ConstexprSwitch<0, 1>), F1, int>);
   static_assert(!std::invocable<decltype(ConstexprSwitch<0, 1, 2>), F1, int>);
+}
+
+TEST(ConstexprUtils, ConstExprForEachType) {
+  /*
+  A lambda, that adds the string representation of a (supported) type to a
+  vector.
+  */
+  std::vector<std::string> typeToStringVector{};
+  auto typeToString = [&typeToStringVector]<typename T>() {
+    if constexpr (ad_utility::isSimilar<T, int>) {
+      typeToStringVector.emplace_back("int");
+    } else if constexpr (ad_utility::isSimilar<T, bool>) {
+      typeToStringVector.emplace_back("bool");
+    } else if constexpr (ad_utility::isSimilar<T, std::string>) {
+      typeToStringVector.emplace_back("std::string");
+    } else {
+      AD_FAIL();
+    }
+  };
+
+  // No types given should end in nothing happening.
+  constExprForEachType<>(typeToString);
+  ASSERT_TRUE(typeToStringVector.empty());
+
+  // Normal call.
+  constExprForEachType<int, bool, std::string, bool, bool, int, int, int>(
+      typeToString);
+  ASSERT_STREQ(typeToStringVector.at(0).c_str(), "int");
+  ASSERT_STREQ(typeToStringVector.at(1).c_str(), "bool");
+  ASSERT_STREQ(typeToStringVector.at(2).c_str(), "std::string");
+  ASSERT_STREQ(typeToStringVector.at(3).c_str(), "bool");
+  ASSERT_STREQ(typeToStringVector.at(4).c_str(), "bool");
+  ASSERT_STREQ(typeToStringVector.at(5).c_str(), "int");
+  ASSERT_STREQ(typeToStringVector.at(6).c_str(), "int");
+  ASSERT_STREQ(typeToStringVector.at(7).c_str(), "int");
 }

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -244,3 +244,10 @@ TEST(ConstexprUtils, ConstExprForEachTypeInVariant) {
     constExprForEachTypeInVariant<std::variant<Ts...>>(func);
   });
 }
+
+TEST(ConstexprUtils, ConstExprForEachTypeInTuple) {
+  // Normal call.
+  testConstExprForEachNormalCall([]<typename... Ts>(const auto& func) {
+    constExprForEachTypeInTuple<std::tuple<Ts...>>(func);
+  });
+}

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -238,16 +238,14 @@ TEST(ConstexprUtils, ConstExprForEachType) {
   ASSERT_TRUE(typeToStringVector.empty());
 }
 
-TEST(ConstexprUtils, ConstExprForEachTypeInVariant) {
-  // Normal call.
+TEST(ConstexprUtils, forEachTypeInTemplateType) {
+  // Normal call with `std::variant`.
   testConstExprForEachNormalCall([]<typename... Ts>(const auto& func) {
-    constExprForEachTypeInVariant<std::variant<Ts...>>(func);
+    forEachTypeInTemplateType<std::variant<Ts...>>(func);
   });
-}
 
-TEST(ConstexprUtils, ConstExprForEachTypeInTuple) {
-  // Normal call.
+  // Normal call with `std::tuple`.
   testConstExprForEachNormalCall([]<typename... Ts>(const auto& func) {
-    constExprForEachTypeInTuple<std::tuple<Ts...>>(func);
+    forEachTypeInTemplateType<std::tuple<Ts...>>(func);
   });
 }

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -225,16 +225,16 @@ void testConstExprForEachNormalCall(
   ASSERT_STREQ(typeToStringVector.at(7).c_str(), "int");
 }
 
-TEST(ConstexprUtils, ConstExprForEachType) {
+TEST(ConstexprUtils, ForEachTypeInParameterPack) {
   // Normal call.
   testConstExprForEachNormalCall([]<typename... Ts>(const auto& func) {
-    constExprForEachType<Ts...>(func);
+    forEachTypeInParameterPack<Ts...>(func);
   });
 
   // No types given should end in nothing happening.
   std::vector<std::string> typeToStringVector{};
   auto typeToString = typeToStringFactory(&typeToStringVector);
-  constExprForEachType<>(typeToString);
+  forEachTypeInParameterPack<>(typeToString);
   ASSERT_TRUE(typeToStringVector.empty());
 }
 

--- a/test/util/ConfigOptionHelpers.h
+++ b/test/util/ConfigOptionHelpers.h
@@ -4,6 +4,7 @@
 
 #pragma once
 #include "util/ConfigManager/ConfigOption.h"
+#include "util/ConstexprUtils.h"
 
 /*
 @brief Call the function with each of the alternatives in
@@ -15,10 +16,6 @@ arguments. Should be passed per deduction.
 */
 template <typename Function>
 static void doForTypeInConfigOptionValueType(Function function) {
-  ad_utility::ConstexprForLoop(
-      std::make_index_sequence<std::variant_size_v<ad_utility::ConfigOption::AvailableTypes>>{},
-      [&function]<size_t index, typename IndexType = std::variant_alternative_t<
-                                    index, ad_utility::ConfigOption::AvailableTypes>>() {
-        function.template operator()<IndexType>();
-      });
+  ad_utility::forEachTypeInTemplateType<
+      ad_utility::ConfigOption::AvailableTypes>(function);
 }


### PR DESCRIPTION
This function allows to automatically call a given templated function for all types that are contained e.g. in a `std::variant` or `std::tuple`. This is mostly used for writing more concise unit tests for templated functions.