### PR TITLE
Make copy instead of using unsafe reference

### DIFF
--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -38,7 +38,7 @@ QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
                    socketDistributors = socketDistributors_, queryId]() {
         auto future = net::dispatch(net::bind_executor(
             globalStrand,
-            std::packaged_task<void()>([&socketDistributors, &queryId]() {
+            std::packaged_task<void()>([socketDistributors, queryId]() {
               bool wasErased = socketDistributors->erase(queryId);
               AD_CORRECTNESS_CHECK(wasErased);
             })));

--- a/src/util/http/websocket/QueryHub.cpp
+++ b/src/util/http/websocket/QueryHub.cpp
@@ -37,11 +37,10 @@ QueryHub::createOrAcquireDistributorInternalUnsafe(QueryId queryId) {
       ioContext_, [&ioContext = ioContext_, globalStrand = globalStrand_,
                    socketDistributors = socketDistributors_, queryId]() {
         auto future = net::dispatch(net::bind_executor(
-            globalStrand,
-            std::packaged_task<void()>([socketDistributors, queryId]() {
+            globalStrand, std::packaged_task{[socketDistributors, queryId]() {
               bool wasErased = socketDistributors->erase(queryId);
               AD_CORRECTNESS_CHECK(wasErased);
-            })));
+            }}));
         // As long as the destructor would have to block anyway, perform work
         // on the `ioContext_`. This avoids blocking in case the destructor
         // already runs inside the `ioContext_`.


### PR DESCRIPTION
I doubt that this will fix the occasional failures of HttpTest, but it definitely fixes undefinged behaviour when the lambda exits without actually running the task. (Should only happen when the io context closes anyways.)