### PR TITLE
Add watchdog for CancellationHandle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,12 @@ if (ENABLE_EXPENSIVE_CHECKS)
     add_definitions("-DAD_ENABLE_EXPENSIVE_CHECKS")
 endif()
 
+if (DISABLE_QUERY_CANCELLATION_WATCH_DOG)
+    message(STATUS "Disable periodic checks that the cancellation flag is checked frequently enough while the result of
+    a query is being computed with a small runtime overhead")
+    add_definitions("-DQLEVER_DISABLE_QUERY_CANCELLATION_WATCH_DOG")
+endif()
+
 ################################
 # STXXL
 ################################

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -291,16 +291,15 @@ Join::ScanMethodType Join::getScanMethod(
   // this works because the join operations execution Context never changes
   // during its lifetime
   const auto& idx = _executionContext->getIndex();
-  const auto scanLambda = [&idx, &scan](
-                              const Permutation::Enum perm,
-                              std::shared_ptr<ad_utility::CancellationHandle<>>
-                                  cancellationHandle) {
-    return [&idx, perm, &scan,
-            cancellationHandle = std::move(cancellationHandle)](Id id) {
-      return idx.scan(id, std::nullopt, perm, scan.additionalColumns(),
-                      cancellationHandle);
-    };
-  };
+  const auto scanLambda =
+      [&idx, &scan](const Permutation::Enum perm,
+                    ad_utility::SharedCancellationHandle cancellationHandle) {
+        return [&idx, perm, &scan,
+                cancellationHandle = std::move(cancellationHandle)](Id id) {
+          return idx.scan(id, std::nullopt, perm, scan.additionalColumns(),
+                          cancellationHandle);
+        };
+      };
   AD_CORRECTNESS_CHECK(scan.getResultWidth() == 3);
   return scanLambda(scan.permutation(), cancellationHandle_);
 }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -291,16 +291,16 @@ Join::ScanMethodType Join::getScanMethod(
   // this works because the join operations execution Context never changes
   // during its lifetime
   const auto& idx = _executionContext->getIndex();
-  const auto scanLambda =
-      [&idx, &scan](
-          const Permutation::Enum perm,
-          std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) {
-        return [&idx, perm, &scan,
-                cancellationHandle = std::move(cancellationHandle)](Id id) {
-          return idx.scan(id, std::nullopt, perm, scan.additionalColumns(),
-                          cancellationHandle);
-        };
-      };
+  const auto scanLambda = [&idx, &scan](
+                              const Permutation::Enum perm,
+                              std::shared_ptr<ad_utility::CancellationHandle<>>
+                                  cancellationHandle) {
+    return [&idx, perm, &scan,
+            cancellationHandle = std::move(cancellationHandle)](Id id) {
+      return idx.scan(id, std::nullopt, perm, scan.additionalColumns(),
+                      cancellationHandle);
+    };
+  };
   AD_CORRECTNESS_CHECK(scan.getResultWidth() == 3);
   return scanLambda(scan.permutation(), cancellationHandle_);
 }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -127,6 +127,7 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       signalQueryUpdate();
       ResultTable result = computeResult();
 
+      checkCancellation([this]() { return "After " + getDescriptor(); });
       // Compute the datatypes that occur in each column of the result.
       // Also assert, that if a column contains UNDEF values, then the
       // `mightContainUndef` flag for that columns is set.
@@ -136,7 +137,6 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       // change in the DEBUG builds.
       AD_EXPENSIVE_CHECK(
           result.checkDefinedness(getExternallyVisibleVariableColumns()));
-      checkCancellation([this]() { return "In " + getDescriptor(); });
       // Make sure that the results that are written to the cache have the
       // correct runtimeInfo. The children of the runtime info are already set
       // correctly because the result was computed, so we can pass `nullopt` as

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -28,7 +28,7 @@ class QueryExecutionTree;
 
 class Operation {
   using SharedCancellationHandle =
-      std::shared_ptr<ad_utility::CancellationHandle>;
+      std::shared_ptr<ad_utility::CancellationHandle<>>;
   using Milliseconds = std::chrono::milliseconds;
 
  public:

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -27,8 +27,7 @@
 class QueryExecutionTree;
 
 class Operation {
-  using SharedCancellationHandle =
-      std::shared_ptr<ad_utility::CancellationHandle<>>;
+  using SharedCancellationHandle = ad_utility::SharedCancellationHandle;
   using Milliseconds = std::chrono::milliseconds;
 
  public:

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -533,7 +533,6 @@ auto Server::setupCancellationHandle(
     const std::shared_ptr<Operation>& rootOperation, TimeLimit timeLimit) const
     -> ad_utility::InvocableWithExactReturnType<void> auto {
   auto cancellationHandle = queryRegistry_.getCancellationHandle(queryId);
-  cancellationHandle->startWatchDog();
   AD_CORRECTNESS_CHECK(cancellationHandle);
   rootOperation->recursivelySetCancellationHandle(
       std::move(cancellationHandle));

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -503,14 +503,14 @@ ad_utility::websocket::OwningQueryId Server::getQueryId(
 
 auto Server::cancelAfterDeadline(
     const net::any_io_executor& executor,
-    std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
+    std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
     TimeLimit timeLimit)
     -> ad_utility::InvocableWithExactReturnType<void> auto {
   auto strand = net::make_strand(executor);
   auto timer = std::make_shared<net::steady_timer>(strand, timeLimit);
 
   auto cancelAfterTimeout =
-      [](std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
+      [](std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
          std::shared_ptr<net::steady_timer> timer) -> net::awaitable<void> {
     // Ignore cancellation exceptions, they are normal
     co_await timer->async_wait(net::as_tuple(net::use_awaitable));
@@ -658,6 +658,8 @@ boost::asio::awaitable<void> Server::processQuery(
     // (tsv, csv, octet-stream, turtle).
     auto sendStreamableResponse = [&](MediaType mediaType) -> Awaitable<void> {
       auto responseGenerator = co_await computeInNewThread([&] {
+        queryRegistry_.getCancellationHandle(messageSender.getQueryId())
+            ->startWatchDog();
         return ExportQueryExecutionTrees::computeResultAsStream(
             plannedQuery.value().parsedQuery_, qet, mediaType);
       });

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -533,6 +533,7 @@ auto Server::setupCancellationHandle(
     const std::shared_ptr<Operation>& rootOperation, TimeLimit timeLimit) const
     -> ad_utility::InvocableWithExactReturnType<void> auto {
   auto cancellationHandle = queryRegistry_.getCancellationHandle(queryId);
+  cancellationHandle->startWatchDog();
   AD_CORRECTNESS_CHECK(cancellationHandle);
   rootOperation->recursivelySetCancellationHandle(
       std::move(cancellationHandle));

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -148,7 +148,7 @@ class Server {
   /// means or because the task has been completed successfully.
   static auto cancelAfterDeadline(
       const net::any_io_executor& executor,
-      std::weak_ptr<ad_utility::CancellationHandle> cancellationHandle,
+      std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
       TimeLimit timeLimit)
       -> ad_utility::InvocableWithExactReturnType<void> auto;
 

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -79,6 +79,9 @@ ResultTable Sort::computeResult() {
   runtimeInfo().addDetail("time-cloning", t.msecs());
   Engine::sort(idTable, sortColumnIndices_);
 
+  // Don't report missed timeout check because sort is not cancellable
+  cancellationHandle_->resetWatchDogState();
+
   LOG(DEBUG) << "Sort result computation done." << endl;
   return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocab()};
 }

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -187,6 +187,8 @@ static constexpr uint32_t PATTERNS_FILE_VERSION = 1;
 // compiler limits for the evaluation of constexpr functions and templates.
 static constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 
+constexpr std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{50};
+
 inline auto& RuntimeParameters() {
   using ad_utility::detail::parameterShortNames::Bool;
   using ad_utility::detail::parameterShortNames::Double;

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -187,6 +187,8 @@ static constexpr uint32_t PATTERNS_FILE_VERSION = 1;
 // compiler limits for the evaluation of constexpr functions and templates.
 static constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 
+// Interval in which an enabled watchdog would check if
+// `CancellationHandle::throwIfCancelled` is called regularly.
 constexpr std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{50};
 
 inline auto& RuntimeParameters() {

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -29,7 +29,8 @@ static auto getBeginAndEnd(auto& range) {
 CompressedRelationReader::IdTableGenerator
 CompressedRelationReader::asyncParallelBlockGenerator(
     auto beginBlock, auto endBlock, ColumnIndices columnIndices,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+    const {
   LazyScanMetadata& details = co_await cppcoro::getDetails;
   if (beginBlock == endBlock) {
     co_return;
@@ -93,7 +94,8 @@ CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
     CompressedRelationMetadata metadata, std::optional<Id> col1Id,
     std::vector<CompressedBlockMetadata> blockMetadata,
     ColumnIndices additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+    const {
   AD_CONTRACT_CHECK(cancellationHandle);
   auto relevantBlocks = getBlocksFromMetadata(metadata, col1Id, blockMetadata);
   auto [beginBlock, endBlock] = getBeginAndEnd(relevantBlocks);
@@ -292,7 +294,8 @@ IdTable CompressedRelationReader::scan(
     const CompressedRelationMetadata& metadata, std::optional<Id> col1Id,
     std::span<const CompressedBlockMetadata> blocks,
     ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+    const {
   auto columnIndices = prepareColumnIndices(col1Id, additionalColumns);
   IdTable result(columnIndices.size(), allocator_);
 

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -29,8 +29,7 @@ static auto getBeginAndEnd(auto& range) {
 CompressedRelationReader::IdTableGenerator
 CompressedRelationReader::asyncParallelBlockGenerator(
     auto beginBlock, auto endBlock, ColumnIndices columnIndices,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-    const {
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   LazyScanMetadata& details = co_await cppcoro::getDetails;
   if (beginBlock == endBlock) {
     co_return;
@@ -94,8 +93,7 @@ CompressedRelationReader::IdTableGenerator CompressedRelationReader::lazyScan(
     CompressedRelationMetadata metadata, std::optional<Id> col1Id,
     std::vector<CompressedBlockMetadata> blockMetadata,
     ColumnIndices additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-    const {
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   AD_CONTRACT_CHECK(cancellationHandle);
   auto relevantBlocks = getBlocksFromMetadata(metadata, col1Id, blockMetadata);
   auto [beginBlock, endBlock] = getBeginAndEnd(relevantBlocks);
@@ -294,8 +292,7 @@ IdTable CompressedRelationReader::scan(
     const CompressedRelationMetadata& metadata, std::optional<Id> col1Id,
     std::span<const CompressedBlockMetadata> blocks,
     ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-    const {
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   auto columnIndices = prepareColumnIndices(col1Id, additionalColumns);
   IdTable result(columnIndices.size(), allocator_);
 

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -421,20 +421,22 @@ class CompressedRelationReader {
    * The arguments `metadata`, `blocks`, and `file` must all be obtained from
    * The same `CompressedRelationWriter` (see below).
    */
-  IdTable scan(
-      const CompressedRelationMetadata& metadata, std::optional<Id> col1Id,
-      std::span<const CompressedBlockMetadata> blocks,
-      ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+  IdTable scan(const CompressedRelationMetadata& metadata,
+               std::optional<Id> col1Id,
+               std::span<const CompressedBlockMetadata> blocks,
+               ColumnIndicesRef additionalColumns,
+               std::shared_ptr<ad_utility::CancellationHandle<>>
+                   cancellationHandle) const;
 
   // Similar to `scan` (directly above), but the result of the scan is lazily
   // computed and returned as a generator of the single blocks that are scanned.
   // The blocks are guaranteed to be in order.
-  IdTableGenerator lazyScan(
-      CompressedRelationMetadata metadata, std::optional<Id> col1Id,
-      std::vector<CompressedBlockMetadata> blockMetadata,
-      ColumnIndices additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+  IdTableGenerator lazyScan(CompressedRelationMetadata metadata,
+                            std::optional<Id> col1Id,
+                            std::vector<CompressedBlockMetadata> blockMetadata,
+                            ColumnIndices additionalColumns,
+                            std::shared_ptr<ad_utility::CancellationHandle<>>
+                                cancellationHandle) const;
 
   // Only get the size of the result for a given permutation XYZ for a given X
   // and Y. This can be done by scanning one or two blocks. Note: The overload
@@ -526,11 +528,12 @@ class CompressedRelationReader {
   // multiple worker threads.
   IdTableGenerator asyncParallelBlockGenerator(
       auto beginBlock, auto endBlock, ColumnIndices columnIndices,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+      const;
 
   // A helper function to abstract away the timeout check:
   static void checkCancellation(
-      const std::shared_ptr<ad_utility::CancellationHandle>&
+      const std::shared_ptr<ad_utility::CancellationHandle<>>&
           cancellationHandle) {
     // Not really expensive but since this should be called
     // very often, try to avoid any extra checks.

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -425,18 +425,16 @@ class CompressedRelationReader {
                std::optional<Id> col1Id,
                std::span<const CompressedBlockMetadata> blocks,
                ColumnIndicesRef additionalColumns,
-               std::shared_ptr<ad_utility::CancellationHandle<>>
-                   cancellationHandle) const;
+               ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // Similar to `scan` (directly above), but the result of the scan is lazily
   // computed and returned as a generator of the single blocks that are scanned.
   // The blocks are guaranteed to be in order.
-  IdTableGenerator lazyScan(CompressedRelationMetadata metadata,
-                            std::optional<Id> col1Id,
-                            std::vector<CompressedBlockMetadata> blockMetadata,
-                            ColumnIndices additionalColumns,
-                            std::shared_ptr<ad_utility::CancellationHandle<>>
-                                cancellationHandle) const;
+  IdTableGenerator lazyScan(
+      CompressedRelationMetadata metadata, std::optional<Id> col1Id,
+      std::vector<CompressedBlockMetadata> blockMetadata,
+      ColumnIndices additionalColumns,
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // Only get the size of the result for a given permutation XYZ for a given X
   // and Y. This can be done by scanning one or two blocks. Note: The overload
@@ -528,13 +526,11 @@ class CompressedRelationReader {
   // multiple worker threads.
   IdTableGenerator asyncParallelBlockGenerator(
       auto beginBlock, auto endBlock, ColumnIndices columnIndices,
-      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-      const;
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // A helper function to abstract away the timeout check:
   static void checkCancellation(
-      const std::shared_ptr<ad_utility::CancellationHandle<>>&
-          cancellationHandle) {
+      const ad_utility::SharedCancellationHandle& cancellationHandle) {
     // Not really expensive but since this should be called
     // very often, try to avoid any extra checks.
     AD_EXPENSIVE_CHECK(cancellationHandle);

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -310,17 +310,16 @@ IdTable Index::scan(
     const TripleComponent& col0String,
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-    const {
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   return pimpl_->scan(col0String, col1String, p, additionalColumns,
                       std::move(cancellationHandle));
 }
 
 // ____________________________________________________________________________
-IdTable Index::scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-                    Permutation::ColumnIndicesRef additionalColumns,
-                    std::shared_ptr<ad_utility::CancellationHandle<>>
-                        cancellationHandle) const {
+IdTable Index::scan(
+    Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+    Permutation::ColumnIndicesRef additionalColumns,
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   return pimpl_->scan(col0Id, col1Id, p, additionalColumns,
                       std::move(cancellationHandle));
 }

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -310,16 +310,17 @@ IdTable Index::scan(
     const TripleComponent& col0String,
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+    const {
   return pimpl_->scan(col0String, col1String, p, additionalColumns,
                       std::move(cancellationHandle));
 }
 
 // ____________________________________________________________________________
-IdTable Index::scan(
-    Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-    Permutation::ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+IdTable Index::scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+                    Permutation::ColumnIndicesRef additionalColumns,
+                    std::shared_ptr<ad_utility::CancellationHandle<>>
+                        cancellationHandle) const {
   return pimpl_->scan(col0Id, col1Id, p, additionalColumns,
                       std::move(cancellationHandle));
 }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -266,13 +266,14 @@ class Index {
       const TripleComponent& col0String,
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+      const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
-  IdTable scan(
-      Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-      Permutation::ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+  IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+               Permutation::ColumnIndicesRef additionalColumns,
+               std::shared_ptr<ad_utility::CancellationHandle<>>
+                   cancellationHandle) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
   // the scan result.

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -266,14 +266,12 @@ class Index {
       const TripleComponent& col0String,
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-      const;
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
   IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
-               std::shared_ptr<ad_utility::CancellationHandle<>>
-                   cancellationHandle) const;
+               ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
   // the scan result.

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1378,7 +1378,8 @@ IdTable IndexImpl::scan(
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     const Permutation::Enum& permutation,
     Permutation::ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+    const {
   std::optional<Id> col0Id = col0String.toValueId(getVocab());
   std::optional<Id> col1Id =
       col1String.has_value() ? col1String.value().get().toValueId(getVocab())
@@ -1391,10 +1392,11 @@ IdTable IndexImpl::scan(
               std::move(cancellationHandle));
 }
 // _____________________________________________________________________________
-IdTable IndexImpl::scan(
-    Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-    Permutation::ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+IdTable IndexImpl::scan(Id col0Id, std::optional<Id> col1Id,
+                        Permutation::Enum p,
+                        Permutation::ColumnIndicesRef additionalColumns,
+                        std::shared_ptr<ad_utility::CancellationHandle<>>
+                            cancellationHandle) const {
   return getPermutation(p).scan(col0Id, col1Id, additionalColumns,
                                 std::move(cancellationHandle));
 }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1378,8 +1378,7 @@ IdTable IndexImpl::scan(
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     const Permutation::Enum& permutation,
     Permutation::ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-    const {
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   std::optional<Id> col0Id = col0String.toValueId(getVocab());
   std::optional<Id> col1Id =
       col1String.has_value() ? col1String.value().get().toValueId(getVocab())
@@ -1392,11 +1391,10 @@ IdTable IndexImpl::scan(
               std::move(cancellationHandle));
 }
 // _____________________________________________________________________________
-IdTable IndexImpl::scan(Id col0Id, std::optional<Id> col1Id,
-                        Permutation::Enum p,
-                        Permutation::ColumnIndicesRef additionalColumns,
-                        std::shared_ptr<ad_utility::CancellationHandle<>>
-                            cancellationHandle) const {
+IdTable IndexImpl::scan(
+    Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+    Permutation::ColumnIndicesRef additionalColumns,
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   return getPermutation(p).scan(col0Id, col1Id, additionalColumns,
                                 std::move(cancellationHandle));
 }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -406,13 +406,14 @@ class IndexImpl {
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       const Permutation::Enum& permutation,
       Permutation::ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+      const;
 
   // _____________________________________________________________________________
-  IdTable scan(
-      Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-      Permutation::ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+  IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+               Permutation::ColumnIndicesRef additionalColumns,
+               std::shared_ptr<ad_utility::CancellationHandle<>>
+                   cancellationHandle) const;
 
   // _____________________________________________________________________________
   size_t getResultSizeOfScan(const TripleComponent& col0,

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -406,14 +406,12 @@ class IndexImpl {
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       const Permutation::Enum& permutation,
       Permutation::ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-      const;
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // _____________________________________________________________________________
   IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
-               std::shared_ptr<ad_utility::CancellationHandle<>>
-                   cancellationHandle) const;
+               ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // _____________________________________________________________________________
   size_t getResultSizeOfScan(const TripleComponent& col0,

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -39,10 +39,9 @@ void Permutation::loadFromDisk(const std::string& onDiskBase) {
 }
 
 // _____________________________________________________________________
-IdTable Permutation::scan(Id col0Id, std::optional<Id> col1Id,
-                          ColumnIndicesRef additionalColumns,
-                          std::shared_ptr<ad_utility::CancellationHandle<>>
-                              cancellationHandle) const {
+IdTable Permutation::scan(
+    Id col0Id, std::optional<Id> col1Id, ColumnIndicesRef additionalColumns,
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   if (!isLoaded_) {
     throw std::runtime_error("This query requires the permutation " +
                              readableName_ + ", which was not loaded");
@@ -131,8 +130,7 @@ Permutation::IdTableGenerator Permutation::lazyScan(
     Id col0Id, std::optional<Id> col1Id,
     std::optional<std::vector<CompressedBlockMetadata>> blocks,
     ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-    const {
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
   if (!meta_.col0IdExists(col0Id)) {
     return {};
   }

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -39,9 +39,10 @@ void Permutation::loadFromDisk(const std::string& onDiskBase) {
 }
 
 // _____________________________________________________________________
-IdTable Permutation::scan(
-    Id col0Id, std::optional<Id> col1Id, ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+IdTable Permutation::scan(Id col0Id, std::optional<Id> col1Id,
+                          ColumnIndicesRef additionalColumns,
+                          std::shared_ptr<ad_utility::CancellationHandle<>>
+                              cancellationHandle) const {
   if (!isLoaded_) {
     throw std::runtime_error("This query requires the permutation " +
                              readableName_ + ", which was not loaded");
@@ -130,7 +131,8 @@ Permutation::IdTableGenerator Permutation::lazyScan(
     Id col0Id, std::optional<Id> col1Id,
     std::optional<std::vector<CompressedBlockMetadata>> blocks,
     ColumnIndicesRef additionalColumns,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const {
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+    const {
   if (!meta_.col0IdExists(col0Id)) {
     return {};
   }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -55,8 +55,7 @@ class Permutation {
   // `CompressedRelationMetaData::scan`.
   IdTable scan(Id col0Id, std::optional<Id> col1Id,
                ColumnIndicesRef additionalColumns,
-               std::shared_ptr<ad_utility::CancellationHandle<>>
-                   cancellationHandle) const;
+               ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks = CompressedRelationReader::MetadataAndBlocks;
@@ -79,8 +78,7 @@ class Permutation {
       Id col0Id, std::optional<Id> col1Id,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
-      const;
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // Return the metadata for the relation specified by the `col0Id`
   // along with the metadata for all the blocks that contain this relation (also

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -53,9 +53,10 @@ class Permutation {
   // If `col1Id` is specified, only the col2 is returned for triples that
   // additionally have the specified col1. .This is just a thin wrapper around
   // `CompressedRelationMetaData::scan`.
-  IdTable scan(
-      Id col0Id, std::optional<Id> col1Id, ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+  IdTable scan(Id col0Id, std::optional<Id> col1Id,
+               ColumnIndicesRef additionalColumns,
+               std::shared_ptr<ad_utility::CancellationHandle<>>
+                   cancellationHandle) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks = CompressedRelationReader::MetadataAndBlocks;
@@ -78,7 +79,8 @@ class Permutation {
       Id col0Id, std::optional<Id> col1Id,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns,
-      std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle) const;
+      std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle)
+      const;
 
   // Return the metadata for the relation specified by the `col0Id`
   // along with the metadata for all the blocks that contain this relation (also

--- a/src/index/PermutationExporterMain.cpp
+++ b/src/index/PermutationExporterMain.cpp
@@ -14,7 +14,7 @@ void dumpToStdout(const Permutation& permutation) {
       ad_utility::makeAllocationMemoryLeftThreadsafeObject(
           ad_utility::MemorySize::max())};
   auto triples = TriplesView(
-      permutation, std::make_shared<ad_utility::CancellationHandle>());
+      permutation, std::make_shared<ad_utility::CancellationHandle<>>());
   size_t i = 0;
   for (auto triple : triples) {
     std::cout << triple[0] << " " << triple[1] << " " << triple[2] << std::endl;

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -34,7 +34,7 @@ inline auto alwaysReturnFalse = [](auto&&...) { return false; };
 template <typename IsTripleIgnored = decltype(detail::alwaysReturnFalse)>
 cppcoro::generator<std::array<Id, 3>> TriplesView(
     const auto& permutation,
-    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
+    ad_utility::SharedCancellationHandle cancellationHandle,
     detail::IgnoredRelations ignoredRanges = {},
     IsTripleIgnored isTripleIgnored = IsTripleIgnored{}) {
   std::sort(ignoredRanges.begin(), ignoredRanges.end());

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -34,7 +34,7 @@ inline auto alwaysReturnFalse = [](auto&&...) { return false; };
 template <typename IsTripleIgnored = decltype(detail::alwaysReturnFalse)>
 cppcoro::generator<std::array<Id, 3>> TriplesView(
     const auto& permutation,
-    std::shared_ptr<ad_utility::CancellationHandle> cancellationHandle,
+    std::shared_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
     detail::IgnoredRelations ignoredRanges = {},
     IsTripleIgnored isTripleIgnored = IsTripleIgnored{}) {
   std::sort(ignoredRanges.begin(), ignoredRanges.end());

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -53,14 +53,11 @@ void CancellationHandle<WatchDogEnabled>::startWatchDog() {
 template <bool WatchDogEnabled>
 void CancellationHandle<WatchDogEnabled>::setStatePreservingCancel(
     CancellationState newState) {
-  if constexpr (WatchDogEnabled) {
-    CancellationState state =
-        cancellationState_.load(std::memory_order_relaxed);
-    while (!detail::isCancelled(state)) {
-      if (cancellationState_.compare_exchange_weak(state, newState,
-                                                   std::memory_order_relaxed)) {
-        break;
-      }
+  CancellationState state = cancellationState_.load(std::memory_order_relaxed);
+  while (!detail::isCancelled(state)) {
+    if (cancellationState_.compare_exchange_weak(state, newState,
+                                                 std::memory_order_relaxed)) {
+      break;
     }
   }
 }
@@ -95,5 +92,6 @@ CancellationHandle<WatchDogEnabled>::computeCheckMissDuration() const
 }
 
 // Make sure to compile correctly.
-template class CancellationHandle<areExpensiveChecksEnabled>;
+template class CancellationHandle<true>;
+template class CancellationHandle<false>;
 }  // namespace ad_utility

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -54,12 +54,10 @@ template <bool WatchDogEnabled>
 void CancellationHandle<WatchDogEnabled>::setStatePreservingCancel(
     CancellationState newState) {
   CancellationState state = cancellationState_.load(std::memory_order_relaxed);
-  while (!detail::isCancelled(state)) {
-    if (cancellationState_.compare_exchange_weak(state, newState,
-                                                 std::memory_order_relaxed)) {
-      break;
-    }
-  }
+  while (!detail::isCancelled(state) &&
+         !cancellationState_.compare_exchange_weak(state, newState,
+                                                   std::memory_order_relaxed))
+    ;
 }
 
 // _____________________________________________________________________________

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -66,7 +66,7 @@ void CancellationHandle<WatchDogEnabled>::setStatePreservingCancel(
 template <bool WatchDogEnabled>
 void CancellationHandle<WatchDogEnabled>::resetWatchDogState() {
   if constexpr (WatchDogEnabled) {
-    setStatePreservingCancel(CancellationState::WAITING_FOR_CHECK);
+    setStatePreservingCancel(CancellationState::NOT_CANCELLED);
   }
 }
 

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -8,11 +8,58 @@
 
 namespace ad_utility {
 
-void CancellationHandle::cancel(CancellationState reason) {
-  AD_CONTRACT_CHECK(reason != CancellationState::NOT_CANCELLED);
+template <bool WatchDogEnabled>
+void CancellationHandle<WatchDogEnabled>::cancel(CancellationState reason) {
+  AD_CONTRACT_CHECK(detail::isCancelled(reason));
 
-  CancellationState notAborted = CancellationState::NOT_CANCELLED;
-  cancellationState_.compare_exchange_strong(notAborted, reason,
-                                             std::memory_order_relaxed);
+  CancellationState state = cancellationState_.load(std::memory_order_relaxed);
+  while (!detail::isCancelled(state)) {
+    if (cancellationState_.compare_exchange_weak(state, reason,
+                                                 std::memory_order_relaxed)) {
+      break;
+    }
+  }
 }
+
+// _____________________________________________________________________________
+template <bool WatchDogEnabled>
+void CancellationHandle<WatchDogEnabled>::startWatchDogInternal()
+    requires WatchDogEnabled {
+  // Setting the atomic here does synchronize memory for assignment,
+  // so this is safe without a mutex
+  bool running = watchDogRunning_.exchange(true);
+  AD_CONTRACT_CHECK(!running);
+  watchDogThread_ = ad_utility::JThread{[this]() {
+    while (watchDogRunning_.load(std::memory_order_relaxed)) {
+      auto state = cancellationState_.load(std::memory_order_relaxed);
+      if (state == CancellationState::NOT_CANCELLED) {
+        cancellationState_.compare_exchange_strong(
+            state, CancellationState::WAITING_FOR_CHECK);
+      } else if (state == CancellationState::WAITING_FOR_CHECK) {
+        cancellationState_.compare_exchange_strong(
+            state, CancellationState::CHECK_WINDOW_MISSED);
+      }
+      std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);
+    }
+  }};
+}
+
+// _____________________________________________________________________________
+template <bool WatchDogEnabled>
+void CancellationHandle<WatchDogEnabled>::startWatchDog() {
+  if constexpr (WatchDogEnabled) {
+    startWatchDogInternal();
+  }
+}
+
+// _____________________________________________________________________________
+template <bool WatchDogEnabled>
+CancellationHandle<WatchDogEnabled>::~CancellationHandle() {
+  if constexpr (WatchDogEnabled) {
+    watchDogRunning_.store(false, std::memory_order_relaxed);
+  }
+}
+
+// Make sure to compile correctly.
+template class CancellationHandle<areExpensiveChecksEnabled>;
 }  // namespace ad_utility

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -54,10 +54,12 @@ template <bool WatchDogEnabled>
 void CancellationHandle<WatchDogEnabled>::setStatePreservingCancel(
     CancellationState newState) {
   CancellationState state = cancellationState_.load(std::memory_order_relaxed);
-  while (!detail::isCancelled(state) &&
-         !cancellationState_.compare_exchange_weak(state, newState,
-                                                   std::memory_order_relaxed))
-    ;
+  while (!detail::isCancelled(state)) {
+    if (cancellationState_.compare_exchange_weak(state, newState,
+                                                 std::memory_order_relaxed)) {
+      break;
+    }
+  }
 }
 
 // _____________________________________________________________________________

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -33,7 +33,7 @@ void CancellationHandle<WatchDogEnabled>::startWatchDogInternal()
       } else if (state == WAITING_FOR_CHECK) {
         if (cancellationState_.compare_exchange_strong(state,
                                                        CHECK_WINDOW_MISSED)) {
-          startTimeoutWindow_ = std::chrono::steady_clock::now();
+          startTimeoutWindow_ = steady_clock::now();
         }
       }
       std::this_thread::sleep_for(DESIRED_CANCELLATION_CHECK_INTERVAL);

--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -36,7 +36,7 @@ void CancellationHandle<WatchDogEnabled>::startWatchDogInternal()
               std::chrono::steady_clock::now().time_since_epoch().count();
         }
       }
-      std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);
+      std::this_thread::sleep_for(DESIRED_CANCELLATION_CHECK_INTERVAL);
     }
   }};
 }

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -168,6 +168,7 @@ class CancellationHandle {
   FRIEND_TEST(CancellationHandle, verifyCheckDoesNotOverrideCancelledState);
   FRIEND_TEST(CancellationHandle,
               verifyCheckAfterDeadlineMissDoesReportProperly);
+  FRIEND_TEST(CancellationHandle, verifyWatchDogDoesNotChangeStateAfterCancel);
 };
 
 using SharedCancellationHandle = std::shared_ptr<CancellationHandle<>>;

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -76,7 +76,8 @@ class CancellationHandle {
   using WatchDogOnly = std::conditional_t<WatchDogEnabled, T, detail::Empty>;
   [[no_unique_address]] WatchDogOnly<std::atomic_bool> watchDogRunning_{false};
   [[no_unique_address]] WatchDogOnly<ad_utility::JThread> watchDogThread_;
-  [[no_unique_address]] WatchDogOnly<std::chrono::steady_clock::rep>
+  [[no_unique_address]] WatchDogOnly<
+      std::atomic<std::chrono::steady_clock::rep>>
       startTimeoutWindow_{0};
 
   template <typename... ArgTypes>

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -31,6 +31,17 @@ enum class CancellationState {
 
 namespace detail {
 
+#if !defined(QLEVER_DISABLE_QUERY_CANCELLATION_WATCH_DO) && LOGLEVEL >= WARN
+constexpr bool ENABLE_QUERY_CANCELLATION_WATCH_DOG = true;
+#else
+#if LOGLEVEL < WARN
+#warning \
+    "QLEVER_ENABLE_QUERY_CANCELLATION_WATCH_DOG is ignored if WARN logging \
+level is disabled"
+#endif
+constexpr bool ENABLE_QUERY_CANCELLATION_WATCH_DOG = false;
+#endif
+
 AD_ALWAYS_INLINE constexpr bool isCancelled(
     CancellationState cancellationState) {
   using enum CancellationState;
@@ -67,7 +78,7 @@ static_assert(std::atomic<CancellationState>::is_always_lock_free);
 
 /// Thread safe wrapper around an atomic variable, providing efficient
 /// checks for cancellation across threads.
-template <bool WatchDogEnabled = areExpensiveChecksEnabled>
+template <bool WatchDogEnabled = detail::ENABLE_QUERY_CANCELLATION_WATCH_DOG>
 class CancellationHandle {
   std::atomic<CancellationState> cancellationState_ =
       CancellationState::NOT_CANCELLED;

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -91,7 +91,7 @@ class CancellationHandle {
   template <typename T>
   using WatchDogOnly = std::conditional_t<WatchDogEnabled, T, detail::Empty>;
   // TODO<Clang18> Use std::jthread and its builtin stop_token.
-  [[no_unique_address]] WatchDogOnly<std::atomic_bool> watchDogRunning_{true};
+  [[no_unique_address]] WatchDogOnly<std::atomic_bool> watchDogRunning_{false};
   [[no_unique_address]] WatchDogOnly<ad_utility::JThread> watchDogThread_;
   [[no_unique_address]] WatchDogOnly<std::atomic<steady_clock::time_point>>
       startTimeoutWindow_{steady_clock::now()};
@@ -124,25 +124,14 @@ class CancellationHandle {
         state, CancellationState::NOT_CANCELLED, std::memory_order_relaxed);
   }
 
-  /// Internal function that creates and starts the watch dog. It will set this
+  /// Internal function that starts the watch dog. It will set this
   /// `CancellationHandle` instance into a state that will log a warning in the
   /// console if `throwIfCancelled` is not called frequently enough.
-  ad_utility::JThread createWatchDogInternal() requires WatchDogEnabled;
-
-  /// Create a `ad_utility::JThread` representing the watch dog thread. If
-  /// `WatchDogEnabled` is false, this will return a default-initialized
-  /// instance that does nothing.
-  ad_utility::JThread createWatchDog();
+  void startWatchDogInternal() requires WatchDogEnabled;
 
   /// Helper function that sets the internal state atomically given that it has
   /// not been cancelled yet. Otherwise no-op.
   void setStatePreservingCancel(CancellationState newState);
-
-  /// Constructor exposed for testing to allow to test this class without
-  /// interference of a watchdog thread that runs in the background.
-  explicit CancellationHandle(ad_utility::JThread&& watchDogThread)
-      requires WatchDogEnabled
-      : watchDogThread_{std::move(watchDogThread)} {}
 
  public:
   /// Sets the cancellation flag so the next call to throwIfCancelled will
@@ -190,17 +179,17 @@ class CancellationHandle {
         cancellationState_.load(std::memory_order_relaxed));
   }
 
+  /// Start the watch dog. Must only be called once per `CancellationHandle`
+  /// instance.
+  void startWatchDog();
+
   /// If this `CancellationHandle` is not cancelled, reset the internal
   /// `cancellationState_` to `CancellationState::NOT_CANCELED`.
   /// Useful to ignore expected gaps in the execution flow.
   void resetWatchDogState();
 
-  /// Default constructor that starts a watch dog thread in the background.
-  /// Note that if `WatchDogEnabled` is false, this will create and destroy
-  /// a default-initialized `ad_utility::JThread` without storing it somewhere.
-  CancellationHandle() : watchDogThread_{createWatchDog()} {}
-
-  // Explicitly delete the copy and move operations
+  // Explicit move-semantics
+  CancellationHandle() = default;
   CancellationHandle(const CancellationHandle&) = delete;
   CancellationHandle& operator=(const CancellationHandle&) = delete;
   ~CancellationHandle();

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -99,6 +99,8 @@ class CancellationHandle {
 
   void startWatchDogInternal() requires WatchDogEnabled;
 
+  void setStatePreservingCancel(CancellationState newState);
+
  public:
   /// Sets the cancellation flag so the next call to throwIfCancelled will throw
   void cancel(CancellationState reason);
@@ -144,6 +146,8 @@ class CancellationHandle {
   }
 
   void startWatchDog();
+
+  void resetWatchDogState();
 
   ~CancellationHandle();
 };

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -97,9 +97,10 @@ class CancellationHandle {
     cancellationState_.compare_exchange_strong(
         state, CancellationState::NOT_CANCELLED, std::memory_order_relaxed);
   }
+  using DurationType =
+      std::remove_const_t<decltype(detail::DESIRED_CHECK_INTERVAL)>;
 
-  decltype(detail::DESIRED_CHECK_INTERVAL) computeCheckMissDuration() const
-      requires WatchDogEnabled;
+  DurationType computeCheckMissDuration() const requires WatchDogEnabled;
 
   void startWatchDogInternal() requires WatchDogEnabled;
 
@@ -153,6 +154,9 @@ class CancellationHandle {
 
   void resetWatchDogState();
 
+  CancellationHandle() = default;
+  CancellationHandle(const CancellationHandle&) = delete;
+  CancellationHandle& operator=(const CancellationHandle&) = delete;
   ~CancellationHandle();
 
   FRIEND_TEST(CancellationHandle, verifyWatchDogDoesChangeState);

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <type_traits>
 
+#include "global/Constants.h"
 #include "util/CompilerExtensions.h"
 #include "util/Exception.h"
 #include "util/Log.h"
@@ -29,8 +30,6 @@ enum class CancellationState {
 };
 
 namespace detail {
-
-constexpr std::chrono::milliseconds DESIRED_CHECK_INTERVAL{50};
 
 AD_ALWAYS_INLINE constexpr bool isCancelled(
     CancellationState cancellationState) {
@@ -88,8 +87,9 @@ class CancellationHandle {
     AD_CORRECTNESS_CHECK(watchDogRunning_.load(std::memory_order_relaxed));
     if (state == CancellationState::CHECK_WINDOW_MISSED) {
       LOG(WARN) << "Cancellation check missed deadline of "
-                << ParseableDuration{detail::DESIRED_CHECK_INTERVAL} << " by "
-                << ParseableDuration{computeCheckMissDuration()} << ". Stage: "
+                << ParseableDuration{DESIRED_CANCELLATION_CHECK_INTERVAL}
+                << " by " << ParseableDuration{computeCheckMissDuration()}
+                << ". Stage: "
                 << std::invoke(detailSupplier, AD_FWD(argTypes)...)
                 << std::endl;
     }
@@ -97,8 +97,9 @@ class CancellationHandle {
     cancellationState_.compare_exchange_strong(
         state, CancellationState::NOT_CANCELLED, std::memory_order_relaxed);
   }
+
   using DurationType =
-      std::remove_const_t<decltype(detail::DESIRED_CHECK_INTERVAL)>;
+      std::remove_const_t<decltype(DESIRED_CANCELLATION_CHECK_INTERVAL)>;
 
   DurationType computeCheckMissDuration() const requires WatchDogEnabled;
 

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -156,6 +156,8 @@ class CancellationHandle {
 
   ~CancellationHandle();
 };
+
+using SharedCancellationHandle = std::shared_ptr<CancellationHandle<>>;
 }  // namespace ad_utility
 
 #endif  // QLEVER_CANCELLATIONHANDLE_H

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -191,7 +191,9 @@ class CancellationHandle {
   }
 
   /// Start the watch dog. Must only be called once per `CancellationHandle`
-  /// instance.
+  /// instance. This allows the constructor to be used to cheaply
+  /// default-initialize an instance of this class (as dummy non-null pointer
+  /// for example).
   void startWatchDog();
 
   /// If this `CancellationHandle` is not cancelled, reset the internal

--- a/src/util/http/websocket/QueryId.h
+++ b/src/util/http/websocket/QueryId.h
@@ -70,7 +70,6 @@ static_assert(!std::is_copy_assignable_v<OwningQueryId>);
 
 /// A factory class to create unique query ids within each individual instance.
 class QueryRegistry {
-  using SharedCancellationHandle = std::shared_ptr<CancellationHandle<>>;
   using SynchronizedType = ad_utility::Synchronized<
       ad_utility::HashMap<QueryId, SharedCancellationHandle>>;
   // Technically no shared pointer is required because the registry lives

--- a/src/util/http/websocket/QueryId.h
+++ b/src/util/http/websocket/QueryId.h
@@ -70,7 +70,7 @@ static_assert(!std::is_copy_assignable_v<OwningQueryId>);
 
 /// A factory class to create unique query ids within each individual instance.
 class QueryRegistry {
-  using SharedCancellationHandle = std::shared_ptr<CancellationHandle>;
+  using SharedCancellationHandle = std::shared_ptr<CancellationHandle<>>;
   using SynchronizedType = ad_utility::Synchronized<
       ad_utility::HashMap<QueryId, SharedCancellationHandle>>;
   // Technically no shared pointer is required because the registry lives
@@ -92,7 +92,7 @@ class QueryRegistry {
     auto queryId = QueryId::idFromString(std::move(id));
     bool success =
         registry_->wlock()
-            ->emplace(queryId, std::make_shared<CancellationHandle>())
+            ->emplace(queryId, std::make_shared<CancellationHandle<>>())
             .second;
     if (success) {
       // Avoid undefined behavior when the registry is no longer alive at the

--- a/src/util/jthread.h
+++ b/src/util/jthread.h
@@ -24,7 +24,7 @@ struct JThread : public std::thread {
     if (joinable()) {
       join();
     }
-    Base::operator=(std::forward<JThread>(other));
+    Base::operator=(std::move(other));
     return *this;
   }
   ~JThread() {

--- a/src/util/jthread.h
+++ b/src/util/jthread.h
@@ -15,11 +15,18 @@ struct JThread : public std::thread {
 #ifdef __cpp_lib_jthread
   static_assert(false,
                 "std::jthread is now supported by libc++, get rid of "
-                "ad_utility::Jthread");
+                "ad_utility::JThread");
 #endif
   using Base = std::thread;
   using Base::Base;
   JThread(JThread&&) noexcept = default;
+  JThread& operator=(JThread&& other) noexcept {
+    if (joinable()) {
+      join();
+    }
+    Base::operator=(std::forward<JThread>(other));
+    return *this;
+  }
   ~JThread() {
     if (joinable()) {
       join();

--- a/src/util/jthread.h
+++ b/src/util/jthread.h
@@ -20,13 +20,6 @@ struct JThread : public std::thread {
   using Base = std::thread;
   using Base::Base;
   JThread(JThread&&) noexcept = default;
-  JThread& operator=(JThread&& other) noexcept {
-    if (joinable()) {
-      join();
-    }
-    Base::operator=(std::move(other));
-    return *this;
-  }
   ~JThread() {
     if (joinable()) {
       join();

--- a/src/util/jthread.h
+++ b/src/util/jthread.h
@@ -20,6 +20,13 @@ struct JThread : public std::thread {
   using Base = std::thread;
   using Base::Base;
   JThread(JThread&&) noexcept = default;
+  JThread& operator=(JThread&& other) noexcept {
+    if (joinable()) {
+      join();
+    }
+    Base::operator=(std::move(other));
+    return *this;
+  }
   ~JThread() {
     if (joinable()) {
       join();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -381,3 +381,5 @@ addLinkAndDiscoverTest(ParallelMultiwayMergeTest)
 addLinkAndDiscoverTest(ParseableDurationTest)
 
 addLinkAndDiscoverTest(ConstantsTest)
+
+addLinkAndDiscoverTest(JThreadTest)

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -261,8 +261,7 @@ TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
   std::ostringstream testStream;
   choice.setStream(&testStream);
 
-  handle.startTimeoutWindow_ =
-      std::chrono::steady_clock::now().time_since_epoch().count();
+  handle.startTimeoutWindow_ = std::chrono::steady_clock::now();
   handle.cancellationState_ = CHECK_WINDOW_MISSED;
   EXPECT_NO_THROW(handle.throwIfCancelled("my-detail"));
   EXPECT_EQ(handle.cancellationState_, NOT_CANCELLED);

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -140,7 +140,7 @@ TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
   std::this_thread::sleep_for(10ms);
   EXPECT_EQ(handle.cancellationState_, WAITING_FOR_CHECK);
 
-  std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);
+  std::this_thread::sleep_for(DESIRED_CANCELLATION_CHECK_INTERVAL);
   EXPECT_EQ(handle.cancellationState_, CHECK_WINDOW_MISSED);
 }
 
@@ -157,11 +157,11 @@ TEST(CancellationHandle, verifyWatchDogDoesNotChangeStateAfterCancel) {
   std::this_thread::sleep_for(10ms);
 
   handle.cancellationState_ = MANUAL;
-  std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);
+  std::this_thread::sleep_for(DESIRED_CANCELLATION_CHECK_INTERVAL);
   EXPECT_EQ(handle.cancellationState_, MANUAL);
 
   handle.cancellationState_ = TIMEOUT;
-  std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);
+  std::this_thread::sleep_for(DESIRED_CANCELLATION_CHECK_INTERVAL);
   EXPECT_EQ(handle.cancellationState_, TIMEOUT);
 }
 
@@ -270,8 +270,8 @@ TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
   EXPECT_THAT(
       std::move(testStream).str(),
       AllOf(HasSubstr("my-detail"),
-            HasSubstr(
-                ParseableDuration{detail::DESIRED_CHECK_INTERVAL}.toString()),
+            HasSubstr(ParseableDuration{DESIRED_CANCELLATION_CHECK_INTERVAL}
+                          .toString()),
             // Check for small miss window
             ContainsRegex("by [0-9]ms")));
 }

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -119,6 +119,12 @@ TYPED_TEST(CancellationHandleFixture,
 
 // _____________________________________________________________________________
 
+TEST(CancellationHandle, ensureObjectLifetimeIsValidWithoutWatchDogStarted) {
+  EXPECT_NO_THROW(CancellationHandle<true>{});
+}
+
+// _____________________________________________________________________________
+
 namespace ad_utility {
 
 TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
@@ -126,6 +132,9 @@ TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
   GTEST_SKIP_("sleep_for is unreliable for macos builds");
 #endif
   CancellationHandle<true> handle;
+
+  EXPECT_EQ(handle.cancellationState_, NOT_CANCELLED);
+  handle.startWatchDog();
 
   // Give thread some time to start
   std::this_thread::sleep_for(10ms);
@@ -142,6 +151,7 @@ TEST(CancellationHandle, verifyWatchDogDoesNotChangeStateAfterCancel) {
   GTEST_SKIP_("sleep_for is unreliable for macos builds");
 #endif
   CancellationHandle<true> handle;
+  handle.startWatchDog();
 
   // Give thread some time to start
   std::this_thread::sleep_for(10ms);
@@ -158,7 +168,7 @@ TEST(CancellationHandle, verifyWatchDogDoesNotChangeStateAfterCancel) {
 // _____________________________________________________________________________
 
 TEST(CancellationHandle, verifyResetWatchDogStateDoesProperlyResetState) {
-  CancellationHandle<true> handle{{}};
+  CancellationHandle<true> handle;
 
   handle.cancellationState_ = NOT_CANCELLED;
   handle.resetWatchDogState();
@@ -210,7 +220,9 @@ TEST(CancellationHandle, verifyResetWatchDogStateIsNoOpWithoutWatchDog) {
 // _____________________________________________________________________________
 
 TEST(CancellationHandle, verifyCheckDoesPleaseWatchDog) {
-  CancellationHandle<true> handle{{}};
+  CancellationHandle<true> handle;
+  // Because watch dog operates async, simulate it here for stable tests.
+  handle.watchDogRunning_ = true;
 
   handle.cancellationState_ = WAITING_FOR_CHECK;
   EXPECT_NO_THROW(handle.throwIfCancelled(""));
@@ -224,7 +236,7 @@ TEST(CancellationHandle, verifyCheckDoesPleaseWatchDog) {
 // _____________________________________________________________________________
 
 TEST(CancellationHandle, verifyCheckDoesNotOverrideCancelledState) {
-  CancellationHandle<true> handle{{}};
+  CancellationHandle<true> handle;
 
   handle.cancellationState_ = MANUAL;
   EXPECT_THROW(handle.throwIfCancelled(""), CancellationException);
@@ -239,7 +251,9 @@ TEST(CancellationHandle, verifyCheckDoesNotOverrideCancelledState) {
 
 TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
   auto& choice = ad_utility::LogstreamChoice::get();
-  CancellationHandle<true> handle{{}};
+  CancellationHandle<true> handle;
+  // Because watch dog operates async, simulate it here for stable tests.
+  handle.watchDogRunning_ = true;
 
   auto& originalOStream = choice.getStream();
   absl::Cleanup cleanup{[&]() { choice.setStream(&originalOStream); }};
@@ -260,4 +274,11 @@ TEST(CancellationHandle, verifyCheckAfterDeadlineMissDoesReportProperly) {
             // Check for small miss window
             ContainsRegex("by [0-9]ms")));
 }
+
+// Make sure member functions still exist when no watch dog functionality
+// is available to make the code simpler. In this case the functions should
+// be no-op.
+static_assert(std::is_member_function_pointer_v<
+              decltype(&CancellationHandle<false>::startWatchDog)>);
+
 }  // namespace ad_utility

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -149,18 +149,15 @@ TEST(CancellationHandle, verifyResetWatchDogStateDoesProperlyResetState) {
 
   handle.cancellationState_ = CancellationState::NOT_CANCELLED;
   handle.resetWatchDogState();
-  // Technically NOT_CANCELLED would be valid behaviour too, but it would
-  // make the code slightly longer, so we just always set it to this state
-  // if it's not cancelled.
-  EXPECT_EQ(handle.cancellationState_, CancellationState::WAITING_FOR_CHECK);
+  EXPECT_EQ(handle.cancellationState_, CancellationState::NOT_CANCELLED);
 
   handle.cancellationState_ = CancellationState::WAITING_FOR_CHECK;
   handle.resetWatchDogState();
-  EXPECT_EQ(handle.cancellationState_, CancellationState::WAITING_FOR_CHECK);
+  EXPECT_EQ(handle.cancellationState_, CancellationState::NOT_CANCELLED);
 
   handle.cancellationState_ = CancellationState::CHECK_WINDOW_MISSED;
   handle.resetWatchDogState();
-  EXPECT_EQ(handle.cancellationState_, CancellationState::WAITING_FOR_CHECK);
+  EXPECT_EQ(handle.cancellationState_, CancellationState::NOT_CANCELLED);
 
   handle.cancellationState_ = CancellationState::MANUAL;
   handle.resetWatchDogState();

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -135,7 +135,8 @@ TEST(CancellationHandle, verifyWatchDogDoesChangeState) {
   EXPECT_EQ(handle.cancellationState_, CancellationState::NOT_CANCELLED);
   handle.startWatchDog();
 
-  std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);
+  // Give thread some time to start
+  std::this_thread::sleep_for(10ms);
   EXPECT_EQ(handle.cancellationState_, CancellationState::WAITING_FOR_CHECK);
 
   std::this_thread::sleep_for(detail::DESIRED_CHECK_INTERVAL);

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -149,7 +149,8 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
 
   ASSERT_EQ(metaData.size(), inputs.size());
 
-  auto cancellationHandle = std::make_shared<ad_utility::CancellationHandle>();
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
   // Check the contents of the metadata.
 
   auto cleanup = ad_utility::makeOnDestructionDontThrowDuringStackUnwinding(

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -34,7 +34,7 @@ auto makeTestScanWidthOne = [](const IndexImpl& index) {
     TripleComponent c1Tc{c1};
     IdTable result = index.scan(
         c0, std::cref(c1Tc), permutation, Permutation::ColumnIndicesRef{},
-        std::make_shared<ad_utility::CancellationHandle>());
+        std::make_shared<ad_utility::CancellationHandle<>>());
     ASSERT_EQ(result, makeIdTableFromVector(expected));
   };
 };
@@ -51,7 +51,7 @@ auto makeTestScanWidthTwo = [](const IndexImpl& index) {
     auto t = generateLocationTrace(l);
     IdTable wol = index.scan(
         c0, std::nullopt, permutation, Permutation::ColumnIndicesRef{},
-        std::make_shared<ad_utility::CancellationHandle>());
+        std::make_shared<ad_utility::CancellationHandle<>>());
     ASSERT_EQ(wol, makeIdTableFromVector(expected));
   };
 };

--- a/test/JThreadTest.cpp
+++ b/test/JThreadTest.cpp
@@ -1,0 +1,59 @@
+//   Copyright 2023, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+
+#include "util/jthread.h"
+
+using ad_utility::JThread;
+
+TEST(JThread, ensureJoinOnDestruction) {
+#ifdef __cpp_lib_jthread
+  GTEST_SKIP_("std::jthread does not require unit tests");
+#endif
+  std::atomic_bool flag = false;
+  {
+    JThread thread{[&flag]() {
+      // Make sure the thread doesn't end before even attempting to join
+      std::this_thread::sleep_for(std::chrono::milliseconds{1});
+      flag = true;
+    }};
+  }
+  EXPECT_TRUE(flag);
+}
+
+// _____________________________________________________________________________
+TEST(JThread, ensureDefaultConstructedObjectIsDestroyedNormally) {
+#ifdef __cpp_lib_jthread
+  GTEST_SKIP_("std::jthread does not require unit tests");
+#endif
+  JThread thread{};
+}
+
+// _____________________________________________________________________________
+TEST(JThread, ensureCorrectMoveSemantics) {
+#ifdef __cpp_lib_jthread
+  GTEST_SKIP_("std::jthread does not require unit tests");
+#endif
+  std::atomic_bool flag1 = false;
+  std::atomic_bool flag2 = false;
+  {
+    JThread thread{[&flag1]() {
+      // Make sure the thread doesn't end before even attempting to join
+      std::this_thread::sleep_for(std::chrono::milliseconds{1});
+      flag1 = true;
+    }};
+
+    thread = JThread{[&flag2]() {
+      // Make sure the thread doesn't end before even attempting to join
+      std::this_thread::sleep_for(std::chrono::milliseconds{1});
+      flag2 = true;
+    }};
+    EXPECT_TRUE(flag1);
+  }
+  EXPECT_TRUE(flag2);
+}

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -143,7 +143,7 @@ TEST_F(OperationTestFixture, verifyCachePreventsInProgressState) {
 
 TEST(OperationTest, verifyExceptionIsThrownOnCancellation) {
   auto qec = getQec();
-  auto handle = std::make_shared<CancellationHandle>();
+  auto handle = std::make_shared<CancellationHandle<>>();
   ShallowParentOperation operation =
       ShallowParentOperation::of<StallForeverOperation>(qec);
   operation.recursivelySetCancellationHandle(handle);

--- a/test/TriplesViewTest.cpp
+++ b/test/TriplesViewTest.cpp
@@ -69,7 +69,7 @@ TEST(TriplesView, AllTriples) {
   std::vector<std::array<Id, 3>> result;
   for (auto triple :
        TriplesView(DummyPermutation{},
-                   std::make_shared<ad_utility::CancellationHandle>())) {
+                   std::make_shared<ad_utility::CancellationHandle<>>())) {
     result.push_back(triple);
   }
   ASSERT_EQ(result, expectedResult());
@@ -84,9 +84,10 @@ TEST(TriplesView, IgnoreRanges) {
   });
   std::vector<std::pair<Id, Id>> ignoredRanges{
       {V(0), V(4)}, {V(7), V(8)}, {V(13), V(87593)}};
-  for (auto triple : TriplesView(
-           DummyPermutation{},
-           std::make_shared<ad_utility::CancellationHandle>(), ignoredRanges)) {
+  for (auto triple :
+       TriplesView(DummyPermutation{},
+                   std::make_shared<ad_utility::CancellationHandle<>>(),
+                   ignoredRanges)) {
     result.push_back(triple);
   }
   ASSERT_EQ(result, expected);
@@ -101,7 +102,7 @@ TEST(TriplesView, IgnoreTriples) {
   std::erase_if(expected, isTripleIgnored);
   for (auto triple :
        TriplesView(DummyPermutation{},
-                   std::make_shared<ad_utility::CancellationHandle>(), {},
+                   std::make_shared<ad_utility::CancellationHandle<>>(), {},
                    isTripleIgnored)) {
     result.push_back(triple);
   }


### PR DESCRIPTION
Implement a mechanism that detects if we check for a cancellation request too sparsely (currently less than every 50ms). This mechanism can be enabled or disabled at compile time (for maximal efficiency) as well as at runtime (to not clutter the log e.g. of unit tests).
The goal is to use this mechanism to automatically find all the places where checks are missing.