### PR TITLE
Write vocabulary files to separate directory

### DIFF
--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -39,7 +39,8 @@ int main(int argc, char** argv) {
   // filled / set depending on the options.
   using ad_utility::NonNegative;
 
-  std::string indexBasename;
+  std::string baseNameIndex;
+  std::string baseNameVocabulary;
   std::string accessToken;
   bool text = false;
   unsigned short port;
@@ -59,8 +60,11 @@ int main(int argc, char** argv) {
   };
   add("help,h", "Produce this help message.");
   // TODO<joka921> Can we output the "required" automatically?
-  add("index-basename,i", po::value<std::string>(&indexBasename)->required(),
+  add("index-basename,i", po::value<std::string>(&baseNameIndex)->required(),
       "The basename of the index files (required).");
+  add("vocabulary-basename,v", po::value<std::string>(&baseNameVocabulary),
+      "The basename of the vocabulary files"
+      " (default: same as basename of the index files).");
   add("port,p", po::value<unsigned short>(&port)->required(),
       "The port on which HTTP requests are served (required).");
   add("access-token,a", po::value<std::string>(&accessToken)->default_value(""),
@@ -122,6 +126,11 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
 
+  // If no vocabulary basename is given, use the index basename.
+  if (baseNameVocabulary.empty()) {
+    baseNameVocabulary = baseNameIndex;
+  }
+
   LOG(INFO) << EMPH_ON << "QLever Server, compiled on "
             << qlever::version::DatetimeOfCompilation << " using git hash "
             << qlever::version::GitShortHash() << EMPH_OFF << std::endl;
@@ -129,7 +138,8 @@ int main(int argc, char** argv) {
   try {
     Server server(port, numSimultaneousQueries, memoryMaxSize,
                   std::move(accessToken), !noPatternTrick);
-    server.run(indexBasename, text, !noPatterns, !onlyPsoAndPosPermutations);
+    server.run(baseNameIndex, baseNameVocabulary, text, !noPatterns,
+               !onlyPsoAndPosPermutations);
   } catch (const std::exception& e) {
     // This code should never be reached as all exceptions should be handled
     // within server.run()

--- a/src/VocabularyMergerMain.cpp
+++ b/src/VocabularyMergerMain.cpp
@@ -24,6 +24,6 @@ int main(int argc, char** argv) {
   auto internalVocabularyAction = [&file](const auto& word) {
     file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
   };
-  m.mergeVocabulary(basename, numFiles, TripleComponentComparator(),
+  m.mergeVocabulary(basename, basename, numFiles, TripleComponentComparator(),
                     internalVocabularyAction, 4_GB);
 }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -54,7 +54,8 @@ Server::Server(unsigned short port, size_t numThreads,
 }
 
 // __________________________________________________________________________
-void Server::initialize(const string& indexBaseName, bool useText,
+void Server::initialize(const string& baseNameIndex,
+                        const string& baseNameVocabulary, bool useText,
                         bool usePatterns, bool loadAllPermutations) {
   LOG(INFO) << "Initializing server ..." << std::endl;
 
@@ -62,7 +63,7 @@ void Server::initialize(const string& indexBaseName, bool useText,
   index_.loadAllPermutations() = loadAllPermutations;
 
   // Init the index.
-  index_.createFromOnDiskIndex(indexBaseName);
+  index_.createFromOnDiskIndex(baseNameIndex, baseNameVocabulary);
   if (useText) {
     index_.addTextFromOnDiskIndex();
   }
@@ -78,8 +79,8 @@ void Server::initialize(const string& indexBaseName, bool useText,
 }
 
 // _____________________________________________________________________________
-void Server::run(const string& indexBaseName, bool useText, bool usePatterns,
-                 bool loadAllPermutations) {
+void Server::run(const string& baseNameIndex, const string& baseNameVocabulary,
+                 bool useText, bool usePatterns, bool loadAllPermutations) {
   using namespace ad_utility::httpUtils;
 
   // Function that handles a request asynchronously, will be passed as argument
@@ -154,7 +155,8 @@ void Server::run(const string& indexBaseName, bool useText, bool usePatterns,
                                std::move(webSocketSessionSupplier)};
 
   // Initialize the index
-  initialize(indexBaseName, useText, usePatterns, loadAllPermutations);
+  initialize(baseNameIndex, baseNameVocabulary, useText, usePatterns,
+             loadAllPermutations);
 
   // Start listening for connections on the server.
   httpServer.run();

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -41,13 +41,15 @@ class Server {
 
  private:
   //! Initialize the server.
-  void initialize(const string& indexBaseName, bool useText,
-                  bool usePatterns = true, bool loadAllPermutations = true);
+  void initialize(const string& baseNameIndex, const string& baseNameVocabulary,
+                  bool useText, bool usePatterns = true,
+                  bool loadAllPermutations = true);
 
  public:
   //! First initialize the server. Then loop, wait for requests and trigger
   //! processing. This method never returns except when throwing an exception.
-  void run(const string& indexBaseName, bool useText, bool usePatterns = true,
+  void run(const string& baseNameIndex, const string& baseNameVocabulary,
+           bool useText, bool usePatterns = true,
            bool loadAllPermutations = true);
 
   Index& index() { return index_; }

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -50,8 +50,9 @@ static const size_t BZIP2_MAX_TOTAL_BUFFER_SIZE = 1 << 30;
 static const size_t THRESHOLD_RELATION_CREATION = 2 << 20;
 
 // ________________________________________________________________
-static const std::string PARTIAL_VOCAB_FILE_NAME = ".tmp.partial-vocabulary.";
-static const std::string PARTIAL_MMAP_IDS = ".tmp.partial-ids-mmap.";
+static const std::string PARTIAL_VOCAB_FILE_NAME =
+    ".tmp.partial-vocabulary.words.";
+static const std::string PARTIAL_MMAP_IDS = ".tmp.partial-vocabulary.ids.";
 
 // ________________________________________________________________
 static const std::string TMP_BASENAME_COMPRESSION =

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -25,8 +25,9 @@ void Index::createFromFile(const std::string& filename) {
 }
 
 // ____________________________________________________________________________
-void Index::createFromOnDiskIndex(const std::string& onDiskBase) {
-  pimpl_->createFromOnDiskIndex(onDiskBase);
+void Index::createFromOnDiskIndex(const std::string& onDiskBaseIndex,
+                                  const std::string& onDiskBaseVocabulary) {
+  pimpl_->createFromOnDiskIndex(onDiskBaseIndex, onDiskBaseVocabulary);
 }
 
 // ____________________________________________________________________________
@@ -193,8 +194,9 @@ const ad_utility::MemorySize& Index::memoryLimitIndexBuilding() const {
 }
 
 // ____________________________________________________________________________
-void Index::setOnDiskBase(const std::string& onDiskBase) {
-  return pimpl_->setOnDiskBase(onDiskBase);
+void Index::setOnDiskBase(const std::string& onDiskBaseIndex,
+                          const std::string& onDiskBaseVocabulary) {
+  return pimpl_->setOnDiskBase(onDiskBaseIndex, onDiskBaseVocabulary);
 }
 
 // ____________________________________________________________________________

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -79,7 +79,8 @@ class Index {
   // constructed using the `createFromFile` method which is typically called via
   // `IndexBuilderMain`. Read necessary metadata into memory and open file
   // handles.
-  void createFromOnDiskIndex(const std::string& onDiskBase);
+  void createFromOnDiskIndex(const std::string& onDiskBaseIndex,
+                             const std::string& onDiskVocabulary);
 
   // Add a text index to a complete KB index. First read the given context
   // file (if file name not empty), then add words from literals (if true).
@@ -181,7 +182,8 @@ class Index {
 
   ad_utility::MemorySize& blocksizePermutationsPerColumn();
 
-  void setOnDiskBase(const std::string& onDiskBase);
+  void setOnDiskBase(const std::string& onDiskBaseIndex,
+                     const std::string& onDiskBaseVocabulary);
 
   void setSettingsFile(const std::string& filename);
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -476,8 +476,8 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
         };
     m._noIdMapsAndIgnoreExternalVocab = true;
     auto mergeResult = m.mergeVocabulary(
-        onDiskBaseVocabulary_ + TMP_BASENAME_COMPRESSION, numFiles,
-        std::less<>(), internalVocabularyActionCompression,
+        onDiskBaseIndex_, onDiskBaseVocabulary_ + TMP_BASENAME_COMPRESSION,
+        numFiles, std::less<>(), internalVocabularyActionCompression,
         memoryLimitIndexBuilding());
     sizeInternalVocabulary = mergeResult.numWordsTotal_;
     LOG(INFO) << "Number of words in internal vocabulary: "
@@ -508,8 +508,8 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
     auto internalVocabularyAction = [&wordWriter](const auto& word) {
       wordWriter.push(word.data(), word.size());
     };
-    return v.mergeVocabulary(onDiskBaseVocabulary_, numFiles, sortPred,
-                             internalVocabularyAction,
+    return v.mergeVocabulary(onDiskBaseIndex_, onDiskBaseVocabulary_, numFiles,
+                             sortPred, internalVocabularyAction,
                              memoryLimitIndexBuilding());
   }();
   LOG(DEBUG) << "Finished merging partial vocabularies" << std::endl;
@@ -526,9 +526,9 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
   LOG(INFO) << "Removing temporary files ..." << std::endl;
   for (size_t i = 0; i < numFiles; ++i) {
     deleteTemporaryFile(
-        absl::StrCat(onDiskBaseVocabulary_, PARTIAL_VOCAB_FILE_NAME, i));
+        absl::StrCat(onDiskBaseIndex_, PARTIAL_VOCAB_FILE_NAME, i));
     if (vocabPrefixCompressed_) {
-      deleteTemporaryFile(absl::StrCat(onDiskBaseVocabulary_,
+      deleteTemporaryFile(absl::StrCat(onDiskBaseIndex_,
                                        TMP_BASENAME_COMPRESSION,
                                        PARTIAL_VOCAB_FILE_NAME, i));
     }
@@ -629,7 +629,7 @@ IndexImpl::convertPartialToGlobalIds(
       return std::nullopt;
     }
     std::string mmapFilename =
-        absl::StrCat(onDiskBaseVocabulary_, PARTIAL_MMAP_IDS, idx);
+        absl::StrCat(onDiskBaseIndex_, PARTIAL_MMAP_IDS, idx);
     auto map = IdMapFromPartialIdMapFile(mmapFilename);
     // Delete the temporary file in which we stored this map
     deleteTemporaryFile(mmapFilename);
@@ -1218,9 +1218,9 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
       << actualCurrentPartialSize << std::endl;
   std::future<void> resultFuture;
   string partialFilename =
-      absl::StrCat(onDiskBaseVocabulary_, PARTIAL_VOCAB_FILE_NAME, numFiles);
+      absl::StrCat(onDiskBaseIndex_, PARTIAL_VOCAB_FILE_NAME, numFiles);
   string partialCompressionFilename =
-      absl::StrCat(onDiskBaseVocabulary_, TMP_BASENAME_COMPRESSION,
+      absl::StrCat(onDiskBaseIndex_, TMP_BASENAME_COMPRESSION,
                    PARTIAL_VOCAB_FILE_NAME, numFiles);
 
   auto lambda = [localIds = std::move(localIds), globalWritePtr,

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -56,10 +56,10 @@ IndexBuilderDataAsFirstPermutationSorter IndexImpl::createIdTriplesAndVocab(
   LOG(INFO) << "Converting external vocabulary to binary format ..."
             << std::endl;
   vocab_.externalizeLiteralsFromTextFile(
-      onDiskBase_ + EXTERNAL_LITS_TEXT_FILE_NAME,
-      onDiskBase_ + EXTERNAL_VOCAB_SUFFIX);
-  deleteTemporaryFile(onDiskBase_ + EXTERNAL_LITS_TEXT_FILE_NAME);
-  // clear vocabulary to save ram (only information from partial binary files
+      onDiskBaseVocabulary_ + EXTERNAL_LITS_TEXT_FILE_NAME,
+      onDiskBaseVocabulary_ + EXTERNAL_VOCAB_SUFFIX);
+  deleteTemporaryFile(onDiskBaseVocabulary_ + EXTERNAL_LITS_TEXT_FILE_NAME);
+  // clear vocabulary to save RAM (only information from partial binary files
   // used from now on). This will preserve information about externalized
   // Prefixes etc.
   vocab_.clear();
@@ -76,10 +76,11 @@ void IndexImpl::compressInternalVocabularyIfSpecified(
   // If we have no compression, this will also copy the whole vocabulary.
   // but since we expect compression to be the default case, this  should not
   // hurt.
-  string vocabFile = onDiskBase_ + INTERNAL_VOCAB_SUFFIX;
-  string vocabFileTmp = onDiskBase_ + ".vocabularyTmp";
+  string vocabFile = onDiskBaseVocabulary_ + INTERNAL_VOCAB_SUFFIX;
+  string vocabFileTmp = onDiskBaseVocabulary_ + ".vocabularyTmp";
   if (vocabPrefixCompressed_) {
-    auto prefixFile = ad_utility::makeOfstream(onDiskBase_ + PREFIX_FILE);
+    auto prefixFile =
+        ad_utility::makeOfstream(onDiskBaseVocabulary_ + PREFIX_FILE);
     for (const auto& prefix : prefixes) {
       prefixFile << RdfEscaping::escapeNewlinesAndBackslashes(prefix)
                  << std::endl;
@@ -352,8 +353,8 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
   parser->integerOverflowBehavior() = turtleParserIntegerOverflowBehavior_;
   parser->invalidLiteralsAreSkipped() = turtleParserSkipIllegalLiterals_;
   ad_utility::Synchronized<std::unique_ptr<TripleVec>> idTriples(
-      std::make_unique<TripleVec>(onDiskBase_ + ".unsorted-triples.dat", 1_GB,
-                                  allocator_));
+      std::make_unique<TripleVec>(onDiskBaseIndex_ + ".unsorted-triples.dat",
+                                  1_GB, allocator_));
   bool parserExhausted = false;
 
   size_t i = 0;
@@ -466,7 +467,8 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
               << "(internal only) ..." << std::endl;
     VocabularyMerger m;
     auto compressionOutfile = ad_utility::makeOfstream(
-        onDiskBase_ + TMP_BASENAME_COMPRESSION + INTERNAL_VOCAB_SUFFIX);
+        onDiskBaseVocabulary_ + TMP_BASENAME_COMPRESSION +
+        INTERNAL_VOCAB_SUFFIX);
     auto internalVocabularyActionCompression =
         [&compressionOutfile](const auto& word) {
           compressionOutfile << RdfEscaping::escapeNewlinesAndBackslashes(word)
@@ -474,8 +476,9 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
         };
     m._noIdMapsAndIgnoreExternalVocab = true;
     auto mergeResult = m.mergeVocabulary(
-        onDiskBase_ + TMP_BASENAME_COMPRESSION, numFiles, std::less<>(),
-        internalVocabularyActionCompression, memoryLimitIndexBuilding());
+        onDiskBaseVocabulary_ + TMP_BASENAME_COMPRESSION, numFiles,
+        std::less<>(), internalVocabularyActionCompression,
+        memoryLimitIndexBuilding());
     sizeInternalVocabulary = mergeResult.numWordsTotal_;
     LOG(INFO) << "Number of words in internal vocabulary: "
               << sizeInternalVocabulary << std::endl;
@@ -484,8 +487,9 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
     compressionOutfile.close();
     // We have to use the "normally" sorted vocabulary for the prefix
     // compression.
-    std::string vocabFileForPrefixCalculation =
-        onDiskBase_ + TMP_BASENAME_COMPRESSION + INTERNAL_VOCAB_SUFFIX;
+    std::string vocabFileForPrefixCalculation = onDiskBaseVocabulary_ +
+                                                TMP_BASENAME_COMPRESSION +
+                                                INTERNAL_VOCAB_SUFFIX;
     prefixes = calculatePrefixes(vocabFileForPrefixCalculation,
                                  NUM_COMPRESSION_PREFIXES, 1, true);
     ad_utility::deleteFile(vocabFileForPrefixCalculation);
@@ -499,12 +503,12 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
                                                           std::string_view b) {
       return (*cmp)(a, b, decltype(vocab_)::SortLevel::TOTAL);
     };
-    auto wordWriter =
-        vocab_.makeUncompressingWordWriter(onDiskBase_ + INTERNAL_VOCAB_SUFFIX);
+    auto wordWriter = vocab_.makeUncompressingWordWriter(onDiskBaseVocabulary_ +
+                                                         INTERNAL_VOCAB_SUFFIX);
     auto internalVocabularyAction = [&wordWriter](const auto& word) {
       wordWriter.push(word.data(), word.size());
     };
-    return v.mergeVocabulary(onDiskBase_, numFiles, sortPred,
+    return v.mergeVocabulary(onDiskBaseVocabulary_, numFiles, sortPred,
                              internalVocabularyAction,
                              memoryLimitIndexBuilding());
   }();
@@ -520,11 +524,13 @@ IndexBuilderDataAsStxxlVector IndexImpl::passFileForVocabulary(
   res.actualPartialSizes = std::move(actualPartialSizes);
 
   LOG(INFO) << "Removing temporary files ..." << std::endl;
-  for (size_t n = 0; n < numFiles; ++n) {
-    deleteTemporaryFile(absl::StrCat(onDiskBase_, PARTIAL_VOCAB_FILE_NAME, n));
+  for (size_t i = 0; i < numFiles; ++i) {
+    deleteTemporaryFile(
+        absl::StrCat(onDiskBaseVocabulary_, PARTIAL_VOCAB_FILE_NAME, i));
     if (vocabPrefixCompressed_) {
-      deleteTemporaryFile(absl::StrCat(onDiskBase_, TMP_BASENAME_COMPRESSION,
-                                       PARTIAL_VOCAB_FILE_NAME, n));
+      deleteTemporaryFile(absl::StrCat(onDiskBaseVocabulary_,
+                                       TMP_BASENAME_COMPRESSION,
+                                       PARTIAL_VOCAB_FILE_NAME, i));
     }
   }
 
@@ -622,7 +628,8 @@ IndexImpl::convertPartialToGlobalIds(
     if (idx >= actualLinesPerPartial.size()) {
       return std::nullopt;
     }
-    std::string mmapFilename = absl::StrCat(onDiskBase_, PARTIAL_MMAP_IDS, idx);
+    std::string mmapFilename =
+        absl::StrCat(onDiskBaseVocabulary_, PARTIAL_MMAP_IDS, idx);
     auto map = IdMapFromPartialIdMapFile(mmapFilename);
     // Delete the temporary file in which we stored this map
     deleteTemporaryFile(mmapFilename);
@@ -727,8 +734,8 @@ IndexImpl::createPermutations(size_t numColumns, auto&& sortedTriples,
                               const Permutation& p1, const Permutation& p2,
                               auto&&... perTripleCallbacks) {
   auto metaData = createPermutationPairImpl(
-      numColumns, onDiskBase_ + ".index" + p1.fileSuffix_,
-      onDiskBase_ + ".index" + p2.fileSuffix_, AD_FWD(sortedTriples),
+      numColumns, onDiskBaseIndex_ + ".index" + p1.fileSuffix_,
+      onDiskBaseIndex_ + ".index" + p2.fileSuffix_, AD_FWD(sortedTriples),
       p1.keyOrder_, AD_FWD(perTripleCallbacks)...);
 
   LOG(INFO) << "Statistics for " << p1.readableName_ << ": "
@@ -753,7 +760,8 @@ void IndexImpl::createPermutationPair(size_t numColumns, auto&& sortedTriples,
   auto writeMetadata = [this](auto& metaData, const auto& permutation) {
     metaData.setName(getKbName());
     ad_utility::File f(
-        absl::StrCat(onDiskBase_, ".index", permutation.fileSuffix_), "r+");
+        absl::StrCat(onDiskBaseIndex_, ".index", permutation.fileSuffix_),
+        "r+");
     metaData.appendToFile(&f);
   };
   LOG(INFO) << "Writing meta data for " << p1.readableName_ << " and "
@@ -763,24 +771,25 @@ void IndexImpl::createPermutationPair(size_t numColumns, auto&& sortedTriples,
 }
 
 // _____________________________________________________________________________
-void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
-  setOnDiskBase(onDiskBase);
+void IndexImpl::createFromOnDiskIndex(const string& onDiskBaseIndex,
+                                      const string& onDiskBaseVocabulary) {
+  setOnDiskBase(onDiskBaseIndex, onDiskBaseVocabulary);
   readConfiguration();
-  vocab_.readFromFile(onDiskBase_ + INTERNAL_VOCAB_SUFFIX,
-                      onDiskBase_ + EXTERNAL_VOCAB_SUFFIX);
+  vocab_.readFromFile(onDiskBaseVocabulary_ + INTERNAL_VOCAB_SUFFIX,
+                      onDiskBaseVocabulary_ + EXTERNAL_VOCAB_SUFFIX);
 
   totalVocabularySize_ = vocab_.size() + vocab_.getExternalVocab().size();
   LOG(DEBUG) << "Number of words in internal and external vocabulary: "
              << totalVocabularySize_ << std::endl;
 
-  pso_.loadFromDisk(onDiskBase_);
-  pos_.loadFromDisk(onDiskBase_);
+  pso_.loadFromDisk(onDiskBaseIndex_);
+  pos_.loadFromDisk(onDiskBaseIndex_);
 
   if (loadAllPermutations_) {
-    ops_.loadFromDisk(onDiskBase_);
-    osp_.loadFromDisk(onDiskBase_);
-    spo_.loadFromDisk(onDiskBase_);
-    sop_.loadFromDisk(onDiskBase_);
+    ops_.loadFromDisk(onDiskBaseIndex_);
+    osp_.loadFromDisk(onDiskBaseIndex_);
+    spo_.loadFromDisk(onDiskBaseIndex_);
+    sop_.loadFromDisk(onDiskBaseIndex_);
   } else {
     LOG(INFO) << "Only the PSO and POS permutation were loaded, SPARQL queries "
                  "with predicate variables will therefore not work"
@@ -791,10 +800,11 @@ void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
   // at all.
   if (usePatterns_) {
     try {
-      PatternCreator::readPatternsFromFile(
-          onDiskBase_ + ".index.patterns", avgNumDistinctSubjectsPerPredicate_,
-          avgNumDistinctPredicatesPerSubject_,
-          numDistinctSubjectPredicatePairs_, patterns_);
+      PatternCreator::readPatternsFromFile(onDiskBaseIndex_ + ".index.patterns",
+                                           avgNumDistinctSubjectsPerPredicate_,
+                                           avgNumDistinctPredicatesPerSubject_,
+                                           numDistinctSubjectPredicatePairs_,
+                                           patterns_);
     } catch (const std::exception& e) {
       LOG(WARN) << "Could not load the patterns. The internal predicate "
                    "`ql:has-predicate` is therefore not available (and certain "
@@ -855,8 +865,10 @@ void IndexImpl::setKbName(const string& name) {
 }
 
 // ____________________________________________________________________________
-void IndexImpl::setOnDiskBase(const std::string& onDiskBase) {
-  onDiskBase_ = onDiskBase;
+void IndexImpl::setOnDiskBase(const std::string& onDiskBaseIndex,
+                              const std::string& onDiskBaseVocabulary) {
+  onDiskBaseIndex_ = onDiskBaseIndex;
+  onDiskBaseVocabulary_ = onDiskBaseVocabulary;
 }
 
 // ____________________________________________________________________________
@@ -886,13 +898,13 @@ void IndexImpl::writeConfiguration() const {
   auto configuration = configurationJson_;
   configuration["git-hash"] = std::string(qlever::version::GitHash);
   configuration["index-format-version"] = qlever::indexFormatVersion;
-  auto f = ad_utility::makeOfstream(onDiskBase_ + CONFIGURATION_FILE);
+  auto f = ad_utility::makeOfstream(onDiskBaseIndex_ + CONFIGURATION_FILE);
   f << configuration;
 }
 
 // ___________________________________________________________________________
 void IndexImpl::readConfiguration() {
-  auto f = ad_utility::makeIfstream(onDiskBase_ + CONFIGURATION_FILE);
+  auto f = ad_utility::makeIfstream(onDiskBaseIndex_ + CONFIGURATION_FILE);
   f >> configurationJson_;
   if (configurationJson_.find("git-hash") != configurationJson_.end()) {
     LOG(INFO) << "The git hash used to build this index was "
@@ -943,7 +955,8 @@ void IndexImpl::readConfiguration() {
   if (configurationJson_.find("prefixes") != configurationJson_.end()) {
     if (configurationJson_["prefixes"]) {
       vector<string> prefixes;
-      auto prefixFile = ad_utility::makeIfstream(onDiskBase_ + PREFIX_FILE);
+      auto prefixFile =
+          ad_utility::makeIfstream(onDiskBaseVocabulary_ + PREFIX_FILE);
       for (string prefix; std::getline(prefixFile, prefix);) {
         prefixes.emplace_back(
             RdfEscaping::unescapeNewlinesAndBackslashes(prefix));
@@ -1205,9 +1218,10 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
       << actualCurrentPartialSize << std::endl;
   std::future<void> resultFuture;
   string partialFilename =
-      absl::StrCat(onDiskBase_, PARTIAL_VOCAB_FILE_NAME, numFiles);
-  string partialCompressionFilename = absl::StrCat(
-      onDiskBase_, TMP_BASENAME_COMPRESSION, PARTIAL_VOCAB_FILE_NAME, numFiles);
+      absl::StrCat(onDiskBaseVocabulary_, PARTIAL_VOCAB_FILE_NAME, numFiles);
+  string partialCompressionFilename =
+      absl::StrCat(onDiskBaseVocabulary_, TMP_BASENAME_COMPRESSION,
+                   PARTIAL_VOCAB_FILE_NAME, numFiles);
 
   auto lambda = [localIds = std::move(localIds), globalWritePtr,
                  items = std::move(items), vocab = &vocab_, partialFilename,
@@ -1554,7 +1568,7 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
     // For now (especially for testing) We build the new pattern format as well
     // as the old one to see that they match.
     PatternCreator patternCreator{
-        onDiskBase_ + ".index.patterns",
+        onDiskBaseIndex_ + ".index.patterns",
         memoryLimitIndexBuilding() / NUM_EXTERNAL_SORTERS_AT_SAME_TIME};
     auto pushTripleToPatterns = [&patternCreator,
                                  &isInternalId](const auto& triple) {
@@ -1608,9 +1622,10 @@ auto IndexImpl::makeSorterImpl(std::string_view permutationName) const {
       return Sorter{AD_FWD(args)...};
     }
   };
-  return apply(absl::StrCat(onDiskBase_, ".", permutationName, "-sorter.dat"),
-               memoryLimitIndexBuilding() / NUM_EXTERNAL_SORTERS_AT_SAME_TIME,
-               allocator_);
+  return apply(
+      absl::StrCat(onDiskBaseIndex_, ".", permutationName, "-sorter.dat"),
+      memoryLimitIndexBuilding() / NUM_EXTERNAL_SORTERS_AT_SAME_TIME,
+      allocator_);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -116,7 +116,8 @@ class IndexImpl {
 
   // Private data members.
  private:
-  string onDiskBase_;
+  string onDiskBaseIndex_;
+  string onDiskBaseVocabulary_;
   string settingsFileName_;
   bool onlyAsciiTurtlePrefixes_ = false;
   bool useParallelParser_ = true;
@@ -213,7 +214,8 @@ class IndexImpl {
 
   // Creates an index object from an on disk index that has previously been
   // constructed. Read necessary meta data into memory and opens file handles.
-  void createFromOnDiskIndex(const string& onDiskBase);
+  void createFromOnDiskIndex(const string& onDiskBaseIndex,
+                             const string& onDiskBaseVocabulary);
 
   // Adds a text index to a complete KB index. First reads the given context
   // file (if file name not empty), then adds words from literals (if true).
@@ -368,7 +370,8 @@ class IndexImpl {
     return blocksizePermutationPerColumn_;
   }
 
-  void setOnDiskBase(const std::string& onDiskBase);
+  void setOnDiskBase(const std::string& onDiskBaseIndex,
+                     const std::string& onDiskBaseVocabulary);
 
   void setSettingsFile(const std::string& filename);
 

--- a/src/index/VocabularyGenerator.h
+++ b/src/index/VocabularyGenerator.h
@@ -113,7 +113,8 @@ class VocabularyMerger {
   // This automatically resets the inner members after finishing, to leave the
   // external interface stateless
   template <typename Comp, typename InternalVocabularyAction>
-  VocabularyMetaData mergeVocabulary(const std::string& fileIdx,
+  VocabularyMetaData mergeVocabulary(const std::string& baseNameIndex,
+                                     const std::string& baseNameVocabulary,
                                      size_t numFiles, Comp comparator,
                                      InternalVocabularyAction& action,
                                      ad_utility::MemorySize memToUse);

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -30,8 +30,9 @@
 // ___________________________________________________________________
 template <typename Comparator, typename InternalVocabularyAction>
 VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
-    const std::string& baseNameExternalVocabulary, size_t numFiles,
-    Comparator comparator, InternalVocabularyAction& internalVocabularyAction,
+    const std::string& baseNameIndex, const std::string& baseNameVocabulary,
+    size_t numFiles, Comparator comparator,
+    InternalVocabularyAction& internalVocabularyAction,
     ad_utility::MemorySize memoryToUse) {
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal. All internal IRIs or literals come before all external ones.
@@ -52,8 +53,8 @@ VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
   std::vector<cppcoro::generator<QueueWord>> generators;
 
   auto makeGenerator = [&](size_t fileIdx) -> cppcoro::generator<QueueWord> {
-    ad_utility::serialization::FileReadSerializer infile{absl::StrCat(
-        baseNameExternalVocabulary, PARTIAL_VOCAB_FILE_NAME, fileIdx)};
+    ad_utility::serialization::FileReadSerializer infile{
+        absl::StrCat(baseNameIndex, PARTIAL_VOCAB_FILE_NAME, fileIdx)};
     uint64_t numWords;
     infile >> numWords;
     TripleComponentWithIndex val;
@@ -64,7 +65,7 @@ VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
     }
   };
   if (!_noIdMapsAndIgnoreExternalVocab) {
-    outfileExternal_ = ad_utility::makeOfstream(baseNameExternalVocabulary +
+    outfileExternal_ = ad_utility::makeOfstream(baseNameVocabulary +
                                                 EXTERNAL_LITS_TEXT_FILE_NAME);
   }
 
@@ -74,7 +75,7 @@ VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
     generators.push_back(makeGenerator(i));
     if (!_noIdMapsAndIgnoreExternalVocab) {
       idVecs_.emplace_back(
-          0, baseNameExternalVocabulary + PARTIAL_MMAP_IDS + std::to_string(i));
+          0, baseNameIndex + PARTIAL_MMAP_IDS + std::to_string(i));
     }
   }
 

--- a/src/index/VocabularyGeneratorImpl.h
+++ b/src/index/VocabularyGeneratorImpl.h
@@ -30,8 +30,8 @@
 // ___________________________________________________________________
 template <typename Comparator, typename InternalVocabularyAction>
 VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
-    const std::string& basename, size_t numFiles, Comparator comparator,
-    InternalVocabularyAction& internalVocabularyAction,
+    const std::string& baseNameExternalVocabulary, size_t numFiles,
+    Comparator comparator, InternalVocabularyAction& internalVocabularyAction,
     ad_utility::MemorySize memoryToUse) {
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal. All internal IRIs or literals come before all external ones.
@@ -52,8 +52,8 @@ VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
   std::vector<cppcoro::generator<QueueWord>> generators;
 
   auto makeGenerator = [&](size_t fileIdx) -> cppcoro::generator<QueueWord> {
-    ad_utility::serialization::FileReadSerializer infile{
-        absl::StrCat(basename, PARTIAL_VOCAB_FILE_NAME, fileIdx)};
+    ad_utility::serialization::FileReadSerializer infile{absl::StrCat(
+        baseNameExternalVocabulary, PARTIAL_VOCAB_FILE_NAME, fileIdx)};
     uint64_t numWords;
     infile >> numWords;
     TripleComponentWithIndex val;
@@ -64,8 +64,8 @@ VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
     }
   };
   if (!_noIdMapsAndIgnoreExternalVocab) {
-    outfileExternal_ =
-        ad_utility::makeOfstream(basename + EXTERNAL_LITS_TEXT_FILE_NAME);
+    outfileExternal_ = ad_utility::makeOfstream(baseNameExternalVocabulary +
+                                                EXTERNAL_LITS_TEXT_FILE_NAME);
   }
 
   // Open and prepare all infiles and mmap output vectors.
@@ -73,7 +73,8 @@ VocabularyMerger::VocabularyMetaData VocabularyMerger::mergeVocabulary(
   for (size_t i = 0; i < numFiles; i++) {
     generators.push_back(makeGenerator(i));
     if (!_noIdMapsAndIgnoreExternalVocab) {
-      idVecs_.emplace_back(0, basename + PARTIAL_MMAP_IDS + std::to_string(i));
+      idVecs_.emplace_back(
+          0, baseNameExternalVocabulary + PARTIAL_MMAP_IDS + std::to_string(i));
     }
   }
 

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -53,8 +53,6 @@ template <typename Iterable>
 void VocabularyOnDisk::buildFromIterable(Iterable&& it,
                                          const string& fileName) {
   {
-    LOG(INFO) << "buildFromIterable: writing vocabulary to " << fileName
-              << std::endl;
     _file.open(fileName.c_str(), "w");
     ad_utility::MmapVector<IndexAndOffset> idsAndOffsets(
         fileName + _offsetSuffix, ad_utility::CreateTag{});

--- a/src/index/VocabularyOnDisk.cpp
+++ b/src/index/VocabularyOnDisk.cpp
@@ -53,6 +53,8 @@ template <typename Iterable>
 void VocabularyOnDisk::buildFromIterable(Iterable&& it,
                                          const string& fileName) {
   {
+    LOG(INFO) << "buildFromIterable: writing vocabulary to " << fileName
+              << std::endl;
     _file.open(fileName.c_str(), "w");
     ad_utility::MmapVector<IndexAndOffset> idsAndOffsets(
         fileName + _offsetSuffix, ad_utility::CreateTag{});

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -57,7 +57,7 @@ class GroupByTest : public ::testing::Test {
     ntFile.close();
     _index.setKbName("group_by_test");
     _index.setTextName("group_by_test");
-    _index.setOnDiskBase("group_ty_test");
+    _index.setOnDiskBase("group_ty_test", "group_by_test");
     _index.createFromFile("group_by_test.nt");
     _index.addTextFromContextFile("group_by_test.words", false);
     _index.buildDocsDB("group_by_test.documents");

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -172,8 +172,9 @@ TEST_F(MergeVocabularyTest, mergeVocabulary) {
     auto internalVocabularyAction = [&file](const auto& word) {
       file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
     };
-    res = m.mergeVocabulary(_basePath, 2, TripleComponentComparator(),
-                            internalVocabularyAction, 1_GB);
+    res =
+        m.mergeVocabulary(_basePath, _basePath, 2, TripleComponentComparator(),
+                          internalVocabularyAction, 1_GB);
   }
 
   // No language tags in text file
@@ -222,7 +223,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
       auto internalVocabularyAction = [&file](const auto& word) {
         file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
       };
-      m.mergeVocabulary(basename, 1, v.getCaseComparator(),
+      m.mergeVocabulary(basename, basename, 1, v.getCaseComparator(),
                         internalVocabularyAction, 1_GB);
     }
     auto idMap = IdMapFromPartialIdMapFile(basename + PARTIAL_MMAP_IDS + "0");
@@ -274,7 +275,7 @@ TEST(VocabularyGenerator, ReadAndWritePartial) {
       auto internalVocabularyAction = [&file](const auto& word) {
         file << RdfEscaping::escapeNewlinesAndBackslashes(word) << '\n';
       };
-      m.mergeVocabulary(basename, 1, v.getCaseComparator(),
+      m.mergeVocabulary(basename, basename, 1, v.getCaseComparator(),
                         internalVocabularyAction, 1_GB);
     }
     auto idMap = IdMapFromPartialIdMapFile(basename + PARTIAL_MMAP_IDS + "0");

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -20,27 +20,26 @@ Index makeIndexWithTestSettings() {
   return index;
 }
 
-std::vector<std::string> getAllIndexFilenames(
-    const std::string& indexBasename) {
-  return {indexBasename + ".ttl",
-          indexBasename + ".index.pos",
-          indexBasename + ".index.pos.meta",
-          indexBasename + ".index.pso",
-          indexBasename + ".index.pso.meta",
-          indexBasename + ".index.sop",
-          indexBasename + ".index.sop.meta",
-          indexBasename + ".index.spo",
-          indexBasename + ".index.spo.meta",
-          indexBasename + ".index.ops",
-          indexBasename + ".index.ops.meta",
-          indexBasename + ".index.osp",
-          indexBasename + ".index.osp.meta",
-          indexBasename + ".index.patterns",
-          indexBasename + ".meta-data.json",
-          indexBasename + ".prefixes",
-          indexBasename + ".vocabulary.internal",
-          indexBasename + ".vocabulary.external",
-          indexBasename + ".vocabulary.external.idsAndOffsets.mmap"};
+std::vector<std::string> getAllIndexFilenames(const std::string& baseName) {
+  return {baseName + ".ttl",
+          baseName + ".index.pos",
+          baseName + ".index.pos.meta",
+          baseName + ".index.pso",
+          baseName + ".index.pso.meta",
+          baseName + ".index.sop",
+          baseName + ".index.sop.meta",
+          baseName + ".index.spo",
+          baseName + ".index.spo.meta",
+          baseName + ".index.ops",
+          baseName + ".index.ops.meta",
+          baseName + ".index.osp",
+          baseName + ".index.osp.meta",
+          baseName + ".index.patterns",
+          baseName + ".meta-data.json",
+          baseName + ".prefixes",
+          baseName + ".vocabulary.internal",
+          baseName + ".vocabulary.external",
+          baseName + ".vocabulary.external.idsAndOffsets.mmap"};
 }
 
 namespace {
@@ -114,7 +113,7 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
 }  // namespace
 
 // ______________________________________________________________
-Index makeTestIndex(const std::string& indexBasename,
+Index makeTestIndex(const std::string& baseName,
                     std::optional<std::string> turtleInput,
                     bool loadAllPermutations, bool usePatterns,
                     bool usePrefixCompression,
@@ -124,7 +123,7 @@ Index makeTestIndex(const std::string& indexBasename,
   // these tests.
   static std::ostringstream ignoreLogStream;
   ad_utility::setGlobalLoggingStream(&ignoreLogStream);
-  std::string inputFilename = indexBasename + ".ttl";
+  std::string inputFilename = baseName + ".ttl";
   if (!turtleInput.has_value()) {
     turtleInput =
         "<x> <label> \"alpha\" . <x> <label> \"älpha\" . <x> <label> \"A\" . "
@@ -146,7 +145,7 @@ Index makeTestIndex(const std::string& indexBasename,
     // triples it may store) ever change, then some unit tests might have to be
     // adapted.
     index.blocksizePermutationsPerColumn() = blocksizePermutations;
-    index.setOnDiskBase(indexBasename);
+    index.setOnDiskBase(baseName, baseName);
     index.usePatterns() = usePatterns;
     index.setPrefixCompression(usePrefixCompression);
     index.loadAllPermutations() = loadAllPermutations;
@@ -162,7 +161,7 @@ Index makeTestIndex(const std::string& indexBasename,
     Index index{ad_utility::makeUnlimitedAllocator<Id>()};
     index.usePatterns() = true;
     index.loadAllPermutations() = true;
-    EXPECT_NO_THROW(index.createFromOnDiskIndex(indexBasename));
+    EXPECT_NO_THROW(index.createFromOnDiskIndex(baseName, baseName));
     EXPECT_EQ(index.loadAllPermutations(), loadAllPermutations);
     EXPECT_EQ(index.usePatterns(), usePatterns);
   }
@@ -170,7 +169,7 @@ Index makeTestIndex(const std::string& indexBasename,
   Index index{ad_utility::makeUnlimitedAllocator<Id>()};
   index.usePatterns() = usePatterns;
   index.loadAllPermutations() = loadAllPermutations;
-  index.createFromOnDiskIndex(indexBasename);
+  index.createFromOnDiskIndex(baseName, baseName);
   if (createTextIndex) {
     index.addTextFromOnDiskIndex();
   }


### PR DESCRIPTION
The vocabulary files can now be written to (and read from) a separate directory than the other index files. This directory can be specified in both `IndexBuilderMain` and `ServerMain` via the new command-line option `--vocabulary-basename` or `-v`. The directory for the index files is specified like before via `--index-basename` or `-i`. If no directory for the vocabulary files is specified, the same directory as for the index files is taken (that was the status quo before this PR).

This is useful for datasets with a huge vocabulary. For example, the vocabulary files for UniProt have a total size of over 3 TB (mostly due to `.vocabulary.external` and `.vocabulary.external.idsAndOffsets`).