### PR TITLE
Fix spurious ASAN errors in HttpTest

### DIFF
--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -144,6 +144,7 @@ class HttpServer {
 
     // Wait until the posted task has successfully executed
     future.wait();
+    ioContext_.stop();
   }
 
  private:

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -144,6 +144,8 @@ class HttpServer {
 
     // Wait until the posted task has successfully executed
     future.wait();
+    // Make sure the tests don't run forever because without this `run()` may
+    // not terminate.
     ioContext_.stop();
   }
 

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -12,8 +12,8 @@ template <bool isSender>
 net::awaitable<std::shared_ptr<
     QueryHub::ConditionalConst<isSender, QueryToSocketDistributor>>>
 QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
-  while (socketDistributors_.contains(queryId)) {
-    auto& reference = socketDistributors_.at(queryId);
+  while (socketDistributors_->contains(queryId)) {
+    auto& reference = socketDistributors_->at(queryId);
     if (auto ptr = reference.pointer_.lock()) {
       if constexpr (isSender) {
         // Ensure only single sender reference is acquired for a single session
@@ -30,24 +30,29 @@ QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
     co_await net::post(net::bind_executor(globalStrand_, net::use_awaitable));
   }
 
-  auto distributor =
-      std::make_shared<QueryToSocketDistributor>(ioContext_, [this, queryId]() {
+  auto distributor = std::make_shared<QueryToSocketDistributor>(
+      ioContext_, [&ioContext = ioContext_, globalStrand = globalStrand_,
+                   socketDistributors = socketDistributors_, queryId]() {
         auto future = net::dispatch(net::bind_executor(
-            globalStrand_, std::packaged_task<void()>([this, &queryId]() {
-              bool wasErased = socketDistributors_.erase(queryId);
+            globalStrand,
+            std::packaged_task<void()>([&socketDistributors, &queryId]() {
+              bool wasErased = socketDistributors->erase(queryId);
               AD_CORRECTNESS_CHECK(wasErased);
             })));
         // As long as the destructor would have to block anyway, perform work
         // on the `ioContext_`. This avoids blocking in case the destructor
         // already runs inside the `ioContext_`.
         // Note: When called on a strand this may block the current strand.
+        // If the ioContext has been stopped for some reason don't wait
+        // for the result, or this will never terminate.
         while (future.wait_for(std::chrono::seconds(0)) !=
-               std::future_status::ready) {
-          ioContext_.poll_one();
+                   std::future_status::ready &&
+               !ioContext.stopped()) {
+          ioContext.poll_one();
         }
       });
-  socketDistributors_.emplace(queryId,
-                              WeakReferenceHolder{distributor, isSender});
+  socketDistributors_->emplace(queryId,
+                               WeakReferenceHolder{distributor, isSender});
   co_return distributor;
 }
 

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -31,6 +31,9 @@ QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
   }
 
   auto distributor = std::make_shared<QueryToSocketDistributor>(
+      // We pass a copy of the `shared_pointer socketDistributors_` here,
+      // because in unit tests the callback might be invoked after this
+      // `QueryHub` was destroyed.
       ioContext_, [&ioContext = ioContext_, globalStrand = globalStrand_,
                    socketDistributors = socketDistributors_, queryId]() {
         auto future = net::dispatch(net::bind_executor(

--- a/src/util/http/websocket/QueryHub.h
+++ b/src/util/http/websocket/QueryHub.h
@@ -37,7 +37,9 @@ class QueryHub {
   net::io_context& ioContext_;
   /// Strand for synchronization
   net::strand<net::any_io_executor> globalStrand_;
-  absl::flat_hash_map<QueryId, WeakReferenceHolder> socketDistributors_{};
+  std::shared_ptr<absl::flat_hash_map<QueryId, WeakReferenceHolder>>
+      socketDistributors_ =
+          std::make_shared<absl::flat_hash_map<QueryId, WeakReferenceHolder>>();
 
   // Expose internal API for testing
   friend net::awaitable<void>


### PR DESCRIPTION
These test failures happened, when tasks were scheduled on an `io_context` and these tasks referenced objects the lifetime of which was shorter than that of the `io_context`. The solution consists of two parts: Pass these references as `shared_ptr` s.t. the lifetime is always sufficient, and make sure to explicily `stop` the `io_context` at the end of test runs to make sure that the tests always can run to completion (another spurious issue).

Note that these issues only arise in unit tests, because in production, all the involved objects live through the whole lifetime of a QLever server instance.