### PR TITLE
Use `LiteralOrIri` instead of `std::string` in `LocalVocab`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ else ()
 endif ()
 
 ## Build targets for address sanitizer
-# AddressSanitize
+
 set(CMAKE_C_FLAGS_ASAN
         "-fsanitize=address -fsanitize=undefined -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
         CACHE STRING "Flags used by the C compiler during AddressSanitizer builds."

--- a/benchmark/GroupByHashMapBenchmark.cpp
+++ b/benchmark/GroupByHashMapBenchmark.cpp
@@ -84,7 +84,9 @@ auto generateRandomLocalVocabAndIndicesVec = [](size_t n, size_t m) {
     for (size_t j = 0; j < m; j++) {
       str += alphanum.at(gen());
     }
-    indices.push_back(localVocab.getIndexAndAddIfNotContained(str));
+    using namespace ad_utility::triple_component;
+    indices.push_back(localVocab.getIndexAndAddIfNotContained(
+        LiteralOrIri::literalWithoutQuotes(str)));
   }
 
   return std::make_pair(std::move(localVocab), indices);

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -197,6 +197,23 @@ ExportQueryExecutionTrees::idToStringAndType(const Index& index, Id id,
       return std::nullopt;
     }
   }
+
+  using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
+  auto handleIriOrLiteral = [&escapeFunction](const LiteralOrIri& word)
+      -> std::optional<std::pair<std::string, const char*>> {
+    if constexpr (onlyReturnLiterals) {
+      if (!word.isLiteral()) {
+        return std::nullopt;
+      }
+    }
+    if constexpr (removeQuotesAndAngleBrackets) {
+      // TODO<joka921> Can we get rid of the string copying here?
+      return std::pair{
+          escapeFunction(std::string{asStringViewUnsafe(word.getContent())}),
+          nullptr};
+    }
+    return std::pair{escapeFunction(word.toStringRepresentation()), nullptr};
+  };
   switch (id.getDatatype()) {
     case Datatype::WordVocabIndex: {
       std::optional<string> entity =
@@ -212,28 +229,10 @@ ExportQueryExecutionTrees::idToStringAndType(const Index& index, Id id,
       auto litOrIri =
           ad_utility::triple_component::LiteralOrIri::fromStringRepresentation(
               entity.value());
-      if constexpr (onlyReturnLiterals) {
-        if (!litOrIri.isLiteral()) {
-          return std::nullopt;
-        }
-      }
-      if constexpr (removeQuotesAndAngleBrackets) {
-        entity = asStringViewUnsafe(litOrIri.getContent());
-      }
-      // TODO<joka921> handle the exporting of literals more correctly.
-      return std::pair{escapeFunction(std::move(entity.value())), nullptr};
+      return handleIriOrLiteral(litOrIri);
     }
     case LocalVocabIndex: {
-      auto word = localVocab.getWord(id.getLocalVocabIndex());
-      if constexpr (onlyReturnLiterals) {
-        if (!word.isLiteral()) {
-          return std::nullopt;
-        }
-      }
-      if constexpr (removeQuotesAndAngleBrackets) {
-        word = RdfEscaping::normalizedContentFromLiteralOrIri(std::move(word));
-      }
-      return std::pair{escapeFunction(std::move(word)), nullptr};
+      return handleIriOrLiteral(localVocab.getWord(id.getLocalVocabIndex()));
     }
     case TextRecordIndex:
       return std::pair{

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -224,9 +224,9 @@ ExportQueryExecutionTrees::idToStringAndType(const Index& index, Id id,
       return std::pair{escapeFunction(std::move(entity.value())), nullptr};
     }
     case LocalVocabIndex: {
-      std::string word = localVocab.getWord(id.getLocalVocabIndex());
+      auto word = localVocab.getWord(id.getLocalVocabIndex());
       if constexpr (onlyReturnLiterals) {
-        if (!word.starts_with('"')) {
+        if (!word.isLiteral()) {
           return std::nullopt;
         }
       }

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -15,9 +15,8 @@
 static constexpr auto valueAdder = []() {
   auto numericValueAdder =
       []<typename T>(T value, double& sum, [[maybe_unused]] const bool& error)
-          requires std::is_arithmetic_v<T> {
-    sum += static_cast<double>(value);
-  };
+          requires std::is_arithmetic_v<T>
+  { sum += static_cast<double>(value); };
   auto nonNumericValueAdder = [](sparqlExpression::detail::NotNumeric,
                                  [[maybe_unused]] const double& sum,
                                  bool& error) { error = true; };
@@ -90,8 +89,7 @@ struct ExtremumAggregationData {
     auto valueIdResultGetter = [](ValueId id) { return id; };
     auto stringResultGetter =
         [localVocab](const ad_utility::triple_component::LiteralOrIri& str) {
-          auto localVocabIndex = localVocab->getIndexAndAddIfNotContained(
-              str.toStringRepresentation());
+          auto localVocabIndex = localVocab->getIndexAndAddIfNotContained(str);
           return ValueId::makeFromLocalVocabIndex(localVocabIndex);
         };
     return std::visit(ad_utility::OverloadCallOperator(valueIdResultGetter,
@@ -163,8 +161,11 @@ struct GroupConcatAggregationData {
 
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(LocalVocab* localVocab) const {
-    auto localVocabIndex =
-        localVocab->getIndexAndAddIfNotContained(currentValue_);
+    using namespace ad_utility::triple_component;
+    using Lit = ad_utility::triple_component::Literal;
+    auto localVocabIndex = localVocab->getIndexAndAddIfNotContained(
+        LiteralOrIri{Lit::literalWithNormalizedContent(
+            asNormalizedStringViewUnsafe(currentValue_))});
     return ValueId::makeFromLocalVocabIndex(localVocabIndex);
   }
 

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -15,8 +15,9 @@
 static constexpr auto valueAdder = []() {
   auto numericValueAdder =
       []<typename T>(T value, double& sum, [[maybe_unused]] const bool& error)
-          requires std::is_arithmetic_v<T>
-  { sum += static_cast<double>(value); };
+          requires std::is_arithmetic_v<T> {
+    sum += static_cast<double>(value);
+  };
   auto nonNumericValueAdder = [](sparqlExpression::detail::NotNumeric,
                                  [[maybe_unused]] const double& sum,
                                  bool& error) { error = true; };

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -8,7 +8,6 @@
 #include "global/Id.h"
 #include "global/ValueId.h"
 
-
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
   LocalVocab localVocabClone;
@@ -44,8 +43,7 @@ LocalVocabIndex LocalVocab::getIndexAndAddIfNotContainedImpl(WordT&& word) {
 }
 
 // _____________________________________________________________________________
-LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(
-    const Entry& word) {
+LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(const Entry& word) {
   return getIndexAndAddIfNotContainedImpl(word);
 }
 
@@ -68,10 +66,10 @@ std::optional<LocalVocabIndex> LocalVocab::getIndexOrNullopt(
 }
 
 // _____________________________________________________________________________
-const LocalVocab::Entry& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
+const LocalVocab::Entry& LocalVocab::getWord(
+    LocalVocabIndex localVocabIndex) const {
   return *localVocabIndex;
 }
-
 
 // _____________________________________________________________________________
 std::vector<LocalVocab::Entry> LocalVocab::getAllWordsForTesting() const {

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -8,6 +8,7 @@
 #include "global/Id.h"
 #include "global/ValueId.h"
 
+
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
   LocalVocab localVocabClone;
@@ -44,19 +45,19 @@ LocalVocabIndex LocalVocab::getIndexAndAddIfNotContainedImpl(WordT&& word) {
 
 // _____________________________________________________________________________
 LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(
-    const std::string& word) {
+    const Entry& word) {
   return getIndexAndAddIfNotContainedImpl(word);
 }
 
 // _____________________________________________________________________________
-LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(std::string&& word) {
+LocalVocabIndex LocalVocab::getIndexAndAddIfNotContained(Entry&& word) {
   return getIndexAndAddIfNotContainedImpl(std::move(word));
 }
 
 // _____________________________________________________________________________
 std::optional<LocalVocabIndex> LocalVocab::getIndexOrNullopt(
-    const std::string& word) const {
-  auto localVocabIndex = primaryWordSet().find(StringAligned16{word});
+    const Entry& word) const {
+  auto localVocabIndex = primaryWordSet().find(word);
   if (localVocabIndex != primaryWordSet().end()) {
     // TODO<Libc++18> Use std::to_address (more idiomatic, but currently breaks
     // the MacOS build.
@@ -67,13 +68,14 @@ std::optional<LocalVocabIndex> LocalVocab::getIndexOrNullopt(
 }
 
 // _____________________________________________________________________________
-const std::string& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
+const LocalVocab::Entry& LocalVocab::getWord(LocalVocabIndex localVocabIndex) const {
   return *localVocabIndex;
 }
 
+
 // _____________________________________________________________________________
-std::vector<std::string> LocalVocab::getAllWordsForTesting() const {
-  std::vector<std::string> result;
+std::vector<LocalVocab::Entry> LocalVocab::getAllWordsForTesting() const {
+  std::vector<Entry> result;
   std::ranges::copy(primaryWordSet(), std::back_inserter(result));
   for (const auto& previous : otherWordSets_) {
     std::ranges::copy(*previous, std::back_inserter(result));

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -18,18 +18,14 @@
 // meant for words that are not part of the normal vocabulary (constructed from
 // the input data at indexing time).
 //
-// TODO: This is a first version of this class with basic functionality. Note
-// that the local vocabulary used to be a simple `std::vector<Entry>`
-// defined inside of the `ResultTable` class. You gotta start somewhere.
-
 class LocalVocab {
  private:
-  using Entry = ad_utility::triple_component::LiteralOrIri;
+  using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
   // A map of the words in the local vocabulary to their local IDs. This is a
   // node hash map because we need the addresses of the words (which are of type
-  // `Entry`) to remain stable over their lifetime in the hash map because
-  // we hand out pointers to them.
-  using Set = absl::node_hash_set<Entry>;
+  // `LiteralOrIri`) to remain stable over their lifetime in the hash map
+  // because we hand out pointers to them.
+  using Set = absl::node_hash_set<LiteralOrIri>;
   std::shared_ptr<Set> primaryWordSet_ = std::make_shared<Set>();
 
   // Local vocabularies from child operations that were merged into this
@@ -61,12 +57,13 @@ class LocalVocab {
   // Get the index of a word in the local vocabulary. If the word was already
   // contained, return the already existing index. If the word was not yet
   // contained, add it, and return the new index.
-  LocalVocabIndex getIndexAndAddIfNotContained(const Entry& word);
-  LocalVocabIndex getIndexAndAddIfNotContained(Entry&& word);
+  LocalVocabIndex getIndexAndAddIfNotContained(const LiteralOrIri& word);
+  LocalVocabIndex getIndexAndAddIfNotContained(LiteralOrIri&& word);
 
   // Get the index of a word in the local vocabulary, or std::nullopt if it is
   // not contained. This is useful for testing.
-  std::optional<LocalVocabIndex> getIndexOrNullopt(const Entry& word) const;
+  std::optional<LocalVocabIndex> getIndexOrNullopt(
+      const LiteralOrIri& word) const;
 
   // The number of words in the vocabulary.
   // Note: This is not constant time, but linear in the number of word sets.
@@ -82,14 +79,14 @@ class LocalVocab {
   bool empty() const { return size() == 0; }
 
   // Return a const reference to the word.
-  const Entry& getWord(LocalVocabIndex localVocabIndex) const;
+  const LiteralOrIri& getWord(LocalVocabIndex localVocabIndex) const;
 
   // Create a local vocab that contains and keeps alive all the words from each
   // of the `vocabs`. The primary word set of the newly created vocab is empty.
   static LocalVocab merge(std::span<const LocalVocab*> vocabs);
 
   // Return all the words from all the word sets as a vector.
-  std::vector<Entry> getAllWordsForTesting() const;
+  std::vector<LiteralOrIri> getAllWordsForTesting() const;
 
  private:
   // Common implementation for the two variants of

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -12,21 +12,24 @@
 
 #include "absl/container/node_hash_set.h"
 #include "global/Id.h"
+#include "parser/LiteralOrIri.h"
 
 // A class for maintaing a local vocabulary with contiguous (local) IDs. This is
 // meant for words that are not part of the normal vocabulary (constructed from
 // the input data at indexing time).
 //
 // TODO: This is a first version of this class with basic functionality. Note
-// that the local vocabulary used to be a simple `std::vector<std::string>`
+// that the local vocabulary used to be a simple `std::vector<Entry>`
 // defined inside of the `ResultTable` class. You gotta start somewhere.
+
 class LocalVocab {
  private:
+  using Entry = ad_utility::triple_component::LiteralOrIri;
   // A map of the words in the local vocabulary to their local IDs. This is a
   // node hash map because we need the addresses of the words (which are of type
-  // `std::string`) to remain stable over their lifetime in the hash map because
+  // `Entry`) to remain stable over their lifetime in the hash map because
   // we hand out pointers to them.
-  using Set = absl::node_hash_set<StringAligned16>;
+  using Set = absl::node_hash_set<Entry>;
   std::shared_ptr<Set> primaryWordSet_ = std::make_shared<Set>();
 
   // Local vocabularies from child operations that were merged into this
@@ -58,13 +61,13 @@ class LocalVocab {
   // Get the index of a word in the local vocabulary. If the word was already
   // contained, return the already existing index. If the word was not yet
   // contained, add it, and return the new index.
-  LocalVocabIndex getIndexAndAddIfNotContained(const std::string& word);
-  LocalVocabIndex getIndexAndAddIfNotContained(std::string&& word);
+  LocalVocabIndex getIndexAndAddIfNotContained(const Entry& word);
+  LocalVocabIndex getIndexAndAddIfNotContained(Entry&& word);
 
   // Get the index of a word in the local vocabulary, or std::nullopt if it is
   // not contained. This is useful for testing.
   std::optional<LocalVocabIndex> getIndexOrNullopt(
-      const std::string& word) const;
+      const Entry& word) const;
 
   // The number of words in the vocabulary.
   // Note: This is not constant time, but linear in the number of word sets.
@@ -80,14 +83,14 @@ class LocalVocab {
   bool empty() const { return size() == 0; }
 
   // Return a const reference to the word.
-  const std::string& getWord(LocalVocabIndex localVocabIndex) const;
+  const Entry& getWord(LocalVocabIndex localVocabIndex) const;
 
   // Create a local vocab that contains and keeps alive all the words from each
   // of the `vocabs`. The primary word set of the newly created vocab is empty.
   static LocalVocab merge(std::span<const LocalVocab*> vocabs);
 
   // Return all the words from all the word sets as a vector.
-  std::vector<std::string> getAllWordsForTesting() const;
+  std::vector<Entry> getAllWordsForTesting() const;
 
  private:
   // Common implementation for the two variants of

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -66,8 +66,7 @@ class LocalVocab {
 
   // Get the index of a word in the local vocabulary, or std::nullopt if it is
   // not contained. This is useful for testing.
-  std::optional<LocalVocabIndex> getIndexOrNullopt(
-      const Entry& word) const;
+  std::optional<LocalVocabIndex> getIndexOrNullopt(const Entry& word) const;
 
   // The number of words in the vocabulary.
   // Note: This is not constant time, but linear in the number of word sets.

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -196,7 +196,7 @@ Id constantExpressionResultToId(T&& result, LocalVocabT& localVocab) {
                             R, ad_utility::triple_component::LiteralOrIri>) {
             return Id::makeFromLocalVocabIndex(
                 localVocab.getIndexAndAddIfNotContained(
-                    AD_FWD(el).toStringRepresentation()));
+                    AD_FWD(el)));
           } else {
             static_assert(ad_utility::isSimilar<R, Id>);
             return el;

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -195,8 +195,7 @@ Id constantExpressionResultToId(T&& result, LocalVocabT& localVocab) {
           if constexpr (ad_utility::isSimilar<
                             R, ad_utility::triple_component::LiteralOrIri>) {
             return Id::makeFromLocalVocabIndex(
-                localVocab.getIndexAndAddIfNotContained(
-                    AD_FWD(el)));
+                localVocab.getIndexAndAddIfNotContained(AD_FWD(el)));
           } else {
             static_assert(ad_utility::isSimilar<R, Id>);
             return el;

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -64,7 +64,9 @@ auto EffectiveBooleanValueGetter::operator()(
                  : True;
     }
     case Datatype::LocalVocabIndex: {
-      return (context->_localVocab.getWord(id.getLocalVocabIndex()).getContent().empty())
+      return (context->_localVocab.getWord(id.getLocalVocabIndex())
+                  .getContent()
+                  .empty())
                  ? False
                  : True;
     }

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -64,7 +64,7 @@ auto EffectiveBooleanValueGetter::operator()(
                  : True;
     }
     case Datatype::LocalVocabIndex: {
-      return (context->_localVocab.getWord(id.getLocalVocabIndex()).empty())
+      return (context->_localVocab.getWord(id.getLocalVocabIndex()).getContent().empty())
                  ? False
                  : True;
     }

--- a/src/global/IndexTypes.h
+++ b/src/global/IndexTypes.h
@@ -6,6 +6,7 @@
 #define QLEVER_INDEXTYPES_H
 
 #include "./TypedIndex.h"
+#include "parser/LiteralOrIri.h"
 
 // Typedefs for several kinds of typed indices that are used across QLever.
 
@@ -14,13 +15,7 @@
 // requests.
 using VocabIndex = ad_utility::TypedIndex<uint64_t, "VocabIndex">;
 
-// A `std::string` that is aligned to 16 bytes s.t. pointers always end with 4
-// bits that are zero and that are reused for payloads in the `ValueId` class.
-struct alignas(16) StringAligned16 : public std::string {
-  using std::string::basic_string;
-  explicit StringAligned16(std::string s) : std::string{std::move(s)} {}
-};
-using LocalVocabIndex = const StringAligned16*;
+using LocalVocabIndex = const ad_utility::triple_component::LiteralOrIri*;
 using TextRecordIndex = ad_utility::TypedIndex<uint64_t, "TextRecordIndex">;
 using WordVocabIndex = ad_utility::TypedIndex<uint64_t, "WordVocabIndex">;
 using BlankNodeIndex = ad_utility::TypedIndex<uint64_t, "BlankNodeIndex">;

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -339,7 +339,7 @@ class ValueId {
         ostr << value.toStringAndType().first;
       } else if constexpr (ad_utility::isSimilar<T, LocalVocabIndex>) {
         AD_CORRECTNESS_CHECK(value != nullptr);
-        ostr << *value;
+        ostr << value->toStringRepresentation();
       } else {
         // T is `VocabIndex | TextRecordIndex`
         ostr << std::to_string(value.get());

--- a/src/parser/LiteralOrIri.h
+++ b/src/parser/LiteralOrIri.h
@@ -18,7 +18,7 @@ static constexpr char iriPrefixChar = '<';
 static constexpr std::string_view iriPrefix{&iriPrefixChar, 1};
 static constexpr std::string_view literalPrefix{&literalPrefixChar, 1};
 // A wrapper class that can contain either an Iri or a Literal object.
-class LiteralOrIri {
+class alignas(16) LiteralOrIri {
  private:
   using LiteralOrIriVariant = std::variant<Literal, Iri>;
   LiteralOrIriVariant data_;
@@ -60,6 +60,11 @@ class LiteralOrIri {
     return H::combine(std::move(h), literalOrIri.data_);
   }
   bool operator==(const LiteralOrIri&) const = default;
+
+  auto operator<=>(const LiteralOrIri& rhs) const {
+    // TODO<joka921> Use something unicode-based for this.
+    return toStringRepresentation() <=> rhs.toStringRepresentation();
+  }
 
   // Return true if object contains an Iri object
   bool isIri() const;

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -225,8 +225,9 @@ class TripleComponent {
         if (isLiteral()) {
           return LoI{std::move(getLiteral())};
         } else {
-          return LoI { std::move(getIri())};
-        }}();
+          return LoI{std::move(getIri())};
+        }
+      }();
       // NOTE: There is a `&&` version of `getIndexAndAddIfNotContained`.
       // Otherwise, `newWord` would be copied here despite the `std::move`.
       id = Id::makeFromLocalVocabIndex(

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -219,18 +219,14 @@ class TripleComponent {
     if (!id) {
       // If `toValueId` could not convert to `Id`, we have a string, which we
       // look up in (and potentially add to) our local vocabulary.
-      AD_CORRECTNESS_CHECK(isString() || isLiteral() || isIri());
-      std::string& newWord = [&]() -> std::string& {
-        if (isString()) {
-          return getString();
+      AD_CORRECTNESS_CHECK(isLiteral() || isIri());
+      using LoI = ad_utility::triple_component::LiteralOrIri;
+      LoI newWord = [&]() -> LoI {
+        if (isLiteral()) {
+          return LoI{std::move(getLiteral())};
         } else {
-          if (isLiteral()) {
-            return getLiteral().toStringRepresentation();
-          } else {
-            return getIri().toStringRepresentation();
-          }
-        }
-      }();
+          return LoI { std::move(getIri())};
+        }}();
       // NOTE: There is a `&&` version of `getIndexAndAddIfNotContained`.
       // Otherwise, `newWord` would be copied here despite the `std::move`.
       id = Id::makeFromLocalVocabIndex(

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -220,18 +220,18 @@ class TripleComponent {
       // If `toValueId` could not convert to `Id`, we have a string, which we
       // look up in (and potentially add to) our local vocabulary.
       AD_CORRECTNESS_CHECK(isLiteral() || isIri());
-      using LoI = ad_utility::triple_component::LiteralOrIri;
-      LoI newWord = [&]() -> LoI {
+      using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
+      auto moveWord = [&]() -> LiteralOrIri {
         if (isLiteral()) {
-          return LoI{std::move(getLiteral())};
+          return LiteralOrIri{std::move(getLiteral())};
         } else {
-          return LoI{std::move(getIri())};
+          return LiteralOrIri{std::move(getIri())};
         }
-      }();
+      };
       // NOTE: There is a `&&` version of `getIndexAndAddIfNotContained`.
       // Otherwise, `newWord` would be copied here despite the `std::move`.
       id = Id::makeFromLocalVocabIndex(
-          localVocab.getIndexAndAddIfNotContained(std::move(newWord)));
+          localVocab.getIndexAndAddIfNotContained(moveWord()));
     }
     return id.value();
   }

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -127,9 +127,12 @@ TEST_F(GroupByTest, doGroupBy) {
 
   // Create an input result table with a local vocabulary.
   auto localVocab = std::make_shared<LocalVocab>();
-  localVocab->getIndexAndAddIfNotContained("<local1>");
-  localVocab->getIndexAndAddIfNotContained("<local2>");
-  localVocab->getIndexAndAddIfNotContained("<local3>");
+  constexpr auto iriref = [](const std::string& s) {
+    return ad_utility::triple_component::LiteralOrIri::iriref(s);
+  };
+  localVocab->getIndexAndAddIfNotContained(iriref("<local1>"));
+  localVocab->getIndexAndAddIfNotContained(iriref("<local2>"));
+  localVocab->getIndexAndAddIfNotContained(iriref("<local3>"));
 
   IdTable inputData(6, makeAllocator());
   // The input data types are KB, KB, VERBATIM, TEXT, FLOAT, STRING.
@@ -1231,7 +1234,9 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatIndex) {
 
   auto getId = makeGetId(qec->getIndex());
   auto getLocalVocabId = [&result](const std::string& word) {
-    auto value = result->localVocab().getIndexOrNullopt(word);
+    auto lit =
+        ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(word);
+    auto value = result->localVocab().getIndexOrNullopt(lit);
     if (value.has_value())
       return ValueId::makeFromLocalVocabIndex(value.value());
     else
@@ -1278,7 +1283,9 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatLocalVocab) {
   auto getId = makeGetId(qec->getIndex());
   auto d = DoubleId;
   auto getLocalVocabId = [&result](const std::string& word) {
-    auto value = result->localVocab().getIndexOrNullopt(word);
+    auto lit =
+        ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(word);
+    auto value = result->localVocab().getIndexOrNullopt(lit);
     if (value.has_value())
       return ValueId::makeFromLocalVocabIndex(value.value());
     else

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -173,9 +173,13 @@ TEST_F(ServiceTest, computeResult) {
   Id idY = getId("<y>");
   const auto& localVocab = result->localVocab();
   EXPECT_EQ(localVocab.size(), 3);
-  std::optional<LocalVocabIndex> idxBla = localVocab.getIndexOrNullopt("<bla>");
-  std::optional<LocalVocabIndex> idxBli = localVocab.getIndexOrNullopt("<bli>");
-  std::optional<LocalVocabIndex> idxBlu = localVocab.getIndexOrNullopt("<blu>");
+  auto get = [&localVocab](const std::string& s) {
+    return localVocab.getIndexOrNullopt(
+        ad_utility::triple_component::LiteralOrIri::iriref(s));
+  };
+  std::optional<LocalVocabIndex> idxBla = get("<bla>");
+  std::optional<LocalVocabIndex> idxBli = get("<bli>");
+  std::optional<LocalVocabIndex> idxBlu = get("<blu>");
   ASSERT_TRUE(idxBli.has_value());
   ASSERT_TRUE(idxBla.has_value());
   ASSERT_TRUE(idxBlu.has_value());

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -3,6 +3,7 @@
 //  Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 
 #include "./util/IdTestHelpers.h"
+#include "./util/TripleComponentTestHelpers.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "global/ValueIdComparators.h"
 #include "gtest/gtest.h"
@@ -82,16 +83,24 @@ struct TestContext {
     zz = getId("\"zz\"@en");
     blank = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0));
 
+    constexpr auto lit = [](std::string_view s) {
+      return ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
+          s);
+    };
+    constexpr auto iri = [](const std::string& s) {
+      return ad_utility::triple_component::LiteralOrIri::iriref(s);
+    };
+
     notInVocabA = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained("\"notInVocabA\""));
+        localVocab.getIndexAndAddIfNotContained(lit("notInVocabA")));
     notInVocabB = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained("\"notInVocabB\""));
+        localVocab.getIndexAndAddIfNotContained(lit("notInVocabB")));
     notInVocabC = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained("<notInVocabC>"));
+        localVocab.getIndexAndAddIfNotContained(iri("<notInVocabC>")));
     notInVocabD = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained("<notInVocabD>"));
+        localVocab.getIndexAndAddIfNotContained(iri("<notInVocabD>")));
     notInVocabAelpha = Id::makeFromLocalVocabIndex(
-        localVocab.getIndexAndAddIfNotContained("\"notInVocabÄlpha\""));
+        localVocab.getIndexAndAddIfNotContained(lit("notInVocabÄlpha")));
 
     // Set up the `table` that represents the previous partial query results. It
     // has five columns/variables: ?ints (only integers), ?doubles (only

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -295,8 +295,9 @@ TEST(ValueId, toDebugString) {
   test(ValueId::makeFromBool(false), "Bool:false");
   test(ValueId::makeFromBool(true), "Bool:true");
   test(makeVocabId(15), "VocabIndex:15");
-  auto str = ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("SomeValue");
-  test(ValueId::makeFromLocalVocabIndex(&str), "LocalVocabIndex:SomeValue");
+  auto str = ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
+      "SomeValue");
+  test(ValueId::makeFromLocalVocabIndex(&str), "LocalVocabIndex:\"SomeValue\"");
   test(makeTextRecordId(37), "TextRecordIndex:37");
   test(makeWordVocabId(42), "WordVocabIndex:42");
   test(makeBlankNodeId(27), "BlankNodeIndex:27");

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -295,7 +295,7 @@ TEST(ValueId, toDebugString) {
   test(ValueId::makeFromBool(false), "Bool:false");
   test(ValueId::makeFromBool(true), "Bool:true");
   test(makeVocabId(15), "VocabIndex:15");
-  StringAligned16 str{"SomeValue"};
+  auto str = ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes("SomeValue");
   test(ValueId::makeFromLocalVocabIndex(&str), "LocalVocabIndex:SomeValue");
   test(makeTextRecordId(37), "TextRecordIndex:37");
   test(makeWordVocabId(42), "WordVocabIndex:42");

--- a/test/ValueIdTestHelpers.h
+++ b/test/ValueIdTestHelpers.h
@@ -62,7 +62,7 @@ inline uint64_t getVocabIndex(ValueId id) { return id.getVocabIndex().get(); }
 // TODO<joka921> Make the tests more precise for the localVocabIndices.
 inline std::string getLocalVocabIndex(ValueId id) {
   AD_CORRECTNESS_CHECK(id.getDatatype() == Datatype::LocalVocabIndex);
-  return *id.getLocalVocabIndex();
+  return std::string{asStringViewUnsafe(id.getLocalVocabIndex()->getContent())};
 }
 inline uint64_t getTextRecordIndex(ValueId id) {
   return id.getTextRecordIndex().get();

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -74,7 +74,8 @@ TEST(Values, computeResult) {
   const auto& table = result->idTable();
   Id x = ad_utility::testing::makeGetId(testQec->getIndex())("<x>");
   auto I = ad_utility::testing::IntId;
-  auto l = result->localVocab().getIndexOrNullopt("<y>");
+  auto l = result->localVocab().getIndexOrNullopt(
+      ad_utility::triple_component::LiteralOrIri::iriref("<y>"));
   ASSERT_TRUE(l.has_value());
   auto U = Id::makeUndefined();
   ASSERT_EQ(table,

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -22,8 +22,9 @@ inline auto VocabId = [](const auto& v) {
 
 inline auto LocalVocabId = [](std::integral auto v) {
   static ad_utility::Synchronized<LocalVocab> localVocab;
+  using namespace ad_utility::triple_component;
   return Id::makeFromLocalVocabIndex(
-      localVocab.wlock()->getIndexAndAddIfNotContained(std::to_string(v)));
+      localVocab.wlock()->getIndexAndAddIfNotContained(LiteralOrIri::literalWithoutQuotes(std::to_string(v))));
 };
 
 inline auto TextRecordId = [](const auto& t) {

--- a/test/util/IdTestHelpers.h
+++ b/test/util/IdTestHelpers.h
@@ -24,7 +24,8 @@ inline auto LocalVocabId = [](std::integral auto v) {
   static ad_utility::Synchronized<LocalVocab> localVocab;
   using namespace ad_utility::triple_component;
   return Id::makeFromLocalVocabIndex(
-      localVocab.wlock()->getIndexAndAddIfNotContained(LiteralOrIri::literalWithoutQuotes(std::to_string(v))));
+      localVocab.wlock()->getIndexAndAddIfNotContained(
+          LiteralOrIri::literalWithoutQuotes(std::to_string(v))));
 };
 
 inline auto TextRecordId = [](const auto& t) {


### PR DESCRIPTION
Continue work started with #1186 (which introduced the class `LiteralOrIri`) and #1318 (which used `LiteralOrIri` instead of `std::string` in all SPARQL expressions). This change now uses `LiteralOrIri` instead of `std::string` whenever dealing with words from a `LocalVocab`.