### PR TITLE
Prefix search now also considers the external vocabulary

### DIFF
--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -184,8 +184,11 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   std::vector<std::pair<Id, Id>> lowerAndUpperIds;
   lowerAndUpperIds.reserve(actualPrefixes.size());
   for (const auto& prefix : actualPrefixes) {
-    lowerAndUpperIds.emplace_back(
-        context->_qec.getIndex().prefix_range(prefix));
+    for (const auto& range :
+         context->_qec.getIndex().prefixRanges(prefix).ranges()) {
+      lowerAndUpperIds.emplace_back(Id::makeFromVocabIndex(range.first),
+                                    Id::makeFromVocabIndex(range.second));
+    }
   }
   auto beg = context->_inputTable.begin() + context->_beginIndex;
   auto end = context->_inputTable.begin() + context->_endIndex;

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -1,6 +1,8 @@
-//  Copyright 2022, University of Freiburg,
-//                  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+// Copyright 2022 - 2024
+// University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #include "./RegexExpression.h"
 
@@ -184,8 +186,8 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   std::vector<std::pair<Id, Id>> lowerAndUpperIds;
   lowerAndUpperIds.reserve(actualPrefixes.size());
   for (const auto& prefix : actualPrefixes) {
-    for (const auto& range :
-         context->_qec.getIndex().prefixRanges(prefix).ranges()) {
+    const auto& ranges = context->_qec.getIndex().prefixRanges(prefix);
+    for (const auto& range : ranges.ranges()) {
       lowerAndUpperIds.emplace_back(Id::makeFromVocabIndex(range.first),
                                     Id::makeFromVocabIndex(range.second));
     }

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -187,9 +187,9 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   lowerAndUpperIds.reserve(actualPrefixes.size());
   for (const auto& prefix : actualPrefixes) {
     const auto& ranges = context->_qec.getIndex().prefixRanges(prefix);
-    for (const auto& range : ranges.ranges()) {
-      lowerAndUpperIds.emplace_back(Id::makeFromVocabIndex(range.first),
-                                    Id::makeFromVocabIndex(range.second));
+    for (const auto& [begin, end] : ranges.ranges()) {
+      lowerAndUpperIds.emplace_back(Id::makeFromVocabIndex(begin),
+                                    Id::makeFromVocabIndex(end));
     }
   }
   auto beg = context->_inputTable.begin() + context->_beginIndex;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -83,8 +83,8 @@ bool Index::getId(const std::string& element, Id* id) const {
 }
 
 // ____________________________________________________________________________
-std::pair<Id, Id> Index::prefix_range(const std::string& prefix) const {
-  return pimpl_->prefix_range(prefix);
+Index::Vocab::PrefixRanges Index::prefixRanges(std::string_view prefix) const {
+  return pimpl_->prefixRanges(prefix);
 }
 
 // ____________________________________________________________________________

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -119,7 +119,7 @@ class Index {
 
   bool getId(const std::string& element, Id* id) const;
 
-  [[nodiscard]] std::pair<Id, Id> prefix_range(const std::string& prefix) const;
+  [[nodiscard]] Vocab::PrefixRanges prefixRanges(std::string_view prefix) const;
 
   [[nodiscard]] const CompactVectorOfStrings<Id>& getPatterns() const;
   /**

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -264,7 +264,7 @@ std::unique_ptr<ExternalSorter<SortByPSO, 5>> IndexImpl::buildOspWithPatterns(
   // Add the `ql:has-pattern` predicate to the sorter such that it will become
   // part of the PSO and POS permutation.
   LOG(INFO) << "Adding " << hasPatternPredicateSortedByPSO->size()
-            << "triples to the POS and PSO permutation for "
+            << " triples to the POS and PSO permutation for "
                "`ql:has-pattern` ..."
             << std::endl;
   auto noPattern = Id::makeFromInt(NO_PATTERN);
@@ -1407,10 +1407,10 @@ bool IndexImpl::getId(const string& element, Id* id) const {
 }
 
 // ___________________________________________________________________________
-std::pair<Id, Id> IndexImpl::prefix_range(const std::string& prefix) const {
+Index::Vocab::PrefixRanges IndexImpl::prefixRanges(
+    std::string_view prefix) const {
   // TODO<joka921> Do we need prefix ranges for numbers?
-  auto [begin, end] = vocab_.prefix_range(prefix);
-  return {Id::makeFromVocabIndex(begin), Id::makeFromVocabIndex(end)};
+  return vocab_.prefixRanges(prefix);
 }
 
 // _____________________________________________________________________________

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -132,12 +132,7 @@ bool Vocabulary<S, C, I>::shouldEntityBeExternalized(const string& word) const {
   // `"prefixes-external": ["@"]` or `"prefixes-external": [""]` in the
   // `.settings.json` file.
   //
-  // TODO: I tried it without the following three lines first, but that didn't
-  // when `"prefixes-external": ["@"]` or `"prefixes-external": [""]`. Why is
-  // that, is this related to `IndexImlp::getIgnoredIdRanges`? Anyway, it's
-  // error-prone that there are related things happening at two (or more)
-  // different places in the code and if they are not perfectly in sync, things
-  // go wrong.
+  // TODO: This points to a bug or inconsistency elsewhere in the code.
   if (word.starts_with("@")) {
     return false;
   }

--- a/src/index/Vocabulary.cpp
+++ b/src/index/Vocabulary.cpp
@@ -1,24 +1,45 @@
-// Copyright 2011, University of Freiburg,
+// Copyright 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Authors: Björn Buchhold <buchholb>,
-//          Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
+// Authors: Björn Buchhold <buchhold@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
-#include "./Vocabulary.h"
+#include "index/Vocabulary.h"
 
 #include <fstream>
 #include <iostream>
 
-#include "../parser/RdfEscaping.h"
-#include "../parser/Tokenizer.h"
-#include "../util/BatchedPipeline.h"
-#include "../util/File.h"
-#include "../util/HashMap.h"
-#include "../util/HashSet.h"
-#include "../util/Serializer/FileSerializer.h"
-#include "../util/json.h"
-#include "./ConstantsIndexBuilding.h"
+#include "index/ConstantsIndexBuilding.h"
+#include "parser/RdfEscaping.h"
+#include "parser/Tokenizer.h"
+#include "util/BatchedPipeline.h"
+#include "util/File.h"
+#include "util/HashMap.h"
+#include "util/HashSet.h"
+#include "util/Serializer/FileSerializer.h"
+#include "util/json.h"
 
 using std::string;
+
+// ____________________________________________________________________________
+template <typename StringType, typename ComparatorType, typename IndexT>
+Vocabulary<StringType, ComparatorType, IndexT>::PrefixRanges::PrefixRanges(
+    const Ranges& ranges)
+    : ranges_(ranges) {
+  for (const auto& range : ranges_) {
+    AD_CONTRACT_CHECK(range.first <= range.second);
+  }
+}
+
+// ____________________________________________________________________________
+template <typename StringType, typename ComparatorType, typename IndexT>
+bool Vocabulary<StringType, ComparatorType, IndexT>::PrefixRanges::contain(
+    IndexT index) const {
+  return std::ranges::any_of(
+      ranges_, [index](const std::pair<IndexT, IndexT>& range) {
+        return range.first <= index && index < range.second;
+      });
+}
 
 // _____________________________________________________________________________
 template <class S, class C, typename I>
@@ -100,12 +121,28 @@ bool Vocabulary<S, C, I>::shouldBeExternalized(const string& word) const {
 // ___________________________________________________________________
 template <class S, class C, class I>
 bool Vocabulary<S, C, I>::shouldEntityBeExternalized(const string& word) const {
-  // Never externalize the internal URIs as they are sometimes added before or
+  // Never externalize the internal IRIs as they are sometimes added before or
   // after the externalization happens and we thus get inconsistent behavior
   // etc. for `ql:langtag`.
   if (word.starts_with(INTERNAL_ENTITIES_URI_PREFIX)) {
     return false;
   }
+  // Never externalize the special IRIs starting with `@` (for example,
+  // @en@rdfs:label). Otherwise, they will not be found with a setting like
+  // `"prefixes-external": ["@"]` or `"prefixes-external": [""]` in the
+  // `.settings.json` file.
+  //
+  // TODO: I tried it without the following three lines first, but that didn't
+  // when `"prefixes-external": ["@"]` or `"prefixes-external": [""]`. Why is
+  // that, is this related to `IndexImlp::getIgnoredIdRanges`? Anyway, it's
+  // error-prone that there are related things happening at two (or more)
+  // different places in the code and if they are not perfectly in sync, things
+  // go wrong.
+  if (word.starts_with("@")) {
+    return false;
+  }
+  // Otherwise, externalize if and only if there is a prefix match for one of
+  // `externalizedPrefixes_`.
   return std::ranges::any_of(externalizedPrefixes_, [&word](const auto& p) {
     return word.starts_with(p);
   });
@@ -187,14 +224,14 @@ std::optional<IdRange<I>> Vocabulary<S, C, I>::getIdRangeForFullTextPrefix(
     const string& word) const {
   AD_CONTRACT_CHECK(word[word.size() - 1] == PREFIX_CHAR);
   IdRange<I> range;
-  auto prefixRange = prefix_range(word.substr(0, word.size() - 1));
-  bool success = prefixRange.second > prefixRange.first;
+  auto [begin, end] =
+      internalVocabulary_.prefix_range(word.substr(0, word.size() - 1));
+  bool notEmpty = end > begin;
 
-  if (success) {
-    range = IdRange{prefixRange.first, prefixRange.second.decremented()};
+  if (notEmpty) {
+    range = IdRange{I::make(begin), I::make(end).decremented()};
     AD_CONTRACT_CHECK(range.first().get() < internalVocabulary_.size());
     AD_CONTRACT_CHECK(range.last().get() < internalVocabulary_.size());
-
     return range;
   }
   return std::nullopt;
@@ -253,10 +290,16 @@ bool Vocabulary<S, C, I>::getId(const string& word, IndexType* idx) const {
 
 // ___________________________________________________________________________
 template <typename S, typename C, typename I>
-auto Vocabulary<S, C, I>::prefix_range(const string& prefix) const
-    -> std::pair<IndexType, IndexType> {
-  auto [begin, end] = internalVocabulary_.prefix_range(prefix);
-  return {IndexType::make(begin), IndexType::make(end)};
+auto Vocabulary<S, C, I>::prefixRanges(std::string_view prefix) const
+    -> Vocabulary<S, C, I>::PrefixRanges {
+  auto rangeInternal = internalVocabulary_.prefix_range(prefix);
+  auto rangeExternal = externalVocabulary_.prefix_range(prefix);
+  auto offset = internalVocabulary_.size();
+  std::pair<I, I> indexRangeInternal{I::make(rangeInternal.first),
+                                     I::make(rangeInternal.second)};
+  std::pair<I, I> indexRangeExternal{I::make(rangeExternal.first + offset),
+                                     I::make(rangeExternal.second + offset)};
+  return PrefixRanges{{indexRangeInternal, indexRangeExternal}};
 }
 
 // _____________________________________________________________________________
@@ -272,43 +315,6 @@ std::optional<std::string_view> Vocabulary<S, C, I>::operator[](
 }
 template std::optional<std::string_view>
 TextVocabulary::operator[]<std::string, void>(IndexType idx) const;
-
-// ___________________________________________________________________________
-template <typename S, typename C, typename I>
-auto Vocabulary<S, C, I>::getRangesForDatatypes() const
-    -> ad_utility::HashMap<Datatypes, std::pair<IndexType, IndexType>> {
-  ad_utility::HashMap<Datatypes, std::pair<IndexType, IndexType>> result;
-  result[Datatypes::Literal] = prefix_range("\"");
-  result[Datatypes::Iri] = prefix_range("<");
-
-  return result;
-};
-
-template <typename S, typename C, typename I>
-template <typename, typename>
-void Vocabulary<S, C, I>::printRangesForDatatypes() {
-  auto ranges = getRangesForDatatypes();
-  auto logRange = [&](const auto& range) {
-    LOG(INFO) << range.first << " " << range.second << std::endl;
-    if (range.second > range.first) {
-      LOG(INFO) << indexToOptionalString(range.first).value() << std::endl;
-      LOG(INFO) << indexToOptionalString(range.second.decremented()).value()
-                << std::endl;
-    }
-    if (range.second.get() < internalVocabulary_.size()) {
-      LOG(INFO) << indexToOptionalString(range.second).value() << std::endl;
-    }
-
-    if (range.first.get() > 0) {
-      LOG(INFO) << indexToOptionalString(range.first.decremented()).value()
-                << std::endl;
-    }
-  };
-
-  for (const auto& pair : ranges) {
-    logRange(pair.second);
-  }
-}
 
 template std::optional<string>
 RdfsVocabulary::indexToOptionalString<CompressedString>(IndexType idx) const;
@@ -327,8 +333,6 @@ template void RdfsVocabulary::initializeExternalizePrefixes<nlohmann::json>(
     const nlohmann::json& prefixes);
 template void RdfsVocabulary::initializeExternalizePrefixes<
     std::vector<std::string>>(const std::vector<std::string>& prefixes);
-
-template void RdfsVocabulary::printRangesForDatatypes();
 
 template void TextVocabulary::writeToFile<std::string, void>(
     const string& fileName) const;

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -2,7 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Björn Buchhold <buchholb>,
 //          Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
-//
 
 #pragma once
 
@@ -15,21 +14,21 @@
 #include <string_view>
 #include <vector>
 
-#include "../global/Constants.h"
-#include "../global/Id.h"
-#include "../global/Pattern.h"
-#include "../util/Exception.h"
-#include "../util/HashMap.h"
-#include "../util/HashSet.h"
-#include "../util/Log.h"
-#include "../util/StringUtils.h"
-#include "./CompressedString.h"
-#include "./StringSortComparator.h"
-#include "./vocabulary/CompressedVocabulary.h"
-#include "./vocabulary/PrefixCompressor.h"
-#include "./vocabulary/UnicodeVocabulary.h"
-#include "./vocabulary/VocabularyInMemory.h"
-#include "VocabularyOnDisk.h"
+#include "global/Constants.h"
+#include "global/Id.h"
+#include "global/Pattern.h"
+#include "index/CompressedString.h"
+#include "index/StringSortComparator.h"
+#include "index/VocabularyOnDisk.h"
+#include "index/vocabulary/CompressedVocabulary.h"
+#include "index/vocabulary/PrefixCompressor.h"
+#include "index/vocabulary/UnicodeVocabulary.h"
+#include "index/vocabulary/VocabularyInMemory.h"
+#include "util/Exception.h"
+#include "util/HashMap.h"
+#include "util/HashSet.h"
+#include "util/Log.h"
+#include "util/StringUtils.h"
 
 using std::string;
 using std::vector;
@@ -54,7 +53,7 @@ class IdRange {
   IndexT last_{};
 };
 
-//! Stream operator for convenience.
+// Stream operator for convenience.
 template <typename IndexType>
 inline std::ostream& operator<<(std::ostream& stream,
                                 const IdRange<IndexType>& idRange) {
@@ -71,13 +70,34 @@ struct Prefix {
   string fulltext_;
 };
 
-//! A vocabulary. Wraps a vector of strings
-//! and provides additional methods for retrieval.
-//! Template parameters that are supported are:
-//! std::string -> no compression is applied
-//! CompressedString -> prefix compression is applied
+// A vocabulary. Wraps a vector of strings and provides additional methods for
+// retrieval. Template parameters that are supported are:
+// std::string -> no compression is applied
+// CompressedString -> prefix compression is applied
 template <typename StringType, typename ComparatorType, typename IndexT>
 class Vocabulary {
+ public:
+  // The index ranges for a prefix + a function to check whether a given index
+  // is contained in one of them.
+  //
+  // NOTE: There are currently two ranges, one for the internal and one for the
+  // external vocabulary. It would be easy to add more ranges.
+  struct PrefixRanges {
+   public:
+    using Ranges = std::array<std::pair<IndexT, IndexT>, 2>;
+
+   private:
+    Ranges ranges_{};
+
+   public:
+    PrefixRanges() = default;
+    explicit PrefixRanges(const Ranges& ranges);
+    const Ranges& ranges() const { return ranges_; }
+    bool operator==(const PrefixRanges& ranges) const = default;
+    bool contain(IndexT index) const;
+  };
+
+ private:
   // The different type of data that is stored in the vocabulary
   enum class Datatypes { Literal, Iri, Float, Date };
 
@@ -89,6 +109,37 @@ class Vocabulary {
   using enable_if_uncompressed =
       std::enable_if_t<!std::is_same_v<T, CompressedString>>;
 
+  static constexpr bool isCompressed_ =
+      std::is_same_v<StringType, CompressedString>;
+
+  // If a word starts with one of those prefixes it will be externalized
+  vector<std::string> externalizedPrefixes_;
+
+  // If a word uses one of these language tags it will be internalized,
+  // defaults to English
+  vector<std::string> internalizedLangs_{"en"};
+
+  using PrefixCompressedVocabulary =
+      CompressedVocabulary<VocabularyInMemory, PrefixCompressor>;
+  using InternalCompressedVocabulary =
+      UnicodeVocabulary<PrefixCompressedVocabulary, ComparatorType>;
+  using InternalUncompressedVocabulary =
+      UnicodeVocabulary<VocabularyInMemory, ComparatorType>;
+  using InternalVocabulary =
+      std::conditional_t<isCompressed_, InternalCompressedVocabulary,
+                         InternalUncompressedVocabulary>;
+  InternalVocabulary internalVocabulary_;
+
+  using ExternalVocabulary =
+      UnicodeVocabulary<VocabularyOnDisk, ComparatorType>;
+  ExternalVocabulary externalVocabulary_;
+
+  // ID ranges for IRIs, blank nodes, and literals. Used for the efficient
+  // computation of the `isIRI`, `isBlankNode`, and `isLiteral` functions.
+  PrefixRanges prefixRangesIris_;
+  PrefixRanges prefixRangesBlankNodes_;
+  PrefixRanges prefixRangesLiterals_;
+
  public:
   using SortLevel = typename ComparatorType::Level;
   using IndexType = IndexT;
@@ -99,10 +150,6 @@ class Vocabulary {
   Vocabulary() {}
   Vocabulary& operator=(Vocabulary&&) noexcept = default;
   Vocabulary(Vocabulary&&) noexcept = default;
-
-  // variable for dispatching
-  static constexpr bool isCompressed_ =
-      std::is_same_v<StringType, CompressedString>;
 
   virtual ~Vocabulary() = default;
 
@@ -147,12 +194,16 @@ class Vocabulary {
   //! Return value signals if something was found at all.
   bool getId(const string& word, IndexType* idx) const;
 
-  //! Get an Id range that matches a prefix.
-  //! Return value also signals if something was found at all.
-  //! CAVEAT! TODO<discovered by joka921>: This is only used for the text index,
-  //! and uses a range, where the last index is still within the range which is
-  //! against C++ conventions!
-  // consider using the prefixRange function.
+  // Get the index range for the given prefix or `std::nullopt` if no word with
+  // the given prefix exists in the vocabulary.
+  //
+  // TODO<discovered by joka921>: This is only used for the text index, and
+  // uses a range, where the last index is still within the range which is
+  // against C++ conventions! Consider using the `prefix_range` function.
+  //
+  // NOTE: Unlike `prefixRanges`, this only looks in the internal vocabulary,
+  // which is OK because for the text index, the external vocabulary is always
+  // empty.
   std::optional<IdRange<IndexType>> getIdRangeForFullTextPrefix(
       const string& word) const;
 
@@ -219,11 +270,8 @@ class Vocabulary {
     return internalVocabulary_.getComparator();
   }
 
-  /// returns the range of IDs where strings of the vocabulary start with the
-  /// prefix according to the collation level the first Id is included in the
-  /// range, the last one not. Currently only supports the Primary collation
-  /// level, due to limitations in the StringSortComparators
-  std::pair<IndexType, IndexType> prefix_range(const string& prefix) const;
+  /// Get prefix ranges for the given prefix.
+  PrefixRanges prefixRanges(std::string_view prefix) const;
 
   [[nodiscard]] const LocaleManager& getLocaleManager() const {
     return getCaseComparator().getLocaleManager();
@@ -235,29 +283,6 @@ class Vocabulary {
 
   // _______________________________________________________________
   IndexType upper_bound(const string& word, const SortLevel level) const;
-
- private:
-  // If a word starts with one of those prefixes it will be externalized
-  vector<std::string> externalizedPrefixes_;
-
-  // If a word uses one of these language tags it will be internalized,
-  // defaults to English
-  vector<std::string> internalizedLangs_{"en"};
-
-  using PrefixCompressedVocabulary =
-      CompressedVocabulary<VocabularyInMemory, PrefixCompressor>;
-  using InternalCompressedVocabulary =
-      UnicodeVocabulary<PrefixCompressedVocabulary, ComparatorType>;
-  using InternalUncompressedVocabulary =
-      UnicodeVocabulary<VocabularyInMemory, ComparatorType>;
-  using InternalVocabulary =
-      std::conditional_t<isCompressed_, InternalCompressedVocabulary,
-                         InternalUncompressedVocabulary>;
-  InternalVocabulary internalVocabulary_;
-
-  using ExternalVocabulary =
-      UnicodeVocabulary<VocabularyOnDisk, ComparatorType>;
-  ExternalVocabulary externalVocabulary_;
 
  public:
   const ExternalVocabulary& getExternalVocab() const {

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -281,7 +281,6 @@ class Vocabulary {
   // _______________________________________________________________
   IndexType upper_bound(const string& word, const SortLevel level) const;
 
- public:
   const ExternalVocabulary& getExternalVocab() const {
     return externalVocabulary_;
   }

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -1,7 +1,8 @@
-// Copyright 2011, University of Freiburg,
+// Copyright 2011 - 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Authors: Björn Buchhold <buchholb>,
-//          Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
+// Authors: Björn Buchhold <buchhold@gmail.com>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de
+//          Hannah Bast <bast@cs.uni-freiburg.de>
 
 #pragma once
 
@@ -266,7 +267,7 @@ class Vocabulary {
     return internalVocabulary_.getComparator();
   }
 
-  /// Get prefix ranges for the given prefix.
+  // Get prefix ranges for the given prefix.
   PrefixRanges prefixRanges(std::string_view prefix) const;
 
   [[nodiscard]] const LocaleManager& getLocaleManager() const {

--- a/src/index/Vocabulary.h
+++ b/src/index/Vocabulary.h
@@ -112,12 +112,14 @@ class Vocabulary {
   static constexpr bool isCompressed_ =
       std::is_same_v<StringType, CompressedString>;
 
-  // If a word starts with one of those prefixes it will be externalized
-  vector<std::string> externalizedPrefixes_;
-
-  // If a word uses one of these language tags it will be internalized,
-  // defaults to English
+  // If a word uses one of these language tags it will be internalized.
   vector<std::string> internalizedLangs_{"en"};
+
+  // If a word starts with one of those prefixes, it will be externalized When
+  // a word matched both `externalizedPrefixes_` and `internalizedLangs_`, it
+  // will be externalized. Qlever-internal prefixes are currently not
+  // externalized.
+  vector<std::string> externalizedPrefixes_;
 
   using PrefixCompressedVocabulary =
       CompressedVocabulary<VocabularyInMemory, PrefixCompressor>;
@@ -133,12 +135,6 @@ class Vocabulary {
   using ExternalVocabulary =
       UnicodeVocabulary<VocabularyOnDisk, ComparatorType>;
   ExternalVocabulary externalVocabulary_;
-
-  // ID ranges for IRIs, blank nodes, and literals. Used for the efficient
-  // computation of the `isIRI`, `isBlankNode`, and `isLiteral` functions.
-  PrefixRanges prefixRangesIris_;
-  PrefixRanges prefixRangesBlankNodes_;
-  PrefixRanges prefixRangesLiterals_;
 
  public:
   using SortLevel = typename ComparatorType::Level;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021, University of Freiburg,
+// Copyright 2021 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Authors:
 //   2021 -    Hannah Bast <bast@cs.uni-freiburg.de>

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -414,6 +414,15 @@ TEST(IndexTest, getIgnoredIdRanges) {
   auto predicatesWithLangtag = std::pair{enLabel, increment(enLabel)};
   // The range of all literals;
   auto literals = std::pair{firstLiteral, increment(lastLiteral)};
+  // Nothing in the external vocabulary for this test.
+  //
+  // TODO: Also have words in the external vocabulary for this test. This
+  // requires making getQec() easier to use when setting only few of the many
+  // default arguments to other values.
+  auto firstIdExternalVocabulary = Id::makeFromVocabIndex(
+      VocabIndex::make(index.getVocab().getInternalVocab().size()));
+  auto emptyRangeExternalVocabulary =
+      std::pair{firstIdExternalVocabulary, firstIdExternalVocabulary};
 
   auto specialIds = qlever::getBoundsForSpecialIds();
   {
@@ -427,7 +436,8 @@ TEST(IndexTest, getIgnoredIdRanges) {
     ASSERT_FALSE(lambda(std::array{x, x, x}));
     EXPECT_THAT(ranges,
                 UnorderedElementsAre(internalEntities, predicatesWithLangtag,
-                                     specialIds));
+                                     specialIds, emptyRangeExternalVocabulary,
+                                     emptyRangeExternalVocabulary));
   }
   {
     auto [ranges, lambda] = index.getIgnoredIdRanges(Permutation::PSO);
@@ -440,7 +450,8 @@ TEST(IndexTest, getIgnoredIdRanges) {
     ASSERT_FALSE(lambda(std::array{x, x, x}));
     EXPECT_THAT(ranges,
                 UnorderedElementsAre(internalEntities, predicatesWithLangtag,
-                                     specialIds));
+                                     specialIds, emptyRangeExternalVocabulary,
+                                     emptyRangeExternalVocabulary));
   }
   {
     auto [ranges, lambda] = index.getIgnoredIdRanges(Permutation::SOP);
@@ -448,7 +459,9 @@ TEST(IndexTest, getIgnoredIdRanges) {
     ASSERT_FALSE(lambda(std::array{x, firstLiteral, label}));
     ASSERT_FALSE(lambda(std::array{x, x, label}));
     EXPECT_THAT(ranges,
-                UnorderedElementsAre(internalEntities, literals, specialIds));
+                UnorderedElementsAre(internalEntities, literals, specialIds,
+                                     emptyRangeExternalVocabulary,
+                                     emptyRangeExternalVocabulary));
   }
   {
     auto [ranges, lambda] = index.getIgnoredIdRanges(Permutation::SPO);
@@ -456,14 +469,17 @@ TEST(IndexTest, getIgnoredIdRanges) {
     ASSERT_FALSE(lambda(std::array{x, label, firstLiteral}));
     ASSERT_FALSE(lambda(std::array{x, label, x}));
     EXPECT_THAT(ranges,
-                UnorderedElementsAre(internalEntities, literals, specialIds));
+                UnorderedElementsAre(internalEntities, literals, specialIds,
+                                     emptyRangeExternalVocabulary,
+                                     emptyRangeExternalVocabulary));
   }
   {
     auto [ranges, lambda] = index.getIgnoredIdRanges(Permutation::OSP);
     ASSERT_TRUE(lambda(std::array{firstLiteral, x, enLabel}));
     ASSERT_FALSE(lambda(std::array{firstLiteral, x, label}));
     ASSERT_FALSE(lambda(std::array{x, x, label}));
-    EXPECT_THAT(ranges, UnorderedElementsAre(internalEntities, specialIds));
+    EXPECT_THAT(ranges, UnorderedElementsAre(internalEntities, specialIds,
+                                             emptyRangeExternalVocabulary));
   }
   {
     auto [ranges, lambda] = index.getIgnoredIdRanges(Permutation::OPS);
@@ -472,7 +488,8 @@ TEST(IndexTest, getIgnoredIdRanges) {
     ASSERT_FALSE(lambda(std::array{x, label, x}));
     auto hasPattern = qlever::specialIds.at(HAS_PATTERN_PREDICATE);
     ASSERT_TRUE(lambda(std::array{firstLiteral, hasPattern, x}));
-    EXPECT_THAT(ranges, UnorderedElementsAre(internalEntities, specialIds));
+    EXPECT_THAT(ranges, UnorderedElementsAre(internalEntities, specialIds,
+                                             emptyRangeExternalVocabulary));
   }
 }
 

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -130,11 +130,8 @@ TEST(Vocabulary, PrefixFilter) {
   auto ranges = vocabulary.prefixRanges("\"exp");
   auto firstIndexExternal =
       VocabIndex::make(vocabulary.getInternalVocab().size());
-  std::pair<VocabIndex, VocabIndex> expectedRangeInternal = {
-      VocabIndex::make(1u), VocabIndex::make(2u)};
-  std::pair<VocabIndex, VocabIndex> expectedRangeExternal = {
-      firstIndexExternal, firstIndexExternal};
   RdfsVocabulary::PrefixRanges expectedRanges{
-      {expectedRangeInternal, expectedRangeExternal}};
+      {std::pair{VocabIndex::make(1u), VocabIndex::make(2u)},
+       {std::pair{firstIndexExternal, firstIndexExternal}}}};
   ASSERT_EQ(ranges, expectedRanges);
 }

--- a/test/VocabularyTest.cpp
+++ b/test/VocabularyTest.cpp
@@ -116,17 +116,25 @@ TEST(VocabularyTest, IncompleteLiterals) {
 }
 
 TEST(Vocabulary, PrefixFilter) {
-  RdfsVocabulary voc;
-  voc.setLocale("en", "US", true);
-  ad_utility::HashSet<string> s;
+  RdfsVocabulary vocabulary;
+  vocabulary.setLocale("en", "US", true);
+  ad_utility::HashSet<string> words;
 
-  s.insert("\"exa\"");
-  s.insert("\"exp\"");
-  s.insert("\"ext\"");
-  s.insert(R"("["Ex-vivo" renal artery revascularization]"@en)");
-  voc.createFromSet(s);
+  words.insert("\"exa\"");
+  words.insert("\"exp\"");
+  words.insert("\"ext\"");
+  words.insert(R"("["Ex-vivo" renal artery revascularization]"@en)");
+  vocabulary.createFromSet(words);
 
-  auto x = voc.prefix_range("\"exp");
-  ASSERT_EQ(x.first.get(), 1u);
-  ASSERT_EQ(x.second.get(), 2u);
+  // Found in internal but not in external vocabulary.
+  auto ranges = vocabulary.prefixRanges("\"exp");
+  auto firstIndexExternal =
+      VocabIndex::make(vocabulary.getInternalVocab().size());
+  std::pair<VocabIndex, VocabIndex> expectedRangeInternal = {
+      VocabIndex::make(1u), VocabIndex::make(2u)};
+  std::pair<VocabIndex, VocabIndex> expectedRangeExternal = {
+      firstIndexExternal, firstIndexExternal};
+  RdfsVocabulary::PrefixRanges expectedRanges{
+      {expectedRangeInternal, expectedRangeExternal}};
+  ASSERT_EQ(ranges, expectedRanges);
 }


### PR DESCRIPTION
So far, the method `Vocabulary::prefix_range` returned a range of indexes of words in the internal vocabulary that match a given prefix. This is now replaced by a method `Vocabulary::prefixRange`, which returns two ranges, one for the internal and one for the external vocabulary. This can easily be extended to more ranges when needed.

Based on this, our efficient implementation for `REGEX` when the regular expression is a prefix, now finds items in both the internal and the external vocabulary (so far: only in the internal vocabulary).

On the side, identified and fixed a bug in the previous code, where the special predicates starting with `@` would not be found if `prefixes-external` matched `@`. As a consequence, QLever now works as it should even with `"prefixes-external": [""]`, that is, even when everything except the QLever-internal predicates ends up in the external vocabulary. In conjunction with https://github.com/ad-freiburg/qlever/pull/1223, this makes it now possible to start a QLever server with very little RAM.