### PR TITLE
Make the LOG class threadsafe

### DIFF
--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -47,9 +47,9 @@ void RuntimeInformation::formatDetailValue(std::ostream& out,
   // native type so they get thousands separators. For everything else we
   // let nlohmann::json handle it.
   if (value.type() == number_float) {
-    out << ad_utility::to_string(value.get<double>(), 2);
+    out << value.get<double>();
   } else if (value.type() == number_unsigned) {
-    out << value.template get<uint64_t>();
+    out << value.get<uint64_t>();
   } else if (value.type() == number_integer) {
     out << value.get<int64_t>();
   } else {

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -43,7 +43,7 @@ void RuntimeInformation::formatDetailValue(std::ostream& out,
                                            std::string_view key,
                                            const nlohmann::json& value) {
   using enum nlohmann::json::value_t;
-  // We want to print doubles with fixed precision and stream ints as their
+  // We want to print doubles th fixed precision and stream ints as their
   // native type so they get thousands separators. For everything else we
   // let nlohmann::json handle it.
   if (value.type() == number_float) {

--- a/src/engine/RuntimeInformation.cpp
+++ b/src/engine/RuntimeInformation.cpp
@@ -43,9 +43,8 @@ void RuntimeInformation::formatDetailValue(std::ostream& out,
                                            std::string_view key,
                                            const nlohmann::json& value) {
   using enum nlohmann::json::value_t;
-  // We want to print doubles th fixed precision and stream ints as their
-  // native type so they get thousands separators. For everything else we
-  // let nlohmann::json handle it.
+  // We want to print doubles and ints as their native type so they get
+  // thousands separators. For everything else we let nlohmann::json handle it.
   if (value.type() == number_float) {
     out << value.get<double>();
   } else if (value.type() == number_unsigned) {

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -108,18 +108,14 @@ class Log {
   static std::ostream& getLog() {
     // use the singleton logging stream as target.
     return LogstreamChoice::get().getStream()
-           << ad_utility::Log::getTimeStamp() << "\t- "
-           << ad_utility::Log::getLevel<LEVEL>();
+           << getTimeStamp() << " - " << getLevel<LEVEL>();
   }
 
   static void imbue(const std::locale& locale) { std::cout.imbue(locale); }
 
   static string getTimeStamp() {
-    auto now = absl::Now();
-    auto ms = absl::ToUnixMillis(now) % 1000;
-    auto timeString =
-        absl::FormatTime("%Y-%m-%d %X", now, absl::LocalTimeZone());
-    return absl::StrFormat("%s.%03d", timeString, ms);
+    return absl::FormatTime("%Y-%m-%d %H:%M:%E3S", absl::Now(),
+                            absl::LocalTimeZone());
   }
 
   template <LogLevel LEVEL>

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -8,9 +8,6 @@
 #include <absl/time/clock.h>
 #include <absl/time/time.h>
 
-#include <chrono>
-#include <ctime>
-#include <iomanip>
 #include <iostream>
 #include <locale>
 #include <sstream>

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -85,22 +85,6 @@ class CommaNumPunct : public std::numpunct<char> {
 
 const static std::locale commaLocale(std::locale(), new CommaNumPunct());
 
-//! String representation of a double with precision and thousandth separators
-inline string to_string(double in, size_t precision) {
-  std::ostringstream buffer;
-  buffer.imbue(commaLocale);
-  buffer << std::setprecision(precision) << std::fixed << in;
-  return std::move(buffer).str();
-}
-
-//! String representation of a long with thousandth separators
-inline string to_string(long in) {
-  std::ostringstream buffer;
-  buffer.imbue(commaLocale);
-  buffer << in;
-  return std::move(buffer).str();
-}
-
 //! Log
 class Log {
  public:

--- a/src/util/Log.h
+++ b/src/util/Log.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <absl/strings/str_format.h>
+#include <absl/time/clock.h>
+#include <absl/time/time.h>
+
 #include <chrono>
 #include <ctime>
 #include <iomanip>
@@ -111,15 +115,11 @@ class Log {
   static void imbue(const std::locale& locale) { std::cout.imbue(locale); }
 
   static string getTimeStamp() {
-    using namespace std::chrono;
-    auto now = system_clock::now();
-    auto inTimeT = system_clock::to_time_t(now);
-    auto ms = duration_cast<milliseconds>(now.time_since_epoch()) % 1000;
-    std::stringstream ss;
-
-    ss << std::put_time(std::localtime(&inTimeT), "%Y-%m-%d %X") << '.'
-       << std::setw(3) << std::setfill('0') << ms.count();
-    return std::move(ss).str();
+    auto now = absl::Now();
+    auto ms = absl::ToUnixMillis(now) % 1000;
+    auto timeString =
+        absl::FormatTime("%Y-%m-%d %X", now, absl::LocalTimeZone());
+    return absl::StrFormat("%s.%03d", timeString, ms);
   }
 
   template <LogLevel LEVEL>


### PR DESCRIPTION
So far, we used `system_clock::now`, `std::put_time` and `std::localtime`, but the latter is not threadsafe. We now use `absl::Now` and `absl::FormatTime`.