### PR TITLE
Add conversion functions from strings to int and double 

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -83,7 +83,7 @@ SparqlExpression::Ptr makeIfExpression(SparqlExpression::Ptr child1,
                                        SparqlExpression::Ptr child3);
 
 SparqlExpression::Ptr makeStrToIntExpression(SparqlExpression::Ptr child);
-// SparqlExpression::Ptr makeStrToDoubleExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeStrToDoubleExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeEncodeForUriExpression(SparqlExpression::Ptr child);
 

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -82,8 +82,8 @@ SparqlExpression::Ptr makeIfExpression(SparqlExpression::Ptr child1,
                                        SparqlExpression::Ptr child2,
                                        SparqlExpression::Ptr child3);
 
-SparqlExpression::Ptr toIntExpression(SparqlExpression::Ptr child);
-SparqlExpression::Ptr toDoubleExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeIntExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeDoubleExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeEncodeForUriExpression(SparqlExpression::Ptr child);
 

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -82,6 +82,9 @@ SparqlExpression::Ptr makeIfExpression(SparqlExpression::Ptr child1,
                                        SparqlExpression::Ptr child2,
                                        SparqlExpression::Ptr child3);
 
+SparqlExpression::Ptr makeStrToIntExpression(SparqlExpression::Ptr child);
+// SparqlExpression::Ptr makeStrToDoubleExpression(SparqlExpression::Ptr child);
+
 SparqlExpression::Ptr makeEncodeForUriExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeIsIriExpression(SparqlExpression::Ptr child);

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -82,8 +82,8 @@ SparqlExpression::Ptr makeIfExpression(SparqlExpression::Ptr child1,
                                        SparqlExpression::Ptr child2,
                                        SparqlExpression::Ptr child3);
 
-SparqlExpression::Ptr makeStrToIntExpression(SparqlExpression::Ptr child);
-SparqlExpression::Ptr makeStrToDoubleExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr toIntExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr toDoubleExpression(SparqlExpression::Ptr child);
 
 SparqlExpression::Ptr makeEncodeForUriExpression(SparqlExpression::Ptr child);
 

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -6,8 +6,8 @@
 
 #include <ranges>
 
-#include "absl/strings/charconv.h"
 #include "absl/strings/ascii.h"
+#include "absl/strings/charconv.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -6,6 +6,8 @@
 
 #include <ranges>
 
+#include "absl/strings/charconv.h"
+#include "absl/strings/ascii.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -420,8 +420,8 @@ template <typename T>
     }
   }
 };
-using ToInt = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;
-using ToDouble = StringExpressionImpl<1, decltype(toNumeric<double>)>;
+using ToIntExpression = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;
+using ToDoubleExpression = StringExpressionImpl<1, decltype(toNumeric<double>)>;
 
 }  // namespace detail::string_expressions
 using namespace detail::string_expressions;
@@ -476,8 +476,10 @@ Expr makeEncodeForUriExpression(Expr child) {
   return make<EncodeForUriExpression>(child);
 }
 
-Expr makeIntExpression(Expr child) { return make<ToInt>(child); }
+Expr makeIntExpression(Expr child) { return make<ToIntExpression>(child); }
 
-Expr makeDoubleExpression(Expr child) { return make<ToDouble>(child); }
+Expr makeDoubleExpression(Expr child) {
+  return make<ToDoubleExpression>(child);
+}
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -399,7 +399,7 @@ class ConcatExpression : public detail::VariadicExpression {
 using EncodeForUriExpression =
     StringExpressionImpl<1, decltype(encodeForUriImpl)>;
 
-// TO_INT
+// TO_NUMERIC (int or double)
 auto InvalidArg = std::errc::invalid_argument;
 auto OutOfRange = std::errc::result_out_of_range;
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -406,9 +406,10 @@ template <typename T>
     return Id::makeUndefined();
   } else {
     auto str = absl::StripAsciiWhitespace(input.value());
+    auto strEnd = str.data() + str.size();
     double resD{};
-    auto conv = absl::from_chars(str.data(), str.data() + str.size(), resD);
-    if (conv.ec != std::error_code{} || conv.ptr != str.data() + str.size()) {
+    auto conv = absl::from_chars(str.data(), strEnd, resD);
+    if (conv.ec != std::error_code{} || conv.ptr != strEnd) {
       return Id::makeUndefined();
     }
     if constexpr (std::is_same_v<T, int64_t>) {
@@ -475,8 +476,8 @@ Expr makeEncodeForUriExpression(Expr child) {
   return make<EncodeForUriExpression>(child);
 }
 
-Expr toIntExpression(Expr child) { return make<ToInt>(child); }
+Expr makeIntExpression(Expr child) { return make<ToInt>(child); }
 
-Expr toDoubleExpression(Expr child) { return make<ToDouble>(child); }
+Expr makeDoubleExpression(Expr child) { return make<ToDouble>(child); }
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -411,7 +411,7 @@ template <typename T>
     T res{};
     const auto& str = input.value();
     auto conv = std::from_chars(str.data(), str.data() + str.size(), res);
-    if (conv.ec == InvalidArg || conv.ec == OutOfRange) {
+    if (conv.ec != std::error_code{} || conv.ptr != str.data() + str.size()) {
       return Id::makeUndefined();
     }
     if (std::is_same_v<T, double>) { return Id::makeFromDouble(res); }

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -401,7 +401,7 @@ using EncodeForUriExpression =
 
 // Expressions that convert a string to a number (int or double).
 template <typename T>
-[[maybe_used]] auto toNumeric = [] (std::optional<std::string> input) {
+[[maybe_used]] auto toNumeric = [](std::optional<std::string> input) {
   if (!input.has_value()) {
     return Id::makeUndefined();
   } else {
@@ -411,11 +411,12 @@ template <typename T>
     if (conv.ec != std::error_code{} || conv.ptr != str.data() + str.size()) {
       return Id::makeUndefined();
     }
-    if constexpr (std::is_same_v<T, int64_t>) { 
+    if constexpr (std::is_same_v<T, int64_t>) {
       auto resT = static_cast<T>(resD);
       return Id::makeFromInt(resT);
+    } else {
+      return Id::makeFromDouble(resD);
     }
-    else { return Id::makeFromDouble(resD); }
   }
 };
 using ToInt = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;
@@ -474,12 +475,8 @@ Expr makeEncodeForUriExpression(Expr child) {
   return make<EncodeForUriExpression>(child);
 }
 
-Expr toIntExpression(Expr child) { 
-  return make<ToInt>(child); 
-}
+Expr toIntExpression(Expr child) { return make<ToInt>(child); }
 
-Expr toDoubleExpression(Expr child) {
-  return make<ToDouble>(child);
-}
+Expr toDoubleExpression(Expr child) { return make<ToDouble>(child); }
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -399,6 +399,25 @@ class ConcatExpression : public detail::VariadicExpression {
 using EncodeForUriExpression =
     StringExpressionImpl<1, decltype(encodeForUriImpl)>;
 
+// TO_INT
+auto InvalidArg = std::errc::invalid_argument;
+auto OutOfRange = std::errc::result_out_of_range;
+
+[[maybe_used]] auto strToIntImpl = [] (std::optional<std::string> input) {
+  if (!input.has_value()) {
+    return Id::makeUndefined();
+  } else {
+    int res{};
+    auto str = boost::lexical_cast<std::string>(*input);
+    auto conv = std::from_chars(str.data(), str.data() + str.size(), res);
+    if (conv.ec == InvalidArg || conv.ec == OutOfRange) {
+      return Id::makeUndefined();
+    }
+    return Id::makeFromInt(res);
+  }
+};
+using MakeStrToInt = StringExpressionImpl<1, decltype(strToIntImpl)>;
+
 }  // namespace detail::string_expressions
 using namespace detail::string_expressions;
 using std::make_unique;
@@ -450,6 +469,10 @@ Expr makeConcatExpression(std::vector<Expr> children) {
 
 Expr makeEncodeForUriExpression(Expr child) {
   return make<EncodeForUriExpression>(child);
+}
+
+Expr makeStrToIntExpression(Expr child) {
+  return make<MakeStrToInt>(child);
 }
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -409,7 +409,7 @@ template <typename T>
     return Id::makeUndefined();
   } else {
     T res{};
-    auto str = boost::lexical_cast<std::string>(*input);
+    const auto& str = input.value();
     auto conv = std::from_chars(str.data(), str.data() + str.size(), res);
     if (conv.ec == InvalidArg || conv.ec == OutOfRange) {
       return Id::makeUndefined();

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -418,7 +418,7 @@ template <typename T>
     else { return Id::makeFromInt(res); }
   }
 };
-using MakeStrToInt = StringExpressionImpl<1, decltype(toNumeric<int>)>;
+using MakeStrToInt = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;
 using MakeDoubleToInt = StringExpressionImpl<1, decltype(toNumeric<double>)>;
 
 }  // namespace detail::string_expressions

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -411,15 +411,15 @@ template <typename T>
     if (conv.ec != std::error_code{} || conv.ptr != str.data() + str.size()) {
       return Id::makeUndefined();
     }
-    if (std::is_same_v<T, int64_t>) { 
+    if constexpr (std::is_same_v<T, int64_t>) { 
       auto resT = static_cast<T>(resD);
       return Id::makeFromInt(resT);
     }
     else { return Id::makeFromDouble(resD); }
   }
 };
-using MakeStrToInt = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;
-using MakeDoubleToInt = StringExpressionImpl<1, decltype(toNumeric<double>)>;
+using ToInt = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;
+using ToDouble = StringExpressionImpl<1, decltype(toNumeric<double>)>;
 
 }  // namespace detail::string_expressions
 using namespace detail::string_expressions;
@@ -474,12 +474,12 @@ Expr makeEncodeForUriExpression(Expr child) {
   return make<EncodeForUriExpression>(child);
 }
 
-Expr makeStrToIntExpression(Expr child) { 
-  return make<MakeStrToInt>(child); 
+Expr toIntExpression(Expr child) { 
+  return make<ToInt>(child); 
 }
 
-Expr makeStrToDoubleExpression(Expr child) {
-  return make<MakeDoubleToInt>(child);
+Expr toDoubleExpression(Expr child) {
+  return make<ToDouble>(child);
 }
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -407,17 +407,20 @@ template <typename T>
   } else {
     auto str = absl::StripAsciiWhitespace(input.value());
     auto strEnd = str.data() + str.size();
-    double resD{};
-    auto conv = absl::from_chars(str.data(), strEnd, resD);
-    if (conv.ec != std::error_code{} || conv.ptr != strEnd) {
-      return Id::makeUndefined();
-    }
+    auto strStart = str.data();
+    T resD{};
     if constexpr (std::is_same_v<T, int64_t>) {
-      auto resT = static_cast<T>(resD);
-      return Id::makeFromInt(resT);
+      auto conv = std::from_chars(strStart, strEnd, resD);
+      if (conv.ec == std::error_code{} && conv.ptr == strEnd) {
+        return Id::makeFromInt(resD);
+      }
     } else {
-      return Id::makeFromDouble(resD);
+      auto conv = absl::from_chars(strStart, strEnd, resD);
+      if (conv.ec == std::error_code{} && conv.ptr == strEnd) {
+        return Id::makeFromDouble(resD);
+      }
     }
+    return Id::makeUndefined();
   }
 };
 using ToIntExpression = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -400,22 +400,22 @@ using EncodeForUriExpression =
     StringExpressionImpl<1, decltype(encodeForUriImpl)>;
 
 // Expressions that convert a string to a number (int or double).
-auto InvalidArg = std::errc::invalid_argument;
-auto OutOfRange = std::errc::result_out_of_range;
-
 template <typename T>
 [[maybe_used]] auto toNumeric = [] (std::optional<std::string> input) {
   if (!input.has_value()) {
     return Id::makeUndefined();
   } else {
-    T res{};
-    const auto& str = input.value();
-    auto conv = std::from_chars(str.data(), str.data() + str.size(), res);
+    auto str = absl::StripAsciiWhitespace(input.value());
+    double resD{};
+    auto conv = absl::from_chars(str.data(), str.data() + str.size(), resD);
     if (conv.ec != std::error_code{} || conv.ptr != str.data() + str.size()) {
       return Id::makeUndefined();
     }
-    if (std::is_same_v<T, double>) { return Id::makeFromDouble(res); }
-    else { return Id::makeFromInt(res); }
+    if (std::is_same_v<T, int64_t>) { 
+      auto resT = static_cast<T>(resD);
+      return Id::makeFromInt(resT);
+    }
+    else { return Id::makeFromDouble(resD); }
   }
 };
 using MakeStrToInt = StringExpressionImpl<1, decltype(toNumeric<int64_t>)>;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -399,7 +399,7 @@ class ConcatExpression : public detail::VariadicExpression {
 using EncodeForUriExpression =
     StringExpressionImpl<1, decltype(encodeForUriImpl)>;
 
-// TO_NUMERIC (int or double)
+// Expressions that convert a string to a number (int or double).
 auto InvalidArg = std::errc::invalid_argument;
 auto OutOfRange = std::errc::result_out_of_range;
 

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -60,8 +60,8 @@ static constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "http://www.opengis.net/def/function/geosparql/"};
 static constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
     "math:", "http://www.w3.org/2005/xpath-functions/math#"};
-static constexpr std::pair<std::string_view, std::string_view> SCHEMA_TYPE = {
-    "xml_schema", "http://www.w3.org/2001/XMLSchema#"};
+static constexpr std::pair<std::string_view, std::string_view> XSD_PREFIX = {
+    "xsd", "http://www.w3.org/2001/XMLSchema#"};
 
 static const std::string INTERNAL_VARIABLE_PREFIX =
     "?_QLever_internal_variable_";

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -60,6 +60,8 @@ static constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "http://www.opengis.net/def/function/geosparql/"};
 static constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
     "math:", "http://www.w3.org/2005/xpath-functions/math#"};
+static constexpr std::pair<std::string_view, std::string_view> SCHEMA_TYPE = {
+    "xml_schema", "http://www.w3.org/2001/XMLSchema#"};
 
 static const std::string INTERNAL_VARIABLE_PREFIX =
     "?_QLever_internal_variable_";

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -121,13 +121,13 @@ ExpressionPtr Visitor::processIriFunctionCall(
       checkNumArgs(1);
       return sparqlExpression::makeTanExpression(std::move(argList[0]));
     }
-  } else if (checkPrefix(SCHEMA_TYPE)) {
+  } else if (checkPrefix(XSD_PREFIX)) {
     if (functionName == "integer" || functionName == "int") {
       checkNumArgs(1);
-      return sparqlExpression::toIntExpression(std::move(argList[0]));
+      return sparqlExpression::makeIntExpression(std::move(argList[0]));
     } else if (functionName == "double" || functionName == "decimal") {
       checkNumArgs(1);
-      return sparqlExpression::toDoubleExpression(std::move(argList[0]));
+      return sparqlExpression::makeDoubleExpression(std::move(argList[0]));
     }
   }
   reportNotSupported(ctx,

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -121,7 +121,19 @@ ExpressionPtr Visitor::processIriFunctionCall(
       checkNumArgs(1);
       return sparqlExpression::makeTanExpression(std::move(argList[0]));
     }
-  }
+  } else if (checkPrefix(SCHEMA_TYPE)) {
+    if (functionName == "integer") {
+      checkNumArgs(1);
+      return sparqlExpression::makeStrToIntExpression(
+        std::move(argList[0])
+      );
+    } else if (functionName == "double") {
+      checkNumArgs(1);
+      return sparqlExpression::makeStrToDoubleExpression(
+        std::move(argList[0])
+      );
+    }
+  } 
   reportNotSupported(ctx,
                      "Function \""s + iri.toStringRepresentation() + "\" is");
 }
@@ -1801,10 +1813,6 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
     return createUnary(&makeIsLiteralExpression);
   } else if (functionName == "isnumeric") {
     return createUnary(&makeIsNumericExpression);
-  } else if (functionName == "INT()") { 
-    return createUnary(&makeStrToIntExpression);
-  } else if (functionName == "DOUBLE()") { 
-    return createUnary(&makeStrToDoubleExpression);
   } else if (functionName == "bound") {
     return makeBoundExpression(
         std::make_unique<VariableExpression>(visit(ctx->var())));

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1801,6 +1801,10 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
     return createUnary(&makeIsLiteralExpression);
   } else if (functionName == "isnumeric") {
     return createUnary(&makeIsNumericExpression);
+  } else if (functionName == "INT()") { 
+    return createUnary(&makeStrToIntExpression);
+  } else if (functionName == "DOUBLE()") { 
+    return createUnary(&makeStrToDoubleExpression);
   } else if (functionName == "bound") {
     return makeBoundExpression(
         std::make_unique<VariableExpression>(visit(ctx->var())));

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -124,14 +124,10 @@ ExpressionPtr Visitor::processIriFunctionCall(
   } else if (checkPrefix(SCHEMA_TYPE)) {
     if (functionName == "integer") {
       checkNumArgs(1);
-      return sparqlExpression::makeStrToIntExpression(
-        std::move(argList[0])
-      );
+      return sparqlExpression::toIntExpression(std::move(argList[0]));
     } else if (functionName == "double") {
       checkNumArgs(1);
-      return sparqlExpression::makeStrToDoubleExpression(
-        std::move(argList[0])
-      );
+      return sparqlExpression::toDoubleExpression(std::move(argList[0]));
     }
   } 
   reportNotSupported(ctx,

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -122,7 +122,7 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return sparqlExpression::makeTanExpression(std::move(argList[0]));
     }
   } else if (checkPrefix(SCHEMA_TYPE)) {
-    if (functionName == "integer") {
+    if (functionName == "integer" || functionName == "int") {
       checkNumArgs(1);
       return sparqlExpression::toIntExpression(std::move(argList[0]));
     } else if (functionName == "double" || functionName == "decimal") {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -129,7 +129,7 @@ ExpressionPtr Visitor::processIriFunctionCall(
       checkNumArgs(1);
       return sparqlExpression::toDoubleExpression(std::move(argList[0]));
     }
-  } 
+  }
   reportNotSupported(ctx,
                      "Function \""s + iri.toStringRepresentation() + "\" is");
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -125,7 +125,7 @@ ExpressionPtr Visitor::processIriFunctionCall(
     if (functionName == "integer") {
       checkNumArgs(1);
       return sparqlExpression::toIntExpression(std::move(argList[0]));
-    } else if (functionName == "double") {
+    } else if (functionName == "double" || functionName == "decimal") {
       checkNumArgs(1);
       return sparqlExpression::toDoubleExpression(std::move(argList[0]));
     }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1534,6 +1534,7 @@ TEST(SparqlParser, FunctionCall) {
   // manually add it when constructing parser inputs.
   auto geof = absl::StrCat("<", GEOF_PREFIX.second);
   auto math = absl::StrCat("<", MATH_PREFIX.second);
+  auto xsd = absl::StrCat("<", XSD_PREFIX.second);
 
   // Correct function calls. Check that the parser picks the correct expression.
   expectFunctionCall(absl::StrCat(geof, "latitude>(?x)"),
@@ -1555,6 +1556,14 @@ TEST(SparqlParser, FunctionCall) {
                      matchUnary(&makeCosExpression));
   expectFunctionCall(absl::StrCat(math, "tan>(?x)"),
                      matchUnary(&makeTanExpression));
+  expectFunctionCall(absl::StrCat(xsd, "int>(?x)"),
+                     matchUnary(&makeIntExpression));
+  expectFunctionCall(absl::StrCat(xsd, "integer>(?x)"),
+                     matchUnary(&makeIntExpression));
+  expectFunctionCall(absl::StrCat(xsd, "double>(?x)"),
+                     matchUnary(&makeDoubleExpression));
+  expectFunctionCall(absl::StrCat(xsd, "decimal>(?x)"),
+                     matchUnary(&makeDoubleExpression));
 
   // Wrong number of arguments.
   expectFunctionCallFails(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -811,11 +811,11 @@ TEST(SparqlExpression, testToNumericExpression) {
   auto checkGetDouble = testUnaryExpression<&makeStrToDoubleExpression>;
   
   checkGetInt(idOrLitOrStringVec(
-    {U, "5.97", "-78.97", "-57BoB36", "11111111111111", "FreBurg1", ""}),
-    Ids{U, I(5), I(-78), I(-57), U, U, U});
+    {U, "5.97", "-78.97", "-5BoB6", "FreBurg1", "", " .", " 42\n", " 0.01 "}),
+    Ids{U, I(5), I(-78), U, U, U, U, I(42), I(0)});
   checkGetDouble(idOrLitOrStringVec(
-    {U, "-122.2", "19,96", "-125878930300334.345","UniFr2", "-ab", "144.86375"}),
-    Ids{U, D(-122.2), D(19), D(-125878930300334.345), U, U, D(144.86375)});
+    {U, "-122.2", "19,96", " 128789334.345 ", "-0.f" , "  0.007 "," -14.75 "}),
+    Ids{U, D(-122.2), U, D(128789334.345), U, D(0.007), D(-14.75)});
 }
 
 // ____________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -807,8 +807,8 @@ TEST(SparqlExpression, isSomethingFunctions) {
 
 // ____________________________________________________________________________
 TEST(SparqlExpression, testToNumericExpression) {
-  auto checkGetInt = testUnaryExpression<&toIntExpression>;
-  auto checkGetDouble = testUnaryExpression<&toDoubleExpression>;
+  auto checkGetInt = testUnaryExpression<&makeIntExpression>;
+  auto checkGetDouble = testUnaryExpression<&makeDoubleExpression>;
 
   checkGetInt(idOrLitOrStringVec({U, "5.97", "-78.97", "-5BoB6", "FreBurg1", "",
                                   " .", " 42\n", " 0.01 "}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -809,13 +809,14 @@ TEST(SparqlExpression, isSomethingFunctions) {
 TEST(SparqlExpression, testToNumericExpression) {
   auto checkGetInt = testUnaryExpression<&toIntExpression>;
   auto checkGetDouble = testUnaryExpression<&toDoubleExpression>;
-  
-  checkGetInt(idOrLitOrStringVec(
-    {U, "5.97", "-78.97", "-5BoB6", "FreBurg1", "", " .", " 42\n", " 0.01 "}),
-    Ids{U, I(5), I(-78), U, U, U, U, I(42), I(0)});
-  checkGetDouble(idOrLitOrStringVec(
-    {U, "-122.2", "19,96", " 128789334.345 ", "-0.f" , "  0.007 "," -14.75 "}),
-    Ids{U, D(-122.2), U, D(128789334.345), U, D(0.007), D(-14.75)});
+
+  checkGetInt(idOrLitOrStringVec({U, "5.97", "-78.97", "-5BoB6", "FreBurg1", "",
+                                  " .", " 42\n", " 0.01 "}),
+              Ids{U, I(5), I(-78), U, U, U, U, I(42), I(0)});
+  checkGetDouble(
+      idOrLitOrStringVec({U, "-122.2", "19,96", " 128789334.345 ", "-0.f",
+                          "  0.007 ", " -14.75 "}),
+      Ids{U, D(-122.2), U, D(128789334.345), U, D(0.007), D(-14.75)});
 }
 
 // ____________________________________________________________________________

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -807,8 +807,8 @@ TEST(SparqlExpression, isSomethingFunctions) {
 
 // ____________________________________________________________________________
 TEST(SparqlExpression, testToNumericExpression) {
-  auto checkGetInt = testUnaryExpression<&makeStrToIntExpression>;
-  auto checkGetDouble = testUnaryExpression<&makeStrToDoubleExpression>;
+  auto checkGetInt = testUnaryExpression<&toIntExpression>;
+  auto checkGetDouble = testUnaryExpression<&toDoubleExpression>;
   
   checkGetInt(idOrLitOrStringVec(
     {U, "5.97", "-78.97", "-5BoB6", "FreBurg1", "", " .", " 42\n", " 0.01 "}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -810,9 +810,9 @@ TEST(SparqlExpression, testToNumericExpression) {
   auto checkGetInt = testUnaryExpression<&makeIntExpression>;
   auto checkGetDouble = testUnaryExpression<&makeDoubleExpression>;
 
-  checkGetInt(idOrLitOrStringVec({U, "5.97", "-78.97", "-5BoB6", "FreBurg1", "",
-                                  " .", " 42\n", " 0.01 "}),
-              Ids{U, I(5), I(-78), U, U, U, U, I(42), I(0)});
+  checkGetInt(idOrLitOrStringVec({U, "  -1275", "5.97", "-78.97", "-5BoB6",
+                                  "FreBurg1", "", " .", " 42\n", " 0.01 ", ""}),
+              Ids{U, I(-1275), U, U, U, U, U, U, I(42), U, U});
   checkGetDouble(
       idOrLitOrStringVec({U, "-122.2", "19,96", " 128789334.345 ", "-0.f",
                           "  0.007 ", " -14.75 "}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -806,6 +806,19 @@ TEST(SparqlExpression, isSomethingFunctions) {
 }
 
 // ____________________________________________________________________________
+TEST(SparqlExpression, testToNumericExpression) {
+  auto checkGetInt = testUnaryExpression<&makeStrToIntExpression>;
+  auto checkGetDouble = testUnaryExpression<&makeStrToDoubleExpression>;
+  
+  checkGetInt(idOrLitOrStringVec(
+    {U, "5.97", "-78.97", "-57BoB36", "11111111111111", "FreBurg1", ""}),
+    Ids{U, I(5), I(-78), I(-57), U, U, U});
+  checkGetDouble(idOrLitOrStringVec(
+    {U, "-122.2", "19,96", "-125878930300334.345","UniFr2", "-ab", "144.86375"}),
+    Ids{U, D(-122.2), D(19), D(-125878930300334.345), U, U, D(144.86375)});
+}
+
+// ____________________________________________________________________________
 TEST(SparqlExpression, geoSparqlExpressions) {
   auto checkLat = testUnaryExpression<&makeLatitudeExpression>;
   auto checkLong = testUnaryExpression<&makeLongitudeExpression>;


### PR DESCRIPTION
Add functions `xsd:integer, xsd:int, xsd:double, xsd:decimal` that convert strings to numeric types.
Currently the following limitations remain, which will be addressed by a future PR:
0. As QLever stores all numeric types with a fixed precision, overflowing integer conversions will currently silently lead to an UNDEF result value. We should make this behavior configurable (e.g. throwing or implicit conversion to decimal/double in this case).
1. The functions currently only take strings, so for example `xsd:int(3)` or `xsd:int(3.2)` will lead to an UNDEF value.