### PR TITLE
Add Labels and Annotations to the Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,6 +78,14 @@ jobs:
           load: false
           push: false
 
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          # We build multiplatform images which have an image index above the
+          # image manifests. Attach the annotations directly to the image index.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: "index"
+
       - name: Build and push
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v5
@@ -96,4 +104,9 @@ jobs:
             adfreiburg/qlever:latest,
             adfreiburg/qlever:${{ github.ref_name == 'master' && format('pr-{0}', steps.pr.outputs.pr_num) || github.ref_name }},
             adfreiburg/qlever:commit-${{ steps.sha.outputs.sha_short }},
+
+          # Set Annotations and Labels that conform to the OpenContainers
+          # Annotations Spec
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
Add Labels and Annotations that conform to the [OpenContainers Annotation Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) to the images published on DockerHub.
These help with automated workflows and also allow users who use the `lates` tag to get detailed information about the container version.

The workflow will add the following information to the image index and image config:
- `org.opencontainers.image.created` timestamp of the build
- `org.opencontainers.image.description` Github project description
- `org.opencontainers.image.licenses` License in a standard format ([SPDX License Expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)) extracted from `LICENSE`
- `org.opencontainers.image.revision` git commit hash
- `org.opencontainers.image.source` URL of the Github repo
- `org.opencontainers.image.title` Github title (`qlever`)
- `org.opencontainers.image.url` URL of the Github repo
- `org.opencontainers.image.version` branch or tag
