### PR TITLE
Use build type `RelWithDebInfo` for sanitizer builds on GitHub actions

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -39,13 +39,13 @@ jobs:
         include:
           - compiler: clang
             compiler-version: 16
-            asan-flags: "-fsanitize=address -fno-omit-frame-pointer -g"
-            build-type: Release
+            asan-flags: "-fsanitize=address -fno-omit-frame-pointer"
+            build-type: RelWithDebInfo
             expensive-tests: false
           - compiler: clang
             compiler-version: 16
-            ubsan-flags: " -fsanitize=undefined -g"
-            build-type: Release
+            ubsan-flags: " -fsanitize=undefined"
+            build-type: RelWithDebInfo
             expensive-tests: false
           - compiler: clang
             compiler-version: 17

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -39,12 +39,12 @@ jobs:
         include:
           - compiler: clang
             compiler-version: 16
-            asan-flags: "-fsanitize=address -fno-omit-frame-pointer"
+            asan-flags: "-fsanitize=address -fno-omit-frame-pointer -g"
             build-type: Release
             expensive-tests: false
           - compiler: clang
             compiler-version: 16
-            ubsan-flags: " -fsanitize=undefined"
+            ubsan-flags: " -fsanitize=undefined -g"
             build-type: Release
             expensive-tests: false
           - compiler: clang


### PR DESCRIPTION
That way we will get at least a somewhat readable stack trace in case those sanitizers report errors.