### PR TITLE
Add support for multiple GROUP BY variables in the HashMap optimization

### DIFF
--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -199,8 +199,8 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
   std::mt19937_64 randomEngine{rd()};
   static constexpr size_t numInputRows = 10'000'000;
   static constexpr size_t numMeasurements = 4;
-  static constexpr size_t multiplicities[] = {5'000'000, 500'000, 50'000, 5'000,
-                                              500,       50,      5};
+  static constexpr size_t multiplicities[] = {
+      5'000'000, 500'000, 50'000, 5'000, 500, 50, 5, 3, 1};
   static constexpr size_t randomStringLength = 3;
 
   template <typename T>

--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -130,44 +130,42 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
   }
 
   void runNumericBenchmarks(BenchmarkResults& results) {
-    for (int i = 0; i < 2; i++) {
-      for (auto multiplicity : multiplicities) {
-        for (auto valueIdType : numericValueIdTypes) {
-          //-----------------------------------------------------------------------------------------------------
-          runTests<AvgExpression>(results, multiplicity, valueIdType, false,
-                                  static_cast<bool>(i));
+    for (auto multiplicity : multiplicities) {
+      for (auto valueIdType : numericValueIdTypes) {
+        //-----------------------------------------------------------------------------------------------------
+        runTests<AvgExpression>(results, multiplicity, valueIdType, false,
+                                false);
 
-          runTests<AvgExpression>(results, multiplicity, valueIdType, true,
-                                  static_cast<bool>(i));
+        runTests<AvgExpression>(results, multiplicity, valueIdType, true,
+                                false);
 
-          //-----------------------------------------------------------------------------------------------------
-          runTests<SumExpression>(results, multiplicity, valueIdType, false,
-                                  static_cast<bool>(i));
+        //-----------------------------------------------------------------------------------------------------
+        runTests<SumExpression>(results, multiplicity, valueIdType, false,
+                                false);
 
-          runTests<SumExpression>(results, multiplicity, valueIdType, true,
-                                  static_cast<bool>(i));
+        runTests<SumExpression>(results, multiplicity, valueIdType, true,
+                                false);
 
-          //-----------------------------------------------------------------------------------------------------
-          runTests<CountExpression>(results, multiplicity, valueIdType, false,
-                                    static_cast<bool>(i));
+        //-----------------------------------------------------------------------------------------------------
+        runTests<CountExpression>(results, multiplicity, valueIdType, false,
+                                  false);
 
-          runTests<CountExpression>(results, multiplicity, valueIdType, true,
-                                    static_cast<bool>(i));
+        runTests<CountExpression>(results, multiplicity, valueIdType, true,
+                                  false);
 
-          //-----------------------------------------------------------------------------------------------------
-          runTests<MinExpression>(results, multiplicity, valueIdType, false,
-                                  static_cast<bool>(i));
+        //-----------------------------------------------------------------------------------------------------
+        runTests<MinExpression>(results, multiplicity, valueIdType, false,
+                                false);
 
-          runTests<MinExpression>(results, multiplicity, valueIdType, true,
-                                  static_cast<bool>(i));
+        runTests<MinExpression>(results, multiplicity, valueIdType, true,
+                                false);
 
-          //-----------------------------------------------------------------------------------------------------
-          runTests<MaxExpression>(results, multiplicity, valueIdType, false,
-                                  static_cast<bool>(i));
+        //-----------------------------------------------------------------------------------------------------
+        runTests<MaxExpression>(results, multiplicity, valueIdType, false,
+                                false);
 
-          runTests<MaxExpression>(results, multiplicity, valueIdType, true,
-                                  static_cast<bool>(i));
-        }
+        runTests<MaxExpression>(results, multiplicity, valueIdType, true,
+                                false);
       }
     }
   }
@@ -207,23 +205,19 @@ class GroupByHashMapBenchmark : public BenchmarkInterface {
   }
 
   void runStringBenchmarks(BenchmarkResults& results) {
-    for (int i = 0; i < 2; i++) {
-      for (auto multiplicity : multiplicities) {
-        runTests<GroupConcatExpression>(results, multiplicity,
-                                        ValueIdType::Strings, false,
-                                        static_cast<bool>(i));
-        runTests<GroupConcatExpression>(results, multiplicity,
-                                        ValueIdType::Strings, true,
-                                        static_cast<bool>(i));
-      }
+    for (auto multiplicity : multiplicities) {
+      runTests<GroupConcatExpression>(results, multiplicity,
+                                      ValueIdType::Strings, false, false);
+      runTests<GroupConcatExpression>(results, multiplicity,
+                                      ValueIdType::Strings, true, false);
     }
   }
 
   BenchmarkResults runAllBenchmarks() final {
     BenchmarkResults results{};
 
-    // runStringBenchmarks(results);
     // runTwoAggregateBenchmarks(results);
+    // runStringBenchmarks(results);
     runNumericBenchmarks(results);
 
     return results;

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1152,11 +1152,10 @@ void GroupBy::evaluateAlias(
   // have to be substituted away before evaluation
 
   auto substitutions = alias.groupedVariables_;
-  auto topLevelGroupedVariable =
-      std::ranges::find_if(substitutions.begin(), substitutions.end(),
-                           [](HashMapGroupedVariableInformation& val) {
-                             return std::get_if<OccurAsRoot>(&val.occurrences_);
-                           });
+  auto topLevelGroupedVariable = std::ranges::find_if(
+      substitutions, [](HashMapGroupedVariableInformation& val) {
+        return std::get_if<OccurAsRoot>(&val.occurrences_);
+      });
 
   if (topLevelGroupedVariable != substitutions.end()) {
     // If the aggregate is at the top of the alias, e.g. `SELECT (?a as ?x)
@@ -1237,10 +1236,8 @@ void GroupBy::createResultFromHashMap(
     LocalVocab* localVocab) {
   // Create result table, filling in the group values, since they might be
   // required in evaluation
-  ad_utility::Timer sortingTimer{
-      ad_utility::timer::Timer::InitialStatus::Started};
+  ad_utility::Timer sortingTimer{ad_utility::Timer::Started};
   auto sortedKeys = aggregationData.getSortedGroupColumns();
-  sortingTimer.stop();
   runtimeInfo().addDetail("timeResultSorting", sortingTimer.msecs());
 
   size_t numberOfGroups = aggregationData.getNumberOfGroups();
@@ -1263,8 +1260,7 @@ void GroupBy::createResultFromHashMap(
   evaluationContext._previousResultsFromSameGroup.resize(getResultWidth());
   evaluationContext._isPartOfGroupBy = true;
 
-  ad_utility::Timer evaluationAndResultsTimer{
-      ad_utility::timer::Timer::InitialStatus::Started};
+  ad_utility::Timer evaluationAndResultsTimer{ad_utility::Timer::Started};
   for (size_t i = 0; i < numberOfGroups; i += GROUP_BY_HASH_MAP_BLOCK_SIZE) {
     checkCancellation();
 
@@ -1277,8 +1273,6 @@ void GroupBy::createResultFromHashMap(
                     localVocab);
     }
   }
-  evaluationAndResultsTimer.stop();
-
   runtimeInfo().addDetail("timeEvaluationAndResults",
                           evaluationAndResultsTimer.msecs());
 }
@@ -1334,10 +1328,8 @@ void GroupBy::computeGroupByForHashMapOptimization(
       _groupByVariables.begin(), _groupByVariables.end()};
   evaluationContext._isPartOfGroupBy = true;
 
-  ad_utility::Timer lookupTimer{
-      ad_utility::timer::Timer::InitialStatus::Stopped};
-  ad_utility::Timer aggregationTimer{
-      ad_utility::timer::Timer::InitialStatus::Stopped};
+  ad_utility::Timer lookupTimer{ad_utility::Timer::Stopped};
+  ad_utility::Timer aggregationTimer{ad_utility::Timer::Stopped};
   for (size_t i = 0; i < subresult.size(); i += GROUP_BY_HASH_MAP_BLOCK_SIZE) {
     checkCancellation();
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -973,7 +973,8 @@ GroupBy::getHashMapAggregationResults(
   auto& aggregateDataVariant =
       aggregationData.getAggregationDataVariant(dataIndex);
 
-  using B = HashMapAggregationData<NUM_GROUP_COLUMNS>::template T<Id>;
+  using B =
+      HashMapAggregationData<NUM_GROUP_COLUMNS>::template ArrayOrVector<Id>;
   for (size_t rowIdx = beginIndex; rowIdx < endIndex; ++rowIdx) {
     B mapKey;
     resizeIfVector(mapKey, aggregationData.numOfGroupedColumns_);
@@ -1050,7 +1051,7 @@ concept SupportedAggregates =
 template <size_t NUM_GROUP_COLUMNS>
 std::vector<size_t>
 GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
-    const T<std::span<const Id>>& groupByCols) {
+    const ArrayOrVector<std::span<const Id>>& groupByCols) {
   AD_CONTRACT_CHECK(groupByCols.size() > 0);
 
   std::vector<size_t> hashEntries;
@@ -1061,7 +1062,7 @@ GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
   //       them row-wise. Is there any advantage to this, or should we transform
   //       the data into a row-wise format before passing it?
   for (size_t i = 0; i < numberOfEntries; ++i) {
-    T<Id> row;
+    ArrayOrVector<Id> row;
     resizeIfVector(row, numOfGroupedColumns_);
 
     // TODO<C++23> use views::enumerate
@@ -1107,12 +1108,12 @@ GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
 
 // _____________________________________________________________________________
 template <size_t NUM_GROUP_COLUMNS>
-[[nodiscard]] GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::T<
+[[nodiscard]] GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::ArrayOrVector<
     std::vector<Id>>
 GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getSortedGroupColumns()
     const {
   // Get data in a row-wise manner.
-  std::vector<T<Id>> sortedKeys;
+  std::vector<ArrayOrVector<Id>> sortedKeys;
   for (const auto& val : map_) {
     sortedKeys.push_back(val.first);
   }
@@ -1121,7 +1122,7 @@ GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getSortedGroupColumns()
   std::ranges::sort(sortedKeys.begin(), sortedKeys.end());
 
   // Get data in a column-wise manner.
-  T<std::vector<Id>> result;
+  ArrayOrVector<std::vector<Id>> result;
   resizeIfVector(result, numOfGroupedColumns_);
 
   for (size_t idx = 0; idx < numOfGroupedColumns_; ++idx)
@@ -1342,7 +1343,7 @@ void GroupBy::computeGroupByForHashMapOptimization(
     auto currentBlockSize = evaluationContext.size();
 
     // Perform HashMap lookup once for all groups in current block
-    using U = HashMapAggregationData<NUM_GROUP_COLUMNS>::template T<
+    using U = HashMapAggregationData<NUM_GROUP_COLUMNS>::template ArrayOrVector<
         std::span<const Id>>;
     U groupValues;
     resizeIfVector(groupValues, columnIndices.size());

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -980,7 +980,7 @@ GroupBy::getHashMapAggregationResults(
     B mapKey;
     resizeIfVector(mapKey, aggregationData.numOfGroupedColumns_);
 
-    for (size_t idx = 0; idx < aggregationData.numOfGroupedColumns_; ++idx) {
+    for (size_t idx = 0; idx < mapKey.size(); ++idx) {
       mapKey.at(idx) = resultTable->getColumn(idx)[rowIdx];
     }
     auto vectorIdx = aggregationData.getIndex(mapKey);
@@ -1127,7 +1127,7 @@ GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getSortedGroupColumns()
   ArrayOrVector<std::vector<Id>> result;
   resizeIfVector(result, numOfGroupedColumns_);
 
-  for (size_t idx = 0; idx < numOfGroupedColumns_; ++idx)
+  for (size_t idx = 0; idx < result.size(); ++idx)
     for (auto& val : sortedKeys) {
       result.at(idx).push_back(val.at(idx));
     }
@@ -1317,6 +1317,9 @@ void GroupBy::computeGroupByForHashMapOptimization(
     IdTable* result, std::vector<HashMapAliasInformation>& aggregateAliases,
     const IdTable& subresult, const std::vector<size_t>& columnIndices,
     LocalVocab* localVocab) {
+  AD_CONTRACT_CHECK(columnIndices.size() == NUM_GROUP_COLUMNS ||
+                    NUM_GROUP_COLUMNS == 0);
+
   // Initialize aggregation data
   HashMapAggregationData<NUM_GROUP_COLUMNS> aggregationData(
       getExecutionContext()->getAllocator(), aggregateAliases,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -291,11 +291,8 @@ class GroupBy : public Operation {
           alloc_{alloc},
           map_{alloc} {
       using enum HashMapAggregateType;
-      size_t numAggregates = 0;
       for (const auto& alias : aggregateAliases) {
         for (const auto& aggregate : alias.aggregateInfo_) {
-          ++numAggregates;
-
           using namespace ad_utility::use_type_identity;
           auto addIf = [this, &aggregate]<typename T>(
                            TI<T>, HashMapAggregateType target) {

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -319,7 +319,6 @@ class GroupBy : public Operation {
           aggregateTypeWithData_.emplace_back(aggregate.aggregateType_);
         }
       }
-      AD_CONTRACT_CHECK(numAggregates > 0);
     }
 
     // Returns a vector containing the offsets for all ids of `groupByCols`,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -279,7 +279,7 @@ class GroupBy : public Operation {
   class HashMapAggregationData {
    public:
     template <typename A>
-    using T =
+    using ArrayOrVector =
         std::conditional_t<NUM_GROUP_COLUMNS != 0,
                            std::array<A, NUM_GROUP_COLUMNS>, std::vector<A>>;
 
@@ -325,10 +325,10 @@ class GroupBy : public Operation {
     // Returns a vector containing the offsets for all ids of `groupByCols`,
     // inserting entries if necessary.
     std::vector<size_t> getHashEntries(
-        const T<std::span<const Id>>& groupByCols);
+        const ArrayOrVector<std::span<const Id>>& groupByCols);
 
     // Return the index of `id`.
-    [[nodiscard]] size_t getIndex(const T<Id>& ids) const {
+    [[nodiscard]] size_t getIndex(const ArrayOrVector<Id>& ids) const {
       return map_.at(ids);
     }
 
@@ -346,7 +346,7 @@ class GroupBy : public Operation {
     }
 
     // Get the values of the grouped column in ascending order.
-    [[nodiscard]] T<std::vector<Id>> getSortedGroupColumns() const;
+    [[nodiscard]] ArrayOrVector<std::vector<Id>> getSortedGroupColumns() const;
 
     // Returns the number of groups.
     [[nodiscard]] size_t getNumberOfGroups() const { return map_.size(); }
@@ -359,7 +359,7 @@ class GroupBy : public Operation {
     // Allocator used for creating new vectors.
     const ad_utility::AllocatorWithLimit<Id>& alloc_;
     // Maps `Id` to vector offsets.
-    ad_utility::HashMapWithMemoryLimit<T<Id>, size_t> map_;
+    ad_utility::HashMapWithMemoryLimit<ArrayOrVector<Id>, size_t> map_;
     // Stores the actual aggregation data.
     std::vector<AggregationDataVectors> aggregationData_;
     // For `GROUP_CONCAT`, we require the type information.

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -261,7 +261,7 @@ class GroupBy : public Operation {
   template <size_t NUM_GROUP_COLUMNS>
   void computeGroupByForHashMapOptimization(
       IdTable* result, std::vector<HashMapAliasInformation>& aggregateAliases,
-      const IdTable& subresult, std::vector<size_t> columnIndices,
+      const IdTable& subresult, const std::vector<size_t>& columnIndices,
       LocalVocab* localVocab);
 
   using AggregationData =

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -171,9 +171,6 @@ class GroupBy : public Operation {
   // `?z`.
   bool computeGroupByForJoinWithFullScan(IdTable* result);
 
-  using KeyType = ValueId;
-  using ValueType = size_t;
-
   // Stores information required for substitution of an expression in an
   // expression tree.
   struct ParentAndChildIndex {
@@ -235,17 +232,17 @@ class GroupBy : public Operation {
 
   // Required data to perform HashMap optimization.
   struct HashMapOptimizationData {
-    // The index of the column that is grouped by.
-    size_t subtreeColumnIndex_;
     // All aliases and the aggregates they contain.
     std::vector<HashMapAliasInformation> aggregateAliases_;
   };
 
   // Create result IdTable by using a HashMap mapping groups to aggregation data
   // and subsequently calling `createResultFromHashMap`.
+  template <size_t GROUPED_COLUMNS>
   void computeGroupByForHashMapOptimization(
       IdTable* result, std::vector<HashMapAliasInformation>& aggregateAliases,
-      const IdTable& subresult, size_t columnIndex, LocalVocab* localVocab);
+      const IdTable& subresult, std::vector<size_t> columnIndices,
+      LocalVocab* localVocab);
 
   using AggregationData =
       std::variant<AvgAggregationData, CountAggregationData, MinAggregationData,
@@ -258,12 +255,21 @@ class GroupBy : public Operation {
 
   // Stores the map which associates Ids with vector offsets and
   // the vectors containing the aggregation data.
+  template <size_t GROUPED_COLUMNS>
   class HashMapAggregationData {
    public:
+    template <typename A>
+    using T =
+        std::conditional_t<GROUPED_COLUMNS != 0, std::array<A, GROUPED_COLUMNS>,
+                           std::vector<A>>;
+
     HashMapAggregationData(
         const ad_utility::AllocatorWithLimit<Id>& alloc,
-        const std::vector<HashMapAliasInformation>& aggregateAliases)
-        : alloc_{alloc}, map_{alloc} {
+        const std::vector<HashMapAliasInformation>& aggregateAliases,
+        size_t numOfGroupedColumns)
+        : numOfGroupedColumns_{numOfGroupedColumns},
+          alloc_{alloc},
+          map_{alloc} {
       using enum HashMapAggregateType;
       size_t numAggregates = 0;
       for (const auto& alias : aggregateAliases) {
@@ -298,10 +304,10 @@ class GroupBy : public Operation {
 
     // Returns a vector containing the offsets for all ids of `ids`,
     // inserting entries if necessary.
-    std::vector<size_t> getHashEntries(std::span<const Id> ids);
+    std::vector<size_t> getHashEntries(T<std::span<const Id>> ids);
 
     // Return the index of `id`.
-    [[nodiscard]] size_t getIndex(Id id) const { return map_.at(id); }
+    [[nodiscard]] size_t getIndex(T<Id> ids) const { return map_.at(ids); }
 
     // Get vector containing the aggregation data at `aggregationDataIndex`.
     AggregationDataVectors& getAggregationDataVariant(
@@ -317,16 +323,20 @@ class GroupBy : public Operation {
     }
 
     // Get the values of the grouped column in ascending order.
-    [[nodiscard]] std::vector<Id> getSortedGroupColumn() const;
+    [[nodiscard]] T<std::vector<Id>> getSortedGroupColumns() const;
 
     // Returns the number of groups.
     [[nodiscard]] size_t getNumberOfGroups() const { return map_.size(); }
+
+    // How many columns we are grouping by, important in case `GROUPED_COLUMNS`
+    // == 0.
+    size_t numOfGroupedColumns_;
 
    private:
     // Allocator used for creating new vectors.
     const ad_utility::AllocatorWithLimit<Id>& alloc_;
     // Maps `Id` to vector offsets.
-    ad_utility::HashMapWithMemoryLimit<KeyType, ValueType> map_;
+    ad_utility::HashMapWithMemoryLimit<T<Id>, size_t> map_;
     // Stores the actual aggregation data.
     std::vector<AggregationDataVectors> aggregationData_;
     // For `GROUP_CONCAT`, we require the type information.
@@ -336,22 +346,28 @@ class GroupBy : public Operation {
   // Returns the aggregation results between `beginIndex` and `endIndex`
   // of the aggregates stored at `dataIndex`,
   // based on the groups stored in the first column of `resultTable`
+  template <size_t GROUPED_COLUMNS>
   sparqlExpression::VectorWithMemoryLimit<ValueId> getHashMapAggregationResults(
-      IdTable* resultTable, const HashMapAggregationData& aggregationData,
+      IdTable* resultTable,
+      const HashMapAggregationData<GROUPED_COLUMNS>& aggregationData,
       size_t dataIndex, size_t beginIndex, size_t endIndex,
       LocalVocab* localVocab);
 
   // Substitute away any occurrences of the grouped variable and of aggregate
   // results, if necessary, and subsequently evaluate the expression of an
   // alias
-  void evaluateAlias(HashMapAliasInformation& alias, IdTable* result,
-                     sparqlExpression::EvaluationContext& evaluationContext,
-                     const HashMapAggregationData& aggregationData,
-                     LocalVocab* localVocab);
+  template <size_t GROUPED_COLUMNS>
+  void evaluateAlias(
+      HashMapAliasInformation& alias, IdTable* result,
+      sparqlExpression::EvaluationContext& evaluationContext,
+      const HashMapAggregationData<GROUPED_COLUMNS>& aggregationData,
+      LocalVocab* localVocab);
 
   // Sort the HashMap by key and create result table.
+  template <size_t GROUPED_COLUMNS>
   void createResultFromHashMap(
-      IdTable* result, const HashMapAggregationData& aggregationData,
+      IdTable* result,
+      const HashMapAggregationData<GROUPED_COLUMNS>& aggregationData,
       std::vector<HashMapAliasInformation>& aggregateAliases,
       LocalVocab* localVocab);
 
@@ -359,8 +375,6 @@ class GroupBy : public Operation {
   // the following conditions hold true:
   // - Runtime parameter is set
   // - Child operation is SORT
-  // - All aggregates are AVG
-  // - Only one grouped variable
   std::optional<HashMapOptimizationData> checkIfHashMapOptimizationPossible(
       std::vector<Aggregate>& aggregates);
 
@@ -375,14 +389,16 @@ class GroupBy : public Operation {
   // Substitute the group values for all occurrences of a group variable.
   void substituteGroupVariable(
       const std::vector<GroupBy::ParentAndChildIndex>& occurrences,
-      IdTable* resultTable) const;
+      IdTable* resultTable, size_t columnIndex) const;
 
   // Substitute the results for all aggregates in `info`. The values of the
   // grouped variable should be at column 0 in `groupValues`.
-  void substituteAllAggregates(std::vector<HashMapAggregateInformation>& info,
-                               size_t beginIndex, size_t endIndex,
-                               const HashMapAggregationData& aggregationData,
-                               IdTable* resultTable, LocalVocab* localVocab);
+  template <size_t GROUPED_COLUMNS>
+  void substituteAllAggregates(
+      std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
+      size_t endIndex,
+      const HashMapAggregationData<GROUPED_COLUMNS>& aggregationData,
+      IdTable* resultTable, LocalVocab* localVocab);
 
   // Check if an expression is of a certain type.
   template <class T>
@@ -402,14 +418,16 @@ class GroupBy : public Operation {
 
   // Find all occurrences of grouped by variable for expression `expr`.
   std::variant<std::vector<ParentAndChildIndex>, OccurenceAsRoot>
-  findGroupedVariable(sparqlExpression::SparqlExpression* expr);
+  findGroupedVariable(sparqlExpression::SparqlExpression* expr,
+                      const Variable& groupedVariable);
 
   // The recursive implementation of `findGroupedVariable` (see above).
   void findGroupedVariableImpl(
       sparqlExpression::SparqlExpression* expr,
       std::optional<ParentAndChildIndex> parentAndChildIndex,
       std::variant<std::vector<ParentAndChildIndex>, OccurenceAsRoot>&
-          substitutions);
+          substitutions,
+      const Variable& groupedVariable);
 
   // Find all aggregates for expression `expr`. Return `std::nullopt`
   // if an unsupported aggregate is found.

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "engine/sparqlExpressions/AggregateExpression.h"
 #include "engine/sparqlExpressions/RelationalExpressionHelpers.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 
@@ -79,13 +80,9 @@ struct ExtremumAggregationData {
       firstValueSet_ = true;
       return;
     }
-    auto impl = [&ctx]<typename X, typename Y>(const X& x, const Y& y) {
-      return toBoolNotUndef(
-          sparqlExpression::compareIdsOrStrings<
-              Comp, valueIdComparators::ComparisonForIncompatibleTypes::
-                        CompareByType>(x, y, ctx));
-    };
-    if (std::visit(impl, value, currentValue_)) currentValue_ = value;
+
+    currentValue_ = sparqlExpression::detail::minMaxLambdaForAllTypes<Comp>(
+        value, currentValue_, ctx);
   }
 
   // _____________________________________________________________________________

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -251,7 +251,7 @@ inline const auto compareIdsOrStrings =
 template <valueIdComparators::Comparison comparison>
 inline const auto minMaxLambdaForAllTypes = []<SingleExpressionResult T>(
                                                 const T& a, const T& b,
-                                                EvaluationContext* ctx) {
+                                                const EvaluationContext* ctx) {
   auto actualImpl = [ctx](const auto& x, const auto& y) {
     return compareIdsOrStrings<comparison>(x, y, ctx);
   };

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -556,7 +556,7 @@ TEST_F(GroupByOptimizations, findGroupedVariable) {
   GroupBy groupBy{ad_utility::testing::getQec(), {Variable{"?a"}}, {}, values};
 
   auto variableAtTop = groupBy.findGroupedVariable(expr1.get(), Variable{"?a"});
-  ASSERT_TRUE(std::get_if<GroupBy::OccurenceAsRoot>(&variableAtTop));
+  ASSERT_TRUE(std::get_if<GroupBy::OccurAsRoot>(&variableAtTop));
 
   auto variableInExpression =
       groupBy.findGroupedVariable(expr2.get(), Variable{"?a"});

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -705,7 +705,7 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimization) {
 // _____________________________________________________________________________
 TEST_F(GroupByOptimizations,
        correctResultForHashMapOptimizationMultipleVariablesInExpression) {
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(true);
 
   parsedQuery::SparqlValues input;
   using TC = TripleComponent;
@@ -760,13 +760,13 @@ TEST_F(GroupByOptimizations,
   EXPECT_EQ(table, expected);
 
   // Disable optimization for following tests
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(false);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(false);
 }
 
 // _____________________________________________________________________________
 TEST_F(GroupByOptimizations,
        correctResultForHashMapOptimizationMultipleVariables) {
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(true);
 
   parsedQuery::SparqlValues input;
   using TC = TripleComponent;
@@ -817,13 +817,13 @@ TEST_F(GroupByOptimizations,
   EXPECT_EQ(table, expected);
 
   // Disable optimization for following tests
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(false);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(false);
 }
 
 // _____________________________________________________________________________
 TEST_F(GroupByOptimizations,
        correctResultForHashMapOptimizationMultipleVariablesOutOfOrder) {
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(true);
 
   parsedQuery::SparqlValues input;
   using TC = TripleComponent;
@@ -874,12 +874,12 @@ TEST_F(GroupByOptimizations,
   EXPECT_EQ(table, expected);
 
   // Disable optimization for following tests
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(false);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(false);
 }
 
 // _____________________________________________________________________________
 TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationManyVariables) {
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(true);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(true);
 
   parsedQuery::SparqlValues input;
   using TC = TripleComponent;
@@ -945,7 +945,7 @@ TEST_F(GroupByOptimizations, correctResultForHashMapOptimizationManyVariables) {
   EXPECT_EQ(table, expected);
 
   // Disable optimization for following tests
-  RuntimeParameters().set<"use-group-by-hash-map-optimization">(false);
+  RuntimeParameters().set<"group-by-hash-map-enabled">(false);
 }
 
 // _____________________________________________________________________________

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -82,6 +82,23 @@ class GroupByTest : public ::testing::Test {
   Index _index = makeIndexWithTestSettings();
 };
 
+TEST_F(GroupByTest, getDescriptor) {
+  auto expr =
+      std::make_unique<sparqlExpression::VariableExpression>(Variable{"?a"});
+  auto alias =
+      Alias{sparqlExpression::SparqlExpressionPimpl{std::move(expr), "?a"},
+            Variable{"?a"}};
+
+  parsedQuery::SparqlValues input;
+  input._variables = {Variable{"?a"}};
+  auto values = ad_utility::makeExecutionTree<Values>(
+      ad_utility::testing::getQec(), input);
+
+  GroupBy groupBy{
+      ad_utility::testing::getQec(), {Variable{"?a"}}, {alias}, values};
+  ASSERT_EQ(groupBy.getDescriptor(), "GroupBy on ?a");
+}
+
 TEST_F(GroupByTest, doGroupBy) {
   using std::string;
   using std::vector;


### PR DESCRIPTION
Add support for multiple grouped columns in `GROUP BY` when using the HashMap optimization.

Also fix a small bug in the GroupBy module.