### PR TITLE
Use a dedicated thread for the timeout triggers

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -503,7 +503,7 @@ ad_utility::websocket::OwningQueryId Server::getQueryId(
 
 auto Server::cancelAfterDeadline(
     std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
-    TimeLimit timeLimit) const
+    TimeLimit timeLimit)
     -> ad_utility::InvocableWithExactReturnType<void> auto {
   net::steady_timer timer{timerExecutor_, timeLimit};
 
@@ -518,7 +518,7 @@ auto Server::cancelAfterDeadline(
 
 // _____________________________________________________________________________
 auto Server::setupCancellationHandle(
-    const ad_utility::websocket::QueryId& queryId, TimeLimit timeLimit) const
+    const ad_utility::websocket::QueryId& queryId, TimeLimit timeLimit)
     -> ad_utility::isInstantiation<
         CancellationHandleAndTimeoutTimerCancel> auto {
   auto cancellationHandle = queryRegistry_.getCancellationHandle(queryId);
@@ -763,7 +763,7 @@ boost::asio::awaitable<void> Server::processQuery(
 // _____________________________________________________________________________
 template <typename Function, typename T>
 Awaitable<T> Server::computeInNewThread(Function function,
-                                        SharedCancellationHandle handle) const {
+                                        SharedCancellationHandle handle) {
   auto runOnExecutor =
       [](auto executor, Function func,
          SharedCancellationHandle handle) -> net::awaitable<T> {
@@ -781,7 +781,7 @@ Awaitable<T> Server::computeInNewThread(Function function,
 // _____________________________________________________________________________
 net::awaitable<Server::PlannedQuery> Server::parseAndPlan(
     const std::string& query, QueryExecutionContext& qec,
-    SharedCancellationHandle handle, TimeLimit timeLimit) const {
+    SharedCancellationHandle handle, TimeLimit timeLimit) {
   auto handleCopy = handle;
   return computeInNewThread(
       [&query, &qec, enablePatternTrick = enablePatternTrick_,

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -6,7 +6,6 @@
 
 #include "engine/Server.h"
 
-#include <cstring>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -14,7 +13,6 @@
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/QueryPlanner.h"
 #include "util/AsioHelpers.h"
-#include "util/CompilerWarnings.h"
 #include "util/MemorySize/MemorySize.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
 #include "util/ParseableDuration.h"
@@ -504,12 +502,11 @@ ad_utility::websocket::OwningQueryId Server::getQueryId(
 // _____________________________________________________________________________
 
 auto Server::cancelAfterDeadline(
-    const net::any_io_executor& executor,
     std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
-    TimeLimit timeLimit)
+    TimeLimit timeLimit) const
     -> ad_utility::InvocableWithExactReturnType<void> auto {
-  auto strand = net::make_strand(executor);
-  auto timer = std::make_shared<net::steady_timer>(strand, timeLimit);
+  // timerExecutor_ is single threaded, so this is safe to do.
+  auto timer = std::make_shared<net::steady_timer>(timerExecutor_, timeLimit);
 
   auto cancelAfterTimeout =
       [](std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
@@ -520,31 +517,28 @@ auto Server::cancelAfterDeadline(
       pointer->cancel(ad_utility::CancellationState::TIMEOUT);
     }
   };
-  net::co_spawn(strand,
+  net::co_spawn(timerExecutor_,
                 cancelAfterTimeout(std::move(cancellationHandle), timer),
                 net::detached);
-  DISABLE_UNINITIALIZED_WARNINGS
   // For some reason gcc 11-13 with -O3 think `executed` may be uninitialized
-  return [strand, timer = std::move(timer), executed = false]() mutable {
+  return [executor = timerExecutor_.get_executor(), timer = std::move(timer),
+          executed = false]() mutable {
     AD_CORRECTNESS_CHECK(!executed);
-    ENABLE_UNINITIALIZED_WARNINGS
     executed = true;
-    // Only run if not moved from
-    net::post(strand, [timer = std::move(timer)]() { timer->cancel(); });
+    net::post(executor, [timer = std::move(timer)]() { timer->cancel(); });
   };
 }
 
 // _____________________________________________________________________________
 auto Server::setupCancellationHandle(
-    const ad_utility::websocket::QueryId& queryId, TimeLimit timeLimit,
-    const net::any_io_executor& executor) const
+    const ad_utility::websocket::QueryId& queryId, TimeLimit timeLimit) const
     -> ad_utility::isInstantiation<
         CancellationHandleAndTimeoutTimerCancel> auto {
   auto cancellationHandle = queryRegistry_.getCancellationHandle(queryId);
   AD_CORRECTNESS_CHECK(cancellationHandle);
   cancellationHandle->startWatchDog();
   absl::Cleanup cancelCancellationHandle{
-      cancelAfterDeadline(executor, cancellationHandle, timeLimit)};
+      cancelAfterDeadline(cancellationHandle, timeLimit)};
   return CancellationHandleAndTimeoutTimerCancel{
       std::move(cancellationHandle), std::move(cancelCancellationHandle)};
 }
@@ -649,8 +643,7 @@ boost::asio::awaitable<void> Server::processQuery(
                               sortPerformanceEstimator_,
                               std::ref(messageSender), pinSubtrees, pinResult);
     auto [cancellationHandle, cancelTimeoutOnDestruction] =
-        setupCancellationHandle(messageSender.getQueryId(), timeLimit,
-                                co_await net::this_coro::executor);
+        setupCancellationHandle(messageSender.getQueryId(), timeLimit);
 
     plannedQuery =
         co_await parseAndPlan(query, qec, cancellationHandle, timeLimit);

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <semaphore>
 #include <string>
 #include <vector>
 
@@ -76,6 +75,9 @@ class Server {
   std::weak_ptr<ad_utility::websocket::QueryHub> queryHub_;
 
   mutable net::static_thread_pool threadPool_;
+
+  /// Executor with a single thread that is used to run timers asynchronously.
+  mutable net::static_thread_pool timerExecutor_{1};
 
   template <typename T>
   using Awaitable = boost::asio::awaitable<T>;
@@ -166,10 +168,9 @@ class Server {
   /// The returned callback can be used to prevent this task from executing
   /// either because the `cancellationHandle` has been aborted by some other
   /// means or because the task has been completed successfully.
-  static auto cancelAfterDeadline(
-      const net::any_io_executor& executor,
+  auto cancelAfterDeadline(
       std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
-      TimeLimit timeLimit)
+      TimeLimit timeLimit) const
       -> ad_utility::InvocableWithExactReturnType<void> auto;
 
   /// Run the SPARQL parser and then the query planner on the `query`. All
@@ -185,8 +186,7 @@ class Server {
   /// `CancellationHandleAndTimeoutTimerCancel`, where the `cancelTimeout_`
   /// member can be invoked to cancel the imminent cancellation via timeout.
   auto setupCancellationHandle(const ad_utility::websocket::QueryId& queryId,
-                               TimeLimit timeLimit,
-                               const net::any_io_executor& executor) const
+                               TimeLimit timeLimit) const
       -> ad_utility::isInstantiation<
           CancellationHandleAndTimeoutTimerCancel> auto;
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -74,10 +74,10 @@ class Server {
   /// the `WebSocketHandler` created for `HttpServer`.
   std::weak_ptr<ad_utility::websocket::QueryHub> queryHub_;
 
-  mutable net::static_thread_pool threadPool_;
+  net::static_thread_pool threadPool_;
 
   /// Executor with a single thread that is used to run timers asynchronously.
-  mutable net::static_thread_pool timerExecutor_{1};
+  net::static_thread_pool timerExecutor_{1};
 
   template <typename T>
   using Awaitable = boost::asio::awaitable<T>;
@@ -147,7 +147,7 @@ class Server {
   /// it's completion, wrapping the result.
   template <typename Function, typename T = std::invoke_result_t<Function>>
   Awaitable<T> computeInNewThread(Function function,
-                                  SharedCancellationHandle handle) const;
+                                  SharedCancellationHandle handle);
 
   /// This method extracts a client-defined query id from the passed HTTP
   /// request if it is present. If it is not present or empty, a new
@@ -170,7 +170,7 @@ class Server {
   /// means or because the task has been completed successfully.
   auto cancelAfterDeadline(
       std::weak_ptr<ad_utility::CancellationHandle<>> cancellationHandle,
-      TimeLimit timeLimit) const
+      TimeLimit timeLimit)
       -> ad_utility::InvocableWithExactReturnType<void> auto;
 
   /// Run the SPARQL parser and then the query planner on the `query`. All
@@ -178,7 +178,7 @@ class Server {
   net::awaitable<PlannedQuery> parseAndPlan(const std::string& query,
                                             QueryExecutionContext& qec,
                                             SharedCancellationHandle handle,
-                                            TimeLimit timeLimit) const;
+                                            TimeLimit timeLimit);
 
   /// Acquire the `CancellationHandle` for the given `QueryId`, start the
   /// watchdog and call `cancelAfterDeadline` to set the timeout after
@@ -186,7 +186,7 @@ class Server {
   /// `CancellationHandleAndTimeoutTimerCancel`, where the `cancelTimeout_`
   /// member can be invoked to cancel the imminent cancellation via timeout.
   auto setupCancellationHandle(const ad_utility::websocket::QueryId& queryId,
-                               TimeLimit timeLimit) const
+                               TimeLimit timeLimit)
       -> ad_utility::isInstantiation<
           CancellationHandleAndTimeoutTimerCancel> auto;
 


### PR DESCRIPTION
The timers that are used to cancel queries if a timeout occurs now use a dedicated thread. This ensures, that the timeout always is triggered directly when it occurs, even if the threads used for computing the queries are currently all busy.