### PR TITLE
Fix a subtle bug in `CompressedExternalIdTableSorter`

### DIFF
--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -667,6 +667,9 @@ class CompressedExternalIdTableSorter
       // requested for the output, and the single block is larger than this
       // blocksize, we manually have to split it into chunks.
       auto& block = this->currentBlock_;
+      if (block.empty()) {
+        co_return;
+      }
       const auto blocksizeOutput = blocksize.value_or(block.numRows());
       if (block.numRows() <= blocksizeOutput) {
         if (this->moveResultOnMerge_) {
@@ -735,7 +738,9 @@ class CompressedExternalIdTableSorter
       }
     }
     numPopped += result.numRows();
-    co_yield std::move(result).template toStatic<N>();
+    if (!result.empty()) {
+      co_yield std::move(result).template toStatic<N>();
+    }
     AD_CORRECTNESS_CHECK(numPopped == this->numElementsPushed_);
   }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -208,11 +208,11 @@ std::unique_ptr<ExternalSorter<SortByPSO, 5>> IndexImpl::buildOspWithPatterns(
   // S P O PatternOfS PatternOfO, sorted by OPS.
   auto blockGenerator =
       [](auto& queue) -> cppcoro::generator<IdTableStatic<0>> {
-    absl::Cleanup cl{[&queue](){
-      LOG(WARN) << "Finishing the queue" << std::endl;
-      queue.finish();
-      LOG(WARN) << "Finished the queue" << std::endl;
-    }};
+    // If an exception occurs in the block that is consuming the blocks yielded
+    // from this generator, we have to explicitly finish the `queue`, otherwise
+    // there will be a deadlock because the threads involved in the queue can
+    // never join.
+    absl::Cleanup cl{[&queue]() { queue.finish(); }};
     while (auto block = queue.pop()) {
       co_yield fixBlockAfterPatternJoin(std::move(block));
     }

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -208,6 +208,11 @@ std::unique_ptr<ExternalSorter<SortByPSO, 5>> IndexImpl::buildOspWithPatterns(
   // S P O PatternOfS PatternOfO, sorted by OPS.
   auto blockGenerator =
       [](auto& queue) -> cppcoro::generator<IdTableStatic<0>> {
+    absl::Cleanup cl{[&queue](){
+      LOG(WARN) << "Finishing the queue" << std::endl;
+      queue.finish();
+      LOG(WARN) << "Finished the queue" << std::endl;
+    }};
     while (auto block = queue.pop()) {
       co_yield fixBlockAfterPatternJoin(std::move(block));
     }

--- a/test/engine/idTable/CompressedExternalIdTableTest.cpp
+++ b/test/engine/idTable/CompressedExternalIdTableTest.cpp
@@ -107,8 +107,13 @@ void testExternalSorterImpl(size_t numDynamicColumns, size_t numRows,
     }
 
     for (size_t k = 0; k < 5; ++k) {
-      auto generator = writer.sortedView();
+      // Also test the case that the blocksize does not exactly divides the
+      // number of inputs.
+      auto blocksize = k == 1 ? 1 : 17;
       using namespace ::testing;
+      auto generator = k == 0 ? std::views::join(ad_utility::OwningView{
+                                    writer.getSortedBlocks(blocksize)})
+                              : writer.sortedView();
       if (mergeMultipleTimes || k == 0) {
         auto result = idTableFromRowGenerator<NumStaticColumns>(
             generator, numDynamicColumns);


### PR DESCRIPTION
Under certain (rare) conditions, `CompressedExternalIdTableSorter::sortedBlocks` produced empty blocks, which led to an exception. This is now fixed. Also make sure that an exception in the building of a permutation pair does not result in a deadlock anymore (as it did for the bug just mentioned), but in a proper error message.