### PR TITLE
Add Docker publish action for multiplatform

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,9 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get short sha
+        id: sha
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -40,11 +43,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
-            joburo:${{ github.sha }},
-            joburo:${{ github.ref }},
-            joburo:latest
-            # Uncomment these lines before setting up the pull request
-            # ${{ github.repository }}:${{ github.sha }},
-            # ${{ github.repository }}:${{ github.ref }},
-            # ${{ github.repository }}:latest
+            joburo/qlever:${{ steps.sha.outputs.sha_short }},
+            joburo/qlever:${{ github.ref_name }},
+            joburo/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,6 +44,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ if github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-20.04
-    if: ${{ github.event.workflow_run.conclusion == "success" }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,9 +45,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           push: true
+          # If this is a push on master, publish with short commit sha
+          # else use the ref name, which has to be the tag in this case.
           tags: >
-            # If this is a push on master, publish with short commit sha
-            # else use the ref name, which has to be the tag in this case.
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == "success" }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,7 +40,11 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
-            ${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }},
-            ${{ github.repository_owner }}/${{ github.repository }}:${{ github.ref }},
-            ${{ github.repository_owner }}/${{ github.repository }}:latest
+            joburo:${{ github.sha }},
+            joburo:${{ github.ref }},
+            joburo:latest
+            # Uncomment these lines before setting up the pull request
+            # ${{ github.repository }}:${{ github.sha }},
+            # ${{ github.repository }}:${{ github.ref }},
+            # ${{ github.repository }}:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,15 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          # Docker multiplatform images require an entry in their manifests. If this
+          # entry is missing, then the images for each platform are considered seperate.
+          # If this action runs on a single runner (i.e. the attribute `platforms`
+          # contains a list of all platforms) then the manifest is configured automatically.
+          # If the build and push is split over multiple runners, then the action requires an additional `merge`
+          # job, which merges the images for each platform into a single multiplatform image.
+          # References:
+          # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
+          # https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
           platforms: linux/amd64,linux/arm64
           push: true
           # If this is a push on master, publish with short commit sha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,6 +47,8 @@ jobs:
           push: true
           # If this is a push on master, publish with short commit sha
           # else use the ref name, which has to be the tag in this case.
+          # We have to explicitly add the "qlever:latest" tag for it to work correctly,
+          # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
           tags: >
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,6 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' ||  github.ref_name != 'master' }}
     strategy:
       fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,7 +42,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
           # If this is a push on master, publish with short commit sha
           # else use the ref name, which has to be the tag in this case.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ steps.sha.outputs.sha_short }},
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ if github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,8 @@ on:
     types:
       - completed
   push:
+   branches:
+      - "master"
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,7 @@ jobs:
           # We have to explicitly add the "qlever:latest" tag for it to work correctly,
           # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
           tags: >
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && format('pr#{0}', steps.pr.outputs.pr_num) || github.ref_name }},
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:commit#${{ steps.sha.outputs.sha_short }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && format('pr-{0}', steps.pr.outputs.pr_num) || github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:commit-${{ steps.sha.outputs.sha_short }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,7 +49,7 @@ jobs:
           # We have to explicitly add the "qlever:latest" tag for it to work correctly,
           # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
           tags: >
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.pr.outputs.pr_num || github.ref_name }},
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ steps.sha.outputs.sha_short }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && format('pr#{0}', steps.pr.outputs.pr_num) || github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:commit#${{ steps.sha.outputs.sha_short }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
-            joburo/qlever:${{ steps.sha.outputs.sha_short }},
-            joburo/qlever:${{ github.ref_name }},
-            joburo/qlever:latest
+            adfreiburg/qlever:${{ steps.sha.outputs.sha_short }},
+            adfreiburg/qlever:${{ github.ref_name }},
+            adfreiburg/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: publish
+name: Docker Publish
 
 on:
   workflow_run:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,9 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-20.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run if this is a push on master and Docker Build succeeded
+    # or if a tag was pushed
+    if: ${{ github.event.workflow_run.conclusion == 'success' ||  github.ref_name != 'master' }}
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +46,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
+            # If this is a push on master, publish with short commit sha
+            # else use the ref name, which has to be the tag in this case.
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,12 +3,10 @@ name: Docker Publish
 on:
   workflow_run:
     workflows : ["docker-build"]
-    branches: ["main"]
+    branches: ["master"]
     types:
       - completed
   push:
-    branches:
-      - "main"
     tags:
       - "v*.*.*"
 
@@ -45,7 +43,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: >
-            adfreiburg/qlever:${{ steps.sha.outputs.sha_short }},
-            adfreiburg/qlever:${{ github.ref_name }},
-            adfreiburg/qlever:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ steps.sha.outputs.sha_short }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,13 +2,11 @@ name: Docker Publish
 
 on:
   workflow_run:
-    workflows : ["docker-build"]
+    workflows : ["Docker build"]
     branches: ["master"]
     types:
       - completed
   push:
-    branches:
-      - "master"
     tags:
       - "v*.*.*"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Get short sha
         id: sha
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get PR number
+        id: pr
+        run: echo "pr_num=$(git log --format=%s -n 1 | sed -nr 's/.*\(\#([0-9]+)\)/\1/p')" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -50,6 +53,7 @@ jobs:
           # We have to explicitly add the "qlever:latest" tag for it to work correctly,
           # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
           tags: >
-            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.sha.outputs.sha_short || github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ github.ref_name == 'master' && steps.pr.outputs.pr_num || github.ref_name }},
+            ${{ secrets.DOCKERHUB_USERNAME }}/qlever:${{ steps.sha.outputs.sha_short }},
             ${{ secrets.DOCKERHUB_USERNAME }}/qlever:latest
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,46 @@
+name: publish
+
+on:
+  workflow_run:
+    workflows : ["docker-build"]
+    branches: ["main"]
+    types:
+      - completed
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: >
+            ${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }},
+            ${{ github.repository_owner }}/${{ github.repository }}:${{ github.ref }},
+            ${{ github.repository_owner }}/${{ github.repository }}:latest
+

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ on:
     types:
       - completed
   push:
-   branches:
+    branches:
       - "master"
     tags:
       - "v*.*.*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -GNinja .. && ninja
-RUN make test
+RUN ctest
 
 FROM base as runtime
 WORKDIR /app


### PR DESCRIPTION
This PR will add a Github action to build and push Docker images for multiple platforms.

The action can be run in two ways:
 1. By pushing (merging) onto the master branch. This event will only trigger the publish action, if the workflow docker-publish has been successfull.
 2. By adding a tag.

The image uploaded to dockerhub will have the following tags:
 - `latest`, in order to overwrite the previous `latest` build. Example: `adfreiburg/qlever:latest`
 - The sha of the commit or tag. Example: `adfreiburg/qlever:9b1891e`
 - The tag or branch which has been pushed (to). Example: `adfreiburg/qlever:v0.0.1`

For each platform, one runner is started. The currently supported platforms are arm64 and amd64. More platforms can be added under `jobs.docker.strategy.platform`.

This PR closes #1030. If there are any platforms missing, let me know.