### PR TITLE
Make the tests for the HTTP server fast again.

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -793,15 +793,18 @@ boost::asio::awaitable<void> Server::processQuery(
 template <std::invocable Function, typename T>
 Awaitable<T> Server::computeInNewThread(Function function,
                                         SharedCancellationHandle handle) {
-  std::promise<std::function<void()>> callbackPromise{};
-  auto callbackFuture = callbackPromise.get_future();
+  // `interruptible` will set the shared state of this promise
+  // with a function that can be used to cancel the timer.
+  std::promise<std::function<void()>> cancelTimerPromise{};
+  auto cancelTimerFuture = cancelTimerPromise.get_future();
 
   auto inner = [function = std::move(function),
-                callbackFuture = std::move(callbackFuture)]() mutable -> T {
+                cancelTimerFuture =
+                    std::move(cancelTimerFuture)]() mutable -> T {
     // Ensure future is ready by the time this is called.
-    AD_CORRECTNESS_CHECK(callbackFuture.wait_for(std::chrono::milliseconds{
+    AD_CORRECTNESS_CHECK(cancelTimerFuture.wait_for(std::chrono::milliseconds{
                              0}) == std::future_status::ready);
-    callbackFuture.get()();
+    cancelTimerFuture.get()();
     return std::invoke(std::move(function));
   };
   // interruptible doesn't make the awaitable return faster when cancelled,
@@ -810,7 +813,7 @@ Awaitable<T> Server::computeInNewThread(Function function,
   return ad_utility::interruptible(
       ad_utility::runFunctionOnExecutor(threadPool_.get_executor(),
                                         std::move(inner), net::use_awaitable),
-      std::move(handle), std::move(callbackPromise));
+      std::move(handle), std::move(cancelTimerPromise));
 }
 
 // _____________________________________________________________________________

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -148,7 +148,7 @@ inline net::awaitable<T> interruptible(
   auto wrapper = [](net::awaitable<T> awaitable,
                     std::shared_ptr<net::steady_timer> timer) mutable
       -> net::awaitable<T> {
-    absl::Cleanup cleanup{[timer = std::move(timer)]() {
+    absl::Cleanup cleanup{[timer = std::move(timer)]() mutable {
       auto strand = timer->get_executor();
       net::dispatch(strand, [timer = std::move(timer)]() { timer->cancel(); });
     }};

--- a/src/util/AsioHelpers.h
+++ b/src/util/AsioHelpers.h
@@ -112,28 +112,33 @@ auto runFunctionOnExecutor(Executor executor, Function function,
 /// on an awaitable object that doesn't do this on its own. It's always better
 /// to integrate cancellation checks right into the awaitable itself, but
 /// sometimes this doesn't work because it's part of a library or boost asio
-/// itself. Once `timerRunning` resolves to `false` (or the awaitable is
-/// finished, whatever happens first), the cancellation checks are stopped.
-/// This needs to be called on a strand or in a single-threaded environment,
-/// otherwise this may lead to race conditions, due to issues with boost asio.
+/// itself. Once the value for `cancelCallback` is set and called by the caller
+/// of this function (or the awaitable is finished, whatever happens first), the
+/// cancellation checks are stopped. This needs to be called on a strand or in a
+/// single-threaded environment, otherwise this will lead to race conditions,
+/// due to issues with boost asio.
 template <typename T>
 inline net::awaitable<T> interruptible(
     net::awaitable<T> awaitable, ad_utility::SharedCancellationHandle handle,
-    std::shared_ptr<std::atomic_flag> timerRunning =
-        std::make_shared<std::atomic_flag>(true),
+    std::promise<std::function<void()>> cancelCallback,
     ad_utility::source_location loc = ad_utility::source_location::current()) {
   using namespace net::experimental::awaitable_operators;
+  auto timer =
+      std::make_shared<net::steady_timer>(co_await net::this_coro::executor);
+  // Provide callback to outer world in order to cancel the timer pre-emptively.
+  cancelCallback.set_value([timer]() {
+    auto strand = timer->get_executor();
+    net::dispatch(strand, [timer = std::move(timer)]() { timer->cancel(); });
+  });
 
-  auto timerLoop = [](std::shared_ptr<std::atomic_flag> timerRunning,
+  auto timerLoop = [](std::shared_ptr<net::steady_timer> timer,
                       ad_utility::SharedCancellationHandle handle,
                       ad_utility::source_location loc) -> net::awaitable<void> {
     constexpr auto timeout = DESIRED_CANCELLATION_CHECK_INTERVAL / 2;
-    absl::Cleanup cleanup{[&timerRunning]() { timerRunning->clear(); }};
-    net::steady_timer timer{co_await net::this_coro::executor};
-    while (timerRunning->test()) {
+    while (true) {
       handle->throwIfCancelled(loc);
-      timer.expires_after(timeout);
-      auto [ec] = co_await timer.async_wait(net::as_tuple(net::deferred));
+      timer->expires_after(timeout);
+      auto [ec] = co_await timer->async_wait(net::as_tuple(net::deferred));
       if (ec) {
         AD_CORRECTNESS_CHECK(ec == net::error::operation_aborted);
         break;
@@ -141,22 +146,33 @@ inline net::awaitable<T> interruptible(
     }
   };
   auto wrapper = [](net::awaitable<T> awaitable,
-                    std::shared_ptr<std::atomic_flag> timerRunning) mutable
+                    std::shared_ptr<net::steady_timer> timer) mutable
       -> net::awaitable<T> {
-    absl::Cleanup cleanup{
-        [timerRunning = std::move(timerRunning)]() { timerRunning->clear(); }};
+    absl::Cleanup cleanup{[timer = std::move(timer)]() {
+      auto strand = timer->get_executor();
+      net::dispatch(strand, [timer = std::move(timer)]() { timer->cancel(); });
+    }};
     co_return co_await std::move(awaitable);
   };
 
-  auto timerClone = timerRunning;
+  auto timerClone = timer;
   try {
     co_return co_await (
         timerLoop(std::move(timerClone), std::move(handle), std::move(loc)) &&
-        wrapper(std::move(awaitable), std::move(timerRunning)));
+        wrapper(std::move(awaitable), std::move(timer)));
   } catch (const net::multiple_exceptions& e) {
     // Ignore other exceptions
     std::rethrow_exception(e.first_exception());
   }
+}
+
+/// Overload without an explicit promise object passed for convenience.
+template <typename T>
+inline net::awaitable<T> interruptible(
+    net::awaitable<T> awaitable, ad_utility::SharedCancellationHandle handle,
+    ad_utility::source_location loc = ad_utility::source_location::current()) {
+  return interruptible(std::move(awaitable), std::move(handle),
+                       std::promise<std::function<void()>>{}, std::move(loc));
 }
 
 /// Helper function to wait for an awaitable that is supposed to be run on an io

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -107,9 +107,7 @@ HttpClientImpl<StreamType>::sendRequest(
                   ad_utility::source_location loc =
                       ad_utility::source_location::current()) -> T {
     return ad_utility::runAndWaitForAwaitable(
-        ad_utility::interruptible(std::move(awaitable), handle,
-                                  std::make_shared<std::atomic_flag>(true),
-                                  std::move(loc)),
+        ad_utility::interruptible(std::move(awaitable), handle, std::move(loc)),
         ioContext_);
   };
 

--- a/test/AsioHelpersTest.cpp
+++ b/test/AsioHelpersTest.cpp
@@ -20,7 +20,8 @@ TEST(AsioHelpers, runFunctionOnExecutorVoid) {
   net::io_context ctx;
   bool a = false;
   auto workGuard = makeWorkGuard(ctx);
-  runFunctionOnExecutor(ctx.get_executor(), [&]() { a = true; }, net::detached);
+  runFunctionOnExecutor(
+      ctx.get_executor(), [&]() { a = true; }, net::detached);
   EXPECT_FALSE(a);
   ctx.poll();
   EXPECT_TRUE(a);

--- a/test/AsioHelpersTest.cpp
+++ b/test/AsioHelpersTest.cpp
@@ -20,8 +20,7 @@ TEST(AsioHelpers, runFunctionOnExecutorVoid) {
   net::io_context ctx;
   bool a = false;
   auto workGuard = makeWorkGuard(ctx);
-  runFunctionOnExecutor(
-      ctx.get_executor(), [&]() { a = true; }, net::detached);
+  runFunctionOnExecutor(ctx.get_executor(), [&]() { a = true; }, net::detached);
   EXPECT_FALSE(a);
   ctx.poll();
   EXPECT_TRUE(a);
@@ -160,15 +159,21 @@ ASYNC_TEST(AsioHelpers, verifyInterruptibleDoesPropagateError) {
 }
 
 // _________________________________________________________________________
-ASYNC_TEST(AsioHelpers, verifyNoCheckIsPerformedWhenTimerIsCancelledEarly) {
+ASYNC_TEST(AsioHelpers, verifyEarlyCancellationOfCallbackDoesCancelEarly) {
   ad_utility::SharedCancellationHandle handle =
       std::make_shared<ad_utility::CancellationHandle<>>();
-  handle->cancel(ad_utility::CancellationState::MANUAL);
   auto sleeperTask = []() -> net::awaitable<void> { co_return; }();
+  std::promise<std::function<void()>> promise{};
+  auto future = promise.get_future();
+  ad_utility::JThread cancelTask{[&future, &handle]() {
+    future.get()();
+    // Make sure first iteration is not affected
+    std::this_thread::sleep_for(std::chrono::milliseconds{5});
+    handle->cancel(ad_utility::CancellationState::MANUAL);
+  }};
 
   EXPECT_NO_THROW(co_await ad_utility::interruptible(
-      std::move(sleeperTask), handle,
-      std::make_shared<std::atomic_flag>(false)));
+      std::move(sleeperTask), handle, std::move(promise)));
 }
 
 // _________________________________________________________________________


### PR DESCRIPTION
While a query waits to be assigned to a computation thread, there is a timer that polls the cancellation handle every 25 ms. Previously there was no way to cancel this timer, which meant that each HTTP request needed at least 25 ms to complete. This was especially annoying in the unit tests which run many requests in tight loops to trigger potential lifetime and threading issues. This is now fixed as this timer can be canceled and is cancelled as early as possible.