### PR TITLE
Print `ConfigOptions` in the order they were specified

### DIFF
--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -97,13 +97,14 @@ void ConfigManager::verifyHashMapEntry(std::string_view jsonPathToEntry,
 }
 
 // ____________________________________________________________________________
+template <ad_utility::InvocableWithExactReturnType<
+    bool, const ConfigManager::HashMapEntry&>
+              Predicate>
 std::vector<std::pair<std::string, const ConfigManager::HashMapEntry&>>
 ConfigManager::allHashMapEntries(
-    const ad_utility::HashMap<std::string, ConfigManager::HashMapEntry>&
-        entries,
+    const ad_utility::HashMap<std::string, HashMapEntry>& entries,
     const bool sortByInitialization, std::string_view pathPrefix,
-    ad_utility::InvocableWithExactReturnType<
-        bool, const ConfigManager::HashMapEntry&> auto&& predicate) {
+    const Predicate& predicate) {
   // `std::reference_wrapper` works with `std::ranges::sort`. `const
   // HashMapEntry&` does not.
   std::vector<

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -642,15 +642,22 @@ ConfigManager::validators(const bool sortByInitialization,
   // Collect the validators from the sub managers.
   std::ranges::for_each(
       std::views::filter(configurationOptions_, isNonEmptySubManager),
-      [&pathPrefix, &allValidators, &sortByInitialization](const auto& pair) {
+      [&pathPrefix, &allValidators](const auto& pair) {
         // Easier access.
         const auto& [jsonPath, hashMapEntry] = pair;
 
-        appendVector(
-            allValidators,
-            hashMapEntry.getSubManager().value()->validators(
-                sortByInitialization, absl::StrCat(pathPrefix, jsonPath)));
+        appendVector(allValidators,
+                     hashMapEntry.getSubManager().value()->validators(
+                         false, absl::StrCat(pathPrefix, jsonPath)));
       });
+
+  // Sort the validators, if wanted.
+  if (sortByInitialization) {
+    std::ranges::sort(allValidators, {},
+                      [](const ConfigOptionValidatorManager& validator) {
+                        return validator.getInitializationId();
+                      });
+  }
 
   return allValidators;
 }

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "util/ConfigManager/ConfigManager.h"
-
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -26,6 +24,7 @@
 #include "util/Algorithm.h"
 #include "util/ComparisonWithNan.h"
 #include "util/ConfigManager/ConfigExceptions.h"
+#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"
@@ -44,19 +43,23 @@ ConfigManager::HashMapEntry::HashMapEntry(Data&& data)
     : data_{std::make_unique<Data>(std::move(data))} {}
 
 // ____________________________________________________________________________
-bool ConfigManager::HashMapEntry::holdsConfigOption() const {
+template <typename T>
+requires isTypeContainedIn<T, ConfigManager::HashMapEntry::Data>
+bool ConfigManager::HashMapEntry::implHolds() const {
   // Make sure, that it is not a null pointer.
   AD_CORRECTNESS_CHECK(data_);
 
-  return std::holds_alternative<ConfigOption>(*data_);
+  return std::holds_alternative<T>(*data_);
+}
+
+// ____________________________________________________________________________
+bool ConfigManager::HashMapEntry::holdsConfigOption() const {
+  return implHolds<ConfigOption>();
 }
 
 // ____________________________________________________________________________
 bool ConfigManager::HashMapEntry::holdsSubManager() const {
-  // Make sure, that it is not a null pointer.
-  AD_CORRECTNESS_CHECK(data_);
-
-  return std::holds_alternative<ConfigManager>(*data_);
+  return implHolds<ConfigManager>();
 }
 
 // ____________________________________________________________________________

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -526,9 +526,12 @@ std::string ConfigManager::printConfigurationDoc(
     return "No configuration options were defined.";
   }
 
-  // Setup for printing the locations of the option in json format, so that
-  // people can easier understand, where everything is.
-  nlohmann::json configuratioOptionsVisualization;
+  /*
+  Setup for printing the locations of the option in json format, so that
+  people can easier understand, where everything is.
+  Note: This json remembers the insertion order.
+  */
+  nlohmann::ordered_json configuratioOptionsVisualization;
 
   /*
   Add the paths of `configOptions_` and have them point to either:
@@ -539,9 +542,11 @@ std::string ConfigManager::printConfigurationDoc(
   - An example value, of the correct type.
   */
   for (const auto& [path, option] : allConfigOptions) {
-    // Pointer to the position of this option in
-    // `configuratioOptionsVisualization`.
-    const nlohmann::json::json_pointer jsonOptionPointer{path};
+    /*
+    Pointer to the position of this option in
+    `configuratioOptionsVisualization`.
+    */
+    const nlohmann::ordered_json::json_pointer jsonOptionPointer{path};
 
     if (printCurrentJsonConfiguration) {
       // We can only use the value, if we are sure, that the value was

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
-#include "util/ConfigManager/ConfigManager.h"
-
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -26,6 +24,7 @@
 #include "util/Algorithm.h"
 #include "util/ComparisonWithNan.h"
 #include "util/ConfigManager/ConfigExceptions.h"
+#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"
@@ -41,8 +40,7 @@
 namespace ad_utility {
 // ____________________________________________________________________________
 ConfigManager::HashMapEntry::HashMapEntry(Data&& data)
-    : data_{std::make_unique<Data>(std::move(data))},
-      initializationId_{numberOfInstances_++} {}
+    : data_{std::make_unique<Data>(std::move(data))} {}
 
 // ____________________________________________________________________________
 bool ConfigManager::HashMapEntry::holdsConfigOption() const {

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
 
+#include "util/ConfigManager/ConfigManager.h"
+
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
@@ -24,7 +26,6 @@
 #include "util/Algorithm.h"
 #include "util/ComparisonWithNan.h"
 #include "util/ConfigManager/ConfigExceptions.h"
-#include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/ConfigUtil.h"

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -424,12 +424,12 @@ class ConfigManager {
   */
   // TODO Can the default values be done in a nicer way?
   template <ad_utility::InvocableWithExactReturnType<bool, const HashMapEntry&>
-                Predicate = decltype([](const HashMapEntry&) { return true; })>
+                Predicate>
   static std::vector<std::pair<std::string, const HashMapEntry&>>
   allHashMapEntries(
       const ad_utility::HashMap<std::string, HashMapEntry>& entries,
-      const bool sortByInitialization = false, std::string_view pathPrefix = "",
-      Predicate&& predicate = {});
+      const bool sortByInitialization, std::string_view pathPrefix,
+      Predicate&& predicate);
 
   /*
   @brief Creates the string representation of a valid `nlohmann::json` pointer

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -520,21 +520,16 @@ class ConfigManager {
              std::string_view pathPrefix = "") const;
 
   /*
-  @brief The implementation for `configurationOptions`.
-
-  @tparam ReturnReference Should be either `ConfigOption&`, or `const
-  ConfigOption&`.
+  @brief The implementation for `configurationOptions`..
 
   @param sortByInitialization If true, the order of the returned `ConfigOption`
   is by initialization order. If false, the order is random.
   @param pathPrefix This prefix will be added to all configuration option json
   paths, that will be returned.
   */
-  template <typename ReturnReference>
-  requires std::same_as<ReturnReference, ConfigOption&> ||
-           std::same_as<ReturnReference, const ConfigOption&>
-  static std::vector<std::pair<std::string, ReturnReference>>
-  configurationOptionsImpl(auto& configurationOptions,
+  static std::vector<std::pair<std::string, const HashMapEntry&>>
+  configurationOptionsImpl(const ad_utility::HashMap<std::string, HashMapEntry>&
+                               configurationOptions,
                            const bool sortByInitialization,
                            std::string_view pathPrefix = "");
 

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -422,14 +422,13 @@ class ConfigManager {
   @param predicate Only the `HashMapEntry` for which a true is returned, will be
   given back.
   */
-  // TODO Can the default values be done in a nicer way?
   template <ad_utility::InvocableWithExactReturnType<bool, const HashMapEntry&>
                 Predicate>
   static std::vector<std::pair<std::string, const HashMapEntry&>>
   allHashMapEntries(
       const ad_utility::HashMap<std::string, HashMapEntry>& entries,
       const bool sortByInitialization, std::string_view pathPrefix,
-      Predicate&& predicate);
+      const Predicate& predicate);
 
   /*
   @brief Creates the string representation of a valid `nlohmann::json` pointer

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -407,6 +407,7 @@ class ConfigManager {
   FRIEND_TEST(ConfigManagerTest, ParseConfigExceptionTest);
   FRIEND_TEST(ConfigManagerTest, ParseShortHandTest);
   FRIEND_TEST(ConfigManagerTest, ContainsOption);
+  FRIEND_TEST(ConfigManagerTest, CollectionFunctionsSorting);
 
   /*
   @brief Creates the string representation of a valid `nlohmann::json` pointer

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -93,6 +93,11 @@ class ConfigManager {
 
       return std::visit(AD_FWD(vis), *data_);
     }
+
+   private:
+    // Implementation for `holdsConfigOption` and `holdsSubManager`.
+    template <typename T>
+    requires isTypeContainedIn<T, Data> bool implHolds() const;
   };
 
   /*

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -407,7 +407,6 @@ class ConfigManager {
   FRIEND_TEST(ConfigManagerTest, ParseConfigExceptionTest);
   FRIEND_TEST(ConfigManagerTest, ParseShortHandTest);
   FRIEND_TEST(ConfigManagerTest, ContainsOption);
-  FRIEND_TEST(ConfigManagerTest, CheckForBrokenPaths);
 
   /*
   @brief Creates the string representation of a valid `nlohmann::json` pointer

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -496,20 +496,28 @@ class ConfigManager {
   @brief A vector to all the configuratio options, held by this manager,
   represented with their json paths and reference to them. Options held by a sub
   manager, are also included with the path to the sub manager as prefix.
+
+  @param sortByInitialization If true, the order of the returned `ConfigOption`
+  is by initialization order. If false, the order is random.
   */
-  std::vector<std::pair<std::string, ConfigOption&>> configurationOptions();
-  std::vector<std::pair<std::string, const ConfigOption&>>
-  configurationOptions() const;
+  std::vector<std::pair<std::string, ConfigOption&>> configurationOptions(
+      const bool sortByInitialization);
+  std::vector<std::pair<std::string, const ConfigOption&>> configurationOptions(
+      const bool sortByInitialization) const;
 
   /*
   @brief Return all `ConfigOptionValidatorManager` held by this manager and its
   sub managers.
 
-  @param patPrefix Prefix for the paths in the exception message. Needed, so
+  @param sortByInitialization If true, the order of the returned
+  `ConfigOptionValidatorManager` is by initialization order. If false, the order
+  is random.
+  @param pathPrefix Prefix for the paths in the exception message. Needed, so
   that a sub manager can include its own path in the error messages.
   */
   std::vector<std::reference_wrapper<const ConfigOptionValidatorManager>>
-  validators(std::string_view pathPrefix = "") const;
+  validators(const bool sortByInitialization,
+             std::string_view pathPrefix = "") const;
 
   /*
   @brief The implementation for `configurationOptions`.
@@ -517,6 +525,8 @@ class ConfigManager {
   @tparam ReturnReference Should be either `ConfigOption&`, or `const
   ConfigOption&`.
 
+  @param sortByInitialization If true, the order of the returned `ConfigOption`
+  is by initialization order. If false, the order is random.
   @param pathPrefix This prefix will be added to all configuration option json
   paths, that will be returned.
   */
@@ -525,6 +535,7 @@ class ConfigManager {
            std::same_as<ReturnReference, const ConfigOption&>
   static std::vector<std::pair<std::string, ReturnReference>>
   configurationOptionsImpl(auto& configurationOptions,
+                           const bool sortByInitialization,
                            std::string_view pathPrefix = "");
 
   /*

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -57,7 +57,7 @@ class ConfigManager {
     std::unique_ptr<Data> data_;
 
     // Describes the order of initialization.
-    static inline size_t numberOfInstances_{0};
+    static inline std::atomic_size_t numberOfInstances_{0};
     size_t initializationId_{numberOfInstances_++};
 
    public:

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -58,7 +58,7 @@ class ConfigManager {
 
     // Describes the order of initialization.
     static inline size_t numberOfInstances_{0};
-    size_t initializationId_;
+    size_t initializationId_{numberOfInstances_++};
 
    public:
     // Construct an instance of this class managing `data`.

--- a/src/util/ConfigManager/Validator.cpp
+++ b/src/util/ConfigManager/Validator.cpp
@@ -3,9 +3,10 @@
 // Author: Andre Schlegel (September of 2023,
 // schlegea@informatik.uni-freiburg.de)
 
+#include "util/ConfigManager/Validator.h"
+
 #include <functional>
 
-#include "util/ConfigManager/Validator.h"
 #include "util/Exception.h"
 
 namespace ad_utility {

--- a/src/util/ConfigManager/Validator.cpp
+++ b/src/util/ConfigManager/Validator.cpp
@@ -3,10 +3,9 @@
 // Author: Andre Schlegel (September of 2023,
 // schlegea@informatik.uni-freiburg.de)
 
-#include "util/ConfigManager/Validator.h"
-
 #include <functional>
 
+#include "util/ConfigManager/Validator.h"
 #include "util/Exception.h"
 
 namespace ad_utility {
@@ -25,5 +24,10 @@ void ConfigOptionValidatorManager::checkValidator() const {
 // ____________________________________________________________________________
 std::string_view ConfigOptionValidatorManager::getDescription() const {
   return descriptor_;
+}
+
+// ____________________________________________________________________________
+size_t ConfigOptionValidatorManager::getInitializationId() const {
+  return initializationId_;
 }
 }  // namespace ad_utility

--- a/src/util/ConfigManager/Validator.h
+++ b/src/util/ConfigManager/Validator.h
@@ -98,6 +98,10 @@ class ConfigOptionValidatorManager {
   // A descripton of the invariant, this validator imposes.
   std::string descriptor_;
 
+  // Describes the order of initialization.
+  static inline size_t numberOfInstances_{0};
+  size_t initializationId_;
+
  public:
   /*
   @brief Create a `ConfigOptionValidatorManager`, which will call the given
@@ -121,16 +125,17 @@ class ConfigOptionValidatorManager {
   requires(std::invocable<TranslationFunction,
                           const ExceptionValidatorParameterTypes> &&
            ...) &&
-          ExceptionValidatorFunction<
-              ExceptionValidatorFunc,
-              std::invoke_result_t<TranslationFunction,
-                                   ExceptionValidatorParameterTypes>...> &&
-          (sizeof...(ExceptionValidatorParameterTypes) > 0)
+              ExceptionValidatorFunction<
+                  ExceptionValidatorFunc,
+                  std::invoke_result_t<TranslationFunction,
+                                       ExceptionValidatorParameterTypes>...> &&
+              (sizeof...(ExceptionValidatorParameterTypes) > 0)
   ConfigOptionValidatorManager(
       ExceptionValidatorFunc exceptionValidatorFunction, std::string descriptor,
       TranslationFunction translationFunction,
       const ExceptionValidatorParameterTypes... configOptionsToBeChecked)
-      : descriptor_{std::move(descriptor)} {
+      : descriptor_{std::move(descriptor)},
+        initializationId_{numberOfInstances_++} {
     wrappedValidatorFunction_ = [translationFunction =
                                      std::move(translationFunction),
                                  exceptionValidatorFunction =
@@ -209,6 +214,10 @@ class ConfigOptionValidatorManager {
   saved validator function, imposes upon the configuration options.
   */
   std::string_view getDescription() const;
+
+  // Return, how many instances of this class were initialized before this
+  // instance.
+  size_t getInitializationId() const;
 };
 
 }  // namespace ad_utility

--- a/src/util/ConfigManager/Validator.h
+++ b/src/util/ConfigManager/Validator.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <concepts>
 #include <functional>
 #include <optional>
@@ -99,7 +100,7 @@ class ConfigOptionValidatorManager {
   std::string descriptor_;
 
   // Describes the order of initialization.
-  static inline size_t numberOfInstances_{0};
+  static inline std::atomic_size_t numberOfInstances_{0};
   size_t initializationId_{numberOfInstances_++};
 
  public:

--- a/src/util/ConfigManager/Validator.h
+++ b/src/util/ConfigManager/Validator.h
@@ -100,7 +100,7 @@ class ConfigOptionValidatorManager {
 
   // Describes the order of initialization.
   static inline size_t numberOfInstances_{0};
-  size_t initializationId_;
+  size_t initializationId_{numberOfInstances_++};
 
  public:
   /*
@@ -125,17 +125,16 @@ class ConfigOptionValidatorManager {
   requires(std::invocable<TranslationFunction,
                           const ExceptionValidatorParameterTypes> &&
            ...) &&
-              ExceptionValidatorFunction<
-                  ExceptionValidatorFunc,
-                  std::invoke_result_t<TranslationFunction,
-                                       ExceptionValidatorParameterTypes>...> &&
-              (sizeof...(ExceptionValidatorParameterTypes) > 0)
+          ExceptionValidatorFunction<
+              ExceptionValidatorFunc,
+              std::invoke_result_t<TranslationFunction,
+                                   ExceptionValidatorParameterTypes>...> &&
+          (sizeof...(ExceptionValidatorParameterTypes) > 0)
   ConfigOptionValidatorManager(
       ExceptionValidatorFunc exceptionValidatorFunction, std::string descriptor,
       TranslationFunction translationFunction,
       const ExceptionValidatorParameterTypes... configOptionsToBeChecked)
-      : descriptor_{std::move(descriptor)},
-        initializationId_{numberOfInstances_++} {
+      : descriptor_{std::move(descriptor)} {
     wrappedValidatorFunction_ = [translationFunction =
                                      std::move(translationFunction),
                                  exceptionValidatorFunction =

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -6,24 +6,31 @@
 #include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <concepts>
 #include <cstddef>
 #include <functional>
 #include <tuple>
 #include <type_traits>
+#include <utility>
+#include <variant>
 #include <vector>
 
 #include "./util/ConfigOptionHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/ValidatorHelpers.h"
 #include "gtest/gtest.h"
+#include "util/Algorithm.h"
 #include "util/ConfigManager/ConfigExceptions.h"
 #include "util/ConfigManager/ConfigManager.h"
 #include "util/ConfigManager/ConfigOption.h"
 #include "util/ConfigManager/ConfigOptionProxy.h"
 #include "util/ConfigManager/ConfigShorthandVisitor.h"
 #include "util/ConfigManager/Validator.h"
+#include "util/ConstexprUtils.h"
 #include "util/CtreHelpers.h"
+#include "util/Forward.h"
+#include "util/TupleForEach.h"
 #include "util/json.h"
 
 using namespace std::string_literals;
@@ -40,8 +47,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
-                 const bool wasSet, const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
+                 const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -58,16 +65,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(
-      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -76,18 +81,14 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
-                                &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
-          &notUsed, 42),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -106,8 +107,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
-                        "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -118,8 +118,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -136,9 +135,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -177,32 +175,28 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
-                   "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(
-      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption(
-      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-      &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+                                   &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s})
-      .addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -221,8 +215,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -240,19 +233,16 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(
-          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -260,8 +250,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
-                            "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -280,17 +270,15 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s, "manager"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"some"s, "option"s}),
-      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
+                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -329,25 +317,22 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config
-      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(
+      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config
-                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
-                                      "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -356,16 +341,14 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
-                      .addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -377,13 +360,10 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s},
-                       "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne =
-      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                       "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo =
-      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                                              "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -416,16 +396,14 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck =
-      [](const nlohmann::json& j, ConfigManager& m,
-         const std::vector<std::pair<int*, int>>& wantedValues) {
-        m.parseConfig(j);
+  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
+                          const std::vector<std::pair<int*, int>>& wantedValues) {
+    m.parseConfig(j);
 
-        std::ranges::for_each(
-            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-              ASSERT_EQ(*wantedValue.first, wantedValue.second);
-            });
-      };
+    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+      ASSERT_EQ(*wantedValue.first, wantedValue.second);
+    });
+  };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -443,16 +421,13 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
-                                         &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
-  parseAndCheck(
-      nlohmann::json::parse(R"--({
+  parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -460,8 +435,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-      managerWithOneSubNoRecursion,
-      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+                managerWithOneSubNoRecursion,
+                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -489,14 +464,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4},
-                 {&daveInfractions, 0},
-                 {&janiceId, 0},
-                 {&janiceInfractions, 6}});
+                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
-                                              &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -518,20 +489,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 =
-      managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 =
-      managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex =
-      managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter =
-      managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -552,10 +519,7 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4},
-                 {&alexInfractions, 0},
-                 {&peterId, 0},
-                 {&peterInfractions, 6}});
+                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -651,11 +615,10 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s},
-                   "Must be set. Has no default value.", &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s},
-                   "Must not be set. Has default value.", &notUsedVector,
-                   {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                   &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                   &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -682,27 +645,20 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_integer)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(
-                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(
-      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+               ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -710,38 +666,32 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
-                   41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s},
-               "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s},
-               "Must not be set. Has default value.", &notUsedVector, {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
+               {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config.parseConfig(nlohmann::json::parse(
-          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
+                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -752,38 +702,29 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 =
-      config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 =
-      config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.",
-                    &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.",
-                      &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s},
-                      "Must be set. Has no default value.", &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s},
-                      "Must not be set. Has default value.", &notUsedVector,
-                      {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
+                      &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
+                      &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -794,15 +735,13 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -814,8 +753,7 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(
-          R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -824,65 +762,59 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.",
-      &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.",
-      &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist =
-      config.addOption("someIntegerlist", "Must be set. Has no default value.",
-                       &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist = config.addOption(
+      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint = config.addOption(
-      "somePositiveFloatingPoint", "Must be set. Has no default value.",
-      &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint =
+      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
+                       &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint = config.addOption(
-      "someNegativFloatingPoint", "Must be set. Has no default value.",
-      &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint =
+      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
+                       &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList = config.addOption(
-      "someFloatingPointList", "Must be set. Has no default value.",
-      &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList =
+      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
+                       &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue = config.addOption(
-      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue =
+      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse = config.addOption(
-      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse =
+      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList =
-      config.addOption("someBooleanList", "Must be set. Has no default value.",
-                       &someBooleanListBoolVector);
+  decltype(auto) someBooleanList = config.addOption(
+      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName = config.addOption(
-      "myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName =
+      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList =
-      config.addOption("someStringList", "Must be set. Has no default value.",
-                       &someStringListStringVector);
+  decltype(auto) someStringList = config.addOption(
+      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption =
-      config.addOption({"depth"s, "here"s, "list"s},
-                       "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption = config.addOption(
+      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -896,22 +828,17 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true,
-              std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
-              4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
-              -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
-              {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true,
-              std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -924,15 +851,13 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
-                                   R"(complicatedKey:42, complicatedKey:43)");
-                               , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
+      , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
-      R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(
-      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -949,8 +874,7 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan =
-      config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -960,12 +884,10 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(
-          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -977,14 +899,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager,
-                    const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      manager.parseConfig(jsonWithNonValidValues),
-      ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
+                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -994,12 +914,11 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption =
-      m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; },
-                 "'numberInRange' must be <=100.", "", numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; },
-                 "'numberInRange' must be >=50.", "", numberInRangeOption);
+  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.", "",
+                 numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.", "",
+                 numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -1013,15 +932,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption =
-      m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) ||
-               (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", "", boolOneOption, boolTwoOption,
-      boolThreeOption);
+      "Exactly one bool must be choosen.", "", boolOneOption, boolTwoOption, boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -1036,16 +952,12 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption =
-      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-      "Every option must have a default value.", "", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
-      nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+                                     "Every option must have a default value.", "", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption =
-      mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -1056,25 +968,19 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter =
-      mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) {
-        return opt.getIdentifier().starts_with('d');
-      },
+      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
       "Every option name must start with the letter d.", "", correctLetter);
-  ASSERT_NO_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') &&
-               opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", "", correctLetter,
-      wrongLetter);
-  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
-      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", "", correctLetter, wrongLetter);
+  ASSERT_ANY_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -1091,9 +997,7 @@ template <typename... Ts>
 std::string generateValidatorName(std::optional<size_t> id) {
   static const std::string prefix = absl::StrCat(
       "Config manager validator<",
-      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
-                  ", "),
-      ">");
+      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), ">");
 
   if (id.has_value()) {
     return absl::StrCat(prefix, " ", id.value());
@@ -1113,9 +1017,8 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(
-    auto addValidatorFunction,
-    ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(auto addValidatorFunction,
+                     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1140,12 +1043,10 @@ void doValidatorTest(
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes,
-               &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func),
-                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1192,13 +1093,11 @@ void doValidatorTest(
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m,
-          ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(
-        adjustVariantArgument.template operator()<Ts...>(variant),
-        generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
+                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1219,17 +1118,14 @@ void doValidatorTest(
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager =
-      [&adjustVariantArgument]<typename... Ts>(
-          size_t variantStart, size_t variantEnd, ConfigManager & m,
-          const nlohmann::json& defaultValues,
-          const std::same_as<
-              nlohmann::json::json_pointer> auto&... configOptionPaths)
-          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
+      size_t variantStart, size_t variantEnd, ConfigManager & m,
+      const nlohmann::json& defaultValues,
+      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
+      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
-         validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1250,11 +1146,9 @@ void doValidatorTest(
       only check, if it was bool validator.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName<Ts...>(std::nullopt));
+        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(std::nullopt));
       } else {
-        checkValidator(m, validJson, invalidJson,
-                       generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1278,8 +1172,7 @@ void doValidatorTest(
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1289,8 +1182,7 @@ void doValidatorTest(
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1321,10 +1213,8 @@ void doValidatorTest(
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &
-       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM,
-          const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1335,8 +1225,7 @@ void doValidatorTest(
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1346,8 +1235,7 @@ void doValidatorTest(
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(
-          i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1356,246 +1244,217 @@ void doValidatorTest(
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type>() {
-        // Variables needed for configuration options.
-        Type firstVar;
+  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
+    // Variables needed for configuration options.
+    Type firstVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption =
-            mNoSub.addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue"),
-                           mNoSubOption));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        decltype(auto) mSubNoValidatorOption =
-            mSubNoValidator.addSubManager({"some"s, "manager"s})
-                .addOption("someValue", "", &firstVar);
-        doTestNoValidatorInSubManager.template operator()<Type>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubNoValidatorOption));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    decltype(auto) mSubNoValidatorOption =
+        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
+    doTestNoValidatorInSubManager.template operator()<Type>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubNoValidatorOption));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption =
-            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue"),
-                mSubWithValidatorOption));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption =
+        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
+                       mSubWithValidatorOption));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests =
-      [&doTestNoValidatorInSubManager,
-       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
-        // Variables needed for configuration options.
-        Type1 firstVar;
-        Type2 secondVar;
+  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
+                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
+                                                                     typename Type2>() {
+    // Variables needed for configuration options.
+    Type1 firstVar;
+    Type2 secondVar;
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 =
-            mNoSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mNoSubOption2 =
-            mNoSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
-                           mNoSubOption1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
-                           mNoSubOption2));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub =
-            mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubNoValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubNoValidatorOption2));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubNoValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubNoValidatorOption2));
 
-        /*
-        With sub manager.
-        Covers the following cases:
-        - Sub manager has validators of its own, however the manager does not.
-        - Sub manager has validators of its own, as does the manager.
-        */
-        ConfigManager mSubWithValidator;
-        ConfigManager& mSubWithValidatorSub =
-            mSubWithValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubWithValidatorOption1 =
-            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-        decltype(auto) mSubWithValidatorOption2 =
-            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-            mSubWithValidator, mSubWithValidatorSub,
-            nlohmann::json(nlohmann::json::value_t::object),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue1"),
-                mSubWithValidatorOption1),
-            std::make_pair(
-                nlohmann::json::json_pointer("/some/manager/someValue2"),
-                mSubWithValidatorOption2));
-      };
+    /*
+    With sub manager.
+    Covers the following cases:
+    - Sub manager has validators of its own, however the manager does not.
+    - Sub manager has validators of its own, as does the manager.
+    */
+    ConfigManager mSubWithValidator;
+    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubWithValidatorOption1 =
+        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+    decltype(auto) mSubWithValidatorOption2 =
+        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       mSubWithValidatorOption1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       mSubWithValidatorOption2));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
-                                       typename Type1, typename Type2>() {
-    // Variables for config options.
-    Type1 var1;
-    Type2 var2;
+  auto doDifferentParameterTests =
+      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
+        // Variables for config options.
+        Type1 var1;
+        Type2 var2;
 
-    /*
-    @brief Helper function, that checks all combinations of valid/invalid values
-    for two single argument parameter validator functions.
+        /*
+        @brief Helper function, that checks all combinations of valid/invalid values
+        for two single argument parameter validator functions.
 
-    @tparam T1, T2 Function parameter type for the first and the second
-    validator.
+        @tparam T1, T2 Function parameter type for the first and the second
+        validator.
 
-    @param m The config manager, on which `parseConfig` will be called on.
-    @param validator1, validator2 A pair consisting of the path to the
-    configuration option, that the validator is looking at, and the `variant`
-    value, that was used to generate the validator function with
-    `addValidatorToConfigManager`.
-    */
-    auto checkAllValidAndInvalidValueCombinations =
-        []<typename T1, typename T2>(
-            ConfigManager& m,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-          /*
-          Input for `parseConfig`. One contains values, that are valid for all
-          validators, the other contains values, that are valid for all
-          validators except one.
-          */
-          nlohmann::json validValueJson(nlohmann::json::value_t::object);
-          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+        @param m The config manager, on which `parseConfig` will be called on.
+        @param validator1, validator2 A pair consisting of the path to the
+        configuration option, that the validator is looking at, and the `variant`
+        value, that was used to generate the validator function with
+        `addValidatorToConfigManager`.
+        */
+        auto checkAllValidAndInvalidValueCombinations =
+            []<typename T1, typename T2>(
+                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+              /*
+              Input for `parseConfig`. One contains values, that are valid for all
+              validators, the other contains values, that are valid for all
+              validators except one.
+              */
+              nlohmann::json validValueJson(nlohmann::json::value_t::object);
+              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-          // Add the valid values.
-          validValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second + 1);
-          validValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second + 1);
+              // Add the valid values.
+              validValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second + 1);
+              validValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second + 1);
 
-          // Value for `validator1` is invalid. Value for `validator2` is valid.
-          invalidValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second);
-          invalidValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second + 1);
-          checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName<Type1>(validator1.second));
+              // Value for `validator1` is invalid. Value for `validator2` is valid.
+              invalidValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second);
+              invalidValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second + 1);
+              checkValidator(m, validValueJson, invalidValueJson,
+                             generateValidatorName<Type1>(validator1.second));
 
-          // Value for `validator1` is valid. Value for `validator2` is invalid.
-          invalidValueJson[validator1.first] =
-              createDummyValueForValidator<Type1>(validator1.second + 1);
-          invalidValueJson[validator2.first] =
-              createDummyValueForValidator<Type2>(validator2.second);
-          checkValidator(m, validValueJson, invalidValueJson,
-                         generateValidatorName<Type2>(validator2.second));
-        };
+              // Value for `validator1` is valid. Value for `validator2` is invalid.
+              invalidValueJson[validator1.first] =
+                  createDummyValueForValidator<Type1>(validator1.second + 1);
+              invalidValueJson[validator2.first] =
+                  createDummyValueForValidator<Type2>(validator2.second);
+              checkValidator(m, validValueJson, invalidValueJson,
+                             generateValidatorName<Type2>(validator2.second));
+            };
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
-                                                           mNoSubOption1);
-    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
-                                                           mNoSubOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub =
-        mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mSubNoValidator, mSubNoValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mSubNoValidator, mSubNoValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mSubNoValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
+                                                               mSubNoValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
+                                                               mSubNoValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mSubNoValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
-    // Sub manager has validators of its own, however the manager does not.
-    ConfigManager mNoValidatorSubValidator;
-    ConfigManager& mNoValidatorSubValidatorSub =
-        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mNoValidatorSubValidatorOption1 =
-        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mNoValidatorSubValidatorOption2 =
-        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mNoValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
+        // Sub manager has validators of its own, however the manager does not.
+        ConfigManager mNoValidatorSubValidator;
+        ConfigManager& mNoValidatorSubValidatorSub =
+            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mNoValidatorSubValidatorOption1 =
+            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mNoValidatorSubValidatorOption2 =
+            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
+                                                               mNoValidatorSubValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
+                                                               mNoValidatorSubValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mNoValidatorSubValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
 
-    // Sub manager has validators of its own, as does the manager.
-    ConfigManager mValidatorSubValidator;
-    ConfigManager& mValidatorSubValidatorSub =
-        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mValidatorSubValidatorOption1 =
-        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-    decltype(auto) mValidatorSubValidatorOption2 =
-        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-    addValidatorToConfigManager.template operator()<Type1>(
-        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
-    addValidatorToConfigManager.template operator()<Type2>(
-        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
-    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-        mValidatorSubValidator,
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       1));
-  };
+        // Sub manager has validators of its own, as does the manager.
+        ConfigManager mValidatorSubValidator;
+        ConfigManager& mValidatorSubValidatorSub =
+            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mValidatorSubValidatorOption1 =
+            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+        decltype(auto) mValidatorSubValidatorOption2 =
+            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
+                                                               mValidatorSubValidatorOption1);
+        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
+                                                               mValidatorSubValidatorOption2);
+        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+            mValidatorSubValidator,
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
+            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1613,72 +1472,61 @@ void doValidatorTest(
 
   // Add the validator and check, if the configuration option with it's current
   // value is in the exception message for failing the validator.
-  auto doExceptionMessageTest =
-      [&addValidatorFunction, &defaultExceptionMessage](
-          size_t variantNumber, ConfigManager& managerToRunParseOn,
-          ConfigManager& managerToAddValidatorTo,
-          ConstConfigOptionProxy<std::string> option,
-          const nlohmann::json::json_pointer& pathToOption) {
-        // The value, which causes the automaticly generated validator with the
-        // given variant to fail.
-        const std::string& failValue =
-            createDummyValueForValidator<std::string>(variantNumber);
+  auto doExceptionMessageTest = [&addValidatorFunction, &defaultExceptionMessage](
+                                    size_t variantNumber, ConfigManager& managerToRunParseOn,
+                                    ConfigManager& managerToAddValidatorTo,
+                                    ConstConfigOptionProxy<std::string> option,
+                                    const nlohmann::json::json_pointer& pathToOption) {
+    // The value, which causes the automaticly generated validator with the
+    // given variant to fail.
+    const std::string& failValue = createDummyValueForValidator<std::string>(variantNumber);
 
-        nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
-        jsonForParsing[pathToOption] = failValue;
+    nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
+    jsonForParsing[pathToOption] = failValue;
 
-        // Adding the validator and checking.
-        std::invoke(addValidatorFunction, variantNumber,
-                    defaultExceptionMessage, managerToAddValidatorTo, option);
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            managerToRunParseOn.parseConfig(jsonForParsing),
-            ::testing::ContainsRegex(
-                absl::StrCat("value '\"", failValue, "\"'")));
-      };
+    // Adding the validator and checking.
+    std::invoke(addValidatorFunction, variantNumber, defaultExceptionMessage,
+                managerToAddValidatorTo, option);
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        managerToRunParseOn.parseConfig(jsonForParsing),
+        ::testing::ContainsRegex(absl::StrCat("value '\"", failValue, "\"'")));
+  };
 
   // No sub manager.
   ConfigManager mNoSub;
-  decltype(auto) mNoSubOption1 =
-      mNoSub.addOption("someValue1", "", &string0, defaultValue);
+  decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &string0, defaultValue);
   doExceptionMessageTest(10, mNoSub, mNoSub, mNoSubOption1,
                          nlohmann::json::json_pointer("/someValue1"));
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager mSubNoValidator;
-  ConfigManager& mSubNoValidatorSub =
-      mSubNoValidator.addSubManager({"some"s, "manager"s});
+  ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mSubNoValidatorOption1 =
       mSubNoValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(
-      10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
-      nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager mNoValidatorSubValidator;
   ConfigManager& mNoValidatorSubValidatorSub =
       mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mNoValidatorSubValidatorOption1 =
-      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0,
-                                            defaultValue);
-  doExceptionMessageTest(
-      10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
-      mNoValidatorSubValidatorOption1,
-      nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+  doExceptionMessageTest(10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
+                         mNoValidatorSubValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager mValidatorSubValidator;
   ConfigManager& mValidatorSubValidatorSub =
       mValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mValidatorSubValidatorOption1 =
-      mValidatorSubValidatorSub.addOption("someValue1", "", &string0,
-                                          defaultValue);
+      mValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
   decltype(auto) mValidatorSubValidatorOption2 =
-      mValidatorSubValidatorSub.addOption("someValue2", "", &string1,
-                                          defaultValue);
-  doExceptionMessageTest(
-      4, mValidatorSubValidator, mValidatorSubValidator,
-      mValidatorSubValidatorOption1,
-      nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mValidatorSubValidatorSub.addOption("someValue2", "", &string1, defaultValue);
+  doExceptionMessageTest(4, mValidatorSubValidator, mValidatorSubValidator,
+                         mValidatorSubValidatorOption1,
+                         nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   /*
   Reseting `mValidatorSubValidatorOption1`, so that the validator, that was
@@ -1688,36 +1536,29 @@ void doValidatorTest(
   fitting constructor.
   */
   nlohmann::json jsonForReset(nlohmann::json::value_t::object);
-  jsonForReset[nlohmann::json::json_pointer("/some/manager/someValue1")] =
-      defaultValue;
+  jsonForReset[nlohmann::json::json_pointer("/some/manager/someValue1")] = defaultValue;
   mValidatorSubValidator.parseConfig(jsonForReset);
 
-  doExceptionMessageTest(
-      5, mValidatorSubValidator, mValidatorSubValidatorSub,
-      mValidatorSubValidatorOption2,
-      nlohmann::json::json_pointer("/some/manager/someValue2"));
+  doExceptionMessageTest(5, mValidatorSubValidator, mValidatorSubValidatorSub,
+                         mValidatorSubValidatorOption2,
+                         nlohmann::json::json_pointer("/some/manager/someValue2"));
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant,
-                                     std::string_view validatorExceptionMessage,
-                                     ConfigManager& m,
-                                     ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
+                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
                    std::string(validatorExceptionMessage), "", optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant,
-                                     std::string validatorExceptionMessage,
-                                     ConfigManager& m,
-                                     ConstConfigOptionProxy<Ts>... optProxy) {
-    m.addValidator(
-        transformValidatorIntoExceptionValidator<Ts...>(
-            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
-            std::move(validatorExceptionMessage)),
-        "", optProxy...);
+  doValidatorTest([]<typename... Ts>(size_t variant, std::string validatorExceptionMessage,
+                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+    m.addValidator(transformValidatorIntoExceptionValidator<Ts...>(
+                       generateDummyNonExceptionValidatorFunction<Ts...>(variant),
+                       std::move(validatorExceptionMessage)),
+                   "", optProxy...);
   });
 }
 
@@ -1749,16 +1590,15 @@ void doValidatorExceptionTest(
         @brief Check, if a call to the `addValidator` function behaves as
         wanted.
         */
-        auto checkAddValidatorBehavior =
-            [&addAlwaysValidValidatorFunction](
-                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-                ConstConfigOptionProxy<T> notValidOption) {
-              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-              AD_EXPECT_THROW_WITH_MESSAGE(
-                  addAlwaysValidValidatorFunction(m, notValidOption),
-                  ::testing::ContainsRegex(
-                      notValidOption.getConfigOption().getIdentifier()));
-            };
+        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
+                                             ConfigManager& m,
+                                             ConstConfigOptionProxy<T> validOption,
+                                             ConstConfigOptionProxy<T> notValidOption) {
+          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+          AD_EXPECT_THROW_WITH_MESSAGE(
+              addAlwaysValidValidatorFunction(m, notValidOption),
+              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+        };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1771,50 +1611,30 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption =
-            mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub =
-            mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption =
-            mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption =
-            mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 =
-            mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option =
-            mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 =
-            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option =
-            mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1822,22 +1642,16 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m,
-                         ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "", "",
-                       validatorArguments...);
+      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "", "", validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m,
-                         ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator(
-            [](const Ts&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
-            "", validatorArguments...);
+      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
+                       "", validatorArguments...);
       });
 }
 
@@ -1858,13 +1672,11 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison =
-      [](std::string_view valueStringRepresentation) {
-        return [wantedString = std::string(valueStringRepresentation)](
-                   const auto&... options) {
-          return ((options.getValueAsString() == wantedString) && ...);
-        };
-      };
+  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
+    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
+      return ((options.getValueAsString() == wantedString) && ...);
+    };
+  };
 
   // Variables for configuration options.
   int firstVar;
@@ -1874,75 +1686,58 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "someOption1", managerWithNoSubManager,
-                                   managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
-                 "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
+                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "Both options", managerWithNoSubManager,
-                                   managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
+                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(
-      managerWithNoSubManager,
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-      "Both options");
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+                 "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
-                                                        &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager(
-          {"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
-          "someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Sub manager option",
-      managerWithSubManagerWhoHasNoValidators,
-      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
+                                   managerWithSubManagerWhoHasNoValidators,
+                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
+  checkValidator(managerWithSubManagerWhoHasNoValidators,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
+                                   managerWithSubManagerWhoHasNoValidators,
+                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+                                   managerWithSubManagerWhoHasNoValidatorsOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Both options",
-      managerWithSubManagerWhoHasNoValidators,
-      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-      managerWithSubManagerWhoHasNoValidatorsOption);
-  checkValidator(
-      managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager(
-          {"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
-          "someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("10"), "Sub manager option",
-      managerHasNoValidatorsButSubManagerDoesSubManager,
-      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(
-      managerHasNoValidatorsButSubManagerDoes,
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-      "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
+                                   managerHasNoValidatorsButSubManagerDoesSubManager,
+                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(managerHasNoValidatorsButSubManagerDoes,
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+                 "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1952,46 +1747,37 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
-                                   "Top manager option", bothHaveValidators,
-                                   bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(
-      generateValueAsStringComparison("20"), "Sub manager option",
-      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
+                                   bothHaveValidators, bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
+                                   bothHaveValidatorsSubManager,
+                                   bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(
-          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction,
-                         std::string validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction, std::string validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage, "",
-                             args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage, "", args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction,
-                         std::string validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction, std::string validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            transformValidatorIntoExceptionValidator<
-                decltype(args.getConfigOption())...>(
+            transformValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
                 validatorFunction, std::move(validatorExceptionMessage)),
             "", args...);
       });
@@ -2019,16 +1805,15 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior =
-      [&addAlwaysValidValidatorFunction]<typename T>(
-          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
-          ConstConfigOptionProxy<T> notValidOption) {
-        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-        AD_EXPECT_THROW_WITH_MESSAGE(
-            addAlwaysValidValidatorFunction(m, notValidOption),
-            ::testing::ContainsRegex(
-                notValidOption.getConfigOption().getIdentifier()));
-      };
+  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
+                                             ConfigManager& m,
+                                             ConstConfigOptionProxy<T> validOption,
+                                             ConstConfigOptionProxy<T> notValidOption) {
+    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        addAlwaysValidValidatorFunction(m, notValidOption),
+        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
+  };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -2043,53 +1828,35 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption =
-      mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
-                                  mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption =
-      mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option =
-      mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 =
-      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option =
-      mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
-                                  mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
-                                  mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) { return true; }, "",
-            "", args...);
+        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
+                             "", args...);
       });
 }
 
@@ -2097,8 +1864,9 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...)
-                -> std::optional<ErrorMessage> { return {std::nullopt}; },
+            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
             "", args...);
       });
 }
@@ -2112,21 +1880,18 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector =
-      std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus =
-      [](const ConfigManager& m,
-         const ContainmentStatusVector& optionsAndWantedStatus) {
-        std::ranges::for_each(
-            optionsAndWantedStatus,
-            [&m](const ContainmentStatusVector::value_type& p) {
-              if (p.second) {
-                ASSERT_TRUE(m.containsOption(*p.first));
-              } else {
-                ASSERT_FALSE(m.containsOption(*p.first));
-              }
-            });
-      };
+  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus = [](const ConfigManager& m,
+                                   const ContainmentStatusVector& optionsAndWantedStatus) {
+    std::ranges::for_each(optionsAndWantedStatus,
+                          [&m](const ContainmentStatusVector::value_type& p) {
+                            if (p.second) {
+                              ASSERT_TRUE(m.containsOption(*p.first));
+                            } else {
+                              ASSERT_FALSE(m.containsOption(*p.first));
+                            }
+                          });
+  };
 
   // Variable for the configuration options.
   int var;
@@ -2137,86 +1902,176 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
-      {&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
-      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back(
-      {&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 =
-      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option =
-      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back(
-      {&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1,
-                         subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2,
-                         subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2,
-                         subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+}
+
+// Describes the order of configuration options and validators inside a configuration manager.
+struct ConfigOptionsAndValidatorsOrder {
+  // The order of the configuration options. Options can be identified via their memory address.
+  std::vector<const ConfigOption*> configOptions_;
+
+  // The order the validators. unfortunately, there is no way, to perfectly identify an instance,
+  // but the description can be used, as long as all the added validators have unique descriptions.
+  std::vector<std::string> validators_;
+
+  // Appends the content of an different `ConfigOptionsAndValidatorsOrder`.
+  template <typename T>
+  requires isSimilar<T, ConfigOptionsAndValidatorsOrder> void append(T&& order) {
+    appendVector(configOptions_, AD_FWD(order.configOptions_));
+    appendVector(validators_, AD_FWD(order.validators_));
+  }
+};
+
+/*
+This is for testing, if the internal helper functions `ConfigManager::validators` and
+`ConfigManager::configurationOptions` sort their return values correctly.
+*/
+TEST(ConfigManagerTest, CollectionFunctionsSorting) {
+  /*
+  Add dummy configuration option for all supported types and dummy validators for them to the given
+  `configManager`.
+
+  @returns The order of all added configuration options and validators.
+  */
+  auto addConfigOptionsAndValidators = [callNum = 0](ConfigManager* manager) mutable {
+    ConfigOptionsAndValidatorsOrder order{};
+
+    // We know, how many instances we will add.
+    order.configOptions_.reserve(std::variant_size_v<ConfigOption::AvailableTypes>);
+    order.validators_.reserve(std::variant_size_v<ConfigOption::AvailableTypes> * 2);
+
+    // Fill the list.
+    forEachTypeInTemplateType<ConfigOption::AvailableTypes>(
+        [&order, &manager, &callNum]<typename T>() {
+          // This variable will never be used, so this SHOULD be okay.
+          T var;
+
+          // Create the options and validators.
+          decltype(auto) opt = manager->addOption({absl::StrCat("Option", callNum++)}, "", &var);
+          order.configOptions_.push_back(&opt.getConfigOption());
+          manager->addValidator([](const T&) { return true; }, "",
+                                absl::StrCat("Normal validator ", callNum), opt);
+          order.validators_.push_back(absl::StrCat("Normal validator ", callNum++));
+          manager->addOptionValidator([](const ConfigOption&) { return true; }, "",
+                                      absl::StrCat("Option validator ", callNum), opt);
+          order.validators_.push_back(absl::StrCat("Option validator ", callNum++));
+        });
+
+    return order;
+  };
+
+  // Check the order of the configuration options and validators inside the configuration manager.
+  auto checkOrder = [](const ConfigManager& manager, const ConfigOptionsAndValidatorsOrder& order,
+                       ad_utility::source_location l = ad_utility::source_location::current()) {
+    // For generating better messages, when failing a test.
+    auto trace{generateLocationTrace(l, "checkOrder")};
+
+    ASSERT_TRUE(std::ranges::equal(
+        manager.configurationOptions(true), order.configOptions_, {},
+        [](const std::pair<std::string, const ConfigOption&>& pair) { return &pair.second; }));
+    ASSERT_TRUE(std::ranges::equal(manager.validators(true), order.validators_, {},
+                                   [](const ConfigOptionValidatorManager& validatorManager) {
+                                     return validatorManager.getDescription();
+                                   }));
+  };
+
+  // First add the options, then the sub manager and then more options to the top manager again.
+  ConfigManager mOptionFirst;
+  auto mOptionFirstOrderOfAll{addConfigOptionsAndValidators(&mOptionFirst)};
+  checkOrder(mOptionFirst, mOptionFirstOrderOfAll);
+
+  // Add the sub manager, together with its config options.
+  ConfigManager& mOptionFirstSub{mOptionFirst.addSubManager({"s"})};
+  auto mOptionFirstSubOrder{addConfigOptionsAndValidators(&mOptionFirstSub)};
+  checkOrder(mOptionFirstSub, mOptionFirstSubOrder);
+  mOptionFirstOrderOfAll.append(mOptionFirstSubOrder);
+  checkOrder(mOptionFirst, mOptionFirstOrderOfAll);
+
+  // Add config options to the top manager.
+  mOptionFirstOrderOfAll.append(addConfigOptionsAndValidators(&mOptionFirst));
+  checkOrder(mOptionFirstSub, mOptionFirstSubOrder);
+  checkOrder(mOptionFirst, mOptionFirstOrderOfAll);
+
+  // First add the sub manager with config options, then options to the top manager and then options
+  // to the sub manager again.
+  ConfigManager mSubManagerFirst;
+  ConfigManager& mSubManagerFirstSub{mSubManagerFirst.addSubManager({"s"})};
+  auto mSubManagerFirstSubOrder{addConfigOptionsAndValidators(&mSubManagerFirstSub)};
+  auto mSubManagerFirstOrderOfAll{mSubManagerFirstSubOrder};
+  checkOrder(mSubManagerFirst, mSubManagerFirstOrderOfAll);
+  checkOrder(mSubManagerFirstSub, mSubManagerFirstSubOrder);
+
+  // Add config options to the top manager.
+  mSubManagerFirstOrderOfAll.append(addConfigOptionsAndValidators(&mSubManagerFirst));
+  checkOrder(mSubManagerFirst, mSubManagerFirstOrderOfAll);
+  checkOrder(mSubManagerFirstSub, mSubManagerFirstSubOrder);
+
+  // Add config options to the sub manager.
+  auto mSubManagerFirstSubOrder2{addConfigOptionsAndValidators(&mSubManagerFirstSub)};
+  mSubManagerFirstOrderOfAll.append(mSubManagerFirstSubOrder2);
+  mSubManagerFirstSubOrder.append(std::move(mSubManagerFirstSubOrder2));
+  checkOrder(mSubManagerFirst, mSubManagerFirstOrderOfAll);
+  checkOrder(mSubManagerFirstSub, mSubManagerFirstSubOrder);
 }
 }  // namespace ad_utility

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1978,8 +1978,8 @@ struct ConfigOptionsAndValidatorsOrder {
   // Appends the content of an different `ConfigOptionsAndValidatorsOrder`.
   template <typename T>
   requires isSimilar<T, ConfigOptionsAndValidatorsOrder> void append(T&& order) {
-    appendVector(configOptions_, AD_FWD(order.configOptions_));
-    appendVector(validators_, AD_FWD(order.validators_));
+    appendVector(configOptions_, AD_FWD(order).configOptions_);
+    appendVector(validators_, AD_FWD(order).validators_);
   }
 };
 

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -47,8 +47,8 @@ to.
 to.
 */
 template <typename T>
-void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable, const bool wasSet,
-                 const T& wantedValue) {
+void checkOption(ConstConfigOptionProxy<T> option, const T& externalVariable,
+                 const bool wasSet, const T& wantedValue) {
   ASSERT_EQ(wasSet, option.getConfigOption().wasSet());
 
   if (wasSet) {
@@ -65,14 +65,16 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   An empty vector that should cause an exception.
   Reason: The last key is used as the name for the to be created `ConfigOption`.
   An empty vector doesn't work with that.
   */
-  ASSERT_ANY_THROW(config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
+  ASSERT_ANY_THROW(
+      config.addOption(std::vector<std::string>{}, "", &notUsed, 42););
 
   /*
   Trying to add a configuration option with a path containing strings with
@@ -81,14 +83,18 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   configuration grammar. Ergo, you can't set values, with such paths per short
   hand, which we don't want.
   */
-  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  ASSERT_THROW(config.addOption({"Shared part"s, "Sense_of_existence"s}, "",
+                                &notUsed, 42);
                , ad_utility::NotValidShortHandNameException);
 
   // Trying to add a configuration option with the same name at the same
   // place, should cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addOption(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "",
+          &notUsed, 42),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
@@ -107,7 +113,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   option. Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s},
+      config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s,
+                        "Answer"s, "42"s},
                        "", &notUsed, 42),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
@@ -118,7 +125,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   this would imply, that the sub manger is part of this new option. Which is not
   supported at the moment.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   AD_EXPECT_THROW_WITH_MESSAGE(config.addOption("sub"s, "", &notUsed, 42),
                                ::testing::ContainsRegex(R"('\[sub\]')"));
 
@@ -135,8 +143,9 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   Trying to add a configuration option, whose path is the path of an already
   added sub manger, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
-                               ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
+      ::testing::ContainsRegex(R"('\[sub\]\[manager\]')"));
 }
 
 /*
@@ -175,28 +184,32 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
 
   // Configuration options for testing.
   int notUsed;
-  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}, "", &notUsed, 42);
+  config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s},
+                   "", &notUsed, 42);
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a config option path, that is is already in
   use.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
+  ASSERT_NO_THROW(
+      config.addOption({"Shared_part"s, "Unique_part"s}, "", &notUsed, 42));
 
   /*
   Adding a config option and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addOption({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
-                                   &notUsed, 42));
+  ASSERT_NO_THROW(config.addOption(
+      {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s}, "",
+      &notUsed, 42));
 
   /*
   Adding a config option, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  config.addSubManager({"sub"s, "manager"s}).addOption("someOpt"s, "", &notUsed, 42);
+  config.addSubManager({"sub"s, "manager"s})
+      .addOption("someOpt"s, "", &notUsed, 42);
   ASSERT_NO_THROW(config.addOption({"sub"s, "man"s}, "", &notUsed, 42));
 
   /*
@@ -215,7 +228,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
   // An empty vector that should cause an exception.
   ASSERT_ANY_THROW(config.addSubManager(std::vector<std::string>{}););
@@ -233,16 +247,19 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   // Trying to add a sub manager with the same name at the same place, should
   // cause an error.
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
-      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
+      config.addSubManager(
+          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s}),
+      ::testing::ContainsRegex(
+          R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]')"));
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added sub manger, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
-                               ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
+      ::testing::ContainsRegex(R"('\[Shared_part\]\[Unique_part_1\]')"));
 
   /*
   Trying to add a sub manager, whose path contains the entire path of an already
@@ -250,8 +267,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
-      config.addSubManager(
-          {"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s, "Answer"s, "42"s}),
+      config.addSubManager({"Shared_part"s, "Unique_part_1"s,
+                            "Sense_of_existence"s, "Answer"s, "42"s}),
       ::testing::ContainsRegex(
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
@@ -270,15 +287,17 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   After all, this would imply, that the sub manger is part of this option. Which
   is not supported at the moment.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s, "manager"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s, "manager"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]\[manager\]')"));
 
   /*
   Trying to add a sub manager, whose path is the path of an already added config
   option, should cause an exception.
   */
-  AD_EXPECT_THROW_WITH_MESSAGE(config.addSubManager({"some"s, "option"s}),
-                               ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.addSubManager({"some"s, "option"s}),
+      ::testing::ContainsRegex(R"('\[some\]\[option\]')"));
 }
 
 /*
@@ -317,22 +336,25 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
 
   // Sub manager for testing. Empty sub manager are not allowed.
   int notUsed;
-  config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
+  config
+      .addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence"s})
       .addOption("ignore", "", &notUsed);
 
   /*
   Adding a sub manager, where the json pointer version of the path is a prefix
   of the json pointer version of a sub manager path, that is is already in use.
   */
-  ASSERT_NO_THROW(
-      config.addSubManager({"Shared_part"s, "Unique_part"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use sub manager path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"Shared_part"s, "Unique_part_1"s, "Sense_of_existence_42"s})
+  ASSERT_NO_THROW(config
+                      .addSubManager({"Shared_part"s, "Unique_part_1"s,
+                                      "Sense_of_existence_42"s})
                       .addOption("ignore", "", &notUsed));
 
   /*
@@ -341,14 +363,16 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   use.
   */
   config.addOption({"some"s, "option"s}, "", &notUsed);
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "opt"s})
+                      .addOption("ignore", "", &notUsed));
 
   /*
   Adding a sub manager and there exists an already in use config option path,
   whose json pointer version is a prefix of the json pointer version of the new
   path.
   */
-  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s}).addOption("ignore", "", &notUsed));
+  ASSERT_NO_THROW(config.addSubManager({"some"s, "options"s})
+                      .addOption("ignore", "", &notUsed));
 }
 
 TEST(ConfigManagerTest, ParseConfigNoSubManager) {
@@ -360,10 +384,13 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
   int thirdInt;
 
   decltype(auto) optionZero =
-      config.addOption({"depth_0"s, "Option_0"s}, "Must be set. Has no default value.", &firstInt);
-  decltype(auto) optionOne = config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
-                                              "Must be set. Has no default value.", &secondInt);
-  decltype(auto) optionTwo = config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
+      config.addOption({"depth_0"s, "Option_0"s},
+                       "Must be set. Has no default value.", &firstInt);
+  decltype(auto) optionOne =
+      config.addOption({"depth_0"s, "depth_1"s, "Option_1"s},
+                       "Must be set. Has no default value.", &secondInt);
+  decltype(auto) optionTwo =
+      config.addOption("Option_2", "Has a default value.", &thirdInt, 2);
 
   // Does the option with the default already have a value?
   checkOption<int>(optionTwo, thirdInt, true, 2);
@@ -396,14 +423,16 @@ TEST(ConfigManagerTest, ParseConfigNoSubManager) {
 TEST(ConfigManagerTest, ParseConfigWithSubManager) {
   // Parse the given configManager with the given json and check, that all the
   // configOption were set correctly.
-  auto parseAndCheck = [](const nlohmann::json& j, ConfigManager& m,
-                          const std::vector<std::pair<int*, int>>& wantedValues) {
-    m.parseConfig(j);
+  auto parseAndCheck =
+      [](const nlohmann::json& j, ConfigManager& m,
+         const std::vector<std::pair<int*, int>>& wantedValues) {
+        m.parseConfig(j);
 
-    std::ranges::for_each(wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
-      ASSERT_EQ(*wantedValue.first, wantedValue.second);
-    });
-  };
+        std::ranges::for_each(
+            wantedValues, [](const std::pair<int*, int>& wantedValue) -> void {
+              ASSERT_EQ(*wantedValue.first, wantedValue.second);
+            });
+      };
 
   // Simple manager, with only one sub manager and no recursion.
   ad_utility::ConfigManager managerWithOneSubNoRecursion{};
@@ -421,13 +450,16 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion, {{&steveId, 40}, {&steveInfractions, 60}});
+                managerWithOneSubNoRecursion,
+                {{&steveId, 40}, {&steveInfractions, 60}});
 
   // Adding configuration options to the top level manager.
   int amountOfPersonal;
-  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithOneSubNoRecursion.addOption("AmountOfPersonal", "",
+                                         &amountOfPersonal, 0);
 
-  parseAndCheck(nlohmann::json::parse(R"--({
+  parseAndCheck(
+      nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
  "personal": {
    "Steve": {
@@ -435,8 +467,8 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
    }
  }
  })--"),
-                managerWithOneSubNoRecursion,
-                {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
+      managerWithOneSubNoRecursion,
+      {{&amountOfPersonal, 1}, {&steveId, 30}, {&steveInfractions, 70}});
 
   // Simple manager, with multiple sub manager and no recursion.
   ad_utility::ConfigManager managerWithMultipleSubNoRecursion{};
@@ -464,10 +496,14 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithMultipleSubNoRecursion,
-                {{&daveId, 4}, {&daveInfractions, 0}, {&janiceId, 0}, {&janiceInfractions, 6}});
+                {{&daveId, 4},
+                 {&daveInfractions, 0},
+                 {&janiceId, 0},
+                 {&janiceInfractions, 6}});
 
   // Adding configuration options to the top level manager.
-  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "", &amountOfPersonal, 0);
+  managerWithMultipleSubNoRecursion.addOption("AmountOfPersonal", "",
+                                              &amountOfPersonal, 0);
 
   parseAndCheck(nlohmann::json::parse(R"--({
  "AmountOfPersonal" : 1,
@@ -489,16 +525,20 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
 
   // Complex manager with recursion.
   ad_utility::ConfigManager managerWithRecursion{};
-  ad_utility::ConfigManager& managerDepth1 = managerWithRecursion.addSubManager({"depth1"s});
-  ad_utility::ConfigManager& managerDepth2 = managerDepth1.addSubManager({"depth2"s});
+  ad_utility::ConfigManager& managerDepth1 =
+      managerWithRecursion.addSubManager({"depth1"s});
+  ad_utility::ConfigManager& managerDepth2 =
+      managerDepth1.addSubManager({"depth2"s});
 
-  ad_utility::ConfigManager& managerAlex = managerDepth2.addSubManager({"personal"s, "Alex"s});
+  ad_utility::ConfigManager& managerAlex =
+      managerDepth2.addSubManager({"personal"s, "Alex"s});
   int alexId;
   managerAlex.addOption("Id", "", &alexId, 8);
   int alexInfractions;
   managerAlex.addOption("Infractions", "", &alexInfractions, 4);
 
-  ad_utility::ConfigManager& managerPeter = managerDepth2.addSubManager({"personal"s, "Peter"s});
+  ad_utility::ConfigManager& managerPeter =
+      managerDepth2.addSubManager({"personal"s, "Peter"s});
   int peterId;
   managerPeter.addOption("Id", "", &peterId, 8);
   int peterInfractions;
@@ -519,7 +559,10 @@ TEST(ConfigManagerTest, ParseConfigWithSubManager) {
  }
  })--"),
                 managerWithRecursion,
-                {{&alexId, 4}, {&alexInfractions, 0}, {&peterId, 0}, {&peterInfractions, 6}});
+                {{&alexId, 4},
+                 {&alexInfractions, 0},
+                 {&peterId, 0},
+                 {&peterInfractions, 6}});
 
   // Add an option to `managerDepth2`.
   int someOptionAtDepth2;
@@ -615,10 +658,11 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
   // Add one option with default and one without.
   int notUsedInt;
   std::vector<int> notUsedVector;
-  config.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                   &notUsedInt);
-  config.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                   &notUsedVector, {40, 41});
+  config.addOption({"depth_0"s, "Without_default"s},
+                   "Must be set. Has no default value.", &notUsedInt);
+  config.addOption({"depth_0"s, "With_default"s},
+                   "Must not be set. Has default value.", &notUsedVector,
+                   {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -645,20 +689,27 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithoutSubManagerTest) {
       ::testing::ContainsRegex(R"('/depth_0/With_default/value')"));
 
   // Parsing with a non json object literal is not allowed.
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::array)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_integer)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::boolean)),
+  ASSERT_THROW(config.parseConfig(
+                   nlohmann::json(nlohmann::json::value_t::number_unsigned)),
                ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::null)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_float)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_integer)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::number_unsigned)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
-  ASSERT_THROW(config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
-               ConfigManagerParseConfigNotJsonObjectLiteralException);
+  ASSERT_THROW(
+      config.parseConfig(nlohmann::json(nlohmann::json::value_t::string)),
+      ConfigManagerParseConfigNotJsonObjectLiteralException);
 }
 
 TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
@@ -666,32 +717,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
 
   // Empty sub managers are not allowed.
   ad_utility::ConfigManager& m1 = config.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
   int notUsedInt;
-  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager')"));
+  config.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt,
+                   41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager')"));
 
   // Add one option with default and one without.
   std::vector<int> notUsedVector;
-  m1.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.", &notUsedInt);
-  m1.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.", &notUsedVector,
-               {40, 41});
+  m1.addOption({"depth_0"s, "Without_default"s},
+               "Must be set. Has no default value.", &notUsedInt);
+  m1.addOption({"depth_0"s, "With_default"s},
+               "Must not be set. Has default value.", &notUsedVector, {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config.parseConfig(nlohmann::json::parse(R"--({})--")),
                ad_utility::ConfigOptionWasntSetException);
 
   // Should throw an exception, if we try set an option, that isn't there.
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "with_default" : [39]}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
-  AD_EXPECT_THROW_WITH_MESSAGE(config.parseConfig(nlohmann::json::parse(
-                                   R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/with_default')"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config.parseConfig(nlohmann::json::parse(
+          R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "test_string" : "test"}}}})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(R"('/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -702,29 +759,38 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"depth_0":{"Without_default":42,
            "With_default" : {"value" : 4}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/depth_0/With_default/value')"));
 
   // Repeat all those tests, but with a second sub manager added to the first
   // one.
   ad_utility::ConfigManager config2{};
 
   // Empty sub managers are not allowed.
-  ad_utility::ConfigManager& config2m1 = config2.addSubManager({"some"s, "manager"s});
-  ad_utility::ConfigManager& config2m2 = config2m1.addSubManager({"some"s, "manager"s});
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
-  config2m1.addOption("Ignore", "Must not be set. Has default value.", &notUsedInt, 41);
-  AD_EXPECT_THROW_WITH_MESSAGE(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
-                               ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  ad_utility::ConfigManager& config2m1 =
+      config2.addSubManager({"some"s, "manager"s});
+  ad_utility::ConfigManager& config2m2 =
+      config2m1.addSubManager({"some"s, "manager"s});
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2.addOption("Ignore", "Must not be set. Has default value.",
+                    &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
+  config2m1.addOption("Ignore", "Must not be set. Has default value.",
+                      &notUsedInt, 41);
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      config2.parseConfig(nlohmann::json::parse(R"--({})--")),
+      ::testing::ContainsRegex(R"('/some/manager/some/manager')"));
 
   // Add one option with default and one without.
-  config2m2.addOption({"depth_0"s, "Without_default"s}, "Must be set. Has no default value.",
-                      &notUsedInt);
-  config2m2.addOption({"depth_0"s, "With_default"s}, "Must not be set. Has default value.",
-                      &notUsedVector, {40, 41});
+  config2m2.addOption({"depth_0"s, "Without_default"s},
+                      "Must be set. Has no default value.", &notUsedInt);
+  config2m2.addOption({"depth_0"s, "With_default"s},
+                      "Must not be set. Has default value.", &notUsedVector,
+                      {40, 41});
 
   // Should throw an exception, if we don't set all options, that must be set.
   ASSERT_THROW(config2.parseConfig(nlohmann::json::parse(R"--({})--")),
@@ -735,13 +801,15 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "with_default" : [39]}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/with_default')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/with_default')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config2.parseConfig(nlohmann::json::parse(
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "test_string" :
            "test"}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/test_string')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/test_string')"));
 
   /*
   Should throw an exception, if we try set an option with a value, that we
@@ -753,7 +821,8 @@ TEST(ConfigManagerTest, ParseConfigExceptionWithSubManagerTest) {
           R"--({"some":{ "manager": {"some":{ "manager":
            {"depth_0":{"Without_default":42, "With_default" : {"value" :
            4}}}}}}})--")),
-      ::testing::ContainsRegex(R"('/some/manager/some/manager/depth_0/With_default/value')"));
+      ::testing::ContainsRegex(
+          R"('/some/manager/some/manager/depth_0/With_default/value')"));
 }
 
 TEST(ConfigManagerTest, ParseShortHandTest) {
@@ -762,59 +831,65 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   // Add integer options.
   int somePositiveNumberInt;
   decltype(auto) somePositiveNumber = config.addOption(
-      "somePositiveNumber", "Must be set. Has no default value.", &somePositiveNumberInt);
+      "somePositiveNumber", "Must be set. Has no default value.",
+      &somePositiveNumberInt);
   int someNegativNumberInt;
   decltype(auto) someNegativNumber = config.addOption(
-      "someNegativNumber", "Must be set. Has no default value.", &someNegativNumberInt);
+      "someNegativNumber", "Must be set. Has no default value.",
+      &someNegativNumberInt);
 
   // Add integer list.
   std::vector<int> someIntegerlistIntVector;
-  decltype(auto) someIntegerlist = config.addOption(
-      "someIntegerlist", "Must be set. Has no default value.", &someIntegerlistIntVector);
+  decltype(auto) someIntegerlist =
+      config.addOption("someIntegerlist", "Must be set. Has no default value.",
+                       &someIntegerlistIntVector);
 
   // Add floating point options.
   float somePositiveFloatingPointFloat;
-  decltype(auto) somePositiveFloatingPoint =
-      config.addOption("somePositiveFloatingPoint", "Must be set. Has no default value.",
-                       &somePositiveFloatingPointFloat);
+  decltype(auto) somePositiveFloatingPoint = config.addOption(
+      "somePositiveFloatingPoint", "Must be set. Has no default value.",
+      &somePositiveFloatingPointFloat);
   float someNegativFloatingPointFloat;
-  decltype(auto) someNegativFloatingPoint =
-      config.addOption("someNegativFloatingPoint", "Must be set. Has no default value.",
-                       &someNegativFloatingPointFloat);
+  decltype(auto) someNegativFloatingPoint = config.addOption(
+      "someNegativFloatingPoint", "Must be set. Has no default value.",
+      &someNegativFloatingPointFloat);
 
   // Add floating point list.
   std::vector<float> someFloatingPointListFloatVector;
-  decltype(auto) someFloatingPointList =
-      config.addOption("someFloatingPointList", "Must be set. Has no default value.",
-                       &someFloatingPointListFloatVector);
+  decltype(auto) someFloatingPointList = config.addOption(
+      "someFloatingPointList", "Must be set. Has no default value.",
+      &someFloatingPointListFloatVector);
 
   // Add boolean options.
   bool boolTrueBool;
-  decltype(auto) boolTrue =
-      config.addOption("boolTrue", "Must be set. Has no default value.", &boolTrueBool);
+  decltype(auto) boolTrue = config.addOption(
+      "boolTrue", "Must be set. Has no default value.", &boolTrueBool);
   bool boolFalseBool;
-  decltype(auto) boolFalse =
-      config.addOption("boolFalse", "Must be set. Has no default value.", &boolFalseBool);
+  decltype(auto) boolFalse = config.addOption(
+      "boolFalse", "Must be set. Has no default value.", &boolFalseBool);
 
   // Add boolean list.
   std::vector<bool> someBooleanListBoolVector;
-  decltype(auto) someBooleanList = config.addOption(
-      "someBooleanList", "Must be set. Has no default value.", &someBooleanListBoolVector);
+  decltype(auto) someBooleanList =
+      config.addOption("someBooleanList", "Must be set. Has no default value.",
+                       &someBooleanListBoolVector);
 
   // Add string option.
   std::string myNameString;
-  decltype(auto) myName =
-      config.addOption("myName", "Must be set. Has no default value.", &myNameString);
+  decltype(auto) myName = config.addOption(
+      "myName", "Must be set. Has no default value.", &myNameString);
 
   // Add string list.
   std::vector<std::string> someStringListStringVector;
-  decltype(auto) someStringList = config.addOption(
-      "someStringList", "Must be set. Has no default value.", &someStringListStringVector);
+  decltype(auto) someStringList =
+      config.addOption("someStringList", "Must be set. Has no default value.",
+                       &someStringListStringVector);
 
   // Add option with deeper level.
   std::vector<int> deeperIntVector;
-  decltype(auto) deeperIntVectorOption = config.addOption(
-      {"depth"s, "here"s, "list"s}, "Must be set. Has no default value.", &deeperIntVector);
+  decltype(auto) deeperIntVectorOption =
+      config.addOption({"depth"s, "here"s, "list"s},
+                       "Must be set. Has no default value.", &deeperIntVector);
 
   // This one will not be changed, in order to test, that options, that are
   // not set at run time, are not changed.
@@ -828,17 +903,22 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(somePositiveNumber, somePositiveNumberInt, true, 42);
   checkOption(someNegativNumber, someNegativNumberInt, true, -42);
 
-  checkOption(someIntegerlist, someIntegerlistIntVector, true, std::vector{40, 41});
+  checkOption(someIntegerlist, someIntegerlistIntVector, true,
+              std::vector{40, 41});
 
-  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true, 4.2f);
-  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true, -4.2f);
+  checkOption(somePositiveFloatingPoint, somePositiveFloatingPointFloat, true,
+              4.2f);
+  checkOption(someNegativFloatingPoint, someNegativFloatingPointFloat, true,
+              -4.2f);
 
-  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true, {4.1f, 4.2f});
+  checkOption(someFloatingPointList, someFloatingPointListFloatVector, true,
+              {4.1f, 4.2f});
 
   checkOption(boolTrue, boolTrueBool, true, true);
   checkOption(boolFalse, boolFalseBool, true, false);
 
-  checkOption(someBooleanList, someBooleanListBoolVector, true, std::vector{true, false, true});
+  checkOption(someBooleanList, someBooleanListBoolVector, true,
+              std::vector{true, false, true});
 
   checkOption(myName, myNameString, true, std::string{"Bernd"});
 
@@ -851,13 +931,15 @@ TEST(ConfigManagerTest, ParseShortHandTest) {
   checkOption(noChange, noChangeInt, true, 10);
 
   // Multiple key value pairs with the same key are not allowed.
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      ad_utility::ConfigManager::parseShortHand(R"(complicatedKey:42, complicatedKey:43)");
-      , ::testing::ContainsRegex("'complicatedKey'"));
+  AD_EXPECT_THROW_WITH_MESSAGE(ad_utility::ConfigManager::parseShortHand(
+                                   R"(complicatedKey:42, complicatedKey:43)");
+                               , ::testing::ContainsRegex("'complicatedKey'"));
 
   // Final test: Is there an exception, if we try to parse the wrong syntax?
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--({"myName" : "Bernd")})--"));
-  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
+  ASSERT_ANY_THROW(ad_utility::ConfigManager::parseShortHand(
+      R"--({"myName" : "Bernd")})--"));
+  ASSERT_ANY_THROW(
+      ad_utility::ConfigManager::parseShortHand(R"--("myName" = "Bernd";)--"));
 }
 
 TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
@@ -874,7 +956,8 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
   ASSERT_NO_THROW(config.printConfigurationDoc(true));
 
-  ad_utility::ConfigManager& subMan = config.addSubManager({"Just"s, "some"s, "sub-manager"});
+  ad_utility::ConfigManager& subMan =
+      config.addSubManager({"Just"s, "some"s, "sub-manager"});
   subMan.addOption("WithDefault", "", &notUsed, 42);
   subMan.addOption("WithoutDefault", "", &notUsed);
   ASSERT_NO_THROW(config.printConfigurationDoc(false));
@@ -884,10 +967,12 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
   subMan.addSubManager({"Just"s, "some"s, "other"s, "sub-manager"});
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(false),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.printConfigurationDoc(true),
-      ::testing::ContainsRegex(R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
+      ::testing::ContainsRegex(
+          R"('/Just/some/sub-manager/Just/some/other/sub-manager')"));
 }
 
 /*
@@ -899,12 +984,14 @@ TEST(ConfigManagerTest, PrintConfigurationDocExistence) {
 the exception thrown for `jsonWithNonValidValues`. Validators have custom
 exception messages, so they should be identifiable.
 */
-void checkValidator(ConfigManager& manager, const nlohmann::json& jsonWithValidValues,
+void checkValidator(ConfigManager& manager,
+                    const nlohmann::json& jsonWithValidValues,
                     const nlohmann::json& jsonWithNonValidValues,
                     std::string_view containedInExpectedErrorMessage) {
   ASSERT_NO_THROW(manager.parseConfig(jsonWithValidValues));
-  AD_EXPECT_THROW_WITH_MESSAGE(manager.parseConfig(jsonWithNonValidValues),
-                               ::testing::ContainsRegex(containedInExpectedErrorMessage));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      manager.parseConfig(jsonWithNonValidValues),
+      ::testing::ContainsRegex(containedInExpectedErrorMessage));
 }
 
 // Human readable examples for `addValidator` with `Validator` functions.
@@ -914,11 +1001,12 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   // The number of the option should be in a range. We define the range by using
   // two validators.
   int someInt;
-  decltype(auto) numberInRangeOption = m.addOption("numberInRange", "", &someInt);
-  m.addValidator([](const int& num) { return num <= 100; }, "'numberInRange' must be <=100.", "",
-                 numberInRangeOption);
-  m.addValidator([](const int& num) { return num > 49; }, "'numberInRange' must be >=50.", "",
-                 numberInRangeOption);
+  decltype(auto) numberInRangeOption =
+      m.addOption("numberInRange", "", &someInt);
+  m.addValidator([](const int& num) { return num <= 100; },
+                 "'numberInRange' must be <=100.", "", numberInRangeOption);
+  m.addValidator([](const int& num) { return num > 49; },
+                 "'numberInRange' must be >=50.", "", numberInRangeOption);
   checkValidator(m, nlohmann::json::parse(R"--({"numberInRange" : 60})--"),
                  nlohmann::json::parse(R"--({"numberInRange" : 101})--"),
                  "'numberInRange' must be <=100.");
@@ -932,12 +1020,15 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
   bool boolTwo;
   decltype(auto) boolTwoOption = m.addOption("boolTwo", "", &boolTwo, false);
   bool boolThree;
-  decltype(auto) boolThreeOption = m.addOption("boolThree", "", &boolThree, false);
+  decltype(auto) boolThreeOption =
+      m.addOption("boolThree", "", &boolThree, false);
   m.addValidator(
       [](bool one, bool two, bool three) {
-        return (one && !two && !three) || (!one && two && !three) || (!one && !two && three);
+        return (one && !two && !three) || (!one && two && !three) ||
+               (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", "", boolOneOption, boolTwoOption, boolThreeOption);
+      "Exactly one bool must be choosen.", "", boolOneOption, boolTwoOption,
+      boolThreeOption);
   checkValidator(
       m,
       nlohmann::json::parse(
@@ -952,12 +1043,16 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
   // Check, if all the options have a default value.
   ConfigManager mAllWithDefault;
   int firstInt;
-  decltype(auto) firstOption = mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
-  mAllWithDefault.addOptionValidator([](const ConfigOption& opt) { return opt.hasDefaultValue(); },
-                                     "Every option must have a default value.", "", firstOption);
-  ASSERT_NO_THROW(mAllWithDefault.parseConfig(nlohmann::json::parse(R"--({"firstOption": 4})--")));
+  decltype(auto) firstOption =
+      mAllWithDefault.addOption("firstOption", "", &firstInt, 10);
+  mAllWithDefault.addOptionValidator(
+      [](const ConfigOption& opt) { return opt.hasDefaultValue(); },
+      "Every option must have a default value.", "", firstOption);
+  ASSERT_NO_THROW(mAllWithDefault.parseConfig(
+      nlohmann::json::parse(R"--({"firstOption": 4})--")));
   int secondInt;
-  decltype(auto) secondOption = mAllWithDefault.addOption("secondOption", "", &secondInt);
+  decltype(auto) secondOption =
+      mAllWithDefault.addOption("secondOption", "", &secondInt);
   mAllWithDefault.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
         return opt1.hasDefaultValue() && opt2.hasDefaultValue();
@@ -968,19 +1063,25 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 
   // We want, that all options names start with the letter `d`.
   ConfigManager mFirstLetter;
-  decltype(auto) correctLetter = mFirstLetter.addOption("dValue", "", &firstInt);
+  decltype(auto) correctLetter =
+      mFirstLetter.addOption("dValue", "", &firstInt);
   mFirstLetter.addOptionValidator(
-      [](const ConfigOption& opt) { return opt.getIdentifier().starts_with('d'); },
+      [](const ConfigOption& opt) {
+        return opt.getIdentifier().starts_with('d');
+      },
       "Every option name must start with the letter d.", "", correctLetter);
-  ASSERT_NO_THROW(mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
+  ASSERT_NO_THROW(
+      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4})--")));
   decltype(auto) wrongLetter = mFirstLetter.addOption("value", "", &secondInt);
   mFirstLetter.addOptionValidator(
       [](const ConfigOption& opt1, const ConfigOption& opt2) {
-        return opt1.getIdentifier().starts_with('d') && opt2.getIdentifier().starts_with('d');
+        return opt1.getIdentifier().starts_with('d') &&
+               opt2.getIdentifier().starts_with('d');
       },
-      "Every option name must start with the letter d.", "", correctLetter, wrongLetter);
-  ASSERT_ANY_THROW(
-      mFirstLetter.parseConfig(nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
+      "Every option name must start with the letter d.", "", correctLetter,
+      wrongLetter);
+  ASSERT_ANY_THROW(mFirstLetter.parseConfig(
+      nlohmann::json::parse(R"--({"dValue": 4, "Value" : 7})--")));
 }
 
 /*
@@ -997,7 +1098,9 @@ template <typename... Ts>
 std::string generateValidatorName(std::optional<size_t> id) {
   static const std::string prefix = absl::StrCat(
       "Config manager validator<",
-      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...}, ", "), ">");
+      lazyStrJoin(std::array{ConfigOption::availableTypesToString<Ts>()...},
+                  ", "),
+      ">");
 
   if (id.has_value()) {
     return absl::StrCat(prefix, " ", id.value());
@@ -1017,8 +1120,9 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
-void doValidatorTest(auto addValidatorFunction,
-                     ad_utility::source_location l = ad_utility::source_location::current()) {
+void doValidatorTest(
+    auto addValidatorFunction,
+    ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
 
@@ -1043,10 +1147,12 @@ void doValidatorTest(auto addValidatorFunction,
           func.template operator()<Ts...>();
         } else {
           doForTypeInConfigOptionValueType(
-              [&callGivenLambdaWithAllCombinationsOfTypes, &func]<typename T>() {
+              [&callGivenLambdaWithAllCombinationsOfTypes,
+               &func]<typename T>() {
                 callGivenLambdaWithAllCombinationsOfTypes
                     .template operator()<NumTemplateParameter - 1, T, Ts...>(
-                        AD_FWD(func), AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
+                        AD_FWD(func),
+                        AD_FWD(callGivenLambdaWithAllCombinationsOfTypes));
               });
         }
       };
@@ -1093,11 +1199,13 @@ void doValidatorTest(auto addValidatorFunction,
   */
   auto addValidatorToConfigManager =
       [&adjustVariantArgument, &addValidatorFunction ]<typename... Ts>(
-          size_t variant, ConfigManager & m, ConstConfigOptionProxy<Ts>... validatorArguments)
+          size_t variant, ConfigManager & m,
+          ConstConfigOptionProxy<Ts>... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
     // Add the new validator
-    addValidatorFunction(adjustVariantArgument.template operator()<Ts...>(variant),
-                         generateValidatorName<Ts...>(variant), m, validatorArguments...);
+    addValidatorFunction(
+        adjustVariantArgument.template operator()<Ts...>(variant),
+        generateValidatorName<Ts...>(variant), m, validatorArguments...);
   };
 
   /*
@@ -1118,14 +1226,17 @@ void doValidatorTest(auto addValidatorFunction,
   @param configOptionPaths Paths to the configuration options, who were  given
   to `addValidatorToConfigManager`.
   */
-  auto testGeneratedValidatorsOfConfigManager = [&adjustVariantArgument]<typename... Ts>(
-      size_t variantStart, size_t variantEnd, ConfigManager & m,
-      const nlohmann::json& defaultValues,
-      const std::same_as<nlohmann::json::json_pointer> auto&... configOptionPaths)
-      requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
+  auto testGeneratedValidatorsOfConfigManager =
+      [&adjustVariantArgument]<typename... Ts>(
+          size_t variantStart, size_t variantEnd, ConfigManager & m,
+          const nlohmann::json& defaultValues,
+          const std::same_as<
+              nlohmann::json::json_pointer> auto&... configOptionPaths)
+          requires(sizeof...(Ts) == sizeof...(configOptionPaths)) {
     // Using the invariant of our function generator, to create valid
     // and none valid values for all added validators.
-    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd; validatorNumber++) {
+    for (size_t validatorNumber = variantStart; validatorNumber < variantEnd;
+         validatorNumber++) {
       nlohmann::json validJson(defaultValues);
       ((validJson[configOptionPaths] = createDummyValueForValidator<Ts>(
             adjustVariantArgument.template operator()<Ts>(variantEnd) + 1)),
@@ -1146,9 +1257,11 @@ void doValidatorTest(auto addValidatorFunction,
       only check, if it was bool validator.
       */
       if constexpr ((std::is_same_v<bool, Ts> && ...)) {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(std::nullopt));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(std::nullopt));
       } else {
-        checkValidator(m, validJson, invalidJson, generateValidatorName<Ts...>(validatorNumber));
+        checkValidator(m, validJson, invalidJson,
+                       generateValidatorName<Ts...>(validatorNumber));
       }
     }
   };
@@ -1172,7 +1285,8 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestNoValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
           ConfigManager & m, const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
@@ -1182,7 +1296,8 @@ void doValidatorTest(auto addValidatorFunction,
 
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1213,8 +1328,10 @@ void doValidatorTest(auto addValidatorFunction,
   here.
   */
   auto doTestAlwaysValidatorInSubManager =
-      [&addValidatorToConfigManager, &testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
-          ConfigManager & m, ConfigManager & subM, const nlohmann::json& defaultValues,
+      [&addValidatorToConfigManager, &
+       testGeneratedValidatorsOfConfigManager ]<typename... Ts>(
+          ConfigManager & m, ConfigManager & subM,
+          const nlohmann::json& defaultValues,
           const std::pair<nlohmann::json::json_pointer,
                           ConstConfigOptionProxy<Ts>>&... validatorArguments)
           requires(sizeof...(Ts) == sizeof...(validatorArguments)) {
@@ -1225,7 +1342,8 @@ void doValidatorTest(auto addValidatorFunction,
     // manager goes correctly.
     for (size_t i = 0; i < NUMBER_OF_VALIDATORS; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, subM, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, subM, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1235,7 +1353,8 @@ void doValidatorTest(auto addValidatorFunction,
     // Now, we add additional validators to the top manager.
     for (size_t i = NUMBER_OF_VALIDATORS; i < NUMBER_OF_VALIDATORS * 2; i++) {
       // Add a new validator
-      addValidatorToConfigManager.template operator()<Ts...>(i, m, validatorArguments.second...);
+      addValidatorToConfigManager.template operator()<Ts...>(
+          i, m, validatorArguments.second...);
 
       // Test all the added validators.
       testGeneratedValidatorsOfConfigManager.template operator()<Ts...>(
@@ -1244,217 +1363,246 @@ void doValidatorTest(auto addValidatorFunction,
   };
 
   // Does all tests for single parameter validators for a given type.
-  auto doSingleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type>() {
-    // Variables needed for configuration options.
-    Type firstVar;
+  auto doSingleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type>() {
+        // Variables needed for configuration options.
+        Type firstVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption = mNoSub.addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue"), mNoSubOption));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption =
+            mNoSub.addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue"),
+                           mNoSubOption));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    decltype(auto) mSubNoValidatorOption =
-        mSubNoValidator.addSubManager({"some"s, "manager"s}).addOption("someValue", "", &firstVar);
-    doTestNoValidatorInSubManager.template operator()<Type>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubNoValidatorOption));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        decltype(auto) mSubNoValidatorOption =
+            mSubNoValidator.addSubManager({"some"s, "manager"s})
+                .addOption("someValue", "", &firstVar);
+        doTestNoValidatorInSubManager.template operator()<Type>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubNoValidatorOption));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption =
-        mSubWithValidatorSub.addOption("someValue", "", &firstVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue"),
-                       mSubWithValidatorOption));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption =
+            mSubWithValidatorSub.addOption("someValue", "", &firstVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue"),
+                mSubWithValidatorOption));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<1>(
       doSingleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Does all tests for validators with two parameter types for the given type
   // combination.
-  auto doDoubleParameterTests = [&doTestNoValidatorInSubManager,
-                                 &doTestAlwaysValidatorInSubManager]<typename Type1,
-                                                                     typename Type2>() {
-    // Variables needed for configuration options.
-    Type1 firstVar;
-    Type2 secondVar;
+  auto doDoubleParameterTests =
+      [&doTestNoValidatorInSubManager,
+       &doTestAlwaysValidatorInSubManager]<typename Type1, typename Type2>() {
+        // Variables needed for configuration options.
+        Type1 firstVar;
+        Type2 secondVar;
 
-    // No sub manager.
-    ConfigManager mNoSub;
-    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mNoSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/someValue1"), mNoSubOption1),
-        std::make_pair(nlohmann::json::json_pointer("/someValue2"), mNoSubOption2));
+        // No sub manager.
+        ConfigManager mNoSub;
+        decltype(auto) mNoSubOption1 =
+            mNoSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mNoSubOption2 =
+            mNoSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mNoSub, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(nlohmann::json::json_pointer("/someValue1"),
+                           mNoSubOption1),
+            std::make_pair(nlohmann::json::json_pointer("/someValue2"),
+                           mNoSubOption2));
 
-    // With sub manager. Sub manager has no validators of its own.
-    ConfigManager mSubNoValidator;
-    ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubNoValidatorOption1 =
-        mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubNoValidatorOption2 =
-        mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubNoValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubNoValidatorOption2));
+        // With sub manager. Sub manager has no validators of its own.
+        ConfigManager mSubNoValidator;
+        ConfigManager& mSubNoValidatorSub =
+            mSubNoValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubNoValidatorOption1 =
+            mSubNoValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubNoValidatorOption2 =
+            mSubNoValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestNoValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubNoValidator, nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubNoValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubNoValidatorOption2));
 
-    /*
-    With sub manager.
-    Covers the following cases:
-    - Sub manager has validators of its own, however the manager does not.
-    - Sub manager has validators of its own, as does the manager.
-    */
-    ConfigManager mSubWithValidator;
-    ConfigManager& mSubWithValidatorSub = mSubWithValidator.addSubManager({"some"s, "manager"s});
-    decltype(auto) mSubWithValidatorOption1 =
-        mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
-    decltype(auto) mSubWithValidatorOption2 =
-        mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
-    doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
-        mSubWithValidator, mSubWithValidatorSub, nlohmann::json(nlohmann::json::value_t::object),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
-                       mSubWithValidatorOption1),
-        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
-                       mSubWithValidatorOption2));
-  };
+        /*
+        With sub manager.
+        Covers the following cases:
+        - Sub manager has validators of its own, however the manager does not.
+        - Sub manager has validators of its own, as does the manager.
+        */
+        ConfigManager mSubWithValidator;
+        ConfigManager& mSubWithValidatorSub =
+            mSubWithValidator.addSubManager({"some"s, "manager"s});
+        decltype(auto) mSubWithValidatorOption1 =
+            mSubWithValidatorSub.addOption("someValue1", "", &firstVar);
+        decltype(auto) mSubWithValidatorOption2 =
+            mSubWithValidatorSub.addOption("someValue2", "", &secondVar);
+        doTestAlwaysValidatorInSubManager.template operator()<Type1, Type2>(
+            mSubWithValidator, mSubWithValidatorSub,
+            nlohmann::json(nlohmann::json::value_t::object),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue1"),
+                mSubWithValidatorOption1),
+            std::make_pair(
+                nlohmann::json::json_pointer("/some/manager/someValue2"),
+                mSubWithValidatorOption2));
+      };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDoubleParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
 
   // Testing, if validators with different parameter types work, when added to
   // the same config manager.
-  auto doDifferentParameterTests =
-      [&addValidatorToConfigManager]<typename Type1, typename Type2>() {
-        // Variables for config options.
-        Type1 var1;
-        Type2 var2;
+  auto doDifferentParameterTests = [&addValidatorToConfigManager]<
+                                       typename Type1, typename Type2>() {
+    // Variables for config options.
+    Type1 var1;
+    Type2 var2;
 
-        /*
-        @brief Helper function, that checks all combinations of valid/invalid values
-        for two single argument parameter validator functions.
+    /*
+    @brief Helper function, that checks all combinations of valid/invalid values
+    for two single argument parameter validator functions.
 
-        @tparam T1, T2 Function parameter type for the first and the second
-        validator.
+    @tparam T1, T2 Function parameter type for the first and the second
+    validator.
 
-        @param m The config manager, on which `parseConfig` will be called on.
-        @param validator1, validator2 A pair consisting of the path to the
-        configuration option, that the validator is looking at, and the `variant`
-        value, that was used to generate the validator function with
-        `addValidatorToConfigManager`.
-        */
-        auto checkAllValidAndInvalidValueCombinations =
-            []<typename T1, typename T2>(
-                ConfigManager& m, const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
-                const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
-              /*
-              Input for `parseConfig`. One contains values, that are valid for all
-              validators, the other contains values, that are valid for all
-              validators except one.
-              */
-              nlohmann::json validValueJson(nlohmann::json::value_t::object);
-              nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
+    @param m The config manager, on which `parseConfig` will be called on.
+    @param validator1, validator2 A pair consisting of the path to the
+    configuration option, that the validator is looking at, and the `variant`
+    value, that was used to generate the validator function with
+    `addValidatorToConfigManager`.
+    */
+    auto checkAllValidAndInvalidValueCombinations =
+        []<typename T1, typename T2>(
+            ConfigManager& m,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator1,
+            const std::pair<nlohmann::json::json_pointer, size_t>& validator2) {
+          /*
+          Input for `parseConfig`. One contains values, that are valid for all
+          validators, the other contains values, that are valid for all
+          validators except one.
+          */
+          nlohmann::json validValueJson(nlohmann::json::value_t::object);
+          nlohmann::json invalidValueJson(nlohmann::json::value_t::object);
 
-              // Add the valid values.
-              validValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              validValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
+          // Add the valid values.
+          validValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          validValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
 
-              // Value for `validator1` is invalid. Value for `validator2` is valid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second + 1);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type1>(validator1.second));
+          // Value for `validator1` is invalid. Value for `validator2` is valid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second + 1);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type1>(validator1.second));
 
-              // Value for `validator1` is valid. Value for `validator2` is invalid.
-              invalidValueJson[validator1.first] =
-                  createDummyValueForValidator<Type1>(validator1.second + 1);
-              invalidValueJson[validator2.first] =
-                  createDummyValueForValidator<Type2>(validator2.second);
-              checkValidator(m, validValueJson, invalidValueJson,
-                             generateValidatorName<Type2>(validator2.second));
-            };
+          // Value for `validator1` is valid. Value for `validator2` is invalid.
+          invalidValueJson[validator1.first] =
+              createDummyValueForValidator<Type1>(validator1.second + 1);
+          invalidValueJson[validator2.first] =
+              createDummyValueForValidator<Type2>(validator2.second);
+          checkValidator(m, validValueJson, invalidValueJson,
+                         generateValidatorName<Type2>(validator2.second));
+        };
 
-        // No sub manager.
-        ConfigManager mNoSub;
-        decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoSub, mNoSubOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoSub, mNoSubOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
+    // No sub manager.
+    ConfigManager mNoSub;
+    decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoSubOption2 = mNoSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(1, mNoSub,
+                                                           mNoSubOption1);
+    addValidatorToConfigManager.template operator()<Type2>(1, mNoSub,
+                                                           mNoSubOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoSub, std::make_pair(nlohmann::json::json_pointer("/someValue1"), 1),
+        std::make_pair(nlohmann::json::json_pointer("/someValue2"), 1));
 
-        // With sub manager. Sub manager has no validators of its own.
-        ConfigManager mSubNoValidator;
-        ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mSubNoValidatorOption1 =
-            mSubNoValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mSubNoValidatorOption2 =
-            mSubNoValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mSubNoValidator,
-                                                               mSubNoValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mSubNoValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // With sub manager. Sub manager has no validators of its own.
+    ConfigManager mSubNoValidator;
+    ConfigManager& mSubNoValidatorSub =
+        mSubNoValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mSubNoValidatorOption1 =
+        mSubNoValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mSubNoValidatorOption2 =
+        mSubNoValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mSubNoValidator, mSubNoValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mSubNoValidator, mSubNoValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mSubNoValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, however the manager does not.
-        ConfigManager mNoValidatorSubValidator;
-        ConfigManager& mNoValidatorSubValidatorSub =
-            mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mNoValidatorSubValidatorOption1 =
-            mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mNoValidatorSubValidatorOption2 =
-            mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mNoValidatorSubValidatorSub,
-                                                               mNoValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mNoValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
+    // Sub manager has validators of its own, however the manager does not.
+    ConfigManager mNoValidatorSubValidator;
+    ConfigManager& mNoValidatorSubValidatorSub =
+        mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mNoValidatorSubValidatorOption1 =
+        mNoValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mNoValidatorSubValidatorOption2 =
+        mNoValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mNoValidatorSubValidatorSub, mNoValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mNoValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
 
-        // Sub manager has validators of its own, as does the manager.
-        ConfigManager mValidatorSubValidator;
-        ConfigManager& mValidatorSubValidatorSub =
-            mValidatorSubValidator.addSubManager({"some"s, "manager"s});
-        decltype(auto) mValidatorSubValidatorOption1 =
-            mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
-        decltype(auto) mValidatorSubValidatorOption2 =
-            mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
-        addValidatorToConfigManager.template operator()<Type1>(1, mValidatorSubValidator,
-                                                               mValidatorSubValidatorOption1);
-        addValidatorToConfigManager.template operator()<Type2>(1, mValidatorSubValidatorSub,
-                                                               mValidatorSubValidatorOption2);
-        checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
-            mValidatorSubValidator,
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"), 1),
-            std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"), 1));
-      };
+    // Sub manager has validators of its own, as does the manager.
+    ConfigManager mValidatorSubValidator;
+    ConfigManager& mValidatorSubValidatorSub =
+        mValidatorSubValidator.addSubManager({"some"s, "manager"s});
+    decltype(auto) mValidatorSubValidatorOption1 =
+        mValidatorSubValidatorSub.addOption("someValue1", "", &var1);
+    decltype(auto) mValidatorSubValidatorOption2 =
+        mValidatorSubValidatorSub.addOption("someValue2", "", &var2);
+    addValidatorToConfigManager.template operator()<Type1>(
+        1, mValidatorSubValidator, mValidatorSubValidatorOption1);
+    addValidatorToConfigManager.template operator()<Type2>(
+        1, mValidatorSubValidatorSub, mValidatorSubValidatorOption2);
+    checkAllValidAndInvalidValueCombinations.template operator()<Type1, Type2>(
+        mValidatorSubValidator,
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue1"),
+                       1),
+        std::make_pair(nlohmann::json::json_pointer("/some/manager/someValue2"),
+                       1));
+  };
 
   callGivenLambdaWithAllCombinationsOfTypes.template operator()<2>(
       doDifferentParameterTests, callGivenLambdaWithAllCombinationsOfTypes);
@@ -1472,61 +1620,72 @@ void doValidatorTest(auto addValidatorFunction,
 
   // Add the validator and check, if the configuration option with it's current
   // value is in the exception message for failing the validator.
-  auto doExceptionMessageTest = [&addValidatorFunction, &defaultExceptionMessage](
-                                    size_t variantNumber, ConfigManager& managerToRunParseOn,
-                                    ConfigManager& managerToAddValidatorTo,
-                                    ConstConfigOptionProxy<std::string> option,
-                                    const nlohmann::json::json_pointer& pathToOption) {
-    // The value, which causes the automaticly generated validator with the
-    // given variant to fail.
-    const std::string& failValue = createDummyValueForValidator<std::string>(variantNumber);
+  auto doExceptionMessageTest =
+      [&addValidatorFunction, &defaultExceptionMessage](
+          size_t variantNumber, ConfigManager& managerToRunParseOn,
+          ConfigManager& managerToAddValidatorTo,
+          ConstConfigOptionProxy<std::string> option,
+          const nlohmann::json::json_pointer& pathToOption) {
+        // The value, which causes the automaticly generated validator with the
+        // given variant to fail.
+        const std::string& failValue =
+            createDummyValueForValidator<std::string>(variantNumber);
 
-    nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
-    jsonForParsing[pathToOption] = failValue;
+        nlohmann::json jsonForParsing(nlohmann::json::value_t::object);
+        jsonForParsing[pathToOption] = failValue;
 
-    // Adding the validator and checking.
-    std::invoke(addValidatorFunction, variantNumber, defaultExceptionMessage,
-                managerToAddValidatorTo, option);
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        managerToRunParseOn.parseConfig(jsonForParsing),
-        ::testing::ContainsRegex(absl::StrCat("value '\"", failValue, "\"'")));
-  };
+        // Adding the validator and checking.
+        std::invoke(addValidatorFunction, variantNumber,
+                    defaultExceptionMessage, managerToAddValidatorTo, option);
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            managerToRunParseOn.parseConfig(jsonForParsing),
+            ::testing::ContainsRegex(
+                absl::StrCat("value '\"", failValue, "\"'")));
+      };
 
   // No sub manager.
   ConfigManager mNoSub;
-  decltype(auto) mNoSubOption1 = mNoSub.addOption("someValue1", "", &string0, defaultValue);
+  decltype(auto) mNoSubOption1 =
+      mNoSub.addOption("someValue1", "", &string0, defaultValue);
   doExceptionMessageTest(10, mNoSub, mNoSub, mNoSubOption1,
                          nlohmann::json::json_pointer("/someValue1"));
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager mSubNoValidator;
-  ConfigManager& mSubNoValidatorSub = mSubNoValidator.addSubManager({"some"s, "manager"s});
+  ConfigManager& mSubNoValidatorSub =
+      mSubNoValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mSubNoValidatorOption1 =
       mSubNoValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+  doExceptionMessageTest(
+      10, mSubNoValidator, mSubNoValidator, mSubNoValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager mNoValidatorSubValidator;
   ConfigManager& mNoValidatorSubValidatorSub =
       mNoValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mNoValidatorSubValidatorOption1 =
-      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
-  doExceptionMessageTest(10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
-                         mNoValidatorSubValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mNoValidatorSubValidatorSub.addOption("someValue1", "", &string0,
+                                            defaultValue);
+  doExceptionMessageTest(
+      10, mNoValidatorSubValidator, mNoValidatorSubValidatorSub,
+      mNoValidatorSubValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager mValidatorSubValidator;
   ConfigManager& mValidatorSubValidatorSub =
       mValidatorSubValidator.addSubManager({"some"s, "manager"s});
   decltype(auto) mValidatorSubValidatorOption1 =
-      mValidatorSubValidatorSub.addOption("someValue1", "", &string0, defaultValue);
+      mValidatorSubValidatorSub.addOption("someValue1", "", &string0,
+                                          defaultValue);
   decltype(auto) mValidatorSubValidatorOption2 =
-      mValidatorSubValidatorSub.addOption("someValue2", "", &string1, defaultValue);
-  doExceptionMessageTest(4, mValidatorSubValidator, mValidatorSubValidator,
-                         mValidatorSubValidatorOption1,
-                         nlohmann::json::json_pointer("/some/manager/someValue1"));
+      mValidatorSubValidatorSub.addOption("someValue2", "", &string1,
+                                          defaultValue);
+  doExceptionMessageTest(
+      4, mValidatorSubValidator, mValidatorSubValidator,
+      mValidatorSubValidatorOption1,
+      nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   /*
   Reseting `mValidatorSubValidatorOption1`, so that the validator, that was
@@ -1536,29 +1695,36 @@ void doValidatorTest(auto addValidatorFunction,
   fitting constructor.
   */
   nlohmann::json jsonForReset(nlohmann::json::value_t::object);
-  jsonForReset[nlohmann::json::json_pointer("/some/manager/someValue1")] = defaultValue;
+  jsonForReset[nlohmann::json::json_pointer("/some/manager/someValue1")] =
+      defaultValue;
   mValidatorSubValidator.parseConfig(jsonForReset);
 
-  doExceptionMessageTest(5, mValidatorSubValidator, mValidatorSubValidatorSub,
-                         mValidatorSubValidatorOption2,
-                         nlohmann::json::json_pointer("/some/manager/someValue2"));
+  doExceptionMessageTest(
+      5, mValidatorSubValidator, mValidatorSubValidatorSub,
+      mValidatorSubValidatorOption2,
+      nlohmann::json::json_pointer("/some/manager/someValue2"));
 }
 
 TEST(ConfigManagerTest, AddNonExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string_view validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string_view validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
     m.addValidator(generateDummyNonExceptionValidatorFunction<Ts...>(variant),
                    std::string(validatorExceptionMessage), "", optProxy...);
   });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidator) {
-  doValidatorTest([]<typename... Ts>(size_t variant, std::string validatorExceptionMessage,
-                                     ConfigManager& m, ConstConfigOptionProxy<Ts>... optProxy) {
-    m.addValidator(transformValidatorIntoExceptionValidator<Ts...>(
-                       generateDummyNonExceptionValidatorFunction<Ts...>(variant),
-                       std::move(validatorExceptionMessage)),
-                   "", optProxy...);
+  doValidatorTest([]<typename... Ts>(size_t variant,
+                                     std::string validatorExceptionMessage,
+                                     ConfigManager& m,
+                                     ConstConfigOptionProxy<Ts>... optProxy) {
+    m.addValidator(
+        transformValidatorIntoExceptionValidator<Ts...>(
+            generateDummyNonExceptionValidatorFunction<Ts...>(variant),
+            std::move(validatorExceptionMessage)),
+        "", optProxy...);
   });
 }
 
@@ -1590,15 +1756,16 @@ void doValidatorExceptionTest(
         @brief Check, if a call to the `addValidator` function behaves as
         wanted.
         */
-        auto checkAddValidatorBehavior = [&addAlwaysValidValidatorFunction](
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-          ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-          AD_EXPECT_THROW_WITH_MESSAGE(
-              addAlwaysValidValidatorFunction(m, notValidOption),
-              ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-        };
+        auto checkAddValidatorBehavior =
+            [&addAlwaysValidValidatorFunction](
+                ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+                ConstConfigOptionProxy<T> notValidOption) {
+              ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+              AD_EXPECT_THROW_WITH_MESSAGE(
+                  addAlwaysValidValidatorFunction(m, notValidOption),
+                  ::testing::ContainsRegex(
+                      notValidOption.getConfigOption().getIdentifier()));
+            };
 
         // An outside configuration option.
         ConfigOption outsideOption("outside", "", &var);
@@ -1611,30 +1778,50 @@ void doValidatorExceptionTest(
 
         // With sub manager.
         ConfigManager mWithSub;
-        decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
-        ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+        decltype(auto) mWithSubOption =
+            mWithSub.addOption("someTopOption", "", &var);
+        ConfigManager& mWithSubSub =
+            mWithSub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWithSubSubOption =
+            mWithSubSub.addOption("someSubOption", "", &var);
         checkAddValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+        checkAddValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
         // With 2 sub manager.
         ConfigManager mWith2Sub;
-        decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
-        ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-        decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-        ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-        decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+        decltype(auto) mWith2SubOption =
+            mWith2Sub.addOption("someTopOption", "", &var);
+        ConfigManager& mWith2SubSub1 =
+            mWith2Sub.addSubManager({"Some"s, "manager"s});
+        decltype(auto) mWith2SubSub1Option =
+            mWith2SubSub1.addOption("someSubOption1", "", &var);
+        ConfigManager& mWith2SubSub2 =
+            mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+        decltype(auto) mWith2SubSub2Option =
+            mWith2SubSub2.addOption("someSubOption2", "", &var);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+        checkAddValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
       };
 
   doForTypeInConfigOptionValueType(doValidatorParameterNotInConfigManagerTest);
@@ -1642,16 +1829,22 @@ void doValidatorExceptionTest(
 
 TEST(ConfigManagerTest, AddNonExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) { return true; }, "", "", validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator([](const Ts&...) { return true; }, "", "",
+                       validatorArguments...);
       });
 }
 
 TEST(ConfigManagerTest, AddExceptionValidatorException) {
   doValidatorExceptionTest(
-      []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... validatorArguments) {
-        m.addValidator([](const Ts&...) -> std::optional<ErrorMessage> { return {std::nullopt}; },
-                       "", validatorArguments...);
+      []<typename... Ts>(ConfigManager& m,
+                         ConstConfigOptionProxy<Ts>... validatorArguments) {
+        m.addValidator(
+            [](const Ts&...) -> std::optional<ErrorMessage> {
+              return {std::nullopt};
+            },
+            "", validatorArguments...);
       });
 }
 
@@ -1672,11 +1865,13 @@ void doAddOptionValidatorTest(
 
   // Generate a lambda, that requires all the given configuration option to have
   // the wanted string as the representation of their value.
-  auto generateValueAsStringComparison = [](std::string_view valueStringRepresentation) {
-    return [wantedString = std::string(valueStringRepresentation)](const auto&... options) {
-      return ((options.getValueAsString() == wantedString) && ...);
-    };
-  };
+  auto generateValueAsStringComparison =
+      [](std::string_view valueStringRepresentation) {
+        return [wantedString = std::string(valueStringRepresentation)](
+                   const auto&... options) {
+          return ((options.getValueAsString() == wantedString) && ...);
+        };
+      };
 
   // Variables for configuration options.
   int firstVar;
@@ -1686,58 +1881,75 @@ void doAddOptionValidatorTest(
   ConfigManager managerWithNoSubManager;
   decltype(auto) managerWithNoSubManagerOption1 =
       managerWithNoSubManager.addOption("someOption1", "", &firstVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "someOption1",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1);
-  checkValidator(managerWithNoSubManager, nlohmann::json::parse(R"--({"someOption1" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 1})--"), "someOption1");
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "someOption1", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1);
+  checkValidator(managerWithNoSubManager,
+                 nlohmann::json::parse(R"--({"someOption1" : 10})--"),
+                 nlohmann::json::parse(R"--({"someOption1" : 1})--"),
+                 "someOption1");
   decltype(auto) managerWithNoSubManagerOption2 =
       managerWithNoSubManager.addOption("someOption2", "", &secondVar);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithNoSubManager, managerWithNoSubManagerOption1,
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Both options", managerWithNoSubManager,
+                                   managerWithNoSubManagerOption1,
                                    managerWithNoSubManagerOption2);
-  checkValidator(managerWithNoSubManager,
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
-                 nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
-                 "Both options");
+  checkValidator(
+      managerWithNoSubManager,
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 10})--"),
+      nlohmann::json::parse(R"--({"someOption1" : 10, "someOption2" : 1})--"),
+      "Both options");
 
   // With sub manager. Sub manager has no validators of its own.
   ConfigManager managerWithSubManagerWhoHasNoValidators;
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsOption =
-      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "", &firstVar, 4);
+      managerWithSubManagerWhoHasNoValidators.addOption("someOption", "",
+                                                        &firstVar, 4);
   ConfigManager& managerWithSubManagerWhoHasNoValidatorsSubManager =
-      managerWithSubManagerWhoHasNoValidators.addSubManager({"Sub"s, "manager"s});
+      managerWithSubManagerWhoHasNoValidators.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerWithSubManagerWhoHasNoValidatorsSubManagerOption =
-      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
-  checkValidator(managerWithSubManagerWhoHasNoValidators,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Both options",
-                                   managerWithSubManagerWhoHasNoValidators,
-                                   managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
-                                   managerWithSubManagerWhoHasNoValidatorsOption);
+      managerWithSubManagerWhoHasNoValidatorsSubManager.addOption(
+          "someOption", "", &secondVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption);
   checkValidator(
       managerWithSubManagerWhoHasNoValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Both options",
+      managerWithSubManagerWhoHasNoValidators,
+      managerWithSubManagerWhoHasNoValidatorsSubManagerOption,
+      managerWithSubManagerWhoHasNoValidatorsOption);
+  checkValidator(
+      managerWithSubManagerWhoHasNoValidators,
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 10}}})--"),
       "Both options");
 
   // Sub manager has validators of its own, however the manager does not.
   ConfigManager managerHasNoValidatorsButSubManagerDoes;
   ConfigManager& managerHasNoValidatorsButSubManagerDoesSubManager =
-      managerHasNoValidatorsButSubManagerDoes.addSubManager({"Sub"s, "manager"s});
+      managerHasNoValidatorsButSubManagerDoes.addSubManager(
+          {"Sub"s, "manager"s});
   decltype(auto) managerHasNoValidatorsButSubManagerDoesSubManagerOption =
-      managerHasNoValidatorsButSubManagerDoesSubManager.addOption("someOption", "", &firstVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Sub manager option",
-                                   managerHasNoValidatorsButSubManagerDoesSubManager,
-                                   managerHasNoValidatorsButSubManagerDoesSubManagerOption);
-  checkValidator(managerHasNoValidatorsButSubManagerDoes,
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
-                 nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
-                 "Sub manager option");
+      managerHasNoValidatorsButSubManagerDoesSubManager.addOption(
+          "someOption", "", &firstVar, 4);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("10"), "Sub manager option",
+      managerHasNoValidatorsButSubManagerDoesSubManager,
+      managerHasNoValidatorsButSubManagerDoesSubManagerOption);
+  checkValidator(
+      managerHasNoValidatorsButSubManagerDoes,
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 10}}})--"),
+      nlohmann::json::parse(R"--({"Sub":{"manager" : {"someOption" : 1}}})--"),
+      "Sub manager option");
 
   // Sub manager has validators of its own, as does the manager.
   ConfigManager bothHaveValidators;
@@ -1747,37 +1959,46 @@ void doAddOptionValidatorTest(
       bothHaveValidators.addSubManager({"Sub"s, "manager"s});
   decltype(auto) bothHaveValidatorsSubManagerOption =
       bothHaveValidatorsSubManager.addOption("someOption", "", &secondVar, 4);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"), "Top manager option",
-                                   bothHaveValidators, bothHaveValidatorsOption);
-  addNonExceptionValidatorFunction(generateValueAsStringComparison("20"), "Sub manager option",
-                                   bothHaveValidatorsSubManager,
-                                   bothHaveValidatorsSubManagerOption);
+  addNonExceptionValidatorFunction(generateValueAsStringComparison("10"),
+                                   "Top manager option", bothHaveValidators,
+                                   bothHaveValidatorsOption);
+  addNonExceptionValidatorFunction(
+      generateValueAsStringComparison("20"), "Sub manager option",
+      bothHaveValidatorsSubManager, bothHaveValidatorsSubManagerOption);
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 1, "Sub":{"manager" : {"someOption" : 20}}})--"),
       "Top manager option");
   checkValidator(
       bothHaveValidators,
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
-      nlohmann::json::parse(R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 20}}})--"),
+      nlohmann::json::parse(
+          R"--({"someOption" : 10, "Sub":{"manager" : {"someOption" : 2}}})--"),
       "Sub manager option");
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction, std::string validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction,
+                         std::string validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator(validatorFunction, validatorExceptionMessage, "", args...);
+        m.addOptionValidator(validatorFunction, validatorExceptionMessage, "",
+                             args...);
       });
 }
 
 TEST(ConfigManagerTest, AddOptionExceptionValidator) {
   doAddOptionValidatorTest(
-      []<typename... Ts>(auto validatorFunction, std::string validatorExceptionMessage,
+      []<typename... Ts>(auto validatorFunction,
+                         std::string validatorExceptionMessage,
                          ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            transformValidatorIntoExceptionValidator<decltype(args.getConfigOption())...>(
+            transformValidatorIntoExceptionValidator<
+                decltype(args.getConfigOption())...>(
                 validatorFunction, std::move(validatorExceptionMessage)),
             "", args...);
       });
@@ -1805,15 +2026,16 @@ void doAddOptionValidatorExceptionTest(
   @brief Check, if a call to the `addOptionValidator` function behaves as
   wanted.
   */
-  auto checkAddOptionValidatorBehavior = [&addAlwaysValidValidatorFunction]<typename T>(
-                                             ConfigManager& m,
-                                             ConstConfigOptionProxy<T> validOption,
-                                             ConstConfigOptionProxy<T> notValidOption) {
-    ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        addAlwaysValidValidatorFunction(m, notValidOption),
-        ::testing::ContainsRegex(notValidOption.getConfigOption().getIdentifier()));
-  };
+  auto checkAddOptionValidatorBehavior =
+      [&addAlwaysValidValidatorFunction]<typename T>(
+          ConfigManager& m, ConstConfigOptionProxy<T> validOption,
+          ConstConfigOptionProxy<T> notValidOption) {
+        ASSERT_NO_THROW(addAlwaysValidValidatorFunction(m, validOption));
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            addAlwaysValidValidatorFunction(m, notValidOption),
+            ::testing::ContainsRegex(
+                notValidOption.getConfigOption().getIdentifier()));
+      };
 
   // An outside configuration option.
   ConfigOption outsideOption("outside", "", &var);
@@ -1828,35 +2050,53 @@ void doAddOptionValidatorExceptionTest(
   ConfigManager mWithSub;
   decltype(auto) mWithSubOption = mWithSub.addOption("someTopOption", "", &var);
   ConfigManager& mWithSubSub = mWithSub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWithSubSubOption = mWithSubSub.addOption("someSubOption", "", &var);
+  decltype(auto) mWithSubSubOption =
+      mWithSubSub.addOption("someSubOption", "", &var);
   checkAddOptionValidatorBehavior(mWithSub, mWithSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption, mWithSubOption);
+  checkAddOptionValidatorBehavior(mWithSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWithSubSub, mWithSubSubOption,
+                                  mWithSubOption);
 
   // With 2 sub manager.
   ConfigManager mWith2Sub;
-  decltype(auto) mWith2SubOption = mWith2Sub.addOption("someTopOption", "", &var);
+  decltype(auto) mWith2SubOption =
+      mWith2Sub.addOption("someTopOption", "", &var);
   ConfigManager& mWith2SubSub1 = mWith2Sub.addSubManager({"Some"s, "manager"s});
-  decltype(auto) mWith2SubSub1Option = mWith2SubSub1.addOption("someSubOption1", "", &var);
-  ConfigManager& mWith2SubSub2 = mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
-  decltype(auto) mWith2SubSub2Option = mWith2SubSub2.addOption("someSubOption2", "", &var);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option, mWith2SubSub2Option);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, outsideOptionProxy);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubOption);
-  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option, mWith2SubSub1Option);
+  decltype(auto) mWith2SubSub1Option =
+      mWith2SubSub1.addOption("someSubOption1", "", &var);
+  ConfigManager& mWith2SubSub2 =
+      mWith2Sub.addSubManager({"Some"s, "other"s, "manager"s});
+  decltype(auto) mWith2SubSub2Option =
+      mWith2SubSub2.addOption("someSubOption2", "", &var);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubOption,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2Sub, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub1, mWith2SubSub1Option,
+                                  mWith2SubSub2Option);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  outsideOptionProxy);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubOption);
+  checkAddOptionValidatorBehavior(mWith2SubSub2, mWith2SubSub2Option,
+                                  mWith2SubSub1Option);
 }
 
 TEST(ConfigManagerTest, AddOptionNoExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
-        m.addOptionValidator([](const decltype(args.getConfigOption())&...) { return true; }, "",
-                             "", args...);
+        m.addOptionValidator(
+            [](const decltype(args.getConfigOption())&...) { return true; }, "",
+            "", args...);
       });
 }
 
@@ -1864,9 +2104,8 @@ TEST(ConfigManagerTest, AddOptionExceptionValidatorException) {
   doAddOptionValidatorExceptionTest(
       []<typename... Ts>(ConfigManager& m, ConstConfigOptionProxy<Ts>... args) {
         m.addOptionValidator(
-            [](const decltype(args.getConfigOption())&...) -> std::optional<ErrorMessage> {
-              return {std::nullopt};
-            },
+            [](const decltype(args.getConfigOption())&...)
+                -> std::optional<ErrorMessage> { return {std::nullopt}; },
             "", args...);
       });
 }
@@ -1880,18 +2119,21 @@ TEST(ConfigManagerTest, ContainsOption) {
   the information, if they should be contained in `m`. If true, it should be, if
   false, it shouldn't.
   */
-  using ContainmentStatusVector = std::vector<std::pair<const ConfigOption*, bool>>;
-  auto checkContainmentStatus = [](const ConfigManager& m,
-                                   const ContainmentStatusVector& optionsAndWantedStatus) {
-    std::ranges::for_each(optionsAndWantedStatus,
-                          [&m](const ContainmentStatusVector::value_type& p) {
-                            if (p.second) {
-                              ASSERT_TRUE(m.containsOption(*p.first));
-                            } else {
-                              ASSERT_FALSE(m.containsOption(*p.first));
-                            }
-                          });
-  };
+  using ContainmentStatusVector =
+      std::vector<std::pair<const ConfigOption*, bool>>;
+  auto checkContainmentStatus =
+      [](const ConfigManager& m,
+         const ContainmentStatusVector& optionsAndWantedStatus) {
+        std::ranges::for_each(
+            optionsAndWantedStatus,
+            [&m](const ContainmentStatusVector::value_type& p) {
+              if (p.second) {
+                ASSERT_TRUE(m.containsOption(*p.first));
+              } else {
+                ASSERT_FALSE(m.containsOption(*p.first));
+              }
+            });
+      };
 
   // Variable for the configuration options.
   int var;
@@ -1902,104 +2144,131 @@ TEST(ConfigManagerTest, ContainsOption) {
   // The vectors for all `ConfigManager` for the vector parameter in
   // `checkContainmentStatus`. Mainly to reduce duplication.
   ContainmentStatusVector mContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{{&outsideOption, false}};
-  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{{&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num1ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth1Num2ContainmentStatusVector{
+      {&outsideOption, false}};
+  ContainmentStatusVector subManagerDepth2ContainmentStatusVector{
+      {&outsideOption, false}};
 
   // Without sub manager.
   ConfigManager m;
   checkContainmentStatus(m, mContainmentStatusVector);
   decltype(auto) topManagerOption = m.addOption("TopLevel", "", &var);
-  mContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&topManagerOption.getConfigOption(), false});
-  subManagerDepth2ContainmentStatusVector.push_back({&topManagerOption.getConfigOption(), false});
+  subManagerDepth2ContainmentStatusVector.push_back(
+      {&topManagerOption.getConfigOption(), false});
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Single sub manager.
   ConfigManager& subManagerDepth1Num1 = m.addSubManager({"subManager1"s});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num1Option =
       subManagerDepth1Num1.addOption("SubManager1", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num1Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), true});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num1Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
 
   // Second sub manager.
   ConfigManager& subManagerDepth1Num2 = m.addSubManager({"subManager2"s});
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
   decltype(auto) subManagerDepth1Num2Option =
       subManagerDepth1Num2.addOption("SubManager2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth1Num2Option.getConfigOption(), true});
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth1Num2Option.getConfigOption(), false});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
 
   // Sub manager in the second sub manager.
-  ConfigManager& subManagerDepth2 = subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
-  decltype(auto) subManagerDepth2Option = subManagerDepth2.addOption("SubManagerDepth2", "", &var);
-  mContainmentStatusVector.push_back({&subManagerDepth2Option.getConfigOption(), true});
+  ConfigManager& subManagerDepth2 =
+      subManagerDepth1Num2.addSubManager({"subManagerDepth2"s});
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
+  decltype(auto) subManagerDepth2Option =
+      subManagerDepth2.addOption("SubManagerDepth2", "", &var);
+  mContainmentStatusVector.push_back(
+      {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth1Num1ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), false});
   subManagerDepth1Num2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
   subManagerDepth2ContainmentStatusVector.push_back(
       {&subManagerDepth2Option.getConfigOption(), true});
-  checkContainmentStatus(subManagerDepth1Num1, subManagerDepth1Num1ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num1,
+                         subManagerDepth1Num1ContainmentStatusVector);
   checkContainmentStatus(m, mContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth1Num2, subManagerDepth1Num2ContainmentStatusVector);
-  checkContainmentStatus(subManagerDepth2, subManagerDepth2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth1Num2,
+                         subManagerDepth1Num2ContainmentStatusVector);
+  checkContainmentStatus(subManagerDepth2,
+                         subManagerDepth2ContainmentStatusVector);
 }
 
-// Describes the order of configuration options and validators inside a configuration manager.
+// Describes the order of configuration options and validators inside a
+// configuration manager.
 struct ConfigOptionsAndValidatorsOrder {
-  // The order of the configuration options. Options can be identified via their memory address.
+  // The order of the configuration options. Options can be identified via their
+  // memory address.
   std::vector<const ConfigOption*> configOptions_;
 
-  // The order the validators. unfortunately, there is no way, to perfectly identify an instance,
-  // but the description can be used, as long as all the added validators have unique descriptions.
+  // The order the validators. unfortunately, there is no way, to perfectly
+  // identify an instance, but the description can be used, as long as all the
+  // added validators have unique descriptions.
   std::vector<std::string> validators_;
 
   // Appends the content of an different `ConfigOptionsAndValidatorsOrder`.
   template <typename T>
-  requires isSimilar<T, ConfigOptionsAndValidatorsOrder> void append(T&& order) {
+  requires isSimilar<T, ConfigOptionsAndValidatorsOrder>
+  void append(T&& order) {
     appendVector(configOptions_, AD_FWD(order).configOptions_);
     appendVector(validators_, AD_FWD(order).validators_);
   }
 };
 
 /*
-This is for testing, if the internal helper functions `ConfigManager::validators` and
-`ConfigManager::configurationOptions` sort their return values correctly.
+This is for testing, if the internal helper functions
+`ConfigManager::validators` and `ConfigManager::configurationOptions` sort their
+return values correctly.
 */
 TEST(ConfigManagerTest, CollectionFunctionsSorting) {
   /*
-  Add dummy configuration option for all supported types and dummy validators for them to the given
-  `configManager`.
+  Add dummy configuration option for all supported types and dummy validators
+  for them to the given `configManager`.
 
   @returns The order of all added configuration options and validators.
   */
-  auto addConfigOptionsAndValidators = [callNum = 0](ConfigManager* manager) mutable {
+  auto addConfigOptionsAndValidators = [callNum =
+                                            0](ConfigManager* manager) mutable {
     ConfigOptionsAndValidatorsOrder order{};
 
     // We know, how many instances we will add.
-    order.configOptions_.reserve(std::variant_size_v<ConfigOption::AvailableTypes>);
-    order.validators_.reserve(std::variant_size_v<ConfigOption::AvailableTypes> * 2);
+    order.configOptions_.reserve(
+        std::variant_size_v<ConfigOption::AvailableTypes>);
+    order.validators_.reserve(
+        std::variant_size_v<ConfigOption::AvailableTypes> * 2);
 
     // Fill the list.
     forEachTypeInTemplateType<ConfigOption::AvailableTypes>(
@@ -2008,35 +2277,47 @@ TEST(ConfigManagerTest, CollectionFunctionsSorting) {
           T var;
 
           // Create the options and validators.
-          decltype(auto) opt = manager->addOption({absl::StrCat("Option", callNum++)}, "", &var);
+          decltype(auto) opt =
+              manager->addOption({absl::StrCat("Option", callNum++)}, "", &var);
           order.configOptions_.push_back(&opt.getConfigOption());
           manager->addValidator([](const T&) { return true; }, "",
-                                absl::StrCat("Normal validator ", callNum), opt);
-          order.validators_.push_back(absl::StrCat("Normal validator ", callNum++));
-          manager->addOptionValidator([](const ConfigOption&) { return true; }, "",
-                                      absl::StrCat("Option validator ", callNum), opt);
-          order.validators_.push_back(absl::StrCat("Option validator ", callNum++));
+                                absl::StrCat("Normal validator ", callNum),
+                                opt);
+          order.validators_.push_back(
+              absl::StrCat("Normal validator ", callNum++));
+          manager->addOptionValidator(
+              [](const ConfigOption&) { return true; }, "",
+              absl::StrCat("Option validator ", callNum), opt);
+          order.validators_.push_back(
+              absl::StrCat("Option validator ", callNum++));
         });
 
     return order;
   };
 
-  // Check the order of the configuration options and validators inside the configuration manager.
-  auto checkOrder = [](const ConfigManager& manager, const ConfigOptionsAndValidatorsOrder& order,
-                       ad_utility::source_location l = ad_utility::source_location::current()) {
+  // Check the order of the configuration options and validators inside the
+  // configuration manager.
+  auto checkOrder = [](const ConfigManager& manager,
+                       const ConfigOptionsAndValidatorsOrder& order,
+                       ad_utility::source_location l =
+                           ad_utility::source_location::current()) {
     // For generating better messages, when failing a test.
     auto trace{generateLocationTrace(l, "checkOrder")};
 
     ASSERT_TRUE(std::ranges::equal(
         manager.configurationOptions(true), order.configOptions_, {},
-        [](const std::pair<std::string, const ConfigOption&>& pair) { return &pair.second; }));
-    ASSERT_TRUE(std::ranges::equal(manager.validators(true), order.validators_, {},
-                                   [](const ConfigOptionValidatorManager& validatorManager) {
-                                     return validatorManager.getDescription();
-                                   }));
+        [](const std::pair<std::string, const ConfigOption&>& pair) {
+          return &pair.second;
+        }));
+    ASSERT_TRUE(std::ranges::equal(
+        manager.validators(true), order.validators_, {},
+        [](const ConfigOptionValidatorManager& validatorManager) {
+          return validatorManager.getDescription();
+        }));
   };
 
-  // First add the options, then the sub manager and then more options to the top manager again.
+  // First add the options, then the sub manager and then more options to the
+  // top manager again.
   ConfigManager mOptionFirst;
   auto mOptionFirstOrderOfAll{addConfigOptionsAndValidators(&mOptionFirst)};
   checkOrder(mOptionFirst, mOptionFirstOrderOfAll);
@@ -2053,22 +2334,25 @@ TEST(ConfigManagerTest, CollectionFunctionsSorting) {
   checkOrder(mOptionFirstSub, mOptionFirstSubOrder);
   checkOrder(mOptionFirst, mOptionFirstOrderOfAll);
 
-  // First add the sub manager with config options, then options to the top manager and then options
-  // to the sub manager again.
+  // First add the sub manager with config options, then options to the top
+  // manager and then options to the sub manager again.
   ConfigManager mSubManagerFirst;
   ConfigManager& mSubManagerFirstSub{mSubManagerFirst.addSubManager({"s"})};
-  auto mSubManagerFirstSubOrder{addConfigOptionsAndValidators(&mSubManagerFirstSub)};
+  auto mSubManagerFirstSubOrder{
+      addConfigOptionsAndValidators(&mSubManagerFirstSub)};
   auto mSubManagerFirstOrderOfAll{mSubManagerFirstSubOrder};
   checkOrder(mSubManagerFirst, mSubManagerFirstOrderOfAll);
   checkOrder(mSubManagerFirstSub, mSubManagerFirstSubOrder);
 
   // Add config options to the top manager.
-  mSubManagerFirstOrderOfAll.append(addConfigOptionsAndValidators(&mSubManagerFirst));
+  mSubManagerFirstOrderOfAll.append(
+      addConfigOptionsAndValidators(&mSubManagerFirst));
   checkOrder(mSubManagerFirst, mSubManagerFirstOrderOfAll);
   checkOrder(mSubManagerFirstSub, mSubManagerFirstSubOrder);
 
   // Add config options to the sub manager.
-  auto mSubManagerFirstSubOrder2{addConfigOptionsAndValidators(&mSubManagerFirstSub)};
+  auto mSubManagerFirstSubOrder2{
+      addConfigOptionsAndValidators(&mSubManagerFirstSub)};
   mSubManagerFirstOrderOfAll.append(mSubManagerFirstSubOrder2);
   mSubManagerFirstSubOrder.append(std::move(mSubManagerFirstSubOrder2));
   checkOrder(mSubManagerFirst, mSubManagerFirstOrderOfAll);


### PR DESCRIPTION
When `ConfigOptions` are printed (e.g. in a help message or to print the current configuration), they are now consistently printed in the order in which they were added to  the corresponding `ConfigManager`. This required non-trivial changes to the code, as conceptually these options are stored in a hash map to access them by their name. These hash maps now also store the order in which the entries were added.