### PR TITLE
Use a proper IRI for the QLever-specific built-in functions

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -39,17 +39,27 @@ static const size_t TEXT_LIMIT_DEFAULT = std::numeric_limits<size_t>::max();
 static const size_t GALLOP_THRESHOLD = 1000;
 
 static const char INTERNAL_PREDICATE_PREFIX_NAME[] = "ql";
-static const char INTERNAL_PREDICATE_PREFIX_IRI[] =
-    "<QLever-internal-function/>";
-static const char CONTAINS_ENTITY_PREDICATE[] =
-    "<QLever-internal-function/contains-entity>";
-static const char CONTAINS_WORD_PREDICATE[] =
-    "<QLever-internal-function/contains-word>";
-static const char CONTAINS_WORD_PREDICATE_NS[] = "ql:contains-word";
-static const char INTERNAL_TEXT_MATCH_PREDICATE[] =
-    "<QLever-internal-function/text>";
-static const char HAS_PREDICATE_PREDICATE[] =
-    "<QLever-internal-function/has-predicate>";
+
+static const std::string INTERNAL_PREDICATE_PREFIX =
+    "http://qlever.cs.uni-freiburg.de/builtin-functions/";
+
+// Return a IRI of the form
+// `<http://qlever.cs.uni-freiburg.de/builtin-functions/concatenationOfSuffixes>`
+constexpr auto makeInternalIri = [](auto&&... suffixes) {
+  return absl::StrCat("<", INTERNAL_PREDICATE_PREFIX, suffixes..., ">");
+};
+static const std::string INTERNAL_ENTITIES_URI_PREFIX =
+    absl::StrCat("<", INTERNAL_PREDICATE_PREFIX);
+static const std::string INTERNAL_PREDICATE_PREFIX_IRI = makeInternalIri("");
+static const std::string CONTAINS_ENTITY_PREDICATE =
+    makeInternalIri("contains-entity");
+static const std::string CONTAINS_WORD_PREDICATE =
+    makeInternalIri("contains-word");
+
+static const std::string INTERNAL_TEXT_MATCH_PREDICATE =
+    makeInternalIri("text");
+static const std::string HAS_PREDICATE_PREDICATE =
+    makeInternalIri("has-predicate");
 static constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "<http://www.opengis.net/def/function/geosparql/"};
 static constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
@@ -65,11 +75,7 @@ static constexpr std::string_view MATCHINGWORD_VARIABLE_PREFIX =
 // For anonymous nodes in Turtle.
 static const std::string ANON_NODE_PREFIX = "QLever-Anon-Node";
 
-static const std::string INTERNAL_ENTITIES_URI_PREFIX =
-    "<QLever-internal-function/";
-
-static const std::string LANGUAGE_PREDICATE =
-    INTERNAL_ENTITIES_URI_PREFIX + "langtag>";
+static const std::string LANGUAGE_PREDICATE = makeInternalIri("langtag");
 
 // TODO<joka921> Move them to their own file, make them strings, remove
 // duplications, etc.

--- a/src/util/Conversions.cpp
+++ b/src/util/Conversions.cpp
@@ -22,18 +22,9 @@ namespace ad_utility {
 
 // _________________________________________________________
 string convertLangtagToEntityUri(const string& tag) {
-  return INTERNAL_ENTITIES_URI_PREFIX + "@" + tag + ">";
+  return makeInternalIri("@", tag);
 }
 
-// _________________________________________________________
-std::optional<string> convertEntityUriToLangtag(const string& word) {
-  static const string prefix = INTERNAL_ENTITIES_URI_PREFIX + "@";
-  if (word.starts_with(prefix)) {
-    return word.substr(prefix.size(), word.size() - prefix.size() - 1);
-  } else {
-    return std::nullopt;
-  }
-}
 // _________________________________________________________
 std::string convertToLanguageTaggedPredicate(const string& pred,
                                              const string& langtag) {

--- a/src/util/Conversions.h
+++ b/src/util/Conversions.h
@@ -13,7 +13,6 @@ namespace ad_utility {
 //! Convert a language tag like "@en" to the corresponding entity uri
 //! for the efficient language filter
 std::string convertLangtagToEntityUri(const std::string& tag);
-std::optional<std::string> convertEntityUriToLangtag(const std::string& word);
 std::string convertToLanguageTaggedPredicate(const std::string& pred,
                                              const std::string& langtag);
 }  // namespace ad_utility

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -402,8 +402,9 @@ TEST(IndexTest, getIgnoredIdRanges) {
     return id;
   };
 
-  Id qlLangtag = getId("<QLever-internal-function/langtag>");
-  Id en = getId("<QLever-internal-function/@en>");
+  Id qlLangtag =
+      getId("<http://qlever.cs.uni-freiburg.de/builtin-functions/langtag>");
+  Id en = getId("<http://qlever.cs.uni-freiburg.de/builtin-functions/@en>");
   Id enLabel = getId("@en@<label>");
   Id label = getId("<label>");
   Id firstLiteral = getId("\"A\"");
@@ -414,7 +415,8 @@ TEST(IndexTest, getIgnoredIdRanges) {
     return Id::makeFromVocabIndex(id.getVocabIndex().incremented());
   };
 
-  // The range of all entities that start with "<QLever-internal-function/"
+  // The range of all entities that start with
+  // "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
   auto internalEntities = std::pair{en, increment(qlLangtag)};
   // The range of all entities that start with @ (like `@en@<label>`)
   auto predicatesWithLangtag = std::pair{enLabel, increment(enLabel)};

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -214,9 +214,13 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(
           "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
-          "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
+          "1 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?x} : "
           "(0, 2)\n"
-          "2 {s: ?c, p: <QLever-internal-function/contains-word>, o: \"abc\"} "
+          "2 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word>, "
+          "o: \"abc\"} "
           ": "
           "(1)",
           tg.asString());
@@ -227,14 +231,14 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
                    QueryPlanner::TripleGraph::Node(
                        0, Var{"?c"}, {"abc"},
                        {
-                           SparqlTriple(
-                               Var{"?c"},
-                               "<QLever-internal-function/contains-entity>",
-                               Var{"?x"}),
-                           SparqlTriple(
-                               Var{"?c"},
-                               "<QLever-internal-function/contains-word>",
-                               lit("\"abc\"")),
+                           SparqlTriple(Var{"?c"},
+                                        "<http://qlever.cs.uni-freiburg.de/"
+                                        "builtin-functions/contains-entity>",
+                                        Var{"?x"}),
+                           SparqlTriple(Var{"?c"},
+                                        "<http://qlever.cs.uni-freiburg.de/"
+                                        "builtin-functions/contains-word>",
+                                        lit("\"abc\"")),
                        }),
                    {1}),
                std::make_pair<Node, vector<size_t>>(
@@ -246,19 +250,27 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
     {
       ParsedQuery pq = SparqlParser::parseQuery(
           "SELECT ?x WHERE {?x <p> <X>. ?c "
-          "<QLever-internal-function/contains-entity> ?x. ?c "
-          "<QLever-internal-function/contains-word> \"abc\" . ?c "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity> ?x. ?c "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word> "
+          "\"abc\" . ?c "
           "ql:contains-entity ?y}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(
           "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
-          "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
+          "1 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?x} : "
           "(0, 2, 3)\n"
-          "2 {s: ?c, p: <QLever-internal-function/contains-word>, o: \"abc\"} "
+          "2 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word>, "
+          "o: \"abc\"} "
           ": "
           "(1, 3)\n"
-          "3 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?y} : "
+          "3 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?y} : "
           "(1, 2)",
           tg.asString());
       tg.collapseTextCliques();
@@ -267,17 +279,18 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
               {std::make_pair<Node, vector<size_t>>(
                    QueryPlanner::TripleGraph::Node(
                        0, Var{"?c"}, {"abc"},
-                       {SparqlTriple(
-                            Var{"?c"},
-                            "<QLever-internal-function/contains-entity>",
-                            Var{"?x"}),
+                       {SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?x"}),
                         SparqlTriple(Var{"?c"},
-                                     "<QLever-internal-function/contains-word>",
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-word>",
                                      lit("\"abc\"")),
-                        SparqlTriple(
-                            Var{"?c"},
-                            "<QLever-internal-function/contains-entity>",
-                            Var{"?y"})}),
+                        SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?y"})}),
                    {1}),
                std::make_pair<Node, vector<size_t>>(
                    QueryPlanner::TripleGraph::Node(
@@ -294,12 +307,18 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(
           "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
-          "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
+          "1 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?x} : "
           "(0, 2, 3)\n"
-          "2 {s: ?c, p: <QLever-internal-function/contains-word>, o: \"abc\"} "
+          "2 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word>, "
+          "o: \"abc\"} "
           ": "
           "(1, 3)\n"
-          "3 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?y} : "
+          "3 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?y} : "
           "(1, 2, 4)\n"
           "4 {s: ?y, p: <P2>, o: <X2>} : (3)",
           tg.asString());
@@ -309,17 +328,18 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
               {std::make_pair<Node, vector<size_t>>(
                    QueryPlanner::TripleGraph::Node(
                        0, Var{"?c"}, {"abc"},
-                       {SparqlTriple(
-                            Var{"?c"},
-                            "<QLever-internal-function/contains-entity>",
-                            Var{"?x"}),
+                       {SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?x"}),
                         SparqlTriple(Var{"?c"},
-                                     "<QLever-internal-function/contains-word>",
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-word>",
                                      lit("\"abc\"")),
-                        SparqlTriple(
-                            Var{"?c"},
-                            "<QLever-internal-function/contains-entity>",
-                            Var{"?y"})}),
+                        SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?y"})}),
                    {1, 2}),
                std::make_pair<Node, vector<size_t>>(
                    QueryPlanner::TripleGraph::Node(
@@ -338,74 +358,84 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
           "ql:contains-entity ?y. ?c2 ql:contains-word \"xx\"}");
       QueryPlanner qp(nullptr);
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
-      TripleGraph expected = TripleGraph(std::vector<
-                                         std::pair<Node, std::vector<size_t>>>(
-          {std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   0, SparqlTriple(Var{"?x"}, "<p>", "<X>")),
-               {1}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   1, SparqlTriple(Var{"?c"},
-                                   "<QLever-internal-function/contains-entity>",
-                                   Var{"?x"})),
-               {0, 2, 3}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   2, SparqlTriple(Var{"?c"},
-                                   "<QLever-internal-function/contains-word>",
-                                   lit("\"abc\""))),
-               {1, 3}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   3, SparqlTriple(Var{"?c"},
-                                   "<QLever-internal-function/contains-entity>",
-                                   Var{"?y"})),
-               {1, 2, 4}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   4, SparqlTriple(Var{"?c2"},
-                                   "<QLever-internal-function/contains-entity>",
-                                   Var{"?y"})),
-               {3, 5}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   5, SparqlTriple(Var{"?c2"},
-                                   "<QLever-internal-function/contains-word>",
-                                   lit("\"xx\""))),
-               {4})}));
+      TripleGraph expected =
+          TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
+              {std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       0, SparqlTriple(Var{"?x"}, "<p>", "<X>")),
+                   {1}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       1, SparqlTriple(Var{"?c"},
+                                       "<http://qlever.cs.uni-freiburg.de/"
+                                       "builtin-functions/contains-entity>",
+                                       Var{"?x"})),
+                   {0, 2, 3}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       2, SparqlTriple(Var{"?c"},
+                                       "<http://qlever.cs.uni-freiburg.de/"
+                                       "builtin-functions/contains-word>",
+                                       lit("\"abc\""))),
+                   {1, 3}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       3, SparqlTriple(Var{"?c"},
+                                       "<http://qlever.cs.uni-freiburg.de/"
+                                       "builtin-functions/contains-entity>",
+                                       Var{"?y"})),
+                   {1, 2, 4}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       4, SparqlTriple(Var{"?c2"},
+                                       "<http://qlever.cs.uni-freiburg.de/"
+                                       "builtin-functions/contains-entity>",
+                                       Var{"?y"})),
+                   {3, 5}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       5, SparqlTriple(Var{"?c2"},
+                                       "<http://qlever.cs.uni-freiburg.de/"
+                                       "builtin-functions/contains-word>",
+                                       lit("\"xx\""))),
+                   {4})}));
 
       ASSERT_TRUE(tg.isSimilar(expected));
       tg.collapseTextCliques();
-      TripleGraph expected2 = TripleGraph(std::vector<
-                                          std::pair<Node, std::vector<size_t>>>(
-          {std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   0, Var{"?c"}, {"abc"},
-                   {SparqlTriple(Var{"?c"},
-                                 "<QLever-internal-function/contains-entity>",
-                                 Var{"?x"}),
-                    SparqlTriple(Var{"?c"},
-                                 "<QLever-internal-function/contains-word>",
-                                 lit("\"abc\"")),
-                    SparqlTriple(Var{"?c"},
-                                 "<QLever-internal-function/contains-entity>",
-                                 Var{"?y"})}),
-               {1, 2}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   1, Var{"?c2"}, {"xx"},
-                   {SparqlTriple(Var{"?c2"},
-                                 "<QLever-internal-function/contains-entity>",
-                                 Var{"?y"}),
-                    SparqlTriple(Var{"?c2"},
-                                 "<QLever-internal-function/contains-word>",
-                                 lit("\"xx\""))}),
-               {0}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   2, SparqlTriple(Var{"?x"}, "<p>", "<X>")),
-               {0})}));
+      TripleGraph expected2 =
+          TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
+              {std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       0, Var{"?c"}, {"abc"},
+                       {SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?x"}),
+                        SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-word>",
+                                     lit("\"abc\"")),
+                        SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?y"})}),
+                   {1, 2}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       1, Var{"?c2"}, {"xx"},
+                       {SparqlTriple(Var{"?c2"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?y"}),
+                        SparqlTriple(Var{"?c2"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-word>",
+                                     lit("\"xx\""))}),
+                   {0}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       2, SparqlTriple(Var{"?x"}, "<p>", "<X>")),
+                   {0})}));
       ASSERT_TRUE(tg.isSimilar(expected2));
     }
     {
@@ -418,54 +448,69 @@ TEST(QueryPlannerTest, testcollapseTextCliques) {
       auto tg = qp.createTripleGraph(&pq.children()[0].getBasic());
       ASSERT_EQ(
           "0 {s: ?x, p: <p>, o: <X>} : (1)\n"
-          "1 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?x} : "
+          "1 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?x} : "
           "(0, 2, 3)\n"
-          "2 {s: ?c, p: <QLever-internal-function/contains-word>, o: \"abc\"} "
+          "2 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word>, "
+          "o: \"abc\"} "
           ": "
           "(1, 3)\n"
-          "3 {s: ?c, p: <QLever-internal-function/contains-entity>, o: ?y} : "
+          "3 {s: ?c, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?y} : "
           "(1, 2, 4, 6)\n"
-          "4 {s: ?c2, p: <QLever-internal-function/contains-entity>, o: ?y} "
+          "4 {s: ?c2, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+          "contains-entity>, o: ?y} "
           ": (3, 5, 6)\n"
-          "5 {s: ?c2, p: <QLever-internal-function/contains-word>, o: \"xx\"} "
+          "5 {s: ?c2, p: "
+          "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word>, "
+          "o: \"xx\"} "
           ": "
           "(4)\n"
           "6 {s: ?y, p: <P2>, o: <X2>} : (3, 4)",
           tg.asString());
       tg.collapseTextCliques();
-      TripleGraph expected2 = TripleGraph(std::vector<
-                                          std::pair<Node, std::vector<size_t>>>(
-          {std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   0, Var{"?c"}, {"abc"},
-                   {SparqlTriple(Var{"?c"},
-                                 "<QLever-internal-function/contains-entity>",
-                                 Var{"?x"}),
-                    SparqlTriple(Var{"?c"},
-                                 "<QLever-internal-function/contains-word>",
-                                 "abc"),
-                    SparqlTriple(Var{"?c"},
-                                 "<QLever-internal-function/contains-entity>",
-                                 Var{"?y"})}),
-               {1, 2, 3}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   1, Var{"?c2"}, {"xx"},
-                   {SparqlTriple(Var{"?c2"},
-                                 "<QLever-internal-function/contains-entity>",
-                                 Var{"?y"}),
-                    SparqlTriple(Var{"?c2"},
-                                 "<QLever-internal-function/contains-word>",
-                                 lit("\"xx\""))}),
-               {0, 3}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   2, SparqlTriple(Var{"?x"}, "<p>", "<X>")),
-               {0}),
-           std::make_pair<Node, vector<size_t>>(
-               QueryPlanner::TripleGraph::Node(
-                   3, SparqlTriple(Var{"?y"}, "<P2>", "<X2>")),
-               {0, 1})}));
+      TripleGraph expected2 =
+          TripleGraph(std::vector<std::pair<Node, std::vector<size_t>>>(
+              {std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       0, Var{"?c"}, {"abc"},
+                       {SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?x"}),
+                        SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-word>",
+                                     "abc"),
+                        SparqlTriple(Var{"?c"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?y"})}),
+                   {1, 2, 3}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       1, Var{"?c2"}, {"xx"},
+                       {SparqlTriple(Var{"?c2"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-entity>",
+                                     Var{"?y"}),
+                        SparqlTriple(Var{"?c2"},
+                                     "<http://qlever.cs.uni-freiburg.de/"
+                                     "builtin-functions/contains-word>",
+                                     lit("\"xx\""))}),
+                   {0, 3}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       2, SparqlTriple(Var{"?x"}, "<p>", "<X>")),
+                   {0}),
+               std::make_pair<Node, vector<size_t>>(
+                   QueryPlanner::TripleGraph::Node(
+                       3, SparqlTriple(Var{"?y"}, "<P2>", "<X2>")),
+                   {0, 1})}));
       ASSERT_TRUE(tg.isSimilar(expected2));
     }
   }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -736,8 +736,12 @@ TEST(SparqlParser, triplesSameSubjectPath) {
   expectTriples("10.0 <bar> true",
                 {{Literal(10.0), PathIri("<bar>"), Literal(true)}});
   expectTriples(
-      "<foo> <QLever-internal-function/contains-word> \"Berlin Freiburg\"",
-      {{Iri("<foo>"), PathIri("<QLever-internal-function/contains-word>"),
+      "<foo> "
+      "<http://qlever.cs.uni-freiburg.de/builtin-functions/contains-word> "
+      "\"Berlin Freiburg\"",
+      {{Iri("<foo>"),
+        PathIri("<http://qlever.cs.uni-freiburg.de/builtin-functions/"
+                "contains-word>"),
         Literal("\"Berlin Freiburg\"")}});
 }
 

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -1178,11 +1178,13 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
     ASSERT_EQ(
         (SparqlTriple{"<somebody>", PropertyPath::fromIri("?p"), Var{"?y"}}),
         triples[0]);
-    ASSERT_EQ((SparqlTriple{
-                  Var{"?y"},
-                  PropertyPath::fromIri("<QLever-internal-function/langtag>"),
-                  "<QLever-internal-function/@en>"}),
-              triples[1]);
+    ASSERT_EQ(
+        (SparqlTriple{
+            Var{"?y"},
+            PropertyPath::fromIri(
+                "<http://qlever.cs.uni-freiburg.de/builtin-functions/langtag>"),
+            "<http://qlever.cs.uni-freiburg.de/builtin-functions/@en>"}),
+        triples[1]);
   }
 
   // Test that the language filter never changes triples with
@@ -1218,10 +1220,12 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
                             PropertyPath::fromIri(CONTAINS_ENTITY_PREDICATE),
                             Var{"?y"}}),
               triples[1]);
-    ASSERT_EQ((SparqlTriple{
-                  Var{"?y"},
-                  PropertyPath::fromIri("<QLever-internal-function/langtag>"),
-                  "<QLever-internal-function/@en>"}),
-              triples[2]);
+    ASSERT_EQ(
+        (SparqlTriple{
+            Var{"?y"},
+            PropertyPath::fromIri(
+                "<http://qlever.cs.uni-freiburg.de/builtin-functions/langtag>"),
+            "<http://qlever.cs.uni-freiburg.de/builtin-functions/@en>"}),
+        triples[2]);
   }
 }


### PR DESCRIPTION
The internal ql: prefix now consistently stands for the well-formed IRI `<http://qlever.cs.uni-freiburg.de/builtin-functions/>`. Fixes #1132 