### PR TITLE
Better error message for three non-distinct variables

### DIFF
--- a/test/CheckUsePatternTrickTest.cpp
+++ b/test/CheckUsePatternTrickTest.cpp
@@ -150,9 +150,11 @@ TEST(CheckUsePatternTrick, isTripleSuitable) {
 
   // The variables in the pattern trick triple must be all different.
   expectNot("SELECT ?p WHERE {?p ql:has-predicate ?p} GROUP BY ?p");
-  expectNot("SELECT ?p WHERE {?s ?p ?p} GROUP BY ?p");
-  expectNot("SELECT ?p WHERE {?s ?p ?s} GROUP BY ?p");
-  expectNot("SELECT ?p WHERE {?p ?p ?s} GROUP BY ?p");
+
+  // Three variables that are not all different are not supported.
+  // expectNot("SELECT ?p WHERE {?s ?p ?p} GROUP BY ?p");
+  // expectNot("SELECT ?p WHERE {?s ?p ?s} GROUP BY ?p");
+  // expectNot("SELECT ?p WHERE {?p ?p ?s} GROUP BY ?p");
 
   // Predicate and object variable must not appear elsewhere in the query.
   expectNot("SELECT ?p WHERE {?s ?p ?o . ?p <is-a> ?z} GROUP BY ?p");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -871,6 +871,12 @@ TEST(SparqlParser, GroupGraphPattern) {
   expectGroupGraphPatternFails("{ }");
   expectGroupGraphPatternFails("{ SELECT *  WHERE { } }");
 
+  // Triples with three variables that are not all different are not supported.
+  expectGroupGraphPatternFails("{ ?y ?x ?x }");
+  expectGroupGraphPatternFails("{ ?x ?y ?x }");
+  expectGroupGraphPatternFails("{ ?x ?x ?y }");
+  expectGroupGraphPatternFails("{ ?x ?x ?x }");
+
   SparqlTriple abc{Var{"?a"}, "?b", Var{"?c"}};
   SparqlTriple def{Var{"?d"}, "?e", Var{"?f"}};
   // Test the Components alone.


### PR DESCRIPTION
Graph patterns like `SELECT * WHERE  { ?s ?p ?s }` are currently not supported by QLever. The error message so far looked like a bug ("Assertion !lastRow.empty() failed"). Now there is a proper error message with a recommendation to use a `FILTER`, see below.

Addresses https://github.com/ad-freiburg/qlever/issues/1283.

An equivalent formulation for the query above is `SELECT * WHERE { ?s ?p ?o FILTER (?s = ?o) }`. However, that only works if all triples fit into RAM. This is a separate issue (it requires lazy processing of FILTER operations), which is on our list.