### PR TITLE
Remove the `const_cast`s from the FSST wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         fsst
         GIT_REPOSITORY https://github.com/cwida/fsst.git
-        GIT_TAG 7dbeff28d8b4f29e020dbf6e2ab88acc268d0106
+        GIT_TAG c8719ef0aa3740da9685ad2738bb9c8ecc327944
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         fsst
         GIT_REPOSITORY https://github.com/cwida/fsst.git
-        GIT_TAG c541ffdc2be43443c6a772eb6207eec1b587dbe8
+        GIT_TAG 7dbeff28d8b4f29e020dbf6e2ab88acc268d0106
 )
 
 

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -19,14 +19,9 @@
 // A simple C++ wrapper around the C-API of the `FSST` library. It consists of
 // two types, a thredsafe `FsstDecoder` that can be used to perform
 // decompression, and a single-threaded `FsstEncoder` for compression.
-// TODO<joka921> There are a lot of `const_cast`s that look rather fishy because
-// they cast away constness. `FSST` currently has many function parameters that
-// are logically const, but are not marked as const. I have opened a PR for FSST
-// to make them const, as soon as this is merged, get rid of all the
-// `const_cast`s and `mutable`s in this file.
 class FsstDecoder {
  private:
-  mutable fsst_decoder_t decoder_;
+  fsst_decoder_t decoder_;
 
  public:
   // The default constructor does lead to an invalid decoder, but is required
@@ -44,7 +39,7 @@ class FsstDecoder {
     output.resize(8 * str.size());
     size_t size = fsst_decompress(
         &decoder_, str.size(),
-        reinterpret_cast<unsigned char*>(const_cast<char*>(str.data())),
+        reinterpret_cast<const unsigned char*>(str.data()),
         output.size(), reinterpret_cast<unsigned char*>(output.data()));
     // FSST compresses at most by a factor of 8.
     AD_CORRECTNESS_CHECK(size <= output.size());
@@ -119,7 +114,7 @@ class FsstEncoder {
     output.resize(7 + 2 * len);
     unsigned char* dummyOutput;
     auto data =
-        reinterpret_cast<unsigned char*>(const_cast<char*>(word.data()));
+        reinterpret_cast<const unsigned char*>(word.data());
     size_t outputLen = 0;
     size_t numCompressed =
         fsst_compress(encoder_.get(), 1, &len, &data, output.size(),

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -15,6 +15,20 @@
 
 #include "util/Exception.h"
 #include "util/Log.h"
+#include "util/TypeTraits.h"
+
+namespace detail {
+// A helper function to cast `char*` to `unsigned char*` and `const char*` to
+// `const unsigned char*` which is used below because FSST always works on
+// unsigned character types. Note that this is one of the few cases where a
+// `reinterpret_cast` is safe.
+constexpr auto castToUnsignedPtr =
+    []<ad_utility::SameAsAny<char*, const char*> T>(T ptr) {
+      using Res = std::conditional_t<std::same_as<T, const char*>,
+                                     const unsigned char*, unsigned char*>;
+      return reinterpret_cast<Res>(ptr);
+    };
+}  // namespace detail
 
 // A simple C++ wrapper around the C-API of the `FSST` library. It consists of
 // two types, a thredsafe `FsstDecoder` that can be used to perform
@@ -36,11 +50,10 @@ class FsstDecoder {
   // Decompress a  single string.
   std::string decompress(std::string_view str) const {
     std::string output;
+    auto cast = detail::castToUnsignedPtr;
     output.resize(8 * str.size());
-    size_t size = fsst_decompress(
-        &decoder_, str.size(),
-        reinterpret_cast<const unsigned char*>(str.data()),
-        output.size(), reinterpret_cast<unsigned char*>(output.data()));
+    size_t size = fsst_decompress(&decoder_, str.size(), cast(str.data()),
+                                  output.size(), cast(output.data()));
     // FSST compresses at most by a factor of 8.
     AD_CORRECTNESS_CHECK(size <= output.size());
     output.resize(size);
@@ -100,6 +113,7 @@ class FsstEncoder {
   };
   using Encoder = std::unique_ptr<fsst_encoder_t, Deleter>;
   Encoder encoder_;
+  static constexpr auto cast = detail::castToUnsignedPtr;
 
  public:
   // Create an `FsstEncoder`. The given `strings` are used to create the
@@ -113,13 +127,11 @@ class FsstEncoder {
     std::string output;
     output.resize(7 + 2 * len);
     unsigned char* dummyOutput;
-    auto data =
-        reinterpret_cast<const unsigned char*>(word.data());
+    auto data = cast(word.data());
     size_t outputLen = 0;
     size_t numCompressed =
         fsst_compress(encoder_.get(), 1, &len, &data, output.size(),
-                      reinterpret_cast<unsigned char*>(output.data()),
-                      &outputLen, &dummyOutput);
+                      cast(output.data()), &outputLen, &dummyOutput);
     AD_CORRECTNESS_CHECK(numCompressed == 1);
     output.resize(outputLen);
     return output;
@@ -150,13 +162,12 @@ class FsstEncoder {
   static std::conditional_t<alsoCompressAll, BulkResult, Encoder> makeEncoder(
       const auto& strings) {
     std::vector<size_t> lengths;
-    std::vector<unsigned char*> pointers;
+    std::vector<const unsigned char*> pointers;
     [[maybe_unused]] size_t totalSize = 0;
     for (const auto& string : strings) {
       lengths.push_back(string.size());
       totalSize += string.size();
-      pointers.push_back(
-          reinterpret_cast<unsigned char*>(const_cast<char*>(string.data())));
+      pointers.push_back(cast(string.data()));
     }
     auto encoder =
         fsst_create(strings.size(), lengths.data(), pointers.data(), 0);
@@ -174,8 +185,7 @@ class FsstEncoder {
       while (true) {
         size_t numCompressed = fsst_compress(
             encoder, strings.size(), lengths.data(), pointers.data(),
-            output.size(), reinterpret_cast<unsigned char*>(output.data()),
-            outputLengths.data(),
+            output.size(), cast(output.data()), outputLengths.data(),
             reinterpret_cast<unsigned char**>(outputPtrs.data()));
         // Typically one iteration should suffice, we repeat in a loop with
         // exponential growth of the output buffer.


### PR DESCRIPTION
Thanks to @joka921's PRs for https://github.com/cwida/fsst, the various `const_cast`s are no longer needed.