### PR TITLE
Work around a mean bug in `boost:asio`

### DIFF
--- a/src/util/http/beast.h
+++ b/src/util/http/beast.h
@@ -37,6 +37,16 @@
 #define BOOST_BEAST_USE_STD_STRING_VIEW
 #endif
 
+// Boost::ASIO currently seems to have a bug when multiple coroutine streams are
+// concurrently in flight because there were multiple calls to `co_spawn`.
+// `ASIO` recycles the memory for awaitable frames, but there seems to only be
+// one global unsynchronized memory pool for this recycling, which leads to all
+// kinds of race conditions. The following constant disables the memory
+// recycling and gets rid of all of those errors and crashes.
+// TODO<joka921> Further analyze and then report this bug to the ASIO
+// developers.
+#define BOOST_ASIO_DISABLE_AWAITABLE_FRAME_RECYCLING
+
 #include <boost/asio.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/beast.hpp>

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -48,7 +48,7 @@ TEST(HttpServer, HttpTest) {
     // Create a client, and send a GET and a POST request in one session.
     // The constants in those test loops can be increased to find threading
     // issues using the thread sanitizer. However, these constants can't be
-    // higher by default because the checks on GitHub actions will run forwever
+    // higher by default because the checks on GitHub actions will run forever
     // if they are.
     {
       std::vector<ad_utility::JThread> threads;
@@ -115,9 +115,7 @@ TEST(HttpServer, HttpTest) {
 
     // Check that after shutting down, no more new connections are accepted.
     httpServer.shutDown();
-    /*
     ASSERT_ANY_THROW(
         HttpClient("localhost", std::to_string(httpServer.getPort())));
-        */
   }
 }

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -17,96 +17,107 @@ using namespace ad_utility::httpUtils;
 using namespace boost::beast::http;
 
 TEST(HttpServer, HttpTest) {
-  // Create and run an HTTP server, which replies to each request with three
-  // lines: the request method (GET, POST, or OTHER), a copy of the request
-  // target (might be empty), and a copy of the request body (might be empty).
-  TestHttpServer httpServer(
-      [](auto request, auto&& send) -> boost::asio::awaitable<void> {
-        std::string methodName;
-        switch (request.method()) {
-          case boost::beast::http::verb::get:
-            methodName = "GET";
-            break;
-          case boost::beast::http::verb::post:
-            methodName = "POST";
-            break;
-          default:
-            methodName = "OTHER";
-        }
-        std::string response = absl::StrCat(
-            methodName, "\n", toStd(request.target()), "\n", request.body());
-        co_return co_await send(createOkResponse(
-            response, request, ad_utility::MediaType::textPlain));
-      });
-  httpServer.runInOwnThread();
-
-  // Create a client, and send a GET and a POST request in one session.
-  // The constants in those test loops can be increased to find threading issues
-  // using the thread sanitizer. However, these constants can't be higher by
-  // default because the checks on GitHub actions will run forwever if they are.
-  {
-    std::vector<ad_utility::JThread> threads;
-    for (size_t i = 0; i < 2; ++i) {
-      threads.emplace_back([&]() {
-        for (size_t j = 0; j < 5; ++j) {
-          {
-            HttpClient httpClient("localhost",
-                                  std::to_string(httpServer.getPort()));
-            ASSERT_EQ(
-                httpClient.sendRequest(verb::get, "localhost", "target1").str(),
-                "GET\ntarget1\n");
-            ASSERT_EQ(
-                httpClient
-                    .sendRequest(verb::post, "localhost", "target1", "body1")
-                    .str(),
-                "POST\ntarget1\nbody1");
+  // This test used to spuriously crash because of something that we (joka92,
+  // RobinTF) currently consider to be a bug in Boost::ASIO. (See
+  // `util/http/beast.h` for details). Repeat this test several times to make
+  // such failures less spurious should they ever reoccur in the future.
+  for (size_t k = 0; k < 10; ++k) {
+    // Create and run an HTTP server, which replies to each request with three
+    // lines: the request method (GET, POST, or OTHER), a copy of the request
+    // target (might be empty), and a copy of the request body (might be empty).
+    TestHttpServer httpServer(
+        [](auto request, auto&& send) -> boost::asio::awaitable<void> {
+          std::string methodName;
+          switch (request.method()) {
+            case boost::beast::http::verb::get:
+              methodName = "GET";
+              break;
+            case boost::beast::http::verb::post:
+              methodName = "POST";
+              break;
+            default:
+              methodName = "OTHER";
           }
-        }
-      });
+          std::string response = absl::StrCat(
+              methodName, "\n", toStd(request.target()), "\n", request.body());
+          co_return co_await send(createOkResponse(
+              response, request, ad_utility::MediaType::textPlain));
+        });
+    httpServer.runInOwnThread();
+
+    // Create a client, and send a GET and a POST request in one session.
+    // The constants in those test loops can be increased to find threading
+    // issues using the thread sanitizer. However, these constants can't be
+    // higher by default because the checks on GitHub actions will run forwever
+    // if they are.
+    {
+      std::vector<ad_utility::JThread> threads;
+      for (size_t i = 0; i < 2; ++i) {
+        threads.emplace_back([&]() {
+          for (size_t j = 0; j < 5; ++j) {
+            {
+              HttpClient httpClient("localhost",
+                                    std::to_string(httpServer.getPort()));
+              ASSERT_EQ(
+                  httpClient.sendRequest(verb::get, "localhost", "target1")
+                      .str(),
+                  "GET\ntarget1\n");
+              ASSERT_EQ(
+                  httpClient
+                      .sendRequest(verb::post, "localhost", "target1", "body1")
+                      .str(),
+                  "POST\ntarget1\nbody1");
+            }
+          }
+        });
+      }
     }
-  }
 
-  // Do the same thing in a second session (to check if everything is still fine
-  // with the server after we have communicated with it for one session).
-  {
-    HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
-    ASSERT_EQ(httpClient.sendRequest(verb::get, "localhost", "target2").str(),
-              "GET\ntarget2\n");
-    ASSERT_EQ(
-        httpClient.sendRequest(verb::post, "localhost", "target2", "body2")
-            .str(),
-        "POST\ntarget2\nbody2");
-  }
+    // Do the same thing in a second session (to check if everything is still
+    // fine with the server after we have communicated with it for one session).
+    {
+      HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
+      ASSERT_EQ(httpClient.sendRequest(verb::get, "localhost", "target2").str(),
+                "GET\ntarget2\n");
+      ASSERT_EQ(
+          httpClient.sendRequest(verb::post, "localhost", "target2", "body2")
+              .str(),
+          "POST\ntarget2\nbody2");
+    }
 
-  // Test if websocket is correctly opened and closed
-  {
-    HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
-    auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
-                                                      "/watch/some-id");
-    // verify request is upgraded
-    ASSERT_EQ(response.base().result(), http::status::switching_protocols);
-  }
+    // Test if websocket is correctly opened and closed
+    {
+      HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
+      auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
+                                                        "/watch/some-id");
+      // verify request is upgraded
+      ASSERT_EQ(response.base().result(), http::status::switching_protocols);
+    }
 
-  // Test if websocket is denied on wrong paths
-  {
-    HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
-    auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
-                                                      "/other-path");
-    // Check for not found error
-    ASSERT_EQ(response.base().result(), http::status::not_found);
-  }
+    // Test if websocket is denied on wrong paths
+    {
+      HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
+      auto response = httpClient.sendWebSocketHandshake(verb::get, "localhost",
+                                                        "/other-path");
+      // Check for not found error
+      ASSERT_EQ(response.base().result(), http::status::not_found);
+    }
 
-  // Also test the convenience function `sendHttpOrHttpsRequest` (which creates
-  // an own client for each request).
-  {
-    Url url{absl::StrCat("http://localhost:", httpServer.getPort(), "/target")};
-    ASSERT_EQ(sendHttpOrHttpsRequest(url, verb::get).str(), "GET\n/target\n");
-    ASSERT_EQ(sendHttpOrHttpsRequest(url, verb::post, "body").str(),
-              "POST\n/target\nbody");
-  }
+    // Also test the convenience function `sendHttpOrHttpsRequest` (which
+    // creates an own client for each request).
+    {
+      Url url{
+          absl::StrCat("http://localhost:", httpServer.getPort(), "/target")};
+      ASSERT_EQ(sendHttpOrHttpsRequest(url, verb::get).str(), "GET\n/target\n");
+      ASSERT_EQ(sendHttpOrHttpsRequest(url, verb::post, "body").str(),
+                "POST\n/target\nbody");
+    }
 
-  // Check that after shutting down, no more new connections are accepted.
-  httpServer.shutDown();
-  ASSERT_ANY_THROW(
-      HttpClient("localhost", std::to_string(httpServer.getPort())));
+    // Check that after shutting down, no more new connections are accepted.
+    httpServer.shutDown();
+    /*
+    ASSERT_ANY_THROW(
+        HttpClient("localhost", std::to_string(httpServer.getPort())));
+        */
+  }
 }


### PR DESCRIPTION
Define `BOOST_ASIO_DISABLE_AWAITABLE_FRAME_RECYCLING` to work around what seems to be a bug in `boost::asio` when different coroutine functions run concurrently.