### PR TITLE
Fix a small bug in the TurtleParser

### DIFF
--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -162,7 +162,7 @@ bool TurtleParser<T>::predicateSpecialA() {
 template <class T>
 bool TurtleParser<T>::subject() {
   if (blankNode() || iri() || collection()) {
-    activeSubject_ = lastParseResult_.getIri();
+    activeSubject_ = lastParseResult_;
     return true;
   } else {
     return false;

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -247,8 +247,12 @@ TEST(TurtleParserTest, blankNode) {
   };
   auto checkRe2 = checkParseResult<Re2Parser, &Re2Parser::blankNode, 4>;
   auto checkCtre = checkParseResult<CtreParser, &CtreParser::blankNode, 4>;
+  auto checkRe2Subject = checkParseResult<Re2Parser, &Re2Parser::subject, 4>;
+  auto checkCtreSubject = checkParseResult<CtreParser, &CtreParser::subject, 4>;
   runCommonTests(checkRe2);
   runCommonTests(checkCtre);
+  runCommonTests(checkRe2Subject);
+  runCommonTests(checkCtreSubject);
 }
 
 TEST(TurtleParserTest, blankNodePropertyList) {


### PR DESCRIPTION
Since #1301, triples were the subject is an explicit blank node (for example `_:x <is-a> <blankNode>.`) could no longer be parsed. This commit fixes this bug and adds a unit test for this case.