### PR TITLE
Remove unused functions from the `GraphPattern` class

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1001,12 +1001,6 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::seedFromPropertyPathTriple(
     const SparqlTriple& triple) {
   std::shared_ptr<ParsedQuery::GraphPattern> pattern =
       seedFromPropertyPath(triple.s_, triple.p_, triple.o_);
-#if LOGLEVEL >= TRACE
-  std::ostringstream out;
-  pattern->toString(out, 0);
-  LOG(TRACE) << "Turned " << triple.asString() << " into " << std::endl;
-  LOG(TRACE) << std::move(out).str() << std::endl << std::endl;
-#endif
   pattern->recomputeIds();
   return optimize(pattern.get());
 }

--- a/src/parser/GraphPattern.h
+++ b/src/parser/GraphPattern.h
@@ -27,7 +27,6 @@ class GraphPattern {
   GraphPattern& operator=(const GraphPattern& other);
   GraphPattern& operator=(GraphPattern&& other) noexcept;
   ~GraphPattern();
-  void toString(std::ostringstream& os, int indentation = 0) const;
   // Traverse the graph pattern tree and assigns a unique ID to every graph
   // pattern.
   void recomputeIds(size_t* id_count = nullptr);

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -67,63 +67,6 @@ void BasicGraphPattern::appendTriples(BasicGraphPattern other) {
   ad_utility::appendVector(_triples, std::move(other._triples));
 }
 
-// _____________________________________________________________________________
-void GraphPatternOperation::toString(std::ostringstream& os,
-                                     int indentation) const {
-  for (int j = 1; j < indentation; ++j) os << "  ";
-
-  visit([&os, indentation](auto&& arg) {
-    using T = std::decay_t<decltype(arg)>;
-    if constexpr (std::is_same_v<T, Optional>) {
-      os << "OPTIONAL ";
-      arg._child.toString(os, indentation);
-    } else if constexpr (std::is_same_v<T, GroupGraphPattern>) {
-      os << "GROUP ";
-      arg._child.toString(os, indentation);
-    } else if constexpr (std::is_same_v<T, Union>) {
-      arg._child1.toString(os, indentation);
-      os << " UNION ";
-      arg._child2.toString(os, indentation);
-    } else if constexpr (std::is_same_v<T, Subquery>) {
-      // TODO<joka921> make the subquery a value-semantics type.
-      os << arg.get().asString();
-    } else if constexpr (std::is_same_v<T, Values>) {
-      os << "VALUES (" << arg._inlineValues.variablesToString() << ") "
-         << arg._inlineValues.valuesToString();
-    } else if constexpr (std::is_same_v<T, Service>) {
-      os << "SERVICE " << arg.serviceIri_.toSparql() << " { "
-         << arg.graphPatternAsString_ << " }";
-    } else if constexpr (std::is_same_v<T, BasicGraphPattern>) {
-      for (size_t i = 0; i + 1 < arg._triples.size(); ++i) {
-        os << "\n";
-        for (int j = 0; j < indentation; ++j) os << "  ";
-        os << arg._triples[i].asString() << ',';
-      }
-      if (arg._triples.size() > 0) {
-        os << "\n";
-        for (int j = 0; j < indentation; ++j) os << "  ";
-        os << arg._triples.back().asString();
-      }
-
-    } else if constexpr (std::is_same_v<T, Bind>) {
-      os << "BIND " << arg._expression.getDescriptor() << " as "
-         << arg._target.name() << "\n";
-      // TODO<joka921> proper ToString (are they used for something?)
-    } else if constexpr (std::is_same_v<T, Minus>) {
-      os << "MINUS ";
-      arg._child.toString(os, indentation);
-    } else {
-      static_assert(std::is_same_v<T, TransPath>);
-      /*
-      os << "TRANS PATH from " << arg._left << " to " << arg._right
-         << " with at least " << arg._min << " and at most " << arg._max
-         << " steps of ";
-      arg._childGraphPattern.toString(os, indentation);
-       */
-    }
-  });
-}
-
 // ____________________________________________________________________________
 cppcoro::generator<const Variable> Bind::containedVariables() const {
   for (const auto* ptr : _expression.containedVariables()) {

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -164,13 +164,5 @@ struct GraphPatternOperation
   [[nodiscard]] const auto& getBasic() const {
     return std::get<BasicGraphPattern>(*this);
   }
-
-  // A string representation of the operation.
-  //
-  // TODO: The implementation of this method duplicates code found in the
-  // implementations of `getCacheKeyImpl` for the individual operations in
-  // `src/engine`. This function is therefore probably redundant (but currently
-  // used in some of our unit tests).
-  void toString(std::ostringstream& os, int indentation = 0) const;
 };
 }  // namespace parsedQuery

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -20,74 +20,6 @@ using std::string;
 using std::vector;
 
 // _____________________________________________________________________________
-string ParsedQuery::asString() const {
-  std::ostringstream os;
-
-  bool usesSelect = hasSelectClause();
-  bool usesAsterisk = usesSelect && selectClause().isAsterisk();
-
-  if (usesSelect) {
-    const auto& selectClause = this->selectClause();
-    // SELECT
-    os << "\nSELECT: {\n\t";
-    // TODO<joka921> is this needed?
-    /*
-    os <<
-    absl::StrJoin(selectClause.varsAndAliasesOrAsterisk_.getSelectedVariables(),
-                        ", ");
-                        */
-    os << "\n}";
-
-    // ALIASES
-    os << "\nALIASES: {\n\t";
-    if (!usesAsterisk) {
-      for (const auto& alias : selectClause.getAliases()) {
-        os << alias._expression.getDescriptor() << "\n\t";
-      }
-      os << "{";
-    }
-  } else if (hasConstructClause()) {
-    const auto& constructClause = this->constructClause().triples_;
-    os << "\n CONSTRUCT {\n\t";
-    for (const auto& triple : constructClause) {
-      os << triple[0].toSparql();
-      os << ' ';
-      os << triple[1].toSparql();
-      os << ' ';
-      os << triple[2].toSparql();
-      os << " .\n";
-    }
-    os << "}";
-  }
-
-  // WHERE
-  os << "\nWHERE: \n";
-  _rootGraphPattern.toString(os, 1);
-
-  os << "\nLIMIT: " << (_limitOffset.limitOrDefault());
-  os << "\nTEXTLIMIT: " << (_limitOffset._textLimit);
-  os << "\nOFFSET: " << (_limitOffset._offset);
-  if (usesSelect) {
-    const auto& selectClause = this->selectClause();
-    os << "\nDISTINCT modifier is " << (selectClause.distinct_ ? "" : "not ")
-       << "present.";
-    os << "\nREDUCED modifier is " << (selectClause.reduced_ ? "" : "not ")
-       << "present.";
-  }
-  os << "\nORDER BY: ";
-  if (_orderBy.empty()) {
-    os << "not specified";
-  } else {
-    for (auto& key : _orderBy) {
-      os << key.variable_.name() << (key.isDescending_ ? " (DESC)" : " (ASC)")
-         << "\t";
-    }
-  }
-  os << "\n";
-  return std::move(os).str();
-}
-
-// _____________________________________________________________________________
 string SparqlPrefix::asString() const {
   std::ostringstream os;
   os << "{" << _prefix << ": " << _uri << "}";
@@ -317,30 +249,6 @@ void ParsedQuery::registerVariableVisibleInQueryBody(const Variable& variable) {
     }
   };
   std::visit(addVariable, _clause);
-}
-
-// _____________________________________________________________________________
-void ParsedQuery::GraphPattern::toString(std::ostringstream& os,
-                                         int indentation) const {
-  for (int j = 1; j < indentation; ++j) os << "  ";
-  os << "{";
-  for (size_t i = 0; i + 1 < _filters.size(); ++i) {
-    os << "\n";
-    for (int j = 0; j < indentation; ++j) os << "  ";
-    os << _filters[i].asString() << ',';
-  }
-  if (!_filters.empty()) {
-    os << "\n";
-    for (int j = 0; j < indentation; ++j) os << "  ";
-    os << _filters.back().asString();
-  }
-  for (const GraphPatternOperation& child : _graphPatterns) {
-    os << "\n";
-    child.toString(os, indentation + 1);
-  }
-  os << "\n";
-  for (int j = 1; j < indentation; ++j) os << "  ";
-  os << "}";
 }
 
 // _____________________________________________________________________________

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -460,21 +460,6 @@ const std::vector<Alias>& ParsedQuery::getAliases() const {
 }
 
 // ____________________________________________________________________________
-cppcoro::generator<const Variable>
-ParsedQuery::getConstructedOrSelectedVariables() const {
-  if (hasSelectClause()) {
-    for (const auto& variable : selectClause().getSelectedVariables()) {
-      co_yield variable;
-    }
-  } else {
-    for (const auto& variable : constructClause().containedVariables()) {
-      co_yield variable;
-    }
-  }
-  // Nothing to yield in the CONSTRUCT case.
-}
-
-// ____________________________________________________________________________
 void ParsedQuery::checkVariableIsVisible(
     const Variable& variable, const std::string& locationDescription,
     const ad_utility::HashSet<Variable>& additionalVisibleVariables,

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -274,8 +274,6 @@ class ParsedQuery {
    */
   void merge(const ParsedQuery& p);
 
-  [[nodiscard]] string asString() const;
-
   // If this is a SELECT query, return all the selected aliases. Return an empty
   // vector for construct clauses.
   [[nodiscard]] const std::vector<Alias>& getAliases() const;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -279,9 +279,4 @@ class ParsedQuery {
   // If this is a SELECT query, return all the selected aliases. Return an empty
   // vector for construct clauses.
   [[nodiscard]] const std::vector<Alias>& getAliases() const;
-  // If this is a SELECT query, yield all the selected variables. If this is a
-  // CONSTRUCT query, yield all the variables that are used in the CONSTRUCT
-  // clause. Note that the result may contain duplicates in the CONSTRUCT case.
-  [[nodiscard]] cppcoro::generator<const Variable>
-  getConstructedOrSelectedVariables() const;
 };

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -69,12 +69,6 @@ inline void PrintTo(const parsedQuery::GraphPattern& pattern,
   s << ::testing::PrintToString(pattern._graphPatterns);
 }
 
-inline void PrintTo(const parsedQuery::GraphPatternOperation& op,
-                    std::ostream* os) {
-  std::ostringstream str;
-  op.toString(str);
-  (*os) << str.str();
-}
 }  // namespace parsedQuery
 
 inline void PrintTo(const Alias& alias, std::ostream* os) {
@@ -332,7 +326,7 @@ inline auto Expression = [](const std::string& descriptor)
   return AD_PROPERTY(sparqlExpression::SparqlExpressionPimpl, getDescriptor,
                      testing::Eq(descriptor));
 };
-}
+}  // namespace detail
 
 // A matcher that tests whether a `SparqlExpression::Ptr` (a `unique_ptr`)
 // actually (via dynamic cast) stores an element of type `ExpressionT`.
@@ -350,7 +344,7 @@ auto GraphPatternOperation =
     [](auto subMatcher) -> Matcher<const p::GraphPatternOperation&> {
   return testing::VariantWith<T>(subMatcher);
 };
-}
+}  // namespace detail
 
 inline auto BindExpression =
     [](const string& expression) -> Matcher<const p::Bind&> {
@@ -524,7 +518,7 @@ inline auto SelectBase =
       AD_FIELD(p::SelectClause, reduced_, testing::Eq(reduced)),
       AD_PROPERTY(p::SelectClause, getAliases, testing::IsEmpty()));
 };
-}
+}  // namespace detail
 
 inline auto AsteriskSelect = [](bool distinct = false,
                                 bool reduced =
@@ -673,7 +667,7 @@ inline auto Optional =
   return detail::GraphPatternOperation<p::Optional>(
       AD_FIELD(p::Optional, _child, subMatcher));
 };
-}
+}  // namespace detail
 
 inline auto Group =
     [](auto&& subMatcher) -> Matcher<const p::GraphPatternOperation&> {
@@ -738,7 +732,7 @@ inline auto GraphPattern =
       AD_FIELD(ParsedQuery::GraphPattern, _graphPatterns,
                testing::ElementsAre(childMatchers...)));
 };
-}
+}  // namespace detail
 
 inline auto GraphPattern =
     MatcherWithDefaultFiltersAndOptional<detail::GraphPattern>{};
@@ -750,7 +744,7 @@ inline auto OptionalGraphPattern = [](vector<std::string>&& filters,
   return detail::Optional(
       detail::GraphPattern(true, filters, childMatchers...));
 };
-}
+}  // namespace detail
 
 inline auto OptionalGraphPattern =
     MatcherWithDefaultFilters<detail::OptionalGraphPattern>{};
@@ -761,7 +755,7 @@ inline auto GroupGraphPattern = [](vector<std::string>&& filters,
     -> Matcher<const p::GraphPatternOperation&> {
   return Group(detail::GraphPattern(false, filters, childMatchers...));
 };
-}
+}  // namespace detail
 
 inline auto GroupGraphPattern =
     MatcherWithDefaultFilters<detail::GroupGraphPattern>{};
@@ -772,7 +766,7 @@ inline auto MinusGraphPattern = [](vector<std::string>&& filters,
     -> Matcher<const p::GraphPatternOperation&> {
   return Minus(detail::GraphPattern(false, filters, childMatchers...));
 };
-}
+}  // namespace detail
 
 inline auto MinusGraphPattern =
     MatcherWithDefaultFilters<detail::MinusGraphPattern>{};


### PR DESCRIPTION
Fixes #378
Remove the `toString` function from the `GraphPattern` and `GraphPatternOperation` class. These functions were only used for printing in case of test failures and their implementation was not useful and poorly maintained anyway.