### PR TITLE
Fix empty index scan result with wrong number of columns

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1869,3 +1869,17 @@ queries:
       - contains_row: [ "<Zelda_Rubinstein>", "Z-da_Rubinst-n", "Zelda_ubinstein" ]
       - contains_row: [ "<Zhang_Peili>", "Zhang_P-li", "Zhang_Peili"]
       - contains_row: [ "<Zlata_Bartl>", "Zlata_Bartl", "Zlata_Batl"]
+
+  - query: pattern-trick-empty-subquery
+    type: no-text
+    sparql: |
+      PREFIX foo: <https://example.org/foo#>
+      SELECT ?p  {
+        ?s foo:bar foo:Baz .
+        ?s ?p ?o
+      }
+      GROUP BY ?p
+    checks:
+      - num_cols: 1
+      - selected: [ "?p" ]
+      - num_rows: 0

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1377,7 +1377,7 @@ IdTable IndexImpl::scan(
   if (!col0Id.has_value() || (col1String.has_value() && !col1Id.has_value())) {
     size_t numColumns = col1String.has_value() ? 1 : 2;
     cancellationHandle->throwIfCancelled();
-    return IdTable{numColumns, allocator_};
+    return IdTable{numColumns + additionalColumns.size(), allocator_};
   }
   return scan(col0Id.value(), col1Id, permutation, additionalColumns,
               cancellationHandle);


### PR DESCRIPTION
This affected index scans that scanned additional columns (for example, the folded patterns) and then yielded an empty result. Now also empty results have the correct number of columns in this case. Fixes #1316.