### PR TITLE
GroupBy using hash maps for `AVG()` expressions

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -218,6 +218,21 @@ queries:
       - contains_row: [ 280, "<New_York_City>" ]
       - order_numeric: { "dir": "DESC", "var": "?count" }
 
+  - query: scientists-group-by-join-avg
+    type: no-text
+    sparql: |
+      SELECT ?place (AVG(?height) as ?avg_height) WHERE {
+          ?x <Country_of_nationality> ?place .
+          ?x <Height> ?height .
+      }
+      GROUP BY ?place
+    checks:
+      - num_cols : 2
+      - num_rows: 40
+      - selected: [ "?place", "?avg_height" ]
+      - contains_row: [ "<Austria>", 1.72 ]
+      - order_string: { "dir": "ASC", var: "?place" }
+
   - query: group-by-and-rand
     type: no-text
     sparql: |

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -317,7 +317,7 @@ ResultTable GroupBy::computeResult() {
     return {std::move(idTable), resultSortedOn(), LocalVocab{}};
   }
 
-  // Check if optimization for sorted join can be applied
+  // Check if optimization for explicitly sorted child can be applied
   auto explicitlySortedParams = checkIfExplicitlySorted();
 
   bool useOptimization = true; // for debugging purposes

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -838,7 +838,7 @@ void GroupBy::computeGroupByForHashMapOptimization(
           exprChildren[0]->evaluate(&evaluationContext);
 
       auto visitor =
-          [&currentBlockSize, &evaluationContext, &i, &hashEntries,
+          [&currentBlockSize, &evaluationContext, &hashEntries,
            &aggregateIndex]<sparqlExpression::SingleExpressionResult T>(
               T&& singleResult) mutable {
             auto generator = sparqlExpression::detail::makeGenerator(

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -685,6 +685,7 @@ bool GroupBy::computeGroupByForJoinWithFullScan(IdTable* result) {
 // _____________________________________________________________________________
 bool GroupBy::computeOptimizedGroupByIfPossible(IdTable* result) {
   if (computeGroupByForSingleIndexScan(result)) {
+    // asdas
     return true;
   } else if (computeGroupByForFullIndexScan(result)) {
     return true;

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -183,20 +183,24 @@ class GroupBy : public Operation {
       _count++;
     };
     [[nodiscard]] ValueId calculateResult() const {
-      if (_error) return ValueId::makeUndefined();
-      else return ValueId::makeFromDouble(_sum / (double) _count);
+      if (_error)
+        return ValueId::makeUndefined();
+      else
+        return ValueId::makeFromDouble(_sum / (double)_count);
     }
   };
 
   template <size_t OUT_WIDTH, size_t numAggregates>
-  bool createResultForSortedSubtree(IdTable* result,
-                                    const ad_utility::HashMap<ValueId,
-                                                              std::array<AverageAggregationData, numAggregates>> & map);
+  bool createResultForSortedSubtree(
+      IdTable* result,
+      const ad_utility::HashMap<
+          ValueId, std::array<AverageAggregationData, numAggregates>>& map);
 
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Sort*`.
-  std::optional<ExplicitlySortedData> checkIfExplicitlySorted(std::vector<Aggregate> aggregates);
+  std::optional<ExplicitlySortedData> checkIfExplicitlySorted(
+      std::vector<Aggregate> aggregates);
 
   // The check whether the optimization just described can be applied and its
   // actual computation are split up in two functions. This struct contains

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -15,6 +15,7 @@
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
+#include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "gtest/gtest.h"
 #include "parser/Alias.h"
 #include "parser/ParsedQuery.h"
@@ -172,17 +173,20 @@ class GroupBy : public Operation {
   // "incrementor" function, a result function, a child expression
   // or expression is passed to "increment" function, along with evalContext?
   struct AverageAggregationData {
-    double _sum;
-    int _count;
-    void increment(double intermediate) {
-      _sum += intermediate;
+    double _sum = 0;
+    int64_t _count = 0;
+    void increment(sparqlExpression::detail::IntOrDouble intermediate) {
+      if (const int64_t* intval = std::get_if<int64_t>(&intermediate))
+        _sum += (double)*intval;
+      else if (const double* dval = std::get_if<double>(&intermediate))
+        _sum += *dval;
       _count++;
     };
     double calculateResult() const { return _sum / _count; }
   };
 
   struct CountAggregationData {
-    int _count;
+    int64_t _count = 0;
     void increment(double intermediate) { _count++; }
     double calculateResult() const { return _count; }
   };

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -158,7 +158,7 @@ class GroupBy : public Operation {
   bool computeGroupByForJoinWithFullScan(IdTable* result);
 
   // TODO: Update documentation
-  template <size_t OUT_WIDTH>
+  template <size_t OUT_WIDTH, size_t numAggregates>
   bool computeGroupByForSortedSubtree(IdTable* result,
                                       std::vector<Aggregate> aggregates,
                                       const IdTable& subresult,
@@ -188,11 +188,10 @@ class GroupBy : public Operation {
     }
   };
 
-  template <size_t OUT_WIDTH>
+  template <size_t OUT_WIDTH, size_t numAggregates>
   bool createResultForSortedSubtree(IdTable* result,
                                     const ad_utility::HashMap<ValueId,
-                                                              std::vector<AverageAggregationData>> & map,
-                                    size_t numAggregates);
+                                                              std::array<AverageAggregationData, numAggregates>> & map);
 
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -25,7 +25,6 @@ using std::vector;
 // Forward declarations for internal member function
 class IndexScan;
 class Join;
-class Sort;
 
 class GroupBy : public Operation {
  private:

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -159,7 +159,7 @@ class GroupBy : public Operation {
 
   // First, check if the query represented by this GROUP BY is of the following
   // form:
-  //  SELECT ?x (COUNT (?x) as ?cnt) WHERE {
+  //  SELECT ?x (AGG(?x) as ?agg) WHERE {
   //    %arbitrary graph pattern that contains ?x, and at least one of ?y and ?z
   //    %arbitrary graph pattern that contains at least one of ?y and ?z,
   //      but not ?x
@@ -167,16 +167,24 @@ class GroupBy : public Operation {
   // Note that `?x` can also appear in the second triple, but then may not
   // appear in the first. The key requirement for this optimization is that
   // the grouped-by variable is not a join column.
-  bool computeGroupByForSortedSubtree(IdTable* result);
+  bool computeGroupByForSortedSubtree(IdTable* result, size_t outWidth,
+                                      std::vector<Aggregate> aggregates,
+                                      const std::shared_ptr<const ResultTable>& subresult,
+                                      size_t columnIndex,
+                                      LocalVocab& localVocab);
 
   struct SortedJoinData {
     size_t subtreeColumnIndex_;
   };
 
+  template <size_t OUT_WIDTH>
+  void processGroups(IdTable* result, std::map<ValueId, IdTable>& columnMap,
+                     const std::vector<Aggregate>& aggregates, LocalVocab* localVocab);
+
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Sort*`.
-  std::optional<SortedJoinData> checkIfSortedJoin(const Sort* sort);
+  std::optional<SortedJoinData> checkIfSortedJoin();
 
   // The check whether the optimization just described can be applied and its
   // actual computation are split up in two functions. This struct contains

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -182,18 +182,10 @@ class GroupBy : public Operation {
         _error = true;
       _count++;
     };
-    ValueId calculateResult() const {
+    [[nodiscard]] ValueId calculateResult() const {
       if (_error) return ValueId::makeUndefined();
       else return ValueId::makeFromDouble(_sum / (double) _count);
     }
-  };
-
-  // TODO
-  struct CountAggregationData {
-    bool _error = false;
-    int64_t _count = 0;
-    void increment(double intermediate) { _count++; }
-    double calculateResult() const { return _count; }
   };
 
   template <size_t OUT_WIDTH>
@@ -205,7 +197,7 @@ class GroupBy : public Operation {
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Sort*`.
-  std::optional<ExplicitlySortedData> checkIfExplicitlySorted();
+  std::optional<ExplicitlySortedData> checkIfExplicitlySorted(std::vector<Aggregate> aggregates);
 
   // The check whether the optimization just described can be applied and its
   // actual computation are split up in two functions. This struct contains

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -183,6 +183,7 @@ static constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 inline auto& RuntimeParameters() {
   using ad_utility::detail::parameterShortNames::Double;
   using ad_utility::detail::parameterShortNames::SizeT;
+  using ad_utility::detail::parameterShortNames::Bool;
   // NOTE: It is important that the value of the static variable is created by
   // an immediately invoked lambda, otherwise we get really strange segfaults on
   // Clang 16 and 17.
@@ -199,7 +200,8 @@ inline auto& RuntimeParameters() {
         SizeT<"cache-max-size-gb-single-entry">{5},
         SizeT<"lazy-index-scan-queue-size">{20},
         SizeT<"lazy-index-scan-num-threads">{10},
-        SizeT<"lazy-index-scan-max-size-materialization">{1'000'000}};
+        SizeT<"lazy-index-scan-max-size-materialization">{1'000'000},
+        Bool<"use-group-by-optimization">{1}};
   }();
   return params;
 }

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -201,7 +201,7 @@ inline auto& RuntimeParameters() {
         SizeT<"lazy-index-scan-queue-size">{20},
         SizeT<"lazy-index-scan-num-threads">{10},
         SizeT<"lazy-index-scan-max-size-materialization">{1'000'000},
-        Bool<"use-group-by-optimization">{1}};
+        Bool<"use-group-by-hash-map-optimization">{true}};
   }();
   return params;
 }

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -181,9 +181,9 @@ static constexpr uint32_t PATTERNS_FILE_VERSION = 1;
 static constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 
 inline auto& RuntimeParameters() {
+  using ad_utility::detail::parameterShortNames::Bool;
   using ad_utility::detail::parameterShortNames::Double;
   using ad_utility::detail::parameterShortNames::SizeT;
-  using ad_utility::detail::parameterShortNames::Bool;
   // NOTE: It is important that the value of the static variable is created by
   // an immediately invoked lambda, otherwise we get really strange segfaults on
   // Clang 16 and 17.

--- a/src/util/HashMap.h
+++ b/src/util/HashMap.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <absl/container/flat_hash_map.h>
+#include <util/AllocatorWithLimit.h>
 
 namespace ad_utility {
 // Wrapper for HashMaps to be used everywhere throughout code for the semantic
@@ -13,4 +14,11 @@ namespace ad_utility {
 // beginning. Feel free to extend it at need.
 template <typename... Ts>
 using HashMap = absl::flat_hash_map<Ts...>;
+
+// A HashMap with a memory limit.
+template <class K, class V,
+          class HashFct = absl::container_internal::hash_default_hash<K>,
+          class EqualElem = absl::container_internal::hash_default_eq<K>,
+          class Alloc = ad_utility::AllocatorWithLimit<std::pair<const K, V>>>
+using HashMapWithMemoryLimit = HashMap<K, V, HashFct, EqualElem, Alloc>;
 }  // namespace ad_utility

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -143,14 +143,19 @@ struct szt {
 };
 struct bl {
   bool operator()(const auto& s) const {
-    if (s == "true") return 1;
-    if (s == "false") return 0;
-    return (bool)std::stoi(s);
+    if (s == "true") return true;
+    if (s == "false") return false;
+    AD_THROW(
+        "The string value for bool parameter must be "
+        "either \"true\" or \"false\".");
   }
 };
 
 struct toString {
   std::string operator()(const auto& s) const { return std::to_string(s); }
+};
+struct boolToString {
+  std::string operator()(const bool& v) const { return v ? "true" : "false"; }
 };
 
 // To/from string for `MemorySize`.
@@ -178,7 +183,7 @@ template <ParameterName Name>
 using String = Parameter<std::string, std::identity, std::identity, Name>;
 
 template <ParameterName Name>
-using Bool = Parameter<bool, bl, toString, Name>;
+using Bool = Parameter<bool, bl, boolToString, Name>;
 
 template <ParameterName Name>
 using MemorySizeParameter =

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -141,6 +141,13 @@ struct dbl {
 struct szt {
   size_t operator()(const auto& s) const { return std::stoull(s); }
 };
+struct bl {
+  bool operator()(const auto& s) const {
+    if (s == "true") return 1;
+    if (s == "false") return 0;
+    return (bool) std::stoi(s);
+  }
+};
 
 struct toString {
   std::string operator()(const auto& s) const { return std::to_string(s); }
@@ -169,6 +176,9 @@ using SizeT = Parameter<size_t, szt, toString, Name>;
 
 template <ParameterName Name>
 using String = Parameter<std::string, std::identity, std::identity, Name>;
+
+template <ParameterName Name>
+using Bool = Parameter<bool, bl, toString, Name>;
 
 template <ParameterName Name>
 using MemorySizeParameter =

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -145,7 +145,7 @@ struct bl {
   bool operator()(const auto& s) const {
     if (s == "true") return 1;
     if (s == "false") return 0;
-    return (bool) std::stoi(s);
+    return (bool)std::stoi(s);
   }
 };
 

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -146,8 +146,7 @@ struct bl {
     if (s == "true") return true;
     if (s == "false") return false;
     AD_THROW(
-        "The string value for bool parameter must be "
-        "either \"true\" or \"false\".");
+        R"(The string value for bool parameter must be either "true" or "false".)");
   }
 };
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -456,7 +456,7 @@ TEST_F(GroupByOptimizations, checkIfHashMapOptimizationPossible) {
   std::vector<Variable> variablesXAndY{varX, varY};
 
   std::vector<ColumnIndex> sortedColumns = {0};
-  Tree sutreeWithSort =
+  Tree subtreeWithSort =
       makeExecutionTree<Sort>(qec, validJoinWhenGroupingByX, sortedColumns);
 
   SparqlExpressionPimpl avgXPimpl = makeAvgPimpl(varX);
@@ -474,23 +474,23 @@ TEST_F(GroupByOptimizations, checkIfHashMapOptimizationPossible) {
   RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
 
   // Must have exactly one variable to group by.
-  testFailure(emptyVariables, aliasesAvgX, sutreeWithSort, avgAggregate);
-  testFailure(variablesXAndY, aliasesAvgX, sutreeWithSort, avgAggregate);
+  testFailure(emptyVariables, aliasesAvgX, subtreeWithSort, avgAggregate);
+  testFailure(variablesXAndY, aliasesAvgX, subtreeWithSort, avgAggregate);
   // Must be AVG aggregate (for now)
-  testFailure(variablesOnlyX, aliasesCountX, sutreeWithSort, countAggregate);
+  testFailure(variablesOnlyX, aliasesCountX, subtreeWithSort, countAggregate);
   // Top operation must be SORT
   testFailure(variablesOnlyX, aliasesAvgX, validJoinWhenGroupingByX,
               avgAggregate);
   // Can not be a nested aggregate
-  testFailure(variablesOnlyX, aliasesAvgCountX, sutreeWithSort,
+  testFailure(variablesOnlyX, aliasesAvgCountX, subtreeWithSort,
               avgCountAggregate);
   // Optimization has to be enabled
   RuntimeParameters().set<"use-group-by-hash-map-optimization">(false);
-  testFailure(variablesOnlyX, aliasesAvgX, sutreeWithSort, avgAggregate);
+  testFailure(variablesOnlyX, aliasesAvgX, subtreeWithSort, avgAggregate);
 
   // Everything is valid for the following example.
   RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
-  GroupBy groupBy{qec, variablesOnlyX, aliasesAvgX, sutreeWithSort};
+  GroupBy groupBy{qec, variablesOnlyX, aliasesAvgX, subtreeWithSort};
   auto optimizedAggregateData =
       groupBy.checkIfHashMapOptimizationPossible(avgAggregate);
   ASSERT_TRUE(optimizedAggregateData.has_value());
@@ -771,13 +771,13 @@ TEST_F(GroupByOptimizations, computeGroupByForFullIndexScan) {
         ::testing::ElementsAre(getId("<a>"), getId("<b>"), getId("<c>"),
                                getId("<x>"), getId("<y>"), getId("<z>")));
     if (includeCount) {
-      EXPECT_THAT(result.getColumn(1),
-                  ::testing::ElementsAre(
-                      IntId(2), IntId(2), IntId(2), IntId(7), IntId(1),
-                      // TODO<joka921> This should be 1.
-                      // There is one triple added <z> @en@<label> "zz"@en which
-                      // is currently not filtered out.
-                      IntId(2)));
+      EXPECT_THAT(
+          result.getColumn(1),
+          ::testing::ElementsAre(I(2), I(2), I(2), I(7), I(1),
+                                 // TODO<joka921> This should be 1.
+                                 // There is one triple added <z> @en@<label>
+                                 // "zz"@en which is currently not filtered out.
+                                 I(2)));
     }
   };
   testWithBothInterfaces(true, true);

--- a/test/ParametersTest.cpp
+++ b/test/ParametersTest.cpp
@@ -16,12 +16,16 @@ TEST(Parameters, First) {
   using FloatParameter = Float<"Float">;
   using IntParameter = SizeT<"SizeT">;
   using DoubleParameter = Double<"Double">;
+  using BoolParameter = Bool<"Bool">;
+  using BoolParameter2 = Bool<"Bool2">;  // to test both results of toString
 
   Parameters pack2(FloatParameter{2.0f}, IntParameter{3ull},
-                   DoubleParameter{42.1});
+                   DoubleParameter{42.1}, BoolParameter{true},
+                   BoolParameter2{true});
   ASSERT_EQ(3ul, pack2.get<"SizeT">());
   ASSERT_FLOAT_EQ(2.0, pack2.get<"Float">());
   ASSERT_DOUBLE_EQ(42.1, pack2.get<"Double">());
+  ASSERT_TRUE(pack2.get<"Bool">());
 
   pack2.set("Float", "42.0");
   ASSERT_EQ(3ul, pack2.get<"SizeT">());
@@ -33,15 +37,20 @@ TEST(Parameters, First) {
   pack2.set("SizeT", "134");
   ASSERT_EQ(pack2.get<"SizeT">(), 134);
 
+  pack2.set("Bool", "false");
+  ASSERT_FALSE(pack2.get<"Bool">());
+
   ASSERT_THROW(pack2.set("NoKey", "24.1"), std::runtime_error);
   // TODO<joka921>: Make this unit test work.
   // ASSERT_THROW(pack2.set("Float", "24.nofloat1"), std::runtime_error);
 
   auto map = pack2.toMap();
-  ASSERT_EQ(3ul, map.size());
+  ASSERT_EQ(5ul, map.size());
   ASSERT_EQ("134", map.at("SizeT"));
   ASSERT_EQ("42.000000", map.at("Float"));
   ASSERT_EQ("16.200000", map.at("Double"));
+  ASSERT_EQ("false", map.at("Bool"));
+  ASSERT_EQ("true", map.at("Bool2"));
 }
 
 // Basic test, if the parameter for `MemorySize` works.
@@ -77,6 +86,7 @@ TEST(Parameters, ParameterConcept) {
   static_assert(IsParameter<SizeT<"SizeT">>);
   static_assert(IsParameter<String<"String">>);
   static_assert(IsParameter<MemorySizeParameter<"MemorySizeParameter">>);
+  static_assert(IsParameter<Bool<"Bool">>);
 
   // Test some other random types.
   static_assert(!IsParameter<std::string>);


### PR DESCRIPTION
This implements an initial implementation of `GROUP BY` that uses a hash map to aggregate the groups and therefore doesn't require a sorted input. Currently this implementation is only used when all the expressions in a group by have the form `AVG(subexpresssionThatDoesn'tContainAggregates)`, but this commit already contains much of the infrastructure that is needed to also implement this version of `GROUP BY` also for the other aggregates and for more complex expressions.