### PR TITLE
Fix build error introduced by previous commit

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1108,7 +1108,7 @@ void GroupBy::createResultFromHashMap(
 // _____________________________________________________________________________
 template <typename A>
 concept SupportedAggregates =
-    ad_utility::isTypeContainedIn<A, GroupBy::Aggregations>;
+    ad_utility::SameAsAnyTypeIn<A, GroupBy::Aggregations>;
 
 // _____________________________________________________________________________
 // Visitor function to extract values from the result of an evaluation of


### PR DESCRIPTION
Note that the `check-index-version` workflow will still fail for this commit because it checks out the previous version of the master, which because of the build error we are fixing here does not compile. Everything should be fine again starting with the next commit after this one.