### PR TITLE
Use HashMap optimization for more complex expressions containing possibly multiple aggregates in an expression tree of an alias.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ endif()
 ######################################
 # BOOST
 ######################################
-find_package(Boost 1.81 COMPONENTS iostreams program_options REQUIRED)
+find_package(Boost 1.81 COMPONENTS iostreams program_options url REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -796,11 +796,17 @@ bool GroupBy::findAggregateMultiple(
 
   auto children = expr->children();
 
+  std::vector<bool> childrenContainUnsupportedAggregate;
   // TODO<C++23> use views::enumerate
   size_t childIndex = 0;
   for (const auto& child : children) {
-    return findAggregateMultiple(expr, child.get(), childIndex++, info);
+    childrenContainUnsupportedAggregate.push_back(
+        findAggregateMultiple(expr, child.get(), childIndex++, info));
   }
+
+  return std::all_of(childrenContainUnsupportedAggregate.begin(),
+                     childrenContainUnsupportedAggregate.end(),
+                     [](const bool v) { return v; });
 }
 
 // _____________________________________________________________________________

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -204,7 +204,7 @@ class GroupBy : public Operation {
     sparqlExpression::SparqlExpression* expr_ = nullptr;
     sparqlExpression::SparqlExpression* parent_ = nullptr;
     std::optional<size_t> nThChild_ = std::nullopt;
-    AggregateType type;
+    AggregateType type_;
     size_t hashMapIndex_ = 0;
   };
 
@@ -249,8 +249,9 @@ class GroupBy : public Operation {
       std::vector<Aggregate>& aggregates);
 
   // Find all aggregates of expression `expr`, collecting this information in
-  // the vector `info`
-  void findAggregateMultiple(sparqlExpression::SparqlExpression* parent,
+  // the vector `info`. Returns `false` in case an unsupported aggregate is
+  // found.
+  bool findAggregateMultiple(sparqlExpression::SparqlExpression* parent,
                              sparqlExpression::SparqlExpression* expr,
                              std::optional<size_t> index,
                              std::vector<HashMapAggregateInformation>& info);

--- a/src/engine/sparqlExpressions/CMakeLists.txt
+++ b/src/engine/sparqlExpressions/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(sparqlExpressions
         LangExpression.cpp NumericUnaryExpressions.cpp NumericBinaryExpressions.cpp DateExpressions.cpp StringExpressions.cpp
         ConditionalExpressions.cpp)
 
-qlever_target_link_libraries(sparqlExpressions index)
+qlever_target_link_libraries(sparqlExpressions index Boost::url)

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -83,6 +83,15 @@ class SparqlExpression {
     });
   }
 
+  // Replace child at index childIndex with newExpression
+  // TODO: Check for memory leaks etc.
+  //       Should be fine, since old expression goes out of scope and hence
+  //       destructor should be called
+  virtual void replaceChild(size_t childIndex,
+                            std::unique_ptr<SparqlExpression> newExpression) {
+    children()[childIndex].swap(newExpression);
+  }
+
   /// Get a unique identifier for this expression, used as cache key.
   virtual string getCacheKey(const VariableToColumnMap& varColMap) const = 0;
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -135,7 +135,7 @@ TEST_F(GroupByTest, doGroupBy) {
   /*
   std::vector<size_t> groupByCols = {0};
   std::string delim1(", ");
-  std::vector<GroupBy::Aggregate> aggregates = {
+  std::vector<GroupBy::AggregateAlias> aggregates = {
       // type                                in out userdata
       {ParsedQuery::AggregateType::COUNT, 1, 1, nullptr},
 
@@ -466,9 +466,10 @@ TEST_F(GroupByOptimizations, checkIfHashMapOptimizationPossible) {
   std::vector<Alias> aliasesAvgCountX{
       Alias{avgCountXPimpl, Variable("?avgcount")}};
 
-  std::vector<GroupBy::Aggregate> countAggregate = {{countXPimpl, 1}};
-  std::vector<GroupBy::Aggregate> avgAggregate = {{avgXPimpl, 1}};
-  std::vector<GroupBy::Aggregate> avgCountAggregate = {{avgCountXPimpl, 1}};
+  std::vector<GroupBy::AggregateAlias> countAggregate = {{countXPimpl, 1}};
+  std::vector<GroupBy::AggregateAlias> avgAggregate = {{avgXPimpl, 1}};
+  std::vector<GroupBy::AggregateAlias> avgCountAggregate = {
+      {avgCountXPimpl, 1}};
 
   // Enable optimization
   RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
@@ -518,7 +519,7 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimization) {
 
   SparqlExpressionPimpl avgYPimpl = makeAvgPimpl(varY);
   std::vector<Alias> aliasesAvgY{Alias{avgYPimpl, Variable{"?avg"}}};
-  std::vector<GroupBy::Aggregate> avgAggregate = {{avgYPimpl, 1}};
+  std::vector<GroupBy::AggregateAlias> avgAggregate = {{avgYPimpl, 1}};
 
   // Calculate result with optimization
   RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);


### PR DESCRIPTION
Adds support for more complex expressions where multiple aggregates may be found throughout an expression tree of an alias, e.g. `(2 * AVG(?x) + (AVG(?x + ?x) - 4) as ?avg)`.

Also adds support for `COUNT` aggregate.
