### PR TITLE
Remove an unused and deprecate section from `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,13 +216,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
 
-
-################################
-# NLOHNMANN-JSON
-################################
-# Header only, nothing to include
-include_directories(third_party/json/)
-
 ################################
 # CTRE, Compile-Time-Regular-Expressions
 ################################


### PR DESCRIPTION
I've noticed a no longer required `include_directories` call and deleted it.