### PR TITLE
For GROUP BY optimization, use vector offsets to access aggregation data.

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -723,13 +723,6 @@ GroupBy::checkIfHashMapOptimizationPossible(std::vector<Aggregate>& aliases) {
     return std::nullopt;
   }
 
-  // TODO<kcaliban> remove this as soon as we have a better implementation
-  //                for multiple aggregates
-  // Only allow up to 5 aliases for now (because of CallFixedSize)
-  if (aliases.size() > 5) {
-    return std::nullopt;
-  }
-
   // Get pointers to all aggregate expressions and their parents
   size_t numAggregates = 0;
   std::vector<HashMapAliasInformation> aliasesWithAggregateInfo;
@@ -748,13 +741,6 @@ GroupBy::checkIfHashMapOptimizationPossible(std::vector<Aggregate>& aliases) {
 
     aliasesWithAggregateInfo.emplace_back(alias._expression, alias._outCol,
                                           foundAggregates.value());
-  }
-
-  // TODO<kcaliban> remove this as soon as we have a better implementation
-  //                for multiple aggregates
-  // Only allow up to 5 aggregates for now (because of CallFixedSize)
-  if (numAggregates > 5) {
-    return std::nullopt;
   }
 
   const Variable& groupByVariable = _groupByVariables.front();

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -246,12 +246,8 @@ class GroupBy : public Operation {
 
   // Stores the map which associates Ids with vector offsets and
   // the vectors containing the aggregation data.
-  struct HashMapAggregationData {
-    // Maps `Id` to vector offsets.
-    ad_utility::HashMapWithMemoryLimit<KeyType, ValueType> map_;
-    // Stores the actual aggregation data.
-    std::vector<std::vector<AverageAggregationData>> aggregationData_;
-
+  class HashMapAggregationData {
+   public:
     HashMapAggregationData(ad_utility::AllocatorWithLimit<Id> alloc,
                            size_t numAggregates)
         : map_{ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>(alloc)},
@@ -285,6 +281,12 @@ class GroupBy : public Operation {
 
     // Returns the number of groups.
     [[nodiscard]] size_t getNumberOfGroups() const { return map_.size(); }
+
+   private:
+    // Maps `Id` to vector offsets.
+    ad_utility::HashMapWithMemoryLimit<KeyType, ValueType> map_;
+    // Stores the actual aggregation data.
+    std::vector<std::vector<AverageAggregationData>> aggregationData_;
   };
 
   // Returns the aggregation results between `beginIndex` and `endIndex`

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -201,16 +201,16 @@ class GroupBy : public Operation {
     sparqlExpression::SparqlExpression* expr_;
     // The index in the `std::array` of the Hash Map where results of this
     // aggregate are stored.
-    size_t hashMapIndex_;
+    size_t aggregateDataIndex;
     // The parent expression of this aggregate, and the index this expression
     // appears in the parents' children, so that it may be substituted away.
     std::optional<ParentAndChildIndex> parentAndIndex_ = std::nullopt;
 
     HashMapAggregateInformation(
-        sparqlExpression::SparqlExpression* expr, size_t hashMapIndex,
+        sparqlExpression::SparqlExpression* expr, size_t aggregateDataIndex,
         std::optional<ParentAndChildIndex> parentAndIndex = std::nullopt)
         : expr_{expr},
-          hashMapIndex_{hashMapIndex},
+          aggregateDataIndex{aggregateDataIndex},
           parentAndIndex_{parentAndIndex} {
       AD_CONTRACT_CHECK(expr != nullptr);
     }
@@ -244,12 +244,68 @@ class GroupBy : public Operation {
       size_t numAggregates, const IdTable& subresult, size_t columnIndex,
       LocalVocab* localVocab);
 
+  // Stores the map which associates Ids with vector offsets and
+  // the vectors containing the aggregation data.
+  struct HashMapAggregationData {
+    // Maps `Id` to vector offsets.
+    ad_utility::HashMapWithMemoryLimit<KeyType, ValueType> map_;
+    // Stores the actual aggregation data.
+    std::vector<std::vector<AverageAggregationData>> aggregationData_;
+
+    // If `id` is not in map, add an element to the `aggregationData_` vectors
+    // and store the index.
+    size_t getOrCreateIndex(Id id) {
+      auto [iterator, wasAdded] = map_.try_emplace(id);
+
+      if (wasAdded) {
+        iterator->second = aggregationData_.at(0).size();
+        for (auto& aggregation : aggregationData_) aggregation.emplace_back();
+      }
+
+      return iterator->second;
+    }
+
+    // Return the index of `id`.
+    [[nodiscard]] size_t getIndex(Id id) const { return map_.at(id); }
+
+    // Get vector containing the aggregation data at `aggregationDataIndex`.
+    std::vector<AverageAggregationData>& getAggregationDataVector(
+        size_t aggregationDataIndex) {
+      return aggregationData_.at(aggregationDataIndex);
+    }
+
+    // Get vector containing the aggregation data at `aggregationDataIndex`,
+    // but const.
+    [[nodiscard]] const std::vector<AverageAggregationData>&
+    getAggregationDataVector(size_t aggregationDataIndex) const {
+      return aggregationData_.at(aggregationDataIndex);
+    }
+
+    // Get the values of the grouped column in ascending order.
+    [[nodiscard]] std::vector<Id> getSortedGroupColumn() const {
+      std::vector<ValueId> sortedKeys;
+      for (const auto& val : map_) {
+        sortedKeys.push_back(val.first);
+      }
+      std::ranges::sort(sortedKeys);
+      return sortedKeys;
+    }
+
+    // Returns the number of groups.
+    [[nodiscard]] size_t getNumberOfGroups() const { return map_.size(); }
+  };
+
+  // Returns the aggregation results between `beginIndex` and `endIndex`
+  // of the aggregates stored at `dataIndex`,
+  // based on the groups stored in the first column of `resultTable`
+  sparqlExpression::VectorWithMemoryLimit<ValueId> getHashMapAggregationResults(
+      IdTable* resultTable, const HashMapAggregationData& aggregationData,
+      size_t dataIndex, size_t beginIndex, size_t endIndex);
+
   // Sort the HashMap by key and create result table.
   void createResultFromHashMap(
-      IdTable* result,
-      const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
+      IdTable* result, const HashMapAggregationData& aggregationData,
       std::vector<HashMapAliasInformation>& aggregateAliases,
-      const std::vector<std::vector<AverageAggregationData>>& aggregationData,
       LocalVocab* localVocab);
 
   // Check if hash map optimization is applicable. This is the case when
@@ -269,23 +325,12 @@ class GroupBy : public Operation {
       sparqlExpression::EvaluationContext& evaluationContext,
       IdTable* resultTable, LocalVocab* localVocab, size_t outCol);
 
-  // In case of aliases that contain an aggregate at the top-level of the
-  // expression tree, e.g. "AVG(?y) as ?avg", we can directly store the values
-  // calculated in our HashMap in the result table.
-  sparqlExpression::VectorWithMemoryLimit<ValueId> extractValuesDirectlyFromMap(
-      size_t beginIndex, size_t endIndex,
-      const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
-      const std::vector<std::vector<AverageAggregationData>>& aggregationData,
-      IdTable* resultTable, size_t hashMapIndex, size_t outCol);
-
   // Substitute the results for all aggregates in `info`. The values of the
   // grouped variable should be at column 0 in `groupValues`.
-  void substituteAllAggregates(
-      std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
-      size_t endIndex,
-      const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
-      const std::vector<std::vector<AverageAggregationData>>& aggregationData,
-      IdTable* resultTable);
+  void substituteAllAggregates(std::vector<HashMapAggregateInformation>& info,
+                               size_t beginIndex, size_t endIndex,
+                               const HashMapAggregationData& aggregationData,
+                               IdTable* resultTable);
 
   // Check if an expression is of a certain type.
   template <class T>

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -257,7 +257,6 @@ class GroupBy : public Operation {
   // - Runtime parameter is set
   // - Child operation is SORT
   // - All aggregates are AVG
-  // - Maximum 5 aliases and 5 aggregates
   // - Only one grouped variable
   std::optional<HashMapOptimizationData> checkIfHashMapOptimizationPossible(
       std::vector<Aggregate>& aggregates);
@@ -282,8 +281,8 @@ class GroupBy : public Operation {
   // Substitute the results for all aggregates in `info`. The values of the
   // grouped variable should be at column 0 in `groupValues`.
   void substituteAllAggregates(
-      std::vector<HashMapAggregateInformation>& info,
-      sparqlExpression::EvaluationContext& evaluationContext,
+      std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
+      size_t endIndex,
       const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
       const std::vector<std::vector<AverageAggregationData>>& aggregationData,
       IdTable* resultTable);

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -265,6 +265,28 @@ class GroupBy : public Operation {
       return iterator->second;
     }
 
+    // Returns a vector containing the offsets for all ids of `ids`,
+    // inserting entries if necessary.
+    std::vector<size_t> getHashEntries(std::span<const Id> ids) {
+      std::vector<size_t> hashEntries;
+      hashEntries.reserve(ids.size());
+
+      for (auto& val : ids) {
+        auto [iterator, wasAdded] = map_.try_emplace(val);
+
+        if (wasAdded) {
+          iterator->second = getNumberOfGroups() - 1;
+        }
+
+        hashEntries.push_back(iterator->second);
+      }
+
+      for (auto& aggregation : aggregationData_)
+        aggregation.resize(getNumberOfGroups());
+
+      return hashEntries;
+    }
+
     // Return the index of `id`.
     [[nodiscard]] size_t getIndex(Id id) const { return map_.at(id); }
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -179,8 +179,7 @@ class GroupBy : public Operation {
   };
 
   using KeyType = ValueId;
-  template <size_t numAggregates>
-  using ValueType = std::array<AverageAggregationData, numAggregates>;
+  using ValueType = size_t;
 
   // Stores information required for substitution of an expression in an
   // expression tree.
@@ -240,18 +239,17 @@ class GroupBy : public Operation {
 
   // Create result IdTable by using a HashMap mapping groups to aggregation data
   // and subsequently calling `createResultFromHashMap`.
-  template <size_t OUT_WIDTH, size_t numAliases, size_t numAggregates>
   void computeGroupByForHashMapOptimization(
       IdTable* result, std::vector<HashMapAliasInformation>& aggregateAliases,
-      const IdTable& subresult, size_t columnIndex, LocalVocab* localVocab);
+      size_t numAggregates, const IdTable& subresult, size_t columnIndex,
+      LocalVocab* localVocab);
 
   // Sort the HashMap by key and create result table.
-  template <size_t OUT_WIDTH, size_t numAliases, size_t numAggregates>
   void createResultFromHashMap(
       IdTable* result,
-      const ad_utility::HashMapWithMemoryLimit<KeyType,
-                                               ValueType<numAggregates>>& map,
+      const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
       std::vector<HashMapAliasInformation>& aggregateAliases,
+      const std::vector<std::vector<AverageAggregationData>>& aggregationData,
       LocalVocab* localVocab);
 
   // Check if hash map optimization is applicable. This is the case when
@@ -275,21 +273,19 @@ class GroupBy : public Operation {
   // In case of aliases that contain an aggregate at the top-level of the
   // expression tree, e.g. "AVG(?y) as ?avg", we can directly store the values
   // calculated in our HashMap in the result table.
-  template <size_t numAggregates>
   sparqlExpression::VectorWithMemoryLimit<ValueId> extractValuesDirectlyFromMap(
       size_t beginIndex, size_t endIndex,
-      const ad_utility::HashMapWithMemoryLimit<KeyType,
-                                               ValueType<numAggregates>>& map,
+      const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
+      const std::vector<std::vector<AverageAggregationData>>& aggregationData,
       IdTable* resultTable, size_t hashMapIndex, size_t outCol);
 
   // Substitute the results for all aggregates in `info`. The values of the
   // grouped variable should be at column 0 in `groupValues`.
-  template <size_t numAggregates>
   void substituteAllAggregates(
       std::vector<HashMapAggregateInformation>& info,
       sparqlExpression::EvaluationContext& evaluationContext,
-      const ad_utility::HashMapWithMemoryLimit<KeyType,
-                                               ValueType<numAggregates>>& map,
+      const ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>& map,
+      const std::vector<std::vector<AverageAggregationData>>& aggregationData,
       IdTable* resultTable);
 
   // Check if an expression is of a certain type.

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -555,7 +555,7 @@ TEST_F(GroupByOptimizations, checkIfHashMapOptimizationPossible) {
   ASSERT_EQ(aggregateAlias.expr_.getPimpl(), avgXPimpl.getPimpl());
   // Check aggregate info is correct
   auto aggregateInfo = aggregateAlias.aggregateInfo_[0];
-  ASSERT_EQ(aggregateInfo.hashMapIndex_, 0);
+  ASSERT_EQ(aggregateInfo.aggregateDataIndex, 0);
   ASSERT_FALSE(aggregateInfo.parentAndIndex_.has_value());
   ASSERT_EQ(aggregateInfo.expr_, avgXPimpl.getPimpl());
 }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -603,7 +603,9 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationNonTrivial) {
   /* Setup query:
   SELECT ?x (AVG(?y) as ?avg)
             (?avg + ((2 * AVG(?y)) * AVG(4 * ?y)) as ?complexAvg)
-            (5.0 as ?const) WHERE {
+            (5.0 as ?const) (42.0 as ?const2) (13.37 as ?const3)
+            (?const + ?const2 + ?const3 + AVG(?y) + AVG(?y) + AVG(?y) as ?sth)
+            WHERE {
     ?z <is-a> ?x .
     ?z <is> ?y
   } GROUP BY ?x
@@ -619,10 +621,11 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationNonTrivial) {
   std::vector<ColumnIndex> sortedColumns = {1};
   Tree sortedJoin = makeExecutionTree<Sort>(qec, join, sortedColumns);
 
+  // (AVG(?y) as ?avg)
   Variable varAvg{"?avg"};
-
   SparqlExpressionPimpl avgYPimpl = makeAvgPimpl(varY);
 
+  // (?avg + ((2 * AVG(?y)) * AVG(4 * ?y)) as ?complexAvg)
   auto fourTimesYExpr = makeMultiplyExpression(makeLiteralDoubleExpr(4.0),
                                                makeVariableExpression(varY));
   auto avgFourTimesYExpr =
@@ -640,13 +643,43 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationNonTrivial) {
       std::move(avgY_plus_twoTimesAvgY_times_avgFourTimesYExpr),
       "(?avg + ((2 * AVG(?y)) * AVG(4 * ?y)) as ?complexAvg)");
 
+  // (5.0 as ?const) (42.0 as ?const2) (13.37 as ?const3)
+  Variable varConst = Variable{"?const"};
   SparqlExpressionPimpl constantFive = makeLiteralDoublePimpl(5.0);
+  Variable varConst2 = Variable{"?const2"};
+  SparqlExpressionPimpl constantFortyTwo = makeLiteralDoublePimpl(42.0);
+  Variable varConst3 = Variable{"?const3"};
+  SparqlExpressionPimpl constantLeet = makeLiteralDoublePimpl(13.37);
+
+  // (?const + ?const2 + ?const3 + AVG(?y) + AVG(?y) + AVG(?y) as ?sth)
+  auto constPlusConst2 = makeAddExpression(makeVariableExpression(varConst),
+                                           makeVariableExpression(varConst2));
+  auto constPlusConst2PlusConst3 = makeAddExpression(
+      std::move(constPlusConst2), makeVariableExpression(varConst3));
+  auto avgY1 =
+      std::make_unique<AvgExpression>(false, makeVariableExpression(varY));
+  auto constPusConst2PlusConst3PlusAvgY =
+      makeAddExpression(std::move(constPlusConst2PlusConst3), std::move(avgY1));
+  auto avgY2 =
+      std::make_unique<AvgExpression>(false, makeVariableExpression(varY));
+  auto constPlusConst2PlusConst3PlusAvgYPlusAvgY = makeAddExpression(
+      std::move(constPusConst2PlusConst3PlusAvgY), std::move(avgY2));
+  auto avgY3 =
+      std::make_unique<AvgExpression>(false, makeVariableExpression(varY));
+  auto constPlusEtc = makeAddExpression(
+      std::move(constPlusConst2PlusConst3PlusAvgYPlusAvgY), std::move(avgY3));
+  SparqlExpressionPimpl constPlusEtcPimpl(
+      std::move(constPlusEtc),
+      "?const + ?const2 + ?const3 + AVG(?y) + AVG(?y) + AVG(?y)");
 
   std::vector<Alias> aliasesAvgY{
       Alias{avgYPimpl, varAvg},
       Alias{avgY_plus_twoTimesAvgY_times_avgFourTimesYPimpl,
             Variable{"?complexAvg"}},
-      Alias{constantFive, Variable{"?const"}}};
+      Alias{constantFive, varConst},
+      Alias{constantFortyTwo, varConst2},
+      Alias{constantLeet, varConst3},
+      Alias{constPlusEtcPimpl, Variable{"?sth"}}};
 
   // Clear cache, calculate result without optimization
   RuntimeParameters().set<"use-group-by-hash-map-optimization">(false);
@@ -701,6 +734,7 @@ TEST_F(GroupByOptimizations, checkIfJoinWithFullScan) {
   ASSERT_EQ(optimizedAggregateData->subtreeColumnIndex_, 0);
 }
 
+// _____________________________________________________________________________
 TEST_F(GroupByOptimizations, computeGroupByForJoinWithFullScan) {
   {
     // One of the invalid cases from the previous test.
@@ -728,8 +762,8 @@ TEST_F(GroupByOptimizations, computeGroupByForJoinWithFullScan) {
                                     source_location l =
                                         source_location::current()) {
     auto trace = generateLocationTrace(l);
-    // Set up a `VALUES` clause with three values for `?x`, two of which (`<x>`
-    // and `<y>`) actually appear in the test knowledge graph.
+    // Set up a `VALUES` clause with three values for `?x`, two of which
+    // (`<x>` and `<y>`) actually appear in the test knowledge graph.
     parsedQuery::SparqlValues sparqlValues;
     sparqlValues._variables.push_back(varX);
     sparqlValues._values.emplace_back(std::vector{TripleComponent{"<x>"}});
@@ -779,6 +813,7 @@ TEST_F(GroupByOptimizations, computeGroupByForJoinWithFullScan) {
   }
 }
 
+// _____________________________________________________________________________
 TEST_F(GroupByOptimizations, computeGroupByForSingleIndexScan) {
   // Assert that a GROUP BY, that is constructed from the given arguments,
   // can not perform the `OptimizedAggregateOnIndexScanChild` optimization.
@@ -845,6 +880,7 @@ TEST_F(GroupByOptimizations, computeGroupByForSingleIndexScan) {
   }
 }
 
+// _____________________________________________________________________________
 TEST_F(GroupByOptimizations, computeGroupByForFullIndexScan) {
   // Assert that a GROUP BY which is constructed from the given arguments
   // can not perform the `GroupByForSingleIndexScan2` optimization.
@@ -923,6 +959,7 @@ auto make = [](auto&&... args) -> SparqlExpression::Ptr {
   return std::make_unique<ExprT>(AD_FWD(args)...);
 };
 }  // namespace
+// _____________________________________________________________________________
 TEST(GroupBy, GroupedVariableInExpressions) {
   parsedQuery::SparqlValues input;
   using TC = TripleComponent;
@@ -934,8 +971,8 @@ TEST(GroupBy, GroupedVariableInExpressions) {
   //
   // Note: The values are chosen such that the results are all integers.
   // Otherwise we would get into trouble with floating point comparisons. A
-  // check with a similar query but with non-integral inputs and results can be
-  // found in the E2E tests.
+  // check with a similar query but with non-integral inputs and results can
+  // be found in the E2E tests.
 
   Variable varA = Variable{"?a"};
   Variable varB = Variable{"?b"};
@@ -985,6 +1022,7 @@ TEST(GroupBy, GroupedVariableInExpressions) {
   EXPECT_EQ(table, expected);
 }
 
+// _____________________________________________________________________________
 TEST(GroupBy, AliasResultReused) {
   parsedQuery::SparqlValues input;
   using TC = TripleComponent;
@@ -996,8 +1034,8 @@ TEST(GroupBy, AliasResultReused) {
   //
   // Note: The values are chosen such that the results are all integers.
   // Otherwise we would get into trouble with floating point comparisons. A
-  // check with a similar query but with non-integral inputs and results can be
-  // found in the E2E tests.
+  // check with a similar query but with non-integral inputs and results can
+  // be found in the E2E tests.
 
   Variable varA = Variable{"?a"};
   Variable varB = Variable{"?b"};
@@ -1049,9 +1087,10 @@ TEST(GroupBy, AliasResultReused) {
 
 }  // namespace
 
-// Expressions in HAVING clauses are converted to special internal aliases. Test
-// the combination of parsing and evaluating such queries.
+// _____________________________________________________________________________
 TEST(GroupBy, AddedHavingRows) {
+  // Expressions in HAVING clauses are converted to special internal aliases.
+  // Test the combination of parsing and evaluating such queries.
   auto query =
       "SELECT ?x (COUNT(?y) as ?count) WHERE {"
       " VALUES (?x ?y) {(0 1) (0 3) (0 5) (1 4) (1 3) } }"


### PR DESCRIPTION
In the hash map-based GROUP BY optimization, the hash map now only stores a mapping from `ID->size_t` where the `size_t` is an index into a vector that stores the actual data. This optimization will make the support for multiple different aggregates much more efficient.