### PR TITLE
Fix bug in `fromStringRepresentation`

### DIFF
--- a/src/parser/LiteralOrIri.h
+++ b/src/parser/LiteralOrIri.h
@@ -46,12 +46,11 @@ class LiteralOrIri {
 
   static LiteralOrIri fromStringRepresentation(std::string internal) {
     char tag = internal.front();
-    if (tag == iriPrefixChar) {
-      return LiteralOrIri{Iri::fromStringRepresentation(std::move(internal))};
-    } else {
-      AD_CORRECTNESS_CHECK(tag == literalPrefixChar);
+    if (tag == literalPrefixChar) {
       return LiteralOrIri{
           Literal::fromStringRepresentation(std::move(internal))};
+    } else {
+      return LiteralOrIri{Iri::fromStringRepresentation(std::move(internal))};
     }
   }
   template <typename H>


### PR DESCRIPTION
#1301 introduced a bug where basic graph patterns like `wdt:Q183 ?p ?o` (fixed subject or object with a language tag, variable predicate) throw an exception. This is now fixed again.