### PR TITLE
Consistently use `dash-case` keys in the JSON output of the benchmark module

### DIFF
--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -53,22 +53,23 @@ class ConfigOptions : public BenchmarkInterface {
 
     manager.addOption("date", "The current date.", &dateString_, "22.3.2023"s);
 
-    auto numSigns = manager.addOption("numSigns", "The number of street signs.",
-                                      &numberOfStreetSigns_, 10000);
+    auto numSigns =
+        manager.addOption("num-signs", "The number of street signs.",
+                          &numberOfStreetSigns_, 10000);
     manager.addValidator([](const int& num) { return num >= 0; },
                          "The number of street signs must be at least 0!",
                          "Negative numbers, or floating point numbers, are not "
-                         "allowed for the configuration option \"numSigns\".",
+                         "allowed for the configuration option \"num-signs\".",
                          numSigns);
 
-    manager.addOption("CoinFlipTry", "The number of succesful coin flips.",
+    manager.addOption("coin-flip-try", "The number of succesful coin flips.",
                       &wonOnTryX_, {false, false, false, false, false});
 
     // Sub manager can be used to organize things better. They are basically
     // just a path prefix for all the options inside it.
     ad_utility::ConfigManager& subManager{
-        manager.addSubManager({"Accounts"s, "Personal"s})};
-    subManager.addOption("Steve"s, "Steves saving account balance.",
+        manager.addSubManager({"accounts"s, "personal"s})};
+    subManager.addOption("steve"s, "Steves saving account balance.",
                          &balanceOnStevesSavingAccount_, -41.9f);
   }
 };
@@ -274,9 +275,9 @@ class BMConfigurationAndMetadataExample : public ConfigOptions {
   BenchmarkResults runAllBenchmarks() final {
     BenchmarkMetadata& meta{getGeneralMetadata()};
     meta.addKeyValuePair("date", dateString_);
-    meta.addKeyValuePair("numberOfStreetSigns", numberOfStreetSigns_);
-    meta.addKeyValuePair("wonOnTryX", wonOnTryX_);
-    meta.addKeyValuePair("Balance on Steves saving account",
+    meta.addKeyValuePair("number-of-street-signs", numberOfStreetSigns_);
+    meta.addKeyValuePair("won-on-try-x", wonOnTryX_);
+    meta.addKeyValuePair("balance-on-steves-saving-account",
                          balanceOnStevesSavingAccount_);
     return BenchmarkResults{};
   }

--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -105,7 +105,7 @@ class BMSingleMeasurements : public ConfigOptions {
         });
 
     // Adding some basic metadata.
-    multipleTimes.metadata().addKeyValuePair("Amount of exponentiations",
+    multipleTimes.metadata().addKeyValuePair("amount-of-exponentiations",
                                              10'000'000'000);
 
     return results;
@@ -139,34 +139,34 @@ class BMGroups : public ConfigOptions {
 
     // Measuring functions.
     auto& loopAddGroup = results.addGroup("loopAdd");
-    loopAddGroup.metadata().addKeyValuePair("Operator", "+");
+    loopAddGroup.metadata().addKeyValuePair("operator", "+");
 
     auto& loopMultiplyGroup = results.addGroup("loopMultiply");
-    loopMultiplyGroup.metadata().addKeyValuePair("Operator", "*");
+    loopMultiplyGroup.metadata().addKeyValuePair("operator", "*");
 
     auto& addMember1 =
         loopAddGroup.addMeasurement("1+1", [&loopAdd]() { loopAdd(1, 1); });
-    addMember1.metadata().addKeyValuePair("Result", 2);
+    addMember1.metadata().addKeyValuePair("result", 2);
 
     auto& addMember2 =
         loopAddGroup.addMeasurement("42+69", [&loopAdd]() { loopAdd(42, 69); });
-    addMember2.metadata().addKeyValuePair("Result", 42 + 69);
+    addMember2.metadata().addKeyValuePair("result", 42 + 69);
 
     auto& addMember3 = loopAddGroup.addMeasurement(
         "10775+24502", [&loopAdd]() { loopAdd(10775, 24502); });
-    addMember3.metadata().addKeyValuePair("Result", 10775 + 24502);
+    addMember3.metadata().addKeyValuePair("result", 10775 + 24502);
 
     auto& multiplicationMember1 = loopMultiplyGroup.addMeasurement(
         "1*1", [&loopMultiply]() { loopMultiply(1, 1); });
-    multiplicationMember1.metadata().addKeyValuePair("Result", 1);
+    multiplicationMember1.metadata().addKeyValuePair("result", 1);
 
     auto& multiplicationMember2 = loopMultiplyGroup.addMeasurement(
         "42*69", [&loopMultiply]() { loopMultiply(42, 69); });
-    multiplicationMember2.metadata().addKeyValuePair("Result", 42 * 69);
+    multiplicationMember2.metadata().addKeyValuePair("result", 42 * 69);
 
     auto& multiplicationMember3 = loopMultiplyGroup.addMeasurement(
         "10775*24502", [&loopMultiply]() { loopMultiply(10775, 24502); });
-    multiplicationMember3.metadata().addKeyValuePair("Result", 10775 * 24502);
+    multiplicationMember3.metadata().addKeyValuePair("result", 10775 * 24502);
 
     // Addtables.
     ResultTable& addTable =
@@ -217,7 +217,7 @@ class BMTables : public ConfigOptions {
         "Adding exponents", {"2^10", "2^11", "Values written out"},
         {"", "2^10", "2^11"});
     // Adding some metadata.
-    tableAddingExponents.metadata().addKeyValuePair("Manually set fields",
+    tableAddingExponents.metadata().addKeyValuePair("manually-set-fields",
                                                     "Row 2");
 
     // Measure the calculating of the exponents.

--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -184,7 +184,7 @@ In both of those, you have to write out the complete path to your configuration 
 For example: Let's say, you defined a configuration option `someNumber` and added it with the path `tableSizes/someNumber`. Then, if you wanted to set it to `20` using JSON, you would have to write:
 
 ```json
-{"tableSizes": "someNumber": 20}
+{"tableSizes": "some-number": 20}
 ```
 
 However, **if** the passed values can't be interpreted as the correct types for the configuration options, an exception will be thrown.

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -52,7 +52,7 @@ ResultEntry::operator std::string() const {
 // ____________________________________________________________________________
 void to_json(nlohmann::ordered_json& j, const ResultEntry& resultEntry) {
   j = nlohmann::ordered_json{{"descriptor", resultEntry.descriptor_},
-                             {"measuredTime", resultEntry.measuredTime_},
+                             {"measured-time", resultEntry.measuredTime_},
                              {"metadata", resultEntry.metadata()}};
 }
 
@@ -106,8 +106,8 @@ ResultGroup::operator std::string() const {
 // ____________________________________________________________________________
 void to_json(nlohmann::ordered_json& j, const ResultGroup& resultGroup) {
   j = nlohmann::ordered_json{{"descriptor", resultGroup.descriptor_},
-                             {"resultEntries", resultGroup.resultEntries_},
-                             {"resultTables", resultGroup.resultTables_},
+                             {"result-entries", resultGroup.resultEntries_},
+                             {"result-tables", resultGroup.resultTables_},
                              {"metadata", resultGroup.metadata()}};
 }
 
@@ -342,7 +342,7 @@ size_t ResultTable::numColumns() const {
 // ____________________________________________________________________________
 void to_json(nlohmann::ordered_json& j, const ResultTable& resultTable) {
   j = nlohmann::ordered_json{{"descriptor", resultTable.descriptor_},
-                             {"columnNames", resultTable.columnNames_},
+                             {"column-names", resultTable.columnNames_},
                              {"entries", resultTable.entries_},
                              {"metadata", resultTable.metadata()}};
 }

--- a/benchmark/infrastructure/BenchmarkToJson.cpp
+++ b/benchmark/infrastructure/BenchmarkToJson.cpp
@@ -19,9 +19,9 @@ void to_json(nlohmann::ordered_json& j, const BenchmarkResults& results) {
   // be serialized, because that is the management class for measured
   // benchmarks. We just want the measured benchmarks.
   j = nlohmann::ordered_json{
-      {"singleMeasurements", results.getSingleMeasurements()},
-      {"resultGroups", results.getGroups()},
-      {"resultTables", results.getTables()}};
+      {"single-measurements", results.getSingleMeasurements()},
+      {"result-groups", results.getGroups()},
+      {"result-tables", results.getTables()}};
 }
 
 /*
@@ -68,7 +68,7 @@ nlohmann::ordered_json zipBenchmarkClassAndBenchmarkResultsToJson(
       benchmarkClassAndBenchmarkResults, [](const auto& pair) {
         return nlohmann::ordered_json{
             {"name", pair.first->name()},
-            {"general metadata", pair.first->getGeneralMetadata()},
+            {"general-metadata", pair.first->getGeneralMetadata()},
             {"measurements", pair.second}};
       });
 }


### PR DESCRIPTION
Previously there was an inconsistent mixture of `camelCase` and `dash-case`. We have decided to use `dash-case` because this is the default for JSON value, in the rest of QLever as well as elsewhere.