### PR TITLE
Add generic `ProgressBar` class + use for index build log 

### DIFF
--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -151,9 +151,7 @@ static const std::string WARNING_ASCII_ONLY_PREFIXES =
 
 static const std::string WARNING_PARALLEL_PARSING =
     "You specified \"parallel-parsing = true\", which enables faster parsing "
-    "for TTL files that don't include multiline literals with unescaped "
-    "newline characters and that have newline characters after the end of "
-    "triples.";
+    "for TTL files with a well-behaved use of newlines";
 static const std::string LOCALE_DEFAULT_LANG = "en";
 static const std::string LOCALE_DEFAULT_COUNTRY = "US";
 static constexpr bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -14,6 +14,7 @@
 #include "index/Vocabulary.h"
 #include "util/HashMap.h"
 #include "util/MmapVector.h"
+#include "util/ProgressBar.h"
 
 using IdPairMMapVec = ad_utility::MmapVector<std::pair<Id, Id>>;
 using IdPairMMapVecView = ad_utility::MmapVectorView<std::pair<Id, Id>>;
@@ -163,7 +164,8 @@ class VocabularyMerger {
       WordCallback auto& internalVocabularyAction,
       WordCallback auto& externalVocabularyAction,
       std::predicate<TripleComponentWithIndex,
-                     TripleComponentWithIndex> auto const& lessThan);
+                     TripleComponentWithIndex> auto const& lessThan,
+      ad_utility::ProgressBar& progressBar);
 
   // Close all associated files and MmapVectors and reset all internal
   // variables.

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -97,14 +97,15 @@ class ProgressBar {
   }
 
   // Progress string with statistics.
-  std::string getProgressString() {
+  std::string getProgressString() const {
     bool notYetFinished = timer_.isRunning();
     // Two helper functions.
     auto withThousandSeparators = [](size_t number) {
       return ad_utility::insertThousandSeparator(std::to_string(number), ',');
     };
     auto speed = [this](size_t numSteps, Timer::Duration duration) {
-      return this->getSpeedDescription_(numSteps / Timer::toSeconds(duration));
+      return this->getSpeedDescription_(static_cast<double>(numSteps) /
+                                        Timer::toSeconds(duration));
     };
     // In the typical use case, where the total number of steps is at least the
     // batch size, show the full statistics. Otherwise, only show the average
@@ -112,12 +113,12 @@ class ProgressBar {
     if (numStepsProcessed_ >= statisticsBatchSize_) {
       // During the computation, always show the last multiple of the batch
       // size. In the end, show the exact number of processed steps.
-      size_t numStepsProcessedShow_ =
+      size_t numStepsProcessedShow =
           notYetFinished
               ? updateWhenThisManyStepsProcessed_ - statisticsBatchSize_
               : numStepsProcessed_;
       return absl::StrCat(
-          displayStringPrefix_, withThousandSeparators(numStepsProcessedShow_),
+          displayStringPrefix_, withThousandSeparators(numStepsProcessedShow),
           " [average speed ", speed(numStepsProcessed_, totalDuration_),
           ", last batch ", speed(statisticsBatchSize_, lastBatchDuration_),
           ", fastest ", speed(statisticsBatchSize_, minBatchDuration_),
@@ -131,7 +132,7 @@ class ProgressBar {
     }
   }
 
-  // Final progress string (should only be called once aftr the computation has
+  // Final progress string (should only be called once after the computation has
   // finished).
   std::string getFinalProgressString() {
     AD_CONTRACT_CHECK(timer_.isRunning(),

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -1,0 +1,162 @@
+// Copyright 2024, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author: Hannah Bast (bast@cs.uni-freiburg.de)
+
+#pragma once
+
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_format.h>
+
+#include <string>
+
+#include "util/StringUtils.h"
+#include "util/Timer.h"
+
+// Default batch size for progress bar.
+static constexpr size_t DEFAULT_PROGRESS_BAR_BATCH_SIZE = 10'000'000;
+
+// Default function for computing speed descriptions.
+static std::string DEFAULT_SPEED_DESCRIPTION_FUNCTION(
+    size_t numSteps, ad_utility::Timer::Duration duration) {
+  double durationSecs = ad_utility::Timer::toSeconds(duration);
+  double speed = (numSteps / 1'000'000) / durationSecs;
+  return absl::StrCat(absl::StrFormat("%.1f", speed), " M/s");
+}
+
+namespace ad_utility {
+
+// A class that keeps track of the progress of a long-running computation which
+// processed in (typically many and small) steps (for example, the lines of a
+// large input file or the triples of a permutation). The total number of steps
+// does not have to be known in advance.
+//
+// For a given number of steps, called the batch size, the class maintains
+// various level statistics of the processing speed per batch (speed for the
+// last batch, average speed, minimum speed, maximum speed, etc.). Note that
+// the batch size is purely a parameter of this class, the actual computation
+// need not proceed in batches in any way.
+//
+// Exampe usage:
+//
+// numTriplesProcessed = 0;
+// ad_utility::ProgressBar progressBar(numTriplesProcessed,
+//                                     "Triples processed: ", 10'000'000);
+// while (...) {
+//   // Code that does the processing.
+//   ++numTriplesProcessed;
+//   if (progressBar.update()) {
+//     LOG(INFO) << progressBar.getProgressString() << std::flush;
+//   }
+// }
+// LOG(INFO) << progressBar.getFinalProgressString() << std::flush;
+//
+class ProgressBar {
+ public:
+  // Use new line for each update (with `\n`) or one line overall (with `\r`).
+  enum class DisplayUpdateOptions { UseNewLine, ReuseLine };
+  static constexpr auto UseNewLine = DisplayUpdateOptions::UseNewLine;
+  static constexpr auto ReuseLine = DisplayUpdateOptions::ReuseLine;
+
+  // Function that returns a string with a speed description (e.g., "3.4 M/s")
+  // from a number of steps and a `Timer::Duration`.
+  using SpeedDescriptionFunction =
+      std::function<std::string(size_t, Timer::Duration)>;
+
+  // Create and initialize a progress bar.
+  //
+  // NOTE: The variable for counting the number of steps must come from the
+  // outside (and be incremented there). That is because the calling code
+  // typically has such a variable anyway (also for other purposes) and it
+  // would we unnatural to have it originally in this class.
+  ProgressBar(size_t& numStepsProcessed, std::string displayStringPrefix,
+              size_t statisticsBatchSize = DEFAULT_PROGRESS_BAR_BATCH_SIZE,
+              SpeedDescriptionFunction getSpeedDescription =
+                  DEFAULT_SPEED_DESCRIPTION_FUNCTION,
+              DisplayUpdateOptions displayUpdateOptions = ReuseLine)
+      : numStepsProcessed_(numStepsProcessed),
+        displayStringPrefix_(std::move(displayStringPrefix)),
+        statisticsBatchSize_(statisticsBatchSize),
+        getSpeedDescription_(std::move(getSpeedDescription)),
+        displayUpdateOptions_(displayUpdateOptions) {}
+
+  // Call this whenever a unit has been processed. Returns `true` if an update
+  // should be displayed, `false` otherwise.
+  //
+  // IMPORTANT: This call is (and should) return `false` most of the time, in
+  // which case it is (and should be) very cheap (namely, and increment and a
+  // simple check).
+  bool update() {
+    if (numStepsProcessed_ < updateWhenThisManyStepsProcessed_) {
+      return false;
+    }
+    Timer::Duration newDuration = timer_.value();
+    lastBatchDuration_ = newDuration - totalDuration_;
+    minBatchDuration_ = std::min(minBatchDuration_, lastBatchDuration_);
+    maxBatchDuration_ = std::max(maxBatchDuration_, lastBatchDuration_);
+    totalDuration_ = newDuration;
+    updateWhenThisManyStepsProcessed_ += statisticsBatchSize_;
+    return true;
+  }
+
+  // Progress string with statistics.
+  std::string getProgressString() {
+    bool notYetFinished = timer_.isRunning();
+    auto& speed = getSpeedDescription_;
+    auto withThousandSeparators = [](size_t number) {
+      return ad_utility::insertThousandSeparator(std::to_string(number), ',');
+    };
+    // During the computation, always show the last multiple of the batch size.
+    // In the end, show the exact (and final) number of processed steps.
+    size_t numStepsProcessedShow_ =
+        notYetFinished
+            ? updateWhenThisManyStepsProcessed_ - statisticsBatchSize_
+            : numStepsProcessed_;
+    return absl::StrCat(
+        displayStringPrefix_, withThousandSeparators(numStepsProcessedShow_),
+        " [average speed ", speed(numStepsProcessed_, totalDuration_),
+        ", last batch ", speed(statisticsBatchSize_, lastBatchDuration_),
+        ", fastest ", speed(statisticsBatchSize_, minBatchDuration_),
+        ", slowest ", speed(statisticsBatchSize_, maxBatchDuration_), "] ",
+        displayUpdateOptions_ == ReuseLine && notYetFinished ? "\r" : "\n");
+  }
+
+  // Final progress string (should only be called once aftr the computation has
+  // finished).
+  std::string getFinalProgressString() {
+    AD_CONTRACT_CHECK(timer_.isRunning(),
+                      "`ProgressBar::getFinalProgressString()` should only be "
+                      "called once after the computation has finished");
+    timer_.stop();
+    totalDuration_ = timer_.value();
+    return getProgressString();
+  }
+
+ private:
+  // The total number of units that have been processed so far.
+  size_t& numStepsProcessed_;
+  // The first part of the display string (e.g., "Triples processed: ").
+  std::string displayStringPrefix_;
+  // Update statistics every this many steps.
+  size_t statisticsBatchSize_;
+  // Function that returns a string with a speed description (e.g., "3.4 M/s")
+  // given a number of steps and a `Timer::Duration`.
+  SpeedDescriptionFunction getSpeedDescription_;
+  // See `DisplayUpdateOptions` above.
+  DisplayUpdateOptions displayUpdateOptions_;
+
+  // Timer that is started as soon as this progress bar is created.
+  Timer timer_{Timer::Started};
+  // Update the statistics when at least this many steps have been processed.
+  size_t updateWhenThisManyStepsProcessed_ = statisticsBatchSize_;
+
+  // Duration of all batches so far.
+  Timer::Duration totalDuration_ = Timer::Duration::zero();
+  // Duration of last batch.
+  Timer::Duration lastBatchDuration_;
+  // Duration of fastest batch.
+  Timer::Duration minBatchDuration_ = Timer::Duration::max();
+  // Duration of slowest batch.
+  Timer::Duration maxBatchDuration_ = Timer::Duration::min();
+};
+
+}  // namespace ad_utility

--- a/src/util/ProgressBar.h
+++ b/src/util/ProgressBar.h
@@ -19,7 +19,7 @@ static constexpr size_t DEFAULT_PROGRESS_BAR_BATCH_SIZE = 10'000'000;
 static std::string DEFAULT_SPEED_DESCRIPTION_FUNCTION(
     size_t numSteps, ad_utility::Timer::Duration duration) {
   double durationSecs = ad_utility::Timer::toSeconds(duration);
-  double speed = (numSteps / 1'000'000) / durationSecs;
+  double speed = (numSteps / 1'000'000.0) / durationSecs;
   return absl::StrCat(absl::StrFormat("%.1f", speed), " M/s");
 }
 

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -76,9 +76,9 @@ cppcoro::generator<ValueType> uniqueView(SortedView view) {
       co_yield previousValueCopy;
     }
   }
-  LOG(INFO) << "Number of inputs to `uniqueView`: " << numInputs << '\n';
-  LOG(INFO) << "Number of unique outputs of `uniqueView`: " << numUnique
-            << std::endl;
+  LOG(DEBUG) << "Number of inputs to `uniqueView`: " << numInputs << '\n';
+  LOG(DEBUG) << "Number of unique outputs of `uniqueView`: " << numUnique
+             << std::endl;
 }
 
 // Takes a view of blocks and yields the elements of the same view, but removes
@@ -110,7 +110,7 @@ cppcoro::generator<typename SortedBlockView::value_type> uniqueBlockView(
     co_yield block;
   }
   LOG(DEBUG) << "Number of inputs to `uniqueView`: " << numInputs << '\n';
-  LOG(INFO) << "Number of unique elements: " << numUnique << std::endl;
+  LOG(DEBUG) << "Number of unique elements: " << numUnique << std::endl;
 }
 
 // A view that owns its underlying storage. It is a rather simple drop-in

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -372,6 +372,8 @@ addLinkAndDiscoverTest(MessageSenderTest http)
 
 addLinkAndDiscoverTest(CancellationHandleTest util)
 
+addLinkAndDiscoverTest(ProgressBarTest util)
+
 addLinkAndDiscoverTest(CachingMemoryResourceTest)
 
 addLinkAndDiscoverTest(ParallelMultiwayMergeTest)

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -25,9 +25,17 @@ TEST(ProgressBar, typicalUsage) {
     // update string with 303'000 steps.
     //
     // TODO: Why does \\d instead of [0-9] not work in the following regex?
+    //
+    // NOTE: For macOS, `std::this_thread::sleep_for` can take much longer
+    // than indicated, resulting in a much lower speed than expected.
     std::string expectedSpeedRegex =
+#ifndef __APPLE__
         "\\[average speed [234]\\.[0-9] M/s, last batch [234]\\.[0-9] M/s"
         ", fastest [234]\\.[0-9] M/s, slowest [234]\\.[0-9] M/s\\] ";
+#else
+        "\\[average speed [0-9]\\.[0-9] M/s, last batch [0-9]\\.[0-9] M/s"
+        ", fastest [0-9]\\.[0-9] M/s, slowest [0-9]\\.[0-9] M/s\\] ";
+#endif
     char lastChar = displayOption == ProgressBar::ReuseLine ? '\r' : '\n';
     std::vector<std::string> expectedUpdateRegexes = {
         "Steps: 100,000 " + expectedSpeedRegex + lastChar,
@@ -59,7 +67,11 @@ TEST(ProgressBar, numberOfStepsLessThanBatchSize) {
   ProgressBar progressBar(numSteps, "Steps: ", 5'000);
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   std::string expectedUpdateRegex =
+#ifndef __APPLE__
       "Steps: 3,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
+#else
+      "Steps: 3,000 \\[average speed [0-9]\\.[0-9] M/s\\] \n";
+#endif
   ASSERT_THAT(progressBar.getFinalProgressString(),
               ::testing::MatchesRegex(expectedUpdateRegex));
 }

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -8,44 +8,58 @@
 #include <regex>
 #include <thread>
 
+#include "../test/util/GTestHelpers.h"
 #include "util/ProgressBar.h"
 #include "util/StringUtils.h"
 
-// _____________________________________________________________________________
+using ad_utility::ProgressBar;
+
+// Test typical use case with multiple updates and a final update.
 TEST(ProgressBar, typicalUsage) {
-  size_t numSteps = 0;
-  ad_utility::ProgressBar progressBar(numSteps, "Steps: ", 100'000,
-                                      DEFAULT_SPEED_DESCRIPTION_FUNCTION,
-                                      ad_utility::ProgressBar::UseNewLine);
-  ASSERT_TRUE(std::regex_match("[4 M/s]", std::regex(R"(\[\d M/s\])")));
-  // We expect three update strings with a speed of around 3 M/s and a final
-  // update string with 303'000 steps.
-  std::string expectedSpeedRegex =
-      R"(\[average speed [234]\.\d+ M/s, last batch [234]\.\d+ M/s)"
-      R"(, fastest [234]\.\d+ M/s, slowest [234]\.\d+ M/s\])";
-  std::vector<std::string> expectedUpdateRegexes = {
-      "Steps: 100,000 " + expectedSpeedRegex,
-      "Steps: 200,000 " + expectedSpeedRegex,
-      "Steps: 300,000 " + expectedSpeedRegex,
-      "Steps: 303,000 " + expectedSpeedRegex};
-  // Helper lamba to check that a progress string matches the expected regex.
-  auto checkProgressString = [&](const std::string& progressString,
-                                 const std::string& expectedRegex) {
-    ASSERT_TRUE(std::regex_search(progressString, std::regex(expectedRegex)))
-        << "Expected: " << expectedRegex << std::endl
-        << "Got     : " << progressString;
-  };
-  size_t numUpdateStrings = 0;
-  for (size_t i = 0; i < 101; ++i) {
-    numSteps += 3'000;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    if (progressBar.update()) {
-      ASSERT_LT(numUpdateStrings + 1, expectedUpdateRegexes.size());
-      checkProgressString(progressBar.getProgressString(),
-                          expectedUpdateRegexes[numUpdateStrings]);
-      ++numUpdateStrings;
+  auto speedDescriptionFunction = DEFAULT_SPEED_DESCRIPTION_FUNCTION;
+  for (auto displayOption : {ProgressBar::UseNewLine, ProgressBar::ReuseLine}) {
+    size_t numSteps = 0;
+    ProgressBar progressBar(numSteps, "Steps: ", 100'000,
+                            speedDescriptionFunction, displayOption);
+    // We expect three update strings with a speed of around 3 M/s and a final
+    // update string with 303'000 steps.
+    //
+    // TODO: Why does \\d instead of [0-9] not work in the following regex?
+    std::string expectedSpeedRegex =
+        "\\[average speed [234]\\.[0-9] M/s, last batch [234]\\.[0-9] M/s"
+        ", fastest [234]\\.[0-9] M/s, slowest [234]\\.[0-9] M/s\\] ";
+    char lastChar = displayOption == ProgressBar::ReuseLine ? '\r' : '\n';
+    std::vector<std::string> expectedUpdateRegexes = {
+        "Steps: 100,000 " + expectedSpeedRegex + lastChar,
+        "Steps: 200,000 " + expectedSpeedRegex + lastChar,
+        "Steps: 300,000 " + expectedSpeedRegex + lastChar,
+        "Steps: 303,000 " + expectedSpeedRegex + "\n"};
+    size_t k = 0;
+    for (size_t i = 0; i < 101; ++i) {
+      numSteps += 3'000;
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      if (progressBar.update()) {
+        ASSERT_LT(k + 1, expectedUpdateRegexes.size());
+        ASSERT_THAT(progressBar.getProgressString(),
+                    ::testing::MatchesRegex(expectedUpdateRegexes[k]));
+        ++k;
+      }
     }
+    ASSERT_THAT(progressBar.getFinalProgressString(),
+                ::testing::MatchesRegex(expectedUpdateRegexes.back()));
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        progressBar.getFinalProgressString(),
+        ::testing::ContainsRegex("should only be called once"));
   }
-  checkProgressString(progressBar.getFinalProgressString(),
-                      expectedUpdateRegexes.back());
+}
+
+// Test special case where the number of steps is less than the batch size.
+TEST(ProgressBar, numberOfStepsLessThanBatchSize) {
+  size_t numSteps = 3'000;
+  ProgressBar progressBar(numSteps, "Steps: ", 5'000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  std::string expectedUpdateRegex =
+      "Steps: 3,000 \\[average speed [234]\\.[0-9] M/s\\] \n";
+  ASSERT_THAT(progressBar.getFinalProgressString(),
+              ::testing::MatchesRegex(expectedUpdateRegex));
 }

--- a/test/ProgressBarTest.cpp
+++ b/test/ProgressBarTest.cpp
@@ -1,0 +1,51 @@
+// Copyright 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Hannah Bast <bast@cs.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <regex>
+#include <thread>
+
+#include "util/ProgressBar.h"
+#include "util/StringUtils.h"
+
+// _____________________________________________________________________________
+TEST(ProgressBar, typicalUsage) {
+  size_t numSteps = 0;
+  ad_utility::ProgressBar progressBar(numSteps, "Steps: ", 100'000,
+                                      DEFAULT_SPEED_DESCRIPTION_FUNCTION,
+                                      ad_utility::ProgressBar::UseNewLine);
+  ASSERT_TRUE(std::regex_match("[4 M/s]", std::regex(R"(\[\d M/s\])")));
+  // We expect three update strings with a speed of around 3 M/s and a final
+  // update string with 303'000 steps.
+  std::string expectedSpeedRegex =
+      R"(\[average speed [234]\.\d+ M/s, last batch [234]\.\d+ M/s)"
+      R"(, fastest [234]\.\d+ M/s, slowest [234]\.\d+ M/s\])";
+  std::vector<std::string> expectedUpdateRegexes = {
+      "Steps: 100,000 " + expectedSpeedRegex,
+      "Steps: 200,000 " + expectedSpeedRegex,
+      "Steps: 300,000 " + expectedSpeedRegex,
+      "Steps: 303,000 " + expectedSpeedRegex};
+  // Helper lamba to check that a progress string matches the expected regex.
+  auto checkProgressString = [&](const std::string& progressString,
+                                 const std::string& expectedRegex) {
+    ASSERT_TRUE(std::regex_search(progressString, std::regex(expectedRegex)))
+        << "Expected: " << expectedRegex << std::endl
+        << "Got     : " << progressString;
+  };
+  size_t numUpdateStrings = 0;
+  for (size_t i = 0; i < 101; ++i) {
+    numSteps += 3'000;
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    if (progressBar.update()) {
+      ASSERT_LT(numUpdateStrings + 1, expectedUpdateRegexes.size());
+      checkProgressString(progressBar.getProgressString(),
+                          expectedUpdateRegexes[numUpdateStrings]);
+      ++numUpdateStrings;
+    }
+  }
+  checkProgressString(progressBar.getFinalProgressString(),
+                      expectedUpdateRegexes.back());
+}

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -8,6 +8,7 @@
 #include "./TripleComponentTestHelpers.h"
 #include "global/SpecialIds.h"
 #include "index/IndexImpl.h"
+#include "util/ProgressBar.h"
 
 namespace ad_utility::testing {
 
@@ -16,10 +17,11 @@ Index makeIndexWithTestSettings() {
   Index index{ad_utility::makeUnlimitedAllocator<Id>()};
   index.setNumTriplesPerBatch(2);
   EXTERNAL_ID_TABLE_SORTER_IGNORE_MEMORY_LIMIT_FOR_TESTING = true;
-  // Decrease some default batch sizes s.t. the very small indices from the test
-  // cases also consist of multiple batches which improves the test coverage.
+  // Decrease various default batch sizes such that there are multiple batches
+  // also for the very small test indices (important for test coverage).
   BUFFER_SIZE_PARTIAL_TO_GLOBAL_ID_MAPPINGS = 10;
   BATCH_SIZE_VOCABULARY_MERGE = 2;
+  DEFAULT_PROGRESS_BAR_BATCH_SIZE = 2;
   index.memoryLimitIndexBuilding() = 50_MB;
   return index;
 }


### PR DESCRIPTION
The new `ProgressBar` class works for any computation that proceeds in countable steps (for example, the lines of an input file or the triples of a permutation). The final number of steps does not need to be known in advance. After each batch of steps, an update string is produced with information about the number of steps processed  so far and statistics about the average processing speed, the speed for the last batch, and the fastest and slowest speed for a batch so far. The batch size is purely a parameter of the class, the actual computation does not need to proceed in batches in any way.

This is now used in all places in the index build, where we showed progress so far, namely: parsing input triples, merging words from the partial vocabularies, converting triples from local to global IDs, and sorting the triples for the various permutation pairs. The index log thus becomes more compact and more informative at the same time.

On the side, make a few other improvements to the index log. For example, when a permutation pair is built, now says which permutations these are (e.g., SPO and SOP) already at the beginning and not only when it's done. This requires a corresponding change in the `index-stats` command of the `qlever` script.