### PR TITLE
Remove functionality from File.h to fix undefined behaviour

### DIFF
--- a/src/TurtleParserMain.cpp
+++ b/src/TurtleParserMain.cpp
@@ -4,13 +4,15 @@
 
 #include <getopt.h>
 
-#include <array>
 #include <fstream>
 #include <iostream>
 #include <string>
 
-#include "./parser/TurtleParser.h"
-#include "./util/Log.h"
+#include "parser/TurtleParser.h"
+#include "util/Log.h"
+
+using std::cout;
+using std::endl;
 
 /**
  * @brief Instantiate a Parser that parses filename and writes the resulting
@@ -36,29 +38,6 @@ void writeNTImpl(std::ostream& out, const std::string& filename) {
   }
 }
 
-template <class Parser>
-void writeLabel(const std::string& filename) {
-  Parser p(filename);
-  std::array<std::string, 3> triple;
-  size_t numTriples = 0;
-  std::unordered_set<std::string> entities;
-  while (p.getLine(triple)) {
-    entities.insert(std::move(triple[0]));
-    entities.insert(std::move(triple[1]));
-    entities.insert(std::move(triple[2]));
-    numTriples++;
-    if (numTriples % 10000000 == 0) {
-      LOG(INFO) << "Parsed " << numTriples << " triples" << std::endl;
-    }
-  }
-  for (const auto& t : entities) {
-    if (t.starts_with('<')) {
-      std::cout << t << " <qlever_label> \"" << t.substr(1, t.size() - 2)
-                << ".\n";
-    }
-  }
-}
-
 /**
  * @brief Decide according to arg fileFormat which parser to use.
  * Then call writeNTImpl with the appropriate parser
@@ -70,7 +49,6 @@ template <class Tokenizer_T>
 void writeNT(std::ostream& out, const string& fileFormat,
              const std::string& filename) {
   if (fileFormat == "ttl" || fileFormat == "nt") {
-    // writeLabel<TurtleStreamParser<Tokenizer_T>>(out, filename);
     writeNTImpl<TurtleStreamParser<Tokenizer_T>>(out, filename);
   } else {
     LOG(ERROR) << "writeNT was called with unknown file format " << fileFormat

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -85,6 +85,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 
 // _____________________________________________________________________________
 ResultTable Bind::computeResult() {
+  using std::endl;
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
   shared_ptr<const ResultTable> subRes = _subtree->getResult();
   LOG(DEBUG) << "Got input to Bind operation." << endl;

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -9,6 +9,7 @@
 #include "engine/CallFixedSize.h"
 #include "engine/QueryExecutionTree.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -16,6 +16,7 @@
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -18,6 +18,7 @@
 #include <type_traits>
 #include <vector>
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -4,9 +4,10 @@
 
 #include "Minus.h"
 
-#include "../util/Exception.h"
-#include "CallFixedSize.h"
+#include "engine/CallFixedSize.h"
+#include "util/Exception.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -8,6 +8,7 @@
 #include "engine/CallFixedSize.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -187,20 +187,20 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
     // caught by the `processQuery` method, where the error message will be
     // printed *and* included in an error response sent to the client.
     LOG(ERROR) << "Waited for a result from another thread which then failed"
-               << endl;
+               << std::endl;
     LOG(DEBUG) << getCacheKey();
     throw ad_utility::AbortException(e);
   } catch (const std::exception& e) {
     // We are in the innermost level of the exception, so print
-    LOG(ERROR) << "Aborted Operation" << endl;
-    LOG(DEBUG) << getCacheKey() << endl;
+    LOG(ERROR) << "Aborted Operation" << std::endl;
+    LOG(DEBUG) << getCacheKey() << std::endl;
     // Rethrow as QUERY_ABORTED allowing us to print the Operation
     // only at innermost failure of a recursive call
     throw ad_utility::AbortException(e);
   } catch (...) {
     // We are in the innermost level of the exception, so print
-    LOG(ERROR) << "Aborted Operation" << endl;
-    LOG(DEBUG) << getCacheKey() << endl;
+    LOG(ERROR) << "Aborted Operation" << std::endl;
+    LOG(DEBUG) << getCacheKey() << std::endl;
     // Rethrow as QUERY_ABORTED allowing us to print the Operation
     // only at innermost failure of a recursive call
     throw ad_utility::AbortException(

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -9,6 +9,7 @@
 #include "engine/CallFixedSize.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -12,6 +12,7 @@
 #include "engine/QueryExecutionTree.h"
 #include "global/ValueIdComparators.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -10,6 +10,7 @@
 #include "CallFixedSize.h"
 #include "QueryExecutionTree.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/TextOperationWithFilter.cpp
+++ b/src/engine/TextOperationWithFilter.cpp
@@ -8,6 +8,7 @@
 
 #include "./QueryExecutionTree.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/engine/TextOperationWithoutFilter.cpp
+++ b/src/engine/TextOperationWithoutFilter.cpp
@@ -8,6 +8,7 @@
 
 #include "./QueryExecutionTree.h"
 
+using std::endl;
 using std::string;
 
 // _____________________________________________________________________________

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -325,6 +325,9 @@ using namespace std::string_view_literals;
 /// Manage the reading of relations from disk that have been previously written
 /// using the `CompressedRelationWriter`.
 class CompressedRelationReader {
+  template <typename T>
+  using vector = std::vector<T>;
+
  public:
   using Allocator = ad_utility::AllocatorWithLimit<Id>;
   using ColumnIndicesRef = std::span<const ColumnIndex>;

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -9,6 +9,7 @@
 #include <absl/strings/str_split.h>
 
 #include <algorithm>
+#include <charconv>
 #include <ranges>
 #include <stxxl/algorithm>
 #include <tuple>
@@ -132,32 +133,32 @@ void IndexImpl::addTextFromContextFile(const string& contextFile,
 // _____________________________________________________________________________
 void IndexImpl::buildDocsDB(const string& docsFileName) {
   LOG(INFO) << "Building DocsDB...\n";
-  ad_utility::File docsFile(docsFileName.c_str(), "r");
+  std::ifstream docsFile{docsFileName};
   std::ofstream ofs(onDiskBase_ + ".text.docsDB", std::ios_base::out);
   // To avoid excessive use of RAM,
   // we write the offsets to and stxxl:vector first;
-  typedef stxxl::vector<off_t> OffVec;
-  OffVec offsets;
+  stxxl::vector<off_t> offsets;
   off_t currentOffset = 0;
   uint64_t currentContextId = 0;
-  char* buf = new char[BUFFER_SIZE_DOCSFILE_LINE];
   string line;
-  while (docsFile.readLine(&line, buf, BUFFER_SIZE_DOCSFILE_LINE)) {
-    size_t tab = line.find('\t');
-    uint64_t contextId = atol(line.substr(0, tab).c_str());
-    line = line.substr(tab + 1);
-    ofs << line;
+  line.reserve(BUFFER_SIZE_DOCSFILE_LINE);
+  while (std::getline(docsFile, line)) {
+    std::string_view lineView = line;
+    size_t tab = lineView.find('\t');
+    uint64_t contextId;
+    std::from_chars(lineView.data(), lineView.data() + tab, contextId);
+    lineView = lineView.substr(tab + 1);
+    ofs << lineView;
     while (currentContextId < contextId) {
       offsets.push_back(currentOffset);
       currentContextId++;
     }
     offsets.push_back(currentOffset);
     currentContextId++;
-    currentOffset += line.size();
+    currentOffset += static_cast<off_t>(lineView.size());
   }
   offsets.push_back(currentOffset);
 
-  delete[] buf;
   ofs.close();
   // Now append the tmp file to the docsDB file.
   ad_utility::File out(string(onDiskBase_ + ".text.docsDB").c_str(), "a");

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -161,7 +161,7 @@ void IndexImpl::buildDocsDB(const string& docsFileName) {
 
   ofs.close();
   // Now append the tmp file to the docsDB file.
-  ad_utility::File out(string(onDiskBase_ + ".text.docsDB").c_str(), "a");
+  ad_utility::File out(onDiskBase_ + ".text.docsDB", "a");
   for (size_t i = 0; i < offsets.size(); ++i) {
     off_t cur = offsets[i];
     out.write(&cur, sizeof(cur));

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -145,7 +145,7 @@ void IndexImpl::buildDocsDB(const string& docsFileName) {
   while (std::getline(docsFile, line)) {
     std::string_view lineView = line;
     size_t tab = lineView.find('\t');
-    uint64_t contextId;
+    uint64_t contextId = 0;
     std::from_chars(lineView.data(), lineView.data() + tab, contextId);
     lineView = lineView.substr(tab + 1);
     ofs << lineView;

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -131,7 +131,7 @@ void IndexImpl::addTextFromContextFile(const string& contextFile,
 }
 
 // _____________________________________________________________________________
-void IndexImpl::buildDocsDB(const string& docsFileName) {
+void IndexImpl::buildDocsDB(const string& docsFileName) const {
   LOG(INFO) << "Building DocsDB...\n";
   std::ifstream docsFile{docsFileName};
   std::ofstream ofs(onDiskBase_ + ".text.docsDB", std::ios_base::out);

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -228,7 +228,7 @@ class IndexImpl {
                               bool addWordsFromLiterals);
 
   // Build docsDB file from given file (one text record per line).
-  void buildDocsDB(const string& docsFile);
+  void buildDocsDB(const string& docsFile) const;
 
   // Adds text index from on disk index that has previously been constructed.
   // Read necessary meta data into memory and opens file handles.

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -123,30 +123,6 @@ class File {
     return fread(targetBuffer, (size_t)1, nofBytesToRead, _file);
   }
 
-  // Reads a line from the file into param line and interprets it as ASCII.
-  // Removes the \n from the end of the string.
-  // Returns null on EOF when no chars have been read.
-  // Throws an Exception if the buffer is not sufficiently large.
-  // Warning: std::getTriple which works on a file stream
-  // is generally more performant (it uses a general stream buffer
-  // to wrap the file)
-  // and appeds char by char to the string.
-  bool readLine(string* line, char* buf, size_t bufferSize) {
-    assert(_file);
-    char* retVal = fgets(buf, bufferSize, _file);
-    size_t stringLength = strlen(buf);
-    if (retVal && stringLength > 0 && buf[stringLength - 1] == '\n') {
-      // Remove the trailing \n
-      buf[stringLength - 1] = 0;
-    } else if (retVal && !isAtEof()) {
-      // Stopped inside a line because the end of the buffer was reached.
-      AD_THROW("Buffer too small when reading from file: " + _name +
-               ". Or the line contains a 0 character.");
-    }
-    *line = buf;
-    return retVal;
-  }
-
   // write to current file pointer position
   // returns number of bytes written
   size_t write(const void* sourceBuffer, size_t nofBytesToWrite) {
@@ -154,28 +130,11 @@ class File {
     return fwrite(sourceBuffer, (size_t)1, nofBytesToWrite, _file);
   }
 
-  // write to current file pointer position
-  // returns number of bytes written
-  void writeLine(const string& line) {
-    assert(_file);
-    write(line.c_str(), line.size());
-    write("\n", 1);
-  }
-
   void flush() { fflush(_file); }
 
   bool isAtEof() {
     assert(_file);
     return feof(_file) != 0;
-  }
-
-  //! Read an ASCII file into a vector of strings.
-  //! Each line represents an entry.
-  void readIntoVector(vector<string>* target, char* buf, size_t bufferSize) {
-    string line;
-    while (readLine(&line, buf, bufferSize)) {
-      target->push_back(line);
-    }
   }
 
   //! Seeks a position in the file.

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <absl/strings/str_cat.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <cassert>
 #include <cerrno>

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cerrno>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -16,17 +16,10 @@
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <vector>
 
 #include "util/Exception.h"
 #include "util/Forward.h"
 #include "util/Log.h"
-
-using std::cerr;
-using std::cout;
-using std::endl;
-using std::string;
-using std::vector;
 
 namespace ad_utility {
 //! Wrapper class for file access. Is supposed to provide
@@ -36,6 +29,8 @@ namespace ad_utility {
 //! to the lack of buffering.
 //! Many methods are copies from the CompleteSearch File.h
 class File {
+  using string = std::string;
+
  private:
   string _name;
   FILE* _file;
@@ -83,8 +78,7 @@ class File {
     if (_file == NULL) {
       std::stringstream err;
       err << "! ERROR opening file \"" << filename << "\" with mode \"" << mode
-          << "\" (" << strerror(errno) << ")" << endl
-          << endl;
+          << "\" (" << strerror(errno) << ")" << std::endl;
       throw std::runtime_error(std::move(err).str());
     }
     _name = filename;
@@ -105,9 +99,8 @@ class File {
       return true;
     }
     if (fclose(_file) != 0) {
-      cout << "! ERROR closing file \"" << _name << "\" (" << strerror(errno)
-           << ")" << endl
-           << endl;
+      std::cout << "! ERROR closing file \"" << _name << "\" ("
+                << strerror(errno) << ")" << std::endl;
       exit(1);
     }
     _file = NULL;
@@ -172,7 +165,7 @@ class File {
     assert(_file);
     off_t returnValue = ftello(_file);
     if (returnValue == (off_t)-1) {
-      cerr << "\n ERROR in tell() : " << strerror(errno) << endl << endl;
+      std::cerr << "\n ERROR in tell() : " << strerror(errno) << std::endl;
       exit(1);
     }
     return returnValue;

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -4,23 +4,21 @@
 
 #pragma once
 #include <absl/strings/str_cat.h>
-#include <assert.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
+#include <cassert>
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 
-#include "./Exception.h"
-#include "./Forward.h"
-#include "Log.h"
+#include "util/Exception.h"
+#include "util/Forward.h"
+#include "util/Log.h"
 
 using std::cerr;
 using std::cout;
@@ -132,11 +130,6 @@ class File {
 
   void flush() { fflush(_file); }
 
-  bool isAtEof() {
-    assert(_file);
-    return feof(_file) != 0;
-  }
-
   //! Seeks a position in the file.
   //! Sets the file position indicator for the stream.
   //! The new position is obtained by adding seekOffset
@@ -170,9 +163,6 @@ class File {
     return bytesRead;
   }
 
-  //! get the underlying file descriptor
-  [[nodiscard]] int getFileDescriptor() const { return fileno(_file); }
-
   //! Returns the number of bytes from the beginning
   //! is 0 on opening. Later equal the number of bytes written.
   //! -1 is returned when an error occurs
@@ -202,11 +192,6 @@ class File {
     read(lastOffset, sizeof(off_t), lastOffsetOffset);
 
     return lastOffsetOffset;
-  }
-
-  // Static method to check if a file exists.
-  static bool exists(const std::filesystem::path& path) {
-    return std::filesystem::exists(path);
   }
 };
 

--- a/src/util/Serializer/FileSerializer.h
+++ b/src/util/Serializer/FileSerializer.h
@@ -67,8 +67,6 @@ class FileReadSerializer {
     }
   }
 
-  bool isExhausted() { return _file.isAtEof(); }
-
   void setSerializationPosition(SerializationPosition position) {
     _file.seek(static_cast<off_t>(position), SEEK_SET);
   }

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -3,9 +3,10 @@
 // Author: Björn Buchhold <buchholb>
 
 #include <gtest/gtest.h>
-#include <stdio.h>
 
-#include "../src/util/File.h"
+#include <cstdio>
+
+#include "util/File.h"
 
 using std::string;
 using std::vector;
@@ -13,7 +14,7 @@ using std::vector;
 namespace ad_utility {
 class FileTest : public ::testing::Test {
  protected:
-  virtual void SetUp() {
+  void SetUp() override {
     {
       File testFile1("_tmp_testFile1", "w");
       string content = "line1\nline2\n";
@@ -47,7 +48,7 @@ class FileTest : public ::testing::Test {
     }
   }
 
-  virtual void TearDown() {
+  void TearDown() override {
     remove("_tmp_testFile1");
     remove("_tmp_testFile2");
     remove("_tmp_testFile3");
@@ -55,100 +56,6 @@ class FileTest : public ::testing::Test {
     remove("_tmp_testFileBinary");
   }
 };
-
-TEST_F(FileTest, testReadLineWithTrailingNewline) {
-  File withTrailingNewline("_tmp_testFile1", "r");
-  string line;
-  vector<string> lines;
-  char buf[1024];
-  while (withTrailingNewline.readLine(&line, buf, 1024)) {
-    lines.push_back(line);
-  }
-  ASSERT_EQ(static_cast<size_t>(2), lines.size());
-  ASSERT_EQ("line1", lines[0]);
-  ASSERT_EQ("line2", lines[1]);
-}
-
-TEST_F(FileTest, testReadLineWithoutTrailingNewline) {
-  File withoutTrailingNewline("_tmp_testFile2", "r");
-  string line;
-  vector<string> lines;
-  char buf[1024];
-  // Read the first line, everything works fine.
-  while (withoutTrailingNewline.readLine(&line, buf, 1024)) {
-    lines.push_back(line);
-  }
-  ASSERT_EQ(static_cast<size_t>(2), lines.size());
-  ASSERT_EQ("line1", lines[0]);
-  ASSERT_EQ("line2", lines[1]);
-}
-
-TEST_F(FileTest, testReadLineFromEmptyFile) {
-  File withoutTrailingNewline("_tmp_testFile4", "r");
-  string line;
-  vector<string> lines;
-  char buf[1024];
-  // Read the first line, everything works fine.
-  while (withoutTrailingNewline.readLine(&line, buf, 1024)) {
-    lines.push_back(line);
-  }
-  ASSERT_EQ(static_cast<size_t>(0), lines.size());
-}
-
-TEST_F(FileTest, testWriteLineAppend) {
-  {
-    File file3("_tmp_testFile3", "a");
-    file3.writeLine("line2");
-  }
-
-  File file3("_tmp_testFile3", "r");
-  string line;
-  vector<string> lines;
-  char buf[1024];
-  while (file3.readLine(&line, buf, 1024)) {
-    lines.push_back(line);
-  }
-  ASSERT_EQ(static_cast<size_t>(2), lines.size());
-  ASSERT_EQ("line1", lines[0]);
-  ASSERT_EQ("line2", lines[1]);
-}
-
-TEST_F(FileTest, testWriteLineWrite) {
-  {
-    File file3("_tmp_testFile3", "w");
-    file3.writeLine("line2");
-  }
-
-  File file3("_tmp_testFile3", "r");
-  string line;
-  vector<string> lines;
-  char buf[1024];
-  while (file3.readLine(&line, buf, 1024)) {
-    lines.push_back(line);
-  }
-  ASSERT_EQ(static_cast<size_t>(1), lines.size());
-  ASSERT_EQ("line2", lines[0]);
-}
-
-TEST_F(FileTest, testReadIntoVector) {
-  File withTrailingNewline("_tmp_testFile1", "r");
-  File withoutTrailingNewline("_tmp_testFile2", "r");
-
-  vector<string> lines1;
-  vector<string> lines2;
-
-  char buf[1024];
-
-  withTrailingNewline.readIntoVector(&lines1, buf, 1024);
-  ASSERT_EQ(static_cast<size_t>(2), lines1.size());
-  ASSERT_EQ("line1", lines1[0]);
-  ASSERT_EQ("line2", lines1[1]);
-
-  withoutTrailingNewline.readIntoVector(&lines2, buf, 1024);
-  ASSERT_EQ(static_cast<size_t>(2), lines2.size());
-  ASSERT_EQ("line1", lines2[0]);
-  ASSERT_EQ("line2", lines2[1]);
-}
 
 TEST(File, move) {
   std::string filename = "testFileMove.tmp";

--- a/test/FileTest.cpp
+++ b/test/FileTest.cpp
@@ -4,59 +4,9 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdio>
-
 #include "util/File.h"
 
-using std::string;
-using std::vector;
-
 namespace ad_utility {
-class FileTest : public ::testing::Test {
- protected:
-  void SetUp() override {
-    {
-      File testFile1("_tmp_testFile1", "w");
-      string content = "line1\nline2\n";
-      testFile1.write(content.c_str(), content.size());
-    }
-    {
-      File testFile2("_tmp_testFile2", "w");
-      string content = "line1\nline2";
-      testFile2.write(content.c_str(), content.size());
-    }
-    {
-      File testFile3("_tmp_testFile3", "w");
-      string content = "line1\n";
-      testFile3.write(content.c_str(), content.size());
-    }
-    {
-      File testFile3("_tmp_testFile4", "w");
-      string content = "";
-      testFile3.write(content.c_str(), content.size());
-    }
-    {
-      File testFileBinary("_tmp_testFileBinary", "w");
-      size_t a = 1;
-      size_t b = 0;
-      size_t c = 5000;
-      off_t off = 3;
-      testFileBinary.write(&a, sizeof(size_t));
-      testFileBinary.write(&b, sizeof(size_t));
-      testFileBinary.write(&c, sizeof(size_t));
-      testFileBinary.write(&off, sizeof(off_t));
-    }
-  }
-
-  void TearDown() override {
-    remove("_tmp_testFile1");
-    remove("_tmp_testFile2");
-    remove("_tmp_testFile3");
-    remove("_tmp_testFile4");
-    remove("_tmp_testFileBinary");
-  }
-};
-
 TEST(File, move) {
   std::string filename = "testFileMove.tmp";
   File file1(filename, "w");


### PR DESCRIPTION
The function  `ad_utiliyt::File::readFile` was was subject to undefined behaviour if the buffer passed to the function does not contain a null terminator. This function is now completely removed and its only usage is replaced by `std::ifstream`.
Also some parts of the class `ad_utility::File` are cleaned up by removing unused functionality and unused includes.