### PR TITLE
Make the `SERVICE` operation cancellable

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -793,8 +793,7 @@ boost::asio::awaitable<void> Server::processQuery(
 template <std::invocable Function, typename T>
 Awaitable<T> Server::computeInNewThread(Function function,
                                         SharedCancellationHandle handle) {
-  std::shared_ptr<std::atomic_flag> timerRunning =
-      std::make_shared<std::atomic_flag>(true);
+  auto timerRunning = std::make_shared<std::atomic_flag>(true);
   auto inner = [function = std::move(function), timerRunning]() mutable -> T {
     timerRunning->clear();
     return std::invoke(std::move(function));

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -793,13 +793,19 @@ boost::asio::awaitable<void> Server::processQuery(
 template <std::invocable Function, typename T>
 Awaitable<T> Server::computeInNewThread(Function function,
                                         SharedCancellationHandle handle) {
-  auto inner = [function = std::move(function),
-                handle = std::move(handle)]() mutable -> T {
-    handle->resetWatchDogState();
+  std::shared_ptr<std::atomic_flag> timerRunning =
+      std::make_shared<std::atomic_flag>(true);
+  auto inner = [function = std::move(function), timerRunning]() mutable -> T {
+    timerRunning->clear();
     return std::invoke(std::move(function));
   };
-  return ad_utility::runFunctionOnExecutor(
-      threadPool_.get_executor(), std::move(inner), net::use_awaitable);
+  // interruptible doesn't make the awaitable return faster when cancelled,
+  // this might still block. However it will make the code check the
+  // cancellation handle while waiting for a thread in the pool to become ready.
+  return ad_utility::interruptible(
+      ad_utility::runFunctionOnExecutor(threadPool_.get_executor(),
+                                        std::move(inner), net::use_awaitable),
+      std::move(handle), std::move(timerRunning));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -112,9 +112,9 @@ ResultTable Service::computeResult() {
   // easy-to-parse format. It might not be the best choice regarding robustness
   // and portability though. In particular, we are not sure how deterministic
   // the TSV output is with respect to the precise encoding of literals.
-  std::istringstream tsvResult =
-      getTsvFunction_(serviceUrl, boost::beast::http::verb::post, serviceQuery,
-                      "application/sparql-query", "text/tab-separated-values");
+  std::istringstream tsvResult = getTsvFunction_(
+      serviceUrl, cancellationHandle_, boost::beast::http::verb::post,
+      serviceQuery, "application/sparql-query", "text/tab-separated-values");
 
   // The first line of the TSV result contains the variable names.
   std::string tsvHeaderRow;

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -113,7 +113,7 @@ ResultTable Service::computeResult() {
   // and portability though. In particular, we are not sure how deterministic
   // the TSV output is with respect to the precise encoding of literals.
   std::istringstream tsvResult = getTsvFunction_(
-      serviceUrl, cancellationHandle_, boost::beast::http::verb::post,
+      serviceUrl, *cancellationHandle_, boost::beast::http::verb::post,
       serviceQuery, "application/sparql-query", "text/tab-separated-values");
 
   // The first line of the TSV result contains the variable names.

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -113,7 +113,7 @@ ResultTable Service::computeResult() {
   // and portability though. In particular, we are not sure how deterministic
   // the TSV output is with respect to the precise encoding of literals.
   std::istringstream tsvResult = getTsvFunction_(
-      serviceUrl, *cancellationHandle_, boost::beast::http::verb::post,
+      serviceUrl, cancellationHandle_, boost::beast::http::verb::post,
       serviceQuery, "application/sparql-query", "text/tab-separated-values");
 
   // The first line of the TSV result contains the variable names.

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -4,8 +4,9 @@
 
 #include "engine/Service.h"
 
-#include "absl/strings/str_cat.h"
-#include "absl/strings/str_split.h"
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+
 #include "engine/CallFixedSize.h"
 #include "engine/Values.h"
 #include "engine/VariableToColumnMap.h"
@@ -13,6 +14,7 @@
 #include "parser/TurtleParser.h"
 #include "util/Exception.h"
 #include "util/HashSet.h"
+#include "util/Views.h"
 #include "util/http/HttpClient.h"
 #include "util/http/HttpUtils.h"
 
@@ -112,9 +114,10 @@ ResultTable Service::computeResult() {
   // easy-to-parse format. It might not be the best choice regarding robustness
   // and portability though. In particular, we are not sure how deterministic
   // the TSV output is with respect to the precise encoding of literals.
-  cppcoro::generator<std::string_view> tsvResult = getTsvFunction_(
-      serviceUrl, cancellationHandle_, boost::beast::http::verb::post,
-      serviceQuery, "application/sparql-query", "text/tab-separated-values");
+  cppcoro::generator<std::string_view> tsvResult = ad_utility::lineByLine(
+      getTsvFunction_(serviceUrl, cancellationHandle_,
+                      boost::beast::http::verb::post, serviceQuery,
+                      "application/sparql-query", "text/tab-separated-values"));
 
   // The first line of the TSV result contains the variable names.
   auto begin = tsvResult.begin();

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -151,6 +151,7 @@ template <size_t I>
 void Service::writeTsvResult(std::istringstream tsvResult, IdTable* idTablePtr,
                              LocalVocab* localVocab) {
   IdTableStatic<I> idTable = std::move(*idTablePtr).toStatic<I>();
+  checkCancellation();
   size_t rowIdx = 0;
   std::vector<size_t> numLocalVocabPerColumn(idTable.numColumns());
   std::string line;
@@ -179,6 +180,7 @@ void Service::writeTsvResult(std::istringstream tsvResult, IdTable* idTablePtr,
       }
     }
     rowIdx++;
+    checkCancellation();
   }
   if (idTable.size() > 1) {
     LOG(INFO) << "Last non-header row of TSV result: " << lastLine << std::endl;
@@ -188,4 +190,5 @@ void Service::writeTsvResult(std::istringstream tsvResult, IdTable* idTablePtr,
   LOG(INFO) << "Number of entries in local vocabulary per column: "
             << absl::StrJoin(numLocalVocabPerColumn, ", ") << std::endl;
   *idTablePtr = std::move(idTable).toDynamic();
+  checkCancellation();
 }

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -34,9 +34,9 @@ class Service : public Operation {
  public:
   // The type of the function used to obtain the results, see below.
   using GetTsvFunction = std::function<std::istringstream(
-      ad_utility::httpUtils::Url, ad_utility::SharedCancellationHandle handle,
-      const boost::beast::http::verb&, std::string_view, std::string_view,
-      std::string_view)>;
+      const ad_utility::httpUtils::Url&,
+      ad_utility::CancellationHandle<>& handle, const boost::beast::http::verb&,
+      std::string_view, std::string_view, std::string_view)>;
 
  private:
   // The parsed SERVICE clause.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -34,8 +34,9 @@ class Service : public Operation {
  public:
   // The type of the function used to obtain the results, see below.
   using GetTsvFunction = std::function<std::istringstream(
-      ad_utility::httpUtils::Url, const boost::beast::http::verb&,
-      std::string_view, std::string_view, std::string_view)>;
+      ad_utility::httpUtils::Url, ad_utility::SharedCancellationHandle handle,
+      const boost::beast::http::verb&, std::string_view, std::string_view,
+      std::string_view)>;
 
  private:
   // The parsed SERVICE clause.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -91,7 +91,7 @@ class Service : public Operation {
   // NOTE: This is similar to `Values::writeValues`, except that we have to
   // parse TSV here and not a VALUES clause. Note that the only reason that
   // `tsvResult` is not `const` here is because the method iterates over the
-  // `std::istringstream` and thus changes it.
+  // input range and thus changes it.
   template <size_t I>
   void writeTsvResult(cppcoro::generator<std::string_view> tsvResult,
                       IdTable* idTable, LocalVocab* localVocab);

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -33,7 +33,7 @@
 class Service : public Operation {
  public:
   // The type of the function used to obtain the results, see below.
-  using GetTsvFunction = std::function<std::istringstream(
+  using GetTsvFunction = std::function<cppcoro::generator<std::string_view>(
       const ad_utility::httpUtils::Url&,
       ad_utility::SharedCancellationHandle handle,
       const boost::beast::http::verb&, std::string_view, std::string_view,
@@ -93,6 +93,6 @@ class Service : public Operation {
   // `tsvResult` is not `const` here is because the method iterates over the
   // `std::istringstream` and thus changes it.
   template <size_t I>
-  void writeTsvResult(std::istringstream tsvResult, IdTable* idTable,
-                      LocalVocab* localVocab);
+  void writeTsvResult(cppcoro::generator<std::string_view> tsvResult,
+                      IdTable* idTable, LocalVocab* localVocab);
 };

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -35,8 +35,9 @@ class Service : public Operation {
   // The type of the function used to obtain the results, see below.
   using GetTsvFunction = std::function<std::istringstream(
       const ad_utility::httpUtils::Url&,
-      ad_utility::CancellationHandle<>& handle, const boost::beast::http::verb&,
-      std::string_view, std::string_view, std::string_view)>;
+      ad_utility::SharedCancellationHandle handle,
+      const boost::beast::http::verb&, std::string_view, std::string_view,
+      std::string_view)>;
 
  private:
   // The parsed SERVICE clause.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -33,7 +33,7 @@
 class Service : public Operation {
  public:
   // The type of the function used to obtain the results, see below.
-  using GetTsvFunction = std::function<cppcoro::generator<std::string_view>(
+  using GetTsvFunction = std::function<cppcoro::generator<std::span<std::byte>>(
       const ad_utility::httpUtils::Url&,
       ad_utility::SharedCancellationHandle handle,
       const boost::beast::http::verb&, std::string_view, std::string_view,

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -112,15 +112,15 @@ auto runFunctionOnExecutor(Executor executor, Function function,
 /// on an awaitable object that doesn't do this on its own. It's always better
 /// to integrate cancellation checks right into the awaitable itself, but
 /// sometimes this doesn't work because it's part of a library or boost asio
-/// itself.
+/// itself. Once `timerRunning` resolves to `false` (or the awaitable is
+/// finished, whatever happens first), the cancellation checks are stopped.
 template <typename T>
 inline net::awaitable<T> interruptible(
     net::awaitable<T> awaitable, ad_utility::SharedCancellationHandle handle,
+    std::shared_ptr<std::atomic_flag> timerRunning =
+        std::make_shared<std::atomic_flag>(true),
     ad_utility::source_location loc = ad_utility::source_location::current()) {
   using namespace net::experimental::awaitable_operators;
-
-  std::shared_ptr<std::atomic_flag> timerRunning =
-      std::make_shared<std::atomic_flag>(true);
 
   auto timerLoop = [](std::shared_ptr<std::atomic_flag> timerRunning,
                       ad_utility::SharedCancellationHandle handle,

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -108,6 +108,11 @@ auto runFunctionOnExecutor(Executor executor, Function function,
       std::move(initiatingFunction), completionToken);
 }
 
+/// Helper function, that checks a cancellation handle regularly while waiting
+/// on an awaitable object that doesn't do this on its own. It's always better
+/// to integrate cancellation checks right into the awaitable itself, but
+/// sometimes this doesn't work because it's part of a library or boost asio
+/// itself.
 template <typename T>
 inline net::awaitable<T> interruptible(
     net::awaitable<T> awaitable, ad_utility::SharedCancellationHandle handle,
@@ -154,7 +159,7 @@ inline net::awaitable<T> interruptible(
          wrapper(std::move(awaitable), std::move(timerRunning));
 }
 
-/// Helper method to wait for an awaitable that is supposed to be run on an io
+/// Helper function to wait for an awaitable that is supposed to be run on an io
 /// context.
 template <typename T>
 inline T runAndWaitForAwaitable(net::awaitable<T> awaitable,

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -7,6 +7,7 @@
 
 #include <future>
 #include <ranges>
+#include <span>
 
 #include "util/Generator.h"
 #include "util/Log.h"

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -199,6 +199,31 @@ auto inPlaceTransformView(Range&& range, Transformation transformation) {
                                           std::move(transformation));
 }
 
+/// Create a generator the consumes the input generator until it finds a newline
+/// character and the yields views of whole lines.
+inline cppcoro::generator<std::string_view> lineByLine(
+    cppcoro::generator<std::span<std::byte>> generator) {
+  std::string aggregateBuffer{};
+  for (auto span : generator) {
+    static_assert(sizeof(char) == sizeof(std::byte));
+    aggregateBuffer += std::string_view{
+        std::bit_cast<const char*>(&*span.begin()), span.size()};
+    size_t lastIndex = 0;
+    size_t currentIndex;
+    while ((currentIndex = aggregateBuffer.find_first_of('\n', lastIndex)) !=
+           std::string::npos) {
+      co_yield std::string_view{aggregateBuffer}.substr(
+          lastIndex, currentIndex - lastIndex);
+      lastIndex = currentIndex + 1;
+    }
+    aggregateBuffer.erase(0, lastIndex);
+  }
+  // Flush remaining buffer if not empty
+  if (!aggregateBuffer.empty()) {
+    co_yield aggregateBuffer;
+  }
+}
+
 }  // namespace ad_utility
 
 #endif  // QLEVER_VIEWS_H

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -202,14 +202,12 @@ auto inPlaceTransformView(Range&& range, Transformation transformation) {
 
 /// Create a generator the consumes the input generator until it finds the given
 /// separator and the yields spans of the chunks of data received in between.
-template <std::ranges::input_range Range,
-          typename SeparatorType =
-              decltype(*std::ranges::begin(std::declval<Range>()))>
-inline cppcoro::generator<std::span<SeparatorType>> reChunkAtSeparator(
-    Range generator, SeparatorType separator) {
-  std::vector<SeparatorType> buffer;
+template <std::ranges::input_range Range, typename ElementType>
+inline cppcoro::generator<std::span<ElementType>> reChunkAtSeparator(
+    Range generator, ElementType separator) {
+  std::vector<ElementType> buffer;
   for (std::ranges::input_range auto chunk : generator) {
-    for (SeparatorType c : chunk) {
+    for (ElementType c : chunk) {
       if (c == separator) {
         co_yield std::span{buffer.data(), buffer.size()};
         buffer.clear();

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -201,7 +201,7 @@ auto inPlaceTransformView(Range&& range, Transformation transformation) {
 }
 
 /// Create a generator the consumes the input generator until it finds the given
-/// separator and the yields spans of the chunks of data received in between.
+/// separator and the yields spans of the chunks of data received inbetween.
 template <std::ranges::input_range Range, typename ElementType>
 inline cppcoro::generator<std::span<ElementType>> reChunkAtSeparator(
     Range generator, ElementType separator) {

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -78,7 +78,6 @@ HttpClientImpl<StreamType>::~HttpClientImpl() {
                   "boost::asio::ssl::stream<boost::asio::ip::tcp::socket>");
     stream_->shutdown(ec);
   }
-  workGuard_.reset();
 }
 
 // ____________________________________________________________________________

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -117,19 +117,19 @@ HttpClientImpl<StreamType>::sendRequest(
   // the body as a `std::istringstream`.
   wait(http::async_write(*stream_, request, net::use_awaitable));
   beast::flat_buffer buffer;
-  http::response_parser<http::buffer_body> response_parser;
-  response_parser.body_limit(std::numeric_limits<std::uint64_t>::max());
-  wait(http::async_read_header(*stream_, buffer, response_parser,
+  http::response_parser<http::buffer_body> responseParser;
+  responseParser.body_limit(std::numeric_limits<std::uint64_t>::max());
+  wait(http::async_read_header(*stream_, buffer, responseParser,
                                net::use_awaitable));
   std::string aggregateBuffer;
-  while (!response_parser.is_done()) {
+  while (!responseParser.is_done()) {
     std::array<std::byte, 4096> staticBuffer;
-    response_parser.get().body().data = staticBuffer.data();
-    response_parser.get().body().size = staticBuffer.size();
+    responseParser.get().body().data = staticBuffer.data();
+    responseParser.get().body().size = staticBuffer.size();
 
-    wait(http::async_read_some(*stream_, buffer, response_parser,
+    wait(http::async_read_some(*stream_, buffer, responseParser,
                                net::use_awaitable));
-    size_t remainingBytes = response_parser.get().body().size;
+    size_t remainingBytes = responseParser.get().body().size;
     co_yield std::span{staticBuffer}.first(staticBuffer.size() -
                                            remainingBytes);
   }

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "util/CancellationHandle.h"
+#include "util/Generator.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/beast.h"
 
@@ -40,12 +41,12 @@ class HttpClientImpl {
 
   // Send a request (the first argument must be either `http::verb::get` or
   // `http::verb::post`) and return the body of the reponse (possibly very
-  // large) as an `std::istringstream`. The same connection can be used for
-  // multiple requests in a row.
+  // large) as an `cppcoro::generator<std::string_view>`. The same connection
+  // can be used for multiple requests in a row.
   //
   // TODO: Read and process the response in chunks. Here is a code example:
   // https://stackoverflow.com/questions/69011767/handling-large-http-response-using-boostbeast
-  std::istringstream sendRequest(
+  cppcoro::generator<std::string_view> sendRequest(
       const boost::beast::http::verb& method, std::string_view host,
       std::string_view target, ad_utility::SharedCancellationHandle handle,
       std::string_view requestBody = "",
@@ -80,7 +81,7 @@ using HttpsClient =
 // URL and obtaining the result as a `std::istringstream`. The protocol (HTTP or
 // HTTPS) is chosen automatically based on the URL. The `requestBody` is the
 // payload sent for POST requests (default: empty).
-std::istringstream sendHttpOrHttpsRequest(
+cppcoro::generator<std::string_view> sendHttpOrHttpsRequest(
     const ad_utility::httpUtils::Url& url,
     ad_utility::SharedCancellationHandle handle,
     const boost::beast::http::verb& method = boost::beast::http::verb::get,

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -15,7 +15,7 @@
 // order of the includes should not matter, and it should certainly not cause
 // segmentation faults.
 
-#include <sstream>
+#include <span>
 #include <string>
 
 #include "util/CancellationHandle.h"
@@ -75,9 +75,9 @@ using HttpsClient =
     HttpClientImpl<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>;
 
 // Global convenience function for sending a request (default: GET) to the given
-// URL and obtaining the result as a `std::istringstream`. The protocol (HTTP or
-// HTTPS) is chosen automatically based on the URL. The `requestBody` is the
-// payload sent for POST requests (default: empty).
+// URL and obtaining the result as a `cppcoro::generator<std::span<std::byte>>`.
+// The protocol (HTTP or HTTPS) is chosen automatically based on the URL. The
+// `requestBody` is the payload sent for POST requests (default: empty).
 cppcoro::generator<std::span<std::byte>> sendHttpOrHttpsRequest(
     const ad_utility::httpUtils::Url& url,
     ad_utility::SharedCancellationHandle handle,

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -43,7 +43,7 @@ class HttpClientImpl {
   // `http::verb::post`) and return the body of the reponse (possibly very
   // large) as an `cppcoro::generator<std::string_view>`. The same connection
   // can be used for multiple requests in a row.
-  cppcoro::generator<std::string_view> sendRequest(
+  cppcoro::generator<std::span<std::byte>> sendRequest(
       const boost::beast::http::verb& method, std::string_view host,
       std::string_view target, ad_utility::SharedCancellationHandle handle,
       std::string_view requestBody = "",
@@ -78,7 +78,7 @@ using HttpsClient =
 // URL and obtaining the result as a `std::istringstream`. The protocol (HTTP or
 // HTTPS) is chosen automatically based on the URL. The `requestBody` is the
 // payload sent for POST requests (default: empty).
-cppcoro::generator<std::string_view> sendHttpOrHttpsRequest(
+cppcoro::generator<std::span<std::byte>> sendHttpOrHttpsRequest(
     const ad_utility::httpUtils::Url& url,
     ad_utility::SharedCancellationHandle handle,
     const boost::beast::http::verb& method = boost::beast::http::verb::get,

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -47,7 +47,7 @@ class HttpClientImpl {
   // https://stackoverflow.com/questions/69011767/handling-large-http-response-using-boostbeast
   std::istringstream sendRequest(
       const boost::beast::http::verb& method, std::string_view host,
-      std::string_view target, ad_utility::SharedCancellationHandle handle,
+      std::string_view target, ad_utility::CancellationHandle<>& handle,
       std::string_view requestBody = "",
       std::string_view contentTypeHeader = "text/plain",
       std::string_view acceptHeader = "text/plain");
@@ -77,7 +77,8 @@ using HttpsClient =
 // HTTPS) is chosen automatically based on the URL. The `requestBody` is the
 // payload sent for POST requests (default: empty).
 std::istringstream sendHttpOrHttpsRequest(
-    ad_utility::httpUtils::Url url, ad_utility::SharedCancellationHandle handle,
+    const ad_utility::httpUtils::Url& url,
+    ad_utility::CancellationHandle<>& handle,
     const boost::beast::http::verb& method = boost::beast::http::verb::get,
     std::string_view postData = "",
     std::string_view contentTypeHeader = "text/plain",

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -43,9 +43,6 @@ class HttpClientImpl {
   // `http::verb::post`) and return the body of the reponse (possibly very
   // large) as an `cppcoro::generator<std::string_view>`. The same connection
   // can be used for multiple requests in a row.
-  //
-  // TODO: Read and process the response in chunks. Here is a code example:
-  // https://stackoverflow.com/questions/69011767/handling-large-http-response-using-boostbeast
   cppcoro::generator<std::string_view> sendRequest(
       const boost::beast::http::verb& method, std::string_view host,
       std::string_view target, ad_utility::SharedCancellationHandle handle,

--- a/test/AsioHelpersTest.cpp
+++ b/test/AsioHelpersTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "util/AsioHelpers.h"
+#include "util/AsyncTestHelpers.h"
 #include "util/http/beast.h"
 
 using namespace ad_utility;
@@ -111,4 +112,56 @@ TEST(AsioHelpers, runFunctionOnExecutorStrands) {
   ctx.poll();
   fut.get();
   EXPECT_EQ(sanityCounter, 2);
+}
+
+// _________________________________________________________________________
+ASYNC_TEST(AsioHelpers, verifyInterruptibleDoesCheckCancellationHandle) {
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  handle->cancel(ad_utility::CancellationState::MANUAL);
+  auto sleeperTask = []() -> net::awaitable<void> {
+    net::steady_timer timer{co_await net::this_coro::executor,
+                            DESIRED_CANCELLATION_CHECK_INTERVAL * 2};
+    co_await timer.async_wait(net::deferred);
+  }();
+
+  EXPECT_THROW(
+      co_await ad_utility::interruptible(std::move(sleeperTask), handle),
+      ad_utility::CancellationException);
+}
+
+// _________________________________________________________________________
+ASYNC_TEST(AsioHelpers, verifyNoCheckIsPerformedWhenTimerIsCancelledEarly) {
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  handle->cancel(ad_utility::CancellationState::MANUAL);
+  auto sleeperTask = []() -> net::awaitable<void> { co_return; }();
+
+  EXPECT_NO_THROW(co_await ad_utility::interruptible(
+      std::move(sleeperTask), handle,
+      std::make_shared<std::atomic_flag>(false)));
+}
+
+// _________________________________________________________________________
+TEST(AsioHelpers, makeSureRunAndWaitForAwaitableWorksAsExpected) {
+  net::io_context ioContext;
+  auto workGuard = makeWorkGuard(ioContext);
+  auto task = []() -> net::awaitable<int> { co_return 42; }();
+
+  EXPECT_EQ(42, ad_utility::runAndWaitForAwaitable(std::move(task), ioContext));
+}
+
+// _________________________________________________________________________
+TEST(AsioHelpers, makeSureRunAndWaitForAwaitablePropagatesErrorCorrectly) {
+  net::io_context ioContext;
+  auto workGuard = makeWorkGuard(ioContext);
+  auto task = []() -> net::awaitable<int> {
+    throw std::exception{};
+    // Make the compiler throw the exception as part of the coroutine, not
+    // when creating it.
+    co_return 0;
+  }();
+
+  EXPECT_THROW(ad_utility::runAndWaitForAwaitable(std::move(task), ioContext),
+               std::exception);
 }

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -2,12 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Author: Hannah Bast (bast@cs.uni-freiburg.de)
 
+#include <absl/strings/str_cat.h>
 #include <gtest/gtest.h>
 
 #include <thread>
 
-#include "./HttpTestHelpers.h"
-#include "absl/strings/str_cat.h"
+#include "HttpTestHelpers.h"
 #include "util/http/HttpClient.h"
 #include "util/http/HttpServer.h"
 #include "util/http/HttpUtils.h"
@@ -17,14 +17,17 @@
 using namespace ad_utility::httpUtils;
 using namespace boost::beast::http;
 
-std::vector<std::string> toVector(
-    cppcoro::generator<std::string_view> generator) {
-  std::vector<std::string> result;
-  for (std::string_view view : generator) {
-    result.emplace_back(view);
+namespace {
+
+/// Join all of the bytes into a big string.
+std::string toString(cppcoro::generator<std::span<std::byte>> generator) {
+  std::string result;
+  for (std::byte byte : generator | std::ranges::views::join) {
+    result.push_back(static_cast<char>(byte));
   }
   return result;
 }
+}  // namespace
 
 TEST(HttpServer, HttpTest) {
   ad_utility::SharedCancellationHandle handle =
@@ -70,13 +73,13 @@ TEST(HttpServer, HttpTest) {
             {
               HttpClient httpClient("localhost",
                                     std::to_string(httpServer.getPort()));
-              ASSERT_EQ(toVector(httpClient.sendRequest(verb::get, "localhost",
+              ASSERT_EQ(toString(httpClient.sendRequest(verb::get, "localhost",
                                                         "target1", handle)),
-                        (std::vector<std::string>{"GET", "target1"}));
+                        "GET\ntarget1\n");
               ASSERT_EQ(
-                  toVector(httpClient.sendRequest(verb::post, "localhost",
+                  toString(httpClient.sendRequest(verb::post, "localhost",
                                                   "target1", handle, "body1")),
-                  (std::vector<std::string>{"POST", "target1", "body1"}));
+                  "POST\ntarget1\nbody1");
             }
           }
         });
@@ -87,12 +90,12 @@ TEST(HttpServer, HttpTest) {
     // fine with the server after we have communicated with it for one session).
     {
       HttpClient httpClient("localhost", std::to_string(httpServer.getPort()));
-      ASSERT_EQ(toVector(httpClient.sendRequest(verb::get, "localhost",
+      ASSERT_EQ(toString(httpClient.sendRequest(verb::get, "localhost",
                                                 "target2", handle)),
-                (std::vector<std::string>{"GET", "target2"}));
-      ASSERT_EQ(toVector(httpClient.sendRequest(verb::post, "localhost",
+                "GET\ntarget2\n");
+      ASSERT_EQ(toString(httpClient.sendRequest(verb::post, "localhost",
                                                 "target2", handle, "body2")),
-                (std::vector<std::string>{"POST", "target2", "body2"}));
+                "POST\ntarget2\nbody2");
     }
 
     // Test if websocket is correctly opened and closed
@@ -121,11 +124,11 @@ TEST(HttpServer, HttpTest) {
     {
       Url url{
           absl::StrCat("http://localhost:", httpServer.getPort(), "/target")};
-      ASSERT_EQ(toVector(sendHttpOrHttpsRequest(url, handle, verb::get)),
-                (std::vector<std::string>{"GET", "/target"}));
+      ASSERT_EQ(toString(sendHttpOrHttpsRequest(url, handle, verb::get)),
+                "GET\n/target\n");
       ASSERT_EQ(
-          toVector(sendHttpOrHttpsRequest(url, handle, verb::post, "body")),
-          (std::vector<std::string>{"POST", "/target", "body"}));
+          toString(sendHttpOrHttpsRequest(url, handle, verb::post, "body")),
+          "POST\n/target\nbody");
     }
 
     // Check that after shutting down, no more new connections are accepted.

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -18,7 +18,8 @@ using namespace ad_utility::httpUtils;
 using namespace boost::beast::http;
 
 TEST(HttpServer, HttpTest) {
-  ad_utility::CancellationHandle<> handle{};
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
   // This test used to spuriously crash because of something that we (joka92,
   // RobinTF) currently consider to be a bug in Boost::ASIO. (See
   // `util/http/beast.h` for details). Repeat this test several times to make

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -18,8 +18,7 @@ using namespace ad_utility::httpUtils;
 using namespace boost::beast::http;
 
 TEST(HttpServer, HttpTest) {
-  ad_utility::SharedCancellationHandle handle =
-      std::make_shared<ad_utility::CancellationHandle<>>();
+  ad_utility::CancellationHandle<> handle{};
   // This test used to spuriously crash because of something that we (joka92,
   // RobinTF) currently consider to be a bug in Boost::ASIO. (See
   // `util/http/beast.h` for details). Repeat this test several times to make

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -43,8 +43,8 @@ class ServiceTest : public ::testing::Test {
   static auto constexpr getTsvFunctionFactory =
       [](const std::string& expectedUrl, const std::string& expectedSparqlQuery,
          const std::string& predefinedResult) -> Service::GetTsvFunction {
-    return [=](ad_utility::httpUtils::Url url,
-               ad_utility::SharedCancellationHandle,
+    return [=](const ad_utility::httpUtils::Url& url,
+               ad_utility::CancellationHandle<>&,
                const boost::beast::http::verb& method,
                std::string_view postData, std::string_view contentTypeHeader,
                std::string_view acceptHeader) -> std::istringstream {

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -44,7 +44,7 @@ class ServiceTest : public ::testing::Test {
       [](const std::string& expectedUrl, const std::string& expectedSparqlQuery,
          const std::string& predefinedResult) -> Service::GetTsvFunction {
     return [=](const ad_utility::httpUtils::Url& url,
-               ad_utility::CancellationHandle<>&,
+               ad_utility::SharedCancellationHandle,
                const boost::beast::http::verb& method,
                std::string_view postData, std::string_view contentTypeHeader,
                std::string_view acceptHeader) -> std::istringstream {

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -44,6 +44,7 @@ class ServiceTest : public ::testing::Test {
       [](const std::string& expectedUrl, const std::string& expectedSparqlQuery,
          const std::string& predefinedResult) -> Service::GetTsvFunction {
     return [=](ad_utility::httpUtils::Url url,
+               ad_utility::SharedCancellationHandle,
                const boost::beast::http::verb& method,
                std::string_view postData, std::string_view contentTypeHeader,
                std::string_view acceptHeader) -> std::istringstream {

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -79,7 +79,7 @@ class ServiceTest : public ::testing::Test {
           co_yield std::as_writable_bytes(std::span{resultCopy});
           start += size;
         }
-      }(std::string{predefinedResult});
+      }(predefinedResult);
     };
   };
 };

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -217,6 +217,26 @@ TEST(Views, verifyLineByLineWorksWithMinimalChunks) {
 }
 
 // __________________________________________________________________________
+TEST(Views, verifyLineByLineWorksWithNoTrailingNewline) {
+  auto generator = []() -> cppcoro::generator<std::span<std::byte>> {
+    std::string_view values = "abc";
+    for (char c : values) {
+      std::byte wrapper = static_cast<std::byte>(c);
+      co_yield std::span{&wrapper, 1};
+    }
+  }();
+
+  auto lineByLineGenerator = ad_utility::lineByLine(std::move(generator));
+
+  auto iterator = lineByLineGenerator.begin();
+  ASSERT_NE(iterator, lineByLineGenerator.end());
+  EXPECT_EQ(*iterator, "abc");
+
+  ++iterator;
+  ASSERT_EQ(iterator, lineByLineGenerator.end());
+}
+
+// __________________________________________________________________________
 TEST(Views, verifyLineByLineWorksWithChunksBiggerThanLines) {
   auto generator = []() -> cppcoro::generator<std::span<std::byte>> {
     auto range = std::string_view{"\nabc\ndefghij\n"} |

--- a/test/util/AsyncTestHelpers.h
+++ b/test/util/AsyncTestHelpers.h
@@ -74,20 +74,22 @@ void runAsyncTest(Func innerRun, size_t numThreads) {
   test_suite_name##_##test_name##_impl
 
 #define ASYNC_TEST_N(test_suite_name, test_name, num_threads)              \
-  net::awaitable<void> TEST_IMPL_NAME(test_suite_name,                     \
-                                      test_name)(net::io_context&);        \
+  net::awaitable<void> TEST_IMPL_NAME(                                     \
+      test_suite_name, test_name)([[maybe_unused]] net::io_context&);      \
   TEST(test_suite_name, test_name) {                                       \
     runAsyncTest(TEST_IMPL_NAME(test_suite_name, test_name), num_threads); \
   }                                                                        \
-  net::awaitable<void> TEST_IMPL_NAME(test_suite_name,                     \
-                                      test_name)(net::io_context & ioContext)
+  net::awaitable<void> TEST_IMPL_NAME(test_suite_name, test_name)(         \
+      [[maybe_unused]] net::io_context & ioContext)
 
 #define ASIO_TEST_N(test_suite_name, test_name, num_threads)               \
-  void TEST_IMPL_NAME(test_suite_name, test_name)(net::io_context&);       \
+  void TEST_IMPL_NAME(test_suite_name,                                     \
+                      test_name)([[maybe_unused]] net::io_context&);       \
   TEST(test_suite_name, test_name) {                                       \
     runAsyncTest(TEST_IMPL_NAME(test_suite_name, test_name), num_threads); \
   }                                                                        \
-  void TEST_IMPL_NAME(test_suite_name, test_name)(net::io_context & ioContext)
+  void TEST_IMPL_NAME(test_suite_name,                                     \
+                      test_name)([[maybe_unused]] net::io_context & ioContext)
 
 // Drop-in replacement for gtest's TEST() macro, but for tests that make
 // use of boost asio's awaitable coroutines. Note that this prevents you


### PR DESCRIPTION
This required some non-trivial changes to the `Service` and `HttpClient` classes, because making a network read operation in Boost ASIO cancellable in Code that is not already asynchronous and without blocking a worker thread is non-trivial.