### PR TITLE
Handle duplicate variables in triples (like `?s ?p ?s`)

### DIFF
--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -58,17 +58,17 @@ HasPredicateScan::HasPredicateScan(QueryExecutionContext* qec,
 // `ScanType`.
 static HasPredicateScan::ScanType getScanType(const SparqlTriple& triple) {
   using enum HasPredicateScan::ScanType;
-  AD_CONTRACT_CHECK(triple._p._iri == HAS_PREDICATE_PREDICATE);
-  if (isVariable(triple._s) && (isVariable(triple._o))) {
-    if (triple._s == triple._o) {
+  AD_CONTRACT_CHECK(triple.p_._iri == HAS_PREDICATE_PREDICATE);
+  if (isVariable(triple.s_) && (isVariable(triple.o_))) {
+    if (triple.s_ == triple.o_) {
       throw std::runtime_error{
           "ql:has-predicate with same variable for subject and object not "
           "supported."};
     }
     return FULL_SCAN;
-  } else if (isVariable(triple._s)) {
+  } else if (isVariable(triple.s_)) {
     return FREE_S;
-  } else if (isVariable(triple._o)) {
+  } else if (isVariable(triple.o_)) {
     return FREE_O;
   } else {
     AD_FAIL();
@@ -80,8 +80,8 @@ HasPredicateScan::HasPredicateScan(QueryExecutionContext* qec,
                                    SparqlTriple triple)
     : Operation{qec},
       type_{getScanType(triple)},
-      subject_{triple._s},
-      object_{triple._o} {}
+      subject_{triple.s_},
+      object_{triple.o_} {}
 
 // ___________________________________________________________________________
 string HasPredicateScan::getCacheKeyImpl() const {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -14,15 +14,14 @@
 
 using std::string;
 
+// TODO<joka921> Code duplication, get rid of the other overload.
 // _____________________________________________________________________________
 IndexScan::IndexScan(QueryExecutionContext* qec, Permutation::Enum permutation,
-                     const SparqlTriple& triple)
+                     const SparqlTripleSimple& triple)
     : Operation(qec),
       permutation_(permutation),
       subject_(triple._s),
-      predicate_(triple._p.getIri().starts_with("?")
-                     ? TripleComponent(Variable{triple._p.getIri()})
-                     : TripleComponent(triple._p.getIri())),
+      predicate_(triple._p),
       object_(triple._o),
       numVariables_(static_cast<size_t>(subject_.isVariable()) +
                     static_cast<size_t>(predicate_.isVariable()) +
@@ -46,6 +45,11 @@ IndexScan::IndexScan(QueryExecutionContext* qec, Permutation::Enum permutation,
     AD_CONTRACT_CHECK(permutedTriple.at(i)->isVariable());
   }
 }
+
+// _____________________________________________________________________________
+IndexScan::IndexScan(QueryExecutionContext* qec, Permutation::Enum permutation,
+                     const SparqlTriple& triple)
+    : IndexScan(qec, permutation, triple.getSimple()) {}
 
 // _____________________________________________________________________________
 string IndexScan::getCacheKeyImpl() const {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -14,19 +14,18 @@
 
 using std::string;
 
-// TODO<joka921> Code duplication, get rid of the other overload.
 // _____________________________________________________________________________
 IndexScan::IndexScan(QueryExecutionContext* qec, Permutation::Enum permutation,
                      const SparqlTripleSimple& triple)
     : Operation(qec),
       permutation_(permutation),
-      subject_(triple._s),
-      predicate_(triple._p),
-      object_(triple._o),
+      subject_(triple.s_),
+      predicate_(triple.p_),
+      object_(triple.o_),
       numVariables_(static_cast<size_t>(subject_.isVariable()) +
                     static_cast<size_t>(predicate_.isVariable()) +
                     static_cast<size_t>(object_.isVariable())) {
-  for (auto& [idx, variable] : triple._additionalScanColumns) {
+  for (auto& [idx, variable] : triple.additionalScanColumns_) {
     additionalColumns_.push_back(idx);
     additionalVariables_.push_back(variable);
   }

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -10,6 +10,7 @@
 using std::string;
 
 class SparqlTriple;
+class SparqlTripleSimple;
 
 class IndexScan : public Operation {
  private:
@@ -30,6 +31,8 @@ class IndexScan : public Operation {
  public:
   IndexScan(QueryExecutionContext* qec, Permutation::Enum permutation,
             const SparqlTriple& triple);
+  IndexScan(QueryExecutionContext* qec, Permutation::Enum permutation,
+            const SparqlTripleSimple& triple);
 
   virtual ~IndexScan() = default;
 

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -734,8 +734,8 @@ QueryPlanner::TripleGraph QueryPlanner::createTripleGraph(
 // _____________________________________________________________________________
 template <typename AddedIndexScanFunction>
 void QueryPlanner::indexScanSingleVarCase(
-    const TripleGraph::Node& node,
-    const AddedIndexScanFunction& addIndexScan, const auto& addFilter) {
+    const TripleGraph::Node& node, const AddedIndexScanFunction& addIndexScan,
+    const auto& addFilter) {
   using enum Permutation::Enum;
 
   auto pushFilter = [&addFilter](Variable var1, Variable var2) {
@@ -880,11 +880,10 @@ void QueryPlanner::indexScanThreeVarsCase(
 }
 
 // _____________________________________________________________________________
-template <typename AddedIndexScanFunction,
-          typename AddFilter>
+template <typename AddedIndexScanFunction, typename AddFilter>
 void QueryPlanner::seedFromOrdinaryTriple(
-    const TripleGraph::Node& node,
-    const AddedIndexScanFunction& addIndexScan, const AddFilter& addFilter) {
+    const TripleGraph::Node& node, const AddedIndexScanFunction& addIndexScan,
+    const AddFilter& addFilter) {
   if (node._variables.size() == 1) {
     indexScanSingleVarCase(node, addIndexScan, addFilter);
   } else if (node._variables.size() == 2) {
@@ -957,11 +956,10 @@ auto QueryPlanner::seedWithScansAndText(
       continue;
     }
 
-
     auto addIndexScan = [this, pushPlan, node](
-        Permutation::Enum permutation,
-        std::optional<decltype(node.triple_)> triple =
-        std::nullopt) {
+                            Permutation::Enum permutation,
+                            std::optional<decltype(node.triple_)> triple =
+                                std::nullopt) {
       if (!triple.has_value()) {
         pushPlan(makeSubtreePlan<IndexScan>(_qec, permutation, node.triple_));
       } else {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -750,10 +750,10 @@ SparqlFilter createEqualFilter(const Variable& var1, const Variable& var2) {
       .resultOfParse_;
 };
 
-// Helper function for `handleRepeatedVariables` below.
-// Replace a single position of the `scanTriple`, denoted by the
-// `rewritePosition` by a new variable, and add a filter, that checks the old
-// and the new value for equality.
+// Helper function for `handleRepeatedVariables` below. Replace a single
+// position of the `scanTriple`, denoted by the `rewritePosition` by a new
+// variable, and add a filter, that checks the old and the new value for
+// equality.
 constexpr auto rewriteSingle =
     [](TriplePosition auto rewritePosition, SparqlTripleSimple& scanTriple,
        const auto& addFilter, const auto& generateUniqueVarName) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -902,10 +902,9 @@ void QueryPlanner::seedFromOrdinaryTriple(
     const TripleGraph::Node& node, const AddedIndexScanFunction& addIndexScan,
     const AddFilter& addFilter) {
   auto triple = node.triple_.getSimple();
-  auto isVar = [](const auto& el) {
-    return static_cast<size_t>(isVariable(el));
-  };
-  size_t numVars = isVar(triple.s_) + isVar(triple.p_) + isVar(triple.o_);
+  const size_t numVars = static_cast<size_t>(isVariable(triple.s_)) +
+                         static_cast<size_t>(isVariable(triple.p_)) +
+                         static_cast<size_t>(isVariable(triple.o_));
   if (numVars == 1) {
     indexScanSingleVarCase(triple, addIndexScan);
   } else if (numVars == 2) {

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -742,9 +742,12 @@ SparqlFilter createEqualFilter(const Variable& var1, const Variable& var2) {
       .resultOfParse_;
 };
 
-template <typename F>
+// A `TriplePosition` is a function that takes a triple and returns a
+// `TripleComponent`, typically the subject, predicate, or object of the triple,
+// hence the name.
+template <typename Function>
 concept TriplePosition =
-    ad_utility::InvocableWithExactReturnType<F, TripleComponent&,
+    ad_utility::InvocableWithExactReturnType<Function, TripleComponent&,
                                              SparqlTripleSimple&>;
 }  // namespace
 
@@ -768,7 +771,7 @@ void QueryPlanner::indexScanSingleVarCase(
   };
 
   // Replace the positions of the `triple` that are specified by the
-  // `rewritePositions` with a new variable, and add a filter, that checks the
+  // `rewritePositions` with a new variable, and add a filter, which checks the
   // old and the new value for equality for each of these rewrites. Then also
   // add an index scan for the rewritten triple.
   auto handleRepeatedVariables = [&triple, &addIndexScan, &rewriteSingle](

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -232,8 +232,7 @@ class QueryPlanner {
   // Add all the possible index scans for the triple represented by the node.
   // The triple is "ordinary" in the sense that it is neither a text triple with
   // ql:contains-word nor a special pattern trick triple.
-  template <typename AddedIndexScanFunction,
-            typename AddFilterFunction>
+  template <typename AddedIndexScanFunction, typename AddFilterFunction>
   void seedFromOrdinaryTriple(const TripleGraph::Node& node,
                               const AddedIndexScanFunction& addIndexScan,
                               const AddFilterFunction& addFilter);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -239,20 +239,19 @@ class QueryPlanner {
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
-  void indexScanSingleVarCase(const TripleGraph::Node& node,
+  void indexScanSingleVarCase(const SparqlTripleSimple& triple,
                               const AddedIndexScanFunction& addIndexScan,
                               const auto& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
-  void indexScanTwoVarsCase(const TripleGraph::Node& node,
+  void indexScanTwoVarsCase(const SparqlTripleSimple& triple,
                             const AddedIndexScanFunction& addIndexScan,
                             const auto& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
-  void indexScanThreeVarsCase(const TripleGraph::Node& node,
-                              const AddedIndexScanFunction& addIndexScan) const;
+  void indexScanThreeVarsCase(const AddedIndexScanFunction& addIndexScan) const;
 
   /**
    * @brief Fills children with all operations that are associated with a single

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -232,17 +232,15 @@ class QueryPlanner {
   // Add all the possible index scans for the triple represented by the node.
   // The triple is "ordinary" in the sense that it is neither a text triple with
   // ql:contains-word nor a special pattern trick triple.
-  template <typename PushPlanFunction, typename AddedIndexScanFunction,
+  template <typename AddedIndexScanFunction,
             typename AddFilterFunction>
   void seedFromOrdinaryTriple(const TripleGraph::Node& node,
-                              const PushPlanFunction& pushPlan,
                               const AddedIndexScanFunction& addIndexScan,
                               const AddFilterFunction& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
-  template <typename PushPlanFunction, typename AddedIndexScanFunction>
+  template <typename AddedIndexScanFunction>
   void indexScanSingleVarCase(const TripleGraph::Node& node,
-                              const PushPlanFunction& pushPlan,
                               const AddedIndexScanFunction& addIndexScan,
                               const auto& addFilter);
 

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -250,7 +250,7 @@ class QueryPlanner {
   template <typename AddedIndexScanFunction>
   void indexScanTwoVarsCase(const TripleGraph::Node& node,
                             const AddedIndexScanFunction& addIndexScan,
-                            const auto& addFilter) const;
+                            const auto& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -240,8 +240,7 @@ class QueryPlanner {
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
   void indexScanSingleVarCase(const SparqlTripleSimple& triple,
-                              const AddedIndexScanFunction& addIndexScan,
-                              const auto& addFilter);
+                              const AddedIndexScanFunction& addIndexScan) const;
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
@@ -251,7 +250,9 @@ class QueryPlanner {
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
-  void indexScanThreeVarsCase(const AddedIndexScanFunction& addIndexScan) const;
+  void indexScanThreeVarsCase(const SparqlTripleSimple& triple,
+                              const AddedIndexScanFunction& addIndexScan,
+                              const auto& addFilter);
 
   /**
    * @brief Fills children with all operations that are associated with a single

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -232,21 +232,25 @@ class QueryPlanner {
   // Add all the possible index scans for the triple represented by the node.
   // The triple is "ordinary" in the sense that it is neither a text triple with
   // ql:contains-word nor a special pattern trick triple.
-  template <typename PushPlanFunction, typename AddedIndexScanFunction>
+  template <typename PushPlanFunction, typename AddedIndexScanFunction,
+            typename AddFilterFunction>
   void seedFromOrdinaryTriple(const TripleGraph::Node& node,
                               const PushPlanFunction& pushPlan,
-                              const AddedIndexScanFunction& addIndexScan);
+                              const AddedIndexScanFunction& addIndexScan,
+                              const AddFilterFunction& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename PushPlanFunction, typename AddedIndexScanFunction>
   void indexScanSingleVarCase(const TripleGraph::Node& node,
                               const PushPlanFunction& pushPlan,
-                              const AddedIndexScanFunction& addIndexScan);
+                              const AddedIndexScanFunction& addIndexScan,
+                              const auto& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
   void indexScanTwoVarsCase(const TripleGraph::Node& node,
-                            const AddedIndexScanFunction& addIndexScan) const;
+                            const AddedIndexScanFunction& addIndexScan,
+                            const auto& addFilter) const;
 
   // Helper function used by the seedFromOrdinaryTriple function
   template <typename AddedIndexScanFunction>
@@ -257,7 +261,12 @@ class QueryPlanner {
    * @brief Fills children with all operations that are associated with a single
    * node in the triple graph (e.g. IndexScans).
    */
-  [[nodiscard]] vector<SubtreePlan> seedWithScansAndText(
+  struct PlansAndFilters {
+    std::vector<SubtreePlan> plans_;
+    std::vector<SparqlFilter> filters_;
+  };
+
+  [[nodiscard]] PlansAndFilters seedWithScansAndText(
       const TripleGraph& tg,
       const vector<vector<QueryPlanner::SubtreePlan>>& children);
 
@@ -430,7 +439,7 @@ class QueryPlanner {
    * it as a filter later on).
    */
   [[nodiscard]] vector<vector<SubtreePlan>> fillDpTab(
-      const TripleGraph& graph, const vector<SparqlFilter>& fs,
+      const TripleGraph& graph, std::vector<SparqlFilter> fs,
       const vector<vector<SubtreePlan>>& children);
 
   // Internal subroutine of `fillDpTab` that  only works on a single connected

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -40,14 +40,14 @@ class QueryPlanner {
 
     struct Node {
       Node(size_t id, SparqlTriple t) : id_(id), triple_(std::move(t)) {
-        if (isVariable(triple_._s)) {
-          _variables.insert(triple_._s.getVariable());
+        if (isVariable(triple_.s_)) {
+          _variables.insert(triple_.s_.getVariable());
         }
-        if (isVariable(triple_._p)) {
-          _variables.insert(Variable{triple_._p._iri});
+        if (isVariable(triple_.p_)) {
+          _variables.insert(Variable{triple_.p_._iri});
         }
-        if (isVariable(triple_._o)) {
-          _variables.insert(triple_._o.getVariable());
+        if (isVariable(triple_.o_)) {
+          _variables.insert(triple_.o_.getVariable());
         }
       }
 

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -97,7 +97,7 @@ string SparqlPrefix::asString() const {
 // _____________________________________________________________________________
 string SparqlTriple::asString() const {
   std::ostringstream os;
-  os << "{s: " << _s << ", p: " << _p << ", o: " << _o << "}";
+  os << "{s: " << s_ << ", p: " << p_ << ", o: " << o_ << "}";
   return std::move(os).str();
 }
 
@@ -407,10 +407,10 @@ void ParsedQuery::GraphPattern::addLanguageFilter(
        _graphPatterns | stdv::transform(ad::getIf<BasicPattern>) |
            stdv::filter(ad::toBool)) {
     for (auto& triple : basicPattern->_triples) {
-      if (triple._o == variable &&
-          (triple._p._operation == PropertyPath::Operation::IRI &&
-           !isVariable(triple._p)) &&
-          !triple._p._iri.starts_with(INTERNAL_ENTITIES_URI_PREFIX)) {
+      if (triple.o_ == variable &&
+          (triple.p_._operation == PropertyPath::Operation::IRI &&
+           !isVariable(triple.p_)) &&
+          !triple.p_._iri.starts_with(INTERNAL_ENTITIES_URI_PREFIX)) {
         matchingTriples.push_back(&triple);
       }
     }
@@ -418,7 +418,7 @@ void ParsedQuery::GraphPattern::addLanguageFilter(
 
   // Replace all the matching triples.
   for (auto* triplePtr : matchingTriples) {
-    triplePtr->_p._iri = '@' + langTag + '@' + triplePtr->_p._iri;
+    triplePtr->p_._iri = '@' + langTag + '@' + triplePtr->p_._iri;
   }
 
   // Handle the case, that no suitable triple (see above) was found. In this

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -67,8 +67,12 @@ template <typename Predicate>
 class SparqlTripleBase {
  public:
   using AdditionalScanColumns = std::vector<std::pair<ColumnIndex, Variable>>;
-  SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o, AdditionalScanColumns additionalScanColumns = {})
-      : s_(std::move(s)), p_(std::move(p)), o_(std::move(o)), additionalScanColumns_(std::move(additionalScanColumns)) {}
+  SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o,
+                   AdditionalScanColumns additionalScanColumns = {})
+      : s_(std::move(s)),
+        p_(std::move(p)),
+        o_(std::move(o)),
+        additionalScanColumns_(std::move(additionalScanColumns)) {}
 
   bool operator==(const SparqlTripleBase& other) const = default;
   TripleComponent s_;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -68,22 +68,17 @@ class SparqlTripleBase {
  public:
   using AdditionalScanColumns = std::vector<std::pair<ColumnIndex, Variable>>;
   SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o, AdditionalScanColumns additionalScanColumns = {})
-      : _s(std::move(s)), _p(std::move(p)), _o(std::move(o)), _additionalScanColumns(std::move(additionalScanColumns)) {}
+      : s_(std::move(s)), p_(std::move(p)), o_(std::move(o)), additionalScanColumns_(std::move(additionalScanColumns)) {}
 
-  /*
-  bool operator==(const SparqlTripleBase& other) const {
-    return _s == other._s && _p == other._p && _o == other._o;
-  }
-   */
   bool operator==(const SparqlTripleBase& other) const = default;
-  TripleComponent _s;
-  Predicate _p;
-  TripleComponent _o;
+  TripleComponent s_;
+  Predicate p_;
+  TripleComponent o_;
   // The additional columns (e.g. patterns) that are to be attached when
   // performing an index scan using this triple.
   // TODO<joka921> On this level we should not store `ColumnIndex`, but the
   // special predicate IRIs that are to be attached here.
-  std::vector<std::pair<ColumnIndex, Variable>> _additionalScanColumns;
+  std::vector<std::pair<ColumnIndex, Variable>> additionalScanColumns_;
 };
 
 // A triple where the predicate is a `TripleComponent`, so a fixed entity or a
@@ -110,10 +105,10 @@ class SparqlTriple : public SparqlTripleBase<PropertyPath> {
   // Convert to a simple triple. Fails with an exception if the predicate
   // actually is a property path.
   SparqlTripleSimple getSimple() const {
-    AD_CONTRACT_CHECK(_p.isIri());
-    TripleComponent p = isVariable(_p._iri) ? TripleComponent{Variable{_p._iri}}
-                                            : TripleComponent(_p._iri);
-    return {_s, p, _o, _additionalScanColumns};
+    AD_CONTRACT_CHECK(p_.isIri());
+    TripleComponent p = isVariable(p_._iri) ? TripleComponent{Variable{p_._iri}}
+                                            : TripleComponent(p_._iri);
+    return {s_, p, o_, additionalScanColumns_};
   }
 };
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -61,28 +61,60 @@ inline bool isVariable(const PropertyPath& elem) {
 
 std::ostream& operator<<(std::ostream& out, const PropertyPath& p);
 
-// Data container for parsed triples from the where clause
-class SparqlTriple {
+// Data container for parsed triples from the where clause.
+// It is templated on the predicate type, see the instantiations below.
+template <typename Predicate>
+class SparqlTripleBase {
  public:
-  SparqlTriple(TripleComponent s, PropertyPath p, TripleComponent o)
-      : _s(std::move(s)), _p(std::move(p)), _o(std::move(o)) {}
+  using AdditionalScanColumns = std::vector<std::pair<ColumnIndex, Variable>>;
+  SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o, AdditionalScanColumns additionalScanColumns = {})
+      : _s(std::move(s)), _p(std::move(p)), _o(std::move(o)), _additionalScanColumns(std::move(additionalScanColumns)) {}
 
-  SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
-      : _s(std::move(s)), _p(PropertyPath::fromIri(p_iri)), _o(std::move(o)) {}
-
-  bool operator==(const SparqlTriple& other) const {
+  /*
+  bool operator==(const SparqlTripleBase& other) const {
     return _s == other._s && _p == other._p && _o == other._o;
   }
+   */
+  bool operator==(const SparqlTripleBase& other) const = default;
   TripleComponent _s;
-  PropertyPath _p;
+  Predicate _p;
   TripleComponent _o;
   // The additional columns (e.g. patterns) that are to be attached when
   // performing an index scan using this triple.
   // TODO<joka921> On this level we should not store `ColumnIndex`, but the
   // special predicate IRIs that are to be attached here.
   std::vector<std::pair<ColumnIndex, Variable>> _additionalScanColumns;
+};
 
+// A triple where the predicate is a `TripleComponent`, so a fixed entity or a
+// variable, but not a property path.
+class SparqlTripleSimple : public SparqlTripleBase<TripleComponent> {
+  using Base = SparqlTripleBase<TripleComponent>;
+  using Base::Base;
+};
+
+// A triple where the predicate is a `PropertyPath` (which technically still
+// might be a variable or fixed entity in the current implementation).
+class SparqlTriple : public SparqlTripleBase<PropertyPath> {
+ public:
+  using Base = SparqlTripleBase<PropertyPath>;
+  using Base::Base;
+
+  // ___________________________________________________________________________
+  SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
+      : Base{std::move(s), PropertyPath::fromIri(p_iri), std::move(o)} {}
+
+  // ___________________________________________________________________________
   [[nodiscard]] string asString() const;
+
+  // Convert to a simple triple. Fails with an exception if the predicate
+  // actually is a property path.
+  SparqlTripleSimple getSimple() const {
+    AD_CONTRACT_CHECK(_p.isIri());
+    TripleComponent p = isVariable(_p._iri) ? TripleComponent{Variable{_p._iri}}
+                                            : TripleComponent(_p._iri);
+    return {_s, p, _o, _additionalScanColumns};
+  }
 };
 
 // Forward declaration

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -199,6 +199,7 @@ class TripleComponent {
   [[nodiscard]] const Variable& getVariable() const {
     return std::get<Variable>(_variant);
   }
+  [[nodiscard]] Variable& getVariable() { return std::get<Variable>(_variant); }
 
   const Literal& getLiteral() const { return std::get<Literal>(_variant); }
   Literal& getLiteral() { return std::get<Literal>(_variant); }

--- a/test/CheckUsePatternTrickTest.cpp
+++ b/test/CheckUsePatternTrickTest.cpp
@@ -271,9 +271,9 @@ TEST(CheckUsePatternTrick, tripleIsCorrectlyRemoved) {
                               ._triples;
     ASSERT_EQ(triples.size(), 1u);
     const auto& triple = triples[0];
-    EXPECT_EQ(triple._s.getVariable().name(), "?x");
-    EXPECT_EQ(triple._p.asString(), HAS_PATTERN_PREDICATE);
-    EXPECT_EQ(triple._o.getVariable().name(), "?p");
+    EXPECT_EQ(triple.s_.getVariable().name(), "?x");
+    EXPECT_EQ(triple.p_.asString(), HAS_PATTERN_PREDICATE);
+    EXPECT_EQ(triple.o_.getVariable().name(), "?p");
   }
 
   {
@@ -289,10 +289,10 @@ TEST(CheckUsePatternTrick, tripleIsCorrectlyRemoved) {
                               ._triples;
     ASSERT_EQ(triples.size(), 1u);
     const auto& triple = triples[0];
-    EXPECT_EQ(triple._s.getVariable().name(), "?x");
-    EXPECT_EQ(triple._p.asString(), "<is-a>");
-    EXPECT_EQ(triple._o.getVariable().name(), "?y");
-    EXPECT_THAT(triple._additionalScanColumns,
+    EXPECT_EQ(triple.s_.getVariable().name(), "?x");
+    EXPECT_EQ(triple.p_.asString(), "<is-a>");
+    EXPECT_EQ(triple.o_.getVariable().name(), "?y");
+    EXPECT_THAT(triple.additionalScanColumns_,
                 ElementsAre(std::pair{ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN,
                                       Variable{"?p"}}));
   }
@@ -310,10 +310,10 @@ TEST(CheckUsePatternTrick, tripleIsCorrectlyRemoved) {
                               ._triples;
     ASSERT_EQ(triples.size(), 1u);
     const auto& triple = triples[0];
-    EXPECT_EQ(triple._s.getVariable().name(), "?y");
-    EXPECT_EQ(triple._p.asString(), "<is-a>");
-    EXPECT_EQ(triple._o.getVariable().name(), "?x");
-    EXPECT_THAT(triple._additionalScanColumns,
+    EXPECT_EQ(triple.s_.getVariable().name(), "?y");
+    EXPECT_EQ(triple.p_.asString(), "<is-a>");
+    EXPECT_EQ(triple.o_.getVariable().name(), "?x");
+    EXPECT_THAT(triple.additionalScanColumns_,
                 ElementsAre(std::pair{ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN,
                                       Variable{"?p"}}));
   }

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -124,7 +124,7 @@ TEST_F(HasPredicateScanTest, patternTrickWithSubtree) {
    * } GROUP BY ?predicate
    */
   auto triple = SparqlTriple{V{"?x"}, "<p3>", V{"?y"}};
-  triple._additionalScanColumns.emplace_back(
+  triple.additionalScanColumns_.emplace_back(
       ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN, V{"?predicate"});
   auto indexScan = ad_utility::makeExecutionTree<IndexScan>(
       qec, Permutation::Enum::PSO, triple);
@@ -144,7 +144,7 @@ TEST_F(HasPredicateScanTest, patternTrickWithSubtreeTwoFixedElements) {
    * } GROUP BY ?predicate
    */
   auto triple = SparqlTriple{V{"?x"}, "<p3>", "<o4>"};
-  triple._additionalScanColumns.emplace_back(
+  triple.additionalScanColumns_.emplace_back(
       ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN, Variable{"?predicate"});
   auto indexScan = ad_utility::makeExecutionTree<IndexScan>(
       qec, Permutation::Enum::POS, triple);

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -867,35 +867,36 @@ TEST(QueryPlanner, TextIndexScanForEntity) {
 }
 
 TEST(QueryPlanner, NonDistinctVariablesInTriple) {
-  auto internal = [](int i) {
+  auto internalVar = [](int i) {
     return absl::StrCat("?_qlever_internal_variable_query_planner_", i);
   };
   auto eq = [](std::string_view l, std::string_view r) {
     return absl::StrCat(l, "=", r);
   };
+
   h::expect("SELECT * WHERE {?s ?p ?s}",
-            h::Filter(eq(internal(0), "?s"),
-                      h::IndexScanFromStrings(internal(0), "?p", "?s")));
+            h::Filter(eq(internalVar(0), "?s"),
+                      h::IndexScanFromStrings(internalVar(0), "?p", "?s")));
   h::expect("SELECT * WHERE {?s ?s ?o}",
-            h::Filter(eq(internal(0), "?s"),
-                      h::IndexScanFromStrings(internal(0), "?s", "?o")));
+            h::Filter(eq(internalVar(0), "?s"),
+                      h::IndexScanFromStrings(internalVar(0), "?s", "?o")));
   h::expect("SELECT * WHERE {?s ?p ?p}",
-            h::Filter(eq(internal(0), "?p"),
-                      h::IndexScanFromStrings("?s", "?p", internal(0))));
+            h::Filter(eq(internalVar(0), "?p"),
+                      h::IndexScanFromStrings("?s", "?p", internalVar(0))));
   h::expect("SELECT * WHERE {?s ?s ?s}",
-            h::Filter(eq(internal(1), "?s"),
-                      h::Filter(eq(internal(0), "?s"),
-                                h::IndexScanFromStrings(internal(1), "?s",
-                                                        internal(0)))));
+            h::Filter(eq(internalVar(1), "?s"),
+                      h::Filter(eq(internalVar(0), "?s"),
+                                h::IndexScanFromStrings(internalVar(1), "?s",
+                                                        internalVar(0)))));
   h::expect("SELECT * WHERE {?s <is-a> ?s}",
-            h::Filter(eq(internal(0), "?s"),
-                      h::IndexScanFromStrings("?s", "<is-a>", internal(0))));
+            h::Filter(eq(internalVar(0), "?s"),
+                      h::IndexScanFromStrings("?s", "<is-a>", internalVar(0))));
   h::expect("SELECT * WHERE {<s> ?p ?p}",
-            h::Filter(eq(internal(0), "?p"),
-                      h::IndexScanFromStrings("<s>", "?p", internal(0))));
+            h::Filter(eq(internalVar(0), "?p"),
+                      h::IndexScanFromStrings("<s>", "?p", internalVar(0))));
   h::expect("SELECT * WHERE {?s ?s <o>}",
-            h::Filter(eq(internal(0), "?s"),
-                      h::IndexScanFromStrings(internal(0), "?s", "<o>")));
+            h::Filter(eq(internalVar(0), "?s"),
+                      h::IndexScanFromStrings(internalVar(0), "?s", "<o>")));
 }
 
 // __________________________________________________________________________

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -882,12 +882,20 @@ TEST(QueryPlanner, NonDistinctVariablesInTriple) {
   h::expect("SELECT * WHERE {?s ?p ?p}",
             h::Filter(eq(internal(0), "?p"),
                       h::IndexScanFromStrings("?s", "?p", internal(0))));
-  // TODO<joka921> Make this better.
-  /*
   h::expect("SELECT * WHERE {?s ?s ?s}",
+            h::Filter(eq(internal(1), "?s"),
+                      h::Filter(eq(internal(0), "?s"),
+                                h::IndexScanFromStrings(internal(1), "?s",
+                                                        internal(0)))));
+  h::expect("SELECT * WHERE {?s <is-a> ?s}",
+            h::Filter(eq(internal(0), "?s"),
+                      h::IndexScanFromStrings("?s", "<is-a>", internal(0))));
+  h::expect("SELECT * WHERE {<s> ?p ?p}",
             h::Filter(eq(internal(0), "?p"),
-                      h::IndexScanFromStrings("?s", "?p", internal(0))));
-                      */
+                      h::IndexScanFromStrings("<s>", "?p", internal(0))));
+  h::expect("SELECT * WHERE {?s ?s <o>}",
+            h::Filter(eq(internal(0), "?s"),
+                      h::IndexScanFromStrings(internal(0), "?s", "<o>")));
 }
 
 // __________________________________________________________________________

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -235,13 +235,14 @@ inline auto TransitivePath =
                       TransitivePathSideMatcher(right))));
     };
 
-// Match a `Filter` operation. The matching of the expression is currently only done via the descriptor.
-constexpr auto Filter = [](std::string_view descriptor, const QetMatcher& childMatcher) {
-  return RootOperation<::Filter>(AllOf(
-      Property("getChildren", &Operation::getChildren,
-               ElementsAre(Pointee(childMatcher))),
-      AD_PROPERTY(::Operation, getDescriptor, HasSubstr(descriptor))
-  ));
+// Match a `Filter` operation. The matching of the expression is currently only
+// done via the descriptor.
+constexpr auto Filter = [](std::string_view descriptor,
+                           const QetMatcher& childMatcher) {
+  return RootOperation<::Filter>(
+      AllOf(Property("getChildren", &Operation::getChildren,
+                     ElementsAre(Pointee(childMatcher))),
+            AD_PROPERTY(::Operation, getDescriptor, HasSubstr(descriptor))));
 };
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -235,6 +235,15 @@ inline auto TransitivePath =
                       TransitivePathSideMatcher(right))));
     };
 
+// Match a `Filter` operation. The matching of the expression is currently only done via the descriptor.
+constexpr auto Filter = [](std::string_view descriptor, const QetMatcher& childMatcher) {
+  return RootOperation<::Filter>(AllOf(
+      Property("getChildren", &Operation::getChildren,
+               ElementsAre(Pointee(childMatcher))),
+      AD_PROPERTY(::Operation, getDescriptor, HasSubstr(descriptor))
+  ));
+};
+
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`
 QueryExecutionTree parseAndPlan(std::string query, QueryExecutionContext* qec) {

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -48,15 +48,15 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(3u, triples.size());
     ASSERT_EQ(Var{"?x"}, selectClause2.getSelectedVariables()[0]);
     ASSERT_EQ(Var{"?z"}, selectClause2.getSelectedVariables()[1]);
-    ASSERT_EQ(Var{"?x"}, triples[0]._s);
-    ASSERT_EQ("<http://rdf.myprefix.com/myrel>", triples[0]._p._iri);
-    ASSERT_EQ(Var{"?y"}, triples[0]._o);
-    ASSERT_EQ(Var{"?y"}, triples[1]._s);
-    ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>", triples[1]._p._iri);
-    ASSERT_EQ(Var{"?z"}, triples[1]._o);
-    ASSERT_EQ(Var{"?y"}, triples[2]._s);
-    ASSERT_EQ("<nsx:rel2>", triples[2]._p._iri);
-    ASSERT_EQ("<http://abc.de>", triples[2]._o);
+    ASSERT_EQ(Var{"?x"}, triples[0].s_);
+    ASSERT_EQ("<http://rdf.myprefix.com/myrel>", triples[0].p_._iri);
+    ASSERT_EQ(Var{"?y"}, triples[0].o_);
+    ASSERT_EQ(Var{"?y"}, triples[1].s_);
+    ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>", triples[1].p_._iri);
+    ASSERT_EQ(Var{"?z"}, triples[1].o_);
+    ASSERT_EQ(Var{"?y"}, triples[2].s_);
+    ASSERT_EQ("<nsx:rel2>", triples[2].p_._iri);
+    ASSERT_EQ("<http://abc.de>", triples[2].o_);
     ASSERT_EQ(std::nullopt, pq._limitOffset._limit);
     ASSERT_EQ(0, pq._limitOffset._offset);
   }
@@ -77,15 +77,15 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(3u, triples.size());
     ASSERT_EQ(Var{"?x"}, selectClause.getSelectedVariables()[0]);
     ASSERT_EQ(Var{"?z"}, selectClause.getSelectedVariables()[1]);
-    ASSERT_EQ(Var{"?x"}, triples[0]._s);
-    ASSERT_EQ("<http://rdf.myprefix.com/myrel>", triples[0]._p._iri);
-    ASSERT_EQ(Var{"?y"}, triples[0]._o);
-    ASSERT_EQ(Var{"?y"}, triples[1]._s);
-    ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>", triples[1]._p._iri);
-    ASSERT_EQ(Var{"?z"}, triples[1]._o);
-    ASSERT_EQ(Var{"?y"}, triples[2]._s);
-    ASSERT_EQ("<nsx:rel2>", triples[2]._p._iri);
-    ASSERT_EQ("<http://abc.de>", triples[2]._o);
+    ASSERT_EQ(Var{"?x"}, triples[0].s_);
+    ASSERT_EQ("<http://rdf.myprefix.com/myrel>", triples[0].p_._iri);
+    ASSERT_EQ(Var{"?y"}, triples[0].o_);
+    ASSERT_EQ(Var{"?y"}, triples[1].s_);
+    ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>", triples[1].p_._iri);
+    ASSERT_EQ(Var{"?z"}, triples[1].o_);
+    ASSERT_EQ(Var{"?y"}, triples[2].s_);
+    ASSERT_EQ("<nsx:rel2>", triples[2].p_._iri);
+    ASSERT_EQ("<http://abc.de>", triples[2].o_);
     ASSERT_EQ(std::nullopt, pq._limitOffset._limit);
     ASSERT_EQ(0, pq._limitOffset._offset);
   }
@@ -105,15 +105,15 @@ TEST(ParserTest, testParse) {
 
     ASSERT_EQ(Var{"?x"}, selectClause.getSelectedVariables()[0]);
     ASSERT_EQ(Var{"?z"}, selectClause.getSelectedVariables()[1]);
-    ASSERT_EQ(Var{"?x"}, triples[0]._s);
-    ASSERT_EQ("<Directed_by>", triples[0]._p._iri);
-    ASSERT_EQ(Var{"?y"}, triples[0]._o);
-    ASSERT_EQ(Var{"?y"}, triples[1]._s);
-    ASSERT_EQ("<http://ns/myrel.extend>", triples[1]._p._iri);
-    ASSERT_EQ(Var{"?z"}, triples[1]._o);
-    ASSERT_EQ(Var{"?y"}, triples[2]._s);
-    ASSERT_EQ("<nsx:rel2>", triples[2]._p._iri);
-    ASSERT_EQ(lit("\"Hello... World\""), triples[2]._o);
+    ASSERT_EQ(Var{"?x"}, triples[0].s_);
+    ASSERT_EQ("<Directed_by>", triples[0].p_._iri);
+    ASSERT_EQ(Var{"?y"}, triples[0].o_);
+    ASSERT_EQ(Var{"?y"}, triples[1].s_);
+    ASSERT_EQ("<http://ns/myrel.extend>", triples[1].p_._iri);
+    ASSERT_EQ(Var{"?z"}, triples[1].o_);
+    ASSERT_EQ(Var{"?y"}, triples[2].s_);
+    ASSERT_EQ("<nsx:rel2>", triples[2].p_._iri);
+    ASSERT_EQ(lit("\"Hello... World\""), triples[2].o_);
     ASSERT_EQ(std::nullopt, pq._limitOffset._limit);
     ASSERT_EQ(0, pq._limitOffset._offset);
   }
@@ -154,12 +154,12 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(1u, filters.size());
     ASSERT_EQ("(?x != ?y)", filters[0].expression_.getDescriptor());
     ASSERT_EQ(4u, triples.size());
-    ASSERT_EQ(Var{"?c"}, triples[2]._s);
-    ASSERT_EQ(CONTAINS_ENTITY_PREDICATE, triples[2]._p._iri);
-    ASSERT_EQ(Var{"?x"}, triples[2]._o);
-    ASSERT_EQ(Var{"?c"}, triples[3]._s);
-    ASSERT_EQ(CONTAINS_WORD_PREDICATE, triples[3]._p._iri);
-    ASSERT_EQ(lit("\"coca* abuse\""), triples[3]._o);
+    ASSERT_EQ(Var{"?c"}, triples[2].s_);
+    ASSERT_EQ(CONTAINS_ENTITY_PREDICATE, triples[2].p_._iri);
+    ASSERT_EQ(Var{"?x"}, triples[2].o_);
+    ASSERT_EQ(Var{"?c"}, triples[3].s_);
+    ASSERT_EQ(CONTAINS_WORD_PREDICATE, triples[3].p_._iri);
+    ASSERT_EQ(lit("\"coca* abuse\""), triples[3].o_);
   }
 
   {
@@ -194,9 +194,9 @@ TEST(ParserTest, testParse) {
     const auto& triples = child._graphPatterns[0].getBasic()._triples;
     auto filters = child._filters;
     ASSERT_EQ(1u, triples.size());
-    ASSERT_EQ(Var{"?y"}, triples[0]._s);
-    ASSERT_EQ("<test2>", triples[0]._p._iri);
-    ASSERT_EQ(Var{"?z"}, triples[0]._o);
+    ASSERT_EQ(Var{"?y"}, triples[0].s_);
+    ASSERT_EQ("<test2>", triples[0].p_._iri);
+    ASSERT_EQ(Var{"?z"}, triples[0].o_);
     ASSERT_EQ(0u, filters.size());
     ASSERT_TRUE(child._optional);
   }
@@ -302,10 +302,10 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
 
-    ASSERT_EQ(c._triples[0]._s, Var{"?city"});
-    ASSERT_EQ(c._triples[0]._p._iri,
+    ASSERT_EQ(c._triples[0].s_, Var{"?city"});
+    ASSERT_EQ(c._triples[0].p_._iri,
               "<http://www.wikidata.org/prop/direct/P31>");
-    ASSERT_EQ(c._triples[0]._o, Var{"?citytype"});
+    ASSERT_EQ(c._triples[0].o_, Var{"?citytype"});
 
     const auto& values1 = std::get<p::Values>(pq.children()[0])._inlineValues;
     vector<Variable> vvars = {Var{"?citytype"}};
@@ -412,9 +412,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
 
-    ASSERT_EQ(c._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c._triples[0]._p._iri, "<directed-by>");
-    ASSERT_EQ(c._triples[0]._o, Var{"?director"});
+    ASSERT_EQ(c._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c._triples[0].p_._iri, "<directed-by>");
+    ASSERT_EQ(c._triples[0].o_, Var{"?director"});
 
     ASSERT_EQ(10u, pq._limitOffset._limit);
     ASSERT_EQ(false, pq._orderBy[0].isDescending_);
@@ -442,9 +442,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(1u, c._triples.size());
     ASSERT_EQ(0u, pq._rootGraphPattern._filters.size());
 
-    ASSERT_EQ(c._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c._triples[0]._p._iri, "<directed-by>");
-    ASSERT_EQ(c._triples[0]._o, Var{"?director"});
+    ASSERT_EQ(c._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c._triples[0].p_._iri, "<directed-by>");
+    ASSERT_EQ(c._triples[0].o_, Var{"?director"});
 
     ASSERT_EQ(10u, pq._limitOffset._limit);
     ASSERT_EQ(true, pq._orderBy[0].isDescending_);
@@ -482,9 +482,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(0, pq._rootGraphPattern._filters.size());
     ASSERT_EQ(3u, pq._limitOffset._offset);
 
-    ASSERT_EQ(c._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c._triples[0]._p._iri, "<directed-by>");
-    ASSERT_EQ(c._triples[0]._o, "<Scott%2C%20Ridley>");
+    ASSERT_EQ(c._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c._triples[0].p_._iri, "<directed-by>");
+    ASSERT_EQ(c._triples[0].o_, "<Scott%2C%20Ridley>");
 
     ASSERT_EQ(20u, pq._limitOffset._limit);
     ASSERT_EQ(true, pq._orderBy[0].isDescending_);
@@ -510,13 +510,13 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ("(?year > \"00-00-2000\")", filter.expression_.getDescriptor());
     ASSERT_EQ(0, parsed_sub_query.get()._limitOffset._offset);
 
-    ASSERT_EQ(c_subquery._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c_subquery._triples[0]._p._iri, "<directed-by>");
-    ASSERT_EQ(c_subquery._triples[0]._o, Var{"?director"});
+    ASSERT_EQ(c_subquery._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c_subquery._triples[0].p_._iri, "<directed-by>");
+    ASSERT_EQ(c_subquery._triples[0].o_, Var{"?director"});
 
-    ASSERT_EQ(c_subquery._triples[1]._s, Var{"?movie"});
-    ASSERT_EQ(c_subquery._triples[1]._p._iri, "<from-year>");
-    ASSERT_EQ(c_subquery._triples[1]._o, Var{"?year"});
+    ASSERT_EQ(c_subquery._triples[1].s_, Var{"?movie"});
+    ASSERT_EQ(c_subquery._triples[1].p_._iri, "<from-year>");
+    ASSERT_EQ(c_subquery._triples[1].o_, Var{"?year"});
 
     ASSERT_EQ(std::nullopt, parsed_sub_query.get()._limitOffset._limit);
     ASSERT_EQ(true, parsed_sub_query.get()._orderBy[0].isDescending_);
@@ -559,9 +559,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(0, pq._rootGraphPattern._filters.size());
     ASSERT_EQ(3u, pq._limitOffset._offset);
 
-    ASSERT_EQ(c._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c._triples[0]._p._iri, "<directed-by>");
-    ASSERT_EQ(c._triples[0]._o, "<Scott%2C%20Ridley>");
+    ASSERT_EQ(c._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c._triples[0].p_._iri, "<directed-by>");
+    ASSERT_EQ(c._triples[0].o_, "<Scott%2C%20Ridley>");
 
     ASSERT_EQ(20u, pq._limitOffset._limit);
     ASSERT_EQ(true, pq._orderBy[0].isDescending_);
@@ -587,9 +587,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ("(?year > \"00-00-2000\")", filter.expression_.getDescriptor());
     ASSERT_EQ(0, parsed_sub_query.get()._limitOffset._offset);
 
-    ASSERT_EQ(c_subquery._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c_subquery._triples[0]._p._iri, "<directed-by>");
-    ASSERT_EQ(c_subquery._triples[0]._o, Var{"?director"});
+    ASSERT_EQ(c_subquery._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c_subquery._triples[0].p_._iri, "<directed-by>");
+    ASSERT_EQ(c_subquery._triples[0].o_, Var{"?director"});
 
     ASSERT_EQ(std::nullopt, parsed_sub_query.get()._limitOffset._limit);
     ASSERT_EQ(true, parsed_sub_query.get()._orderBy[0].isDescending_);
@@ -613,9 +613,9 @@ TEST(ParserTest, testParse) {
     ASSERT_EQ(0u, aux_parsed_sub_sub_query._rootGraphPattern._filters.size());
     ASSERT_EQ(0, aux_parsed_sub_sub_query._limitOffset._offset);
 
-    ASSERT_EQ(c_sub_subquery._triples[0]._s, Var{"?movie"});
-    ASSERT_EQ(c_sub_subquery._triples[0]._p._iri, "<from-year>");
-    ASSERT_EQ(c_sub_subquery._triples[0]._o, Var{"?year"});
+    ASSERT_EQ(c_sub_subquery._triples[0].s_, Var{"?movie"});
+    ASSERT_EQ(c_sub_subquery._triples[0].p_._iri, "<from-year>");
+    ASSERT_EQ(c_sub_subquery._triples[0].o_, Var{"?year"});
 
     ASSERT_EQ(std::nullopt, aux_parsed_sub_sub_query._limitOffset._limit);
     ASSERT_EQ(0u, aux_parsed_sub_sub_query._orderBy.size());
@@ -739,15 +739,15 @@ TEST(ParserTest, testExpandPrefixes) {
   ASSERT_EQ(3u, c._triples.size());
   ASSERT_EQ(Var{"?x"}, selectClause.getSelectedVariables()[0]);
   ASSERT_EQ(Var{"?z"}, selectClause.getSelectedVariables()[1]);
-  ASSERT_EQ(Var{"?x"}, c._triples[0]._s);
-  ASSERT_EQ("<http://rdf.myprefix.com/myrel>", c._triples[0]._p._iri);
-  ASSERT_EQ(Var{"?y"}, c._triples[0]._o);
-  ASSERT_EQ(Var{"?y"}, c._triples[1]._s);
-  ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>", c._triples[1]._p._iri);
-  ASSERT_EQ(Var{"?z"}, c._triples[1]._o);
-  ASSERT_EQ(Var{"?y"}, c._triples[2]._s);
-  ASSERT_EQ("<nsx:rel2>", c._triples[2]._p._iri);
-  ASSERT_EQ("<http://abc.de>", c._triples[2]._o);
+  ASSERT_EQ(Var{"?x"}, c._triples[0].s_);
+  ASSERT_EQ("<http://rdf.myprefix.com/myrel>", c._triples[0].p_._iri);
+  ASSERT_EQ(Var{"?y"}, c._triples[0].o_);
+  ASSERT_EQ(Var{"?y"}, c._triples[1].s_);
+  ASSERT_EQ("<http://rdf.myprefix.com/ns/myrel>", c._triples[1].p_._iri);
+  ASSERT_EQ(Var{"?z"}, c._triples[1].o_);
+  ASSERT_EQ(Var{"?y"}, c._triples[2].s_);
+  ASSERT_EQ("<nsx:rel2>", c._triples[2].p_._iri);
+  ASSERT_EQ("<http://abc.de>", c._triples[2].o_);
   ASSERT_EQ(std::nullopt, pq._limitOffset._limit);
   ASSERT_EQ(0, pq._limitOffset._offset);
 }
@@ -762,12 +762,12 @@ TEST(ParserTest, testLiterals) {
   const auto& c = pq.children()[0].getBasic();
   ASSERT_TRUE(selectClause.isAsterisk());
   ASSERT_EQ(2u, c._triples.size());
-  ASSERT_EQ(true, c._triples[0]._s);
-  ASSERT_EQ("<test:myrel>", c._triples[0]._p._iri);
-  ASSERT_EQ(10, c._triples[0]._o);
-  ASSERT_EQ(10.2, c._triples[1]._s);
-  ASSERT_EQ("<test:myrel>", c._triples[1]._p._iri);
-  ASSERT_EQ(DateOrLargeYear{Date(2000, 1, 1, -1)}, c._triples[1]._o);
+  ASSERT_EQ(true, c._triples[0].s_);
+  ASSERT_EQ("<test:myrel>", c._triples[0].p_._iri);
+  ASSERT_EQ(10, c._triples[0].o_);
+  ASSERT_EQ(10.2, c._triples[1].s_);
+  ASSERT_EQ("<test:myrel>", c._triples[1].p_._iri);
+  ASSERT_EQ(DateOrLargeYear{Date(2000, 1, 1, -1)}, c._triples[1].o_);
 }
 
 TEST(ParserTest, testSolutionModifiers) {
@@ -904,12 +904,12 @@ TEST(ParserTest, testSolutionModifiers) {
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(Var{"?movie"}, selectClause.getSelectedVariables()[0]);
     ASSERT_EQ(2u, c._triples.size());
-    ASSERT_EQ(Var{"?movie"}, c._triples[0]._s);
-    ASSERT_EQ("<from-year>", c._triples[0]._p._iri);
-    ASSERT_EQ(DateOrLargeYear{Date(2000, 1, 1)}, c._triples[0]._o);
-    ASSERT_EQ(Var{"?movie"}, c._triples[1]._s);
-    ASSERT_EQ("<directed-by>", c._triples[1]._p._iri);
-    ASSERT_EQ("<Scott%2C%20Ridley>", c._triples[1]._o);
+    ASSERT_EQ(Var{"?movie"}, c._triples[0].s_);
+    ASSERT_EQ("<from-year>", c._triples[0].p_._iri);
+    ASSERT_EQ(DateOrLargeYear{Date(2000, 1, 1)}, c._triples[0].o_);
+    ASSERT_EQ(Var{"?movie"}, c._triples[1].s_);
+    ASSERT_EQ("<directed-by>", c._triples[1].p_._iri);
+    ASSERT_EQ("<Scott%2C%20Ridley>", c._triples[1].o_);
   }
 
   {
@@ -927,12 +927,12 @@ TEST(ParserTest, testSolutionModifiers) {
     ASSERT_EQ(1u, selectClause.getSelectedVariables().size());
     ASSERT_EQ(Var{"?movie"}, selectClause.getSelectedVariables()[0]);
     ASSERT_EQ(2u, c._triples.size());
-    ASSERT_EQ(Var{"?movie"}, c._triples[0]._s);
-    ASSERT_EQ("<from-year>", c._triples[0]._p._iri);
-    ASSERT_EQ(DateOrLargeYear{Date(2000, 1, 1)}, c._triples[0]._o);
-    ASSERT_EQ(Var{"?movie"}, c._triples[1]._s);
-    ASSERT_EQ("<directed-by>", c._triples[1]._p._iri);
-    ASSERT_EQ("<Scott%2C%20Ridley>", c._triples[1]._o);
+    ASSERT_EQ(Var{"?movie"}, c._triples[0].s_);
+    ASSERT_EQ("<from-year>", c._triples[0].p_._iri);
+    ASSERT_EQ(DateOrLargeYear{Date(2000, 1, 1)}, c._triples[0].o_);
+    ASSERT_EQ(Var{"?movie"}, c._triples[1].s_);
+    ASSERT_EQ("<directed-by>", c._triples[1].p_._iri);
+    ASSERT_EQ("<Scott%2C%20Ridley>", c._triples[1].o_);
   }
 
   {

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -324,9 +324,9 @@ TEST(IndexScan, additionalColumn) {
   auto qec = getQec("<x> <y> <z>.");
   using V = Variable;
   SparqlTriple triple{V{"?x"}, "<y>", V{"?z"}};
-  triple._additionalScanColumns.emplace_back(
+  triple.additionalScanColumns_.emplace_back(
       ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN, V{"?xpattern"});
-  triple._additionalScanColumns.emplace_back(
+  triple.additionalScanColumns_.emplace_back(
       ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN, V{"?ypattern"});
   auto scan = IndexScan{qec, Permutation::PSO, triple};
   ASSERT_EQ(scan.getResultWidth(), 4);


### PR DESCRIPTION
Correctly handle triples of the form `?x ?x ?x`, `?x ?y ?y`, `?x ?x <fixed>` , `?x <fixed> ?x`, etc. These triples are all rewritten such that the variables are all different and suitable `FILTER` operations are added.

In particular, this fixes the cryptic error message reported in #1283. However, the result of the query without the added `FILTER` is currently still materialized so that a query like `SELECT * WHERE { ?s ?p ?s }` will run out of RAM on a large dataset like Wikidata. Once we have implemented a lazy `FILTER` operation that will become feasible.