### PR TITLE
Finally publish docker images again

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Docker build and publish
 
 on:
   push:
-    branches: ["master"]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
There still was a minor bug in the workflow left which prohibited the docker containers to be built and published on pushes to the master branch. This should now be fixed.