### PR TITLE
Refactoring preliminaries for lazy operations (Part 1)

### DIFF
--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -5,35 +5,27 @@ A quick introduction and tutorial for the macro benchmark infrastructure.
 As of July 2023 the benchmark infrastructure has the following features:
 
 - Measuring the execution time of a function in seconds.
-- Organizing a benchmark as a single measurement, as a table of measurements, or as a group of single measurements and
-  tables.
+- Organizing a benchmark as a single measurement, as a table of measurements, or as a group of single measurements and tables.
 - Printing the measured benchmarks and/or exporting them as a JSON formatted file.
 - Adding metadata information to benchmarks.
-- Passing values at runtime via pre-defined configuration options, which can be set either using a JSON file, or per
-  shorthand in the CLI.
+- Passing values at runtime via pre-defined configuration options, which can be set either using a JSON file, or per shorthand in the CLI.
 
-However, support for the prevention of compiler optimization in benchmarks is not available and still in the planning
-stage. This can sabotage measured execution times and should be kept in mind, while writing benchmarks.  
-For example: An expression without a return type and without side effects will get optimized out. Like, for example,
-when you are trying to measure a `getter` function without using the returned value.
+However, support for the prevention of compiler optimization in benchmarks is not available and still in the planning stage. This can sabotage measured execution times and should be kept in mind, while writing benchmarks.  
+For example: An expression without a return type and without side effects will get optimized out. Like, for example, when you are trying to measure a `getter` function without using the returned value.
 
 # How to write a basic benchmark
 
-This will be a rather undetailed tutorial, because all the functions and classes have their own documentation, which I
-do not want to repeat.
+This will be a rather undetailed tutorial, because all the functions and classes have their own documentation, which I do not want to repeat.
 
 For a quick hands-on example of the general usage and all features, see `benchmark/BenchmarkExamples.cpp`.
 
-Larger collections of benchmarks, or even a single one, are organized into classes, that inherit
-from `BenchmarkInterface` in `benchmark/infrastructure/Benchmark.h`.  
+Larger collections of benchmarks, or even a single one, are organized into classes, that inherit from `BenchmarkInterface` in `benchmark/infrastructure/Benchmark.h`.  
 Those class implementations should have their own `.cpp` file in the folder `benchmark`.
 
 ## Writing the class
 
-To write your own class, first include `benchmark/infrastructure/Benchmark.h` in you file. It includes all needed
-classes, interfaces and types.  
-Secondly, you should write your class inside the `ad_benchmark` namespace, where all benchmark infrastructure can be
-found.
+To write your own class, first include `benchmark/infrastructure/Benchmark.h` in you file. It includes all needed classes, interfaces and types.  
+Secondly, you should write your class inside the `ad_benchmark` namespace, where all benchmark infrastructure can be found.
 
 Now, the interface for benchmark classes has 5 functions:
 
@@ -41,18 +33,15 @@ Now, the interface for benchmark classes has 5 functions:
 - `getGeneralMetadata`
 - `runAllBenchmarks`
 - `getConfigManager`
-- `updateDefaultGeneralMetadata`
+- `updateDefaultGeneralMetadata`  
 
 `name` should just return the name of your benchmark class, so that you can easily identify it later.
 
-`getGeneralMetadata` and `getConfigManager`are getters for member variables, that are used for advanced features. So
-they can be safely ignored for the time being.
+`getGeneralMetadata` and `getConfigManager`are getters for member variables, that are used for advanced features. So they can be safely ignored for the time being.
 
 `updateDefaultGeneralMetadata` exists solely for the infrastructure and should be ignored.
 
-`runAllBenchmarks` is where you actually measure your functions using the classes of `BenchmarkMeasurementContainer.h`,
-which should be created using `BenchmarkResults`, who will save them and later pass them on for processing by the
-infrastructure.
+`runAllBenchmarks` is where you actually measure your functions using the classes of `BenchmarkMeasurementContainer.h`, which should be created using `BenchmarkResults`, who will save them and later pass them on for processing by the infrastructure.
 Which could look like this:
 
 ```c++
@@ -110,8 +99,7 @@ BenchmarkResults runAllBenchmarks(){
 }
 ```
 
-After writing your class, you will have to register it. For that, simply call the macro `AD_REGISTER_BENCHMARK` with
-your class name and all needed arguments for construction inside the `ad_benchmark` namespace.  
+After writing your class, you will have to register it. For that, simply call the macro `AD_REGISTER_BENCHMARK` with your class name and all needed arguments for construction inside the `ad_benchmark` namespace.  
 For example:
 
 ```c++
@@ -121,30 +109,24 @@ AD_REGISTER_BENCHMARK(MyClass, ConstructorArgument1, ConstructorArgument2, ...);
 ## CMake
 
 Registering your finished benchmark class with CMake is rather easy.  
-Simply add the line `addAndLinkBenchmark(MyBenchmarkClassFile)`, without the ending `.cpp`, to the
-file `benchmark/CMakeLists.txt`.  
+Simply add the line `addAndLinkBenchmark(MyBenchmarkClassFile)`, without the ending `.cpp`, to the file `benchmark/CMakeLists.txt`.  
 It will now be compiled. The compiled version can be found inside the `benchmark` folder inside your build directory.
 
 # Using advanced benchmark features
 
 ## Metadata
 
-Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata information will be included in the
-printed output of a compiled benchmark file and in the JSON file export.
+Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata information will be included in the printed output of a compiled benchmark file and in the JSON file export.
 
 You can find instances of `BenchmarkMetadata` for your usage at 4 locations:
 
-- At `metadata()` of created `ResultEntry` objects, in order to give metadata information about the benchmark
-  measurement.
+- At `metadata()` of created `ResultEntry` objects, in order to give metadata information about the benchmark measurement.
 
 - At `metadata()` of created `ResultGroup` objects, in order to give metadata information about the group.
 
-- At `metadata()` of created `Result` objects, in order to give metadata information about the table.
+- At `metadata()` of created `ResultTable` objects, in order to give metadata information about the table.
 
-- In your own class, under the getter `getGeneralMetadata()`. The returned member variable exists in order to give more
-  general metadata information about your benchmark class. This is mostly, so that you don't have to constantly repeat
-  metadata information, that are true for all the things you are measuring, in other places. For example, this would be
-  a good place to give the name of an algorithm, if your whole benchmark class is about measuring the runtimes of one.
+- In your own class, under the getter `getGeneralMetadata()`. The returned member variable exists in order to give more general metadata information about your benchmark class. This is mostly, so that you don't have to constantly repeat metadata information, that are true for all the things you are measuring, in other places. For example, this would be a good place to give the name of an algorithm, if your whole benchmark class is about measuring the runtimes of one.
 
 ## Runtime configuration
 
@@ -153,9 +135,7 @@ Defining the configuration options and passing values to them.
 
 ### Adding options
 
-Adding configuration options is done by adding configuration option to the private member variable `manager_`,
-accessible via a getter, by using the function `ConfigManager::addOption`. That is best done in the constructor of your
-class.
+Adding configuration options is done by adding configuration option to the private member variable `manager_`, accessible via a getter, by using the function `ConfigManager::addOption`. That is best done in the constructor of your class.
 
 In our system a configuration option is described by a handful of characteristics:
 
@@ -166,23 +146,21 @@ In our system a configuration option is described by a handful of characteristic
 3. If it has a default value. If it hasn't, people will always have to provide their own value at run time.
 
 4. What **type** of values it takes. The following types are available:
+   
+   - `bool`.
+   - `std::string`.
+   - `int`.
+   - `size_t`
+   - `float`.
+   - A `std::vector` of the previous options.
 
-    - `bool`.
-    - `std::string`.
-    - `int`.
-    - `size_t`
-    - `float`.
-    - A `std::vector` of the previous options.
+However, unlike the default value, the value it takes, isn't saved internally.  
 
-However, unlike the default value, the value it takes, isn't saved internally.
-
-Instead, it takes a pointer to a variable of the type, that it itself takes, at construction. Whenever `ConfigOption`
-gets set to a value, the variable, for which the pointer was passed, is set to that value.
+Instead, it takes a pointer to a variable of the type, that it itself takes, at construction. Whenever `ConfigOption` gets set to a value, the variable, for which the pointer was passed, is set to that value.
 
 Note, that also happens at the time of creation, if a default value was given.
 
-In order to organize `ConfigOption`s easier, `ConfigManager` uses JSON like paths, but made up entirely of strings, for
-identification. Those are defined at the time of creation of the option and can't be changed later.
+In order to organize `ConfigOption`s easier, `ConfigManager` uses JSON like paths, but made up entirely of strings, for identification. Those are defined at the time of creation of the option and can't be changed later.
 
 ### Passing values
 
@@ -190,36 +168,23 @@ Setting the values of the configuration options at runtime can be done in two wa
 
 1. Writing a JSON file and passing the file location via CLI.
 
-2. Using the shorthand described in `src/util/ConfigManager/generated/ConfigShorthand.g4`, by writing it directly as an
-   argument via CLI. Note: The shorthand will overwrite the value of any configuration option, if both ways try to set
-   it.
+2. Using the shorthand described in `src/util/ConfigManager/generated/ConfigShorthand.g4`, by writing it directly as an argument via CLI. Note: The shorthand will overwrite the value of any configuration option, if both ways try to set it.
 
-The shorthand is basically just normal JSON, but adjusted for easier usage. There are 3 big changes.
+The shorthand is basically just normal JSON, but adjusted for easier usage. There are 3 big changes.  
 
-First, there are no line breaks allowed. The shorthand is build for usage directly in the CLI, so that is an unneeded
-feature
+First, there are no line breaks allowed. The shorthand is build for usage directly in the CLI, so that is an unneeded feature
 
-Second, because a configuration is always represented by a JSON object, a shorthand string is always treated, as if it
-had `{}` braces at the beginning and end.
+Second, because a configuration is always represented by a JSON object, a shorthand string is always treated, as if it had `{}` braces at the beginning and end.  
 
-Third, the keys of key-value pairs, for example `"key" : value`, don't need to be surrounded with `"`. `"` is a special
-symbol in the CLI, and we want to save you the extra work of always typing `\"key\"`.
+Third, the keys of key-value pairs, for example `"key" : value`, don't need to be surrounded with `"`. `"` is a special symbol in the CLI, and we want to save you the extra work of always typing `\"key\"`.
 
-Using those two ways of passing information, the configuration options held by an internally created `ConfigManager`
-object, will be set.
+Using those two ways of passing information, the configuration options held by an internally created `ConfigManager` object, will be set.
 
-In both of those, you have to write out the complete path to your configuration option and write the value, you wish to
-set it to, at the end.  
-For example: Let's say, you defined a configuration option `someNumber` and added it with the
-path `tableSizes/someNumber`. Then, if you wanted to set it to `20` using JSON, you would have to write:
+In both of those, you have to write out the complete path to your configuration option and write the value, you wish to set it to, at the end.  
+For example: Let's say, you defined a configuration option `someNumber` and added it with the path `tableSizes/someNumber`. Then, if you wanted to set it to `20` using JSON, you would have to write:
 
 ```json
-{
-  "tableSizes": "some-number"
-  :
-  20
-}
+{"tableSizes": "some-number": 20}
 ```
 
-However, **if** the passed values can't be interpreted as the correct types for the configuration options, an exception
-will be thrown.
+However, **if** the passed values can't be interpreted as the correct types for the configuration options, an exception will be thrown.

--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -5,27 +5,35 @@ A quick introduction and tutorial for the macro benchmark infrastructure.
 As of July 2023 the benchmark infrastructure has the following features:
 
 - Measuring the execution time of a function in seconds.
-- Organizing a benchmark as a single measurement, as a table of measurements, or as a group of single measurements and tables.
+- Organizing a benchmark as a single measurement, as a table of measurements, or as a group of single measurements and
+  tables.
 - Printing the measured benchmarks and/or exporting them as a JSON formatted file.
 - Adding metadata information to benchmarks.
-- Passing values at runtime via pre-defined configuration options, which can be set either using a JSON file, or per shorthand in the CLI.
+- Passing values at runtime via pre-defined configuration options, which can be set either using a JSON file, or per
+  shorthand in the CLI.
 
-However, support for the prevention of compiler optimization in benchmarks is not available and still in the planning stage. This can sabotage measured execution times and should be kept in mind, while writing benchmarks.  
-For example: An expression without a return type and without side effects will get optimized out. Like, for example, when you are trying to measure a `getter` function without using the returned value.
+However, support for the prevention of compiler optimization in benchmarks is not available and still in the planning
+stage. This can sabotage measured execution times and should be kept in mind, while writing benchmarks.  
+For example: An expression without a return type and without side effects will get optimized out. Like, for example,
+when you are trying to measure a `getter` function without using the returned value.
 
 # How to write a basic benchmark
 
-This will be a rather undetailed tutorial, because all the functions and classes have their own documentation, which I do not want to repeat.
+This will be a rather undetailed tutorial, because all the functions and classes have their own documentation, which I
+do not want to repeat.
 
 For a quick hands-on example of the general usage and all features, see `benchmark/BenchmarkExamples.cpp`.
 
-Larger collections of benchmarks, or even a single one, are organized into classes, that inherit from `BenchmarkInterface` in `benchmark/infrastructure/Benchmark.h`.  
+Larger collections of benchmarks, or even a single one, are organized into classes, that inherit
+from `BenchmarkInterface` in `benchmark/infrastructure/Benchmark.h`.  
 Those class implementations should have their own `.cpp` file in the folder `benchmark`.
 
 ## Writing the class
 
-To write your own class, first include `benchmark/infrastructure/Benchmark.h` in you file. It includes all needed classes, interfaces and types.  
-Secondly, you should write your class inside the `ad_benchmark` namespace, where all benchmark infrastructure can be found.
+To write your own class, first include `benchmark/infrastructure/Benchmark.h` in you file. It includes all needed
+classes, interfaces and types.  
+Secondly, you should write your class inside the `ad_benchmark` namespace, where all benchmark infrastructure can be
+found.
 
 Now, the interface for benchmark classes has 5 functions:
 
@@ -33,15 +41,18 @@ Now, the interface for benchmark classes has 5 functions:
 - `getGeneralMetadata`
 - `runAllBenchmarks`
 - `getConfigManager`
-- `updateDefaultGeneralMetadata`  
+- `updateDefaultGeneralMetadata`
 
 `name` should just return the name of your benchmark class, so that you can easily identify it later.
 
-`getGeneralMetadata` and `getConfigManager`are getters for member variables, that are used for advanced features. So they can be safely ignored for the time being.
+`getGeneralMetadata` and `getConfigManager`are getters for member variables, that are used for advanced features. So
+they can be safely ignored for the time being.
 
 `updateDefaultGeneralMetadata` exists solely for the infrastructure and should be ignored.
 
-`runAllBenchmarks` is where you actually measure your functions using the classes of `BenchmarkMeasurementContainer.h`, which should be created using `BenchmarkResults`, who will save them and later pass them on for processing by the infrastructure.
+`runAllBenchmarks` is where you actually measure your functions using the classes of `BenchmarkMeasurementContainer.h`,
+which should be created using `BenchmarkResults`, who will save them and later pass them on for processing by the
+infrastructure.
 Which could look like this:
 
 ```c++
@@ -99,7 +110,8 @@ BenchmarkResults runAllBenchmarks(){
 }
 ```
 
-After writing your class, you will have to register it. For that, simply call the macro `AD_REGISTER_BENCHMARK` with your class name and all needed arguments for construction inside the `ad_benchmark` namespace.  
+After writing your class, you will have to register it. For that, simply call the macro `AD_REGISTER_BENCHMARK` with
+your class name and all needed arguments for construction inside the `ad_benchmark` namespace.  
 For example:
 
 ```c++
@@ -109,24 +121,30 @@ AD_REGISTER_BENCHMARK(MyClass, ConstructorArgument1, ConstructorArgument2, ...);
 ## CMake
 
 Registering your finished benchmark class with CMake is rather easy.  
-Simply add the line `addAndLinkBenchmark(MyBenchmarkClassFile)`, without the ending `.cpp`, to the file `benchmark/CMakeLists.txt`.  
+Simply add the line `addAndLinkBenchmark(MyBenchmarkClassFile)`, without the ending `.cpp`, to the
+file `benchmark/CMakeLists.txt`.  
 It will now be compiled. The compiled version can be found inside the `benchmark` folder inside your build directory.
 
 # Using advanced benchmark features
 
 ## Metadata
 
-Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata information will be included in the printed output of a compiled benchmark file and in the JSON file export.
+Setting metadata is handled by the `BenchmarkMetadata` class. The set metadata information will be included in the
+printed output of a compiled benchmark file and in the JSON file export.
 
 You can find instances of `BenchmarkMetadata` for your usage at 4 locations:
 
-- At `metadata()` of created `ResultEntry` objects, in order to give metadata information about the benchmark measurement.
+- At `metadata()` of created `ResultEntry` objects, in order to give metadata information about the benchmark
+  measurement.
 
 - At `metadata()` of created `ResultGroup` objects, in order to give metadata information about the group.
 
-- At `metadata()` of created `ResultTable` objects, in order to give metadata information about the table.
+- At `metadata()` of created `Result` objects, in order to give metadata information about the table.
 
-- In your own class, under the getter `getGeneralMetadata()`. The returned member variable exists in order to give more general metadata information about your benchmark class. This is mostly, so that you don't have to constantly repeat metadata information, that are true for all the things you are measuring, in other places. For example, this would be a good place to give the name of an algorithm, if your whole benchmark class is about measuring the runtimes of one.
+- In your own class, under the getter `getGeneralMetadata()`. The returned member variable exists in order to give more
+  general metadata information about your benchmark class. This is mostly, so that you don't have to constantly repeat
+  metadata information, that are true for all the things you are measuring, in other places. For example, this would be
+  a good place to give the name of an algorithm, if your whole benchmark class is about measuring the runtimes of one.
 
 ## Runtime configuration
 
@@ -135,7 +153,9 @@ Defining the configuration options and passing values to them.
 
 ### Adding options
 
-Adding configuration options is done by adding configuration option to the private member variable `manager_`, accessible via a getter, by using the function `ConfigManager::addOption`. That is best done in the constructor of your class.
+Adding configuration options is done by adding configuration option to the private member variable `manager_`,
+accessible via a getter, by using the function `ConfigManager::addOption`. That is best done in the constructor of your
+class.
 
 In our system a configuration option is described by a handful of characteristics:
 
@@ -146,21 +166,23 @@ In our system a configuration option is described by a handful of characteristic
 3. If it has a default value. If it hasn't, people will always have to provide their own value at run time.
 
 4. What **type** of values it takes. The following types are available:
-   
-   - `bool`.
-   - `std::string`.
-   - `int`.
-   - `size_t`
-   - `float`.
-   - A `std::vector` of the previous options.
 
-However, unlike the default value, the value it takes, isn't saved internally.  
+    - `bool`.
+    - `std::string`.
+    - `int`.
+    - `size_t`
+    - `float`.
+    - A `std::vector` of the previous options.
 
-Instead, it takes a pointer to a variable of the type, that it itself takes, at construction. Whenever `ConfigOption` gets set to a value, the variable, for which the pointer was passed, is set to that value.
+However, unlike the default value, the value it takes, isn't saved internally.
+
+Instead, it takes a pointer to a variable of the type, that it itself takes, at construction. Whenever `ConfigOption`
+gets set to a value, the variable, for which the pointer was passed, is set to that value.
 
 Note, that also happens at the time of creation, if a default value was given.
 
-In order to organize `ConfigOption`s easier, `ConfigManager` uses JSON like paths, but made up entirely of strings, for identification. Those are defined at the time of creation of the option and can't be changed later.
+In order to organize `ConfigOption`s easier, `ConfigManager` uses JSON like paths, but made up entirely of strings, for
+identification. Those are defined at the time of creation of the option and can't be changed later.
 
 ### Passing values
 
@@ -168,23 +190,36 @@ Setting the values of the configuration options at runtime can be done in two wa
 
 1. Writing a JSON file and passing the file location via CLI.
 
-2. Using the shorthand described in `src/util/ConfigManager/generated/ConfigShorthand.g4`, by writing it directly as an argument via CLI. Note: The shorthand will overwrite the value of any configuration option, if both ways try to set it.
+2. Using the shorthand described in `src/util/ConfigManager/generated/ConfigShorthand.g4`, by writing it directly as an
+   argument via CLI. Note: The shorthand will overwrite the value of any configuration option, if both ways try to set
+   it.
 
-The shorthand is basically just normal JSON, but adjusted for easier usage. There are 3 big changes.  
+The shorthand is basically just normal JSON, but adjusted for easier usage. There are 3 big changes.
 
-First, there are no line breaks allowed. The shorthand is build for usage directly in the CLI, so that is an unneeded feature
+First, there are no line breaks allowed. The shorthand is build for usage directly in the CLI, so that is an unneeded
+feature
 
-Second, because a configuration is always represented by a JSON object, a shorthand string is always treated, as if it had `{}` braces at the beginning and end.  
+Second, because a configuration is always represented by a JSON object, a shorthand string is always treated, as if it
+had `{}` braces at the beginning and end.
 
-Third, the keys of key-value pairs, for example `"key" : value`, don't need to be surrounded with `"`. `"` is a special symbol in the CLI, and we want to save you the extra work of always typing `\"key\"`.
+Third, the keys of key-value pairs, for example `"key" : value`, don't need to be surrounded with `"`. `"` is a special
+symbol in the CLI, and we want to save you the extra work of always typing `\"key\"`.
 
-Using those two ways of passing information, the configuration options held by an internally created `ConfigManager` object, will be set.
+Using those two ways of passing information, the configuration options held by an internally created `ConfigManager`
+object, will be set.
 
-In both of those, you have to write out the complete path to your configuration option and write the value, you wish to set it to, at the end.  
-For example: Let's say, you defined a configuration option `someNumber` and added it with the path `tableSizes/someNumber`. Then, if you wanted to set it to `20` using JSON, you would have to write:
+In both of those, you have to write out the complete path to your configuration option and write the value, you wish to
+set it to, at the end.  
+For example: Let's say, you defined a configuration option `someNumber` and added it with the
+path `tableSizes/someNumber`. Then, if you wanted to set it to `20` using JSON, you would have to write:
 
 ```json
-{"tableSizes": "some-number": 20}
+{
+  "tableSizes": "some-number"
+  :
+  20
+}
 ```
 
-However, **if** the passed values can't be interpreted as the correct types for the configuration options, an exception will be thrown.
+However, **if** the passed values can't be interpreted as the correct types for the configuration options, an exception
+will be thrown.

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -81,10 +81,10 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 }
 
 // _____________________________________________________________________________
-ResultTable Bind::computeResult() {
+Result Bind::computeResult() {
   using std::endl;
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
-  shared_ptr<const ResultTable> subRes = _subtree->getResult();
+  shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Got input to Bind operation." << endl;
   IdTable idTable{getExecutionContext()->getAllocator()};
 
@@ -114,7 +114,7 @@ ResultTable Bind::computeResult() {
 template <size_t IN_WIDTH, size_t OUT_WIDTH>
 void Bind::computeExpressionBind(
     IdTable* outputIdTable, LocalVocab* outputLocalVocab,
-    const ResultTable& inputResultTable,
+    const Result& inputResultTable,
     sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), _subtree->getVariableColumns(),

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -81,7 +81,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 }
 
 // _____________________________________________________________________________
-Result Bind::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Bind::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult();

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -84,7 +84,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 Result Bind::computeResult([[maybe_unused]] bool requestLazyness) {
   using std::endl;
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
-  shared_ptr<const Result> subRes = _subtree->getResult();
+  std::shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Got input to Bind operation." << endl;
   IdTable idTable{getExecutionContext()->getAllocator()};
 

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -81,7 +81,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 }
 
 // _____________________________________________________________________________
-Result Bind::computeResult() {
+Result Bind::computeResult([[maybe_unused]] bool requestLazyness) {
   using std::endl;
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
   shared_ptr<const Result> subRes = _subtree->getResult();

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -46,7 +46,7 @@ class Bind : public Operation {
   [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Implementation for the binding of arbitrary expressions.
   template <size_t IN_WIDTH, size_t OUT_WIDTH>

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -46,13 +46,13 @@ class Bind : public Operation {
   [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   // Implementation for the binding of arbitrary expressions.
   template <size_t IN_WIDTH, size_t OUT_WIDTH>
   void computeExpressionBind(
       IdTable* outputIdTable, LocalVocab* outputLocalVocab,
-      const ResultTable& inputResultTable,
+      const Result& inputResultTable,
       sparqlExpression::SparqlExpression* expression) const;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -46,7 +46,7 @@ class Bind : public Operation {
   [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
  private:
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   // Implementation for the binding of arbitrary expressions.
   template <size_t IN_WIDTH, size_t OUT_WIDTH>

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -2,7 +2,7 @@ add_subdirectory(sparqlExpressions)
 add_library(SortPerformanceEstimator SortPerformanceEstimator.cpp)
 qlever_target_link_libraries(SortPerformanceEstimator)
 add_library(engine
-        Engine.cpp QueryExecutionTree.cpp Operation.cpp ResultTable.cpp LocalVocab.cpp
+        Engine.cpp QueryExecutionTree.cpp Operation.cpp Result.cpp LocalVocab.cpp
         IndexScan.cpp Join.cpp Sort.cpp
         Distinct.cpp OrderBy.cpp Filter.cpp
         Server.cpp QueryPlanner.cpp QueryPlanningCostFactors.cpp

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -132,10 +132,10 @@ void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
   }
 }
 // ____________________________________________________________________________
-ResultTable CartesianProductJoin::computeResult() {
+Result CartesianProductJoin::computeResult() {
   IdTable result{getExecutionContext()->getAllocator()};
   result.setNumColumns(getResultWidth());
-  std::vector<std::shared_ptr<const ResultTable>> subResults;
+  std::vector<std::shared_ptr<const Result>> subResults;
 
   // We don't need to fully materialize the child results if we have a LIMIT
   // specified and an OFFSET of 0.
@@ -210,7 +210,7 @@ ResultTable CartesianProductJoin::computeResult() {
   auto subResultsDeref = std::views::transform(
       subResults, [](auto& x) -> decltype(auto) { return *x; });
   return {std::move(result), resultSortedOn(),
-          ResultTable::getMergedLocalVocab(subResultsDeref)};
+          Result::getMergedLocalVocab(subResultsDeref)};
 }
 
 // ____________________________________________________________________________

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -132,7 +132,7 @@ void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
   }
 }
 // ____________________________________________________________________________
-Result CartesianProductJoin::computeResult() {
+Result CartesianProductJoin::computeResult([[maybe_unused]] bool requestLazyness) {
   IdTable result{getExecutionContext()->getAllocator()};
   result.setNumColumns(getResultWidth());
   std::vector<std::shared_ptr<const Result>> subResults;
@@ -154,7 +154,7 @@ Result CartesianProductJoin::computeResult() {
     }
     subResults.push_back(child.getResult());
     // Early stopping: If one of the results is empty, we can stop early.
-    if (subResults.back()->size() == 0) {
+    if (subResults.back()->idTable().size() == 0) {
       break;
     }
     // Example for the following calculation: If we have a LIMIT of 1000 and
@@ -162,13 +162,14 @@ Result CartesianProductJoin::computeResult() {
     // needs to evaluate only its first 10 results. The +1 is because integer
     // divisions are rounded down by default.
     if (limitIfPresent.has_value()) {
-      limitIfPresent.value()._limit =
-          limitIfPresent.value()._limit.value() / subResults.back()->size() + 1;
+      limitIfPresent.value()._limit = limitIfPresent.value()._limit.value() /
+                                          subResults.back()->idTable().size() +
+                                      1;
     }
   }
 
   auto sizesView = std::views::transform(
-      subResults, [](const auto& child) { return child->size(); });
+      subResults, [](const auto& child) { return child->idTable().size(); });
   auto totalResultSize = std::accumulate(sizesView.begin(), sizesView.end(),
                                          1UL, std::multiplies{});
 

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -132,7 +132,8 @@ void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
   }
 }
 // ____________________________________________________________________________
-Result CartesianProductJoin::computeResult([[maybe_unused]] bool requestLazyness) {
+Result CartesianProductJoin::computeResult(
+    [[maybe_unused]] bool requestLaziness) {
   IdTable result{getExecutionContext()->getAllocator()};
   result.setNumColumns(getResultWidth());
   std::vector<std::shared_ptr<const Result>> subResults;

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -79,7 +79,7 @@ class CartesianProductJoin : public Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   // Copy each element from the `inputColumn` `groupSize` times to the
   // `targetColumn`. Repeat until the `targetColumn` is copletely filled. Skip

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -79,7 +79,7 @@ class CartesianProductJoin : public Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   // Copy each element from the `inputColumn` `groupSize` times to the
   // `targetColumn`. Repeat until the `targetColumn` is copletely filled. Skip

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -79,7 +79,7 @@ class CartesianProductJoin : public Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Copy each element from the `inputColumn` `groupSize` times to the
   // `targetColumn`. Repeat until the `targetColumn` is copletely filled. Skip

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -100,7 +100,8 @@ size_t CountAvailablePredicates::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-Result CountAvailablePredicates::computeResult([[maybe_unused]] bool requestLazyness) {
+Result CountAvailablePredicates::computeResult(
+    [[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "CountAvailablePredicates result computation..." << std::endl;
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(2);

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -100,7 +100,7 @@ size_t CountAvailablePredicates::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-ResultTable CountAvailablePredicates::computeResult() {
+Result CountAvailablePredicates::computeResult() {
   LOG(DEBUG) << "CountAvailablePredicates result computation..." << std::endl;
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(2);
@@ -137,7 +137,7 @@ ResultTable CountAvailablePredicates::computeResult() {
                                                              patterns);
     return {std::move(idTable), resultSortedOn(), LocalVocab{}};
   } else {
-    std::shared_ptr<const ResultTable> subresult = subtree_->getResult();
+    std::shared_ptr<const Result> subresult = subtree_->getResult();
     LOG(DEBUG) << "CountAvailablePredicates subresult computation done."
                << std::endl;
 

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -100,7 +100,7 @@ size_t CountAvailablePredicates::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-Result CountAvailablePredicates::computeResult() {
+Result CountAvailablePredicates::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "CountAvailablePredicates result computation..." << std::endl;
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(2);

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -16,8 +16,8 @@
 using std::string;
 using std::vector;
 
-// This Operation takes a ResultTable with at least one column containing ids,
-// and a column index referring to such a column. It then creates a ResultTable
+// This Operation takes a Result with at least one column containing ids,
+// and a column index referring to such a column. It then creates a Result
 // containing two columns, the first one filled with the ids of all predicates
 // for which there is an entry in the index with one of the entities in the
 // specified input column as its subject. The second output column contains a
@@ -103,6 +103,6 @@ class CountAvailablePredicates : public Operation {
   void computePatternTrickAllEntities(
       IdTable* result, const CompactVectorOfStrings<Id>& patterns) const;
 
-  ResultTable computeResult() override;
+  Result computeResult() override;
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -103,6 +103,6 @@ class CountAvailablePredicates : public Operation {
   void computePatternTrickAllEntities(
       IdTable* result, const CompactVectorOfStrings<Id>& patterns) const;
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -103,6 +103,6 @@ class CountAvailablePredicates : public Operation {
   void computePatternTrickAllEntities(
       IdTable* result, const CompactVectorOfStrings<Id>& patterns) const;
 
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -37,7 +37,7 @@ VariableToColumnMap Distinct::computeVariableToColumnMap() const {
 }
 
 // _____________________________________________________________________________
-Result Distinct::computeResult() {
+Result Distinct::computeResult([[maybe_unused]] bool requestLazyness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   shared_ptr<const Result> subRes = _subtree->getResult();

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "engine/CallFixedSize.h"
+#include "engine/Engine.h"
 #include "engine/QueryExecutionTree.h"
 
 using std::endl;
@@ -40,7 +41,7 @@ VariableToColumnMap Distinct::computeVariableToColumnMap() const {
 Result Distinct::computeResult([[maybe_unused]] bool requestLazyness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
-  shared_ptr<const Result> subRes = _subtree->getResult();
+  std::shared_ptr<const Result> subRes = _subtree->getResult();
 
   LOG(DEBUG) << "Distinct result computation..." << endl;
   idTable.setNumColumns(subRes->idTable().numColumns());

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -37,10 +37,10 @@ VariableToColumnMap Distinct::computeVariableToColumnMap() const {
 }
 
 // _____________________________________________________________________________
-ResultTable Distinct::computeResult() {
+Result Distinct::computeResult() {
   IdTable idTable{getExecutionContext()->getAllocator()};
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
-  shared_ptr<const ResultTable> subRes = _subtree->getResult();
+  shared_ptr<const Result> subRes = _subtree->getResult();
 
   LOG(DEBUG) << "Distinct result computation..." << endl;
   idTable.setNumColumns(subRes->idTable().numColumns());

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -38,7 +38,7 @@ VariableToColumnMap Distinct::computeVariableToColumnMap() const {
 }
 
 // _____________________________________________________________________________
-Result Distinct::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Distinct::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult();

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -55,7 +55,7 @@ class Distinct : public Operation {
   [[nodiscard]] string getCacheKeyImpl() const override;
 
  private:
-  virtual ResultTable computeResult() override;
+  virtual Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -55,7 +55,7 @@ class Distinct : public Operation {
   [[nodiscard]] string getCacheKeyImpl() const override;
 
  private:
-  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -55,7 +55,7 @@ class Distinct : public Operation {
   [[nodiscard]] string getCacheKeyImpl() const override;
 
  private:
-  virtual Result computeResult() override;
+  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -29,7 +29,7 @@ cppcoro::generator<QueryExecutionTree::StringTriple>
 ExportQueryExecutionTrees::constructQueryResultToTriples(
     const QueryExecutionTree& qet,
     const ad_utility::sparql_types::Triples& constructTriples,
-    LimitOffsetClause limitAndOffset, std::shared_ptr<const ResultTable> res,
+    LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> res,
     CancellationHandle cancellationHandle) {
   for (size_t i : getRowIndices(limitAndOffset, res->idTable())) {
     ConstructQueryExportContext context{i, *res, qet.getVariableColumns(),
@@ -57,7 +57,7 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
         const QueryExecutionTree& qet,
         const ad_utility::sparql_types::Triples& constructTriples,
         LimitOffsetClause limitAndOffset,
-        std::shared_ptr<const ResultTable> resultTable,
+        std::shared_ptr<const Result> resultTable,
         CancellationHandle cancellationHandle) {
   resultTable->logResultSize();
   auto generator = ExportQueryExecutionTrees::constructQueryResultToTriples(
@@ -92,7 +92,7 @@ ExportQueryExecutionTrees::constructQueryResultBindingsToQLeverJSON(
     const QueryExecutionTree& qet,
     const ad_utility::sparql_types::Triples& constructTriples,
     const LimitOffsetClause& limitAndOffset,
-    std::shared_ptr<const ResultTable> res,
+    std::shared_ptr<const Result> res,
     CancellationHandle cancellationHandle) {
   auto generator = constructQueryResultToTriples(qet, constructTriples,
                                                  limitAndOffset, std::move(res),
@@ -110,7 +110,7 @@ ExportQueryExecutionTrees::constructQueryResultBindingsToQLeverJSON(
 nlohmann::json ExportQueryExecutionTrees::idTableToQLeverJSONArray(
     const QueryExecutionTree& qet, const LimitOffsetClause& limitAndOffset,
     const QueryExecutionTree::ColumnIndicesAndTypes& columns,
-    std::shared_ptr<const ResultTable> resultTable,
+    std::shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   AD_CORRECTNESS_CHECK(resultTable != nullptr);
   const IdTable& data = resultTable->idTable();
@@ -268,7 +268,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultToSparqlJSON(
     const QueryExecutionTree& qet,
     const parsedQuery::SelectClause& selectClause,
     const LimitOffsetClause& limitAndOffset,
-    shared_ptr<const ResultTable> resultTable,
+    shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   using nlohmann::json;
 
@@ -388,7 +388,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultBindingsToQLeverJSON(
     const QueryExecutionTree& qet,
     const parsedQuery::SelectClause& selectClause,
     const LimitOffsetClause& limitAndOffset,
-    shared_ptr<const ResultTable> resultTable,
+    shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   AD_CORRECTNESS_CHECK(resultTable != nullptr);
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
@@ -418,7 +418,7 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
 
   // This call triggers the possibly expensive computation of the query result
   // unless the result is already cached.
-  shared_ptr<const ResultTable> resultTable = qet.getResult();
+  shared_ptr<const Result> resultTable = qet.getResult();
   resultTable->logResultSize();
   LOG(DEBUG) << "Converting result IDs to their corresponding strings ..."
              << std::endl;
@@ -563,7 +563,7 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
       selectClause.getSelectedVariablesAsStrings();
   // This call triggers the possibly expensive computation of the query result
   // unless the result is already cached.
-  shared_ptr<const ResultTable> resultTable = qet.getResult();
+  shared_ptr<const Result> resultTable = qet.getResult();
 
   // In the XML format, the variables don't include the question mark.
   auto varsWithoutQuestionMark = std::views::transform(
@@ -606,7 +606,7 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
     const QueryExecutionTree& qet,
     const ad_utility::sparql_types::Triples& constructTriples,
     LimitOffsetClause limitAndOffset,
-    std::shared_ptr<const ResultTable> resultTable,
+    std::shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   static_assert(format == MediaType::octetStream || format == MediaType::csv ||
                 format == MediaType::tsv || format == MediaType::sparqlXml);
@@ -638,7 +638,7 @@ nlohmann::json ExportQueryExecutionTrees::computeQueryResultAsQLeverJSON(
     const ParsedQuery& query, const QueryExecutionTree& qet,
     const ad_utility::Timer& requestTimer, uint64_t maxSend,
     CancellationHandle cancellationHandle) {
-  shared_ptr<const ResultTable> resultTable = qet.getResult();
+  shared_ptr<const Result> resultTable = qet.getResult();
   resultTable->logResultSize();
   auto timeResultComputation = requestTimer.msecs();
 
@@ -725,7 +725,7 @@ nlohmann::json ExportQueryExecutionTrees::computeSelectQueryResultAsSparqlJSON(
     AD_THROW(
         "SPARQL-compliant JSON format is only supported for SELECT queries");
   }
-  shared_ptr<const ResultTable> resultTable = qet.getResult();
+  shared_ptr<const Result> resultTable = qet.getResult();
   resultTable->logResultSize();
   nlohmann::json j;
   auto limitAndOffset = query._limitOffset;

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -91,8 +91,7 @@ nlohmann::json
 ExportQueryExecutionTrees::constructQueryResultBindingsToQLeverJSON(
     const QueryExecutionTree& qet,
     const ad_utility::sparql_types::Triples& constructTriples,
-    const LimitOffsetClause& limitAndOffset,
-    std::shared_ptr<const Result> res,
+    const LimitOffsetClause& limitAndOffset, std::shared_ptr<const Result> res,
     CancellationHandle cancellationHandle) {
   auto generator = constructQueryResultToTriples(qet, constructTriples,
                                                  limitAndOffset, std::move(res),
@@ -605,8 +604,7 @@ ad_utility::streams::stream_generator
 ExportQueryExecutionTrees::constructQueryResultToStream(
     const QueryExecutionTree& qet,
     const ad_utility::sparql_types::Triples& constructTriples,
-    LimitOffsetClause limitAndOffset,
-    std::shared_ptr<const Result> resultTable,
+    LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   static_assert(format == MediaType::octetStream || format == MediaType::csv ||
                 format == MediaType::tsv || format == MediaType::sparqlXml);
@@ -642,7 +640,7 @@ nlohmann::json ExportQueryExecutionTrees::computeQueryResultAsQLeverJSON(
   resultTable->logResultSize();
   auto timeResultComputation = requestTimer.msecs();
 
-  size_t resultSize = resultTable->size();
+  size_t resultSize = resultTable->idTable().size();
 
   nlohmann::json j;
 

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -267,7 +267,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultToSparqlJSON(
     const QueryExecutionTree& qet,
     const parsedQuery::SelectClause& selectClause,
     const LimitOffsetClause& limitAndOffset,
-    shared_ptr<const Result> resultTable,
+    std::shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   using nlohmann::json;
 
@@ -387,7 +387,7 @@ nlohmann::json ExportQueryExecutionTrees::selectQueryResultBindingsToQLeverJSON(
     const QueryExecutionTree& qet,
     const parsedQuery::SelectClause& selectClause,
     const LimitOffsetClause& limitAndOffset,
-    shared_ptr<const Result> resultTable,
+    std::shared_ptr<const Result> resultTable,
     CancellationHandle cancellationHandle) {
   AD_CORRECTNESS_CHECK(resultTable != nullptr);
   LOG(DEBUG) << "Resolving strings for finished binary result...\n";
@@ -417,7 +417,7 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
 
   // This call triggers the possibly expensive computation of the query result
   // unless the result is already cached.
-  shared_ptr<const Result> resultTable = qet.getResult();
+  std::shared_ptr<const Result> resultTable = qet.getResult();
   resultTable->logResultSize();
   LOG(DEBUG) << "Converting result IDs to their corresponding strings ..."
              << std::endl;
@@ -562,7 +562,7 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
       selectClause.getSelectedVariablesAsStrings();
   // This call triggers the possibly expensive computation of the query result
   // unless the result is already cached.
-  shared_ptr<const Result> resultTable = qet.getResult();
+  std::shared_ptr<const Result> resultTable = qet.getResult();
 
   // In the XML format, the variables don't include the question mark.
   auto varsWithoutQuestionMark = std::views::transform(
@@ -636,7 +636,7 @@ nlohmann::json ExportQueryExecutionTrees::computeQueryResultAsQLeverJSON(
     const ParsedQuery& query, const QueryExecutionTree& qet,
     const ad_utility::Timer& requestTimer, uint64_t maxSend,
     CancellationHandle cancellationHandle) {
-  shared_ptr<const Result> resultTable = qet.getResult();
+  std::shared_ptr<const Result> resultTable = qet.getResult();
   resultTable->logResultSize();
   auto timeResultComputation = requestTimer.msecs();
 
@@ -723,7 +723,7 @@ nlohmann::json ExportQueryExecutionTrees::computeSelectQueryResultAsSparqlJSON(
     AD_THROW(
         "SPARQL-compliant JSON format is only supported for SELECT queries");
   }
-  shared_ptr<const Result> resultTable = qet.getResult();
+  std::shared_ptr<const Result> resultTable = qet.getResult();
   resultTable->logResultSize();
   nlohmann::json j;
   auto limitAndOffset = query._limitOffset;

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -111,7 +111,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const parsedQuery::SelectClause& selectClause,
       const LimitOffsetClause& limitAndOffset,
-      shared_ptr<const ResultTable> resultTable,
+      shared_ptr<const Result> resultTable,
       CancellationHandle cancellationHandle);
 
   /**
@@ -132,7 +132,7 @@ class ExportQueryExecutionTrees {
   static nlohmann::json idTableToQLeverJSONArray(
       const QueryExecutionTree& qet, const LimitOffsetClause& limitAndOffset,
       const QueryExecutionTree::ColumnIndicesAndTypes& columns,
-      std::shared_ptr<const ResultTable> resultTable,
+      std::shared_ptr<const Result> resultTable,
       CancellationHandle cancellationHandle);
 
   // ___________________________________________________________________________
@@ -140,7 +140,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const ad_utility::sparql_types::Triples& constructTriples,
       const LimitOffsetClause& limitAndOffset,
-      std::shared_ptr<const ResultTable> res,
+      std::shared_ptr<const Result> res,
       CancellationHandle cancellationHandle);
 
   // Generate an RDF graph for a CONSTRUCT query.
@@ -148,7 +148,7 @@ class ExportQueryExecutionTrees {
   constructQueryResultToTriples(
       const QueryExecutionTree& qet,
       const ad_utility::sparql_types::Triples& constructTriples,
-      LimitOffsetClause limitAndOffset, std::shared_ptr<const ResultTable> res,
+      LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> res,
       CancellationHandle cancellationHandle);
 
   // ___________________________________________________________________________
@@ -156,7 +156,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const parsedQuery::SelectClause& selectClause,
       const LimitOffsetClause& limitAndOffset,
-      shared_ptr<const ResultTable> resultTable,
+      shared_ptr<const Result> resultTable,
       CancellationHandle cancellationHandle);
 
   // ___________________________________________________________________________
@@ -165,7 +165,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const ad_utility::sparql_types::Triples& constructTriples,
       LimitOffsetClause limitAndOffset,
-      std::shared_ptr<const ResultTable> resultTable,
+      std::shared_ptr<const Result> resultTable,
       CancellationHandle cancellationHandle);
 
   // _____________________________________________________________________________

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -111,7 +111,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const parsedQuery::SelectClause& selectClause,
       const LimitOffsetClause& limitAndOffset,
-      shared_ptr<const Result> resultTable,
+      std::shared_ptr<const Result> resultTable,
       CancellationHandle cancellationHandle);
 
   /**
@@ -140,8 +140,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const ad_utility::sparql_types::Triples& constructTriples,
       const LimitOffsetClause& limitAndOffset,
-      std::shared_ptr<const Result> res,
-      CancellationHandle cancellationHandle);
+      std::shared_ptr<const Result> res, CancellationHandle cancellationHandle);
 
   // Generate an RDF graph for a CONSTRUCT query.
   static cppcoro::generator<QueryExecutionTree::StringTriple>
@@ -156,7 +155,7 @@ class ExportQueryExecutionTrees {
       const QueryExecutionTree& qet,
       const parsedQuery::SelectClause& selectClause,
       const LimitOffsetClause& limitAndOffset,
-      shared_ptr<const Result> resultTable,
+      std::shared_ptr<const Result> resultTable,
       CancellationHandle cancellationHandle);
 
   // ___________________________________________________________________________

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -43,7 +43,7 @@ string Filter::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result Filter::computeResult() {
+Result Filter::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Filter result computation..." << endl;

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -45,7 +45,7 @@ string Filter::getDescriptor() const {
 // _____________________________________________________________________________
 Result Filter::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
-  shared_ptr<const Result> subRes = _subtree->getResult();
+  std::shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Filter result computation..." << endl;
   checkCancellation();
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -43,7 +43,7 @@ string Filter::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result Filter::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Filter::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Filter result computation..." << endl;

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -43,9 +43,9 @@ string Filter::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ResultTable Filter::computeResult() {
+Result Filter::computeResult() {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
-  shared_ptr<const ResultTable> subRes = _subtree->getResult();
+  shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Filter result computation..." << endl;
   checkCancellation();
 
@@ -63,7 +63,7 @@ ResultTable Filter::computeResult() {
 // _____________________________________________________________________________
 template <size_t WIDTH>
 void Filter::computeFilterImpl(IdTable* outputIdTable,
-                               const ResultTable& inputResultTable) {
+                               const Result& inputResultTable) {
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), _subtree->getVariableColumns(),
       inputResultTable.idTable(), getExecutionContext()->getAllocator(),

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -58,7 +58,7 @@ class Filter : public Operation {
     return _subtree->getVariableColumns();
   }
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   template <size_t WIDTH>
   void computeFilterImpl(IdTable* outputIdTable,

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -58,9 +58,9 @@ class Filter : public Operation {
     return _subtree->getVariableColumns();
   }
 
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   template <size_t WIDTH>
   void computeFilterImpl(IdTable* outputIdTable,
-                         const ResultTable& inputResultTable);
+                         const Result& inputResultTable);
 };

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -58,7 +58,7 @@ class Filter : public Operation {
     return _subtree->getVariableColumns();
   }
 
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   template <size_t WIDTH>
   void computeFilterImpl(IdTable* outputIdTable,

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -309,7 +309,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   *dynResult = std::move(result).toDynamic();
 }
 
-Result GroupBy::computeResult() {
+Result GroupBy::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -222,9 +222,9 @@ void GroupBy::processGroup(
  * @param blockEnd Where the group ends.
  * @param input The input Table.
  * @param result
- * @param inTable The input ResultTable, which is required for its local
+ * @param inTable The input Result, which is required for its local
  *                vocabulary
- * @param outTable The output ResultTable, the vocabulary of which needs to be
+ * @param outTable The output Result, the vocabulary of which needs to be
  *                 expanded for GROUP_CONCAT aggregates
  * @param distinctHashSet An empty hash set. This is only passed in as an
  *                        argument to allow for efficient reusage of its
@@ -309,7 +309,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   *dynResult = std::move(result).toDynamic();
 }
 
-ResultTable GroupBy::computeResult() {
+Result GroupBy::computeResult() {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -335,7 +335,7 @@ ResultTable GroupBy::computeResult() {
   auto hashMapOptimizationParams =
       checkIfHashMapOptimizationPossible(aggregates);
 
-  std::shared_ptr<const ResultTable> subresult;
+  std::shared_ptr<const Result> subresult;
   if (hashMapOptimizationParams.has_value()) {
     const auto* child = _subtree->getRootOperation()->getChildren().at(0);
     // Skip sorting

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -309,7 +309,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   *dynResult = std::move(result).toDynamic();
 }
 
-Result GroupBy::computeResult([[maybe_unused]] bool requestLazyness) {
+Result GroupBy::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -89,7 +89,7 @@ class GroupBy : public Operation {
  private:
   VariableToColumnMap computeVariableToColumnMap() const override;
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   template <size_t OUT_WIDTH>
   void processGroup(const Aggregate& expression,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -89,7 +89,7 @@ class GroupBy : public Operation {
  private:
   VariableToColumnMap computeVariableToColumnMap() const override;
 
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   template <size_t OUT_WIDTH>
   void processGroup(const Aggregate& expression,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -89,7 +89,7 @@ class GroupBy : public Operation {
  private:
   VariableToColumnMap computeVariableToColumnMap() const override;
 
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   template <size_t OUT_WIDTH>
   void processGroup(const Aggregate& expression,

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -254,7 +254,7 @@ size_t HasPredicateScan::getCostEstimate() {
 }
 
 // ___________________________________________________________________________
-Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLazyness) {
+Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -254,7 +254,7 @@ size_t HasPredicateScan::getCostEstimate() {
 }
 
 // ___________________________________________________________________________
-Result HasPredicateScan::computeResult() {
+Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLazyness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -254,7 +254,7 @@ size_t HasPredicateScan::getCostEstimate() {
 }
 
 // ___________________________________________________________________________
-ResultTable HasPredicateScan::computeResult() {
+Result HasPredicateScan::computeResult() {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
 
@@ -365,7 +365,7 @@ void HasPredicateScan::computeFullScan(
 
 // ___________________________________________________________________________
 template <int WIDTH>
-ResultTable HasPredicateScan::computeSubqueryS(
+Result HasPredicateScan::computeSubqueryS(
     IdTable* dynResult, const CompactVectorOfStrings<Id>& patterns) {
   auto subresult = subtree().getResult();
   auto patternCol = subtreeColIdx();

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -106,10 +106,10 @@ class HasPredicateScan : public Operation {
 
   template <int WIDTH>
   Result computeSubqueryS(IdTable* result,
-                               const CompactVectorOfStrings<Id>& patterns);
+                          const CompactVectorOfStrings<Id>& patterns);
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -105,11 +105,11 @@ class HasPredicateScan : public Operation {
                               size_t resultSize);
 
   template <int WIDTH>
-  ResultTable computeSubqueryS(IdTable* result,
+  Result computeSubqueryS(IdTable* result,
                                const CompactVectorOfStrings<Id>& patterns);
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -109,7 +109,7 @@ class HasPredicateScan : public Operation {
                                const CompactVectorOfStrings<Id>& patterns);
 
  private:
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -123,7 +123,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
   return variableToColumnMap;
 }
 // _____________________________________________________________________________
-Result IndexScan::computeResult() {
+Result IndexScan::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "IndexScan result computation...\n";
   IdTable idTable{getExecutionContext()->getAllocator()};
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -123,7 +123,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
   return variableToColumnMap;
 }
 // _____________________________________________________________________________
-ResultTable IndexScan::computeResult() {
+Result IndexScan::computeResult() {
   LOG(DEBUG) << "IndexScan result computation...\n";
   IdTable idTable{getExecutionContext()->getAllocator()};
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -123,7 +123,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
   return variableToColumnMap;
 }
 // _____________________________________________________________________________
-Result IndexScan::computeResult([[maybe_unused]] bool requestLazyness) {
+Result IndexScan::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "IndexScan result computation...\n";
   IdTable idTable{getExecutionContext()->getAllocator()};
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -104,7 +104,7 @@ class IndexScan : public Operation {
   std::array<const TripleComponent* const, 3> getPermutedTriple() const;
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -104,7 +104,7 @@ class IndexScan : public Operation {
   std::array<const TripleComponent* const, 3> getPermutedTriple() const;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -104,7 +104,7 @@ class IndexScan : public Operation {
   std::array<const TripleComponent* const, 3> getPermutedTriple() const;
 
  private:
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -123,9 +123,8 @@ Result Join::computeResult([[maybe_unused]] bool requestLaziness) {
     // cache". So effectively, this returns the result if it is small, contains
     // UNDEF values, or is contained in the cache, otherwise `nullptr`.
     return tree.getRootOperation()->getResult(
-        false, (isSmall || containsUndef)
-                   ? ComputationMode::ONLY_IF_CACHED
-                   : ComputationMode::FULLY_MATERIALIZED);
+        false, (isSmall || containsUndef) ? ComputationMode::FULLY_MATERIALIZED
+                                          : ComputationMode::ONLY_IF_CACHED);
   };
 
   auto leftResIfCached = getCachedOrSmallResult(*_left, _leftJoinCol);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -90,7 +90,7 @@ string Join::getCacheKeyImpl() const {
 string Join::getDescriptor() const { return "Join on " + _joinVar.name(); }
 
 // _____________________________________________________________________________
-Result Join::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Join::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   size_t leftWidth = _left->getResultWidth();
   size_t rightWidth = _right->getResultWidth();

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -90,7 +90,7 @@ string Join::getCacheKeyImpl() const {
 string Join::getDescriptor() const { return "Join on " + _joinVar.name(); }
 
 // _____________________________________________________________________________
-Result Join::computeResult() {
+Result Join::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   size_t leftWidth = _left->getResultWidth();
   size_t rightWidth = _right->getResultWidth();
@@ -156,7 +156,7 @@ Result Join::computeResult() {
   shared_ptr<const Result> leftRes =
       leftResIfCached ? leftResIfCached : _left->getResult();
   checkCancellation();
-  if (leftRes->size() == 0) {
+  if (leftRes->idTable().size() == 0) {
     _right->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
     // TODO<joka921, hannahbast, SPARQL update> When we add triples to the
     // index, the vocabularies of index scans will not necessarily be empty and

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -90,7 +90,7 @@ string Join::getCacheKeyImpl() const {
 string Join::getDescriptor() const { return "Join on " + _joinVar.name(); }
 
 // _____________________________________________________________________________
-ResultTable Join::computeResult() {
+Result Join::computeResult() {
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   size_t leftWidth = _left->getResultWidth();
   size_t rightWidth = _right->getResultWidth();
@@ -153,7 +153,7 @@ ResultTable Join::computeResult() {
     }
   }
 
-  shared_ptr<const ResultTable> leftRes =
+  shared_ptr<const Result> leftRes =
       leftResIfCached ? leftResIfCached : _left->getResult();
   checkCancellation();
   if (leftRes->size() == 0) {
@@ -181,7 +181,7 @@ ResultTable Join::computeResult() {
             leftRes->getSharedLocalVocab()};
   }
 
-  shared_ptr<const ResultTable> rightRes =
+  shared_ptr<const Result> rightRes =
       rightResIfCached ? rightResIfCached : _right->getResult();
   checkCancellation();
   join(leftRes->idTable(), _leftJoinCol, rightRes->idTable(), _rightJoinCol,
@@ -191,7 +191,7 @@ ResultTable Join::computeResult() {
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),
-          ResultTable::getMergedLocalVocab(*leftRes, *rightRes)};
+          Result::getMergedLocalVocab(*leftRes, *rightRes)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -123,8 +123,9 @@ Result Join::computeResult([[maybe_unused]] bool requestLaziness) {
     // cache". So effectively, this returns the result if it is small, contains
     // UNDEF values, or is contained in the cache, otherwise `nullptr`.
     return tree.getRootOperation()->getResult(
-        false, (isSmall || containsUndef) ? ComputationMode::CACHE_ONLY
-                                          : ComputationMode::FULL);
+        false, (isSmall || containsUndef)
+                   ? ComputationMode::ONLY_IF_CACHED
+                   : ComputationMode::FULLY_MATERIALIZED);
   };
 
   auto leftResIfCached = getCachedOrSmallResult(*_left, _leftJoinCol);

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -122,8 +122,9 @@ Result Join::computeResult([[maybe_unused]] bool requestLazyness) {
     // The third argument means "only get the result if it can be read from the
     // cache". So effectively, this returns the result if it is small, contains
     // UNDEF values, or is contained in the cache, otherwise `nullptr`.
-    return tree.getRootOperation()->getResult(false,
-                                              !(isSmall || containsUndef));
+    return tree.getRootOperation()->getResult(
+        false, (isSmall || containsUndef) ? ComputationMode::CACHE_ONLY
+                                          : ComputationMode::FULL);
   };
 
   auto leftResIfCached = getCachedOrSmallResult(*_left, _leftJoinCol);
@@ -153,7 +154,7 @@ Result Join::computeResult([[maybe_unused]] bool requestLazyness) {
     }
   }
 
-  shared_ptr<const Result> leftRes =
+  std::shared_ptr<const Result> leftRes =
       leftResIfCached ? leftResIfCached : _left->getResult();
   checkCancellation();
   if (leftRes->idTable().size() == 0) {
@@ -181,7 +182,7 @@ Result Join::computeResult([[maybe_unused]] bool requestLazyness) {
             leftRes->getSharedLocalVocab()};
   }
 
-  shared_ptr<const Result> rightRes =
+  std::shared_ptr<const Result> rightRes =
       rightResIfCached ? rightResIfCached : _right->getResult();
   checkCancellation();
   join(leftRes->idTable(), _leftJoinCol, rightRes->idTable(), _rightJoinCol,

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -122,6 +122,7 @@ Result Join::computeResult([[maybe_unused]] bool requestLaziness) {
     // The third argument means "only get the result if it can be read from the
     // cache". So effectively, this returns the result if it is small, contains
     // UNDEF values, or is contained in the cache, otherwise `nullptr`.
+    // TODO<joka921> Add a unit test that checks the correct conditions
     return tree.getRootOperation()->getResult(
         false, (isSmall || containsUndef) ? ComputationMode::FULLY_MATERIALIZED
                                           : ComputationMode::ONLY_IF_CACHED);

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -115,7 +115,7 @@ class Join : public Operation {
   virtual string getCacheKeyImpl() const override;
 
  private:
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -115,7 +115,7 @@ class Join : public Operation {
   virtual string getCacheKeyImpl() const override;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -115,7 +115,7 @@ class Join : public Operation {
   virtual string getCacheKeyImpl() const override;
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -32,7 +32,7 @@ string Minus::getCacheKeyImpl() const {
 string Minus::getDescriptor() const { return "Minus"; }
 
 // _____________________________________________________________________________
-ResultTable Minus::computeResult() {
+Result Minus::computeResult() {
   LOG(DEBUG) << "Minus result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -56,7 +56,7 @@ ResultTable Minus::computeResult() {
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),
-          ResultTable::getMergedLocalVocab(*leftResult, *rightResult)};
+          Result::getMergedLocalVocab(*leftResult, *rightResult)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -32,7 +32,7 @@ string Minus::getCacheKeyImpl() const {
 string Minus::getDescriptor() const { return "Minus"; }
 
 // _____________________________________________________________________________
-Result Minus::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Minus::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Minus result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -32,7 +32,7 @@ string Minus::getCacheKeyImpl() const {
 string Minus::getDescriptor() const { return "Minus"; }
 
 // _____________________________________________________________________________
-Result Minus::computeResult() {
+Result Minus::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "Minus result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -43,8 +43,9 @@ Result Minus::computeResult() {
 
   LOG(DEBUG) << "Minus subresult computation done" << std::endl;
 
-  LOG(DEBUG) << "Computing minus of results of size " << leftResult->size()
-             << " and " << rightResult->size() << endl;
+  LOG(DEBUG) << "Computing minus of results of size "
+             << leftResult->idTable().size() << " and "
+             << rightResult->idTable().size() << endl;
 
   int leftWidth = leftResult->idTable().numColumns();
   int rightWidth = rightResult->idTable().numColumns();

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -72,7 +72,7 @@ class Minus : public Operation {
       const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
       size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -72,7 +72,7 @@ class Minus : public Operation {
       const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
       size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -72,7 +72,7 @@ class Minus : public Operation {
       const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
       size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -60,7 +60,7 @@ string MultiColumnJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLazyness) {
+Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -59,7 +59,7 @@ string MultiColumnJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ResultTable MultiColumnJoin::computeResult() {
+Result MultiColumnJoin::computeResult() {
   LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -86,7 +86,7 @@ ResultTable MultiColumnJoin::computeResult() {
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),
-          ResultTable::getMergedLocalVocab(*leftResult, *rightResult)};
+          Result::getMergedLocalVocab(*leftResult, *rightResult)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -6,6 +6,7 @@
 
 #include "engine/AddCombinedRowToTable.h"
 #include "engine/CallFixedSize.h"
+#include "engine/Engine.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
 
 using std::endl;

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -59,7 +59,7 @@ string MultiColumnJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result MultiColumnJoin::computeResult() {
+Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -75,7 +75,8 @@ Result MultiColumnJoin::computeResult() {
   LOG(DEBUG) << "MultiColumnJoin subresult computation done." << std::endl;
 
   LOG(DEBUG) << "Computing a multi column join between results of size "
-             << leftResult->size() << " and " << rightResult->size() << endl;
+             << leftResult->idTable().size() << " and "
+             << rightResult->idTable().size() << endl;
 
   computeMultiColumnJoin(leftResult->idTable(), rightResult->idTable(),
                          _joinColumns, &idTable);

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -63,7 +63,7 @@ class MultiColumnJoin : public Operation {
       IdTable* resultMightBeUnsorted);
 
  private:
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -63,7 +63,7 @@ class MultiColumnJoin : public Operation {
       IdTable* resultMightBeUnsorted);
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -63,7 +63,7 @@ class MultiColumnJoin : public Operation {
       IdTable* resultMightBeUnsorted);
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -40,7 +40,7 @@ class NeutralElementOperation : public Operation {
   };
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     IdTable idTable{getExecutionContext()->getAllocator()};
     idTable.setNumColumns(0);
     idTable.resize(1);

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -40,7 +40,7 @@ class NeutralElementOperation : public Operation {
   };
 
  private:
-  ResultTable computeResult() override {
+  Result computeResult() override {
     IdTable idTable{getExecutionContext()->getAllocator()};
     idTable.setNumColumns(0);
     idTable.resize(1);

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -40,7 +40,7 @@ class NeutralElementOperation : public Operation {
   };
 
  private:
-  Result computeResult() override {
+  Result computeResult([[maybe_unused]] bool requestLazyness) override {
     IdTable idTable{getExecutionContext()->getAllocator()};
     idTable.setNumColumns(0);
     idTable.resize(1);

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -125,8 +125,6 @@ std::shared_ptr<const Result> Operation::getResult(
       runtimeInfo().status_ = RuntimeInformation::Status::inProgress;
       signalQueryUpdate();
       Result result = computeResult(computationMode == ComputationMode::LAZY);
-      AD_CONTRACT_CHECK(computationMode == ComputationMode::LAZY ||
-                        result.isDataEvaluated());
 
       checkCancellation();
       // Compute the datatypes that occur in each column of the result.

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -70,8 +70,8 @@ void Operation::recursivelySetTimeConstraint(
 }
 
 // ________________________________________________________________________
-shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
-                                                   bool onlyReadFromCache) {
+shared_ptr<const Result> Operation::getResult(bool isRoot,
+                                              bool onlyReadFromCache) {
   ad_utility::Timer timer{ad_utility::Timer::Started};
 
   if (isRoot) {
@@ -124,7 +124,7 @@ shared_ptr<const ResultTable> Operation::getResult(bool isRoot,
       checkCancellation();
       runtimeInfo().status_ = RuntimeInformation::Status::inProgress;
       signalQueryUpdate();
-      ResultTable result = computeResult();
+      Result result = computeResult();
 
       checkCancellation();
       // Compute the datatypes that occur in each column of the result.
@@ -221,7 +221,7 @@ std::chrono::milliseconds Operation::remainingTime() const {
 
 // _______________________________________________________________________
 void Operation::updateRuntimeInformationOnSuccess(
-    const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
+    const Result& resultTable, ad_utility::CacheStatus cacheStatus,
     Milliseconds duration, std::optional<RuntimeInformation> runtimeInfo) {
   _runtimeInfo->totalTime_ = duration;
   _runtimeInfo->numRows_ = resultTable.size();

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -124,7 +124,8 @@ std::shared_ptr<const Result> Operation::getResult(
       checkCancellation();
       runtimeInfo().status_ = RuntimeInformation::Status::inProgress;
       signalQueryUpdate();
-      Result result = computeResult(computationMode == ComputationMode::LAZY);
+      Result result =
+          computeResult(computationMode == ComputationMode::LAZY_IF_SUPPORTED);
 
       checkCancellation();
       // Compute the datatypes that occur in each column of the result.
@@ -159,7 +160,7 @@ std::shared_ptr<const Result> Operation::getResult(
       return CacheValue{std::move(result), runtimeInfo()};
     };
 
-    bool onlyReadFromCache = computationMode == ComputationMode::CACHE_ONLY;
+    bool onlyReadFromCache = computationMode == ComputationMode::ONLY_IF_CACHED;
 
     auto result = pinResult ? cache.computeOncePinned(cacheKey, computeLambda,
                                                       onlyReadFromCache)

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -21,7 +21,11 @@
 // forward declaration needed to break dependencies
 class QueryExecutionTree;
 
-enum class ComputationMode { FULL, CACHE_ONLY, LAZY };
+enum class ComputationMode {
+  FULLY_MATERIALIZED,
+  ONLY_IF_CACHED,
+  LAZY_IF_SUPPORTED
+};
 
 class Operation {
   using SharedCancellationHandle = ad_utility::SharedCancellationHandle;
@@ -152,7 +156,7 @@ class Operation {
    */
   std::shared_ptr<const Result> getResult(
       bool isRoot = false,
-      ComputationMode computationMode = ComputationMode::FULL);
+      ComputationMode computationMode = ComputationMode::FULLY_MATERIALIZED);
 
   // Use the same cancellation handle for all children of an operation (= query
   // plan rooted at that operation). As soon as one child is aborted, the whole

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -10,7 +10,7 @@
 #include <memory>
 
 #include "engine/QueryExecutionContext.h"
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/RuntimeInformation.h"
 #include "engine/VariableToColumnMap.h"
 #include "parser/data/LimitOffsetClause.h"
@@ -146,8 +146,8 @@ class Operation {
    * @return A shared pointer to the result. May only be `nullptr` if
    * `onlyReadFromCache` is true.
    */
-  shared_ptr<const ResultTable> getResult(bool isRoot = false,
-                                          bool onlyReadFromCache = false);
+  shared_ptr<const Result> getResult(bool isRoot = false,
+                                     bool onlyReadFromCache = false);
 
   // Use the same cancellation handle for all children of an operation (= query
   // plan rooted at that operation). As soon as one child is aborted, the whole
@@ -195,9 +195,7 @@ class Operation {
   // Direct access to the `computeResult()` method. This should be only used for
   // testing, otherwise the `getResult()` function should be used which also
   // sets the runtime info and uses the cache.
-  virtual ResultTable computeResultOnlyForTesting() final {
-    return computeResult();
-  }
+  virtual Result computeResultOnlyForTesting() final { return computeResult(); }
 
  protected:
   // The QueryExecutionContext for this particular element.
@@ -246,7 +244,7 @@ class Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  virtual ResultTable computeResult() = 0;
+  virtual Result computeResult() = 0;
 
   // Create and store the complete runtime information for this operation after
   // it has either been succesfully computed or read from the cache.
@@ -260,7 +258,7 @@ class Operation {
   // allowed when `cacheStatus` is `cachedPinned` or `cachedNotPinned`,
   // otherwise a runtime check will fail.
   virtual void updateRuntimeInformationOnSuccess(
-      const ResultTable& resultTable, ad_utility::CacheStatus cacheStatus,
+      const Result& resultTable, ad_utility::CacheStatus cacheStatus,
       Milliseconds duration,
       std::optional<RuntimeInformation> runtimeInfo) final;
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -201,8 +201,8 @@ class Operation {
   // testing, otherwise the `getResult()` function should be used which also
   // sets the runtime info and uses the cache.
   virtual Result computeResultOnlyForTesting(
-      bool requestLazyness = false) final {
-    return computeResult(requestLazyness);
+      bool requestLaziness = false) final {
+    return computeResult(requestLaziness);
   }
 
  protected:

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -147,7 +147,8 @@ class Operation {
    * `onlyReadFromCache` is true.
    */
   shared_ptr<const Result> getResult(bool isRoot = false,
-                                     bool onlyReadFromCache = false);
+                                     bool onlyReadFromCache = false,
+                                     bool requestLazyness = false);
 
   // Use the same cancellation handle for all children of an operation (= query
   // plan rooted at that operation). As soon as one child is aborted, the whole
@@ -195,7 +196,10 @@ class Operation {
   // Direct access to the `computeResult()` method. This should be only used for
   // testing, otherwise the `getResult()` function should be used which also
   // sets the runtime info and uses the cache.
-  virtual Result computeResultOnlyForTesting() final { return computeResult(); }
+  virtual Result computeResultOnlyForTesting(
+      bool requestLazyness = false) final {
+    return computeResult(requestLazyness);
+  }
 
  protected:
   // The QueryExecutionContext for this particular element.
@@ -244,7 +248,7 @@ class Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  virtual Result computeResult() = 0;
+  virtual Result computeResult(bool requestLazyness) = 0;
 
   // Create and store the complete runtime information for this operation after
   // it has either been succesfully computed or read from the cache.

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -88,7 +88,7 @@ string OptionalJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result OptionalJoin::computeResult() {
+Result OptionalJoin::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -104,7 +104,8 @@ Result OptionalJoin::computeResult() {
   LOG(DEBUG) << "OptionalJoin subresult computation done." << std::endl;
 
   LOG(DEBUG) << "Computing optional join between results of size "
-             << leftResult->size() << " and " << rightResult->size() << endl;
+             << leftResult->idTable().size() << " and "
+             << rightResult->idTable().size() << endl;
 
   optionalJoin(leftResult->idTable(), rightResult->idTable(), _joinColumns,
                &idTable, implementation_);

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -88,7 +88,7 @@ string OptionalJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ResultTable OptionalJoin::computeResult() {
+Result OptionalJoin::computeResult() {
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -115,7 +115,7 @@ ResultTable OptionalJoin::computeResult() {
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return {std::move(idTable), resultSortedOn(),
-          ResultTable::getMergedLocalVocab(*leftResult, *rightResult)};
+          Result::getMergedLocalVocab(*leftResult, *rightResult)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -89,7 +89,7 @@ string OptionalJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result OptionalJoin::computeResult([[maybe_unused]] bool requestLazyness) {
+Result OptionalJoin::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -7,6 +7,7 @@
 
 #include "engine/AddCombinedRowToTable.h"
 #include "engine/CallFixedSize.h"
+#include "engine/Engine.h"
 #include "util/JoinAlgorithms/JoinAlgorithms.h"
 
 using std::endl;

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -75,7 +75,7 @@ class OptionalJoin : public Operation {
  private:
   void computeSizeEstimateAndMultiplicities();
 
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -75,7 +75,7 @@ class OptionalJoin : public Operation {
  private:
   void computeSizeEstimateAndMultiplicities();
 
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -75,7 +75,7 @@ class OptionalJoin : public Operation {
  private:
   void computeSizeEstimateAndMultiplicities();
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -62,10 +62,10 @@ std::string OrderBy::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ResultTable OrderBy::computeResult() {
+Result OrderBy::computeResult() {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
-  shared_ptr<const ResultTable> subRes = subtree_->getResult();
+  shared_ptr<const Result> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
   auto sortEstimateCancellationFactor =

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -63,7 +63,7 @@ std::string OrderBy::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result OrderBy::computeResult([[maybe_unused]] bool requestLazyness) {
+Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include "engine/CallFixedSize.h"
+#include "engine/Engine.h"
 #include "engine/QueryExecutionTree.h"
 #include "global/RuntimeParameters.h"
 #include "global/ValueIdComparators.h"
@@ -65,7 +66,7 @@ std::string OrderBy::getDescriptor() const {
 Result OrderBy::computeResult([[maybe_unused]] bool requestLazyness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
-  shared_ptr<const Result> subRes = subtree_->getResult();
+  std::shared_ptr<const Result> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
   auto sortEstimateCancellationFactor =

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -62,7 +62,7 @@ std::string OrderBy::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result OrderBy::computeResult() {
+Result OrderBy::computeResult([[maybe_unused]] bool requestLazyness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
   shared_ptr<const Result> subRes = subtree_->getResult();
@@ -71,7 +71,7 @@ Result OrderBy::computeResult() {
   auto sortEstimateCancellationFactor =
       RuntimeParameters().get<"sort-estimate-cancellation-factor">();
   if (getExecutionContext()->getSortPerformanceEstimator().estimatedSortTime(
-          subRes->size(), subRes->width()) >
+          subRes->idTable().size(), subRes->idTable().numColumns()) >
       remainingTime() * sortEstimateCancellationFactor) {
     // The estimated time for this sort is much larger than the actually
     // remaining time, cancel this operation

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -78,7 +78,7 @@ class OrderBy : public Operation {
   }
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override {
     return subtree_->getVariableColumns();

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -78,7 +78,7 @@ class OrderBy : public Operation {
   }
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override {
     return subtree_->getVariableColumns();

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -78,7 +78,7 @@ class OrderBy : public Operation {
   }
 
  private:
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override {
     return subtree_->getVariableColumns();

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -47,8 +47,9 @@ class CacheValue {
   struct SizeGetter {
     ad_utility::MemorySize operator()(const CacheValue& cacheValue) const {
       if (const auto& tablePtr = cacheValue._resultTable; tablePtr) {
-        return ad_utility::MemorySize::bytes(tablePtr->size() *
-                                             tablePtr->width() * sizeof(Id));
+        return ad_utility::MemorySize::bytes(tablePtr->idTable().size() *
+                                             tablePtr->idTable().numColumns() *
+                                             sizeof(Id));
       } else {
         return 0_B;
       }

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -13,7 +13,7 @@
 
 #include "engine/Engine.h"
 #include "engine/QueryPlanningCostFactors.h"
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/RuntimeInformation.h"
 #include "engine/SortPerformanceEstimator.h"
 #include "global/Constants.h"
@@ -31,18 +31,15 @@ using std::vector;
 
 class CacheValue {
  private:
-  std::shared_ptr<const ResultTable> _resultTable;
+  std::shared_ptr<const Result> _resultTable;
   RuntimeInformation _runtimeInfo;
 
  public:
-  explicit CacheValue(ResultTable resultTable, RuntimeInformation runtimeInfo)
-      : _resultTable(
-            std::make_shared<const ResultTable>(std::move(resultTable))),
+  explicit CacheValue(Result resultTable, RuntimeInformation runtimeInfo)
+      : _resultTable(std::make_shared<const Result>(std::move(resultTable))),
         _runtimeInfo(std::move(runtimeInfo)) {}
 
-  const shared_ptr<const ResultTable>& resultTable() const {
-    return _resultTable;
-  }
+  const shared_ptr<const Result>& resultTable() const { return _resultTable; }
 
   const RuntimeInformation& runtimeInfo() const { return _runtimeInfo; }
 

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -9,25 +9,16 @@
 #include <memory>
 #include <shared_mutex>
 #include <string>
-#include <vector>
 
-#include "engine/Engine.h"
 #include "engine/QueryPlanningCostFactors.h"
 #include "engine/Result.h"
 #include "engine/RuntimeInformation.h"
 #include "engine/SortPerformanceEstimator.h"
-#include "global/Constants.h"
 #include "global/Id.h"
 #include "index/Index.h"
 #include "util/Cache.h"
 #include "util/ConcurrentCache.h"
-#include "util/Log.h"
 #include "util/Synchronized.h"
-#include "util/http/websocket/QueryId.h"
-
-using std::shared_ptr;
-using std::string;
-using std::vector;
 
 class CacheValue {
  private:
@@ -39,7 +30,9 @@ class CacheValue {
       : _resultTable(std::make_shared<const Result>(std::move(resultTable))),
         _runtimeInfo(std::move(runtimeInfo)) {}
 
-  const shared_ptr<const Result>& resultTable() const { return _resultTable; }
+  const std::shared_ptr<const Result>& resultTable() const {
+    return _resultTable;
+  }
 
   const RuntimeInformation& runtimeInfo() const { return _runtimeInfo; }
 

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -158,7 +158,8 @@ std::vector<std::array<ColumnIndex, 2>> QueryExecutionTree::getJoinColumns(
 }
 
 // ____________________________________________________________________________
-std::pair<std::shared_ptr<QueryExecutionTree>, shared_ptr<QueryExecutionTree>>
+std::pair<std::shared_ptr<QueryExecutionTree>,
+          std::shared_ptr<QueryExecutionTree>>
 QueryExecutionTree::createSortedTrees(
     std::shared_ptr<QueryExecutionTree> qetA,
     std::shared_ptr<QueryExecutionTree> qetB,

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -84,7 +84,7 @@ size_t QueryExecutionTree::getCostEstimate() {
 size_t QueryExecutionTree::getSizeEstimate() {
   if (!sizeEstimate_.has_value()) {
     if (cachedResult_) {
-      sizeEstimate_ = cachedResult_->size();
+      sizeEstimate_ = cachedResult_->idTable().size();
     } else {
       // if we are in a unit test setting and there is no QueryExecutionContest
       // specified it is the rootOperation_'s obligation to handle this case
@@ -98,7 +98,7 @@ size_t QueryExecutionTree::getSizeEstimate() {
 // _____________________________________________________________________________
 bool QueryExecutionTree::knownEmptyResult() {
   if (cachedResult_) {
-    return cachedResult_->size() == 0;
+    return cachedResult_->idTable().size() == 0;
   }
   return rootOperation_->knownEmptyResult();
 }

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -51,8 +51,10 @@ class QueryExecutionTree {
 
   size_t getResultWidth() const { return rootOperation_->getResultWidth(); }
 
-  std::shared_ptr<const Result> getResult(bool requestLazyness = false) const {
-    return rootOperation_->getResult(isRoot(), false, requestLazyness);
+  std::shared_ptr<const Result> getResult(bool requestLaziness = false) const {
+    return rootOperation_->getResult(isRoot(), requestLaziness
+                                                   ? ComputationMode::LAZY
+                                                   : ComputationMode::FULL);
   }
 
   // A variable, its column index in the Id space result, and the `ResultType`

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -52,9 +52,9 @@ class QueryExecutionTree {
   size_t getResultWidth() const { return rootOperation_->getResultWidth(); }
 
   std::shared_ptr<const Result> getResult(bool requestLaziness = false) const {
-    return rootOperation_->getResult(isRoot(), requestLaziness
-                                                   ? ComputationMode::LAZY
-                                                   : ComputationMode::FULL);
+    return rootOperation_->getResult(
+        isRoot(), requestLaziness ? ComputationMode::LAZY_IF_SUPPORTED
+                                  : ComputationMode::FULLY_MATERIALIZED);
   }
 
   // A variable, its column index in the Id space result, and the `ResultType`

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -51,8 +51,8 @@ class QueryExecutionTree {
 
   size_t getResultWidth() const { return rootOperation_->getResultWidth(); }
 
-  std::shared_ptr<const Result> getResult() const {
-    return rootOperation_->getResult(isRoot());
+  std::shared_ptr<const Result> getResult(bool requestLazyness = false) const {
+    return rootOperation_->getResult(isRoot(), false, requestLazyness);
   }
 
   // A variable, its column index in the Id space result, and the `ResultType`

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -51,7 +51,7 @@ class QueryExecutionTree {
 
   size_t getResultWidth() const { return rootOperation_->getResultWidth(); }
 
-  std::shared_ptr<const ResultTable> getResult() const {
+  std::shared_ptr<const Result> getResult() const {
     return rootOperation_->getResult(isRoot());
   }
 
@@ -192,7 +192,7 @@ class QueryExecutionTree {
   bool isRoot_ = false;  // used to distinguish the root from child
                          // operations/subtrees when pinning only the result.
 
-  std::shared_ptr<const ResultTable> cachedResult_ = nullptr;
+  std::shared_ptr<const Result> cachedResult_ = nullptr;
 
  public:
   // Helper class to avoid bug in g++ that leads to memory corruption when

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -6,8 +6,9 @@
 
 #include "engine/QueryPlanner.h"
 
+#include <absl/strings/str_split.h>
+
 #include <algorithm>
-#include <ctime>
 
 #include "engine/Bind.h"
 #include "engine/CartesianProductJoin.h"

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -5,23 +5,20 @@
 //   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
 
 #pragma once
-#include <set>
+
 #include <vector>
 
-#include "absl/strings/str_join.h"
-#include "absl/strings/str_split.h"
 #include "engine/CheckUsePatternTrick.h"
-#include "engine/Filter.h"
 #include "engine/QueryExecutionTree.h"
 #include "parser/GraphPattern.h"
 #include "parser/ParsedQuery.h"
-
-using std::vector;
 
 class QueryPlanner {
   using TextLimitMap =
       ad_utility::HashMap<Variable, parsedQuery::TextLimitMetaObject>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
+  template <typename T>
+  using vector = std::vector<T>;
 
  public:
   explicit QueryPlanner(QueryExecutionContext* qec,

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -136,7 +136,7 @@ class QueryPlanner {
                                                     std::move(operation))} {}
 
     std::shared_ptr<QueryExecutionTree> _qet;
-    std::shared_ptr<ResultTable> _cachedResult;
+    std::shared_ptr<Result> _cachedResult;
     uint64_t _idsOfIncludedNodes = 0;
     uint64_t _idsOfIncludedFilters = 0;
     uint64_t idsOfIncludedTextLimits_ = 0;

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -23,11 +23,10 @@ string Result::asDebugString() const {
 }
 
 // _____________________________________________________________________________
-auto Result::getMergedLocalVocab(const Result& resultTable1,
-                                 const Result& resultTable2)
+auto Result::getMergedLocalVocab(const Result& result1, const Result& result2)
     -> SharedLocalVocabWrapper {
   return getMergedLocalVocab(
-      std::array{std::cref(resultTable1), std::cref(resultTable2)});
+      std::array{std::cref(result1), std::cref(result2)});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -4,13 +4,12 @@
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
-#include "engine/ResultTable.h"
-
 #include "engine/LocalVocab.h"
+#include "engine/Result.h"
 #include "util/Exception.h"
 
 // _____________________________________________________________________________
-string ResultTable::asDebugString() const {
+string Result::asDebugString() const {
   std::ostringstream os;
   os << "First (up to) 5 rows of result with size:\n";
   for (size_t i = 0; i < std::min<size_t>(5, idTable().size()); ++i) {
@@ -23,21 +22,19 @@ string ResultTable::asDebugString() const {
 }
 
 // _____________________________________________________________________________
-auto ResultTable::getMergedLocalVocab(const ResultTable& resultTable1,
-                                      const ResultTable& resultTable2)
+auto Result::getMergedLocalVocab(const Result& resultTable1,
+                                 const Result& resultTable2)
     -> SharedLocalVocabWrapper {
   return getMergedLocalVocab(
       std::array{std::cref(resultTable1), std::cref(resultTable2)});
 }
 
 // _____________________________________________________________________________
-LocalVocab ResultTable::getCopyOfLocalVocab() const {
-  return localVocab().clone();
-}
+LocalVocab Result::getCopyOfLocalVocab() const { return localVocab().clone(); }
 
 // _____________________________________________________________________________
-ResultTable::ResultTable(IdTable idTable, vector<ColumnIndex> sortedBy,
-                         SharedLocalVocabWrapper localVocab)
+Result::Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
+               SharedLocalVocabWrapper localVocab)
     : _idTable{std::move(idTable)},
       _sortedBy{std::move(sortedBy)},
       localVocab_{std::move(localVocab.localVocab_)} {
@@ -60,13 +57,13 @@ ResultTable::ResultTable(IdTable idTable, vector<ColumnIndex> sortedBy,
 }
 
 // _____________________________________________________________________________
-ResultTable::ResultTable(IdTable idTable, vector<ColumnIndex> sortedBy,
-                         LocalVocab&& localVocab)
-    : ResultTable(std::move(idTable), std::move(sortedBy),
-                  SharedLocalVocabWrapper{std::move(localVocab)}) {}
+Result::Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
+               LocalVocab&& localVocab)
+    : Result(std::move(idTable), std::move(sortedBy),
+             SharedLocalVocabWrapper{std::move(localVocab)}) {}
 
 // _____________________________________________________________________________
-void ResultTable::applyLimitOffset(const LimitOffsetClause& limitOffset) {
+void Result::applyLimitOffset(const LimitOffsetClause& limitOffset) {
   // Apply the OFFSET clause. If the offset is `0` or the offset is larger
   // than the size of the `IdTable`, then this has no effect and runtime
   // `O(1)` (see the docs for `std::shift_left`).
@@ -85,7 +82,7 @@ void ResultTable::applyLimitOffset(const LimitOffsetClause& limitOffset) {
 }
 
 // _____________________________________________________________________________
-auto ResultTable::getOrComputeDatatypeCountsPerColumn()
+auto Result::getOrComputeDatatypeCountsPerColumn()
     -> const DatatypeCountsPerColumn& {
   if (datatypeCountsPerColumn_.has_value()) {
     return datatypeCountsPerColumn_.value();
@@ -103,7 +100,7 @@ auto ResultTable::getOrComputeDatatypeCountsPerColumn()
 }
 
 // _____________________________________________________________
-bool ResultTable::checkDefinedness(const VariableToColumnMap& varColMap) {
+bool Result::checkDefinedness(const VariableToColumnMap& varColMap) {
   const auto& datatypesPerColumn = getOrComputeDatatypeCountsPerColumn();
   return std::ranges::all_of(varColMap, [&](const auto& varAndCol) {
     const auto& [columnIndex, mightContainUndef] = varAndCol.second;

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -16,7 +16,6 @@
 #include "global/Id.h"
 #include "parser/data/LimitOffsetClause.h"
 #include "util/Generator.h"
-#include "util/Log.h"
 
 // The result of an `Operation`. This is the class QLever uses for all
 // intermediate or final results when processing a SPARQL query. The actual data

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -121,8 +121,8 @@ class Result {
 
   // Like `getSharedLocalVocabFrom`, but takes more than one result and merges
   // all the corresponding local vocabs.
-  static SharedLocalVocabWrapper getMergedLocalVocab(
-      const Result& resultTable1, const Result& resultTable2);
+  static SharedLocalVocabWrapper getMergedLocalVocab(const Result& result1,
+                                                     const Result& result2);
 
   // Overload for more than two `Results`
   template <std::ranges::forward_range R>

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <ranges>
-#include <variant>
 #include <vector>
 
 #include "engine/LocalVocab.h"

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <ranges>
+#include <variant>
 #include <vector>
 
 #include "engine/LocalVocab.h"
@@ -22,7 +23,7 @@
 class Result {
  private:
   // The actual entries.
-  IdTable _idTable;
+  std::variant<IdTable> _idTable;
 
   // The column indices by which the result is sorted (primary sort key first).
   // Empty if the result is not sorted on any column.
@@ -48,8 +49,7 @@ class Result {
     // `shared_ptr`. Other code can obtain a `SharedLocalVocabWrapper` from a
     // `Result` and pass this wrapper into another `Result`, but it
     // can never access the `shared_ptr` directly.
-    std::shared_ptr<const LocalVocab> localVocab_ =
-        std::make_shared<const LocalVocab>();
+    std::shared_ptr<const LocalVocab> localVocab_;
     explicit SharedLocalVocabWrapper(LocalVocabPtr localVocab)
         : localVocab_{std::move(localVocab)} {}
     friend class Result;
@@ -97,13 +97,13 @@ class Result {
   virtual ~Result() = default;
 
   // Get the number of rows of this result.
-  size_t size() const { return _idTable.size(); }
+  size_t size() const { return std::get<0>(_idTable).size(); }
 
   // Get the number of columns of this result.
-  size_t width() const { return _idTable.numColumns(); }
+  size_t width() const { return std::get<0>(_idTable).numColumns(); }
 
   // Const access to the underlying `IdTable`.
-  const IdTable& idTable() const { return _idTable; }
+  const IdTable& idTable() const { return std::get<0>(_idTable); }
 
   // Const access to the columns by which the `idTable()` is sorted.
   const std::vector<ColumnIndex>& sortedBy() const { return _sortedBy; }

--- a/src/engine/ResultType.h
+++ b/src/engine/ResultType.h
@@ -6,11 +6,11 @@
 
 namespace qlever {
 
-// Enumerate the types of entries we can have in a `ResultTable`.
+// Enumerate the types of entries we can have in a `Result`.
 //
 // NOTE: This was used in an old version of the QLever code, but no longer is
 // (because reality is more complicated than "one type per column"). The class
-// is still needed for the correctness of the code, see `ResultTable.h`.
+// is still needed for the correctness of the code, see `Result.h`.
 //
 // TODO: Properly keep track of result types again. In particular, efficiency
 // should benefit in the common use case where all entries in a column have a

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -83,7 +83,7 @@ size_t Service::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-ResultTable Service::computeResult() {
+Result Service::computeResult() {
   // Get the URL of the SPARQL endpoint.
   std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
   AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -83,7 +83,7 @@ size_t Service::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-Result Service::computeResult() {
+Result Service::computeResult([[maybe_unused]] bool requestLazyness) {
   // Get the URL of the SPARQL endpoint.
   std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
   AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -83,7 +83,7 @@ size_t Service::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-Result Service::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Service::computeResult([[maybe_unused]] bool requestLaziness) {
   // Get the URL of the SPARQL endpoint.
   std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
   AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -80,7 +80,7 @@ class Service : public Operation {
   std::string getCacheKeyImpl() const override;
 
   // Compute the result using `getTsvFunction_`.
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   // Write the given TSV result to the given result object. The `I` is the width
   // of the result table.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -80,7 +80,7 @@ class Service : public Operation {
   std::string getCacheKeyImpl() const override;
 
   // Compute the result using `getTsvFunction_`.
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   // Write the given TSV result to the given result object. The `I` is the width
   // of the result table.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -80,7 +80,7 @@ class Service : public Operation {
   std::string getCacheKeyImpl() const override;
 
   // Compute the result using `getTsvFunction_`.
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Write the given TSV result to the given result object. The `I` is the width
   // of the result table.

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -50,7 +50,7 @@ std::string Sort::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result Sort::computeResult() {
+Result Sort::computeResult([[maybe_unused]] bool requestLazyness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
   shared_ptr<const Result> subRes = subtree_->getResult();
@@ -59,7 +59,7 @@ Result Sort::computeResult() {
   auto sortEstimateCancellationFactor =
       RuntimeParameters().get<"sort-estimate-cancellation-factor">();
   if (getExecutionContext()->getSortPerformanceEstimator().estimatedSortTime(
-          subRes->size(), subRes->width()) >
+          subRes->idTable().size(), subRes->idTable().numColumns()) >
       remainingTime() * sortEstimateCancellationFactor) {
     // The estimated time for this sort is much larger than the actually
     // remaining time, cancel this operation

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 
 #include "engine/CallFixedSize.h"
+#include "engine/Engine.h"
 #include "engine/QueryExecutionTree.h"
 #include "global/RuntimeParameters.h"
 
@@ -53,7 +54,7 @@ std::string Sort::getDescriptor() const {
 Result Sort::computeResult([[maybe_unused]] bool requestLazyness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
-  shared_ptr<const Result> subRes = subtree_->getResult();
+  std::shared_ptr<const Result> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
   auto sortEstimateCancellationFactor =

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -50,10 +50,10 @@ std::string Sort::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ResultTable Sort::computeResult() {
+Result Sort::computeResult() {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
-  shared_ptr<const ResultTable> subRes = subtree_->getResult();
+  shared_ptr<const Result> subRes = subtree_->getResult();
 
   // TODO<joka921> proper timeout for sorting operations
   auto sortEstimateCancellationFactor =

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -51,7 +51,7 @@ std::string Sort::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result Sort::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -67,7 +67,7 @@ class Sort : public Operation {
   }
 
  private:
-  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()
       const override {

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -67,7 +67,7 @@ class Sort : public Operation {
   }
 
  private:
-  virtual ResultTable computeResult() override;
+  virtual Result computeResult() override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()
       const override {

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -67,7 +67,7 @@ class Sort : public Operation {
   }
 
  private:
-  virtual Result computeResult() override;
+  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()
       const override {

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -14,7 +14,7 @@ TextIndexScanForEntity::TextIndexScanForEntity(
       word_(std::move(word)) {}
 
 // _____________________________________________________________________________
-Result TextIndexScanForEntity::computeResult() {
+Result TextIndexScanForEntity::computeResult([[maybe_unused]] bool requestLazyness) {
   IdTable idTable = getExecutionContext()->getIndex().getEntityMentionsForWord(
       word_, getExecutionContext()->getAllocator());
 

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -14,7 +14,8 @@ TextIndexScanForEntity::TextIndexScanForEntity(
       word_(std::move(word)) {}
 
 // _____________________________________________________________________________
-Result TextIndexScanForEntity::computeResult([[maybe_unused]] bool requestLazyness) {
+Result TextIndexScanForEntity::computeResult(
+    [[maybe_unused]] bool requestLaziness) {
   IdTable idTable = getExecutionContext()->getIndex().getEntityMentionsForWord(
       word_, getExecutionContext()->getAllocator());
 

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -14,7 +14,7 @@ TextIndexScanForEntity::TextIndexScanForEntity(
       word_(std::move(word)) {}
 
 // _____________________________________________________________________________
-ResultTable TextIndexScanForEntity::computeResult() {
+Result TextIndexScanForEntity::computeResult() {
   IdTable idTable = getExecutionContext()->getIndex().getEntityMentionsForWord(
       word_, getExecutionContext()->getAllocator());
 

--- a/src/engine/TextIndexScanForEntity.h
+++ b/src/engine/TextIndexScanForEntity.h
@@ -101,7 +101,7 @@ class TextIndexScanForEntity : public Operation {
     return std::get<FixedEntity>(varOrFixed_.entity_).second;
   }
 
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForEntity.h
+++ b/src/engine/TextIndexScanForEntity.h
@@ -101,7 +101,7 @@ class TextIndexScanForEntity : public Operation {
     return std::get<FixedEntity>(varOrFixed_.entity_).second;
   }
 
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForEntity.h
+++ b/src/engine/TextIndexScanForEntity.h
@@ -101,7 +101,7 @@ class TextIndexScanForEntity : public Operation {
     return std::get<FixedEntity>(varOrFixed_.entity_).second;
   }
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -13,7 +13,8 @@ TextIndexScanForWord::TextIndexScanForWord(QueryExecutionContext* qec,
       isPrefix_(word_.ends_with('*')) {}
 
 // _____________________________________________________________________________
-Result TextIndexScanForWord::computeResult([[maybe_unused]] bool requestLazyness) {
+Result TextIndexScanForWord::computeResult(
+    [[maybe_unused]] bool requestLaziness) {
   IdTable idTable = getExecutionContext()->getIndex().getWordPostingsForTerm(
       word_, getExecutionContext()->getAllocator());
 

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -13,7 +13,7 @@ TextIndexScanForWord::TextIndexScanForWord(QueryExecutionContext* qec,
       isPrefix_(word_.ends_with('*')) {}
 
 // _____________________________________________________________________________
-ResultTable TextIndexScanForWord::computeResult() {
+Result TextIndexScanForWord::computeResult() {
   IdTable idTable = getExecutionContext()->getIndex().getWordPostingsForTerm(
       word_, getExecutionContext()->getAllocator());
 

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -13,7 +13,7 @@ TextIndexScanForWord::TextIndexScanForWord(QueryExecutionContext* qec,
       isPrefix_(word_.ends_with('*')) {}
 
 // _____________________________________________________________________________
-Result TextIndexScanForWord::computeResult() {
+Result TextIndexScanForWord::computeResult([[maybe_unused]] bool requestLazyness) {
   IdTable idTable = getExecutionContext()->getIndex().getWordPostingsForTerm(
       word_, getExecutionContext()->getAllocator());
 

--- a/src/engine/TextIndexScanForWord.h
+++ b/src/engine/TextIndexScanForWord.h
@@ -48,9 +48,9 @@ class TextIndexScanForWord : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
  private:
-  // Returns a ResultTable containing an IdTable with the columns being
+  // Returns a Result containing an IdTable with the columns being
   // the text variable and the completed word (if it was prefixed)
-  ResultTable computeResult() override;
+  Result computeResult() override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForWord.h
+++ b/src/engine/TextIndexScanForWord.h
@@ -50,7 +50,7 @@ class TextIndexScanForWord : public Operation {
  private:
   // Returns a Result containing an IdTable with the columns being
   // the text variable and the completed word (if it was prefixed)
-  Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForWord.h
+++ b/src/engine/TextIndexScanForWord.h
@@ -50,7 +50,7 @@ class TextIndexScanForWord : public Operation {
  private:
   // Returns a Result containing an IdTable with the columns being
   // the text variable and the completed word (if it was prefixed)
-  Result computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextLimit.cpp
+++ b/src/engine/TextLimit.cpp
@@ -18,11 +18,12 @@ TextLimit::TextLimit(QueryExecutionContext* qec, const size_t limit,
       scoreColumns_(scoreColumns) {}
 
 // _____________________________________________________________________________
-ResultTable TextLimit::computeResult() {
-  shared_ptr<const ResultTable> childRes = child_->getResult();
+Result TextLimit::computeResult([[maybe_unused]] bool requestLaziness) {
+  std::shared_ptr<const Result> childRes = child_->getResult();
 
   if (limit_ == 0) {
-    return {IdTable(childRes->width(), getExecutionContext()->getAllocator()),
+    return {IdTable(childRes->idTable().numColumns(),
+                    getExecutionContext()->getAllocator()),
             resultSortedOn(), childRes->getSharedLocalVocab()};
   }
 

--- a/src/engine/TextLimit.h
+++ b/src/engine/TextLimit.h
@@ -61,7 +61,7 @@ class TextLimit : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
  private:
-  ResultTable computeResult() override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {child_.get()}; }
 };

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -140,9 +140,9 @@ class TransitivePathImpl : public TransitivePathBase {
    * on the time it takes to compute the hull. The set of nodes on the
    * start side should be as small as possible.
    *
-   * @return ResultTable The result of the TransitivePath operation
+   * @return Result The result of the TransitivePath operation
    */
-  ResultTable computeResult() override {
+  Result computeResult() override {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(
@@ -150,7 +150,7 @@ class TransitivePathImpl : public TransitivePathBase {
           "not supported");
     }
     auto [startSide, targetSide] = decideDirection();
-    shared_ptr<const ResultTable> subRes = subtree_->getResult();
+    shared_ptr<const Result> subRes = subtree_->getResult();
 
     IdTable idTable{allocator()};
 
@@ -159,7 +159,7 @@ class TransitivePathImpl : public TransitivePathBase {
     size_t subWidth = subRes->idTable().numColumns();
 
     if (startSide.isBoundVariable()) {
-      shared_ptr<const ResultTable> sideRes =
+      shared_ptr<const Result> sideRes =
           startSide.treeAndCol_.value().first->getResult();
       size_t sideWidth = sideRes->idTable().numColumns();
 
@@ -169,7 +169,7 @@ class TransitivePathImpl : public TransitivePathBase {
                       sideRes->idTable());
 
       return {std::move(idTable), resultSortedOn(),
-              ResultTable::getMergedLocalVocab(*sideRes, *subRes)};
+              Result::getMergedLocalVocab(*sideRes, *subRes)};
     }
     CALL_FIXED_SIZE((std::array{resultWidth_, subWidth}),
                     &TransitivePathImpl<T>::computeTransitivePath, this,

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -150,7 +150,7 @@ class TransitivePathImpl : public TransitivePathBase {
           "not supported");
     }
     auto [startSide, targetSide] = decideDirection();
-    shared_ptr<const Result> subRes = subtree_->getResult();
+    std::shared_ptr<const Result> subRes = subtree_->getResult();
 
     IdTable idTable{allocator()};
 
@@ -159,7 +159,7 @@ class TransitivePathImpl : public TransitivePathBase {
     size_t subWidth = subRes->idTable().numColumns();
 
     if (startSide.isBoundVariable()) {
-      shared_ptr<const Result> sideRes =
+      std::shared_ptr<const Result> sideRes =
           startSide.treeAndCol_.value().first->getResult();
       size_t sideWidth = sideRes->idTable().numColumns();
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -142,7 +142,7 @@ class TransitivePathImpl : public TransitivePathBase {
    *
    * @return Result The result of the TransitivePath operation
    */
-  Result computeResult() override {
+  Result computeResult([[maybe_unused]] bool requestLazyness) override {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -142,7 +142,7 @@ class TransitivePathImpl : public TransitivePathBase {
    *
    * @return Result The result of the TransitivePath operation
    */
-  Result computeResult([[maybe_unused]] bool requestLazyness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -158,7 +158,7 @@ size_t Union::getCostEstimate() {
          getSizeEstimateBeforeLimit();
 }
 
-Result Union::computeResult() {
+Result Union::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "Union result computation..." << std::endl;
   shared_ptr<const Result> subRes1 = _subtrees[0]->getResult();
   shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -158,7 +158,7 @@ size_t Union::getCostEstimate() {
          getSizeEstimateBeforeLimit();
 }
 
-Result Union::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Union::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Union result computation..." << std::endl;
   std::shared_ptr<const Result> subRes1 = _subtrees[0]->getResult();
   std::shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();
@@ -174,7 +174,7 @@ Result Union::computeResult([[maybe_unused]] bool requestLazyness) {
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
   return Result{std::move(idTable), resultSortedOn(),
-                     Result::getMergedLocalVocab(*subRes1, *subRes2)};
+                Result::getMergedLocalVocab(*subRes1, *subRes2)};
 }
 
 void Union::computeUnion(

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -158,10 +158,10 @@ size_t Union::getCostEstimate() {
          getSizeEstimateBeforeLimit();
 }
 
-ResultTable Union::computeResult() {
+Result Union::computeResult() {
   LOG(DEBUG) << "Union result computation..." << std::endl;
-  shared_ptr<const ResultTable> subRes1 = _subtrees[0]->getResult();
-  shared_ptr<const ResultTable> subRes2 = _subtrees[1]->getResult();
+  shared_ptr<const Result> subRes1 = _subtrees[0]->getResult();
+  shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();
   LOG(DEBUG) << "Union subresult computation done." << std::endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};
@@ -173,8 +173,8 @@ ResultTable Union::computeResult() {
   LOG(DEBUG) << "Union result computation done" << std::endl;
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
-  return ResultTable{std::move(idTable), resultSortedOn(),
-                     ResultTable::getMergedLocalVocab(*subRes1, *subRes2)};
+  return Result{std::move(idTable), resultSortedOn(),
+                     Result::getMergedLocalVocab(*subRes1, *subRes2)};
 }
 
 void Union::computeUnion(

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -75,7 +75,7 @@ VariableToColumnMap Union::computeVariableToColumnMap() const {
   // subtrees and if it is guaranteed to be bound in all the subtrees.
   auto mightContainUndef = [this](const Variable& var) {
     return std::ranges::any_of(
-        _subtrees, [&](const shared_ptr<QueryExecutionTree>& subtree) {
+        _subtrees, [&](const std::shared_ptr<QueryExecutionTree>& subtree) {
           const auto& varCols = subtree->getVariableColumns();
           return !varCols.contains(var) ||
                  (varCols.at(var).mightContainUndef_ ==
@@ -160,8 +160,8 @@ size_t Union::getCostEstimate() {
 
 Result Union::computeResult([[maybe_unused]] bool requestLazyness) {
   LOG(DEBUG) << "Union result computation..." << std::endl;
-  shared_ptr<const Result> subRes1 = _subtrees[0]->getResult();
-  shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();
+  std::shared_ptr<const Result> subRes1 = _subtrees[0]->getResult();
+  std::shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();
   LOG(DEBUG) << "Union subresult computation done." << std::endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -61,7 +61,7 @@ class Union : public Operation {
   }
 
  private:
-  virtual Result computeResult() override;
+  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -61,7 +61,7 @@ class Union : public Operation {
   }
 
  private:
-  virtual ResultTable computeResult() override;
+  virtual Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -61,7 +61,7 @@ class Union : public Operation {
   }
 
  private:
-  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -108,7 +108,7 @@ void Values::computeMultiplicities() {
 }
 
 // ____________________________________________________________________________
-Result Values::computeResult([[maybe_unused]] bool requestLazyness) {
+Result Values::computeResult([[maybe_unused]] bool requestLaziness) {
   // Set basic properties of the result table.
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -108,7 +108,7 @@ void Values::computeMultiplicities() {
 }
 
 // ____________________________________________________________________________
-ResultTable Values::computeResult() {
+Result Values::computeResult() {
   // Set basic properties of the result table.
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -108,7 +108,7 @@ void Values::computeMultiplicities() {
 }
 
 // ____________________________________________________________________________
-Result Values::computeResult() {
+Result Values::computeResult([[maybe_unused]] bool requestLazyness) {
   // Set basic properties of the result table.
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -48,7 +48,7 @@ class Values : public Operation {
 
  public:
   // These two are also used by class `Service`, hence public.
-  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
+  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -48,7 +48,7 @@ class Values : public Operation {
 
  public:
   // These two are also used by class `Service`, hence public.
-  virtual Result computeResult() override;
+  virtual Result computeResult([[maybe_unused]] bool requestLazyness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -48,7 +48,7 @@ class Values : public Operation {
 
  public:
   // These two are also used by class `Service`, hence public.
-  virtual ResultTable computeResult() override;
+  virtual Result computeResult() override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -9,7 +9,7 @@
 #include <re2/re2.h>
 
 #include "engine/ExportQueryExecutionTrees.h"
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/sparqlExpressions/SparqlExpressionTypes.h"
 #include "global/Id.h"
 #include "util/ConstexprSmallString.h"

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -12,7 +12,7 @@
 #include <stxxl/vector>
 #include <vector>
 
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
 #include "global/Pattern.h"
 #include "global/SpecialIds.h"

--- a/src/parser/data/ConstructQueryExportContext.h
+++ b/src/parser/data/ConstructQueryExportContext.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/VariableToColumnMap.h"
 #include "parser/data/Variable.h"
 #include "util/HashMap.h"
@@ -18,7 +18,7 @@ enum struct PositionInTriple : int { SUBJECT, PREDICATE, OBJECT };
 // All the data that is needed to evaluate an element in a construct query.
 struct ConstructQueryExportContext {
   const size_t _row;
-  const ResultTable& _res;
+  const Result& _res;
   const VariableToColumnMap& _variableColumns;
   const Index& _qecIndex;
 };

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -29,7 +29,7 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
   // Call stack. Most notably the check which columns belongs to this variable
   // should be much further up in the call stack.
   size_t row = context._row;
-  const ResultTable& res = context._res;
+  const Result& res = context._res;
   const auto& variableColumns = context._variableColumns;
   const Index& qecIndex = context._qecIndex;
   const auto& idTable = res.idTable();

--- a/test/BenchmarkMeasurementContainerTest.cpp
+++ b/test/BenchmarkMeasurementContainerTest.cpp
@@ -88,7 +88,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultGroup) {
 }
 
 /*
-Check the content of a `ResultTable` row.
+Check the content of a `Result` row.
 */
 static void checkResultTableRow(const ResultTable& table,
                                 const size_t& rowNumber,
@@ -157,7 +157,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTable) {
   Special case: A table with no columns. Should throw an exception
   on creation, because you can't add columns after creation and a table without
   columns is quite the stupid idea. Additionally, operations on such an empty
-  table can create segmentation faults. The string conversion of `ResultTable`
+  table can create segmentation faults. The string conversion of `Result`
   uses `std::ranges::max`, which really doesn't play well with empty vectors.
   */
   ASSERT_ANY_THROW(ResultTable("1 by 0 table", {"Test"}, {}));
@@ -308,7 +308,7 @@ TEST(BenchmarkMeasurementContainerTest, ResultTableEraseRow) {
 
 TEST(BenchmarkMeasurementContainerTest, ResultGroupDeleteMember) {
   /*
-  Add the given number of dummy `ResultEntry`s and dummy `ResultTable`s to the
+  Add the given number of dummy `ResultEntry`s and dummy `Result`s to the
   given group.
   */
   auto addDummyMembers = [](ResultGroup* group, const size_t numOfEntries) {

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -193,7 +193,7 @@ TEST_F(GroupByTest, doGroupBy) {
       {ParsedQuery::AggregateType::AVG, 3, 22, nullptr},
       {ParsedQuery::AggregateType::AVG, 4, 23, nullptr}};
 
-  ResultTable outTable{allocator()};
+  Result outTable{allocator()};
 
   // This is normally done when calling computeResult in the GroupBy
   // operation.

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -21,7 +21,7 @@
 #include "engine/OptionalJoin.h"
 #include "engine/OrderBy.h"
 #include "engine/QueryExecutionTree.h"
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/Sort.h"
 #include "engine/TransitivePathBase.h"
 #include "engine/Union.h"
@@ -189,7 +189,7 @@ TEST(LocalVocab, propagation) {
     };
     std::ranges::transform(expectedWordsAsStrings,
                            std::back_inserter(expectedWords), toLitOrIri);
-    std::shared_ptr<const ResultTable> resultTable = operation.getResult();
+    std::shared_ptr<const Result> resultTable = operation.getResult();
     ASSERT_TRUE(resultTable)
         << "Operation: " << operation.getDescriptor() << std::endl;
     TestWords localVocabWords =

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -152,7 +152,7 @@ TEST(OperationTest, verifyExceptionIsThrownOnCancellation) {
     std::this_thread::sleep_for(5ms);
     handle->cancel(CancellationState::TIMEOUT);
   }};
-  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(operation.computeResult(),
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(operation.computeResult(false),
                                         ::testing::HasSubstr("timed out"),
                                         ad_utility::CancellationException);
 }

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -39,7 +39,7 @@ TEST(OperationTest, getResultOnlyCached) {
   NeutralElementOperation n{qec};
   // The second `true` means "only read the result if it was cached".
   // We have just cleared the cache, and so this should return `nullptr`.
-  EXPECT_EQ(n.getResult(true, ComputationMode::CACHE_ONLY), nullptr);
+  EXPECT_EQ(n.getResult(true, ComputationMode::ONLY_IF_CACHED), nullptr);
   EXPECT_EQ(n.runtimeInfo().status_, RuntimeInformation::Status::notStarted);
   // Nothing has been stored in the cache by this call.
   EXPECT_EQ(qec->getQueryTreeCache().numNonPinnedEntries(), 0);
@@ -58,7 +58,7 @@ TEST(OperationTest, getResultOnlyCached) {
   // When we now request to only return the result if it is cached, we should
   // get exactly the same `shared_ptr` as with the previous call.
   NeutralElementOperation n3{qec};
-  EXPECT_EQ(n3.getResult(true, ComputationMode::CACHE_ONLY), result);
+  EXPECT_EQ(n3.getResult(true, ComputationMode::ONLY_IF_CACHED), result);
   EXPECT_EQ(n3.runtimeInfo().cacheStatus_,
             ad_utility::CacheStatus::cachedNotPinned);
 
@@ -67,7 +67,7 @@ TEST(OperationTest, getResultOnlyCached) {
   QueryExecutionContext qecCopy{*qec};
   qecCopy._pinResult = true;
   NeutralElementOperation n4{&qecCopy};
-  EXPECT_EQ(n4.getResult(true, ComputationMode::CACHE_ONLY), result);
+  EXPECT_EQ(n4.getResult(true, ComputationMode::ONLY_IF_CACHED), result);
 
   // The cache status is `cachedNotPinned` because we found the element cached
   // but not pinned (it does reflect the status BEFORE the operation).
@@ -79,7 +79,7 @@ TEST(OperationTest, getResultOnlyCached) {
   // We have pinned the result, so requesting it again should return a pinned
   // result.
   qecCopy._pinResult = false;
-  EXPECT_EQ(n4.getResult(true, ComputationMode::CACHE_ONLY), result);
+  EXPECT_EQ(n4.getResult(true, ComputationMode::ONLY_IF_CACHED), result);
   EXPECT_EQ(n4.runtimeInfo().cacheStatus_,
             ad_utility::CacheStatus::cachedPinned);
 

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -39,7 +39,7 @@ TEST(OperationTest, getResultOnlyCached) {
   NeutralElementOperation n{qec};
   // The second `true` means "only read the result if it was cached".
   // We have just cleared the cache, and so this should return `nullptr`.
-  EXPECT_EQ(n.getResult(true, true), nullptr);
+  EXPECT_EQ(n.getResult(true, ComputationMode::CACHE_ONLY), nullptr);
   EXPECT_EQ(n.runtimeInfo().status_, RuntimeInformation::Status::notStarted);
   // Nothing has been stored in the cache by this call.
   EXPECT_EQ(qec->getQueryTreeCache().numNonPinnedEntries(), 0);
@@ -58,7 +58,7 @@ TEST(OperationTest, getResultOnlyCached) {
   // When we now request to only return the result if it is cached, we should
   // get exactly the same `shared_ptr` as with the previous call.
   NeutralElementOperation n3{qec};
-  EXPECT_EQ(n3.getResult(true, true), result);
+  EXPECT_EQ(n3.getResult(true, ComputationMode::CACHE_ONLY), result);
   EXPECT_EQ(n3.runtimeInfo().cacheStatus_,
             ad_utility::CacheStatus::cachedNotPinned);
 
@@ -67,7 +67,7 @@ TEST(OperationTest, getResultOnlyCached) {
   QueryExecutionContext qecCopy{*qec};
   qecCopy._pinResult = true;
   NeutralElementOperation n4{&qecCopy};
-  EXPECT_EQ(n4.getResult(true, true), result);
+  EXPECT_EQ(n4.getResult(true, ComputationMode::CACHE_ONLY), result);
 
   // The cache status is `cachedNotPinned` because we found the element cached
   // but not pinned (it does reflect the status BEFORE the operation).
@@ -79,7 +79,7 @@ TEST(OperationTest, getResultOnlyCached) {
   // We have pinned the result, so requesting it again should return a pinned
   // result.
   qecCopy._pinResult = false;
-  EXPECT_EQ(n4.getResult(true, true), result);
+  EXPECT_EQ(n4.getResult(true, ComputationMode::CACHE_ONLY), result);
   EXPECT_EQ(n4.runtimeInfo().cacheStatus_,
             ad_utility::CacheStatus::cachedPinned);
 

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -4,10 +4,14 @@
 
 #pragma once
 
+#include <gmock/gmock-matchers.h>
+#include <gmock/gmock.h>
+
 #include "./util/GTestHelpers.h"
 #include "engine/Bind.h"
 #include "engine/CartesianProductJoin.h"
 #include "engine/CountAvailablePredicates.h"
+#include "engine/Filter.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
 #include "engine/MultiColumnJoin.h"
@@ -21,8 +25,6 @@
 #include "engine/TextLimit.h"
 #include "engine/TransitivePathBase.h"
 #include "engine/Union.h"
-#include "gmock/gmock-matchers.h"
-#include "gmock/gmock.h"
 #include "parser/SparqlParser.h"
 #include "util/IndexTestHelpers.h"
 

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -163,7 +163,7 @@ TEST_F(ServiceTest, computeResult) {
       getTsvFunctionFactory(
           expectedUrl, expectedSparqlQuery,
           "?x\t?y\n<x>\t<y>\n<bla>\t<bli>\n<blu>\t<bla>\n<bli>\t<blu>\n")};
-  std::shared_ptr<const ResultTable> result = serviceOperation4.getResult();
+  std::shared_ptr<const Result> result = serviceOperation4.getResult();
 
   // Check that `<x>` and `<y>` were contained in the original vocabulary and
   // that `<bla>`, `<bli>`, `<blu>` were added to the (initially empty) local

--- a/test/SparqlDataTypesTest.cpp
+++ b/test/SparqlDataTypesTest.cpp
@@ -16,7 +16,7 @@ using enum PositionInTriple;
 namespace {
 struct ContextWrapper {
   Index _index{ad_utility::makeUnlimitedAllocator<Id>()};
-  ResultTable _resultTable{
+  Result _resultTable{
       IdTable{ad_utility::testing::makeAllocator()}, {}, LocalVocab{}};
   // TODO<joka921> `VariableToColumnMap`
   VariableToColumnMap _hashMap{};
@@ -27,7 +27,7 @@ struct ContextWrapper {
 
   void setIdTable(IdTable&& table) {
     _resultTable =
-        ResultTable{std::move(table), {}, _resultTable.getSharedLocalVocab()};
+        Result{std::move(table), {}, _resultTable.getSharedLocalVocab()};
   }
 };
 

--- a/test/ValuesTest.cpp
+++ b/test/ValuesTest.cpp
@@ -9,7 +9,7 @@
 #include "./util/IdTableHelpers.h"
 #include "./util/IdTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "engine/Values.h"
 #include "engine/idTable/IdTable.h"
 #include "util/IndexTestHelpers.h"

--- a/test/engine/TextIndexScanForEntityTest.cpp
+++ b/test/engine/TextIndexScanForEntityTest.cpp
@@ -32,8 +32,8 @@ TEST(TextIndexScanForEntity, EntityScanBasic) {
   ASSERT_EQ(s1.getResultWidth(), 3);
 
   auto result = s1.computeResultOnlyForTesting();
-  ASSERT_EQ(result.width(), 3);
-  ASSERT_EQ(result.size(), 3);
+  ASSERT_EQ(result.idTable().numColumns(), 3);
+  ASSERT_EQ(result.idTable().size(), 3);
 
   // NOTE: because of the way the graph above is constructed, the entities are
   // texts
@@ -61,8 +61,8 @@ TEST(TextIndexScanForEntity, FixedEntityScan) {
 
   auto result = s3.computeResultOnlyForTesting();
   ASSERT_EQ(s3.getResultWidth(), 2);
-  ASSERT_EQ(result.width(), 2);
-  ASSERT_EQ(result.size(), 1);
+  ASSERT_EQ(result.idTable().numColumns(), 2);
+  ASSERT_EQ(result.idTable().size(), 1);
 
   using enum ColumnIndexAndTypeInfo::UndefStatus;
   VariableToColumnMap expectedVariables = {
@@ -78,8 +78,8 @@ TEST(TextIndexScanForEntity, FixedEntityScan) {
   fixedEntity = "\"he failed the test\"";
   TextIndexScanForEntity s4{qec, Variable{"?text4"}, fixedEntity, "test*"};
   result = s4.computeResultOnlyForTesting();
-  ASSERT_EQ(result.width(), 2);
-  ASSERT_EQ(result.size(), 1);
+  ASSERT_EQ(result.idTable().numColumns(), 2);
+  ASSERT_EQ(result.idTable().size(), 1);
 
   ASSERT_EQ(fixedEntity, h::getTextRecordFromResultTable(qec, result, 0));
 }

--- a/test/engine/TextIndexScanForWordTest.cpp
+++ b/test/engine/TextIndexScanForWordTest.cpp
@@ -32,8 +32,8 @@ TEST(TextIndexScanForWord, WordScanPrefix) {
   ASSERT_EQ(s1.getResultWidth(), 2);
 
   auto result = s1.computeResultOnlyForTesting();
-  ASSERT_EQ(result.width(), 2);
-  ASSERT_EQ(result.size(), 3);
+  ASSERT_EQ(result.idTable().numColumns(), 2);
+  ASSERT_EQ(result.idTable().size(), 3);
   s2.getExternallyVisibleVariableColumns();
 
   using enum ColumnIndexAndTypeInfo::UndefStatus;
@@ -63,8 +63,8 @@ TEST(TextIndexScanForWord, WordScanBasic) {
   ASSERT_EQ(s1.getResultWidth(), 1);
 
   auto result = s1.computeResultOnlyForTesting();
-  ASSERT_EQ(result.width(), 1);
-  ASSERT_EQ(result.size(), 2);
+  ASSERT_EQ(result.idTable().numColumns(), 1);
+  ASSERT_EQ(result.idTable().size(), 2);
 
   ASSERT_EQ("\"he failed the test\"",
             h::getTextRecordFromResultTable(qec, result, 0));
@@ -76,8 +76,8 @@ TEST(TextIndexScanForWord, WordScanBasic) {
   ASSERT_EQ(s2.getResultWidth(), 1);
 
   result = s2.computeResultOnlyForTesting();
-  ASSERT_EQ(result.width(), 1);
-  ASSERT_EQ(result.size(), 1);
+  ASSERT_EQ(result.idTable().numColumns(), 1);
+  ASSERT_EQ(result.idTable().size(), 1);
 
   ASSERT_EQ("\"testing can help\"",
             h::getTextRecordFromResultTable(qec, result, 0));

--- a/test/engine/TextIndexScanTestHelpers.h
+++ b/test/engine/TextIndexScanTestHelpers.h
@@ -9,7 +9,7 @@ namespace textIndexScanTestHelpers {
 // obtain the textRecord using idToOptionalString.
 // TODO: Implement a more elegant/stable version
 inline string getTextRecordFromResultTable(const QueryExecutionContext* qec,
-                                           const ResultTable& result,
+                                           const Result& result,
                                            const size_t& rowIndex) {
   return qec->getIndex()
       .idToOptionalString(
@@ -18,7 +18,7 @@ inline string getTextRecordFromResultTable(const QueryExecutionContext* qec,
 }
 
 inline string getEntityFromResultTable(const QueryExecutionContext* qec,
-                                       const ResultTable& result,
+                                       const Result& result,
                                        const size_t& rowIndex) {
   return qec->getIndex()
       .idToOptionalString(
@@ -27,7 +27,7 @@ inline string getEntityFromResultTable(const QueryExecutionContext* qec,
 }
 
 inline string getWordFromResultTable(const QueryExecutionContext* qec,
-                                     const ResultTable& result,
+                                     const Result& result,
                                      const size_t& rowIndex) {
   return qec->getIndex()
       .idToOptionalString(

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -49,7 +49,7 @@ class ValuesForTesting : public Operation {
   size_t& costEstimate() { return costEstimate_; }
 
   // ___________________________________________________________________________
-  Result computeResult([[maybe_unused]] bool requestLazyness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     auto table = table_.clone();
     if (supportsLimit_) {
       table.erase(table.begin() + getLimit().upperBound(table.size()),

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -49,7 +49,7 @@ class ValuesForTesting : public Operation {
   size_t& costEstimate() { return costEstimate_; }
 
   // ___________________________________________________________________________
-  Result computeResult() override {
+  Result computeResult([[maybe_unused]] bool requestLazyness) override {
     auto table = table_.clone();
     if (supportsLimit_) {
       table.erase(table.begin() + getLimit().upperBound(table.size()),

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -6,7 +6,7 @@
 
 #include "engine/Operation.h"
 #include "engine/QueryExecutionContext.h"
-#include "engine/ResultTable.h"
+#include "engine/Result.h"
 #include "util/Algorithm.h"
 #include "util/Random.h"
 
@@ -49,7 +49,7 @@ class ValuesForTesting : public Operation {
   size_t& costEstimate() { return costEstimate_; }
 
   // ___________________________________________________________________________
-  ResultTable computeResult() override {
+  Result computeResult() override {
     auto table = table_.clone();
     if (supportsLimit_) {
       table.erase(table.begin() + getLimit().upperBound(table.size()),

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -31,7 +31,7 @@ class StallForeverOperation : public Operation {
   using Operation::Operation;
   // Do-nothing operation that runs for 100ms without computing anything, but
   // which can be cancelled.
-  Result computeResult([[maybe_unused]] bool requestLazyness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     auto end = std::chrono::steady_clock::now() + 100ms;
     while (std::chrono::steady_clock::now() < end) {
       checkCancellation();
@@ -73,7 +73,7 @@ class ShallowParentOperation : public Operation {
     return {child_.get()};
   }
 
-  Result computeResult([[maybe_unused]] bool requestLazyness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     auto childResult = child_->getResult();
     return {childResult->idTable().clone(), resultSortedOn(),
             childResult->getSharedLocalVocab()};

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -31,7 +31,7 @@ class StallForeverOperation : public Operation {
   using Operation::Operation;
   // Do-nothing operation that runs for 100ms without computing anything, but
   // which can be cancelled.
-  ResultTable computeResult() override {
+  Result computeResult() override {
     auto end = std::chrono::steady_clock::now() + 100ms;
     while (std::chrono::steady_clock::now() < end) {
       checkCancellation();
@@ -73,7 +73,7 @@ class ShallowParentOperation : public Operation {
     return {child_.get()};
   }
 
-  ResultTable computeResult() override {
+  Result computeResult() override {
     auto childResult = child_->getResult();
     return {childResult->idTable().clone(), resultSortedOn(),
             childResult->getSharedLocalVocab()};

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -31,7 +31,7 @@ class StallForeverOperation : public Operation {
   using Operation::Operation;
   // Do-nothing operation that runs for 100ms without computing anything, but
   // which can be cancelled.
-  Result computeResult() override {
+  Result computeResult([[maybe_unused]] bool requestLazyness) override {
     auto end = std::chrono::steady_clock::now() + 100ms;
     while (std::chrono::steady_clock::now() < end) {
       checkCancellation();
@@ -73,7 +73,7 @@ class ShallowParentOperation : public Operation {
     return {child_.get()};
   }
 
-  Result computeResult() override {
+  Result computeResult([[maybe_unused]] bool requestLazyness) override {
     auto childResult = child_->getResult();
     return {childResult->idTable().clone(), resultSortedOn(),
             childResult->getSharedLocalVocab()};


### PR DESCRIPTION
This PR contains all the changes from the infrastructure for lazy operation evaluation (#1350)  that are simple and repetitive, but touch many files. In particular:

* Rename the `ResultTable` class to `Result` (a TODO suggested by @hannahbast some time ago).
* Add a new parameter `bool requestLaziness` to `Operation::computeResult`. This parameter is currently unused.