### PR TITLE
Change resolution for timeouts to milliseconds

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -223,26 +223,28 @@ net::awaitable<std::optional<Server::TimeLimit>>
 Server::verifyUserSubmittedQueryTimeout(
     std::optional<std::string_view> userTimeout, bool accessTokenOk,
     const ad_utility::httpUtils::HttpRequest auto& request, auto& send) const {
-  TimeLimit timeLimit = RuntimeParameters().get<"default-query-timeout">();
+  auto defaultTimeout = RuntimeParameters().get<"default-query-timeout">();
+  using DefaultUnit = decltype(defaultTimeout)::DurationType;
   // TODO<GCC12> Use the monadic operations for std::optional
   if (userTimeout.has_value()) {
     auto timeoutCandidate =
         ad_utility::ParseableDuration<TimeLimit>::fromString(
             userTimeout.value());
-    if (timeoutCandidate > timeLimit && !accessTokenOk) {
+    if (TimeLimit{timeoutCandidate} > DefaultUnit{defaultTimeout} &&
+        !accessTokenOk) {
       co_await send(ad_utility::httpUtils::createForbiddenResponse(
           absl::StrCat("User submitted timeout was higher than what is "
                        "currently allowed by "
                        "this instance (",
-                       timeLimit.count(),
-                       "s). Please use a valid-access token to override this "
+                       defaultTimeout.toString(),
+                       "). Please use a valid-access token to override this "
                        "server configuration."),
           request));
       co_return std::nullopt;
     }
     co_return timeoutCandidate;
   }
-  co_return timeLimit;
+  co_return std::chrono::duration_cast<TimeLimit>(DefaultUnit{defaultTimeout});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -80,7 +80,7 @@ class Server {
   template <typename T>
   using Awaitable = boost::asio::awaitable<T>;
 
-  using TimeLimit = std::chrono::seconds;
+  using TimeLimit = std::chrono::milliseconds;
 
   using SharedCancellationHandle = ad_utility::SharedCancellationHandle;
 

--- a/src/util/ParseableDuration.h
+++ b/src/util/ParseableDuration.h
@@ -25,6 +25,9 @@ class ParseableDuration {
  private:
   DurationType duration_{};
 
+  template <typename Other>
+  friend class ParseableDuration;
+
  public:
   ParseableDuration() = default;
   // Implicit conversion is on purpose!
@@ -36,6 +39,13 @@ class ParseableDuration {
   // supports it.
   auto operator<=>(const ParseableDuration& other) const noexcept {
     return duration_.count() <=> other.duration_.count();
+  }
+
+  template <typename Other>
+  auto operator<=>(const ParseableDuration<Other>& other) const noexcept {
+    using CommonType = std::common_type_t<DurationType, Other>;
+    return CommonType{duration_}.count() <=>
+           CommonType{other.duration_}.count();
   }
 
   bool operator==(const ParseableDuration&) const noexcept = default;

--- a/src/util/ParseableDuration.h
+++ b/src/util/ParseableDuration.h
@@ -17,8 +17,12 @@ namespace ad_utility {
 
 // Wrapper type for std::chrono::duration<> to avoid having to declare
 // this in the std::chrono namespace.
-template <typename DurationType>
+template <typename DT>
 class ParseableDuration {
+ public:
+  using DurationType = DT;
+
+ private:
   DurationType duration_{};
 
  public:


### PR DESCRIPTION
The resolution was seconds, which was too coarse. Now it's milliseconds. This is required by https://github.com/ad-freiburg/qlever-ui/pull/73.