### PR TITLE
Fix bug in lazy join between blocks

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -237,45 +237,53 @@ CompressedRelationReader::getBlocksForJoin(
   auto relevantBlocks1 = getBlocksFromMetadata(metadataAndBlocks1);
   auto relevantBlocks2 = getBlocksFromMetadata(metadataAndBlocks2);
 
-  auto metadataForBlock =
-      [&](const CompressedBlockMetadata& block) -> decltype(auto) {
-    if (relevantBlocks1.data() <= &block &&
-        &block < relevantBlocks1.data() + relevantBlocks1.size()) {
-      return metadataAndBlocks1;
-    } else {
-      return metadataAndBlocks2;
-    }
+  // Associate a block together with the relevant ID (col1 or col2) for this
+  // join from the first and last triple.
+  struct BlockAndIds {
+    const CompressedBlockMetadata& block_;
+    Id first_;
+    Id last_;
   };
 
-  auto blockLessThanBlock = [&](const CompressedBlockMetadata& block1,
-                                const CompressedBlockMetadata& block2) {
-    return getRelevantIdFromTriple(block1.lastTriple_,
-                                   metadataForBlock(block1)) <
-           getRelevantIdFromTriple(block2.firstTriple_,
-                                   metadataForBlock(block2));
+  // Transform a single block into a `BlockAndIds` struct (see above).
+  auto getFirstAndLastId = [](const MetadataAndBlocks& metadata) {
+    return [&metadata](const CompressedBlockMetadata& block) -> BlockAndIds {
+      return {block, getRelevantIdFromTriple(block.firstTriple_, metadata),
+              getRelevantIdFromTriple(block.lastTriple_, metadata)};
+    };
+  };
+
+  // Associate all the blocks with their relevant IDs. We need this relevant Ids
+  // to join the blocks.
+  auto blocksWithIds1 = std::views::transform(
+      relevantBlocks1, getFirstAndLastId(metadataAndBlocks1));
+  auto blocksWithIds2 = std::views::transform(
+      relevantBlocks2, getFirstAndLastId(metadataAndBlocks2));
+
+  auto blockLessThanBlock = [&](const BlockAndIds& block1,
+                                const BlockAndIds& block2) {
+    return block1.last_ < block2.first_;
   };
 
   std::array<std::vector<CompressedBlockMetadata>, 2> result;
 
-  AD_CONTRACT_CHECK(
-      std::ranges::is_sorted(relevantBlocks1, blockLessThanBlock));
-  AD_CONTRACT_CHECK(
-      std::ranges::is_sorted(relevantBlocks2, blockLessThanBlock));
+  AD_CONTRACT_CHECK(std::ranges::is_sorted(blocksWithIds1, blockLessThanBlock));
+  AD_CONTRACT_CHECK(std::ranges::is_sorted(blocksWithIds2, blockLessThanBlock));
 
   // Find the matching blocks on each side by performing binary search on the
   // other side. Note that it is tempting to reuse the `zipperJoinWithUndef`
   // routine, but this doesn't work because the implicit equality defined by
   // `!lessThan(a,b) && !lessThan(b, a)` is not transitive.
-  for (const auto& block : relevantBlocks1) {
-    if (!std::ranges::equal_range(relevantBlocks2, block, blockLessThanBlock)
+  for (const auto& block : blocksWithIds1) {
+    if (!std::ranges::equal_range(blocksWithIds2, block, blockLessThanBlock)
              .empty()) {
-      result[0].push_back(block);
+      result[0].push_back(block.block_);
     }
   }
-  for (const auto& block : relevantBlocks2) {
-    if (!std::ranges::equal_range(relevantBlocks1, block, blockLessThanBlock)
+  for (const auto& block : blocksWithIds2) {
+    if (!std::ranges::equal_range(blocksWithIds2, block, blockLessThanBlock)
              .empty()) {
-      result[1].push_back(block);
+      result[1].push_back(block.block_);
     }
   }
 

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -392,15 +392,15 @@ class CompressedRelationReader {
       std::span<const Id> joinColumn,
       const MetadataAndBlocks& metadataAndBlocks);
 
-  // For each of `metadataAndBlocks1, metadataAndBlocks2` get the blocks (an
+  // For each of `metadataAndBlocks, metadataAndBlocks2` get the blocks (an
   // ordered subset of the blocks in the `scanMetadata` that might contain
   // matching elements in the following scenario: The result of
-  // `metadataAndBlocks1` is joined with the result of `metadataAndBlocks2`. For
+  // `metadataAndBlocks` is joined with the result of `metadataAndBlocks2`. For
   // each of the inputs the join column is the first column that is not fixed by
   // the metadata, so the middle column (col1) in case the `scanMetadata`
   // doesn't contain a `col1Id`, or the last column (col2) else.
   static std::array<std::vector<CompressedBlockMetadata>, 2> getBlocksForJoin(
-      const MetadataAndBlocks& metadataAndBlocks1,
+      const MetadataAndBlocks& metadataAndBlocks,
       const MetadataAndBlocks& metadataAndBlocks2);
 
   /**


### PR DESCRIPTION
There was a bug in the lazy join when the blocks of the left operand overlapped with the blocks from the right operand. This is now fixed. Here is a query that resulted in an assert failure before and that now works as it should: https://qlever.cs.uni-freiburg.de/wikidata/t4rYnv .