### PR TITLE
Properly handle newlines and tabs in prefix compression

### DIFF
--- a/src/index/FTSAlgorithms.cpp
+++ b/src/index/FTSAlgorithms.cpp
@@ -44,8 +44,8 @@ Index::WordEntityPostings FTSAlgorithms::filterByRange(
     // TODO<joka921> Can we make the returned `IndexType` a template parameter
     // of the vocabulary, s.t. we have a vocabulary that stores `WordIndex`es
     // directly?
-    if (wordIdsInput[i] >= idRange._first.get() &&
-        wordIdsInput[i] <= idRange._last.get()) {
+    if (wordIdsInput[i] >= idRange.first().get() &&
+        wordIdsInput[i] <= idRange.last().get()) {
       wepResult.cids_[nofResultElements] = wepPreFilter.cids_[i];
       wepResult.scores_[nofResultElements] = wepPreFilter.scores_[i];
       wordIdsResult[nofResultElements++] = wordIdsInput[i];

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -1146,7 +1146,7 @@ void IndexImpl::dumpAsciiLists(const vector<string>& lists,
       IdRange idRange;
       textVocab_.getIdRangeForFullTextPrefix(lists[i], &idRange);
       TextBlockMetaData tbmd =
-          textMeta_.getBlockInfoByWordRange(idRange._first, idRange._last);
+          textMeta_.getBlockInfoByWordRange(idRange.first_, idRange.last_);
       if (decGapsFreq) {
         vector<Id> eids;
         vector<Id> cids;
@@ -1412,16 +1412,17 @@ auto IndexImpl::getTextBlockMetadataForWordOrPrefix(const std::string& word)
       return std::nullopt;
     }
   } else {
-    if (!textVocab_.getId(word, &idRange._first)) {
+    WordVocabIndex idx;
+    if (!textVocab_.getId(word, &idx)) {
       LOG(INFO) << "Term: " << word << " not in vocabulary\n";
       return std::nullopt;
     }
-    idRange._last = idRange._first;
+    idRange = IdRange{idx, idx};
   }
-  const auto& tbmd = textMeta_.getBlockInfoByWordRange(idRange._first.get(),
-                                                       idRange._last.get());
+  const auto& tbmd = textMeta_.getBlockInfoByWordRange(idRange.first().get(),
+                                                       idRange.last().get());
   bool hasToBeFiltered = tbmd._cl.hasMultipleWords() &&
-                         !(tbmd._firstWordId == idRange._first.get() &&
-                           tbmd._lastWordId == idRange._last.get());
+                         !(tbmd._firstWordId == idRange.first().get() &&
+                           tbmd._lastWordId == idRange.last().get());
   return TextBlockMetadataAndWordInfo{tbmd, hasToBeFiltered, idRange};
 }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -80,7 +80,7 @@ void IndexImpl::compressInternalVocabularyIfSpecified(
   if (vocabPrefixCompressed_) {
     auto prefixFile = ad_utility::makeOfstream(onDiskBase_ + PREFIX_FILE);
     for (const auto& prefix : prefixes) {
-      prefixFile << prefix << std::endl;
+      prefixFile << RdfEscaping::escapeNewlinesAndBackslashes(prefix) << std::endl;
     }
   }
   configurationJson_["prefixes"] = vocabPrefixCompressed_;
@@ -819,7 +819,7 @@ void IndexImpl::readConfiguration() {
       vector<string> prefixes;
       auto prefixFile = ad_utility::makeIfstream(onDiskBase_ + PREFIX_FILE);
       for (string prefix; std::getline(prefixFile, prefix);) {
-        prefixes.emplace_back(std::move(prefix));
+        prefixes.emplace_back(RdfEscaping::unescapeNewlinesAndBackslashes(prefix));
       }
       vocab_.buildCodebookForPrefixCompression(prefixes);
     } else {

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -80,7 +80,8 @@ void IndexImpl::compressInternalVocabularyIfSpecified(
   if (vocabPrefixCompressed_) {
     auto prefixFile = ad_utility::makeOfstream(onDiskBase_ + PREFIX_FILE);
     for (const auto& prefix : prefixes) {
-      prefixFile << RdfEscaping::escapeNewlinesAndBackslashes(prefix) << std::endl;
+      prefixFile << RdfEscaping::escapeNewlinesAndBackslashes(prefix)
+                 << std::endl;
     }
   }
   configurationJson_["prefixes"] = vocabPrefixCompressed_;
@@ -819,7 +820,8 @@ void IndexImpl::readConfiguration() {
       vector<string> prefixes;
       auto prefixFile = ad_utility::makeIfstream(onDiskBase_ + PREFIX_FILE);
       for (string prefix; std::getline(prefixFile, prefix);) {
-        prefixes.emplace_back(RdfEscaping::unescapeNewlinesAndBackslashes(prefix));
+        prefixes.emplace_back(
+            RdfEscaping::unescapeNewlinesAndBackslashes(prefix));
       }
       vocab_.buildCodebookForPrefixCompression(prefixes);
     } else {

--- a/test/FTSAlgorithmsTest.cpp
+++ b/test/FTSAlgorithmsTest.cpp
@@ -22,9 +22,8 @@ auto V = VocabId;
 }  // namespace
 
 TEST(FTSAlgorithmsTest, filterByRangeTest) {
-  IdRange<WordVocabIndex> idRange;
-  idRange._first = WordVocabIndex::make(5);
-  idRange._last = WordVocabIndex::make(7);
+  IdRange<WordVocabIndex> idRange{WordVocabIndex::make(5),
+                                  WordVocabIndex::make(7)};
 
   Index::WordEntityPostings wep;
   Index::WordEntityPostings resultWep;

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -586,3 +586,27 @@ TEST(IndexTest, trivialGettersAndSetters) {
   EXPECT_EQ(index.memoryLimitIndexBuilding(), 7_kB);
   EXPECT_EQ(std::as_const(index).memoryLimitIndexBuilding(), 7_kB);
 }
+
+TEST(IndexTest, NewlinesInPrefixCompression) {
+  std::string input;
+  for (size_t i : ad_utility::integerRange(200UL)) {
+    input.append(
+        absl::StrCat("<a> <b> \"\"\"\nabc\t\n34as\n\ndj", i, "\"\"\".\n"));
+  }
+  const QueryExecutionContext* ctx = nullptr;
+
+  ASSERT_NO_THROW(ctx = getQec(input));
+  AD_CORRECTNESS_CHECK(ctx != nullptr);
+  using namespace ::testing;
+
+  const auto& prefixes = ctx->getIndex()
+                             .getVocab()
+                             .getInternalVocab()
+                             .getUnderlyingVocabulary()
+                             .getCompressor()
+                             .prefixToCode();
+
+  // There must be at least one of the compression prefixes that compresses the
+  // common structure of the literals.
+  EXPECT_THAT(prefixes, Contains(ContainsRegex("\nabc\t\n")));
+}

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -51,23 +51,23 @@ TEST(VocabularyTest, getIdRangeForFullTextPrefixTest) {
   IdRange retVal;
   // Match exactly one
   ASSERT_TRUE(v.getIdRangeForFullTextPrefix("wordA1*", &retVal));
-  ASSERT_EQ(word0 + 1, retVal._first.get());
-  ASSERT_EQ(word0 + 1, retVal._last.get());
+  ASSERT_EQ(word0 + 1, retVal.first().get());
+  ASSERT_EQ(word0 + 1, retVal.last().get());
 
   // Match all
   ASSERT_TRUE(v.getIdRangeForFullTextPrefix("word*", &retVal));
-  ASSERT_EQ(word0, retVal._first.get());
-  ASSERT_EQ(word0 + 4, retVal._last.get());
+  ASSERT_EQ(word0, retVal.first().get());
+  ASSERT_EQ(word0 + 4, retVal.last().get());
 
   // Match first two
   ASSERT_TRUE(v.getIdRangeForFullTextPrefix("wordA*", &retVal));
-  ASSERT_EQ(word0, retVal._first.get());
-  ASSERT_EQ(word0 + 1, retVal._last.get());
+  ASSERT_EQ(word0, retVal.first().get());
+  ASSERT_EQ(word0 + 1, retVal.last().get());
 
   // Match last three
   ASSERT_TRUE(v.getIdRangeForFullTextPrefix("wordB*", &retVal));
-  ASSERT_EQ(word0 + 2, retVal._first.get());
-  ASSERT_EQ(word0 + 4, retVal._last.get());
+  ASSERT_EQ(word0 + 2, retVal.first().get());
+  ASSERT_EQ(word0 + 4, retVal.last().get());
 
   ASSERT_FALSE(v.getIdRangeForFullTextPrefix("foo*", &retVal));
 }


### PR DESCRIPTION
Newlines and tabs are now properly escaped in the prefix compression, which is important for the serialization to the `.prefixes` file, and unescaped when read back in from that file. Fixes #1204 