### PR TITLE
Add a git pre-commit hook for clang-format

### DIFF
--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -1,0 +1,16 @@
+# See .pre-commit-config.yaml for usage instructions.
+repos:
+    # Uses the local clang-format
+  - repo: local
+    hooks:
+      # Inspired by https://github.com/doublify/pre-commit-clang-format and
+      # https://github.com/pre-commit/mirrors-clang-format
+      - id: clang-format-16
+        name: clang-format
+        description: Format files with ClangFormat16.
+        entry: clang-format-16 -i
+        language: system
+        'types_or': [ c++, c ]
+        args: [ "-style=file" ]
+        require_serial: false
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 # Usage:
 # - Install pre-commit: `pip install pre-commit` (once).ci:
 # - In the main directory of QLever run `pre-commit install`
+# - Each git commit will now automatically be formatted. Note that
+# - commits will fail if the hook reformats your files, so you
+# - have to run git commit twice in order to first format and then
+# - actually commit.
 # To use your local clang-format-16:
 # - comment out the hook from https://github.com/pre-commit/mirrors-clang-format
 # - comment in the local hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# To use your local clang-format-16:
+# - comment out the hook from https://github.com/pre-commit/mirrors-clang-format
+# - comment in the local hook
+# - run `pre-commit install`
+repos:
+  # Uses a packaged version of clang-format from https://github.com/ssciwr/clang-format-wheel
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v16.0.6'
+    hooks:
+      - id: clang-format
+        'types_or': [ c++, c ]
+    # Uses the local clang-format
+#  - repo: local
+#    hooks:
+#      # Inspired by https://github.com/doublify/pre-commit-clang-format and
+#      # https://github.com/pre-commit/mirrors-clang-format
+#      - id: clang-format-16
+#        name: clang-format
+#        description: Format files with ClangFormat16.
+#        entry: clang-format-16 -i
+#        language: system
+#        'types_or': [ c++, c ]
+#        args: [ "-style=file" ]
+#        require_serial: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+# Usage:
+# - Install pre-commit: `pip install pre-commit` (once).ci:
+# - In the main directory of QLever run `pre-commit install`
 # To use your local clang-format-16:
 # - comment out the hook from https://github.com/pre-commit/mirrors-clang-format
 # - comment in the local hook

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,12 @@
 # Usage:
 # - Install pre-commit: `pip install pre-commit` (once).ci:
-# - In the main directory of QLever run `pre-commit install`
+# - In the main directory of QLever run
+#   - `pre-commit install` to use a package version of clang-format
+#   - `pre-commit install -c .pre-commit-config-local.yaml` to use the local clang-format
 # - Each git commit will now automatically be formatted. Note that
 # - commits will fail if the hook reformats your files, so you
 # - have to run git commit twice in order to first format and then
 # - actually commit.
-# To use your local clang-format-16:
-# - comment out the hook from https://github.com/pre-commit/mirrors-clang-format
-# - comment in the local hook
-# - run `pre-commit install`
 repos:
   # Uses a packaged version of clang-format from https://github.com/ssciwr/clang-format-wheel
   - repo: https://github.com/pre-commit/mirrors-clang-format
@@ -16,16 +14,3 @@ repos:
     hooks:
       - id: clang-format
         'types_or': [ c++, c ]
-    # Uses the local clang-format
-#  - repo: local
-#    hooks:
-#      # Inspired by https://github.com/doublify/pre-commit-clang-format and
-#      # https://github.com/pre-commit/mirrors-clang-format
-#      - id: clang-format-16
-#        name: clang-format
-#        description: Format files with ClangFormat16.
-#        entry: clang-format-16 -i
-#        language: system
-#        'types_or': [ c++, c ]
-#        args: [ "-style=file" ]
-#        require_serial: false

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -261,7 +261,7 @@ class TripleComponent {
       AD_CONTRACT_CHECK(!s.starts_with('?'));
       AD_CONTRACT_CHECK(!s.starts_with('"'));
       AD_CONTRACT_CHECK(!s.starts_with('\''));
-      // A dummy commit which was wrongly formatted
+      // A dummy ommit which was wrongly formatted
     }
   }
 };

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -261,7 +261,6 @@ class TripleComponent {
       AD_CONTRACT_CHECK(!s.starts_with('?'));
       AD_CONTRACT_CHECK(!s.starts_with('"'));
       AD_CONTRACT_CHECK(!s.starts_with('\''));
-      // A dummy ommit which was wrongly formatted
     }
   }
 };

--- a/src/parser/TripleComponent.h
+++ b/src/parser/TripleComponent.h
@@ -261,6 +261,7 @@ class TripleComponent {
       AD_CONTRACT_CHECK(!s.starts_with('?'));
       AD_CONTRACT_CHECK(!s.starts_with('"'));
       AD_CONTRACT_CHECK(!s.starts_with('\''));
+      // A dummy commit which was wrongly formatted
     }
   }
 };


### PR DESCRIPTION
This hook can be used to automatically format all changed files before commiting them. For the instructions to install this hook, see its configuration file `.pre-comit-config.yaml`.