### PR TITLE
Stop Watchdog early if no longer required

### DIFF
--- a/src/util/CancellationHandle.cpp
+++ b/src/util/CancellationHandle.cpp
@@ -43,6 +43,10 @@ void CancellationHandle<Mode>::startWatchDogInternal() requires WatchDogEnabled
         startTimeoutWindow_ = steady_clock::now();
         cancellationState_.compare_exchange_strong(state, CHECK_WINDOW_MISSED,
                                                    std::memory_order_relaxed);
+      } else if (detail::isCancelled(state)) {
+        // No need to keep the watchdog running if the handle was cancelled
+        // already
+        break;
       }
     } while (!watchDogState_.conditionVariable_.wait_for(
         lock, DESIRED_CANCELLATION_CHECK_INTERVAL,

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -290,6 +290,7 @@ class CancellationHandle {
   FRIEND_TEST(CancellationHandle, verifyIsCancelledDoesPleaseWatchDog);
   FRIEND_TEST(CancellationHandle,
               verifyPleaseWatchDogDoesNotAcceptInvalidState);
+  FRIEND_TEST(CancellationHandle, verifyWatchDogEndsEarlyIfCancelled);
 };
 
 using SharedCancellationHandle = std::shared_ptr<CancellationHandle<>>;

--- a/test/CancellationHandleTest.cpp
+++ b/test/CancellationHandleTest.cpp
@@ -439,6 +439,24 @@ TEST(CancellationHandle, verifyIsCancelledDoesPleaseWatchDog) {
 
 // _____________________________________________________________________________
 
+TEST(CancellationHandle, verifyWatchDogEndsEarlyIfCancelled) {
+  CancellationHandle<ENABLED> handle;
+  handle.cancel(MANUAL);
+
+  handle.startWatchDog();
+  // Wait for Watchdog to start
+  std::this_thread::sleep_for(1ms);
+
+  handle.cancellationState_ = WAITING_FOR_CHECK;
+
+  // Wait for one watchdog cycle + tolerance
+  std::this_thread::sleep_for(DESIRED_CANCELLATION_CHECK_INTERVAL + 1ms);
+  // If the watchdog were running it would've set this to CHECK_WINDOW_MISSED
+  EXPECT_EQ(handle.cancellationState_, WAITING_FOR_CHECK);
+}
+
+// _____________________________________________________________________________
+
 TEST(CancellationHandle, expectDisabledHandleIsAlwaysFalse) {
   CancellationHandle<DISABLED> handle;
 


### PR DESCRIPTION
This is a rather small optimization that cleans up the watchdog thread once the query gets cancelled. Previously it was only cleaned up once the cancellation handle was destroyed, which typically is only shortly after the cancellation.