### PR TITLE
Disable GROUP BY HashMap optimization for distinct aggregate expressions.

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -772,14 +772,19 @@ std::optional<T*> GroupBy::hasType(sparqlExpression::SparqlExpression* expr) {
 }
 
 // _____________________________________________________________________________
-bool GroupBy::isSupportedAggregate(sparqlExpression::SparqlExpression* expr) {
+bool GroupBy::isUnsupportedAggregate(sparqlExpression::SparqlExpression* expr) {
   using namespace sparqlExpression;
 
-  return !(hasType<SumExpression>(expr).has_value() ||
-           hasType<MinExpression>(expr).has_value() ||
-           hasType<MaxExpression>(expr).has_value() ||
-           hasType<CountExpression>(expr).has_value() ||
-           hasType<GroupConcatExpression>(expr).has_value());
+  // `expr` is not an aggregate, so it cannot be an unsupported aggregate
+  if (!expr->isAggregate()) return false;
+
+  // `expr` is an unsupported aggregate
+  if (hasType<SumExpression>(expr) || hasType<MinExpression>(expr) ||
+      hasType<MaxExpression>(expr) || hasType<CountExpression>(expr) ||
+      hasType<GroupConcatExpression>(expr))
+    return true;
+
+  return false;
 }
 
 // _____________________________________________________________________________
@@ -805,7 +810,7 @@ bool GroupBy::findAggregatesImpl(
   }
 
   // Unsupported aggregates
-  if (!isSupportedAggregate(expr)) return false;
+  if (isUnsupportedAggregate(expr)) return false;
 
   auto children = expr->children();
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -328,6 +328,10 @@ class GroupBy : public Operation {
   template <class T>
   static std::optional<T*> hasType(sparqlExpression::SparqlExpression* expr);
 
+  // Check if an expression is any of any type in `Exprs`
+  template <typename... Exprs>
+  static bool hasAnyType(const auto& expr);
+
   // Check if an expression is a currently supported aggregate.
   // TODO<kcaliban> As soon as all aggregates are supported, implement and use a
   //                `isAggregate` function in SparqlExpressions instead.

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -345,8 +345,8 @@ class GroupBy : public Operation {
 
   // The recursive implementation of `findAggregates` (see above).
   static bool findAggregatesImpl(
-      sparqlExpression::SparqlExpression* parent,
-      sparqlExpression::SparqlExpression* expr, std::optional<size_t> index,
+      sparqlExpression::SparqlExpression* expr,
+      std::optional<ParentAndChildIndex> parentAndChildIndex,
       std::vector<HashMapAggregateInformation>& info);
 
   // The check whether the optimization just described can be applied and its

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -250,9 +250,7 @@ class GroupBy : public Operation {
    public:
     HashMapAggregationData(ad_utility::AllocatorWithLimit<Id> alloc,
                            size_t numAggregates)
-        : map_{ad_utility::HashMapWithMemoryLimit<KeyType, ValueType>(alloc)},
-          aggregationData_{
-              std::vector<std::vector<AverageAggregationData>>(numAggregates)} {
+        : map_{alloc}, aggregationData_{numAggregates} {
       AD_CONTRACT_CHECK(numAggregates > 0);
     }
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -331,7 +331,7 @@ class GroupBy : public Operation {
   // Check if an expression is a currently supported aggregate.
   // TODO<kcaliban> As soon as all aggregates are supported, implement and use a
   //                `isAggregate` function in SparqlExpressions instead.
-  static bool isSupportedAggregate(sparqlExpression::SparqlExpression* expr);
+  static bool isUnsupportedAggregate(sparqlExpression::SparqlExpression* expr);
 
   // Find all aggregates for expression `expr`. Return `std::nullopt`
   // if an unsupported aggregate is found.

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -326,7 +326,7 @@ class GroupBy : public Operation {
 
   // Check if an expression is of a certain type.
   template <class T>
-  static bool hasType(sparqlExpression::SparqlExpression* expr);
+  static std::optional<T*> hasType(sparqlExpression::SparqlExpression* expr);
 
   // Check if an expression is a currently supported aggregate.
   // TODO<kcaliban> As soon as all aggregates are supported, implement and use a

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -62,6 +62,9 @@ class AggregateExpression : public SparqlExpression {
       const VariableToColumnMap& varColMap) const override;
 
   // __________________________________________________________________________
+  bool isDistinct() const { return _distinct; }
+
+  // __________________________________________________________________________
   [[nodiscard]] std::optional<SparqlExpressionPimpl::VariableAndDistinctness>
   getVariableForCount() const override;
 

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -62,7 +62,7 @@ class AggregateExpression : public SparqlExpression {
       const VariableToColumnMap& varColMap) const override;
 
   // __________________________________________________________________________
-  bool isDistinct() const { return _distinct; }
+  bool isDistinct() const override { return _distinct; }
 
   // __________________________________________________________________________
   [[nodiscard]] std::optional<SparqlExpressionPimpl::VariableAndDistinctness>

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -54,8 +54,8 @@ class AggregateExpression : public SparqlExpression {
   // _________________________________________________________________________
   vector<Variable> getUnaggregatedVariables() override;
 
-  // An `AggregateExpression` (obviously) contains an aggregate.
-  bool containsAggregate() const override { return true; }
+  // _________________________________________________________________________
+  bool isAggregate() const override { return true; }
 
   // __________________________________________________________________________
   [[nodiscard]] string getCacheKey(

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -63,7 +63,9 @@ class GroupConcatExpression : public SparqlExpression {
   vector<Variable> getUnaggregatedVariables() override { return {}; }
 
   // A `GroupConcatExpression` is an aggregate.
-  bool containsAggregate() const override { return true; }
+  bool isAggregate() const override { return true; }
+
+  bool isDistinct() const { return distinct_; }
 
   [[nodiscard]] string getCacheKey(
       const VariableToColumnMap& varColMap) const override {

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -65,7 +65,7 @@ class GroupConcatExpression : public SparqlExpression {
   // A `GroupConcatExpression` is an aggregate.
   bool isAggregate() const override { return true; }
 
-  bool isDistinct() const { return distinct_; }
+  bool isDistinct() const override { return distinct_; }
 
   [[nodiscard]] string getCacheKey(
       const VariableToColumnMap& varColMap) const override {

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -89,8 +89,10 @@ class SparqlExpression {
 
   // Check if an expression is distinct (only applies to aggregates)
   virtual bool isDistinct() const {
-    AD_CONTRACT_CHECK(isAggregate());
-    return false;
+    AD_THROW(
+        "isDistinct() maybe only called for aggregate expressions. If this is "
+        "an aggregate expression, then the implementation of isDistinct() is "
+        "missing for this expression. Please report this to the developers.");
   }
 
   // Replace child at index `childIndex` with `newExpression`

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -88,7 +88,10 @@ class SparqlExpression {
   virtual bool isAggregate() const { return false; }
 
   // Check if an expression is distinct (only applies to aggregates)
-  virtual bool isDistinct() const { AD_CONTRACT_CHECK(this->isAggregate()); }
+  virtual bool isDistinct() const {
+    AD_CONTRACT_CHECK(this->isAggregate());
+    return false;
+  }
 
   // Replace child at index `childIndex` with `newExpression`
   virtual void replaceChild(size_t childIndex,

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -89,7 +89,7 @@ class SparqlExpression {
 
   // Check if an expression is distinct (only applies to aggregates)
   virtual bool isDistinct() const {
-    AD_CONTRACT_CHECK(this->isAggregate());
+    AD_CONTRACT_CHECK(isAggregate());
     return false;
   }
 

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -87,6 +87,9 @@ class SparqlExpression {
   // Check if expression is aggregate
   virtual bool isAggregate() const { return false; }
 
+  // Check if an expression is distinct (only applies to aggregates)
+  virtual bool isDistinct() const { AD_CONTRACT_CHECK(this->isAggregate()); }
+
   // Replace child at index `childIndex` with `newExpression`
   virtual void replaceChild(size_t childIndex,
                             std::unique_ptr<SparqlExpression> newExpression) {

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -77,11 +77,15 @@ class SparqlExpression {
   // Return true iff this expression contains an aggregate like SUM, COUNT etc.
   // This information is needed to check if there is an implicit GROUP BY in a
   // query because any of the selected aliases contains an aggregate.
-  virtual bool containsAggregate() const {
+  virtual bool containsAggregate() const final {
+    if (isAggregate()) return true;
     return std::ranges::any_of(children(), [](const Ptr& child) {
       return child->containsAggregate();
     });
   }
+
+  // Check if expression is aggregate
+  virtual bool isAggregate() const { return false; }
 
   // Replace child at index `childIndex` with `newExpression`
   virtual void replaceChild(size_t childIndex,

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -43,6 +43,7 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
   EXPECT_EQ(res, expectedResult);
 };
 
+// ______________________________________________________________________________
 TEST(AggregateExpression, max) {
   auto testMaxId = testAggregate<MaxExpression, Id>;
   testMaxId({I(3), U, I(0), I(4), U, (I(-1))}, I(4));
@@ -54,6 +55,7 @@ TEST(AggregateExpression, max) {
   testMaxString({"alpha", "äpfel", "Beta", "unfug"}, "äpfel");
 }
 
+// ______________________________________________________________________________
 TEST(AggregateExpression, min) {
   auto testMinId = testAggregate<MinExpression, Id>;
   testMinId({I(3), I(0), I(4), (I(-1))}, I(-1));
@@ -66,6 +68,7 @@ TEST(AggregateExpression, min) {
   testMinString({"alpha", "äpfel", "Beta", "unfug"}, "Beta");
 }
 
+// ______________________________________________________________________________
 TEST(AggregateExpression, sum) {
   auto testSumId = testAggregate<SumExpression, Id>;
   testSumId({I(3), D(23.3), I(0), I(4), (I(-1))}, D(29.3));
@@ -79,6 +82,7 @@ TEST(AggregateExpression, sum) {
   testSumString({"alpha", "äpfel", "Beta", "unfug"}, U);
 }
 
+// ______________________________________________________________________________
 TEST(AggregateExpression, count) {
   auto testCountId = testAggregate<CountExpression, Id>;
   testCountId({I(3), D(23.3), I(0), I(4), (I(-1))}, I(5));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -9,10 +9,9 @@
 
 #include "./SparqlExpressionTestHelpers.h"
 #include "./util/GTestHelpers.h"
-#include "./util/IdTestHelpers.h"
+#include "engine/sparqlExpressions/AggregateExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
-#include "engine/sparqlExpressions/RelationalExpressions.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "util/AllocatorTestHelpers.h"
 #include "util/Conversions.h"
@@ -893,4 +892,25 @@ TEST(SparqlExpression, replaceChildThrowsIfOutOfRange) {
 
   ASSERT_THROW(expr.replaceChild(1, std::move(exprToSubstitute)),
                ad_utility::Exception);
+}
+
+// ______________________________________________________________________________
+TEST(SparqlExpression, isAggregateAndIsDistinct) {
+  sparqlExpression::IdExpression idExpr(ValueId::makeFromInt(42));
+
+  ASSERT_FALSE(idExpr.isAggregate());
+  ASSERT_THROW(idExpr.isDistinct(), ad_utility::Exception);
+
+  Variable varX("?x");
+  sparqlExpression::detail::AvgExpression avgExpression(
+      false, std::make_unique<VariableExpression>(varX));
+
+  ASSERT_TRUE(avgExpression.isAggregate());
+  ASSERT_FALSE(avgExpression.isDistinct());
+
+  sparqlExpression::detail::AvgExpression avgDistinctExpression(
+      true, std::make_unique<VariableExpression>(varX));
+
+  ASSERT_TRUE(avgDistinctExpression.isAggregate());
+  ASSERT_TRUE(avgDistinctExpression.isDistinct());
 }


### PR DESCRIPTION
We currently have no implementation for this case, so the results would be wrong. As soon as at least one of the aggregates is distinct, we fall back to the classical implementation that first sorts by the grouped columns.