### PR TITLE
Store `col0Id` in permutations, smaller `.meta` files, improved full scan

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -163,7 +163,8 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
           ->getIndex()
           .getImpl()
           .getPermutation(Permutation::Enum::PSO)
-          .lazyScan(qlever::specialIds.at(HAS_PATTERN_PREDICATE), std::nullopt,
+          .lazyScan({qlever::specialIds.at(HAS_PATTERN_PREDICATE), std::nullopt,
+                     std::nullopt},
                     std::nullopt, {}, cancellationHandle_);
   for (const auto& idTable : fullHasPattern) {
     for (const auto& patternId : idTable.getColumn(1)) {

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -555,47 +555,19 @@ bool GroupBy::computeGroupByForFullIndexScan(IdTable* result) {
     const auto& permutation =
         getExecutionContext()->getIndex().getPimpl().getPermutation(
             permutationEnum.value());
-    IdTableStatic<NUM_COLS> table = std::move(*idTable).toStatic<NUM_COLS>();
-    const auto& metaData = permutation.meta_.data();
-    // TODO<joka921> the reserve is too large because of the ignored
-    // triples. We would need to incorporate the information how many
-    // added "relations" are in each permutationEnum during index building.
-    table.reserve(metaData.size());
-    for (auto it = metaData.ordered_begin(); it != metaData.ordered_end();
-         ++it) {
-      Id id = decltype(metaData.ordered_begin())::getIdFromElement(*it);
-
-      // Check whether this is an `@en@...` predicate in a `Pxx`
-      // permutationEnum, a literal in a `Sxx` permutationEnum or some other
-      // entity that was added only for internal reasons.
-      if (std::ranges::any_of(ignoredRanges, [&id](const auto& pair) {
-            return id >= pair.first && id < pair.second;
-          })) {
-        continue;
-      }
-      Id count = Id::makeFromInt(
-          decltype(metaData.ordered_begin())::getNumRowsFromElement(*it));
-      // TODO<joka921> The count is actually not accurate at least for the
-      // `Sxx` and `Oxx` permutations because it contains the triples with
-      // predicate
-      // `@en@rdfs:label` etc. The probably easiest way to fix this is to
-      // exclude these triples from those permutations (they are only
-      // relevant for queries with a fixed subject), but then we would
-      // need to make sure, that we don't accidentally break the language
-      // filters for queries like
-      // `<fixedSubject> @en@rdfs:label ?labels`, for which the best
-      // query plan potentially goes through the `SPO` relation.
-      // Alternatively we would have to write an additional number
-      // `numNonAddedTriples` to the `IndexMetaData` which would further
-      // increase their size.
-      // TODO<joka921> Discuss this with Hannah.
-      table.emplace_back();
-      table(table.size() - 1, 0) = id;
-      if (numCounts == 1) {
-        table(table.size() - 1, 1) = count;
-      }
+    auto table = permutation.getDistinctCol0IdsAndCounts(cancellationHandle_);
+    if (NUM_COLS == 1) {
+      table.setColumnSubset({{0}});
     }
-    *idTable = std::move(table).toDynamic();
+    // TODO<joka921> This is only semi-efficient.
+    auto end = std::ranges::remove_if(table, [&ignoredRanges](const auto& row) {
+      return std::ranges::any_of(ignoredRanges,
+                                 [id = row[0]](const auto& pair) {
+                                   return id >= pair.first && id < pair.second;
+                                 });
+    });
+    table.resize(end.begin() - table.begin());
+    *idTable = std::move(table);
   };
   ad_utility::callFixedSize(numCols, doComputationForNumberOfColumns, result);
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -438,9 +438,9 @@ bool GroupBy::computeGroupByForSingleIndexScan(IdTable* result) {
           getPermutationForThreeVariableTriple(*_subtree, var, var);
       AD_CONTRACT_CHECK(permutation.has_value());
       table(0, 0) = Id::makeFromInt(
-          getIndex().getImpl().numDistinctCol0(permutation.value()).normal_);
+          getIndex().getImpl().numDistinctCol0(permutation.value()).normal);
     } else {
-      table(0, 0) = Id::makeFromInt(getIndex().numTriples().normal_);
+      table(0, 0) = Id::makeFromInt(getIndex().numTriples().normal);
     }
   } else {
     // TODO<joka921> The two variables IndexScans should also account for the

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -266,13 +266,13 @@ ResultTable HasPredicateScan::computeResult() {
   idTable.setNumColumns(getResultWidth());
 
   const CompactVectorOfStrings<Id>& patterns = getIndex().getPatterns();
-  auto hasPattern =
-      getExecutionContext()
-          ->getIndex()
-          .getImpl()
-          .getPermutation(Permutation::Enum::PSO)
-          .lazyScan(qlever::specialIds.at(HAS_PATTERN_PREDICATE), std::nullopt,
-                    std::nullopt, {}, cancellationHandle_);
+  auto hasPattern = getExecutionContext()
+                        ->getIndex()
+                        .getImpl()
+                        .getPermutation(Permutation::Enum::PSO)
+                        .lazyScan({qlever::specialIds.at(HAS_PATTERN_PREDICATE),
+                                   std::nullopt, std::nullopt},
+                                  std::nullopt, {}, cancellationHandle_);
 
   auto getId = [this](const TripleComponent tc) {
     std::optional<Id> id = tc.toValueId(getIndex().getVocab());
@@ -340,8 +340,9 @@ void HasPredicateScan::computeFreeO(
                         ->getIndex()
                         .getImpl()
                         .getPermutation(Permutation::Enum::PSO)
-                        .scan(qlever::specialIds.at(HAS_PATTERN_PREDICATE),
-                              subjectAsId, {}, cancellationHandle_);
+                        .scan({qlever::specialIds.at(HAS_PATTERN_PREDICATE),
+                               subjectAsId, std::nullopt},
+                              {}, cancellationHandle_);
   AD_CORRECTNESS_CHECK(hasPattern.numRows() <= 1);
   for (Id patternId : hasPattern.getColumn(0)) {
     const auto& pattern = patterns[patternId.getInt()];

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -188,31 +188,7 @@ size_t IndexScan::computeSizeEstimate() const {
 }
 
 // _____________________________________________________________________________
-size_t IndexScan::getCostEstimate() {
-  if (numVariables_ != 3) {
-    return getSizeEstimateBeforeLimit();
-  } else {
-    // The computation of the `full scan` estimate must be consistent with the
-    // full scan dummy joins in `Join.cpp` for correct query planning.
-    // The following calculation is done in a way that makes materializing a
-    // full index scan always more expensive than implicitly computing it in the
-    // so-called "dummy joins" (see `Join.h` and `Join.cpp`). The assumption is,
-    // that materializing a single triple via a full index scan is 10'000 more
-    // expensive than materializing it via some other means.
-
-    // Note that we cannot set the cost to `infinity` or `max`, because this
-    // might lead to overflows in upstream operations when the cost estimate is
-    // an integer (this currently is the case). When implementing them as
-    // floating point numbers, a cost estimate of `infinity` would
-    // remove the ability to distinguish the costs of plans that perform full
-    // scans but still have different overall costs.
-    // TODO<joka921> The conceptually right way to do this is to make the cost
-    // estimate a tuple `(numFullIndexScans, costEstimateForRemainder)`.
-    // Implement this functionality.
-
-    return getSizeEstimateBeforeLimit() * 10'000;
-  }
-}
+size_t IndexScan::getCostEstimate() { return getSizeEstimateBeforeLimit(); }
 
 // _____________________________________________________________________________
 void IndexScan::determineMultiplicities() {

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -303,8 +303,8 @@ Permutation::IdTableGenerator IndexScan::getLazyScan(
     col1Id = s.getPermutedTriple()[1]->toValueId(index.getVocab()).value();
   }
   return index.getPermutation(s.permutation())
-      .lazyScan(col0Id, col1Id, std::move(blocks), s.additionalColumns(),
-                s.cancellationHandle_);
+      .lazyScan({col0Id, col1Id, std::nullopt}, std::move(blocks),
+                s.additionalColumns(), s.cancellationHandle_);
 };
 
 // ________________________________________________________________
@@ -321,7 +321,7 @@ std::optional<Permutation::MetadataAndBlocks> IndexScan::getMetadataForScan(
   }
 
   return index.getPermutation(s.permutation())
-      .getMetadataAndBlocks(col0Id.value(), col1Id);
+      .getMetadataAndBlocks({col0Id.value(), col1Id, std::nullopt});
 };
 
 // ________________________________________________________________

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -333,13 +333,9 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
   };
 
   AD_CONTRACT_CHECK(getFirstVariable(s1) == getFirstVariable(s2));
-  // TODO<joka921> This check could be reinstated,
-  // it tests that we only have a single join column
-  /*
   if (s1.numVariables_ == 2 && s2.numVariables_ == 2) {
     AD_CONTRACT_CHECK(*s1.getPermutedTriple()[2] != *s2.getPermutedTriple()[2]);
   }
-   */
 
   auto metaBlocks1 = getMetadataForScan(s1);
   auto metaBlocks2 = getMetadataForScan(s2);

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -235,7 +235,7 @@ void IndexScan::computeFullScan(IdTable* result,
 
   // This implementation computes the complete knowledge graph, except the
   // internal triples.
-  uint64_t resultSize = getIndex().numTriples().normal_;
+  uint64_t resultSize = getIndex().numTriples().normal;
   if (getLimit()._limit.has_value() && getLimit()._limit < resultSize) {
     resultSize = getLimit()._limit.value();
   }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -199,9 +199,7 @@ size_t Join::getResultWidth() const {
 }
 
 // _____________________________________________________________________________
-vector<ColumnIndex> Join::resultSortedOn() const {
-  return {_leftJoinCol};
-}
+vector<ColumnIndex> Join::resultSortedOn() const { return {_leftJoinCol}; }
 
 // _____________________________________________________________________________
 float Join::getMultiplicity(size_t col) {
@@ -218,9 +216,7 @@ size_t Join::getCostEstimate() {
 
   // TODO<joka921> once the `getCostEstimate` functions are `const`,
   // the argument can also be `const auto`
-  auto costOfSubtree = [](auto& subtree) {
-    return subtree->getCostEstimate();
-  };
+  auto costOfSubtree = [](auto& subtree) { return subtree->getCostEstimate(); };
 
   return getSizeEstimateBeforeLimit() + costJoin + costOfSubtree(_left) +
          costOfSubtree(_right);
@@ -264,8 +260,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
              << " * " << jcMultiplicityInResult << " * " << nofDistinctInResult
              << std::endl;
 
-  for (auto i = ColumnIndex{0};
-       i < _left->getResultWidth(); ++i) {
+  for (auto i = ColumnIndex{0}; i < _left->getResultWidth(); ++i) {
     double oldMult = _left->getMultiplicity(i);
     double m = std::max(
         1.0, oldMult * _right->getMultiplicity(_rightJoinCol) * corrFactor);
@@ -277,7 +272,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
     _multiplicities.emplace_back(m);
   }
   for (auto i = ColumnIndex{0}; i < _right->getResultWidth(); ++i) {
-    if (i == _rightJoinCol)   {
+    if (i == _rightJoinCol) {
       continue;
     }
     double oldMult = _right->getMultiplicity(i);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -41,13 +41,6 @@ Join::Join(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
   if (t1->getCacheKey() > t2->getCacheKey()) {
     swapChildren();
   }
-  if (isFullScanDummy(t1)) {
-    AD_CONTRACT_CHECK(!isFullScanDummy(t2));
-    swapChildren();
-  } else if (t1->getType() == QueryExecutionTree::SCAN &&
-             t2->getType() != QueryExecutionTree::SCAN) {
-    swapChildren();
-  }
   _left = std::move(t1);
   _leftJoinCol = t1JoinCol;
   _right = std::move(t2);
@@ -94,22 +87,11 @@ ResultTable Join::computeResult() {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(leftWidth + rightWidth - 1);
 
-  // TODO<joka921> Reinstate once the estimates are correct again.
-  /*
   if (_left->knownEmptyResult() || _right->knownEmptyResult()) {
     _left->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
     _right->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
     return {std::move(idTable), resultSortedOn(), LocalVocab()};
   }
-   */
-
-  /*
-  // Check for joins with dummy
-  AD_CORRECTNESS_CHECK(!isFullScanDummy(_left));
-  if (isFullScanDummy(_right)) {
-    return computeResultForJoinWithFullScanDummy();
-  }
-   */
 
   // Always materialize results that meet one of the following criteria:
   // * They are already present in the cache
@@ -202,10 +184,6 @@ ResultTable Join::computeResult() {
 
 // _____________________________________________________________________________
 VariableToColumnMap Join::computeVariableToColumnMap() const {
-  AD_CORRECTNESS_CHECK(!isFullScanDummy(_left));
-  if (isFullScanDummy(_right)) {
-    AD_CORRECTNESS_CHECK(_rightJoinCol == ColumnIndex{0});
-  }
   return makeVarToColMapForJoinOperation(
       _left->getVariableColumns(), _right->getVariableColumns(),
       {{_leftJoinCol, _rightJoinCol}}, BinOpType::Join,
@@ -222,11 +200,7 @@ size_t Join::getResultWidth() const {
 
 // _____________________________________________________________________________
 vector<ColumnIndex> Join::resultSortedOn() const {
-  if (!isFullScanDummy(_left)) {
-    return {_leftJoinCol};
-  } else {
-    return {ColumnIndex{2 + _rightJoinCol}};
-  }
+  return {_leftJoinCol};
 }
 
 // _____________________________________________________________________________
@@ -240,119 +214,16 @@ float Join::getMultiplicity(size_t col) {
 
 // _____________________________________________________________________________
 size_t Join::getCostEstimate() {
-  size_t costJoin;
-
-  // The cost estimates of the "Join with full scan" case must be consistent
-  // with the estimates for the materialization of a full scan. For a detailed
-  // discussion see the comments in `IndexScan::getCostEstimate()` (in
-  // `IndexScan.cpp`)
-  if (isFullScanDummy(_left)) {
-    size_t nofDistinctTabJc = static_cast<size_t>(
-        _right->getSizeEstimate() / _right->getMultiplicity(_rightJoinCol));
-    float averageScanSize = _left->getMultiplicity(_leftJoinCol);
-
-    costJoin = nofDistinctTabJc * averageScanSize * 10'000;
-  } else if (isFullScanDummy(_right)) {
-    size_t nofDistinctTabJc = static_cast<size_t>(
-        _left->getSizeEstimate() / _left->getMultiplicity(_leftJoinCol));
-    float averageScanSize = _right->getMultiplicity(_rightJoinCol);
-    costJoin = nofDistinctTabJc * averageScanSize * 10'000;
-  } else {
-    // Normal case:
-    costJoin = _left->getSizeEstimate() + _right->getSizeEstimate();
-  }
+  size_t costJoin = _left->getSizeEstimate() + _right->getSizeEstimate();
 
   // TODO<joka921> once the `getCostEstimate` functions are `const`,
   // the argument can also be `const auto`
-  auto costIfNotFullScan = [](auto& subtree) {
-    return isFullScanDummy(subtree) ? size_t{0} : subtree->getCostEstimate();
+  auto costOfSubtree = [](auto& subtree) {
+    return subtree->getCostEstimate();
   };
 
-  return getSizeEstimateBeforeLimit() + costJoin + costIfNotFullScan(_left) +
-         costIfNotFullScan(_right);
-}
-
-// _____________________________________________________________________________
-ResultTable Join::computeResultForJoinWithFullScanDummy() {
-  IdTable idTable{getExecutionContext()->getAllocator()};
-  LOG(DEBUG) << "Join by making multiple scans..." << endl;
-  AD_CORRECTNESS_CHECK(!isFullScanDummy(_left) && isFullScanDummy(_right));
-  _right->getRootOperation()->updateRuntimeInformationWhenOptimizedOut(
-      {}, RuntimeInformation::Status::lazilyMaterialized);
-  idTable.setNumColumns(_left->getResultWidth() + 2);
-
-  shared_ptr<const ResultTable> nonDummyRes = _left->getResult();
-
-  doComputeJoinWithFullScanDummyRight(nonDummyRes->idTable(), &idTable);
-  LOG(DEBUG) << "Join (with dummy) done. Size: " << idTable.size() << endl;
-  checkCancellation();
-  return {std::move(idTable), resultSortedOn(),
-          nonDummyRes->getSharedLocalVocab()};
-}
-
-// _____________________________________________________________________________
-Join::ScanMethodType Join::getScanMethod(
-    std::shared_ptr<QueryExecutionTree> fullScanDummyTree) const {
-  ScanMethodType scanMethod;
-  IndexScan& scan =
-      *static_cast<IndexScan*>(fullScanDummyTree->getRootOperation().get());
-
-  // this works because the join operations execution Context never changes
-  // during its lifetime
-  const auto& idx = _executionContext->getIndex();
-  const auto scanLambda =
-      [&idx, &scan](const Permutation::Enum perm,
-                    ad_utility::SharedCancellationHandle cancellationHandle) {
-        return [&idx, perm, &scan,
-                cancellationHandle = std::move(cancellationHandle)](Id id) {
-          return idx.scan(id, std::nullopt, perm, scan.additionalColumns(),
-                          cancellationHandle);
-        };
-      };
-  AD_CORRECTNESS_CHECK(scan.getResultWidth() == 3);
-  return scanLambda(scan.permutation(), cancellationHandle_);
-}
-
-// _____________________________________________________________________________
-void Join::doComputeJoinWithFullScanDummyRight(const IdTable& ndr,
-                                               IdTable* res) const {
-  if (ndr.empty()) {
-    return;
-  }
-  // Get the scan method (depends on type of dummy tree), use a function ptr.
-  const ScanMethodType scan = getScanMethod(_right);
-  // Iterate through non-dummy.
-  Id currentJoinId = ndr(0, _leftJoinCol);
-  // TODO<C++23> This can be simplified using `std::views::chunk_by`.
-  auto joinItemFrom = ndr.begin();
-  auto joinItemEnd = ndr.begin();
-  for (size_t i = 0; i < ndr.size(); ++i) {
-    // For each different element in the join column.
-    if (ndr(i, _leftJoinCol) == currentJoinId) {
-      ++joinItemEnd;
-    } else {
-      // Do a scan.
-      LOG(TRACE) << "Inner scan with ID: " << currentJoinId << endl;
-      // The scan is a relatively expensive disk operation, so we can afford to
-      // check for timeouts before each call.
-      checkCancellation();
-      IdTable jr = scan(currentJoinId);
-      LOG(TRACE) << "Got #items: " << jr.size() << endl;
-      // Build the cross product.
-      appendCrossProduct(joinItemFrom, joinItemEnd, jr.cbegin(), jr.cend(),
-                         res);
-      // Reset
-      currentJoinId = ndr[i][_leftJoinCol];
-      joinItemFrom = joinItemEnd;
-      ++joinItemEnd;
-    }
-  }
-  // Do the scan for the final element.
-  LOG(TRACE) << "Inner scan with ID: " << currentJoinId << endl;
-  IdTable jr = scan(currentJoinId);
-  LOG(TRACE) << "Got #items: " << jr.size() << endl;
-  // Build the cross product.
-  appendCrossProduct(joinItemFrom, joinItemEnd, jr.cbegin(), jr.cend(), res);
+  return getSizeEstimateBeforeLimit() + costJoin + costOfSubtree(_left) +
+         costOfSubtree(_right);
 }
 
 // _____________________________________________________________________________
@@ -381,14 +252,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
       _right->getSizeEstimate() *
       (static_cast<double>(nofDistinctInResult) / nofDistinctRight);
 
-  double corrFactor =
-      _executionContext
-          ? ((isFullScanDummy(_left) || isFullScanDummy(_right))
-                 ? _executionContext->getCostFactor(
-                       "DUMMY_JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR")
-                 : _executionContext->getCostFactor(
-                       "JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR"))
-          : 1;
+  double corrFactor = 1;
 
   double jcMultiplicityInResult = _left->getMultiplicity(_leftJoinCol) *
                                   _right->getMultiplicity(_rightJoinCol);
@@ -400,7 +264,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
              << " * " << jcMultiplicityInResult << " * " << nofDistinctInResult
              << std::endl;
 
-  for (auto i = isFullScanDummy(_left) ? ColumnIndex{1} : ColumnIndex{0};
+  for (auto i = ColumnIndex{0};
        i < _left->getResultWidth(); ++i) {
     double oldMult = _left->getMultiplicity(i);
     double m = std::max(
@@ -413,7 +277,7 @@ void Join::computeSizeEstimateAndMultiplicities() {
     _multiplicities.emplace_back(m);
   }
   for (auto i = ColumnIndex{0}; i < _right->getResultWidth(); ++i) {
-    if (i == _rightJoinCol && !isFullScanDummy(_left)) {
+    if (i == _rightJoinCol)   {
       continue;
     }
     double oldMult = _right->getMultiplicity(i);
@@ -428,28 +292,6 @@ void Join::computeSizeEstimateAndMultiplicities() {
   }
 
   assert(_multiplicities.size() == getResultWidth());
-}
-
-// ______________________________________________________________________________
-void Join::appendCrossProduct(const IdTable::const_iterator& leftBegin,
-                              const IdTable::const_iterator& leftEnd,
-                              const IdTable::const_iterator& rightBegin,
-                              const IdTable::const_iterator& rightEnd,
-                              IdTable* res) const {
-  for (auto itl = leftBegin; itl != leftEnd; ++itl) {
-    for (auto itr = rightBegin; itr != rightEnd; ++itr) {
-      const auto& l = *itl;
-      const auto& r = *itr;
-      res->emplace_back();
-      size_t backIdx = res->size() - 1;
-      for (size_t i = 0; i < l.numColumns(); i++) {
-        (*res)(backIdx, i) = l[i];
-      }
-      for (size_t i = 0; i < r.numColumns(); i++) {
-        (*res)(backIdx, l.numColumns() + i) = r[i];
-      }
-    }
-  }
 }
 
 // ______________________________________________________________________________

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -248,7 +248,10 @@ void Join::computeSizeEstimateAndMultiplicities() {
       _right->getSizeEstimate() *
       (static_cast<double>(nofDistinctInResult) / nofDistinctRight);
 
-  double corrFactor = 1;
+  double corrFactor = _executionContext
+                          ? _executionContext->getCostFactor(
+                                "JOIN_SIZE_ESTIMATE_CORRECTION_FACTOR")
+                          : 1.0;
 
   double jcMultiplicityInResult = _left->getMultiplicity(_leftJoinCol) *
                                   _right->getMultiplicity(_rightJoinCol);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -205,7 +205,7 @@ vector<ColumnIndex> Join::resultSortedOn() const {
 
 // _____________________________________________________________________________
 float Join::getMultiplicity(size_t col) {
-  if (_multiplicities.size() == 0) {
+  if (_multiplicities.empty()) {
     computeSizeEstimateAndMultiplicities();
     _sizeEstimateComputed = true;
   }

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -94,17 +94,22 @@ ResultTable Join::computeResult() {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(leftWidth + rightWidth - 1);
 
+  // TODO<joka921> Reinstate once the estimates are correct again.
+  /*
   if (_left->knownEmptyResult() || _right->knownEmptyResult()) {
     _left->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
     _right->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
     return {std::move(idTable), resultSortedOn(), LocalVocab()};
   }
+   */
 
+  /*
   // Check for joins with dummy
   AD_CORRECTNESS_CHECK(!isFullScanDummy(_left));
   if (isFullScanDummy(_right)) {
     return computeResultForJoinWithFullScanDummy();
   }
+   */
 
   // Always materialize results that meet one of the following criteria:
   // * They are already present in the cache

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -117,19 +117,6 @@ class Join : public Operation {
   void hashJoin(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
                 ColumnIndex jc2, IdTable* dynRes);
 
-  static bool isFullScanDummy(std::shared_ptr<QueryExecutionTree> tree) {
-    if (tree->getType() != QueryExecutionTree::SCAN) {
-      return false;
-    }
-    // Note: it is not sufficient to check `getResultWidth == 3` as
-    // the index scan might also have 2 variables + one additional column
-    // for the pattern trick (or any other additional column that we might add
-    // in the future).
-    const auto& scan =
-        dynamic_cast<const IndexScan&>(*tree->getRootOperation());
-    return scan.numVariables() == 3;
-  }
-
  protected:
   virtual string getCacheKeyImpl() const override;
 
@@ -137,8 +124,6 @@ class Join : public Operation {
   ResultTable computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
-
-  ResultTable computeResultForJoinWithFullScanDummy();
 
   // A special implementation that is called when both children are
   // `IndexScan`s. Uses the lazy scans to only retrieve the subset of the
@@ -159,8 +144,6 @@ class Join : public Operation {
 
   ScanMethodType getScanMethod(
       std::shared_ptr<QueryExecutionTree> fullScanDummyTree) const;
-
-  void doComputeJoinWithFullScanDummyRight(const IdTable& v, IdTable* r) const;
 
   void appendCrossProduct(const IdTable::const_iterator& leftBegin,
                           const IdTable::const_iterator& leftEnd,

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -135,8 +135,8 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       // individual results, but that requires changes in each individual
       // operation, therefore we currently only perform this expensive
       // change in the DEBUG builds.
-      // TODO<joka921> Why does this fail? Do we have wrong definedness values with
-      // the full scans?
+      // TODO<joka921> Why does this fail? Do we have wrong definedness values
+      // with the full scans?
       /*
       AD_EXPENSIVE_CHECK(
           result.checkDefinedness(getExternallyVisibleVariableColumns()));

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -135,8 +135,12 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       // individual results, but that requires changes in each individual
       // operation, therefore we currently only perform this expensive
       // change in the DEBUG builds.
+      // TODO<joka921> Why does this fail? Do we have wrong definedness values with
+      // the full scans?
+      /*
       AD_EXPENSIVE_CHECK(
           result.checkDefinedness(getExternallyVisibleVariableColumns()));
+          */
       // Make sure that the results that are written to the cache have the
       // correct runtimeInfo. The children of the runtime info are already set
       // correctly because the result was computed, so we can pass `nullopt` as

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -135,8 +135,6 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       // individual results, but that requires changes in each individual
       // operation, therefore we currently only perform this expensive
       // change in the DEBUG builds.
-      // TODO<joka921> Why does this fail? Do we have wrong definedness values
-      // with the full scans?
       AD_EXPENSIVE_CHECK(
           result.checkDefinedness(getExternallyVisibleVariableColumns()));
       // Make sure that the results that are written to the cache have the

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -137,10 +137,8 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       // change in the DEBUG builds.
       // TODO<joka921> Why does this fail? Do we have wrong definedness values
       // with the full scans?
-      /*
       AD_EXPENSIVE_CHECK(
           result.checkDefinedness(getExternallyVisibleVariableColumns()));
-          */
       // Make sure that the results that are written to the cache have the
       // correct runtimeInfo. The children of the runtime info are already set
       // correctly because the result was computed, so we can pass `nullopt` as

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -135,3 +135,14 @@ ResultTable OrderBy::computeResult() {
   LOG(DEBUG) << "OrderBy result computation done." << endl;
   return {std::move(idTable), resultSortedOn(), subRes->getSharedLocalVocab()};
 }
+
+// ___________________________________________________________________
+OrderBy::SortedVariables OrderBy::getSortedVariables() const {
+  SortedVariables result;
+  for (const auto& [colIdx, isDescending] : sortIndices_) {
+    using enum AscOrDesc;
+    result.emplace_back(subtree_->getVariableAndInfoByColumnIndex(colIdx).first,
+                        isDescending ? Desc : Asc);
+  }
+  return result;
+}

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -45,10 +45,12 @@ class OrderBy : public Operation {
 
   void setTextLimit(size_t limit) override { subtree_->setTextLimit(limit); }
 
-  // Expose the variables on which this OrderBy is performed. Currently mostly used for testing.
-  enum AscOrDesc { Asc, Desc};
+  // Expose the variables on which this OrderBy is performed. Currently mostly
+  // used for testing.
+  enum class AscOrDesc { Asc, Desc };
   using SortedVariables = std::vector<std::pair<Variable, AscOrDesc>>;
   SortedVariables getSortedVariables() const;
+
  private:
   uint64_t getSizeEstimateBeforeLimit() override {
     return subtree_->getSizeEstimate();

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -45,6 +45,10 @@ class OrderBy : public Operation {
 
   void setTextLimit(size_t limit) override { subtree_->setTextLimit(limit); }
 
+  // Expose the variables on which this OrderBy is performed. Currently mostly used for testing.
+  enum AscOrDesc { Asc, Desc};
+  using SortedVariables = std::vector<std::pair<Variable, AscOrDesc>>;
+  SortedVariables getSortedVariables() const;
  private:
   uint64_t getSizeEstimateBeforeLimit() override {
     return subtree_->getSizeEstimate();

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -444,18 +444,18 @@ json Server::composeStatsJson() const {
   json result;
   result["name-index"] = index_.getKbName();
   result["num-permutations"] = (index_.hasAllPermutations() ? 6 : 2);
-  result["num-predicates-normal"] = index_.numDistinctPredicates().normal_;
-  result["num-predicates-internal"] = index_.numDistinctPredicates().internal_;
+  result["num-predicates-normal"] = index_.numDistinctPredicates().normal;
+  result["num-predicates-internal"] = index_.numDistinctPredicates().internal;
   if (index_.hasAllPermutations()) {
-    result["num-subjects-normal"] = index_.numDistinctSubjects().normal_;
-    result["num-subjects-internal"] = index_.numDistinctSubjects().internal_;
-    result["num-objects-normal"] = index_.numDistinctObjects().normal_;
-    result["num-objects-internal"] = index_.numDistinctObjects().internal_;
+    result["num-subjects-normal"] = index_.numDistinctSubjects().normal;
+    result["num-subjects-internal"] = index_.numDistinctSubjects().internal;
+    result["num-objects-normal"] = index_.numDistinctObjects().normal;
+    result["num-objects-internal"] = index_.numDistinctObjects().internal;
   }
 
   auto numTriples = index_.numTriples();
-  result["num-triples-normal"] = numTriples.normal_;
-  result["num-triples-internal"] = numTriples.internal_;
+  result["num-triples-normal"] = numTriples.normal;
+  result["num-triples-internal"] = numTriples.internal;
   result["name-text-index"] = index_.getTextName();
   result["num-text-records"] = index_.getNofTextRecords();
   result["num-word-occurrences"] = index_.getNofWordPostings();

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -201,8 +201,8 @@ constexpr std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{50};
 // In the PSO and PSO permutations the patterns of the subject and object are
 // stored at the following indices. Note that the col0 (the P) is not part of
 // the result, so the column order for PSO is S O PatternS PatternO.
-constexpr size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 2;
-constexpr size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 3;
+constexpr size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 3;
+constexpr size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 4;
 
 inline auto& RuntimeParameters() {
   using ad_utility::detail::parameterShortNames::Bool;

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -603,7 +603,7 @@ IdTable CompressedRelationReader::getDistinctCol0IdsAndCounts(
   // `currentCount` is added to `table`, and `currentCol1Id` and `currentCount`
   // are reset.
   auto processCol1Id = [&table, &currentCol1Id, &currentCount](
-      std::optional<Id> col1Id, size_t howMany) {
+                           std::optional<Id> col1Id, size_t howMany) {
     if (col1Id != currentCol1Id) {
       if (currentCol1Id.has_value()) {
         table.push_back({currentCol1Id.value(), Id::makeFromInt(currentCount)});

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -453,8 +453,7 @@ DecompressedBlock CompressedRelationReader::readPossiblyIncompleteBlock(
     }
     const auto& column = block.getColumn(columnIdx);
     auto matchingRange = std::ranges::equal_range(
-        column.begin() + beginIdx, column.begin() + endIdx,
-                                              relevantId.value());
+        column.begin() + beginIdx, column.begin() + endIdx, relevantId.value());
     beginIdx = matchingRange.begin() - column.begin();
     endIdx = matchingRange.end() - column.begin();
   };

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -451,12 +451,12 @@ DecompressedBlock CompressedRelationReader::readPossiblyIncompleteBlock(
     if (!relevantId.has_value()) {
       return;
     }
-    const auto& col0Column = block.getColumn(columnIdx);
-    auto col0Range = std::ranges::equal_range(col0Column.begin() + beginIdx,
-                                              col0Column.begin() + endIdx,
+    const auto& column = block.getColumn(columnIdx);
+    auto matchingRange = std::ranges::equal_range(
+        column.begin() + beginIdx, column.begin() + endIdx,
                                               relevantId.value());
-    beginIdx = col0Range.begin() - col0Column.begin();
-    endIdx = col0Range.end() - col0Column.begin();
+    beginIdx = matchingRange.begin() - column.begin();
+    endIdx = matchingRange.end() - column.begin();
   };
 
   // The order of the calls is important because the block is sorted by [col0Id,

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -740,11 +740,15 @@ CompressedRelationReader::getRelevantBlocks(
   // Get all the blocks  that possibly might contain our pair of col0Id and
   // col1Id
   CompressedBlockMetadata key;
-  auto setKey = [&key, &scanSpec](auto getterA, auto getterB) {
-    std::invoke(getterA, key.firstTriple_) =
-        std::invoke(getterB, scanSpec).value_or(Id::min());
-    std::invoke(getterA, key.lastTriple_) =
-        std::invoke(getterB, scanSpec).value_or(Id::max());
+
+  auto setOrDefault = [&scanSpec](auto getterA, auto getterB, auto& triple,
+                                  auto defaultValue) {
+    std::invoke(getterA, triple) =
+        std::invoke(getterB, scanSpec).value_or(defaultValue);
+  };
+  auto setKey = [&setOrDefault, &key](auto getterA, auto getterB) {
+    setOrDefault(getterA, getterB, key.firstTriple_, Id::min());
+    setOrDefault(getterA, getterB, key.lastTriple_, Id::max());
   };
   using PermutedTriple = CompressedBlockMetadata::PermutedTriple;
   setKey(&PermutedTriple::col0Id_, &ScanSpecification::col0Id);

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -575,7 +575,8 @@ class CompressedRelationReader {
   static std::vector<ColumnIndex> prepareColumnIndices(
       const ScanSpecification& ids, ColumnIndicesRef additionalColumns);
 
-  // ____________________________________________________________________________
+  // The common implementation for `getDistinctCol0IdsAndCounts` and
+  // `getCol1IdsAndCounts`.
   IdTable getDistinctColIdsAndCountsImpl(
       auto idGetter, ScanSpecification ids,
       const std::vector<CompressedBlockMetadata>& allBlocksMetadata,

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -80,7 +80,6 @@ struct CompressedBlockMetadata {
     Id col0Id_;
     Id col1Id_;
     Id col2Id_;
-    bool operator==(const PermutedTriple&) const = default;
     auto operator<=>(const PermutedTriple&) const = default;
 
     // Formatted output for debugging.
@@ -339,7 +338,12 @@ class CompressedRelationReader {
   using ColumnIndices = std::vector<ColumnIndex>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
 
-  // TODO<joka921> Document and think of name.
+  // The specification of a scan operation for a given permutation.
+  // Can either be a full scan (all three elements are `std::nullopt`),
+  // a scan for a fixed `col0Id`, a scan for a fixed `col0Id` and `col1Id`,
+  // or even a scan for a single triple to check whether it is contained in
+  // the knowledge graph at all. The values which are `nullopt` become variables
+  // and are returned as columns in the result of the scan.
   class ScanSpecification {
    private:
     using T = std::optional<Id>;

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -437,7 +437,7 @@ class CompressedRelationReader {
    * The arguments `metadata`, `blocks`, and `file` must all be obtained from
    * The same `CompressedRelationWriter` (see below).
    */
-  IdTable scan(ScanSpecification ids,
+  IdTable scan(const ScanSpecification& ids,
                std::span<const CompressedBlockMetadata> blocks,
                ColumnIndicesRef additionalColumns,
                ad_utility::SharedCancellationHandle cancellationHandle) const;
@@ -457,7 +457,7 @@ class CompressedRelationReader {
   // these scans can be retrieved from the `CompressedRelationMetadata`
   // directly.
   size_t getResultSizeOfScan(
-      ScanSpecification ids,
+      const ScanSpecification& ids,
       const vector<CompressedBlockMetadata>& blocks) const;
 
   // For a given relation, determine the `col1Id`s and their counts. This is
@@ -476,7 +476,7 @@ class CompressedRelationReader {
   // by the `medata`. If the `col1Id` is specified (not `nullopt`), then the
   // blocks are additionally filtered by the given `col1Id`.
   static std::span<const CompressedBlockMetadata> getRelevantBlocks(
-      ScanSpecification ids,
+      const ScanSpecification& ids,
       std::span<const CompressedBlockMetadata> blockMetadata);
 
   // The same function, but specify the arguments as the `MetadataAndBlocks`
@@ -541,8 +541,7 @@ class CompressedRelationReader {
   // NOTE: When all triples in the block match the `col1Id`, this method makes
   // an unnecessary copy of the block. Therefore, if you know that you need the
   // whole block, use `readAndDecompressBlock` instead.
-  DecompressedBlock readPossiblyIncompleteBlock(
-      Id col0Id, std::optional<Id> col1Id,
+  DecompressedBlock readPossiblyIncompleteBlock( const ScanSpecification& ids,
       const CompressedBlockMetadata& blockMetadata,
       std::optional<std::reference_wrapper<LazyScanMetadata>> scanMetadata,
       ColumnIndicesRef columnIndices) const;

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -339,14 +339,37 @@ class CompressedRelationReader {
 
   // TODO<joka921> Document and think of name.
   class ScanSpecification {
-   public:
-    std::optional<Id> col0Id_;
-    std::optional<Id> col1Id_;
-    std::optional<Id> col2Id_;
+    using T = std::optional<Id>;
+   private:
+    T col0Id_;
+    T col1Id_;
+    T col2Id_;
 
-    const std::optional<Id>& col0Id() const { return col0Id_; }
-    const std::optional<Id>& col1Id() const { return col1Id_; }
-    const std::optional<Id>& col2Id() const { return col2Id_; }
+    void validate() const {
+      bool c0 = col0Id_.has_value();
+      bool c1 = col1Id_.has_value();
+      bool c2 = col2Id_.has_value();
+      if (!c0) {
+        AD_CORRECTNESS_CHECK(!c1 && !c2);
+      }
+      if (!c1) {
+        AD_CORRECTNESS_CHECK(!c2);
+      }
+    }
+
+   public:
+    ScanSpecification(T col0Id, T col1Id, T col2Id) :  col0Id_{col0Id}, col1Id_{col1Id}, col2Id_{col2Id} {
+      validate();
+    }
+    const T& col0Id() const { return col0Id_; }
+    const T& col1Id() const { return col1Id_; }
+    const T& col2Id() const { return col2Id_; }
+
+    // Only used in tests.
+    void setCol1Id(T col1Id) {
+      col1Id_ = col1Id;
+      validate();
+    }
   };
 
   // The metadata of a single relation together with a subset of its

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -375,7 +375,6 @@ class CompressedRelationReader {
 
   using IdTableGenerator = cppcoro::generator<IdTable, LazyScanMetadata>;
 
-
  private:
   // This cache stores a small number of decompressed blocks. Its current
   // purpose is to make the e2e-tests run fast. They contain many SPARQL queries
@@ -446,8 +445,7 @@ class CompressedRelationReader {
   // computed and returned as a generator of the single blocks that are scanned.
   // The blocks are guaranteed to be in order.
   CompressedRelationReader::IdTableGenerator lazyScan(
-      ScanSpecification ids,
-      std::vector<CompressedBlockMetadata> blockMetadata,
+      ScanSpecification ids, std::vector<CompressedBlockMetadata> blockMetadata,
       ColumnIndices additionalColumns,
       ad_utility::SharedCancellationHandle cancellationHandle) const;
 
@@ -463,8 +461,7 @@ class CompressedRelationReader {
   // For a given relation, determine the `col1Id`s and their counts. This is
   // used for `computeGroupByObjectWithCount`.
   IdTable getDistinctCol1IdsAndCounts(
-      Id col0Id,
-      const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
+      Id col0Id, const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
       ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   std::optional<CompressedRelationMetadata> getMetadataForSmallRelation(
@@ -541,7 +538,8 @@ class CompressedRelationReader {
   // NOTE: When all triples in the block match the `col1Id`, this method makes
   // an unnecessary copy of the block. Therefore, if you know that you need the
   // whole block, use `readAndDecompressBlock` instead.
-  DecompressedBlock readPossiblyIncompleteBlock( const ScanSpecification& ids,
+  DecompressedBlock readPossiblyIncompleteBlock(
+      const ScanSpecification& ids,
       const CompressedBlockMetadata& blockMetadata,
       std::optional<std::reference_wrapper<LazyScanMetadata>> scanMetadata,
       ColumnIndicesRef columnIndices) const;

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -456,6 +456,10 @@ class CompressedRelationReader {
       const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
       ad_utility::SharedCancellationHandle cancellationHandle) const;
 
+  std::optional<CompressedRelationMetadata> getMetadataForSmallRelation(
+      const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
+      Id col0Id) const;
+
   // Get the contiguous subrange of the given `blockMetadata` for the blocks
   // that contain the triples that have the relationId/col0Id that was specified
   // by the `medata`. If the `col1Id` is specified (not `nullopt`), then the
@@ -527,8 +531,8 @@ class CompressedRelationReader {
   // an unnecessary copy of the block. Therefore, if you know that you need the
   // whole block, use `readAndDecompressBlock` instead.
   DecompressedBlock readPossiblyIncompleteBlock(
-      const CompressedRelationMetadata& relationMetadata,
-      std::optional<Id> col1Id, const CompressedBlockMetadata& blockMetadata,
+      Id col0Id, std::optional<Id> col1Id,
+      const CompressedBlockMetadata& blockMetadata,
       std::optional<std::reference_wrapper<LazyScanMetadata>> scanMetadata,
       ColumnIndicesRef columnIndices) const;
 

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -339,8 +339,9 @@ class CompressedRelationReader {
 
   // TODO<joka921> Document and think of name.
   class ScanSpecification {
-    using T = std::optional<Id>;
    private:
+    using T = std::optional<Id>;
+
     T col0Id_;
     T col1Id_;
     T col2Id_;
@@ -358,7 +359,8 @@ class CompressedRelationReader {
     }
 
    public:
-    ScanSpecification(T col0Id, T col1Id, T col2Id) :  col0Id_{col0Id}, col1Id_{col1Id}, col2Id_{col2Id} {
+    ScanSpecification(T col0Id, T col1Id, T col2Id)
+        : col0Id_{col0Id}, col1Id_{col1Id}, col2Id_{col2Id} {
       validate();
     }
     const T& col0Id() const { return col0Id_; }

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -574,6 +574,12 @@ class CompressedRelationReader {
   // whether the `col1Id` is specified or not.
   static std::vector<ColumnIndex> prepareColumnIndices(
       const ScanSpecification& ids, ColumnIndicesRef additionalColumns);
+
+  // ____________________________________________________________________________
+  IdTable getDistinctColIdsAndCountsImpl(
+      auto idGetter, ScanSpecification ids,
+      const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
 };
 
 // TODO<joka921>

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -216,9 +216,12 @@ class CompressedRelationWriter {
    * @param permutation The permutation to be build (as a permutation of the
    * array `[0, 1, 2]`). The `sortedTriples` must be sorted by this permutation.
    */
-  static std::pair<std::vector<CompressedBlockMetadata>,
-                   std::vector<CompressedBlockMetadata>>
-  createPermutationPair(
+  struct PermutationPairResult {
+    size_t numDistinctCol0_;
+    std::vector<CompressedBlockMetadata> blockMetadata_;
+    std::vector<CompressedBlockMetadata> blockMetadataSwitched_;
+  };
+  static PermutationPairResult createPermutationPair(
       const std::string& basename, WriterAndCallback writerAndCallback1,
       WriterAndCallback writerAndCallback2,
       cppcoro::generator<IdTableStatic<0>> sortedTriples,
@@ -462,6 +465,12 @@ class CompressedRelationReader {
   // used for `computeGroupByObjectWithCount`.
   IdTable getDistinctCol1IdsAndCounts(
       Id col0Id, const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
+
+  // For all `col0Ids` determine their counts. This is
+  // used for `computeGroupByForFullScan`.
+  IdTable getDistinctCol0IdsAndCounts(
+      const std::vector<CompressedBlockMetadata>& allBlocksMetadata,
       ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   std::optional<CompressedRelationMetadata> getMetadataForSmallRelation(

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -273,7 +273,7 @@ IdTable Index::scan(
     const TripleComponent& col0String,
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
-    ad_utility::SharedCancellationHandle cancellationHandle) const {
+    const ad_utility::SharedCancellationHandle& cancellationHandle) const {
   return pimpl_->scan(col0String, col1String, p, additionalColumns,
                       std::move(cancellationHandle));
 }
@@ -282,7 +282,7 @@ IdTable Index::scan(
 IdTable Index::scan(
     Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
-    ad_utility::SharedCancellationHandle cancellationHandle) const {
+    const ad_utility::SharedCancellationHandle& cancellationHandle) const {
   return pimpl_->scan(col0Id, col1Id, p, additionalColumns,
                       std::move(cancellationHandle));
 }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -35,16 +35,16 @@ class Index {
   // statistics (number of triples, distinct number of subjects, etc.) for which
   // the value differs when you also consider the added triples.
   struct NumNormalAndInternal {
-    size_t normal_{};
-    size_t internal_{};
-    size_t normalAndInternal_() const { return normal_ + internal_; }
+    size_t normal{};
+    size_t internal{};
+    size_t normalAndInternal_() const { return normal + internal; }
     bool operator==(const NumNormalAndInternal&) const = default;
     static NumNormalAndInternal fromNormalAndTotal(size_t normal,
                                                    size_t total) {
       AD_CONTRACT_CHECK(total >= normal);
       return {normal, total - normal};
     }
-    NLOHMANN_DEFINE_TYPE_INTRUSIVE(NumNormalAndInternal, normal_, internal_);
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(NumNormalAndInternal, normal, internal);
   };
 
   // Store all information about possible search results from the text index in

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -17,6 +17,7 @@
 #include "index/Vocabulary.h"
 #include "parser/TripleComponent.h"
 #include "util/CancellationHandle.h"
+#include "util/json.h"
 
 // Forward declarations.
 class IdTable;
@@ -38,6 +39,12 @@ class Index {
     size_t internal_{};
     size_t normalAndInternal_() const { return normal_ + internal_; }
     bool operator==(const NumNormalAndInternal&) const = default;
+    static NumNormalAndInternal fromNormalAndTotal(size_t normal,
+                                                   size_t total) {
+      AD_CONTRACT_CHECK(total >= normal);
+      return {normal, total - normal};
+    }
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(NumNormalAndInternal, normal_, internal_);
   };
 
   // Store all information about possible search results from the text index in

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -240,12 +240,13 @@ class Index {
       const TripleComponent& col0String,
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
-      ad_utility::SharedCancellationHandle cancellationHandle) const;
+      const ad_utility::SharedCancellationHandle& cancellationHandle) const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
-  IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-               Permutation::ColumnIndicesRef additionalColumns,
-               ad_utility::SharedCancellationHandle cancellationHandle) const;
+  IdTable scan(
+      Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+      Permutation::ColumnIndicesRef additionalColumns,
+      const ad_utility::SharedCancellationHandle& cancellationHandle) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
   // the scan result.

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -36,6 +36,6 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1289, DateOrLargeYear{Date{2024, 3, 2}}};
+    1289, DateOrLargeYear{Date{2024, 3, 1}}};
 
 }  // namespace qlever

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -36,6 +36,6 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1289, DateOrLargeYear{Date{2024, 3, 1}}};
+    1289, DateOrLargeYear{Date{2024, 3, 2}}};
 
 }  // namespace qlever

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -36,6 +36,6 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1289, DateOrLargeYear{Date{2024, 2, 28}}};
+    1289, DateOrLargeYear{Date{2024, 3, 1}}};
 
 }  // namespace qlever

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -36,6 +36,6 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1223, DateOrLargeYear{Date{2024, 1, 18}}};
+    1289, DateOrLargeYear{Date{2024, 2, 28}}};
 
 }  // namespace qlever

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -728,14 +728,14 @@ IndexImpl::createPermutations(size_t numColumns, auto&& sortedTriples,
                               const Permutation& p1, const Permutation& p2,
                               auto&&... perTripleCallbacks) {
   auto metaData = createPermutationPairImpl(
-      numColumns, onDiskBase_ + ".index" + p1.fileSuffix_,
-      onDiskBase_ + ".index" + p2.fileSuffix_, AD_FWD(sortedTriples),
-      p1.keyOrder_, AD_FWD(perTripleCallbacks)...);
+      numColumns, onDiskBase_ + ".index" + p1.fileSuffix(),
+      onDiskBase_ + ".index" + p2.fileSuffix(), AD_FWD(sortedTriples),
+      p1.keyOrder(), AD_FWD(perTripleCallbacks)...);
 
   const auto& [_, meta1, meta2] = metaData;
-  LOG(INFO) << "Statistics for " << p1.readableName_ << ": "
+  LOG(INFO) << "Statistics for " << p1.readableName() << ": "
             << meta1.statistics() << std::endl;
-  LOG(INFO) << "Statistics for " << p2.readableName_ << ": "
+  LOG(INFO) << "Statistics for " << p2.readableName() << ": "
             << meta2.statistics() << std::endl;
 
   return metaData;
@@ -755,11 +755,11 @@ size_t IndexImpl::createPermutationPair(size_t numColumns, auto&& sortedTriples,
   auto writeMetadata = [this](auto& metaData, const auto& permutation) {
     metaData.setName(getKbName());
     ad_utility::File f(
-        absl::StrCat(onDiskBase_, ".index", permutation.fileSuffix_), "r+");
+        absl::StrCat(onDiskBase_, ".index", permutation.fileSuffix()), "r+");
     metaData.appendToFile(&f);
   };
-  LOG(INFO) << "Writing meta data for " << p1.readableName_ << " and "
-            << p2.readableName_ << " ..." << std::endl;
+  LOG(INFO) << "Writing meta data for " << p1.readableName() << " and "
+            << p2.readableName() << " ..." << std::endl;
   writeMetadata(metaData1, p1);
   writeMetadata(metaData2, p2);
   return numDistinctC0;
@@ -1435,7 +1435,7 @@ vector<float> IndexImpl::getMultiplicities(
       numTriples / numDistinctSubjects().normalAndInternal_(),
       numTriples / numDistinctPredicates().normalAndInternal_(),
       numTriples / numDistinctObjects().normalAndInternal_()};
-  return {m[p.keyOrder_[0]], m[p.keyOrder_[1]], m[p.keyOrder_[2]]};
+  return {m[p.keyOrder()[0]], m[p.keyOrder()[1]], m[p.keyOrder()[2]]};
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1461,7 +1461,8 @@ IdTable IndexImpl::scan(
     Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
     ad_utility::SharedCancellationHandle cancellationHandle) const {
-  return getPermutation(p).scan(col0Id, col1Id, additionalColumns,
+  return getPermutation(p).scan({col0Id, col1Id, std::nullopt},
+                                additionalColumns,
                                 std::move(cancellationHandle));
 }
 
@@ -1475,7 +1476,7 @@ size_t IndexImpl::getResultSizeOfScan(
     return 0;
   }
   const Permutation& p = getPermutation(permutation);
-  return p.getResultSizeOfScan(col0Id.value(), col1Id.value());
+  return p.getResultSizeOfScan({col0Id.value(), col1Id.value(), std::nullopt});
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -671,8 +671,8 @@ IndexImpl::convertPartialToGlobalIds(
 }
 
 // _____________________________________________________________________________
-std::pair<IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
-          IndexImpl::IndexMetaDataMmapDispatcher::WriteType>
+std::tuple<size_t, IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
+           IndexImpl::IndexMetaDataMmapDispatcher::WriteType>
 IndexImpl::createPermutationPairImpl(size_t numColumns, const string& fileName1,
                                      const string& fileName2,
                                      auto&& sortedTriples,
@@ -705,10 +705,12 @@ IndexImpl::createPermutationPairImpl(size_t numColumns, const string& fileName1,
   std::vector<std::function<void(const IdTableStatic<0>&)>> perBlockCallbacks{
       liftCallback(perTripleCallbacks)...};
 
-  std::tie(metaData1.blockData(), metaData2.blockData()) =
+  auto [numDistinctCol0, blockData1, blockData2] =
       CompressedRelationWriter::createPermutationPair(
           fileName1, {writer1, callback1}, {writer2, callback2},
           AD_FWD(sortedTriples), permutation, perBlockCallbacks);
+  metaData1.blockData() = std::move(blockData1);
+  metaData2.blockData() = std::move(blockData2);
 
   // There previously was a bug in the CompressedIdTableSorter that lead to
   // semantically correct blocks, but with too large block sizes for the twin
@@ -716,12 +718,12 @@ IndexImpl::createPermutationPairImpl(size_t numColumns, const string& fileName1,
   AD_CORRECTNESS_CHECK(metaData1.blockData().size() ==
                        metaData2.blockData().size());
 
-  return {std::move(metaData1), std::move(metaData2)};
+  return {numDistinctCol0, std::move(metaData1), std::move(metaData2)};
 }
 
 // ________________________________________________________________________
-std::pair<IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
-          IndexImpl::IndexMetaDataMmapDispatcher::WriteType>
+std::tuple<size_t, IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
+           IndexImpl::IndexMetaDataMmapDispatcher::WriteType>
 IndexImpl::createPermutations(size_t numColumns, auto&& sortedTriples,
                               const Permutation& p1, const Permutation& p2,
                               auto&&... perTripleCallbacks) {
@@ -730,20 +732,21 @@ IndexImpl::createPermutations(size_t numColumns, auto&& sortedTriples,
       onDiskBase_ + ".index" + p2.fileSuffix_, AD_FWD(sortedTriples),
       p1.keyOrder_, AD_FWD(perTripleCallbacks)...);
 
+  const auto& [_, meta1, meta2] = metaData;
   LOG(INFO) << "Statistics for " << p1.readableName_ << ": "
-            << metaData.first.statistics() << std::endl;
+            << meta1.statistics() << std::endl;
   LOG(INFO) << "Statistics for " << p2.readableName_ << ": "
-            << metaData.second.statistics() << std::endl;
+            << meta2.statistics() << std::endl;
 
   return metaData;
 }
 
 // ________________________________________________________________________
-void IndexImpl::createPermutationPair(size_t numColumns, auto&& sortedTriples,
-                                      const Permutation& p1,
-                                      const Permutation& p2,
-                                      auto&&... perTripleCallbacks) {
-  auto [metaData1, metaData2] = createPermutations(
+size_t IndexImpl::createPermutationPair(size_t numColumns, auto&& sortedTriples,
+                                        const Permutation& p1,
+                                        const Permutation& p2,
+                                        auto&&... perTripleCallbacks) {
+  auto [numDistinctC0, metaData1, metaData2] = createPermutations(
       numColumns, AD_FWD(sortedTriples), p1, p2, AD_FWD(perTripleCallbacks)...);
   // Set the name of this newly created pair of `IndexMetaData` objects.
   // NOTE: When `setKbName` was called, it set the name of pso_.meta_,
@@ -759,6 +762,7 @@ void IndexImpl::createPermutationPair(size_t numColumns, auto&& sortedTriples,
             << p2.readableName_ << " ..." << std::endl;
   writeMetadata(metaData1, p1);
   writeMetadata(metaData2, p2);
+  return numDistinctC0;
 }
 
 // _____________________________________________________________________________
@@ -998,24 +1002,28 @@ void IndexImpl::readConfiguration() {
             "was built with an older version of QLever and should be rebuilt")};
       }
     } else {
-      target = Target{*it};
+      target = static_cast<Target>(*it);
     }
   };
 
   loadDataMember("has-all-permutations", loadAllPermutations_, true);
   loadDataMember("num-predicates-normal", numPredicatesNormal_);
   // These might be missing if there are only two permutations.
-  loadDataMember("num-subjects-normal", numSubjectsNormal_, 0);
-  loadDataMember("num-objects-normal", numObjectsNormal_, 0);
-  loadDataMember("num-triples-normal", numTriplesNormal_);
+  loadDataMember("num-subjects-normal", numSubjectsNormal_,
+                 NumNormalAndInternal{});
+  loadDataMember("num-objects-normal", numObjectsNormal_,
+                 NumNormalAndInternal{});
+  loadDataMember("num-triples-normal", numTriplesNormal_,
+                 NumNormalAndInternal{});
 
   // Compute unique ID for this index.
   //
   // TODO: This is a simplistic way. It would be better to incorporate bytes
   // from the index files.
-  indexId_ = absl::StrCat("#", getKbName(), ".", numTriplesNormal_, ".",
-                          numSubjectsNormal_, ".", numPredicatesNormal_, ".",
-                          numObjectsNormal_);
+  indexId_ = absl::StrCat("#", getKbName(), ".", numTriplesNormal_.normal_, ".",
+                          numSubjectsNormal_.normal_, ".",
+                          numPredicatesNormal_.normal_, ".",
+                          numObjectsNormal_.normal_);
 }
 
 // ___________________________________________________________________________
@@ -1285,7 +1293,7 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
 
 // ____________________________________________________________________________
 IndexImpl::NumNormalAndInternal IndexImpl::numTriples() const {
-  return {numTriplesNormal_, PSO().meta_.getNofTriples() - numTriplesNormal_};
+  return numTriplesNormal_;
 }
 
 // ____________________________________________________________________________
@@ -1320,8 +1328,7 @@ Index::NumNormalAndInternal IndexImpl::numDistinctSubjects() const {
       "Can only get # distinct subjects if all 6 permutations "
       "have been registered on sever start (and index build time) "
       "with the -a option.");
-  auto numActually = numSubjectsNormal_;
-  return {numActually, spo_.metaData().getNofDistinctC1() - numActually};
+  return numSubjectsNormal_;
 }
 
 // __________________________________________________________________________
@@ -1331,15 +1338,12 @@ Index::NumNormalAndInternal IndexImpl::numDistinctObjects() const {
       "Can only get # distinct objects if all 6 permutations "
       "have been registered on sever start (and index build time) "
       "with the -a option.");
-  auto numActually = numObjectsNormal_;
-  return {numActually, osp_.metaData().getNofDistinctC1() - numActually};
+  return numObjectsNormal_;
 }
 
 // __________________________________________________________________________
 Index::NumNormalAndInternal IndexImpl::numDistinctPredicates() const {
-  auto numActually = numPredicatesNormal_;
-  // TODO<joka921> This is wrong, as not everybody has correct metadata.
-  return {numActually, pso_.metaData().getNofDistinctC1() - numActually};
+  return numPredicatesNormal_;
 }
 
 // __________________________________________________________________________
@@ -1520,18 +1524,25 @@ void IndexImpl::createPSOAndPOS(size_t numColumns, auto& isInternalId,
 
 {
   size_t numTriplesNormal = 0;
-  auto countTriplesNormal = [&numTriplesNormal,
+  size_t numTriplesTotal = 0;
+  auto countTriplesNormal = [&numTriplesNormal, &numTriplesTotal,
                              &isInternalId](const auto& triple) mutable {
+    ++numTriplesTotal;
     numTriplesNormal += std::ranges::none_of(triple, isInternalId);
   };
   size_t numPredicatesNormal = 0;
-  createPermutationPair(
-      numColumns, AD_FWD(sortedTriples), pso_, pos_,
-      nextSorter.makePushCallback()...,
-      makeNumDistinctIdsCounter<1>(numPredicatesNormal, isInternalId),
-      countTriplesNormal);
-  configurationJson_["num-predicates-normal"] = numPredicatesNormal;
-  configurationJson_["num-triples-normal"] = numTriplesNormal;
+  auto predicateCounter =
+      makeNumDistinctIdsCounter<1>(numPredicatesNormal, isInternalId);
+  size_t numPredicatesTotal =
+      createPermutationPair(numColumns, AD_FWD(sortedTriples), pso_, pos_,
+                            nextSorter.makePushCallback()...,
+                            std::ref(predicateCounter), countTriplesNormal);
+  configurationJson_["num-predicates-normal"] =
+      NumNormalAndInternal::fromNormalAndTotal(numPredicatesNormal,
+                                               numPredicatesTotal);
+  configurationJson_["num-triples-normal"] =
+      NumNormalAndInternal::fromNormalAndTotal(numTriplesNormal,
+                                               numTriplesTotal);
   writeConfiguration();
 };
 
@@ -1542,6 +1553,7 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
     size_t numColumns, auto& isInternalId, BlocksOfTriples sortedTriples,
     NextSorter&&... nextSorter) {
   size_t numSubjectsNormal = 0;
+  size_t numSubjectsTotal = 0;
   auto numSubjectCounter =
       makeNumDistinctIdsCounter<0>(numSubjectsNormal, isInternalId);
   std::optional<PatternCreator::TripleSorter> result;
@@ -1559,19 +1571,28 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
       auto tripleArr = std::array{triple[0], triple[1], triple[2]};
       patternCreator.processTriple(tripleArr, ignoreForPatterns);
     };
-    createPermutationPair(numColumns, AD_FWD(sortedTriples), spo_, sop_,
-                          nextSorter.makePushCallback()...,
-                          pushTripleToPatterns, numSubjectCounter);
+    numSubjectsTotal = createPermutationPair(
+        numColumns, AD_FWD(sortedTriples), spo_, sop_,
+        nextSorter.makePushCallback()..., pushTripleToPatterns,
+        std::ref(numSubjectCounter));
     patternCreator.finish();
-    configurationJson_["num-subjects-normal"] = numSubjectsNormal;
+    configurationJson_["num-subjects-normal"] =
+        NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
+                                                 numSubjectsTotal);
     writeConfiguration();
     result = std::move(patternCreator).getTripleSorter();
   } else {
     AD_CORRECTNESS_CHECK(sizeof...(nextSorter) == 1);
-    createPermutationPair(numColumns, AD_FWD(sortedTriples), spo_, sop_,
-                          nextSorter.makePushCallback()..., numSubjectCounter);
+    numSubjectsTotal = createPermutationPair(
+        numColumns, AD_FWD(sortedTriples), spo_, sop_,
+        nextSorter.makePushCallback()..., std::ref(numSubjectCounter));
+    configurationJson_["num-subjects-normal"] =
+        NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
+                                                 numSubjectsTotal);
   }
-  configurationJson_["num-subjects-normal"] = numSubjectsNormal;
+  configurationJson_["num-subjects-normal"] =
+      NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
+                                               numSubjectsTotal);
   writeConfiguration();
   return result;
 };
@@ -1585,11 +1606,14 @@ void IndexImpl::createOSPAndOPS(size_t numColumns, auto& isInternalId,
   // For the last pair of permutations we don't need a next sorter, so we
   // have no fourth argument.
   size_t numObjectsNormal = 0;
-  createPermutationPair(
+  auto objectCounter =
+      makeNumDistinctIdsCounter<2>(numObjectsNormal, isInternalId);
+  size_t numObjectsTotal = createPermutationPair(
       numColumns, AD_FWD(sortedTriples), osp_, ops_,
-      nextSorter.makePushCallback()...,
-      makeNumDistinctIdsCounter<2>(numObjectsNormal, isInternalId));
-  configurationJson_["num-objects-normal"] = numObjectsNormal;
+      nextSorter.makePushCallback()..., std::ref(objectCounter));
+  configurationJson_["num-objects-normal"] =
+      NumNormalAndInternal::fromNormalAndTotal(numObjectsNormal,
+                                               numObjectsTotal);
   configurationJson_["has-all-permutations"] = true;
   writeConfiguration();
 };

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -732,7 +732,9 @@ IndexImpl::createPermutations(size_t numColumns, auto&& sortedTriples,
       onDiskBase_ + ".index" + p2.fileSuffix(), AD_FWD(sortedTriples),
       p1.keyOrder(), AD_FWD(perTripleCallbacks)...);
 
-  const auto& [_, meta1, meta2] = metaData;
+  auto& [numDistinctCol0, meta1, meta2] = metaData;
+  meta1.calculateStatistics(numDistinctCol0);
+  meta2.calculateStatistics(numDistinctCol0);
   LOG(INFO) << "Statistics for " << p1.readableName() << ": "
             << meta1.statistics() << std::endl;
   LOG(INFO) << "Statistics for " << p2.readableName() << ": "
@@ -1017,9 +1019,9 @@ void IndexImpl::readConfiguration() {
   //
   // TODO: This is a simplistic way. It would be better to incorporate bytes
   // from the index files.
-  indexId_ = absl::StrCat("#", getKbName(), ".", numTriples_.normal_, ".",
-                          numSubjects_.normal_, ".", numPredicates_.normal_,
-                          ".", numObjects_.normal_);
+  indexId_ = absl::StrCat("#", getKbName(), ".", numTriples_.normal, ".",
+                          numSubjects_.normal, ".", numPredicates_.normal, ".",
+                          numObjects_.normal);
 }
 
 // ___________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -685,11 +685,9 @@ IndexImpl::createPermutationPairImpl(size_t numColumns, const string& fileName1,
   metaData1.setup(fileName1 + MMAP_FILE_SUFFIX, ad_utility::CreateTag{});
   metaData2.setup(fileName2 + MMAP_FILE_SUFFIX, ad_utility::CreateTag{});
 
-  CompressedRelationWriter writer1{numColumns - 1,
-                                   ad_utility::File(fileName1, "w"),
+  CompressedRelationWriter writer1{numColumns, ad_utility::File(fileName1, "w"),
                                    blocksizePermutationPerColumn_};
-  CompressedRelationWriter writer2{numColumns - 1,
-                                   ad_utility::File(fileName2, "w"),
+  CompressedRelationWriter writer2{numColumns, ad_utility::File(fileName2, "w"),
                                    blocksizePermutationPerColumn_};
 
   // Lift a callback that works on single elements to a callback that works on

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1338,6 +1338,7 @@ Index::NumNormalAndInternal IndexImpl::numDistinctObjects() const {
 // __________________________________________________________________________
 Index::NumNormalAndInternal IndexImpl::numDistinctPredicates() const {
   auto numActually = numPredicatesNormal_;
+  // TODO<joka921> This is wrong, as not everybody has correct metadata.
   return {numActually, pso_.metaData().getNofDistinctC1() - numActually};
 }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1007,23 +1007,21 @@ void IndexImpl::readConfiguration() {
   };
 
   loadDataMember("has-all-permutations", loadAllPermutations_, true);
-  loadDataMember("num-predicates-normal", numPredicatesNormal_);
+  loadDataMember("num-predicates", numPredicates_);
   // These might be missing if there are only two permutations.
-  loadDataMember("num-subjects-normal", numSubjectsNormal_,
+  loadDataMember("num-subjects", numSubjects_,
                  NumNormalAndInternal{});
-  loadDataMember("num-objects-normal", numObjectsNormal_,
+  loadDataMember("num-objects", numObjects_,
                  NumNormalAndInternal{});
-  loadDataMember("num-triples-normal", numTriplesNormal_,
+  loadDataMember("num-triples", numTriples_,
                  NumNormalAndInternal{});
 
   // Compute unique ID for this index.
   //
   // TODO: This is a simplistic way. It would be better to incorporate bytes
   // from the index files.
-  indexId_ = absl::StrCat("#", getKbName(), ".", numTriplesNormal_.normal_, ".",
-                          numSubjectsNormal_.normal_, ".",
-                          numPredicatesNormal_.normal_, ".",
-                          numObjectsNormal_.normal_);
+  indexId_ = absl::StrCat("#", getKbName(), ".", numTriples_.normal_, ".",
+                   numSubjects_.normal_, ".", numPredicates_.normal_, ".", numObjects_.normal_);
 }
 
 // ___________________________________________________________________________
@@ -1293,7 +1291,7 @@ std::future<void> IndexImpl::writeNextPartialVocabulary(
 
 // ____________________________________________________________________________
 IndexImpl::NumNormalAndInternal IndexImpl::numTriples() const {
-  return numTriplesNormal_;
+  return numTriples_;
 }
 
 // ____________________________________________________________________________
@@ -1328,7 +1326,7 @@ Index::NumNormalAndInternal IndexImpl::numDistinctSubjects() const {
       "Can only get # distinct subjects if all 6 permutations "
       "have been registered on sever start (and index build time) "
       "with the -a option.");
-  return numSubjectsNormal_;
+  return numSubjects_;
 }
 
 // __________________________________________________________________________
@@ -1338,12 +1336,12 @@ Index::NumNormalAndInternal IndexImpl::numDistinctObjects() const {
       "Can only get # distinct objects if all 6 permutations "
       "have been registered on sever start (and index build time) "
       "with the -a option.");
-  return numObjectsNormal_;
+  return numObjects_;
 }
 
 // __________________________________________________________________________
 Index::NumNormalAndInternal IndexImpl::numDistinctPredicates() const {
-  return numPredicatesNormal_;
+  return numPredicates_;
 }
 
 // __________________________________________________________________________
@@ -1537,10 +1535,10 @@ void IndexImpl::createPSOAndPOS(size_t numColumns, auto& isInternalId,
       createPermutationPair(numColumns, AD_FWD(sortedTriples), pso_, pos_,
                             nextSorter.makePushCallback()...,
                             std::ref(predicateCounter), countTriplesNormal);
-  configurationJson_["num-predicates-normal"] =
+  configurationJson_["num-predicates"] =
       NumNormalAndInternal::fromNormalAndTotal(numPredicatesNormal,
                                                numPredicatesTotal);
-  configurationJson_["num-triples-normal"] =
+  configurationJson_["num-triples"] =
       NumNormalAndInternal::fromNormalAndTotal(numTriplesNormal,
                                                numTriplesTotal);
   writeConfiguration();
@@ -1576,7 +1574,7 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
         nextSorter.makePushCallback()..., pushTripleToPatterns,
         std::ref(numSubjectCounter));
     patternCreator.finish();
-    configurationJson_["num-subjects-normal"] =
+    configurationJson_["num-subjects"] =
         NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
                                                  numSubjectsTotal);
     writeConfiguration();
@@ -1586,11 +1584,11 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
     numSubjectsTotal = createPermutationPair(
         numColumns, AD_FWD(sortedTriples), spo_, sop_,
         nextSorter.makePushCallback()..., std::ref(numSubjectCounter));
-    configurationJson_["num-subjects-normal"] =
+    configurationJson_["num-subjects"] =
         NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
                                                  numSubjectsTotal);
   }
-  configurationJson_["num-subjects-normal"] =
+  configurationJson_["num-subjects"] =
       NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
                                                numSubjectsTotal);
   writeConfiguration();
@@ -1611,7 +1609,7 @@ void IndexImpl::createOSPAndOPS(size_t numColumns, auto& isInternalId,
   size_t numObjectsTotal = createPermutationPair(
       numColumns, AD_FWD(sortedTriples), osp_, ops_,
       nextSorter.makePushCallback()..., std::ref(objectCounter));
-  configurationJson_["num-objects-normal"] =
+  configurationJson_["num-objects"] =
       NumNormalAndInternal::fromNormalAndTotal(numObjectsNormal,
                                                numObjectsTotal);
   configurationJson_["has-all-permutations"] = true;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -681,7 +681,7 @@ IndexImpl::createPermutationPairImpl(size_t numColumns, const string& fileName1,
   LOG(INFO) << "Creating a pair of index permutations ..." << std::endl;
   using MetaData = IndexMetaDataMmapDispatcher::WriteType;
   MetaData metaData1, metaData2;
-  static_assert(MetaData::_isMmapBased);
+  static_assert(MetaData::isMmapBased_);
   metaData1.setup(fileName1 + MMAP_FILE_SUFFIX, ad_utility::CreateTag{});
   metaData2.setup(fileName2 + MMAP_FILE_SUFFIX, ad_utility::CreateTag{});
 
@@ -1446,7 +1446,7 @@ IdTable IndexImpl::scan(
     std::optional<std::reference_wrapper<const TripleComponent>> col1String,
     const Permutation::Enum& permutation,
     Permutation::ColumnIndicesRef additionalColumns,
-    ad_utility::SharedCancellationHandle cancellationHandle) const {
+    const ad_utility::SharedCancellationHandle& cancellationHandle) const {
   std::optional<Id> col0Id = col0String.toValueId(getVocab());
   std::optional<Id> col1Id =
       col1String.has_value() ? col1String.value().get().toValueId(getVocab())
@@ -1457,16 +1457,15 @@ IdTable IndexImpl::scan(
     return IdTable{numColumns, allocator_};
   }
   return scan(col0Id.value(), col1Id, permutation, additionalColumns,
-              std::move(cancellationHandle));
+              cancellationHandle);
 }
 // _____________________________________________________________________________
 IdTable IndexImpl::scan(
     Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
-    ad_utility::SharedCancellationHandle cancellationHandle) const {
+    const ad_utility::SharedCancellationHandle& cancellationHandle) const {
   return getPermutation(p).scan({col0Id, col1Id, std::nullopt},
-                                additionalColumns,
-                                std::move(cancellationHandle));
+                                additionalColumns, cancellationHandle);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1009,19 +1009,17 @@ void IndexImpl::readConfiguration() {
   loadDataMember("has-all-permutations", loadAllPermutations_, true);
   loadDataMember("num-predicates", numPredicates_);
   // These might be missing if there are only two permutations.
-  loadDataMember("num-subjects", numSubjects_,
-                 NumNormalAndInternal{});
-  loadDataMember("num-objects", numObjects_,
-                 NumNormalAndInternal{});
-  loadDataMember("num-triples", numTriples_,
-                 NumNormalAndInternal{});
+  loadDataMember("num-subjects", numSubjects_, NumNormalAndInternal{});
+  loadDataMember("num-objects", numObjects_, NumNormalAndInternal{});
+  loadDataMember("num-triples", numTriples_, NumNormalAndInternal{});
 
   // Compute unique ID for this index.
   //
   // TODO: This is a simplistic way. It would be better to incorporate bytes
   // from the index files.
   indexId_ = absl::StrCat("#", getKbName(), ".", numTriples_.normal_, ".",
-                   numSubjects_.normal_, ".", numPredicates_.normal_, ".", numObjects_.normal_);
+                          numSubjects_.normal_, ".", numPredicates_.normal_,
+                          ".", numObjects_.normal_);
 }
 
 // ___________________________________________________________________________
@@ -1538,9 +1536,8 @@ void IndexImpl::createPSOAndPOS(size_t numColumns, auto& isInternalId,
   configurationJson_["num-predicates"] =
       NumNormalAndInternal::fromNormalAndTotal(numPredicatesNormal,
                                                numPredicatesTotal);
-  configurationJson_["num-triples"] =
-      NumNormalAndInternal::fromNormalAndTotal(numTriplesNormal,
-                                               numTriplesTotal);
+  configurationJson_["num-triples"] = NumNormalAndInternal::fromNormalAndTotal(
+      numTriplesNormal, numTriplesTotal);
   writeConfiguration();
 };
 
@@ -1588,9 +1585,8 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
         NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
                                                  numSubjectsTotal);
   }
-  configurationJson_["num-subjects"] =
-      NumNormalAndInternal::fromNormalAndTotal(numSubjectsNormal,
-                                               numSubjectsTotal);
+  configurationJson_["num-subjects"] = NumNormalAndInternal::fromNormalAndTotal(
+      numSubjectsNormal, numSubjectsTotal);
   writeConfiguration();
   return result;
 };
@@ -1609,9 +1605,8 @@ void IndexImpl::createOSPAndOPS(size_t numColumns, auto& isInternalId,
   size_t numObjectsTotal = createPermutationPair(
       numColumns, AD_FWD(sortedTriples), osp_, ops_,
       nextSorter.makePushCallback()..., std::ref(objectCounter));
-  configurationJson_["num-objects"] =
-      NumNormalAndInternal::fromNormalAndTotal(numObjectsNormal,
-                                               numObjectsTotal);
+  configurationJson_["num-objects"] = NumNormalAndInternal::fromNormalAndTotal(
+      numObjectsNormal, numObjectsTotal);
   configurationJson_["has-all-permutations"] = true;
   writeConfiguration();
 };

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -380,7 +380,7 @@ class IndexImpl {
 
   const string& getTextName() const { return textMeta_.getName(); }
 
-  const string& getKbName() const { return pso_.metaData().getName(); }
+  const string& getKbName() const { return pso_.getKbName(); }
 
   const string& getIndexId() const { return indexId_; }
 
@@ -390,7 +390,7 @@ class IndexImpl {
     return textMeta_.getNofEntityPostings();
   }
 
-  bool hasAllPermutations() const { return SPO().isLoaded_; }
+  bool hasAllPermutations() const { return SPO().isLoaded(); }
 
   // _____________________________________________________________________________
   vector<float> getMultiplicities(const TripleComponent& key,

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -154,10 +154,10 @@ class IndexImpl {
 
   // These statistics all do *not* include the triples that are added by
   // QLever for more efficient query processing.
-  NumNormalAndInternal numSubjectsNormal_;
-  NumNormalAndInternal numPredicatesNormal_;
-  NumNormalAndInternal numObjectsNormal_;
-  NumNormalAndInternal numTriplesNormal_;
+  NumNormalAndInternal numSubjects_;
+  NumNormalAndInternal numPredicates_;
+  NumNormalAndInternal numObjects_;
+  NumNormalAndInternal numTriples_;
   string indexId_;
   /**
    * @brief Maps pattern ids to sets of predicate ids.

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -403,12 +403,13 @@ class IndexImpl {
       std::optional<std::reference_wrapper<const TripleComponent>> col1String,
       const Permutation::Enum& permutation,
       Permutation::ColumnIndicesRef additionalColumns,
-      ad_utility::SharedCancellationHandle cancellationHandle) const;
+      const ad_utility::SharedCancellationHandle& cancellationHandle) const;
 
   // _____________________________________________________________________________
-  IdTable scan(Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
-               Permutation::ColumnIndicesRef additionalColumns,
-               ad_utility::SharedCancellationHandle cancellationHandle) const;
+  IdTable scan(
+      Id col0Id, std::optional<Id> col1Id, Permutation::Enum p,
+      Permutation::ColumnIndicesRef additionalColumns,
+      const ad_utility::SharedCancellationHandle& cancellationHandle) const;
 
   // _____________________________________________________________________________
   size_t getResultSizeOfScan(const TripleComponent& col0,

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -152,8 +152,6 @@ class IndexImpl {
   size_t parserBatchSize_ = PARSER_BATCH_SIZE;
   size_t numTriplesPerBatch_ = NUM_TRIPLES_PER_PARTIAL_VOCAB;
 
-  // These statistics all do *not* include the triples that are added by
-  // QLever for more efficient query processing.
   NumNormalAndInternal numSubjects_;
   NumNormalAndInternal numPredicates_;
   NumNormalAndInternal numObjects_;

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -154,10 +154,10 @@ class IndexImpl {
 
   // These statistics all do *not* include the triples that are added by
   // QLever for more efficient query processing.
-  size_t numSubjectsNormal_ = 0;
-  size_t numPredicatesNormal_ = 0;
-  size_t numObjectsNormal_ = 0;
-  size_t numTriplesNormal_ = 0;
+  NumNormalAndInternal numSubjectsNormal_;
+  NumNormalAndInternal numPredicatesNormal_;
+  NumNormalAndInternal numObjectsNormal_;
+  NumNormalAndInternal numTriplesNormal_;
   string indexId_;
   /**
    * @brief Maps pattern ids to sets of predicate ids.
@@ -485,8 +485,8 @@ class IndexImpl {
 
   // TODO<joka921> Get rid of the `numColumns` by including them into the
   // `sortedTriples` argument.
-  std::pair<IndexMetaDataMmapDispatcher::WriteType,
-            IndexMetaDataMmapDispatcher::WriteType>
+  std::tuple<size_t, IndexMetaDataMmapDispatcher::WriteType,
+             IndexMetaDataMmapDispatcher::WriteType>
   createPermutationPairImpl(size_t numColumns, const string& fileName1,
                             const string& fileName2, auto&& sortedTriples,
                             std::array<size_t, 3> permutation,
@@ -503,9 +503,11 @@ class IndexImpl {
   // the SPO permutation is also needed for patterns (see usage in
   // IndexImpl::createFromFile function)
 
-  void createPermutationPair(size_t numColumns, auto&& sortedTriples,
-                             const Permutation& p1, const Permutation& p2,
-                             auto&&... perTripleCallbacks);
+  [[nodiscard]] size_t createPermutationPair(size_t numColumns,
+                                             auto&& sortedTriples,
+                                             const Permutation& p1,
+                                             const Permutation& p2,
+                                             auto&&... perTripleCallbacks);
 
   // wrapper for createPermutation that saves a lot of code duplications
   // Writes the permutation that is specified by argument permutation
@@ -516,8 +518,8 @@ class IndexImpl {
   // Careful: only multiplicities for first column is valid after call, need to
   // call exchangeMultiplicities as done by createPermutationPair
   // the optional is std::nullopt if vec and thus the index is empty
-  std::pair<IndexMetaDataMmapDispatcher::WriteType,
-            IndexMetaDataMmapDispatcher::WriteType>
+  std::tuple<size_t, IndexMetaDataMmapDispatcher::WriteType,
+             IndexMetaDataMmapDispatcher::WriteType>
   createPermutations(size_t numColumns, auto&& sortedTriples,
                      const Permutation& p1, const Permutation& p2,
                      auto&&... perTripleCallbacks);

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -30,17 +30,17 @@ using std::vector;
 // meta data or vice versa.
 class WrongFormatException : public std::exception {
  public:
-  WrongFormatException(std::string msg) : _msg(std::move(msg)) {}
-  const char* what() const throw() { return _msg.c_str(); }
+  WrongFormatException(std::string msg) : msg_(std::move(msg)) {}
+  const char* what() const throw() { return msg_.c_str(); }
 
  private:
-  std::string _msg;
+  std::string msg_;
 };
 
 // Struct so that we can return this in a single variable.
 struct VersionInfo {
-  uint64_t _version;
-  size_t _nOfBytes;
+  uint64_t version_;
+  size_t nOfBytes_;
 };
 
 // Magic numbers to separate different types of meta data.
@@ -77,22 +77,22 @@ class IndexMetaData {
 
   // Private member variables.
  private:
-  off_t _offsetAfter = 0;
+  off_t offsetAfter_ = 0;
 
-  string _name;
-  string _filename;
+  string name_;
+  string filename_;
 
-  // TODO: For each of the following two (_data and _blockData), both the type
+  // TODO: For each of the following two (data_ and blockData_), both the type
   // name and the variable name are terrible.
 
   // For each relation, its meta data.
-  MapType _data;
+  MapType data_;
   // For each compressed block, its meta data.
-  BlocksType _blockData;
+  BlocksType blockData_;
 
-  size_t _totalElements = 0;
-  size_t _numDistinctCol0 = 0;
-  uint64_t _version = V_CURRENT;
+  size_t totalElements_ = 0;
+  size_t numDistinctCol0_ = 0;
+  uint64_t version_ = V_CURRENT;
 
   // Public methods.
  public:
@@ -101,14 +101,14 @@ class IndexMetaData {
   IndexMetaData() = default;
 
   // Pass all arguments that are needed for initialization to the underlying
-  // implementation of `_data` (which is of type `MapType`).
+  // implementation of `data_` (which is of type `MapType`).
   template <typename... dataArgs>
   void setup(dataArgs&&... args) {
-    _data.setup(std::forward<dataArgs>(args)...);
+    data_.setup(std::forward<dataArgs>(args)...);
   }
 
   // `isPersistentMetaData` is true when we do not need to add relation meta
-  // data to _data, but assume that it is already contained in _data. This must
+  // data to data_, but assume that it is already contained in data_. This must
   // be a compile time parameter because we have to avoid instantation of member
   // function set() when `MapType` is read only  (e.g., when based on
   // MmapVectorView).
@@ -132,13 +132,13 @@ class IndexMetaData {
                               std::is_same<MetaWrapperMmapView, T>::value;
   };
   // Compile time information whether this instatiation if MMapBased or not
-  static constexpr bool _isMmapBased = IsMmapBased<MapType>::value;
+  static constexpr bool isMmapBased_ = IsMmapBased<MapType>::value;
 
   // This magic number is written when serializing the IndexMetaData to a file.
   // This is used to check whether this is a really old index that requires
   // rebuilding.
   static constexpr uint64_t MAGIC_NUMBER_FOR_SERIALIZATION =
-      _isMmapBased ? MAGIC_NUMBER_MMAP_META_DATA_VERSION
+      isMmapBased_ ? MAGIC_NUMBER_MMAP_META_DATA_VERSION
                    : MAGIC_NUMBER_SPARSE_META_DATA_VERSION;
 
   // Write meta data to file with given name (contents will be overwritten if
@@ -166,16 +166,16 @@ class IndexMetaData {
   // be computed.
   string statistics() const;
 
-  void setName(const string& name) { _name = name; }
+  void setName(const string& name) { name_ = name; }
 
-  const string& getName() const { return _name; }
+  const string& getName() const { return name_; }
 
-  size_t getVersion() const { return _version; }
+  size_t getVersion() const { return version_; }
 
-  const MapType& data() const { return _data; }
+  const MapType& data() const { return data_; }
 
-  BlocksType& blockData() { return _blockData; }
-  const BlocksType& blockData() const { return _blockData; }
+  BlocksType& blockData() { return blockData_; }
+  const BlocksType& blockData() const { return blockData_; }
 
   // Symmetric serialization function for the ad_utility::serialization module.
   AD_SERIALIZE_FRIEND_FUNCTION(IndexMetaData) {
@@ -195,7 +195,7 @@ class IndexMetaData {
           "Please rebuild the index.");
     }
 
-    serializer | arg._version;
+    serializer | arg.version_;
     // This check might only become false, if we are reading from the serializer
     if (arg.getVersion() != V_CURRENT) {
       throw WrongFormatException(
@@ -204,16 +204,16 @@ class IndexMetaData {
     }
 
     // Serialize the rest of the data members
-    serializer | arg._name;
-    serializer | arg._data;
-    serializer | arg._blockData;
-    serializer | arg._offsetAfter;
-    serializer | arg._totalElements;
-    serializer | arg._numDistinctCol0;
+    serializer | arg.name_;
+    serializer | arg.data_;
+    serializer | arg.blockData_;
+    serializer | arg.offsetAfter_;
+    serializer | arg.totalElements_;
+    serializer | arg.numDistinctCol0_;
   }
 };
 
-// ____________________________________________________________________________
+// ___________________________________________________________________________
 template <class MapType>
 ad_utility::File& operator<<(ad_utility::File& f,
                              const IndexMetaData<MapType>& imd);

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -91,8 +91,7 @@ class IndexMetaData {
   BlocksType _blockData;
 
   size_t _totalElements = 0;
-  size_t _totalBytes = 0;
-  size_t _totalBlocks = 0;
+  size_t _numDistinctC0 = 0;
   uint64_t _version = V_CURRENT;
 
   // Public methods.
@@ -161,10 +160,11 @@ class IndexMetaData {
 
   // Calculate and save statistics that are expensive to calculate so we only
   // have to do this once during the index build and not at server start.
-  void calculateExpensiveStatistics();
-  string statistics() const;
+  void calculateStatistics(size_t numDistinctC0);
 
-  size_t getNofTriples() const { return _totalElements; }
+  // The number of distinct Col0Ids has to be passed in manually, as it cannot
+  // be computed.
+  string statistics() const;
 
   void setName(const string& name) { _name = name; }
 
@@ -207,11 +207,9 @@ class IndexMetaData {
     serializer | arg._name;
     serializer | arg._data;
     serializer | arg._blockData;
-
     serializer | arg._offsetAfter;
     serializer | arg._totalElements;
-    serializer | arg._totalBytes;
-    serializer | arg._totalBlocks;
+    serializer | arg._numDistinctC0;
   }
 };
 

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -91,7 +91,7 @@ class IndexMetaData {
   BlocksType _blockData;
 
   size_t _totalElements = 0;
-  size_t _numDistinctC0 = 0;
+  size_t _numDistinctCol0 = 0;
   uint64_t _version = V_CURRENT;
 
   // Public methods.
@@ -160,7 +160,7 @@ class IndexMetaData {
 
   // Calculate and save statistics that are expensive to calculate so we only
   // have to do this once during the index build and not at server start.
-  void calculateStatistics(size_t numDistinctC0);
+  void calculateStatistics(size_t numDistinctCol0);
 
   // The number of distinct Col0Ids has to be passed in manually, as it cannot
   // be computed.
@@ -209,7 +209,7 @@ class IndexMetaData {
     serializer | arg._blockData;
     serializer | arg._offsetAfter;
     serializer | arg._totalElements;
-    serializer | arg._numDistinctC0;
+    serializer | arg._numDistinctCol0;
   }
 };
 

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -170,8 +170,6 @@ class IndexMetaData {
 
   const string& getName() const { return _name; }
 
-  size_t getNofDistinctC1() const;
-
   size_t getVersion() const { return _version; }
 
   const MapType& data() const { return _data; }

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -94,20 +94,17 @@ string IndexMetaData<MapType>::statistics() const {
   ad_utility::ReadableNumberFacet facet(1);
   std::locale locWithNumberGrouping(loc, &facet);
   os.imbue(locWithNumberGrouping);
-  os << "#relations = " << _data.size() << ", #blocks = " << _blockData.size()
+  os << "#relations = " << _numDistinctC0 << ", #blocks = " << _blockData.size()
      << ", #triples = " << _totalElements;
   return std::move(os).str();
 }
 
 // __________________________________________________________________
 template <class MapType>
-void IndexMetaData<MapType>::calculateExpensiveStatistics() {
+void IndexMetaData<MapType>::calculateStatistics(size_t numDistinctC0) {
   _totalElements = 0;
-  _totalBytes = 0;
-  _totalBlocks = 0;
-  for (auto it = _data.cbegin(); it != _data.cend(); ++it) {
-    auto el = *it;
-    _totalElements += el.second.getNofElements();
-    _totalBytes += getTotalBytesForRelation(el.first);
+  _numDistinctC0 = numDistinctC0;
+  for (const auto& block : _blockData) {
+    _totalElements += block.numRows_;
   }
 }

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -94,16 +94,17 @@ string IndexMetaData<MapType>::statistics() const {
   ad_utility::ReadableNumberFacet facet(1);
   std::locale locWithNumberGrouping(loc, &facet);
   os.imbue(locWithNumberGrouping);
-  os << "#relations = " << _numDistinctC0 << ", #blocks = " << _blockData.size()
+  os << "#relations = " << _numDistinctCol0
+     << ", #blocks = " << _blockData.size()
      << ", #triples = " << _totalElements;
   return std::move(os).str();
 }
 
 // __________________________________________________________________
 template <class MapType>
-void IndexMetaData<MapType>::calculateStatistics(size_t numDistinctC0) {
+void IndexMetaData<MapType>::calculateStatistics(size_t numDistinctCol0) {
   _totalElements = 0;
-  _numDistinctC0 = numDistinctC0;
+  _numDistinctCol0 = numDistinctCol0;
   for (const auto& block : _blockData) {
     _totalElements += block.numRows_;
   }

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -18,28 +18,28 @@ template <bool isPersistentMetaData>
 void IndexMetaData<MapType>::add(AddType addedValue) {
   // only add rmd to _data if it's not already present there
   if constexpr (!isPersistentMetaData) {
-    _totalElements += addedValue.getNofElements();
-    _data.set(addedValue.col0Id_, addedValue);
+    totalElements_ += addedValue.getNofElements();
+    data_.set(addedValue.col0Id_, addedValue);
   }
 }
 
 // _____________________________________________________________________________
 template <class MapType>
 off_t IndexMetaData<MapType>::getOffsetAfter() const {
-  return _offsetAfter;
+  return offsetAfter_;
 }
 
 // _____________________________________________________________________________
 template <class MapType>
 typename IndexMetaData<MapType>::GetType IndexMetaData<MapType>::getMetaData(
     Id col0Id) const {
-  return _data.getAsserted(col0Id);
+  return data_.getAsserted(col0Id);
 }
 
 // _____________________________________________________________________________
 template <class MapType>
 bool IndexMetaData<MapType>::col0IdExists(Id col0Id) const {
-  return _data.count(col0Id) > 0;
+  return data_.count(col0Id) > 0;
 }
 
 // ____________________________________________________________________________
@@ -94,18 +94,18 @@ string IndexMetaData<MapType>::statistics() const {
   ad_utility::ReadableNumberFacet facet(1);
   std::locale locWithNumberGrouping(loc, &facet);
   os.imbue(locWithNumberGrouping);
-  os << "#relations = " << _numDistinctCol0
-     << ", #blocks = " << _blockData.size()
-     << ", #triples = " << _totalElements;
+  os << "#relations = " << numDistinctCol0_
+     << ", #blocks = " << blockData_.size()
+     << ", #triples = " << totalElements_;
   return std::move(os).str();
 }
 
 // __________________________________________________________________
 template <class MapType>
 void IndexMetaData<MapType>::calculateStatistics(size_t numDistinctCol0) {
-  _totalElements = 0;
-  _numDistinctCol0 = numDistinctCol0;
-  for (const auto& block : _blockData) {
-    _totalElements += block.numRows_;
+  totalElements_ = 0;
+  numDistinctCol0_ = numDistinctCol0;
+  for (const auto& block : blockData_) {
+    totalElements_ += block.numRows_;
   }
 }

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -99,12 +99,6 @@ string IndexMetaData<MapType>::statistics() const {
   return std::move(os).str();
 }
 
-// ______________________________________________
-template <class MapType>
-size_t IndexMetaData<MapType>::getNofDistinctC1() const {
-  return _data.size();
-}
-
 // __________________________________________________________________
 template <class MapType>
 void IndexMetaData<MapType>::calculateExpensiveStatistics() {

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -47,21 +47,20 @@ IdTable Permutation::scan(
                              readableName_ + ", which was not loaded");
   }
 
-  return reader().scan(ids, meta_.blockData(),
-                       additionalColumns, std::move(cancellationHandle));
+  return reader().scan(ids, meta_.blockData(), additionalColumns,
+                       std::move(cancellationHandle));
 }
 
 // _____________________________________________________________________
 size_t Permutation::getResultSizeOfScan(const ScanSpecification& ids) const {
-  return reader().getResultSizeOfScan(ids,
-                                      meta_.blockData());
+  return reader().getResultSizeOfScan(ids, meta_.blockData());
 }
 
 // ____________________________________________________________________________
 IdTable Permutation::getDistinctCol1IdsAndCounts(
     Id col0Id, ad_utility::SharedCancellationHandle cancellationHandle) const {
-  return reader().getDistinctCol1IdsAndCounts(
-      col0Id, meta_.blockData(), cancellationHandle);
+  return reader().getDistinctCol1IdsAndCounts(col0Id, meta_.blockData(),
+                                              cancellationHandle);
 }
 
 // _____________________________________________________________________
@@ -129,9 +128,8 @@ Permutation::IdTableGenerator Permutation::lazyScan(
     ColumnIndicesRef additionalColumns,
     ad_utility::SharedCancellationHandle cancellationHandle) const {
   if (!blocks.has_value()) {
-    auto blockSpan = CompressedRelationReader::getRelevantBlocks(
-        ids,
-        meta_.blockData());
+    auto blockSpan =
+        CompressedRelationReader::getRelevantBlocks(ids, meta_.blockData());
     blocks = std::vector(blockSpan.begin(), blockSpan.end());
   }
   ColumnIndices columns{additionalColumns.begin(), additionalColumns.end()};

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -16,7 +16,7 @@ Permutation::Permutation(Enum permutation, Allocator allocator)
 
 // _____________________________________________________________________
 void Permutation::loadFromDisk(const std::string& onDiskBase) {
-  if constexpr (MetaData::_isMmapBased) {
+  if constexpr (MetaData::isMmapBased_) {
     meta_.setup(onDiskBase + ".index" + fileSuffix_ + MMAP_FILE_SUFFIX,
                 ad_utility::ReuseTag(), ad_utility::AccessPattern::Random);
   }
@@ -48,7 +48,7 @@ IdTable Permutation::scan(const ScanSpecification& scanSpec,
   }
 
   return reader().scan(scanSpec, meta_.blockData(), additionalColumns,
-                       std::move(cancellationHandle));
+                       cancellationHandle);
 }
 
 // _____________________________________________________________________

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -41,7 +41,7 @@ void Permutation::loadFromDisk(const std::string& onDiskBase) {
 // _____________________________________________________________________
 IdTable Permutation::scan(
     const ScanSpecification& ids, ColumnIndicesRef additionalColumns,
-    ad_utility::SharedCancellationHandle cancellationHandle) const {
+    const CancellationHandle& cancellationHandle) const {
   if (!isLoaded_) {
     throw std::runtime_error("This query requires the permutation " +
                              readableName_ + ", which was not loaded");
@@ -58,14 +58,14 @@ size_t Permutation::getResultSizeOfScan(const ScanSpecification& ids) const {
 
 // ____________________________________________________________________________
 IdTable Permutation::getDistinctCol1IdsAndCounts(
-    Id col0Id, ad_utility::SharedCancellationHandle cancellationHandle) const {
+    Id col0Id, const CancellationHandle& cancellationHandle) const {
   return reader().getDistinctCol1IdsAndCounts(col0Id, meta_.blockData(),
                                               cancellationHandle);
 }
 
 // ____________________________________________________________________________
 IdTable Permutation::getDistinctCol0IdsAndCounts(
-    ad_utility::SharedCancellationHandle cancellationHandle) const {
+    const CancellationHandle& cancellationHandle) const {
   return reader().getDistinctCol0IdsAndCounts(meta_.blockData(),
                                               cancellationHandle);
 }
@@ -110,6 +110,7 @@ std::string_view Permutation::toString(Permutation::Enum permutation) {
   AD_FAIL();
 }
 
+// _____________________________________________________________________
 std::optional<CompressedRelationMetadata> Permutation::getMetadata(
     Id col0Id) const {
   if (meta_.col0IdExists(col0Id)) {
@@ -117,6 +118,7 @@ std::optional<CompressedRelationMetadata> Permutation::getMetadata(
   }
   return reader().getMetadataForSmallRelation(meta_.blockData(), col0Id);
 }
+
 // _____________________________________________________________________
 std::optional<Permutation::MetadataAndBlocks> Permutation::getMetadataAndBlocks(
     const ScanSpecification& ids) const {
@@ -141,5 +143,5 @@ Permutation::IdTableGenerator Permutation::lazyScan(
   }
   ColumnIndices columns{additionalColumns.begin(), additionalColumns.end()};
   return reader().lazyScan(ids, std::move(blocks.value()), std::move(columns),
-                           cancellationHandle);
+                           std::move(cancellationHandle));
 }

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -63,6 +63,13 @@ IdTable Permutation::getDistinctCol1IdsAndCounts(
                                               cancellationHandle);
 }
 
+// ____________________________________________________________________________
+IdTable Permutation::getDistinctCol0IdsAndCounts(
+    ad_utility::SharedCancellationHandle cancellationHandle) const {
+  return reader().getDistinctCol0IdsAndCounts(meta_.blockData(),
+                                              cancellationHandle);
+}
+
 // _____________________________________________________________________
 std::array<size_t, 3> Permutation::toKeyOrder(Permutation::Enum permutation) {
   using enum Permutation::Enum;

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -130,7 +130,7 @@ std::optional<Permutation::MetadataAndBlocks> Permutation::getMetadataAndBlocks(
 
 // _____________________________________________________________________
 Permutation::IdTableGenerator Permutation::lazyScan(
-    ScanSpecification ids,
+    const ScanSpecification& ids,
     std::optional<std::vector<CompressedBlockMetadata>> blocks,
     ColumnIndicesRef additionalColumns,
     ad_utility::SharedCancellationHandle cancellationHandle) const {

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -61,7 +61,7 @@ size_t Permutation::getResultSizeOfScan(const ScanSpecification& ids) const {
 IdTable Permutation::getDistinctCol1IdsAndCounts(
     Id col0Id, ad_utility::SharedCancellationHandle cancellationHandle) const {
   return reader().getDistinctCol1IdsAndCounts(
-      col0Id, allBlocksMetadata, cancellationHandle);
+      col0Id, meta_.blockData(), cancellationHandle);
 }
 
 // _____________________________________________________________________
@@ -135,7 +135,6 @@ Permutation::IdTableGenerator Permutation::lazyScan(
     blocks = std::vector(blockSpan.begin(), blockSpan.end());
   }
   ColumnIndices columns{additionalColumns.begin(), additionalColumns.end()};
-  return reader().lazyScan(relationMetadata.value(), col1Id,
-                           std::optional<Id>(), std::move(blocks.value()),
-                           std::move(columns), cancellationHandle);
+  return reader().lazyScan(ids, std::move(blocks.value()), std::move(columns),
+                           cancellationHandle);
 }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -55,8 +55,7 @@ class Permutation {
   // If `col1Id` is specified, only the col2 is returned for triples that
   // additionally have the specified col1. .This is just a thin wrapper around
   // `CompressedRelationMetaData::scan`.
-  IdTable scan(const ScanSpecification& ids,
-               ColumnIndicesRef additionalColumns,
+  IdTable scan(const ScanSpecification& ids, ColumnIndicesRef additionalColumns,
                ad_utility::SharedCancellationHandle cancellationHandle) const;
 
   // For a given relation, determine the `col1Id`s and their counts. This is

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -36,6 +36,8 @@ class Permutation {
   using ColumnIndicesRef = CompressedRelationReader::ColumnIndicesRef;
   using ColumnIndices = CompressedRelationReader::ColumnIndices;
 
+  using ScanSpecification = CompressedRelationReader::ScanSpecification;
+
   // Convert a permutation to the corresponding string, etc. `PSO` is converted
   // to "PSO".
   static std::string_view toString(Enum permutation);
@@ -53,7 +55,7 @@ class Permutation {
   // If `col1Id` is specified, only the col2 is returned for triples that
   // additionally have the specified col1. .This is just a thin wrapper around
   // `CompressedRelationMetaData::scan`.
-  IdTable scan(Id col0Id, std::optional<Id> col1Id,
+  IdTable scan(const ScanSpecification& ids,
                ColumnIndicesRef additionalColumns,
                ad_utility::SharedCancellationHandle cancellationHandle) const;
 
@@ -81,7 +83,7 @@ class Permutation {
   // `MetadataAndBlocks` class and make this a strong class that always
   // maintains its invariants.
   IdTableGenerator lazyScan(
-      Id col0Id, std::optional<Id> col1Id,
+      ScanSpecification ids,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns,
       ad_utility::SharedCancellationHandle cancellationHandle) const;
@@ -93,11 +95,11 @@ class Permutation {
   // prefiltered by the `col1Id` if specified). If the `col0Id` does not exist
   // in this permutation, `nullopt` is returned.
   std::optional<MetadataAndBlocks> getMetadataAndBlocks(
-      Id col0Id, std::optional<Id> col1Id) const;
+      const ScanSpecification& ids) const;
 
   /// Similar to the previous `scan` function, but only get the size of the
   /// result
-  size_t getResultSizeOfScan(Id col0Id, Id col1Id) const;
+  size_t getResultSizeOfScan(const ScanSpecification& ids) const;
 
   // _______________________________________________________
   void setKbName(const string& name) { meta_.setName(name); }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -56,7 +56,8 @@ class Permutation {
   // If `col1Id` is specified, only the col2 is returned for triples that
   // additionally have the specified col1. .This is just a thin wrapper around
   // `CompressedRelationMetaData::scan`.
-  IdTable scan(const ScanSpecification& ids, ColumnIndicesRef additionalColumns,
+  IdTable scan(const ScanSpecification& scanSpec,
+               ColumnIndicesRef additionalColumns,
                const CancellationHandle& cancellationHandle) const;
 
   // For a given relation, determine the `col1Id`s and their counts. This is
@@ -86,7 +87,7 @@ class Permutation {
   // `MetadataAndBlocks` class and make this a strong class that always
   // maintains its invariants.
   IdTableGenerator lazyScan(
-      const ScanSpecification& ids,
+      const ScanSpecification& scanSpec,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns,
       CancellationHandle cancellationHandle) const;
@@ -98,11 +99,11 @@ class Permutation {
   // prefiltered by the `col1Id` if specified). If the `col0Id` does not exist
   // in this permutation, `nullopt` is returned.
   std::optional<MetadataAndBlocks> getMetadataAndBlocks(
-      const ScanSpecification& ids) const;
+      const ScanSpecification& scanSpec) const;
 
   /// Similar to the previous `scan` function, but only get the size of the
   /// result
-  size_t getResultSizeOfScan(const ScanSpecification& ids) const;
+  size_t getResultSizeOfScan(const ScanSpecification& scanSpec) const;
 
   // _______________________________________________________
   void setKbName(const string& name) { meta_.setName(name); }
@@ -123,7 +124,7 @@ class Permutation {
   const array<size_t, 3>& keyOrder() const { return keyOrder_; };
 
   // _______________________________________________________
-  const bool& isLoaded() const {return isLoaded_;}
+  const bool& isLoaded() const { return isLoaded_; }
 
  private:
   // for Log output, e.g. "POS"

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -35,6 +35,7 @@ class Permutation {
   using Allocator = ad_utility::AllocatorWithLimit<Id>;
   using ColumnIndicesRef = CompressedRelationReader::ColumnIndicesRef;
   using ColumnIndices = CompressedRelationReader::ColumnIndices;
+  using CancellationHandle = ad_utility::SharedCancellationHandle;
 
   using ScanSpecification = CompressedRelationReader::ScanSpecification;
 
@@ -56,16 +57,16 @@ class Permutation {
   // additionally have the specified col1. .This is just a thin wrapper around
   // `CompressedRelationMetaData::scan`.
   IdTable scan(const ScanSpecification& ids, ColumnIndicesRef additionalColumns,
-               ad_utility::SharedCancellationHandle cancellationHandle) const;
+               const CancellationHandle& cancellationHandle) const;
 
   // For a given relation, determine the `col1Id`s and their counts. This is
   // used for `computeGroupByObjectWithCount`. The `col0Id` must have metadata
   // in `meta_`.
   IdTable getDistinctCol1IdsAndCounts(
-      Id col0Id, ad_utility::SharedCancellationHandle cancellationHandle) const;
+      Id col0Id, const CancellationHandle& cancellationHandle) const;
 
   IdTable getDistinctCol0IdsAndCounts(
-      ad_utility::SharedCancellationHandle cancellationHandle) const;
+      const CancellationHandle& cancellationHandle) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks = CompressedRelationReader::MetadataAndBlocks;
@@ -88,7 +89,7 @@ class Permutation {
       const ScanSpecification& ids,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns,
-      ad_utility::SharedCancellationHandle cancellationHandle) const;
+      CancellationHandle cancellationHandle) const;
 
   std::optional<CompressedRelationMetadata> getMetadata(Id col0Id) const;
 
@@ -106,15 +107,32 @@ class Permutation {
   // _______________________________________________________
   void setKbName(const string& name) { meta_.setName(name); }
 
+  // _______________________________________________________
+  const std::string& getKbName() const { return meta_.getName(); }
+
+  // _______________________________________________________
   const CompressedRelationReader& reader() const { return reader_.value(); }
 
+  // _______________________________________________________
+  const std::string& readableName() const { return readableName_; }
+
+  // _______________________________________________________
+  const std::string& fileSuffix() const { return fileSuffix_; }
+
+  // _______________________________________________________
+  const array<size_t, 3>& keyOrder() const { return keyOrder_; };
+
+  // _______________________________________________________
+  const bool& isLoaded() const {return isLoaded_;}
+
+ private:
   // for Log output, e.g. "POS"
-  const std::string readableName_;
+  std::string readableName_;
   // e.g. ".pos"
-  const std::string fileSuffix_;
+  std::string fileSuffix_;
   // order of the 3 keys S(0), P(1), and O(2) for which this permutation is
   // sorted, for example {1, 0, 2} for PSO.
-  const array<size_t, 3> keyOrder_;
+  array<size_t, 3> keyOrder_;
 
   const MetaData& metaData() const { return meta_; }
   MetaData meta_;

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -64,6 +64,9 @@ class Permutation {
   IdTable getDistinctCol1IdsAndCounts(
       Id col0Id, ad_utility::SharedCancellationHandle cancellationHandle) const;
 
+  IdTable getDistinctCol0IdsAndCounts(
+      ad_utility::SharedCancellationHandle cancellationHandle) const;
+
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks = CompressedRelationReader::MetadataAndBlocks;
 

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -85,7 +85,7 @@ class Permutation {
   // `MetadataAndBlocks` class and make this a strong class that always
   // maintains its invariants.
   IdTableGenerator lazyScan(
-      ScanSpecification ids,
+      const ScanSpecification& ids,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns,
       ad_utility::SharedCancellationHandle cancellationHandle) const;

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -86,6 +86,8 @@ class Permutation {
       ColumnIndicesRef additionalColumns,
       ad_utility::SharedCancellationHandle cancellationHandle) const;
 
+  std::optional<CompressedRelationMetadata> getMetadata(Id col0Id) const;
+
   // Return the metadata for the relation specified by the `col0Id`
   // along with the metadata for all the blocks that contain this relation (also
   // prefiltered by the `col1Id` if specified). If the `col0Id` does not exist

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -66,9 +66,9 @@ cppcoro::generator<std::array<Id, 3>> TriplesView(
           ignoreLow = Id::max();
           ignoreHigh = Id::max();
         }
-        if (triple[0] >= ignoreLow && triple[0] < ignoreHigh) {
-          continue;
-        }
+      }
+      if (triple[0] >= ignoreLow && triple[0] < ignoreHigh) {
+        continue;
       }
       co_yield triple;
     }

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -72,7 +72,7 @@ cppcoro::generator<std::array<Id, 3>> TriplesView(
     for (auto it = begin; it != end; ++it) {
       Id id = it.getId();
       auto blockGenerator = permutation.lazyScan(
-          id, std::nullopt, std::nullopt,
+          id, std::nullopt, std::optional<Id>(), std::nullopt,
           CompressedRelationReader::ColumnIndices{}, cancellationHandle);
       for (const IdTable& col1And2 : blockGenerator) {
         AD_CORRECTNESS_CHECK(col1And2.numColumns() == 2);

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -52,8 +52,8 @@ cppcoro::generator<std::array<Id, 3>> TriplesView(
   for (const IdTable& cols : blockGenerator) {
     AD_CORRECTNESS_CHECK(cols.numColumns() == 3);
     for (const auto& row : cols) {
-      // TODO<joka921> This can be much more efficient without copying etc. and
-      // with prefiltering.
+      // TODO<joka921> This can be done much more efficient without copying etc.
+      // and with prefiltering.
       std::array<Id, 3> triple{row[0], row[1], row[2]};
       if (isTripleIgnored(triple)) [[unlikely]] {
         continue;

--- a/src/index/TriplesView.h
+++ b/src/index/TriplesView.h
@@ -37,54 +37,41 @@ cppcoro::generator<std::array<Id, 3>> TriplesView(
     ad_utility::SharedCancellationHandle cancellationHandle,
     detail::IgnoredRelations ignoredRanges = {},
     IsTripleIgnored isTripleIgnored = IsTripleIgnored{}) {
-  std::sort(ignoredRanges.begin(), ignoredRanges.end());
+  std::ranges::sort(ignoredRanges);
 
-  const auto& metaData = permutation.meta_.data();
-  // The argument `ignoredRanges` specifies the ignored ranges, but we need to
-  // compute the ranges that are allowed (the inverse).
-  using Iterator = std::decay_t<decltype(metaData.ordered_begin())>;
-  std::vector<std::pair<Iterator, Iterator>> allowedRanges;
-
-  // Add sentinels.
-  // TODO<joka921> implement Index::prefixRange with all the logic.
-  ignoredRanges.insert(ignoredRanges.begin(), {Id::min(), Id::min()});
-  ignoredRanges.insert(ignoredRanges.end(), {Id::max(), Id::max()});
-  auto orderedBegin = metaData.ordered_begin();
-  auto orderedEnd = metaData.ordered_end();
-
-  // Convert the `ignoredRanges` to the `allowedRanges`. The algorithm
-  // works because of the sentinels.
-  for (auto it = ignoredRanges.begin(); it != ignoredRanges.end() - 1; ++it) {
-    auto beginOfAllowed = std::lower_bound(
-        orderedBegin, orderedEnd, it->second,
-        [](const auto& meta, const auto& id) {
-          return decltype(orderedBegin)::getIdFromElement(meta) < id;
-        });
-    auto endOfAllowed = std::lower_bound(
-        orderedBegin, orderedEnd, (it + 1)->first,
-        [](const auto& meta, const auto& id) {
-          return decltype(orderedBegin)::getIdFromElement(meta) < id;
-        });
-    allowedRanges.emplace_back(beginOfAllowed, endOfAllowed);
+  auto blockGenerator = permutation.lazyScan(
+      {std::nullopt, std::nullopt, std::nullopt}, std::nullopt,
+      CompressedRelationReader::ColumnIndices{}, cancellationHandle);
+  auto ignoreIt = ignoredRanges.begin();
+  Id ignoreLow = Id::max();
+  Id ignoreHigh = Id::max();
+  if (ignoreIt != ignoredRanges.end()) {
+    std::tie(ignoreLow, ignoreHigh) = *ignoreIt;
+    ++ignoreIt;
   }
-
-  for (auto& [begin, end] : allowedRanges) {
-    for (auto it = begin; it != end; ++it) {
-      Id id = it.getId();
-      auto blockGenerator = permutation.lazyScan(
-          id, std::nullopt, std::optional<Id>(), std::nullopt,
-          CompressedRelationReader::ColumnIndices{}, cancellationHandle);
-      for (const IdTable& col1And2 : blockGenerator) {
-        AD_CORRECTNESS_CHECK(col1And2.numColumns() == 2);
-        for (const auto& row : col1And2) {
-          std::array<Id, 3> triple{id, row[0], row[1]};
-          if (isTripleIgnored(triple)) [[unlikely]] {
-            continue;
-          }
-          co_yield triple;
+  for (const IdTable& cols : blockGenerator) {
+    AD_CORRECTNESS_CHECK(cols.numColumns() == 3);
+    for (const auto& row : cols) {
+      // TODO<joka921> This can be much more efficient without copying etc. and
+      // with prefiltering.
+      std::array<Id, 3> triple{row[0], row[1], row[2]};
+      if (isTripleIgnored(triple)) [[unlikely]] {
+        continue;
+      }
+      if (triple[0] > ignoreHigh) {
+        if (ignoreIt != ignoredRanges.end()) {
+          std::tie(ignoreLow, ignoreHigh) = *ignoreIt;
+          ++ignoreIt;
+        } else {
+          ignoreLow = Id::max();
+          ignoreHigh = Id::max();
+        }
+        if (triple[0] >= ignoreLow && triple[0] < ignoreHigh) {
+          continue;
         }
       }
-      cancellationHandle->throwIfCancelled();
+      co_yield triple;
     }
+    cancellationHandle->throwIfCancelled();
   }
 }

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -177,8 +177,8 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
 
     table.clear();
     for (const auto& block :
-         reader.lazyScan(metaData[i], std::nullopt, blocks, additionalColumns,
-                         cancellationHandle)) {
+         reader.lazyScan(metaData[i], std::nullopt, std::optional<Id>(), blocks,
+                         additionalColumns, cancellationHandle)) {
       table.insertAtEnd(block.begin(), block.end());
     }
     checkThatTablesAreEqual(col1And2, table);
@@ -199,9 +199,9 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
       EXPECT_EQ(size, tableWidthOne.numRows());
       checkThatTablesAreEqual(col3, tableWidthOne);
       tableWidthOne.clear();
-      for (const auto& block :
-           reader.lazyScan(metaData[i], V(lastCol1Id), blocks,
-                           Permutation::ColumnIndices{}, cancellationHandle)) {
+      for (const auto& block : reader.lazyScan(
+               metaData[i], V(lastCol1Id), std::optional<Id>(), blocks,
+               Permutation::ColumnIndices{}, cancellationHandle)) {
         tableWidthOne.insertAtEnd(block.begin(), block.end());
       }
       checkThatTablesAreEqual(col3, tableWidthOne);

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -172,16 +172,16 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
     ASSERT_FLOAT_EQ(m.numRows_ / static_cast<float>(i + 1),
                     m.multiplicityCol1_);
     // Scan for all distinct `col0` and check that we get the expected result.
-    CompressedRelationReader::ScanSpecification ids{metaData[i].col0Id_,
-                                                    std::nullopt, std::nullopt};
+    CompressedRelationReader::ScanSpecification scanSpec{
+        metaData[i].col0Id_, std::nullopt, std::nullopt};
     IdTable table =
-        reader.scan(ids, blocks, additionalColumns, cancellationHandle);
+        reader.scan(scanSpec, blocks, additionalColumns, cancellationHandle);
     const auto& col1And2 = inputs[i].col1And2_;
     checkThatTablesAreEqual(col1And2, table);
 
     table.clear();
-    for (const auto& block :
-         reader.lazyScan(ids, blocks, additionalColumns, cancellationHandle)) {
+    for (const auto& block : reader.lazyScan(
+             scanSpec, blocks, additionalColumns, cancellationHandle)) {
       table.insertAtEnd(block.begin(), block.end());
     }
     checkThatTablesAreEqual(col1And2, table);
@@ -193,17 +193,19 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
     std::vector<std::array<int, 1>> col3;
 
     auto scanAndCheck = [&]() {
-      CompressedRelationReader::ScanSpecification ids{
+      CompressedRelationReader::ScanSpecification scanSpec{
           metaData[i].col0Id_, V(lastCol1Id), std::nullopt};
-      auto size = reader.getResultSizeOfScan(ids, blocks);
-      IdTable tableWidthOne = reader.scan(
-          ids, blocks, Permutation::ColumnIndicesRef{}, cancellationHandle);
+      auto size = reader.getResultSizeOfScan(scanSpec, blocks);
+      IdTable tableWidthOne =
+          reader.scan(scanSpec, blocks, Permutation::ColumnIndicesRef{},
+                      cancellationHandle);
       ASSERT_EQ(tableWidthOne.numColumns(), 1);
       EXPECT_EQ(size, tableWidthOne.numRows());
       checkThatTablesAreEqual(col3, tableWidthOne);
       tableWidthOne.clear();
-      for (const auto& block : reader.lazyScan(
-               ids, blocks, Permutation::ColumnIndices{}, cancellationHandle)) {
+      for (const auto& block :
+           reader.lazyScan(scanSpec, blocks, Permutation::ColumnIndices{},
+                           cancellationHandle)) {
         tableWidthOne.insertAtEnd(block.begin(), block.end());
       }
       checkThatTablesAreEqual(col3, tableWidthOne);
@@ -410,7 +412,7 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
 
   // Test with a fixed col1Id. We now join on the last column, the first column
   // is fixed (42), and the second column is also fixed (4).
-  metadataAndBlocks.ids_.setCol1Id(V(4));
+  metadataAndBlocks.scanSpec_.setCol1Id(V(4));
   test({V(11), V(27), V(30)}, {block2, block3});
   test({V(12)}, {block2});
   test({V(13)}, {block3});
@@ -486,18 +488,18 @@ TEST(CompressedRelationReader, getBlocksForJoin) {
   // Test for only the `col0Id` fixed.
   test({std::vector{block2, block3, block4}, std::vector{blockB2, blockB3}});
   // Test with a fixed col1Id on both sides. We now join on the last column.
-  metadataAndBlocks.ids_.setCol1Id(V(20));
-  metadataAndBlocksB.ids_.setCol1Id(V(38));
+  metadataAndBlocks.scanSpec_.setCol1Id(V(20));
+  metadataAndBlocksB.scanSpec_.setCol1Id(V(38));
   test({std::vector{block4}, std::vector{blockB4, blockB5}});
 
   // Fix only the col1Id of the left input.
-  metadataAndBlocks.ids_.setCol1Id(V(4));
-  metadataAndBlocksB.ids_.setCol1Id(std::nullopt);
+  metadataAndBlocks.scanSpec_.setCol1Id(V(4));
+  metadataAndBlocksB.scanSpec_.setCol1Id(std::nullopt);
   test({std::vector{block2}, std::vector{blockB2, blockB3}});
 
   // Fix only the col1Id of the right input.
-  metadataAndBlocks.ids_.setCol1Id(std::nullopt);
-  metadataAndBlocksB.ids_.setCol1Id(V(7));
+  metadataAndBlocks.scanSpec_.setCol1Id(std::nullopt);
+  metadataAndBlocksB.scanSpec_.setCol1Id(V(7));
   test({std::vector{block4, block5}, std::vector{blockB3}});
 }
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -170,9 +170,10 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
     ASSERT_FLOAT_EQ(m.numRows_ / static_cast<float>(i + 1),
                     m.multiplicityCol1_);
     // Scan for all distinct `col0` and check that we get the expected result.
-    CompressedRelationReader::ScanSpecification ids{metaData[i].col0Id_, std::nullopt, std::nullopt};
-    IdTable table = reader.scan(ids, blocks,
-                                additionalColumns, cancellationHandle);
+    CompressedRelationReader::ScanSpecification ids{metaData[i].col0Id_,
+                                                    std::nullopt, std::nullopt};
+    IdTable table =
+        reader.scan(ids, blocks, additionalColumns, cancellationHandle);
     const auto& col1And2 = inputs[i].col1And2_;
     checkThatTablesAreEqual(col1And2, table);
 
@@ -190,19 +191,17 @@ void testCompressedRelations(const auto& inputs, std::string testCaseName,
     std::vector<std::array<int, 1>> col3;
 
     auto scanAndCheck = [&]() {
-      CompressedRelationReader::ScanSpecification ids{metaData[i].col0Id_, V(lastCol1Id), std::nullopt};
-      auto size =
-          reader.getResultSizeOfScan(ids, blocks);
-      IdTable tableWidthOne =
-          reader.scan(ids, blocks,
-                      Permutation::ColumnIndicesRef{}, cancellationHandle);
+      CompressedRelationReader::ScanSpecification ids{
+          metaData[i].col0Id_, V(lastCol1Id), std::nullopt};
+      auto size = reader.getResultSizeOfScan(ids, blocks);
+      IdTable tableWidthOne = reader.scan(
+          ids, blocks, Permutation::ColumnIndicesRef{}, cancellationHandle);
       ASSERT_EQ(tableWidthOne.numColumns(), 1);
       EXPECT_EQ(size, tableWidthOne.numRows());
       checkThatTablesAreEqual(col3, tableWidthOne);
       tableWidthOne.clear();
-      for (const auto& block : reader.lazyScan(ids,
-                blocks,
-               Permutation::ColumnIndices{}, cancellationHandle)) {
+      for (const auto& block : reader.lazyScan(
+               ids, blocks, Permutation::ColumnIndices{}, cancellationHandle)) {
         tableWidthOne.insertAtEnd(block.begin(), block.end());
       }
       checkThatTablesAreEqual(col3, tableWidthOne);
@@ -386,7 +385,7 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
 
   std::vector blocks{block1, block2, block3};
   CompressedRelationReader::MetadataAndBlocks metadataAndBlocks{
-    {relation.col0Id_, std::nullopt, std::nullopt}, blocks, std::nullopt};
+      {relation.col0Id_, std::nullopt, std::nullopt}, blocks, std::nullopt};
 
   auto test = [&metadataAndBlocks](
                   const std::vector<Id>& joinColumn,
@@ -432,7 +431,7 @@ TEST(CompressedRelationReader, getBlocksForJoin) {
 
   std::vector blocks{block1, block2, block3, block4, block5};
   CompressedRelationReader::MetadataAndBlocks metadataAndBlocks{
-    {relation.col0Id_, std::nullopt, std::nullopt}, blocks, std::nullopt};
+      {relation.col0Id_, std::nullopt, std::nullopt}, blocks, std::nullopt};
 
   CompressedBlockMetadata blockB1{
       {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}};
@@ -453,7 +452,7 @@ TEST(CompressedRelationReader, getBlocksForJoin) {
 
   std::vector blocksB{blockB1, blockB2, blockB3, blockB4, blockB5, blockB6};
   CompressedRelationReader::MetadataAndBlocks metadataAndBlocksB{
-    {V(47), std::nullopt, std::nullopt}, blocksB, std::nullopt};
+      {V(47), std::nullopt, std::nullopt}, blocksB, std::nullopt};
 
   auto test = [&metadataAndBlocks, &metadataAndBlocksB](
                   const std::array<std::vector<CompressedBlockMetadata>, 2>&

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -410,7 +410,7 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
 
   // Test with a fixed col1Id. We now join on the last column, the first column
   // is fixed (42), and the second column is also fixed (4).
-  metadataAndBlocks.ids_.col1Id_ = V(4);
+  metadataAndBlocks.ids_.setCol1Id(V(4));
   test({V(11), V(27), V(30)}, {block2, block3});
   test({V(12)}, {block2});
   test({V(13)}, {block3});
@@ -486,18 +486,18 @@ TEST(CompressedRelationReader, getBlocksForJoin) {
   // Test for only the `col0Id` fixed.
   test({std::vector{block2, block3, block4}, std::vector{blockB2, blockB3}});
   // Test with a fixed col1Id on both sides. We now join on the last column.
-  metadataAndBlocks.ids_.col1Id_ = V(20);
-  metadataAndBlocksB.ids_.col1Id_ = V(38);
+  metadataAndBlocks.ids_.setCol1Id(V(20));
+  metadataAndBlocksB.ids_.setCol1Id(V(38));
   test({std::vector{block4}, std::vector{blockB4, blockB5}});
 
   // Fix only the col1Id of the left input.
-  metadataAndBlocks.ids_.col1Id_ = V(4);
-  metadataAndBlocksB.ids_.col1Id_ = std::nullopt;
+  metadataAndBlocks.ids_.setCol1Id(V(4));
+  metadataAndBlocksB.ids_.setCol1Id(std::nullopt);
   test({std::vector{block2}, std::vector{blockB2, blockB3}});
 
   // Fix only the col1Id of the right input.
-  metadataAndBlocks.ids_.col1Id_ = std::nullopt;
-  metadataAndBlocksB.ids_.col1Id_ = V(7);
+  metadataAndBlocks.ids_.setCol1Id(std::nullopt);
+  metadataAndBlocksB.ids_.setCol1Id(V(7));
   test({std::vector{block4, block5}, std::vector{blockB3}});
 }
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -241,8 +241,8 @@ void testWithDifferentBlockSizes(const std::vector<RelationInput>& inputs,
 TEST(CompressedRelationWriter, SmallRelations) {
   std::vector<RelationInput> inputs;
   for (int i = 1; i < 200; ++i) {
-    inputs.push_back(RelationInput{
-        i, {{i - 1, i + 1}, { i - 1, i + 2}, {i, i - 1}}});
+    inputs.push_back(
+        RelationInput{i, {{i - 1, i + 1}, {i - 1, i + 2}, {i, i - 1}}});
   }
   testWithDifferentBlockSizes(inputs, "smallRelations");
 }

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -239,8 +239,8 @@ void testWithDifferentBlockSizes(const std::vector<RelationInput>& inputs,
 TEST(CompressedRelationWriter, SmallRelations) {
   std::vector<RelationInput> inputs;
   for (int i = 1; i < 200; ++i) {
-    inputs.push_back(
-        RelationInput{i, {{i - 1, i + 1}, {i - 1, i + 2}, {i, i - 1}}});
+    inputs.push_back(RelationInput{
+        i, {{i, i - 1, i + 1}, {i, i - 1, i + 2}, {i, i, i - 1}}});
   }
   testWithDifferentBlockSizes(inputs, "smallRelations");
 }

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -43,8 +43,7 @@ class HasPredicateScanTest : public ::testing::Test {
   void runTest(Operation& operation, const VectorTable& expectedElements) {
     auto expected = makeIdTableFromVector(expectedElements);
     auto res = operation.getResult();
-    EXPECT_THAT(res->idTable(),
-                ::testing::ElementsAreArray(expected));
+    EXPECT_THAT(res->idTable(), ::testing::ElementsAreArray(expected));
   }
 
   // Expect that the result of the `operation` matches the `expectedElements`,

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -43,10 +43,6 @@ class HasPredicateScanTest : public ::testing::Test {
   void runTest(Operation& operation, const VectorTable& expectedElements) {
     auto expected = makeIdTableFromVector(expectedElements);
     auto res = operation.getResult();
-    for (auto &[key, value] : operation.getExternallyVisibleVariableColumns()) {
-      LOG(INFO) << key.name() << ' ' << value.columnIndex_ << std::endl;
-
-    }
     EXPECT_THAT(res->idTable(),
                 ::testing::ElementsAreArray(expected));
   }
@@ -116,7 +112,7 @@ TEST_F(HasPredicateScanTest, subtree) {
   auto indexScan = ad_utility::makeExecutionTree<IndexScan>(
       qec, Permutation::Enum::OPS, SparqlTriple{V{"?x"}, "?y", "<o4>"});
   auto scan = HasPredicateScan{qec, indexScan, 1, V{"?predicate"}};
-  runTest(scan, {{p3, y, p}, {p3, y, p3}});
+  runTest(scan, {{y, p, p3}, {y, p3, p3}});
 }
 
 // ____________________________________________________________

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -42,7 +42,12 @@ class HasPredicateScanTest : public ::testing::Test {
   // Expect that the result of the `operation` matches the `expectedElements`.
   void runTest(Operation& operation, const VectorTable& expectedElements) {
     auto expected = makeIdTableFromVector(expectedElements);
-    EXPECT_THAT(operation.getResult()->idTable(),
+    auto res = operation.getResult();
+    for (auto &[key, value] : operation.getExternallyVisibleVariableColumns()) {
+      LOG(INFO) << key.name() << ' ' << value.columnIndex_ << std::endl;
+
+    }
+    EXPECT_THAT(res->idTable(),
                 ::testing::ElementsAreArray(expected));
   }
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -93,21 +93,27 @@ TEST(IndexTest, createFromTurtleTest) {
       Id c2 = getId("<c2>");
 
       // TODO<joka921> We could also test the multiplicities here.
-      ASSERT_TRUE(index.PSO().metaData().col0IdExists(b));
-      ASSERT_TRUE(index.PSO().metaData().col0IdExists(b2));
-      ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
-      ASSERT_FALSE(index.PSO().metaData().col0IdExists(c));
-      ASSERT_FALSE(index.PSO().metaData().col0IdExists(
-          Id::makeFromVocabIndex(VocabIndex::make(735))));
-      ASSERT_FALSE(index.PSO().metaData().getMetaData(b).isFunctional());
-      ASSERT_TRUE(index.PSO().metaData().getMetaData(b2).isFunctional());
+      ASSERT_TRUE(index.PSO().getMetadata(b).has_value());
+      ASSERT_TRUE(index.PSO().getMetadata(b2).has_value());
+      ASSERT_FALSE(index.PSO().getMetadata(a2).has_value());
+      ASSERT_FALSE(index.PSO().getMetadata(c).has_value());
+      ASSERT_FALSE(
+          index.PSO()
+              .getMetadata(Id::makeFromVocabIndex(VocabIndex::make(735)))
+              .has_value());
+      ASSERT_FALSE(index.PSO().getMetadata(b).value().isFunctional());
+      ASSERT_TRUE(index.PSO().getMetadata(b2).value().isFunctional());
 
-      ASSERT_TRUE(index.POS().metaData().col0IdExists(b));
-      ASSERT_TRUE(index.POS().metaData().col0IdExists(b2));
-      ASSERT_FALSE(index.POS().metaData().col0IdExists(a));
-      ASSERT_FALSE(index.POS().metaData().col0IdExists(c));
-      ASSERT_TRUE(index.POS().metaData().getMetaData(b).isFunctional());
-      ASSERT_TRUE(index.POS().metaData().getMetaData(b2).isFunctional());
+      ASSERT_TRUE(index.POS().getMetadata(b).has_value());
+      ASSERT_TRUE(index.POS().getMetadata(b2).has_value());
+      ASSERT_FALSE(index.POS().getMetadata(a2).has_value());
+      ASSERT_FALSE(index.POS().getMetadata(c).has_value());
+      ASSERT_FALSE(
+          index.POS()
+              .getMetadata(Id::makeFromVocabIndex(VocabIndex::make(735)))
+              .has_value());
+      ASSERT_TRUE(index.POS().getMetadata(b).value().isFunctional());
+      ASSERT_TRUE(index.POS().getMetadata(b2).value().isFunctional());
 
       // Relation b
       // Pair index
@@ -151,13 +157,13 @@ TEST(IndexTest, createFromTurtleTest) {
       Id c = getId("<c>");
       Id isA = getId("<is-a>");
 
-      ASSERT_TRUE(index.PSO().metaData().col0IdExists(isA));
-      ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
+      ASSERT_TRUE(index.PSO().getMetadata(isA).has_value());
+      ASSERT_FALSE(index.PSO().getMetadata(a).has_value());
 
-      ASSERT_FALSE(index.PSO().metaData().getMetaData(isA).isFunctional());
+      ASSERT_FALSE(index.PSO().getMetadata(isA).value().isFunctional());
 
-      ASSERT_TRUE(index.POS().metaData().col0IdExists(isA));
-      ASSERT_FALSE(index.POS().metaData().getMetaData(isA).isFunctional());
+      ASSERT_TRUE(index.POS().getMetadata(isA).has_value());
+      ASSERT_FALSE(index.POS().getMetadata(isA).value().isFunctional());
 
       auto testTwo = makeTestScanWidthTwo(index);
       testTwo("<is-a>", Permutation::PSO,
@@ -200,19 +206,19 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
   Id a = getId("<a>");
   Id c = getId("<c>");
 
-  ASSERT_TRUE(index.PSO().metaData().col0IdExists(b));
-  ASSERT_TRUE(index.PSO().metaData().col0IdExists(b2));
-  ASSERT_FALSE(index.PSO().metaData().col0IdExists(a));
-  ASSERT_FALSE(index.PSO().metaData().col0IdExists(c));
-  ASSERT_FALSE(index.PSO().metaData().getMetaData(b).isFunctional());
-  ASSERT_TRUE(index.PSO().metaData().getMetaData(b2).isFunctional());
+  ASSERT_TRUE(index.PSO().getMetadata(b).has_value());
+  ASSERT_TRUE(index.PSO().getMetadata(b2).has_value());
+  ASSERT_FALSE(index.PSO().getMetadata(a).has_value());
+  ASSERT_FALSE(index.PSO().getMetadata(c).has_value());
+  ASSERT_FALSE(index.PSO().getMetadata(b).value().isFunctional());
+  ASSERT_TRUE(index.PSO().getMetadata(b2).value().isFunctional());
 
-  ASSERT_TRUE(index.POS().metaData().col0IdExists(b));
-  ASSERT_TRUE(index.POS().metaData().col0IdExists(b2));
-  ASSERT_FALSE(index.POS().metaData().col0IdExists(a));
-  ASSERT_FALSE(index.POS().metaData().col0IdExists(c));
-  ASSERT_TRUE(index.POS().metaData().getMetaData(b).isFunctional());
-  ASSERT_TRUE(index.POS().metaData().getMetaData(b2).isFunctional());
+  ASSERT_TRUE(index.POS().getMetadata(b).has_value());
+  ASSERT_TRUE(index.POS().getMetadata(b2).has_value());
+  ASSERT_FALSE(index.POS().getMetadata(a).has_value());
+  ASSERT_FALSE(index.POS().getMetadata(c).has_value());
+  ASSERT_TRUE(index.POS().getMetadata(b).value().isFunctional());
+  ASSERT_TRUE(index.POS().getMetadata(b2).value().isFunctional());
 };
 
 TEST(IndexTest, indexId) {

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -333,10 +333,10 @@ TEST(IndexTest, emptyIndex) {
   const IndexImpl& emptyIndexWithoutCompression =
       getQec("", true, true, false)->getIndex().getImpl();
 
-  EXPECT_EQ(emptyIndexWithCompression.numTriples().normal_, 0u);
-  EXPECT_EQ(emptyIndexWithoutCompression.numTriples().normal_, 0u);
-  EXPECT_EQ(emptyIndexWithCompression.numTriples().internal_, 0u);
-  EXPECT_EQ(emptyIndexWithoutCompression.numTriples().internal_, 0u);
+  EXPECT_EQ(emptyIndexWithCompression.numTriples().normal, 0u);
+  EXPECT_EQ(emptyIndexWithoutCompression.numTriples().normal, 0u);
+  EXPECT_EQ(emptyIndexWithCompression.numTriples().internal, 0u);
+  EXPECT_EQ(emptyIndexWithoutCompression.numTriples().internal, 0u);
   auto test = makeTestScanWidthTwo(emptyIndexWithCompression);
   // Test that scanning an empty index works, but yields an empty permutation.
   test("<x>", Permutation::PSO, {});
@@ -511,35 +511,35 @@ TEST(IndexTest, NumDistinctEntities) {
   // TODO<joka921> Also check the number of triples and the number of
   // added things.
   auto subjects = index.numDistinctSubjects();
-  EXPECT_EQ(subjects.normal_, 3);
+  EXPECT_EQ(subjects.normal, 3);
   // All literals with language tags are added subjects.
-  EXPECT_EQ(subjects.internal_, 1);
+  EXPECT_EQ(subjects.internal, 1);
   EXPECT_EQ(subjects, index.numDistinctCol0(Permutation::SPO));
   EXPECT_EQ(subjects, index.numDistinctCol0(Permutation::SOP));
 
   auto predicates = index.numDistinctPredicates();
-  EXPECT_EQ(predicates.normal_, 2);
+  EXPECT_EQ(predicates.normal, 2);
   // The added predicates are `ql:has-pattern`, `ql:langtag`, and one added
   // predicate for each combination of predicate+language that is actually used
   // (e.g. `@en@label`).
-  EXPECT_EQ(predicates.internal_, 3);
+  EXPECT_EQ(predicates.internal, 3);
   EXPECT_EQ(predicates, index.numDistinctCol0(Permutation::PSO));
   EXPECT_EQ(predicates, index.numDistinctCol0(Permutation::POS));
 
   auto objects = index.numDistinctObjects();
-  EXPECT_EQ(objects.normal_, 7);
+  EXPECT_EQ(objects.normal, 7);
   // One added object for each language that is used.
   // Note: The pattern indices from the `ql:has-pattern` predicate are currently
-  // not part of `objects.internal_`, but they are also not very important.
-  EXPECT_EQ(objects.internal_, 1);
+  // not part of `objects.internal`, but they are also not very important.
+  EXPECT_EQ(objects.internal, 1);
   EXPECT_EQ(objects, index.numDistinctCol0(Permutation::OSP));
   EXPECT_EQ(objects, index.numDistinctCol0(Permutation::OPS));
 
   auto numTriples = index.numTriples();
-  EXPECT_EQ(numTriples.normal_, 7);
+  EXPECT_EQ(numTriples.normal, 7);
   // Two added triples for each triple that has an object with a language tag
   // and one triple per subject for the pattern.
-  EXPECT_EQ(numTriples.internal_, 5);
+  EXPECT_EQ(numTriples.internal, 5);
 
   auto multiplicities = index.getMultiplicities(Permutation::SPO);
   EXPECT_FLOAT_EQ(multiplicities[0], 12.0 / 4.0);

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -234,7 +234,8 @@ void testJoinOperation(Join& join, const ExpectedColumns& expected) {
   ASSERT_EQ(table.numColumns(), expected.size());
   for (const auto& [var, columnAndStatus] : expected) {
     const auto& [colIndex, undefStatus] = varToCols.at(var);
-    decltype(auto) column = table.getColumn(colIndex);
+    decltype(auto) columnSpan = table.getColumn(colIndex);
+    std::vector column(columnSpan.begin(), columnSpan.end());
     EXPECT_EQ(undefStatus, columnAndStatus.second);
     EXPECT_THAT(column, ::testing::ElementsAreArray(columnAndStatus.first))
         << "Columns for variable " << var.name() << " did not match";

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -291,8 +291,7 @@ TEST(JoinTest, joinWithFullScanPSO) {
   auto p = id("<p>");
   auto a = id("<a>");
   auto o = id("<o>");
-  auto expected = makeIdTableFromVector(
-      {{a, x, I(3)}, {o, x, x}});
+  auto expected = makeIdTableFromVector({{a, x, I(3)}, {o, x, x}});
   VariableToColumnMap expectedVariables{
       {Variable{"?p"}, makeAlwaysDefinedColumn(0)},
       {Variable{"?s"}, makeAlwaysDefinedColumn(1)},
@@ -311,16 +310,16 @@ TEST(JoinTest, joinWithFullScanPSO) {
         qec, OPS, SparqlTriple{Var{"?s2"}, "?p2", Var{"?s"}});
     // The knowledge graph is "<x> <p> 1 . <x> <o> <x> . <x> <a> 3 ."
     auto expected = makeIdTableFromVector(
-        {{x, a, I(3), o, x}, {x, o, x, o, x}, {x, p,  I(1), o, x}});
-    VariableToColumnMap expectedVariables {
-      {Variable{"?s"}, makeAlwaysDefinedColumn(0)},
-          {Variable{"?p"}, makeAlwaysDefinedColumn(1)},
-          {Variable{"?o"}, makeAlwaysDefinedColumn(2)},
-          {Variable{"?p2"}, makeAlwaysDefinedColumn(3)},
-          {Variable{"?s2"}, makeAlwaysDefinedColumn(4)}};
-          auto join = Join{qec, fullScanSPO, fullScanOPS, 0, 0};
-      testJoinOperation(join, makeExpectedColumns(expectedVariables, expected));
-    }
+        {{x, a, I(3), o, x}, {x, o, x, o, x}, {x, p, I(1), o, x}});
+    VariableToColumnMap expectedVariables{
+        {Variable{"?s"}, makeAlwaysDefinedColumn(0)},
+        {Variable{"?p"}, makeAlwaysDefinedColumn(1)},
+        {Variable{"?o"}, makeAlwaysDefinedColumn(2)},
+        {Variable{"?p2"}, makeAlwaysDefinedColumn(3)},
+        {Variable{"?s2"}, makeAlwaysDefinedColumn(4)}};
+    auto join = Join{qec, fullScanSPO, fullScanOPS, 0, 0};
+    testJoinOperation(join, makeExpectedColumns(expectedVariables, expected));
+  }
 }
 
 // The following two tests run different code depending on the setting of the

--- a/test/JoinTest.cpp
+++ b/test/JoinTest.cpp
@@ -286,8 +286,13 @@ TEST(JoinTest, joinWithFullScanPSO) {
   auto join = Join{qec, fullScanPSO, valuesTree, 0, 0};
 
   auto id = ad_utility::testing::makeGetId(qec->getIndex());
+
+  auto x = id("<x>");
+  auto p = id("<p>");
+  auto a = id("<a>");
+  auto o = id("<o>");
   auto expected = makeIdTableFromVector(
-      {{id("<a>"), id("<x>"), I(3)}, {id("<o>"), id("<x>"), id("<x>")}});
+      {{a, x, I(3)}, {o, x, x}});
   VariableToColumnMap expectedVariables{
       {Variable{"?p"}, makeAlwaysDefinedColumn(0)},
       {Variable{"?s"}, makeAlwaysDefinedColumn(1)},
@@ -304,14 +309,15 @@ TEST(JoinTest, joinWithFullScanPSO) {
         qec, SPO, SparqlTriple{Var{"?s"}, "?p", Var{"?o"}});
     auto fullScanOPS = ad_utility::makeExecutionTree<IndexScan>(
         qec, OPS, SparqlTriple{Var{"?s2"}, "?p2", Var{"?s"}});
+    // The knowledge graph is "<x> <p> 1 . <x> <o> <x> . <x> <a> 3 ."
     auto expected = makeIdTableFromVector(
-        {{id("<a>"), id("<x>"), I(3)}, {id("<o>"), id("<x>"), id("<x>")}});
+        {{x, a, I(3), o, x}, {x, o, x, o, x}, {x, p,  I(1), o, x}});
     VariableToColumnMap expectedVariables {
       {Variable{"?s"}, makeAlwaysDefinedColumn(0)},
           {Variable{"?p"}, makeAlwaysDefinedColumn(1)},
           {Variable{"?o"}, makeAlwaysDefinedColumn(2)},
-          {Variable{"?s2"}, makeAlwaysDefinedColumn(0)},
-          {Variable{"?p2"}, makeAlwaysDefinedColumn(1)}};
+          {Variable{"?p2"}, makeAlwaysDefinedColumn(3)},
+          {Variable{"?s2"}, makeAlwaysDefinedColumn(4)}};
           auto join = Join{qec, fullScanSPO, fullScanOPS, 0, 0};
       testJoinOperation(join, makeExpectedColumns(expectedVariables, expected));
     }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -254,20 +254,16 @@ TEST(QueryPlanner, joinOfTwoScans) {
 }
 
 TEST(QueryPlanner, testActorsBornInEurope) {
-  ParsedQuery pq = SparqlParser::parseQuery(
+  auto scan = h::IndexScanFromStrings;
+  h::expect(
       "PREFIX : <pre/>\n"
       "SELECT ?a \n "
       "WHERE {?a :profession :Actor . ?a :born-in ?c. ?c :in :Europe}\n"
-      "ORDER BY ?a");
-  QueryPlanner qp = makeQueryPlanner();
-  QueryExecutionTree qet = qp.createExecutionTree(pq);
-  ASSERT_EQ(27493u, qet.getCostEstimate());
-  ASSERT_EQ(qet.getCacheKey(),
-            "ORDER BY on columns:asc(0) \nJOIN\nSORT(internal) on "
-            "columns:asc(1) \nJOIN\nSCAN POS with P = \"<pre/profession>\", O "
-            "= \"<pre/Actor>\" join-column: [0]\n|X|\nSCAN PSO with P = "
-            "\"<pre/born-in>\" join-column: [0] join-column: [1]\n|X|\nSCAN "
-            "POS with P = \"<pre/in>\", O = \"<pre/Europe>\" join-column: [0]");
+      "ORDER BY ?a",
+      h::OrderBy(
+          h::UnorderedJoins(scan("?a", "<pre/profession>", "<pre/Actor>"),
+                            scan("?a", "<pre/born-in>", "?c"),
+                            scan("?c", "<pre/in>", "<pre/Europe>"))));
 }
 
 TEST(QueryPlanner, testStarTwoFree) {

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -261,7 +261,8 @@ TEST(QueryPlanner, testActorsBornInEurope) {
       "SELECT ?a \n "
       "WHERE {?a :profession :Actor . ?a :born-in ?c. ?c :in :Europe}\n"
       "ORDER BY ?a",
-      h::OrderBy({{Variable{"?a"}, Asc}},
+      h::OrderBy(
+          {{Variable{"?a"}, Asc}},
           h::UnorderedJoins(scan("?a", "<pre/profession>", "<pre/Actor>"),
                             scan("?a", "<pre/born-in>", "?c"),
                             scan("?c", "<pre/in>", "<pre/Europe>"))));

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -255,12 +255,13 @@ TEST(QueryPlanner, joinOfTwoScans) {
 
 TEST(QueryPlanner, testActorsBornInEurope) {
   auto scan = h::IndexScanFromStrings;
+  using enum ::OrderBy::AscOrDesc;
   h::expect(
       "PREFIX : <pre/>\n"
       "SELECT ?a \n "
       "WHERE {?a :profession :Actor . ?a :born-in ?c. ?c :in :Europe}\n"
       "ORDER BY ?a",
-      h::OrderBy(
+      h::OrderBy({{Variable{"?a"}, Asc}},
           h::UnorderedJoins(scan("?a", "<pre/profession>", "<pre/Actor>"),
                             scan("?a", "<pre/born-in>", "?c"),
                             scan("?c", "<pre/in>", "<pre/Europe>"))));

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -12,10 +12,10 @@
 #include "engine/Join.h"
 #include "engine/MultiColumnJoin.h"
 #include "engine/NeutralElementOperation.h"
+#include "engine/OrderBy.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/QueryPlanner.h"
 #include "engine/Sort.h"
-#include "engine/OrderBy.h"
 #include "engine/TextIndexScanForEntity.h"
 #include "engine/TextIndexScanForWord.h"
 #include "engine/TransitivePath.h"
@@ -247,13 +247,13 @@ constexpr auto Filter = [](std::string_view descriptor,
 };
 
 // Match an `OrderBy` operation
-constexpr auto OrderBy =
-    [](const ::OrderBy::SortedVariables& sortedVariables, const QetMatcher& childMatcher) {
-      return RootOperation<::OrderBy>(AllOf(
-          Property("getChildren", &Operation::getChildren,
-                   ElementsAre(Pointee(childMatcher))),
-          AD_PROPERTY(::OrderBy, getSortedVariables, Eq(sortedVariables))));
-    };
+constexpr auto OrderBy = [](const ::OrderBy::SortedVariables& sortedVariables,
+                            const QetMatcher& childMatcher) {
+  return RootOperation<::OrderBy>(
+      AllOf(Property("getChildren", &Operation::getChildren,
+                     ElementsAre(Pointee(childMatcher))),
+            AD_PROPERTY(::OrderBy, getSortedVariables, Eq(sortedVariables))));
+};
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -236,8 +236,14 @@ inline auto TransitivePath =
                       TransitivePathSideMatcher(right))));
     };
 
-// TODO<joka921> We also have to match the sorted variables etc.
-constexpr auto OrderBy = MatchTypeAndOrderedChildren<::OrderBy>;
+// Match an `OrderBy` operation
+constexpr auto OrderBy =
+    [](const ::OrderBy::SortedVariables& sortedVariables, const QetMatcher& childMatcher) {
+      return RootOperation<::OrderBy>(AllOf(
+          Property("getChildren", &Operation::getChildren,
+                   ElementsAre(Pointee(childMatcher))),
+          AD_PROPERTY(::OrderBy, getSortedVariables, Eq(sortedVariables))));
+    };
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -15,6 +15,7 @@
 #include "engine/QueryExecutionTree.h"
 #include "engine/QueryPlanner.h"
 #include "engine/Sort.h"
+#include "engine/OrderBy.h"
 #include "engine/TextIndexScanForEntity.h"
 #include "engine/TextIndexScanForWord.h"
 #include "engine/TransitivePath.h"
@@ -234,6 +235,9 @@ inline auto TransitivePath =
           AD_PROPERTY(TransitivePath, getRight,
                       TransitivePathSideMatcher(right))));
     };
+
+// TODO<joka921> We also have to match the sorted variables etc.
+constexpr auto OrderBy = MatchTypeAndOrderedChildren<::OrderBy>;
 
 /// Parse the given SPARQL `query`, pass it to a `QueryPlanner` with empty
 /// execution context, and return the resulting `QueryExecutionTree`

--- a/test/TriplesViewTest.cpp
+++ b/test/TriplesViewTest.cpp
@@ -14,13 +14,17 @@ auto V = ad_utility::testing::VocabId;
 // This struct mocks the structure of the actual `Permutation::Enum` types used
 // in QLever for testing the `TriplesView`.
 struct DummyPermutation {
-  IdTable scan(Id col0Id, std::optional<Id> col1Id) const {
-    IdTable result(2, ad_utility::makeUnlimitedAllocator<Id>());
+  IdTable scan(std::optional<Id> col0IdDummy, std::optional<Id> col1Id) const {
+    IdTable result(3, ad_utility::makeUnlimitedAllocator<Id>());
     AD_CORRECTNESS_CHECK(!col1Id.has_value());
-    result.reserve(col0Id.getVocabIndex().get());
-    for (size_t i = 0; i < col0Id.getVocabIndex().get(); ++i) {
-      result.push_back(std::array{V((i + 1) * col0Id.getVocabIndex().get()),
-                                  V((i + 2) * col0Id.getVocabIndex().get())});
+    AD_CORRECTNESS_CHECK(!col0IdDummy.has_value());
+    std::vector<Id> ids{V(1), V(3), V(5), V(7), V(8), V(10), V(13)};
+    for (auto col0Id : ids) {
+      for (size_t i = 0; i < col0Id.getVocabIndex().get(); ++i) {
+        result.push_back(std::array{col0Id,
+                                    V((i + 1) * col0Id.getVocabIndex().get()),
+                                    V((i + 2) * col0Id.getVocabIndex().get())});
+      }
     }
     return result;
   }
@@ -31,7 +35,7 @@ struct DummyPermutation {
       std::span<const ColumnIndex>, const auto&) const {
     AD_CORRECTNESS_CHECK(!blocks.has_value());
     // TODO<joka921> These tests have to be rewritten.
-    auto table = scan(ids.col0Id().value(), ids.col1Id());
+    auto table = scan(ids.col0Id(), ids.col1Id());
     co_yield table;
   }
 

--- a/test/TriplesViewTest.cpp
+++ b/test/TriplesViewTest.cpp
@@ -26,11 +26,12 @@ struct DummyPermutation {
   }
 
   cppcoro::generator<IdTable> lazyScan(
-      Id col0Id, std::optional<Id> col1Id,
+      CompressedRelationReader::ScanSpecification ids,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       std::span<const ColumnIndex>, const auto&) const {
     AD_CORRECTNESS_CHECK(!blocks.has_value());
-    auto table = scan(col0Id, col1Id);
+    // TODO<joka921> These tests have to be rewritten.
+    auto table = scan(ids.col0Id().value(), ids.col1Id());
     co_yield table;
   }
 

--- a/test/TriplesViewTest.cpp
+++ b/test/TriplesViewTest.cpp
@@ -30,12 +30,11 @@ struct DummyPermutation {
   }
 
   cppcoro::generator<IdTable> lazyScan(
-      CompressedRelationReader::ScanSpecification ids,
+      CompressedRelationReader::ScanSpecification scanSpec,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       std::span<const ColumnIndex>, const auto&) const {
     AD_CORRECTNESS_CHECK(!blocks.has_value());
-    // TODO<joka921> These tests have to be rewritten.
-    auto table = scan(ids.col0Id(), ids.col1Id());
+    auto table = scan(scanSpec.col0Id(), scanSpec.col1Id());
     co_yield table;
   }
 

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -88,7 +88,6 @@ void testLazyScanForJoinOfTwoScans(
 
 // Test that setting up the lazy partial scans between `tripleLeft` and
 // `tripleRight` on the given `kg` throws an exception.
-/*
 void testLazyScanThrows(const std::string& kg, const SparqlTriple& tripleLeft,
                         const SparqlTriple& tripleRight,
                         source_location l = source_location::current()) {
@@ -98,7 +97,6 @@ void testLazyScanThrows(const std::string& kg, const SparqlTriple& tripleLeft,
   IndexScan s2{qec, Permutation::PSO, tripleRight};
   EXPECT_ANY_THROW(IndexScan::lazyScanForJoinOfTwoScans(s1, s2));
 }
- */
 
 // Test that a lazy partial scan for a join of the `scanTriple` with a
 // materialized join column result that is specified by the `columnEntries`
@@ -136,8 +134,6 @@ void testLazyScanWithColumnThrows(
         TripleComponent{entry}.toValueId(qec->getIndex().getVocab()).value());
   }
 
-  // TODO<joka921> This works now, test it
-  /*
   // We need this to suppress the warning about a [[nodiscard]] return value
   // being unused.
   auto makeScan = [&column, &s1]() {
@@ -145,7 +141,6 @@ void testLazyScanWithColumnThrows(
         IndexScan::lazyScanForJoinOfColumnWithScan(column, s1);
   };
   EXPECT_ANY_THROW(makeScan());
-   */
 }
 }  // namespace
 
@@ -235,12 +230,10 @@ TEST(IndexScan, lazyScanForJoinOfTwoScans) {
   }
 
   // Corner cases
-  // TODO<joka921> These work now, test them.
-  /*
   {
     std::string kg = "<a> <b> <c> .";
-    // Triples with three variables are not supported.
     SparqlTriple xyz{Tc{Var{"?x"}}, "?y", Tc{Var{"?z"}}};
+    testLazyScanThrows(kg, xyz, xqz);
     testLazyScanThrows(kg, xyz, xqz);
     testLazyScanThrows(kg, xyz, xyz);
     testLazyScanThrows(kg, xqz, xyz);
@@ -253,7 +246,6 @@ TEST(IndexScan, lazyScanForJoinOfTwoScans) {
     // match.
     testLazyScanThrows(kg, abc, abc);
   }
-   */
 }
 
 TEST(IndexScan, lazyScanForJoinOfColumnWithScanTwoVariables) {
@@ -316,9 +308,11 @@ TEST(IndexScan, lazyScanForJoinOfColumnWithScanCornerCases) {
       "<b> <p> <B2> ."
       "<b> <q> <xb>. <b> <q> <xb2> .";
 
-  // Full index scans (three variables) are not supported.
+  // Full index scan (three variables).
   std::vector<std::string> column{"<a>", "<b>", "<q>", "<xb>"};
-  testLazyScanWithColumnThrows(kg, threeVars, column);
+  // only `<q>` matches (we join on the predicate), so we only get the last
+  // block.
+  testLazyScanForJoinWithColumn(kg, threeVars, column, {{5, 7}});
 
   // The join column must be sorted.
   if constexpr (ad_utility::areExpensiveChecksEnabled) {

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -338,7 +338,7 @@ TEST(IndexScan, additionalColumn) {
   ASSERT_THAT(scan.getExternallyVisibleVariableColumns(),
               ::testing::UnorderedElementsAreArray(expected));
   ASSERT_THAT(scan.getCacheKey(),
-              ::testing::ContainsRegex("Additional Columns: 2 3"));
+              ::testing::ContainsRegex("Additional Columns: 3 4"));
   auto res = scan.computeResultOnlyForTesting();
   auto getId = makeGetId(qec->getIndex());
   auto I = IntId;

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -88,6 +88,7 @@ void testLazyScanForJoinOfTwoScans(
 
 // Test that setting up the lazy partial scans between `tripleLeft` and
 // `tripleRight` on the given `kg` throws an exception.
+/*
 void testLazyScanThrows(const std::string& kg, const SparqlTriple& tripleLeft,
                         const SparqlTriple& tripleRight,
                         source_location l = source_location::current()) {
@@ -97,6 +98,7 @@ void testLazyScanThrows(const std::string& kg, const SparqlTriple& tripleLeft,
   IndexScan s2{qec, Permutation::PSO, tripleRight};
   EXPECT_ANY_THROW(IndexScan::lazyScanForJoinOfTwoScans(s1, s2));
 }
+ */
 
 // Test that a lazy partial scan for a join of the `scanTriple` with a
 // materialized join column result that is specified by the `columnEntries`
@@ -134,6 +136,8 @@ void testLazyScanWithColumnThrows(
         TripleComponent{entry}.toValueId(qec->getIndex().getVocab()).value());
   }
 
+  // TODO<joka921> This works now, test it
+  /*
   // We need this to suppress the warning about a [[nodiscard]] return value
   // being unused.
   auto makeScan = [&column, &s1]() {
@@ -141,6 +145,7 @@ void testLazyScanWithColumnThrows(
         IndexScan::lazyScanForJoinOfColumnWithScan(column, s1);
   };
   EXPECT_ANY_THROW(makeScan());
+   */
 }
 }  // namespace
 
@@ -230,6 +235,8 @@ TEST(IndexScan, lazyScanForJoinOfTwoScans) {
   }
 
   // Corner cases
+  // TODO<joka921> These work now, test them.
+  /*
   {
     std::string kg = "<a> <b> <c> .";
     // Triples with three variables are not supported.
@@ -246,6 +253,7 @@ TEST(IndexScan, lazyScanForJoinOfTwoScans) {
     // match.
     testLazyScanThrows(kg, abc, abc);
   }
+   */
 }
 
 TEST(IndexScan, lazyScanForJoinOfColumnWithScanTwoVariables) {

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -104,12 +104,15 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     checkConsistencyForCol0IdAndPermutation(objectId, OSP, 0, col0IdTag);
   };
 
-  auto cancellationHandle = std::make_shared<ad_utility::CancellationHandle<>>();
-  auto predicates = index.getImpl().PSO().getDistinctCol0IdsAndCounts(cancellationHandle);
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  auto predicates =
+      index.getImpl().PSO().getDistinctCol0IdsAndCounts(cancellationHandle);
   for (const auto& predicate : predicates.getColumn(0)) {
     checkConsistencyForPredicate(predicate);
   }
-  auto objects = index.getImpl().OSP().getDistinctCol0IdsAndCounts(cancellationHandle);
+  auto objects =
+      index.getImpl().OSP().getDistinctCol0IdsAndCounts(cancellationHandle);
   for (const auto& object : objects.getColumn(0)) {
     checkConsistencyForObject(object);
   }

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -103,13 +103,15 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     checkConsistencyForCol0IdAndPermutation(objectId, OPS, 1, col0IdTag);
     checkConsistencyForCol0IdAndPermutation(objectId, OSP, 0, col0IdTag);
   };
-  const auto& predicates = index.getImpl().PSO().metaData().data();
-  for (const auto& predicate : predicates) {
-    checkConsistencyForPredicate(predicate.col0Id_);
+
+  auto cancellationHandle = std::make_shared<ad_utility::CancellationHandle<>>();
+  auto predicates = index.getImpl().PSO().getDistinctCol0IdsAndCounts(cancellationHandle);
+  for (const auto& predicate : predicates.getColumn(0)) {
+    checkConsistencyForPredicate(predicate);
   }
-  const auto& objects = index.getImpl().OSP().metaData().data();
-  for (const auto& object : objects) {
-    checkConsistencyForObject(object.col0Id_);
+  auto objects = index.getImpl().OSP().getDistinctCol0IdsAndCounts(cancellationHandle);
+  for (const auto& object : objects.getColumn(0)) {
+    checkConsistencyForObject(object);
   }
   // NOTE: The SPO and SOP permutations currently don't have patterns stored.
   // with them.

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -83,12 +83,12 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
         ASSERT_EQ(scanResult.numColumns(), 4u);
         for (const auto& row : scanResult) {
           auto patternIdx =
-              row[ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN].getInt();
+              row[ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN - 1].getInt();
           Id subjectId = row[subjectColIdx];
           checkSingleElement(index, patternIdx, subjectId);
           Id objectId = objectColIdx == col0IdTag ? col0Id : row[objectColIdx];
           auto patternIdxObject =
-              row[ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN].getInt();
+              row[ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN - 1].getInt();
           checkSingleElement(index, patternIdxObject, objectId);
         }
       };
@@ -180,7 +180,7 @@ Index makeTestIndex(const std::string& indexBasename,
   ad_utility::setGlobalLoggingStream(&std::cout);
 
   if (usePatterns && loadAllPermutations) {
-    checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);
+    // checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);
   }
   return index;
 }

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -180,7 +180,7 @@ Index makeTestIndex(const std::string& indexBasename,
   ad_utility::setGlobalLoggingStream(&std::cout);
 
   if (usePatterns && loadAllPermutations) {
-     checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);
+    checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);
   }
   return index;
 }

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -180,7 +180,7 @@ Index makeTestIndex(const std::string& indexBasename,
   ad_utility::setGlobalLoggingStream(&std::cout);
 
   if (usePatterns && loadAllPermutations) {
-    // checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);
+     checkConsistencyBetweenPatternPredicateAndAdditionalColumn(index);
   }
   return index;
 }


### PR DESCRIPTION
The `col0Id` is now stored in each permutation (one of the `.index.???` files) just like the `col1Id` and the `col2Id`. The `.meta` file for each permutation now only stores information for those `col0Id` that span multiple blocks. Despite the increased capabilities (see below), the relevant code is now simpler and easier to understand because `col0Id`, `col1Id`, and `col2Id` can now be treated in an analogous fashion.

This change reduces the size of the `.meta` files to a small fraction of their previous size (they used to be very large for permutations with many "relations", that is, for SPO and SOP with many subjects, and for OSP and OPS with many objects). In contrast, the size of the `.index.???` files inceases only little because they are compressed and due to their sort order contain long runs of triples with the same `col0Id`. In total, this change reduces the total size of the index files by half or even more.

In a closely related change, full index scans (queries involving patterns like `?s ?p ?o` and which need to read the full triples with `col0Id`, `col1Id`, `col2Id` from a permutation), can now be treated just like normal scans. This removes a lot of the extra code that accumulated over time for the special treatment of full scans. Also, these scans are now as efficient (per block) as a normal index scan. Another nice side effect is that full scans with GROUP BY and COUNT can now be processed with the code from #1263.