### PR TITLE
Refactor index builder, i.p. makes it easier to change permutation build order

### DIFF
--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -604,7 +604,8 @@ class CompressedExternalIdTableSorter
       } else {
         for (size_t i = 0; i < block.numRows(); i += blocksizeOutput) {
           size_t upper = std::min(i + blocksizeOutput, block.numRows());
-          auto curBlock = IdTableStatic<NumStaticCols>(this->numColumns_, this->writer_.allocator());
+          auto curBlock = IdTableStatic<NumStaticCols>(
+              this->numColumns_, this->writer_.allocator());
           curBlock.reserve(upper - i);
           curBlock.insertAtEnd(block.begin() + i, block.begin() + upper);
           co_yield std::move(curBlock).template toStatic<N>();

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -596,7 +596,9 @@ class CompressedExternalIdTableSorter
   cppcoro::generator<IdTableStatic<N>> sortedBlocks(
       std::optional<size_t> blocksize = std::nullopt) {
     if (!this->transformAndPushLastBlock()) {
-      // There was only one block, return it.
+      // There was only one block, return it. If a blocksize was explicitly
+      // requested for the output, and the single block is larger than this
+      // blocksize, we manually have to split it into chunks.
       auto& block = this->currentBlock_;
       const auto blocksizeOutput = blocksize.value_or(block.numRows());
       if (block.numRows() <= blocksizeOutput) {

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -535,7 +535,7 @@ class CompressedExternalIdTableSorter
 
  public:
   // Constructor.
-  explicit CompressedExternalIdTableSorter(
+  CompressedExternalIdTableSorter(
       std::string filename, size_t numCols, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
       MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE,
@@ -550,7 +550,7 @@ class CompressedExternalIdTableSorter
 
   // When we have a static number of columns, then the `numCols` argument to the
   // constructor is redundant.
-  explicit CompressedExternalIdTableSorter(
+  CompressedExternalIdTableSorter(
       std::string filename, ad_utility::MemorySize memory,
       ad_utility::AllocatorWithLimit<Id> allocator,
       MemorySize blocksizeCompression = DEFAULT_BLOCKSIZE_EXTERNAL_ID_TABLE,

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -597,7 +597,19 @@ class CompressedExternalIdTableSorter
       std::optional<size_t> blocksize = std::nullopt) {
     if (!this->transformAndPushLastBlock()) {
       // There was only one block, return it.
-      co_yield std::move(this->currentBlock_).template toStatic<N>();
+      auto& block = this->currentBlock_;
+      const auto blocksizeOutput = blocksize.value_or(block.numRows());
+      if (block.numRows() <= blocksizeOutput) {
+        co_yield std::move(this->currentBlock_).template toStatic<N>();
+      } else {
+        for (size_t i = 0; i < block.numRows(); i += blocksizeOutput) {
+          size_t upper = std::min(i + blocksizeOutput, block.numRows());
+          auto curBlock = IdTableStatic<NumStaticCols>(this->numColumns_, this->writer_.allocator());
+          curBlock.reserve(upper - i);
+          curBlock.insertAtEnd(block.begin() + i, block.begin() + upper);
+          co_yield std::move(curBlock).template toStatic<N>();
+        }
+      }
       co_return;
     }
     auto rowGenerators =

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -377,7 +377,7 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
 }
 
 // _____________________________________________________________________________
-std::unique_ptr<PsoSorter> IndexImpl::convertPartialToGlobalIds(
+std::unique_ptr<FirstPermutationSorter> IndexImpl::convertPartialToGlobalIds(
     TripleVec& data, const vector<size_t>& actualLinesPerPartial,
     size_t linesPerPartial) {
   LOG(INFO) << "Converting triples from local IDs to global IDs ..."
@@ -386,7 +386,7 @@ std::unique_ptr<PsoSorter> IndexImpl::convertPartialToGlobalIds(
              << std::endl;
 
   // Iterate over all partial vocabularies.
-  auto resultPtr = std::make_unique<PsoSorter>(
+  auto resultPtr = std::make_unique<FirstPermutationSorter>(
       onDiskBase_ + ".pso-sorter.dat",
       memoryLimitIndexBuilding() / NUM_EXTERNAL_SORTERS_AT_SAME_TIME,
       allocator_);

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -459,8 +459,8 @@ class IndexImpl {
   void compressInternalVocabularyIfSpecified(
       const std::vector<std::string>& prefixes);
 
-  // Return a turtle parser that parser the `filename`. The parser will be
-  // configured to either parser in parallel or not, and to either use the
+  // Return a Turtle parser that parses the given file. The parser will be
+  // configured to either parse in parallel or not, and to either use the
   // CTRE-based relaxed parser or not, depending on the settings of the
   // corresponding member variables.
   std::unique_ptr<TurtleParserBase> makeTurtleParser(
@@ -714,7 +714,8 @@ class IndexImpl {
 
   // Functions to create the pairs of permutations during the index build. Each
   // of them takes the following arguments:
-  // * `isInternalId` a callable that takes an `Id` and returns true iff the
+  // * `isQleverInternalId` a callable that takes an `Id` and returns true iff
+  // the
   //    corresponding IRI was internally added by QLever and not part of the
   //    knowledge graph.
   // * `sortedInput`  The input, must be sorted by the first permutation in the

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -715,8 +715,7 @@ class IndexImpl {
   // Functions to create the pairs of permutations during the index build. Each
   // of them takes the following arguments:
   // * `isQleverInternalId` a callable that takes an `Id` and returns true iff
-  // the
-  //    corresponding IRI was internally added by QLever and not part of the
+  //    the corresponding IRI was internally added by QLever and not part of the
   //    knowledge graph.
   // * `sortedInput`  The input, must be sorted by the first permutation in the
   //    function name.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -694,4 +694,19 @@ class IndexImpl {
 
     return std::pair{std::move(ignoredRanges), std::move(isTripleIgnored)};
   }
+
+  // Functions only required for index building.
+  template <typename... NextSorter> requires(sizeof...(NextSorter) <= 1)
+  void createSPOAndSOP(auto& isInternalId,
+                                  auto&& spoSorter, NextSorter&&... nextSorter);
+  template <typename... NextSorter> requires(sizeof...(NextSorter) <= 1)
+  void createOSPAndOPS ( auto isInternalId,
+                                    auto&& ospSorter, NextSorter&&... nextSorter);
+  template <typename... NextSorter> requires(sizeof...(NextSorter) <= 1)
+  void createPSOAndPOS(auto& isInternalId, auto&& psoSorter, NextSorter&&... nextSorter);
+
+  // TODO<joka921> The Comparator and permutationName could be also inferred from the permutation.
+  template<typename Comparator>
+  ExternalSorter<Comparator> makeSorter(std::string_view permutationName);
+
 };

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -60,7 +60,7 @@ template <typename Comparator>
 using ExternalSorter =
     ad_utility::CompressedExternalIdTableSorter<Comparator, 3>;
 
-using PsoSorter = ExternalSorter<SortByPSO>;
+using FirstPermutationSorter = ExternalSorter<SortByPSO>;
 
 // Several data that are passed along between different phases of the
 // index builder.
@@ -84,7 +84,7 @@ struct IndexBuilderDataAsStxxlVector : IndexBuilderDataBase {
 // All the data from IndexBuilderDataBase and a ExternalSorter that stores all
 // ID triples sorted by the PSO permutation.
 struct IndexBuilderDataAsPsoSorter : IndexBuilderDataBase {
-  using SorterPtr = std::unique_ptr<ExternalSorter<SortByPSO>>;
+  using SorterPtr = std::unique_ptr<FirstPermutationSorter>;
   SorterPtr psoSorter;
   IndexBuilderDataAsPsoSorter(const IndexBuilderDataBase& base,
                               SorterPtr sorter)

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -60,7 +60,12 @@ template <typename Comparator>
 using ExternalSorter =
     ad_utility::CompressedExternalIdTableSorter<Comparator, 3>;
 
-using FirstPermutationSorter = ExternalSorter<SortByPSO>;
+using FirstPermutation = SortBySPO;
+using FirstPermutationSorter = ExternalSorter<FirstPermutation>;
+using SecondPermutation = SortByOSP;
+using ThirdPermutation = SortByPSO;
+
+
 
 // Several data that are passed along between different phases of the
 // index builder.
@@ -450,7 +455,7 @@ class IndexImpl {
       std::unique_ptr<ItemMapArray> items, auto localIds,
       ad_utility::Synchronized<std::unique_ptr<TripleVec>>* globalWritePtr);
 
-  std::unique_ptr<ExternalSorter<SortByPSO>> convertPartialToGlobalIds(
+  std::unique_ptr<FirstPermutationSorter> convertPartialToGlobalIds(
       TripleVec& data, const vector<size_t>& actualLinesPerPartial,
       size_t linesPerPartial);
 
@@ -709,4 +714,16 @@ class IndexImpl {
   template<typename Comparator>
   ExternalSorter<Comparator> makeSorter(std::string_view permutationName);
 
+  void firstPermutation(auto&&... args) {
+    static_assert(std::is_same_v<FirstPermutation, SortBySPO>);
+    return createSPOAndSOP(AD_FWD(args)...);
+  }
+  void secondPermutation(auto&&... args) {
+    static_assert(std::is_same_v<SecondPermutation, SortByOSP> );
+    return createOSPAndOPS(AD_FWD(args)...);
+  }
+  void thirdPermutation(auto&&... args) {
+    static_assert(std::is_same_v<ThirdPermutation, SortByPSO> );
+    return createPSOAndPOS(AD_FWD(args)...);
+  }
 };

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -459,6 +459,13 @@ class IndexImpl {
   void compressInternalVocabularyIfSpecified(
       const std::vector<std::string>& prefixes);
 
+  // Return a turtle parser that parser the `filename`. The parser will be
+  // configured to either parser in parallel or not, and to either use the
+  // CTRE-based relaxed parser or not, depending on the settings of the
+  // corresponding member variables.
+  std::unique_ptr<TurtleParserBase> makeTurtleParser(
+      const std::string& filename);
+
   std::unique_ptr<FirstPermutationSorter> convertPartialToGlobalIds(
       TripleVec& data, const vector<size_t>& actualLinesPerPartial,
       size_t linesPerPartial);

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -60,12 +60,10 @@ template <typename Comparator>
 using ExternalSorter =
     ad_utility::CompressedExternalIdTableSorter<Comparator, 3>;
 
-using FirstPermutation = SortBySPO;
+using FirstPermutation = SortByPSO;
 using FirstPermutationSorter = ExternalSorter<FirstPermutation>;
-using SecondPermutation = SortByOSP;
-using ThirdPermutation = SortByPSO;
-
-
+using SecondPermutation = SortBySPO;
+using ThirdPermutation = SortByOSP;
 
 // Several data that are passed along between different phases of the
 // index builder.
@@ -88,13 +86,13 @@ struct IndexBuilderDataAsStxxlVector : IndexBuilderDataBase {
 
 // All the data from IndexBuilderDataBase and a ExternalSorter that stores all
 // ID triples sorted by the PSO permutation.
-struct IndexBuilderDataAsPsoSorter : IndexBuilderDataBase {
+struct IndexBuilderDataAsFirstPermutationSorter : IndexBuilderDataBase {
   using SorterPtr = std::unique_ptr<FirstPermutationSorter>;
-  SorterPtr psoSorter;
-  IndexBuilderDataAsPsoSorter(const IndexBuilderDataBase& base,
-                              SorterPtr sorter)
-      : IndexBuilderDataBase{base}, psoSorter{std::move(sorter)} {}
-  IndexBuilderDataAsPsoSorter() = default;
+  SorterPtr sorter_;
+  IndexBuilderDataAsFirstPermutationSorter(const IndexBuilderDataBase& base,
+                                           SorterPtr sorter)
+      : IndexBuilderDataBase{base}, sorter_{std::move(sorter)} {}
+  IndexBuilderDataAsFirstPermutationSorter() = default;
 };
 
 class IndexImpl {
@@ -429,7 +427,7 @@ class IndexImpl {
   // permutations. Member vocab_ will be empty after this because it is not
   // needed for index creation once the TripleVec is set up and it would be a
   // waste of RAM.
-  IndexBuilderDataAsPsoSorter createIdTriplesAndVocab(
+  IndexBuilderDataAsFirstPermutationSorter createIdTriplesAndVocab(
       std::shared_ptr<TurtleParserBase> parser);
 
   // ___________________________________________________________________
@@ -454,6 +452,12 @@ class IndexImpl {
       size_t numLines, size_t numFiles, size_t actualCurrentPartialSize,
       std::unique_ptr<ItemMapArray> items, auto localIds,
       ad_utility::Synchronized<std::unique_ptr<TripleVec>>* globalWritePtr);
+
+  //  Apply the prefix compression to the internal vocabulary. Is called by
+  //  `createFromFile` after the vocabularies
+  // have been created and merged.
+  void compressInternalVocabularyIfSpecified(
+      const std::vector<std::string>& prefixes);
 
   std::unique_ptr<FirstPermutationSorter> convertPartialToGlobalIds(
       TripleVec& data, const vector<size_t>& actualLinesPerPartial,
@@ -699,31 +703,64 @@ class IndexImpl {
 
     return std::pair{std::move(ignoredRanges), std::move(isTripleIgnored)};
   }
+  using BlocksOfTriples = cppcoro::generator<IdTableStatic<0>>;
+  // Functions to create the pairs of permutations during the index build. Each
+  // of them takes the following arguments:
+  // * `isInternalId` a callable that takes an `Id` and returns true iff the
+  // corresponding IRI was internally added by
+  //    QLever and not part of the knowledge graph.
+  // * `sortedInput`  The input, must be sorted by the first permutation in the
+  // function name. Unfortunately we currently
+  //                   have no way of statically determining the correct
+  //                   sorting.
+  // * `nextSorter` A callback that is invoked for each row in each of the
+  // blocks in the input. Typically used to set up
+  //                the sorting for the subsequent pair of permutations.
 
-  // Functions only required for index building.
-  template <typename... NextSorter> requires(sizeof...(NextSorter) <= 1)
-  void createSPOAndSOP(auto& isInternalId,
-                                  auto&& spoSorter, NextSorter&&... nextSorter);
-  template <typename... NextSorter> requires(sizeof...(NextSorter) <= 1)
-  void createOSPAndOPS ( auto isInternalId,
-                                    auto&& ospSorter, NextSorter&&... nextSorter);
-  template <typename... NextSorter> requires(sizeof...(NextSorter) <= 1)
-  void createPSOAndPOS(auto& isInternalId, auto&& psoSorter, NextSorter&&... nextSorter);
+  // Create the SPO and SOP permutations. Also count the number of distinct
+  // actual (not internal) subjects in the input and write it to the metadata.
+  // Also builds the patterns if specified.
+  template <typename... NextSorter>
+  requires(sizeof...(NextSorter) <= 1)
+  void createSPOAndSOP(auto& isInternalId, BlocksOfTriples sortedInput,
+                       NextSorter&&... nextSorter);
+  // Create the OSP and OPS permutations. Additionally count the number of
+  // distinct objects and write it to the metadata.
+  template <typename... NextSorter>
+  requires(sizeof...(NextSorter) <= 1)
+  void createOSPAndOPS(auto& isInternalId, BlocksOfTriples sortedInput,
+                       NextSorter&&... nextSorter);
 
-  // TODO<joka921> The Comparator and permutationName could be also inferred from the permutation.
-  template<typename Comparator>
-  ExternalSorter<Comparator> makeSorter(std::string_view permutationName);
+  // Create the PSO and POS permutations. Additionally count the number of
+  // distinct predicates and the number of actual triples and write them to the
+  // metadata.
+  template <typename... NextSorter>
+  requires(sizeof...(NextSorter) <= 1)
+  void createPSOAndPOS(auto& isInternalId, BlocksOfTriples sortedInput,
+                       NextSorter&&... nextSorter);
 
-  void firstPermutation(auto&&... args) {
-    static_assert(std::is_same_v<FirstPermutation, SortBySPO>);
+  // Set up one of the permutation sorters with the appropriate memory limit.
+  // The `permutationName` is used to determine the filename and must be unique
+  // for each call during one index build.
+  template <typename Comparator>
+  ExternalSorter<Comparator> makeSorter(std::string_view permutationName) const;
+
+  // Aliases for the three functions above that should be consistently used.
+  // They assert that the order of the permutations as communicated by the
+  // function names are consistent with the aliases for the sorters, i.e. that
+  // `createFirstPermutationPair` corresponds to the `FirstPermutation`.
+  void createFirstPermutationPair(auto&&... args) {
+    static_assert(std::is_same_v<FirstPermutation, SortByPSO>);
+    return createPSOAndPOS(AD_FWD(args)...);
+  }
+
+  void createSecondPermutationPair(auto&&... args) {
+    static_assert(std::is_same_v<SecondPermutation, SortBySPO>);
     return createSPOAndSOP(AD_FWD(args)...);
   }
-  void secondPermutation(auto&&... args) {
-    static_assert(std::is_same_v<SecondPermutation, SortByOSP> );
+
+  void createThirdPermutationPair(auto&&... args) {
+    static_assert(std::is_same_v<ThirdPermutation, SortByOSP>);
     return createOSPAndOPS(AD_FWD(args)...);
-  }
-  void thirdPermutation(auto&&... args) {
-    static_assert(std::is_same_v<ThirdPermutation, SortByPSO> );
-    return createPSOAndPOS(AD_FWD(args)...);
   }
 };

--- a/src/index/StxxlSortFunctors.h
+++ b/src/index/StxxlSortFunctors.h
@@ -33,11 +33,11 @@ struct SortTriple {
 };
 
 using SortByPSO = SortTriple<1, 0, 2>;
-using SortByPOS = SortTriple<1, 2, 0>;
+//using SortByPOS = SortTriple<1, 2, 0>;
 using SortBySPO = SortTriple<0, 1, 2>;
-using SortBySOP = SortTriple<0, 2, 1>;
+//using SortBySOP = SortTriple<0, 2, 1>;
 using SortByOSP = SortTriple<2, 0, 1>;
-using SortByOPS = SortTriple<2, 1, 0>;
+//using SortByOPS = SortTriple<2, 1, 0>;
 
 // TODO<joka921> Which of those are actually "IDs" and which are something else?
 struct SortText {

--- a/src/index/StxxlSortFunctors.h
+++ b/src/index/StxxlSortFunctors.h
@@ -6,23 +6,17 @@
 #include <array>
 #include <tuple>
 
-#include "../global/Id.h"
-
-using std::array;
-using std::tuple;
+#include "global/Id.h"
 
 template <int i0, int i1, int i2>
 struct SortTriple {
   using T = std::array<Id, 3>;
   // comparison function
   bool operator()(const auto& a, const auto& b) const {
-    if (a[i0] == b[i0]) {
-      if (a[i1] == b[i1]) {
-        return a[i2] < b[i2];
-      }
-      return a[i1] < b[i1];
-    }
-    return a[i0] < b[i0];
+    auto permute = [](const auto& x) {
+      return std::tie(x[i0], x[i1], x[i2]);
+    };
+    return permute(a) < permute(b);
   }
 
   // Value that is strictly smaller than any input element.
@@ -33,11 +27,8 @@ struct SortTriple {
 };
 
 using SortByPSO = SortTriple<1, 0, 2>;
-//using SortByPOS = SortTriple<1, 2, 0>;
 using SortBySPO = SortTriple<0, 1, 2>;
-//using SortBySOP = SortTriple<0, 2, 1>;
 using SortByOSP = SortTriple<2, 0, 1>;
-//using SortByOPS = SortTriple<2, 1, 0>;
 
 // TODO<joka921> Which of those are actually "IDs" and which are something else?
 struct SortText {
@@ -45,23 +36,11 @@ struct SortText {
                        Score, bool>;
   // comparison function
   bool operator()(const T& a, const T& b) const {
-    if (std::get<0>(a) == std::get<0>(b)) {
-      if (std::get<4>(a) == std::get<4>(b)) {
-        if (std::get<1>(a) == std::get<1>(b)) {
-          if (std::get<2>(a) == std::get<2>(b)) {
-            return std::get<3>(a) < std::get<3>(b);
-          } else {
-            return std::get<2>(a) < std::get<2>(b);
-          }
-        } else {
-          return std::get<1>(a) < std::get<1>(b);
-        }
-      } else {
-        return !std::get<4>(a);
-      }
-    } else {
-      return std::get<0>(a) < std::get<0>(b);
-    }
+    auto permute = [](const T& x) {
+      using namespace std;
+      return tie(get<0>(x), get<4>(x), get<1>(x), get<2>(x), get<3>(x));
+    };
+    return permute(a) < permute(b);
   }
 
   // min sentinel = value which is strictly smaller that any input element

--- a/src/index/StxxlSortFunctors.h
+++ b/src/index/StxxlSortFunctors.h
@@ -13,9 +13,7 @@ struct SortTriple {
   using T = std::array<Id, 3>;
   // comparison function
   bool operator()(const auto& a, const auto& b) const {
-    auto permute = [](const auto& x) {
-      return std::tie(x[i0], x[i1], x[i2]);
-    };
+    auto permute = [](const auto& x) { return std::tie(x[i0], x[i1], x[i2]); };
     return permute(a) < permute(b);
   }
 

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -76,7 +76,8 @@ class VocabularyMerger {
     IdRangeForPrefix internalEntities_{INTERNAL_ENTITIES_URI_PREFIX};
 
     // Return true iff the `id` belongs to one of the two ranges that contain
-    // the internal IDs that were added by QLever and not part of the input.
+    // the internal IDs that were added by QLever and were not part of the
+    // input.
     bool isQleverInternalId(Id id) const {
       return internalEntities_.contains(id) ||
              langTaggedPredicates_.contains(id);

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -76,8 +76,8 @@ class VocabularyMerger {
     IdRangeForPrefix internalEntities_{INTERNAL_ENTITIES_URI_PREFIX};
 
     // Return true iff the `id` belongs to one of the two ranges that contain
-    // the internal IDs.
-    bool isInternalId(Id id) const {
+    // the internal IDs that were added by QLever and not part of the input.
+    bool isQleverInternalId(Id id) const {
       return internalEntities_.contains(id) ||
              langTaggedPredicates_.contains(id);
     }

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -4,21 +4,19 @@
 #pragma once
 
 #include <string>
-#include <stxxl/vector>
 #include <utility>
 
-#include "../global/Constants.h"
-#include "../global/Id.h"
-#include "../util/HashMap.h"
-#include "../util/MmapVector.h"
-#include "./ConstantsIndexBuilding.h"
-#include "./IndexBuilderTypes.h"
-#include "Vocabulary.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
+#include "global/Constants.h"
+#include "global/Id.h"
+#include "index/ConstantsIndexBuilding.h"
+#include "index/IndexBuilderTypes.h"
+#include "index/Vocabulary.h"
+#include "util/HashMap.h"
+#include "util/MmapVector.h"
 
 using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
-using std::string;
 
 using TripleVec = ad_utility::CompressedExternalIdTable<3>;
 
@@ -41,7 +39,8 @@ class VocabularyMerger {
     // sorted order. After that, the range `[begin(), end())` is the range of
     // all the words that start with the prefix.
     struct IdRangeForPrefix {
-      IdRangeForPrefix(std::string prefix) : prefix_{std::move(prefix)} {}
+      explicit IdRangeForPrefix(std::string prefix)
+          : prefix_{std::move(prefix)} {}
       // Check if `word` starts with the `prefix_`. If so, `wordIndex`
       // will become part of the range that this struct represents.
       // For this to work, all the words that start with the `prefix_` have to
@@ -61,6 +60,9 @@ class VocabularyMerger {
       Id begin() const { return begin_; }
       Id end() const { return end_; }
 
+      // Return true iff the `id` belongs to this range.
+      bool contains(Id id) const { return begin_ <= id && id < end_; }
+
      private:
       Id begin_ = ID_NO_VALUE;
       Id end_ = ID_NO_VALUE;
@@ -72,6 +74,13 @@ class VocabularyMerger {
                                 // the vocabulary)
     IdRangeForPrefix langTaggedPredicates_{"@"};
     IdRangeForPrefix internalEntities_{INTERNAL_ENTITIES_URI_PREFIX};
+
+    // Return true iff the `id` belongs to one of the two ranges that contain
+    // the internal IDs.
+    bool isInternalId(Id id) const {
+      return internalEntities_.contains(id) ||
+             langTaggedPredicates_.contains(id);
+    }
   };
 
  private:

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -82,7 +82,8 @@ cppcoro::generator<ValueType> uniqueView(SortedView view) {
 // Takes a view of blocks and yields the elements of the same view, but removes
 // consecutive duplicates inside the blocks and across block boundaries.
 template <typename SortedBlockView,
-          typename ValueType = SortedBlockView::value_type::value_type>
+          typename ValueType = std::ranges::range_value_t<
+              std::ranges::range_value_t<SortedBlockView>>>
 cppcoro::generator<typename SortedBlockView::value_type> uniqueBlockView(
     SortedBlockView view) {
   size_t numInputs = 0;

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -65,8 +65,20 @@ TEST(IndexTest, createFromTurtleTest) {
           "<a>  <b>  <c2> .\n"
           "<a>  <b2> <c> .\n"
           "<a2> <b2> <c2> .";
-      const IndexImpl& index =
-          getQec(kb, loadAllPermutations, loadPatterns)->getIndex().getImpl();
+
+      auto getIndex = [&]() -> decltype(auto) {
+        [[maybe_unused]] decltype(auto) ref =
+            getQec(kb, loadAllPermutations, loadPatterns)->getIndex().getImpl();
+        return ref;
+      };
+      if (!loadAllPermutations && loadPatterns) {
+        AD_EXPECT_THROW_WITH_MESSAGE(
+            getIndex(),
+            ::testing::HasSubstr(
+                "patterns can only be built when all 6 permutations"));
+        return;
+      }
+      const IndexImpl& index = getIndex();
 
       auto getId = makeGetId(getQec(kb)->getIndex());
       Id a = getId("<a>");
@@ -546,7 +558,7 @@ TEST(IndexTest, NumDistinctEntities) {
 }
 
 TEST(IndexTest, NumDistinctEntitiesCornerCases) {
-  const IndexImpl& index = getQec("", false)->getIndex().getImpl();
+  const IndexImpl& index = getQec("", false, false)->getIndex().getImpl();
   AD_EXPECT_THROW_WITH_MESSAGE(index.numDistinctSubjects(),
                                ::testing::ContainsRegex("if all 6"));
   AD_EXPECT_THROW_WITH_MESSAGE(index.numDistinctObjects(),

--- a/test/engine/idTable/CompressedExternalIdTableTest.cpp
+++ b/test/engine/idTable/CompressedExternalIdTableTest.cpp
@@ -101,7 +101,7 @@ void testExternalSorter(size_t numDynamicColumns, size_t numRows,
   using namespace ad_utility::memory_literals;
 
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
-  ad_utility::CompressedExternalIdTableSorter<SortByOPS, NumStaticColumns>
+  ad_utility::CompressedExternalIdTableSorter<SortByOSP, NumStaticColumns>
       writer{filename, numDynamicColumns, memoryToUse,
              ad_utility::testing::makeAllocator(), 5_kB};
 
@@ -114,7 +114,7 @@ void testExternalSorter(size_t numDynamicColumns, size_t numRows,
       writer.push(row);
     }
 
-    std::ranges::sort(randomTable, SortByOPS{});
+    std::ranges::sort(randomTable, SortByOSP{});
 
     auto generator = writer.sortedView();
 
@@ -142,7 +142,7 @@ TEST(CompressedExternalIdTable, sorterMemoryLimit) {
 
   // only 100 bytes of memory, not sufficient for merging
   ad_utility::EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = false;
-  ad_utility::CompressedExternalIdTableSorter<SortByOPS, 0> writer{
+  ad_utility::CompressedExternalIdTableSorter<SortByOSP, 0> writer{
       filename, 3, 100_B, ad_utility::testing::makeAllocator()};
 
   CopyableIdTable<0> randomTable = createRandomlyFilledIdTable(100, 3);


### PR DESCRIPTION
Code from the large `createFromFile` method was moved to separate methods, which makes the code much clearer. In particular, it is now easy to change the order in which the permutations are built. 