### PR TITLE
Consistently replace `boost::asio::dispatch` by `boost::asio::post`

### DIFF
--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -19,10 +19,6 @@ namespace net = boost::asio;
 /// this coroutine was co_spawned on.
 /// IMPORTANT: If the coroutine is cancelled, no guarantees are given. Make
 /// sure to keep that in mind when handling cancellation errors!
-// TODO<RobinTF, joka921> When using `net::dispatch()` instead of `net::post()`
-// and the `awaitable` itself dispatches to a strand, then this strand is not
-// left in all cases when leaving this function. Further investigate whether we
-// lack understanding here or whether this is a bug in `Boost::ASIO`.
 template <typename T>
 inline net::awaitable<T> resumeOnOriginalExecutor(net::awaitable<T> awaitable) {
   std::exception_ptr exceptionPtr;

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -75,4 +75,13 @@ QueryHub::createOrAcquireDistributorForReceiving(QueryId queryId) {
   return resumeOnOriginalExecutor(
       createOrAcquireDistributorInternal<false>(std::move(queryId)));
 }
+
+// _____________________________________________________________________________
+
+// Clang does not seem to keep this instantiation around when called directly,
+// so we need to explicitly instantiate it here for the
+// QueryHub_testCorrectReschedulingForEmptyPointerOnDestruct test to compile
+// properly
+template net::awaitable<std::shared_ptr<const QueryToSocketDistributor>>
+    QueryHub::createOrAcquireDistributorInternalUnsafe<false>(QueryId);
 }  // namespace ad_utility::websocket

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -38,7 +38,7 @@ QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
               AD_CORRECTNESS_CHECK(wasErased);
             })));
         // We may block the current strand, but we won't block the `ioContext_`
-        // until the task is executed
+        // while the task is being executed
         while (future.wait_for(std::chrono::seconds(0)) !=
                std::future_status::ready) {
           ioContext_.poll_one();

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -37,8 +37,10 @@ QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
               bool wasErased = socketDistributors_.erase(queryId);
               AD_CORRECTNESS_CHECK(wasErased);
             })));
-        // We may block the current strand, but we won't block the `ioContext_`
-        // while the task is being executed
+        // As long as the destructor would have to block anyway, perform work
+        // on the `ioContext_`. This avoids blocking in case the destructor
+        // already runs inside the `ioContext_`.
+        // Note: When called on a strand this may block the current strand.
         while (future.wait_for(std::chrono::seconds(0)) !=
                std::future_status::ready) {
           ioContext_.poll_one();

--- a/src/util/http/websocket/QueryHub.h
+++ b/src/util/http/websocket/QueryHub.h
@@ -44,10 +44,6 @@ class QueryHub {
   QueryHub_testCorrectReschedulingForEmptyPointerOnDestruct_coroutine(
       net::io_context&);
 
-  friend net::awaitable<void>
-  QueryHub_testCorrectReschedulingForEmptyPointerOnSignalEnd_coroutine(
-      net::io_context&);
-
   /// Implementation of createOrAcquireDistributorForSending and
   /// createOrAcquireDistributorForReceiving, without thread safety,
   /// exposed for testing

--- a/src/util/http/websocket/QueryHub.h
+++ b/src/util/http/websocket/QueryHub.h
@@ -39,8 +39,20 @@ class QueryHub {
   net::strand<net::any_io_executor> globalStrand_;
   absl::flat_hash_map<QueryId, WeakReferenceHolder> socketDistributors_{};
 
+  // Expose internal API for testing
+  friend net::awaitable<void>
+  QueryHub_testCorrectReschedulingForEmptyPointerOnDestruct_coroutine(
+      net::io_context&);
+
   /// Implementation of createOrAcquireDistributorForSending and
-  /// createOrAcquireDistributorForReceiving
+  /// createOrAcquireDistributorForReceiving, without thread safety,
+  /// exposed for testing
+  template <bool isSender>
+  net::awaitable<
+      std::shared_ptr<ConditionalConst<isSender, QueryToSocketDistributor>>>
+      createOrAcquireDistributorInternalUnsafe(QueryId);
+
+  /// createOrAcquireDistributorInternalUnsafe, but dispatched on global strand
   template <bool isSender>
   net::awaitable<
       std::shared_ptr<ConditionalConst<isSender, QueryToSocketDistributor>>>

--- a/src/util/http/websocket/QueryHub.h
+++ b/src/util/http/websocket/QueryHub.h
@@ -44,6 +44,10 @@ class QueryHub {
   QueryHub_testCorrectReschedulingForEmptyPointerOnDestruct_coroutine(
       net::io_context&);
 
+  friend net::awaitable<void>
+  QueryHub_testCorrectReschedulingForEmptyPointerOnSignalEnd_coroutine(
+      net::io_context&);
+
   /// Implementation of createOrAcquireDistributorForSending and
   /// createOrAcquireDistributorForReceiving, without thread safety,
   /// exposed for testing
@@ -74,9 +78,6 @@ class QueryHub {
   /// be called arbitrarily often during the lifetime of a single query session.
   net::awaitable<std::shared_ptr<const QueryToSocketDistributor>>
       createOrAcquireDistributorForReceiving(QueryId);
-
-  /// Expose strand for testing
-  auto getStrand() const { return globalStrand_; }
 };
 }  // namespace ad_utility::websocket
 

--- a/src/util/http/websocket/QueryToSocketDistributor.cpp
+++ b/src/util/http/websocket/QueryToSocketDistributor.cpp
@@ -12,8 +12,8 @@
 
 namespace ad_utility::websocket {
 
-net::awaitable<void> QueryToSocketDistributor::dispatchToStrand() const {
-  return net::dispatch(net::bind_executor(strand_, net::use_awaitable));
+net::awaitable<void> QueryToSocketDistributor::postToStrand() const {
+  return net::post(net::bind_executor(strand_, net::use_awaitable));
 }
 
 // _____________________________________________________________________________
@@ -42,7 +42,7 @@ void QueryToSocketDistributor::wakeUpWaitingListeners() {
 net::awaitable<void> QueryToSocketDistributor::addQueryStatusUpdate(
     std::string payload) {
   auto sharedPayload = std::make_shared<const std::string>(std::move(payload));
-  co_await dispatchToStrand();
+  co_await postToStrand();
   AD_CONTRACT_CHECK(!finished_);
   data_.push_back(std::move(sharedPayload));
   wakeUpWaitingListeners();
@@ -51,7 +51,7 @@ net::awaitable<void> QueryToSocketDistributor::addQueryStatusUpdate(
 // _____________________________________________________________________________
 
 net::awaitable<void> QueryToSocketDistributor::signalEnd() {
-  co_await dispatchToStrand();
+  co_await postToStrand();
   AD_CONTRACT_CHECK(!finished_);
   finished_ = true;
   wakeUpWaitingListeners();
@@ -63,7 +63,7 @@ net::awaitable<void> QueryToSocketDistributor::signalEnd() {
 
 net::awaitable<std::shared_ptr<const std::string>>
 QueryToSocketDistributor::waitForNextDataPiece(size_t index) const {
-  co_await dispatchToStrand();
+  co_await postToStrand();
 
   if (index < data_.size()) {
     co_return data_.at(index);

--- a/src/util/http/websocket/QueryToSocketDistributor.h
+++ b/src/util/http/websocket/QueryToSocketDistributor.h
@@ -49,7 +49,7 @@ class QueryToSocketDistributor {
 
   /// Schedule a coroutine onto the strand of this instance.
   /// Make sure to co_await this before accessing any member of this class.
-  net::awaitable<void> dispatchToStrand() const;
+  net::awaitable<void> postToStrand() const;
 
  public:
   /// Constructor that builds a new strand from the provided io context.

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -95,7 +95,7 @@ net::awaitable<void> WebSocketSession::handleSession(
   auto executor = co_await net::this_coro::executor;
   AD_CONTRACT_CHECK(
       executor.target<net::strand<net::io_context::executor_type>>());
-  co_await net::dispatch(net::use_awaitable);
+  co_await net::post(net::use_awaitable);
 
   auto queryIdString = extractQueryId(request.target());
   AD_CORRECTNESS_CHECK(!queryIdString.empty());

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -93,9 +93,11 @@ net::awaitable<void> WebSocketSession::handleSession(
     tcp::socket socket) {
   // Make sure access to new websocket is on a strand and therefore thread safe
   auto executor = co_await net::this_coro::executor;
-  AD_CONTRACT_CHECK(
-      executor.target<net::strand<net::io_context::executor_type>>());
-  co_await net::post(net::use_awaitable);
+  auto strandExecutor =
+      executor.target<net::strand<net::io_context::executor_type>>();
+  AD_CONTRACT_CHECK(strandExecutor);
+  AD_CONTRACT_CHECK(strandExecutor->running_in_this_thread());
+  AD_CONTRACT_CHECK(socket.get_executor() == *strandExecutor);
 
   auto queryIdString = extractQueryId(request.target());
   AD_CORRECTNESS_CHECK(!queryIdString.empty());

--- a/test/AsioHelpersTest.cpp
+++ b/test/AsioHelpersTest.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/asio/bind_executor.hpp>
 #include <boost/asio/co_spawn.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/detached.hpp>
@@ -26,21 +27,25 @@ TEST(AsioHelpers, resumeOnOriginalExecutor) {
 
   uint32_t sanityCounter = 0;
 
-  auto innerAwaitable = [&sanityCounter, strand2]() -> net::awaitable<int> {
-    co_await net::post(strand2, net::use_awaitable);
+  auto innerAwaitable = [&sanityCounter, strand1,
+                         strand2]() -> net::awaitable<int> {
+    co_await net::post(net::bind_executor(strand2, net::use_awaitable));
     // sanity check
+    EXPECT_FALSE(strand1.running_in_this_thread());
     EXPECT_TRUE(strand2.running_in_this_thread());
     sanityCounter++;
     co_return 1337;
   };
 
-  auto outerAwaitable = [&sanityCounter, &innerAwaitable,
-                         strand1]() -> net::awaitable<void> {
+  auto outerAwaitable = [&sanityCounter, &innerAwaitable, strand1,
+                         strand2]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     auto value = co_await resumeOnOriginalExecutor(innerAwaitable());
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     EXPECT_EQ(value, 1337);
     sanityCounter++;
   };
@@ -65,9 +70,12 @@ TEST(AsioHelpers, resumeOnOriginalExecutorVoidOverload) {
                          strand2]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
-    co_await resumeOnOriginalExecutor(net::post(strand2, net::use_awaitable));
+    EXPECT_FALSE(strand2.running_in_this_thread());
+    co_await resumeOnOriginalExecutor(
+        net::post(net::bind_executor(strand2, net::use_awaitable)));
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     sanityFlag = true;
   };
 
@@ -87,22 +95,26 @@ TEST(AsioHelpers, resumeOnOriginalExecutorWhenException) {
 
   uint32_t sanityCounter = 0;
 
-  auto innerAwaitable = [&sanityCounter, strand2]() -> net::awaitable<int> {
-    co_await net::post(strand2, net::use_awaitable);
+  auto innerAwaitable = [&sanityCounter, strand1,
+                         strand2]() -> net::awaitable<int> {
+    co_await net::post(net::bind_executor(strand2, net::use_awaitable));
     // sanity check
+    EXPECT_FALSE(strand1.running_in_this_thread());
     EXPECT_TRUE(strand2.running_in_this_thread());
     sanityCounter++;
     throw std::runtime_error{"Expected"};
   };
 
-  auto outerAwaitable = [&sanityCounter, &innerAwaitable,
-                         strand1]() -> net::awaitable<void> {
+  auto outerAwaitable = [&sanityCounter, &innerAwaitable, strand1,
+                         strand2]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  std::runtime_error);
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     sanityCounter++;
   };
 
@@ -122,22 +134,26 @@ TEST(AsioHelpers, resumeOnOriginalExecutorVoidOverloadWhenException) {
 
   uint32_t sanityCounter = 0;
 
-  auto innerAwaitable = [&sanityCounter, strand2]() -> net::awaitable<void> {
-    co_await net::post(strand2, net::use_awaitable);
+  auto innerAwaitable = [&sanityCounter, strand1,
+                         strand2]() -> net::awaitable<void> {
+    co_await net::post(net::bind_executor(strand2, net::use_awaitable));
     // sanity check
+    EXPECT_FALSE(strand1.running_in_this_thread());
     EXPECT_TRUE(strand2.running_in_this_thread());
     sanityCounter++;
     throw std::runtime_error{"Expected"};
   };
 
-  auto outerAwaitable = [&sanityCounter, &innerAwaitable,
-                         strand1]() -> net::awaitable<void> {
+  auto outerAwaitable = [&sanityCounter, &innerAwaitable, strand1,
+                         strand2]() -> net::awaitable<void> {
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  std::runtime_error);
     // Verify we're back on the same strand
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     sanityCounter++;
   };
 
@@ -170,10 +186,11 @@ TEST(AsioHelpers, resumeOnOriginalExecutorWhenCancelled) {
 
   uint32_t sanityCounter = 0;
 
-  auto innerAwaitable = [&sanityCounter, strand2,
+  auto innerAwaitable = [&sanityCounter, strand1, strand2,
                          &infiniteTimer]() -> net::awaitable<void> {
-    co_await net::post(strand2, net::use_awaitable);
+    co_await net::post(net::bind_executor(strand2, net::use_awaitable));
     // sanity check
+    EXPECT_FALSE(strand1.running_in_this_thread());
     EXPECT_TRUE(strand2.running_in_this_thread());
     sanityCounter++;
     co_await infiniteTimer.async_wait(net::use_awaitable);
@@ -181,12 +198,16 @@ TEST(AsioHelpers, resumeOnOriginalExecutorWhenCancelled) {
 
   auto outerAwaitable = [&sanityCounter, &innerAwaitable, strand1, strand2,
                          strand3]() -> net::awaitable<void> {
-    co_await net::post(strand1, net::use_awaitable);
+    co_await net::post(net::bind_executor(strand1, net::use_awaitable));
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
+    EXPECT_FALSE(strand3.running_in_this_thread());
     EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  boost::system::system_error);
     // Verify we're on the strand the cancellation happened
+    EXPECT_FALSE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     EXPECT_TRUE(strand3.running_in_this_thread());
     sanityCounter++;
   };
@@ -214,23 +235,29 @@ TEST(AsioHelpers, resumeOnOriginalExecutorVoidOverloadWhenCancelled) {
 
   uint32_t sanityCounter = 0;
 
-  auto innerAwaitable = [&sanityCounter, strand2,
+  auto innerAwaitable = [&sanityCounter, strand1, strand2, strand3,
                          &infiniteTimer]() -> net::awaitable<void> {
-    co_await net::post(strand2, net::use_awaitable);
+    co_await net::post(net::bind_executor(strand2, net::use_awaitable));
     // sanity check
+    EXPECT_FALSE(strand1.running_in_this_thread());
     EXPECT_TRUE(strand2.running_in_this_thread());
+    EXPECT_FALSE(strand3.running_in_this_thread());
     sanityCounter++;
     co_await infiniteTimer.async_wait(net::use_awaitable);
   };
 
   auto outerAwaitable = [&sanityCounter, &innerAwaitable, strand1, strand2,
                          strand3]() -> net::awaitable<void> {
-    co_await net::post(strand1, net::use_awaitable);
+    co_await net::post(net::bind_executor(strand1, net::use_awaitable));
     // Sanity check
     EXPECT_TRUE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
+    EXPECT_FALSE(strand3.running_in_this_thread());
     EXPECT_THROW(co_await resumeOnOriginalExecutor(innerAwaitable()),
                  boost::system::system_error);
     // Verify we're on the strand the cancellation happened
+    EXPECT_FALSE(strand1.running_in_this_thread());
+    EXPECT_FALSE(strand2.running_in_this_thread());
     EXPECT_TRUE(strand3.running_in_this_thread());
     sanityCounter++;
   };

--- a/test/MessageSenderTest.cpp
+++ b/test/MessageSenderTest.cpp
@@ -49,28 +49,32 @@ ASYNC_TEST(MessageSender, callingOperatorBroadcastsPayload) {
   OwningQueryId queryId = queryRegistry.uniqueId();
   QueryHub queryHub{ioContext};
 
-  auto distributor = co_await queryHub.createOrAcquireDistributorForReceiving(
-      queryId.toQueryId());
+  {
+    auto distributor = co_await queryHub.createOrAcquireDistributorForReceiving(
+        queryId.toQueryId());
 
-  auto updateWrapper =
-      co_await MessageSender::create(std::move(queryId), queryHub);
+    auto updateWrapper =
+        co_await MessageSender::create(std::move(queryId), queryHub);
 
-  updateWrapper("Still");
-  updateWrapper("Dre");
+    updateWrapper("Still");
+    updateWrapper("Dre");
 
-  net::deadline_timer timer{ioContext, boost::posix_time::seconds(2)};
+    net::deadline_timer timer{ioContext, boost::posix_time::seconds(2)};
 
-  auto result = co_await (distributor->waitForNextDataPiece(0) ||
-                          timer.async_wait(net::use_awaitable));
+    auto result = co_await (distributor->waitForNextDataPiece(0) ||
+                            timer.async_wait(net::use_awaitable));
 
-  using PayloadType = std::shared_ptr<const std::string>;
+    using PayloadType = std::shared_ptr<const std::string>;
 
-  EXPECT_THAT(result, VariantWith<PayloadType>(Pointee("Still"s)));
+    EXPECT_THAT(result, VariantWith<PayloadType>(Pointee("Still"s)));
 
-  result = co_await (distributor->waitForNextDataPiece(1) ||
-                     timer.async_wait(net::use_awaitable));
+    result = co_await (distributor->waitForNextDataPiece(1) ||
+                       timer.async_wait(net::use_awaitable));
 
-  using PayloadType = std::shared_ptr<const std::string>;
+    EXPECT_THAT(result, VariantWith<PayloadType>(Pointee("Dre"s)));
+  }
 
-  EXPECT_THAT(result, VariantWith<PayloadType>(Pointee("Dre"s)));
+  // Make sure we wait for the destructor of the distributor to unregister
+  // itself asynchronously from the query hub before destroying the query hub
+  co_await net::post(net::use_awaitable);
 }

--- a/test/MessageSenderTest.cpp
+++ b/test/MessageSenderTest.cpp
@@ -74,7 +74,8 @@ ASYNC_TEST(MessageSender, callingOperatorBroadcastsPayload) {
     EXPECT_THAT(result, VariantWith<PayloadType>(Pointee("Dre"s)));
   }
 
-  // Make sure we wait for the destructor of the distributor to unregister
-  // itself asynchronously from the query hub before destroying the query hub
+  // The destructor of `MessageSender` calls `signalEnd` on the distributor
+  // instance asynchronously, so we need to wait for it to be executed before
+  // destroying the backing `QueryHub` instance.
   co_await net::post(net::use_awaitable);
 }

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -128,6 +128,8 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnSignalEnd, 3) {
 
 // _____________________________________________________________________________
 
+namespace ad_utility::websocket {
+
 ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
   QueryHub queryHub{ioContext};
   QueryId queryId = QueryId::idFromString("abc");
@@ -150,12 +152,14 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
   // sporadically fail
   std::this_thread::sleep_for(std::chrono::milliseconds(2));
   distributor =
-      co_await queryHub.createOrAcquireDistributorForReceiving(queryId);
+      co_await queryHub.createOrAcquireDistributorInternalUnsafe<false>(
+          queryId);
   EXPECT_FALSE(!comparison.owner_before(distributor) &&
                !distributor.owner_before(comparison));
   co_await net::post(net::use_awaitable);
   future.wait();
 }
+}  // namespace ad_utility::websocket
 
 // _____________________________________________________________________________
 

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -106,34 +106,6 @@ ASYNC_TEST(QueryHub, simulateLifecycleWithDifferentQueryIds) {
 
 namespace ad_utility::websocket {
 
-ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnSignalEnd, 3) {
-  QueryHub queryHub{ioContext};
-  QueryId queryId = QueryId::idFromString("abc");
-
-  auto distributor1 =
-      co_await queryHub.createOrAcquireDistributorForSending(queryId);
-
-  co_await net::dispatch(
-      net::bind_executor(queryHub.globalStrand_, net::use_awaitable));
-  auto future =
-      net::co_spawn(ioContext, distributor1->signalEnd(), net::use_future);
-
-  // Wait until signalEnd() blocks, increase time if tests sporadically fail
-  std::this_thread::sleep_for(std::chrono::milliseconds(2));
-
-  auto distributor2 =
-      co_await queryHub.createOrAcquireDistributorForSending(queryId);
-  EXPECT_NE(distributor1, distributor2);
-
-  future.wait();
-}
-
-}  // namespace ad_utility::websocket
-
-// _____________________________________________________________________________
-
-namespace ad_utility::websocket {
-
 ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
   QueryHub queryHub{ioContext};
   QueryId queryId = QueryId::idFromString("abc");

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -127,10 +127,12 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
                        distributor.reset();
                      }));
 
-  // Wait until destructor of distributor blocks, add short sleep if tests
-  // sporadically fail, because technically the flag would need to be triggered
-  // inside the destructor, not before it.
+  // Wait until destructor of distributor blocks, increase sleep duration if
+  // tests sporadically fail, because technically the flag needs to be
+  // triggered inside the destructor, not before it.
   flag.wait(false);
+  std::this_thread::sleep_for(std::chrono::milliseconds{1});
+
   distributor =
       co_await queryHub.createOrAcquireDistributorInternalUnsafe<false>(
           queryId);

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -163,6 +163,7 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
   co_await net::post(net::use_awaitable);
   future.wait();
 }
+
 }  // namespace ad_utility::websocket
 
 // _____________________________________________________________________________

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -104,6 +104,8 @@ ASYNC_TEST(QueryHub, simulateLifecycleWithDifferentQueryIds) {
 
 // _____________________________________________________________________________
 
+namespace ad_utility::websocket {
+
 ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnSignalEnd, 3) {
   QueryHub queryHub{ioContext};
   QueryId queryId = QueryId::idFromString("abc");
@@ -112,7 +114,7 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnSignalEnd, 3) {
       co_await queryHub.createOrAcquireDistributorForSending(queryId);
 
   co_await net::dispatch(
-      net::bind_executor(queryHub.getStrand(), net::use_awaitable));
+      net::bind_executor(queryHub.globalStrand_, net::use_awaitable));
   auto future =
       net::co_spawn(ioContext, distributor1->signalEnd(), net::use_future);
 
@@ -125,6 +127,8 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnSignalEnd, 3) {
 
   future.wait();
 }
+
+}  // namespace ad_utility::websocket
 
 // _____________________________________________________________________________
 
@@ -139,7 +143,7 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
   std::weak_ptr<const QueryToSocketDistributor> comparison = distributor;
 
   co_await net::dispatch(
-      net::bind_executor(queryHub.getStrand(), net::use_awaitable));
+      net::bind_executor(queryHub.globalStrand_, net::use_awaitable));
   auto future = net::post(ioContext,
                           std::packaged_task<void()>(
                               [distributor = std::move(distributor)]() mutable {

--- a/test/QueryHubTest.cpp
+++ b/test/QueryHubTest.cpp
@@ -127,9 +127,12 @@ ASYNC_TEST_N(QueryHub, testCorrectReschedulingForEmptyPointerOnDestruct, 2) {
                        distributor.reset();
                      }));
 
-  // Wait until destructor of distributor blocks, increase sleep duration if
-  // tests sporadically fail, because technically the flag needs to be
-  // triggered inside the destructor, not before it.
+  // Conceptually we'd have to wait until the destructor of the distributor
+  // schedules a task on the strand of the query hub. However, because the boost
+  // asio API does not provide this flexibility, we instead have to rely on
+  // a small sleep to give the destructor enough time to do the scheduling.
+  // Increase the amount of milliseconds if this test starts to sporadically
+  // fail.
   flag.wait(false);
   std::this_thread::sleep_for(std::chrono::milliseconds{1});
 


### PR DESCRIPTION
`dispatch` and `post` have a different behavior when being called from a `strand`. `post` consistently gives up the current strand while `dispatch` keeps it. This might lead to deadlocks when the handler that is `dispatch`ed tries to acquire the same strand again.
Also extend the unit tests for the asynchronous websocket module s.t. they cover more of these subtleties.
See also #1149 which applied a similar fix (but not consistently across the codebase) as part of an urgent bugfix.