### PR TITLE
Remove spurious warning at the end of index build

### DIFF
--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -241,6 +241,7 @@ int main(int argc, char** argv) {
     if (!docsfile.empty()) {
       index.buildDocsDB(docsfile);
     }
+    ad_utility::deleteFile(stxxlFileName, false);
   } catch (std::exception& e) {
     LOG(ERROR) << e.what() << std::endl;
     exit(2);

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -241,7 +241,6 @@ int main(int argc, char** argv) {
     if (!docsfile.empty()) {
       index.buildDocsDB(docsfile);
     }
-    ad_utility::deleteFile(stxxlFileName);
   } catch (std::exception& e) {
     LOG(ERROR) << e.what() << std::endl;
     exit(2);


### PR DESCRIPTION
The current code tries to delete the `.stxxl-disk` file, which is no longer there (because we no longer use STXXL for sorting).