### PR TITLE
Allow the loading of indices with two permutations

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -58,8 +58,8 @@ void Server::initialize(const string& indexBaseName, bool useText,
                         bool usePatterns, bool loadAllPermutations) {
   LOG(INFO) << "Initializing server ..." << std::endl;
 
-  index_.setUsePatterns(usePatterns);
-  index_.setLoadAllPermutations(loadAllPermutations);
+  index_.usePatterns() = usePatterns;
+  index_.loadAllPermutations() = loadAllPermutations;
 
   // Init the index.
   index_.createFromOnDiskIndex(indexBaseName);

--- a/src/index/CreatePatternsMain.cpp
+++ b/src/index/CreatePatternsMain.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
 
   try {
     Index index{ad_utility::makeUnlimitedAllocator<Id>()};
-    index.setUsePatterns(false);
+    index.usePatterns() = false;
     index.createFromOnDiskIndex(baseName);
     index.addPatternsToExistingIndex();
   } catch (const std::exception& e) {

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -207,14 +207,10 @@ void Index::setTextName(const std::string& name) {
 }
 
 // ____________________________________________________________________________
-void Index::setUsePatterns(bool usePatterns) {
-  return pimpl_->setUsePatterns(usePatterns);
-}
+bool& Index::usePatterns() { return pimpl_->usePatterns(); }
 
 // ____________________________________________________________________________
-void Index::setLoadAllPermutations(bool loadAllPermutations) {
-  return pimpl_->setLoadAllPermutations(loadAllPermutations);
-}
+bool& Index::loadAllPermutations() { return pimpl_->loadAllPermutations(); }
 
 // ____________________________________________________________________________
 void Index::setKeepTempFiles(bool keepTempFiles) {

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -205,9 +205,9 @@ class Index {
 
   void setTextName(const std::string& name);
 
-  void setUsePatterns(bool usePatterns);
+  bool& usePatterns();
 
-  void setLoadAllPermutations(bool loadAllPermutations);
+  bool& loadAllPermutations();
 
   void setKeepTempFiles(bool keepTempFiles);
 

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
       "Disable the precomputation for `ql:has-predicate`.");
   add("no-compressed-vocabulary,N", po::bool_switch(&noPrefixCompression),
       "Do not apply prefix compression to the vocabulary (default: do apply).");
-  add("only-pos-and-pso-permutations,o", po::bool_switch(&onlyPsoAndPos),
+  add("only-pso-and-pos-permutations,o", po::bool_switch(&onlyPsoAndPos),
       "Only build the PSO and POS permutations. This is faster, but then "
       "queries with predicate variables are not supported");
 

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -180,12 +180,12 @@ int main(int argc, char** argv) {
 
     index.setKbName(kbIndexName);
     index.setTextName(textIndexName);
-    index.setUsePatterns(!noPatterns);
+    index.usePatterns() = !noPatterns;
     index.setOnDiskBase(baseName);
     index.setKeepTempFiles(keepTemporaryFiles);
     index.setSettingsFile(settingsFile);
     index.setPrefixCompression(!noPrefixCompression);
-    index.setLoadAllPermutations(!onlyPsoAndPos);
+    index.loadAllPermutations() = !onlyPsoAndPos;
     // NOTE: If `onlyAddTextIndex` is true, we do not want to construct an
     // index, but we assume that it already exists. In particular, we then need
     // the vocabulary from the KB index for building the text index.

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -985,9 +985,20 @@ void IndexImpl::readConfiguration() {
     target = std::decay_t<decltype(target)>{*it};
   };
 
+  auto loadDataMemberWithDefault = [this](std::string_view key, auto& target,
+                                          auto defaultValue) {
+    auto it = configurationJson_.find(key);
+    if (it == configurationJson_.end()) {
+      target = defaultValue;
+    } else {
+      target = std::decay_t<decltype(target)>{*it};
+    }
+  };
+
   loadRequestedDataMember("num-predicates-normal", numPredicatesNormal_);
-  loadRequestedDataMember("num-subjects-normal", numSubjectsNormal_);
-  loadRequestedDataMember("num-objects-normal", numObjectsNormal_);
+  // These might be missing if there are only two permutations.
+  loadDataMemberWithDefault("num-subjects-normal", numSubjectsNormal_, 0);
+  loadDataMemberWithDefault("num-objects-normal", numObjectsNormal_, 0);
   loadRequestedDataMember("num-triples-normal", numTriplesNormal_);
 }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -751,10 +751,19 @@ void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
   }
 
   if (usePatterns_) {
-    PatternCreator::readPatternsFromFile(
-        onDiskBase_ + ".index.patterns", avgNumDistinctSubjectsPerPredicate_,
-        avgNumDistinctPredicatesPerSubject_, numDistinctSubjectPredicatePairs_,
-        patterns_, hasPattern_);
+    try {
+      PatternCreator::readPatternsFromFile(
+          onDiskBase_ + ".index.patterns", avgNumDistinctSubjectsPerPredicate_,
+          avgNumDistinctPredicatesPerSubject_,
+          numDistinctSubjectPredicatePairs_, patterns_, hasPattern_);
+    } catch (const std::exception& e) {
+      LOG(WARN) << "Could not load the patterns. Likely this index was built "
+                   "without patterns, the pattern trick will therefore not be "
+                   "available. To suppress this warning, start the server with "
+                   "the `--no-patterns` option. The error message was "
+                << e.what() << std::endl;
+      usePatterns_ = false;
+    }
   }
 }
 
@@ -846,12 +855,10 @@ void IndexImpl::setKeepTempFiles(bool keepTempFiles) {
 }
 
 // _____________________________________________________________________________
-void IndexImpl::setUsePatterns(bool usePatterns) { usePatterns_ = usePatterns; }
+bool& IndexImpl::usePatterns() { return usePatterns_; }
 
 // _____________________________________________________________________________
-void IndexImpl::setLoadAllPermutations(bool loadAllPermutations) {
-  loadAllPermutations_ = loadAllPermutations;
-}
+bool& IndexImpl::loadAllPermutations() { return loadAllPermutations_; }
 
 // ____________________________________________________________________________
 void IndexImpl::setSettingsFile(const std::string& filename) {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -353,9 +353,9 @@ class IndexImpl {
 
   void setTextName(const string& name);
 
-  void setUsePatterns(bool usePatterns);
+  bool& usePatterns();
 
-  void setLoadAllPermutations(bool loadAllPermutations);
+  bool& loadAllPermutations();
 
   void setKeepTempFiles(bool keepTempFiles);
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -58,109 +58,116 @@ auto makeTestScanWidthTwo = [](const IndexImpl& index) {
 }  // namespace
 
 TEST(IndexTest, createFromTurtleTest) {
-  {
-    std::string kb =
-        "<a>  <b>  <c> . \n"
-        "<a>  <b>  <c2> .\n"
-        "<a>  <b2> <c> .\n"
-        "<a2> <b2> <c2> .";
-    const IndexImpl& index = getQec(kb)->getIndex().getImpl();
-
-    auto getId = makeGetId(getQec(kb)->getIndex());
-    Id a = getId("<a>");
-    Id b = getId("<b>");
-    Id c = getId("<c>");
-    Id a2 = getId("<a2>");
-    Id b2 = getId("<b2>");
-    Id c2 = getId("<c2>");
-
-    // TODO<joka921> We could also test the multiplicities here.
-    ASSERT_TRUE(index.PSO().metaData().col0IdExists(b));
-    ASSERT_TRUE(index.PSO().metaData().col0IdExists(b2));
-    ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
-    ASSERT_FALSE(index.PSO().metaData().col0IdExists(c));
-    ASSERT_FALSE(index.PSO().metaData().col0IdExists(
-        Id::makeFromVocabIndex(VocabIndex::make(735))));
-    ASSERT_FALSE(index.PSO().metaData().getMetaData(b).isFunctional());
-    ASSERT_TRUE(index.PSO().metaData().getMetaData(b2).isFunctional());
-
-    ASSERT_TRUE(index.POS().metaData().col0IdExists(b));
-    ASSERT_TRUE(index.POS().metaData().col0IdExists(b2));
-    ASSERT_FALSE(index.POS().metaData().col0IdExists(a));
-    ASSERT_FALSE(index.POS().metaData().col0IdExists(c));
-    ASSERT_TRUE(index.POS().metaData().getMetaData(b).isFunctional());
-    ASSERT_TRUE(index.POS().metaData().getMetaData(b2).isFunctional());
-
-    // Relation b
-    // Pair index
-    auto testTwo = makeTestScanWidthTwo(index);
-    testTwo("<b>", Permutation::PSO, {{a, c}, {a, c2}});
-    std::vector<std::array<Id, 2>> buffer;
-
-    // Relation b2
-    testTwo("<b2>", Permutation::PSO, {{a, c}, {a2, c2}});
-
+  auto runTest = [](bool loadAllPermutations, bool loadPatterns) {
     {
-      // Test for a previous bug in the scan of two fixed elements: An assertion
-      // wrongly failed if the first Id existed in the permutation, but no
-      // compressed block was found via binary search that could possibly
-      // contain the combination of the ids. In this example <b2> is the largest
-      // predicate that occurs and <c2> is larger than the largest subject that
-      // appears with <b2>.
-      auto testOne = makeTestScanWidthOne(index);
-      testOne("<b2>", "<c2>", Permutation::PSO, {});
+      std::string kb =
+          "<a>  <b>  <c> . \n"
+          "<a>  <b>  <c2> .\n"
+          "<a>  <b2> <c> .\n"
+          "<a2> <b2> <c2> .";
+      const IndexImpl& index =
+          getQec(kb, loadAllPermutations, loadPatterns)->getIndex().getImpl();
+
+      auto getId = makeGetId(getQec(kb)->getIndex());
+      Id a = getId("<a>");
+      Id b = getId("<b>");
+      Id c = getId("<c>");
+      Id a2 = getId("<a2>");
+      Id b2 = getId("<b2>");
+      Id c2 = getId("<c2>");
+
+      // TODO<joka921> We could also test the multiplicities here.
+      ASSERT_TRUE(index.PSO().metaData().col0IdExists(b));
+      ASSERT_TRUE(index.PSO().metaData().col0IdExists(b2));
+      ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
+      ASSERT_FALSE(index.PSO().metaData().col0IdExists(c));
+      ASSERT_FALSE(index.PSO().metaData().col0IdExists(
+          Id::makeFromVocabIndex(VocabIndex::make(735))));
+      ASSERT_FALSE(index.PSO().metaData().getMetaData(b).isFunctional());
+      ASSERT_TRUE(index.PSO().metaData().getMetaData(b2).isFunctional());
+
+      ASSERT_TRUE(index.POS().metaData().col0IdExists(b));
+      ASSERT_TRUE(index.POS().metaData().col0IdExists(b2));
+      ASSERT_FALSE(index.POS().metaData().col0IdExists(a));
+      ASSERT_FALSE(index.POS().metaData().col0IdExists(c));
+      ASSERT_TRUE(index.POS().metaData().getMetaData(b).isFunctional());
+      ASSERT_TRUE(index.POS().metaData().getMetaData(b2).isFunctional());
+
+      // Relation b
+      // Pair index
+      auto testTwo = makeTestScanWidthTwo(index);
+      testTwo("<b>", Permutation::PSO, {{a, c}, {a, c2}});
+      std::vector<std::array<Id, 2>> buffer;
+
+      // Relation b2
+      testTwo("<b2>", Permutation::PSO, {{a, c}, {a2, c2}});
+
+      {
+        // Test for a previous bug in the scan of two fixed elements: An
+        // assertion wrongly failed if the first Id existed in the permutation,
+        // but no compressed block was found via binary search that could
+        // possibly contain the combination of the ids. In this example <b2> is
+        // the largest predicate that occurs and <c2> is larger than the largest
+        // subject that appears with <b2>.
+        auto testOne = makeTestScanWidthOne(index);
+        testOne("<b2>", "<c2>", Permutation::PSO, {});
+      }
     }
-  }
-  {
-    std::string kb =
-        "<a> <is-a> <1> .\n"
-        "<a> <is-a> <2> .\n"
-        "<a> <is-a> <0> .\n"
-        "<b> <is-a> <3> .\n"
-        "<b> <is-a> <0> .\n"
-        "<c> <is-a> <1> .\n"
-        "<c> <is-a> <2> .\n";
+    {
+      std::string kb =
+          "<a> <is-a> <1> .\n"
+          "<a> <is-a> <2> .\n"
+          "<a> <is-a> <0> .\n"
+          "<b> <is-a> <3> .\n"
+          "<b> <is-a> <0> .\n"
+          "<c> <is-a> <1> .\n"
+          "<c> <is-a> <2> .\n";
 
-    const IndexImpl& index = getQec(kb)->getIndex().getImpl();
+      const IndexImpl& index = getQec(kb)->getIndex().getImpl();
 
-    auto getId = makeGetId(getQec(kb)->getIndex());
-    Id zero = getId("<0>");
-    Id one = getId("<1>");
-    Id two = getId("<2>");
-    Id three = getId("<3>");
-    Id a = getId("<a>");
-    Id b = getId("<b>");
-    Id c = getId("<c>");
-    Id isA = getId("<is-a>");
+      auto getId = makeGetId(getQec(kb)->getIndex());
+      Id zero = getId("<0>");
+      Id one = getId("<1>");
+      Id two = getId("<2>");
+      Id three = getId("<3>");
+      Id a = getId("<a>");
+      Id b = getId("<b>");
+      Id c = getId("<c>");
+      Id isA = getId("<is-a>");
 
-    ASSERT_TRUE(index.PSO().metaData().col0IdExists(isA));
-    ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
+      ASSERT_TRUE(index.PSO().metaData().col0IdExists(isA));
+      ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
 
-    ASSERT_FALSE(index.PSO().metaData().getMetaData(isA).isFunctional());
+      ASSERT_FALSE(index.PSO().metaData().getMetaData(isA).isFunctional());
 
-    ASSERT_TRUE(index.POS().metaData().col0IdExists(isA));
-    ASSERT_FALSE(index.POS().metaData().getMetaData(isA).isFunctional());
+      ASSERT_TRUE(index.POS().metaData().col0IdExists(isA));
+      ASSERT_FALSE(index.POS().metaData().getMetaData(isA).isFunctional());
 
-    auto testTwo = makeTestScanWidthTwo(index);
-    testTwo("<is-a>", Permutation::PSO,
-            {{a, zero},
-             {a, one},
-             {a, two},
-             {b, zero},
-             {b, three},
-             {c, one},
-             {c, two}});
+      auto testTwo = makeTestScanWidthTwo(index);
+      testTwo("<is-a>", Permutation::PSO,
+              {{a, zero},
+               {a, one},
+               {a, two},
+               {b, zero},
+               {b, three},
+               {c, one},
+               {c, two}});
 
-    // is-a for POS
-    testTwo("<is-a>", Permutation::POS,
-            {{zero, a},
-             {zero, b},
-             {one, a},
-             {one, c},
-             {two, a},
-             {two, c},
-             {three, b}});
-  }
+      // is-a for POS
+      testTwo("<is-a>", Permutation::POS,
+              {{zero, a},
+               {zero, b},
+               {one, a},
+               {one, c},
+               {two, a},
+               {two, c},
+               {three, b}});
+    }
+  };
+  runTest(true, true);
+  runTest(true, false);
+  runTest(false, false);
+  runTest(false, true);
 }
 
 TEST(CreatePatterns, createPatterns) {

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -95,14 +95,25 @@ inline Index makeTestIndex(
     // adapted.
     index.blocksizePermutationsInBytes() = blocksizePermutationsInBytes;
     index.setOnDiskBase(indexBasename);
-    index.setUsePatterns(usePatterns);
+    index.usePatterns() = usePatterns;
     index.setPrefixCompression(usePrefixCompression);
-    index.setLoadAllPermutations(loadAllPermutations);
+    index.loadAllPermutations() = loadAllPermutations;
     index.createFromFile(inputFilename);
   }
+  if (!usePatterns || !loadAllPermutations) {
+    // If we have no patterns, or only two permutations, then check the graceful
+    // fallback even if the options were not explicitly specified during the
+    // loading of the server.
+    Index index{ad_utility::makeUnlimitedAllocator<Id>()};
+    index.usePatterns() = true;
+    index.loadAllPermutations() = true;
+    EXPECT_NO_THROW(index.createFromOnDiskIndex(indexBasename));
+    EXPECT_EQ(index.loadAllPermutations(), loadAllPermutations);
+    EXPECT_EQ(index.usePatterns(), usePatterns);
+  }
   Index index{ad_utility::makeUnlimitedAllocator<Id>()};
-  index.setUsePatterns(usePatterns);
-  index.setLoadAllPermutations(loadAllPermutations);
+  index.usePatterns() = usePatterns;
+  index.loadAllPermutations() = loadAllPermutations;
   index.createFromOnDiskIndex(indexBasename);
   ad_utility::setGlobalLoggingStream(&std::cout);
   return index;

--- a/test/IndexTestHelpers.h
+++ b/test/IndexTestHelpers.h
@@ -97,6 +97,7 @@ inline Index makeTestIndex(
     index.setOnDiskBase(indexBasename);
     index.setUsePatterns(usePatterns);
     index.setPrefixCompression(usePrefixCompression);
+    index.setLoadAllPermutations(loadAllPermutations);
     index.createFromFile(inputFilename);
   }
   Index index{ad_utility::makeUnlimitedAllocator<Id>()};


### PR DESCRIPTION
So far, when the index was built with only two permutations, the server start failed, because the keys `num-subjects-normal`  and `num-objects-normal` were not found in the `.meta-data.json` file (because this information is obtained from computing the SPO/SOP and OPS/OSP permutations pairs). Now these two values are simply set to zero when the keys are not found in the ".meta-data.json". Fixes #1142 