### PR TITLE
Fix the `check_index_version` workflow

### DIFF
--- a/.github/workflows/check_index_version.yml
+++ b/.github/workflows/check_index_version.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install compiler
       uses: ./.github/workflows/install-compiler-ubuntu
       with:
-        compiler: {{matrix.compiler}}
+        compiler: ${{matrix.compiler}}
         compiler-version: ${{matrix.compiler-version}}
     - name: Configure CMake Master
       working-directory: ${{github.workspace}}/master

--- a/.github/workflows/check_index_version.yml
+++ b/.github/workflows/check_index_version.yml
@@ -36,9 +36,9 @@ jobs:
         ref: 'master'
 
     - name: Install dependencies
-      uses: ./.github/workflows/install-dependencies-ubuntu
+      uses: ./pr/.github/workflows/install-dependencies-ubuntu
     - name: Install compiler
-      uses: ./.github/workflows/install-compiler-ubuntu
+      uses: ./pr/.github/workflows/install-compiler-ubuntu
       with:
         compiler: ${{matrix.compiler}}
         compiler-version: ${{matrix.compiler-version}}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -145,7 +145,7 @@ else()
     linkAndDiscoverTest(TokenTest parser re2 util)
 endif()
 
-addLinkAndDiscoverTest(TurtleParserTest parser re2)
+addLinkAndDiscoverTestSerial(TurtleParserTest parser re2)
 
 addLinkAndDiscoverTest(MultiColumnJoinTest engine)
 

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -786,7 +786,7 @@ TEST(TurtleParserTest, exceptionPropagation) {
 // Test that exceptions in the batched reading of the input file are properly
 // propagated.
 TEST(TurtleParserTest, exceptionPropagationFileBufferReading) {
-  std::string filename{"turtleParserEmptyInput.dat"};
+  std::string filename{"turtleParserExceptionPropagationFileBufferReading.dat"};
   auto testWithParser = [&]<typename Parser>(bool useBatchInterface,
                                              std::string_view input) {
     {


### PR DESCRIPTION
In the last refactoring of our GitHub workflows I accidentally broke the `check_index_version` workflow.
This commit fixes this workflow again.
It also applies some small changes to the turtle parser's tests to see, whether this addresses the spurious failures on GitHub actions.