### PR TITLE
Parse update queries

### DIFF
--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -18,6 +18,7 @@
 #include "parser/PropertyPath.h"
 #include "parser/SelectClause.h"
 #include "parser/TripleComponent.h"
+#include "parser/UpdateClause.h"
 #include "parser/data/GroupKey.h"
 #include "parser/data/LimitOffsetClause.h"
 #include "parser/data/OrderKey.h"
@@ -49,74 +50,7 @@ class SparqlPrefix {
   bool operator==(const SparqlPrefix&) const = default;
 };
 
-inline bool isVariable(const string& elem) { return elem.starts_with("?"); }
-inline bool isVariable(const TripleComponent& elem) {
-  return elem.isVariable();
-}
-
-inline bool isVariable(const PropertyPath& elem) {
-  return elem._operation == PropertyPath::Operation::IRI &&
-         isVariable(elem._iri);
-}
-
 std::ostream& operator<<(std::ostream& out, const PropertyPath& p);
-
-// Data container for parsed triples from the where clause.
-// It is templated on the predicate type, see the instantiations below.
-template <typename Predicate>
-class SparqlTripleBase {
- public:
-  using AdditionalScanColumns = std::vector<std::pair<ColumnIndex, Variable>>;
-  SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o,
-                   AdditionalScanColumns additionalScanColumns = {})
-      : s_(std::move(s)),
-        p_(std::move(p)),
-        o_(std::move(o)),
-        additionalScanColumns_(std::move(additionalScanColumns)) {}
-
-  bool operator==(const SparqlTripleBase& other) const = default;
-  TripleComponent s_;
-  Predicate p_;
-  TripleComponent o_;
-  // The additional columns (e.g. patterns) that are to be attached when
-  // performing an index scan using this triple.
-  // TODO<joka921> On this level we should not store `ColumnIndex`, but the
-  // special predicate IRIs that are to be attached here.
-  std::vector<std::pair<ColumnIndex, Variable>> additionalScanColumns_;
-};
-
-// A triple where the predicate is a `TripleComponent`, so a fixed entity or a
-// variable, but not a property path.
-class SparqlTripleSimple : public SparqlTripleBase<TripleComponent> {
-  using Base = SparqlTripleBase<TripleComponent>;
-  using Base::Base;
-};
-
-// A triple where the predicate is a `PropertyPath` (which technically still
-// might be a variable or fixed entity in the current implementation).
-class SparqlTriple : public SparqlTripleBase<PropertyPath> {
- public:
-  using Base = SparqlTripleBase<PropertyPath>;
-  using Base::Base;
-
-  // ___________________________________________________________________________
-  SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
-      : Base{std::move(s), PropertyPath::fromIri(p_iri), std::move(o)} {}
-
-  // ___________________________________________________________________________
-  [[nodiscard]] string asString() const;
-
-  // Convert to a simple triple. Fails with an exception if the predicate
-  // actually is a property path.
-  SparqlTripleSimple getSimple() const {
-    AD_CONTRACT_CHECK(p_.isIri());
-    TripleComponent p =
-        isVariable(p_._iri)
-            ? TripleComponent{Variable{p_._iri}}
-            : TripleComponent(TripleComponent::Iri::fromIriref(p_._iri));
-    return {s_, p, o_, additionalScanColumns_};
-  }
-};
 
 // Forward declaration
 namespace parsedQuery {
@@ -131,6 +65,8 @@ class ParsedQuery {
   using SelectClause = parsedQuery::SelectClause;
 
   using ConstructClause = parsedQuery::ConstructClause;
+
+  using UpdateClause = parsedQuery::UpdateClause;
 
   ParsedQuery() = default;
 
@@ -147,7 +83,8 @@ class ParsedQuery {
 
   // explicit default initialisation because the constructor
   // of SelectClause is private
-  std::variant<SelectClause, ConstructClause> _clause{SelectClause{}};
+  std::variant<SelectClause, ConstructClause, UpdateClause> _clause{
+      SelectClause{}};
 
   [[nodiscard]] bool hasSelectClause() const {
     return std::holds_alternative<SelectClause>(_clause);
@@ -155,6 +92,10 @@ class ParsedQuery {
 
   [[nodiscard]] bool hasConstructClause() const {
     return std::holds_alternative<ConstructClause>(_clause);
+  }
+
+  [[nodiscard]] bool hasUpdateClause() const {
+    return std::holds_alternative<UpdateClause>(_clause);
   }
 
   [[nodiscard]] decltype(auto) selectClause() const {
@@ -165,12 +106,20 @@ class ParsedQuery {
     return std::get<ConstructClause>(_clause);
   }
 
+  [[nodiscard]] decltype(auto) updateClause() const {
+    return std::get<UpdateClause>(_clause);
+  }
+
   [[nodiscard]] decltype(auto) selectClause() {
     return std::get<SelectClause>(_clause);
   }
 
   [[nodiscard]] decltype(auto) constructClause() {
     return std::get<ConstructClause>(_clause);
+  }
+
+  [[nodiscard]] decltype(auto) updateClause() {
+    return std::get<UpdateClause>(_clause);
   }
 
   // Add a variable, that was found in the query body.

--- a/src/parser/SparqlTriple.h
+++ b/src/parser/SparqlTriple.h
@@ -61,8 +61,8 @@ class SparqlTriple : public SparqlTripleBase<PropertyPath> {
   using Base::Base;
 
   // ___________________________________________________________________________
-  SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
-      : Base{std::move(s), PropertyPath::fromIri(p_iri), std::move(o)} {}
+  SparqlTriple(TripleComponent s, const std::string& iri, TripleComponent o)
+      : Base{std::move(s), PropertyPath::fromIri(iri), std::move(o)} {}
 
   // ___________________________________________________________________________
   [[nodiscard]] string asString() const;

--- a/src/parser/SparqlTriple.h
+++ b/src/parser/SparqlTriple.h
@@ -77,4 +77,15 @@ class SparqlTriple : public SparqlTripleBase<PropertyPath> {
             : TripleComponent(TripleComponent::Iri::fromIriref(p_._iri));
     return {s_, p, o_, additionalScanColumns_};
   }
+
+  // Constructs SparqlTriple from a simple triple. Fails with an exception if
+  // the predicate is neither a variable nor an iri.
+  static SparqlTriple fromSimple(const SparqlTripleSimple& triple) {
+    AD_CONTRACT_CHECK(triple.p_.isVariable() || triple.p_.isIri());
+    PropertyPath p = triple.p_.isVariable()
+                         ? PropertyPath::fromVariable(triple.p_.getVariable())
+                         : PropertyPath::fromIri(
+                               triple.p_.getIri().toStringRepresentation());
+    return {triple.s_, p, triple.o_};
+  }
 };

--- a/src/parser/SparqlTriple.h
+++ b/src/parser/SparqlTriple.h
@@ -1,6 +1,7 @@
 //  Copyright 2024, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
-//  Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+//  Authors: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+//           Johannes Kalmbach <johannes.kalmbach@gmail.com>
 
 #pragma once
 

--- a/src/parser/Triples.h
+++ b/src/parser/Triples.h
@@ -1,0 +1,79 @@
+//  Copyright 2024, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+
+#pragma once
+
+#include <vector>
+
+#include "PropertyPath.h"
+#include "TripleComponent.h"
+#include "global/Id.h"
+#include "parser/data/Variable.h"
+
+inline bool isVariable(const string& elem) { return elem.starts_with("?"); }
+inline bool isVariable(const TripleComponent& elem) {
+  return elem.isVariable();
+}
+
+inline bool isVariable(const PropertyPath& elem) {
+  return elem._operation == PropertyPath::Operation::IRI &&
+         isVariable(elem._iri);
+}
+
+// Data container for parsed triples from the where clause.
+// It is templated on the predicate type, see the instantiations below.
+template <typename Predicate>
+class SparqlTripleBase {
+ public:
+  using AdditionalScanColumns = std::vector<std::pair<ColumnIndex, Variable>>;
+  SparqlTripleBase(TripleComponent s, Predicate p, TripleComponent o,
+                   AdditionalScanColumns additionalScanColumns = {})
+      : s_(std::move(s)),
+        p_(std::move(p)),
+        o_(std::move(o)),
+        additionalScanColumns_(std::move(additionalScanColumns)) {}
+
+  bool operator==(const SparqlTripleBase& other) const = default;
+  TripleComponent s_;
+  Predicate p_;
+  TripleComponent o_;
+  // The additional columns (e.g. patterns) that are to be attached when
+  // performing an index scan using this triple.
+  // TODO<joka921> On this level we should not store `ColumnIndex`, but the
+  // special predicate IRIs that are to be attached here.
+  std::vector<std::pair<ColumnIndex, Variable>> additionalScanColumns_;
+};
+
+// A triple where the predicate is a `TripleComponent`, so a fixed entity or a
+// variable, but not a property path.
+class SparqlTripleSimple : public SparqlTripleBase<TripleComponent> {
+  using Base = SparqlTripleBase<TripleComponent>;
+  using Base::Base;
+};
+
+// A triple where the predicate is a `PropertyPath` (which technically still
+// might be a variable or fixed entity in the current implementation).
+class SparqlTriple : public SparqlTripleBase<PropertyPath> {
+ public:
+  using Base = SparqlTripleBase<PropertyPath>;
+  using Base::Base;
+
+  // ___________________________________________________________________________
+  SparqlTriple(TripleComponent s, const std::string& p_iri, TripleComponent o)
+      : Base{std::move(s), PropertyPath::fromIri(p_iri), std::move(o)} {}
+
+  // ___________________________________________________________________________
+  [[nodiscard]] string asString() const;
+
+  // Convert to a simple triple. Fails with an exception if the predicate
+  // actually is a property path.
+  SparqlTripleSimple getSimple() const {
+    AD_CONTRACT_CHECK(p_.isIri());
+    TripleComponent p =
+        isVariable(p_._iri)
+            ? TripleComponent{Variable{p_._iri}}
+            : TripleComponent(TripleComponent::Iri::fromIriref(p_._iri));
+    return {s_, p, o_, additionalScanColumns_};
+  }
+};

--- a/src/parser/UpdateClause.h
+++ b/src/parser/UpdateClause.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "parser/SelectClause.h"
-#include "parser/Triples.h"
+#include "parser/SparqlTriple.h"
 #include "parser/data/Types.h"
 
 namespace parsedQuery {
@@ -14,8 +14,8 @@ struct UpdateClause : ClauseBase {
   std::vector<SparqlTripleSimple> toDelete_;
 
   UpdateClause() = default;
-  explicit UpdateClause(std::vector<SparqlTripleSimple> toInsert,
-                        std::vector<SparqlTripleSimple> toDelete)
+  UpdateClause(std::vector<SparqlTripleSimple> toInsert,
+               std::vector<SparqlTripleSimple> toDelete)
       : toInsert_{std::move(toInsert)}, toDelete_{std::move(toDelete)} {}
 };
 }  // namespace parsedQuery

--- a/src/parser/UpdateClause.h
+++ b/src/parser/UpdateClause.h
@@ -1,0 +1,22 @@
+//  Copyright 2024, University of Freiburg,
+//  Chair of Algorithms and Data Structures.
+//  Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+
+#pragma once
+
+#include "parser/SelectClause.h"
+#include "parser/Triples.h"
+#include "parser/data/Types.h"
+
+namespace parsedQuery {
+struct UpdateClause : ClauseBase {
+  // Triples with no variables.
+  std::vector<SparqlTripleSimple> toInsert_;
+  std::vector<SparqlTripleSimple> toDelete_;
+
+  UpdateClause() = default;
+  explicit UpdateClause(std::vector<SparqlTripleSimple> toInsert,
+                        std::vector<SparqlTripleSimple> toDelete)
+      : toInsert_{std::move(toInsert)}, toDelete_{std::move(toDelete)} {}
+};
+}  // namespace parsedQuery

--- a/src/parser/UpdateClause.h
+++ b/src/parser/UpdateClause.h
@@ -10,7 +10,6 @@
 
 namespace parsedQuery {
 struct UpdateClause : ClauseBase {
-  // Triples with no variables.
   std::vector<SparqlTripleSimple> toInsert_;
   std::vector<SparqlTripleSimple> toDelete_;
 

--- a/src/parser/data/GraphRef.h
+++ b/src/parser/data/GraphRef.h
@@ -1,0 +1,17 @@
+// Copyright 2024, University of Freiburg,
+//                 Chair of Algorithms and Data Structures.
+// Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+
+#pragma once
+
+#include <variant>
+
+#include "parser/Iri.h"
+
+using GraphRef = TripleComponent::Iri;
+struct DEFAULT {};
+struct NAMED {};
+struct ALL {};
+
+using GraphRefAll = std::variant<GraphRef, DEFAULT, NAMED, ALL>;
+using GraphOrDefault = std::variant<GraphRef, DEFAULT>;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -437,13 +437,10 @@ std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> Visitor::visit(
         registerIfVariable(triple.p_);
         registerIfVariable(triple.o_);
 
-        if (triple.p_.isVariable() || triple.p_.isIri()) {
-          return SparqlTriple::fromSimple(triple);
-        } else {
-          // The predicate comes from a rule in the grammar (`verb`) which only
-          // allows variables and IRIs.
-          AD_FAIL();
-        }
+        // The predicate comes from a rule in the grammar (`verb`) which only
+        // allows variables and IRIs.
+        AD_CORRECTNESS_CHECK(triple.p_.isVariable() || triple.p_.isIri());
+        return SparqlTriple::fromSimple(triple);
       };
   GraphPattern pattern;
   pattern._graphPatterns.emplace_back(BasicGraphPattern{

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -329,10 +329,14 @@ std::optional<Values> Visitor::visit(Parser::ValuesClauseContext* ctx) {
 ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
   visit(ctx->prologue());
 
+  auto query = visit(ctx->update1());
+
   if (ctx->update()) {
+    parsedQuery_ = ParsedQuery{};
     reportNotSupported(ctx->update(), "Multiple updates in one query are");
   }
-  return visit(ctx->update1());
+
+  return query;
 }
 
 // ____________________________________________________________________________________
@@ -342,8 +346,6 @@ ParsedQuery Visitor::visit(Parser::Update1Context* ctx) {
   } else if (ctx->clear()) {
     return visit(ctx->clear());
   }
-
-  // TODO: updates can be chained; think about how to enable this
 
   parsedQuery_._clause = parsedQuery::UpdateClause();
 
@@ -365,7 +367,7 @@ ParsedQuery Visitor::visit(Parser::Update1Context* ctx) {
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(Parser::LoadContext* ctx) {
+void Visitor::visit(const Parser::LoadContext* ctx) const {
   reportNotSupported(ctx, "SPARQL 1.1 Update Load is");
 }
 
@@ -386,27 +388,27 @@ ParsedQuery Visitor::visit(Parser::ClearContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(Parser::DropContext* ctx) {
+void Visitor::visit(const Parser::DropContext* ctx) const {
   reportNotSupported(ctx, "SPARQL 1.1 Update Drop is");
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(Parser::CreateContext* ctx) {
+void Visitor::visit(const Parser::CreateContext* ctx) const {
   reportNotSupported(ctx, "SPARQL 1.1 Update Create is");
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(Parser::AddContext* ctx) {
+void Visitor::visit(const Parser::AddContext* ctx) const {
   reportNotSupported(ctx, "SPARQL 1.1 Update Add is");
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(Parser::MoveContext* ctx) {
+void Visitor::visit(const Parser::MoveContext* ctx) const {
   reportNotSupported(ctx, "SPARQL 1.1 Update Move is");
 }
 
 // ____________________________________________________________________________________
-void Visitor::visit(Parser::CopyContext* ctx) {
+void Visitor::visit(const Parser::CopyContext* ctx) const {
   reportNotSupported(ctx, "SPARQL 1.1 Update Copy is");
 }
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -432,7 +432,7 @@ std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> Visitor::visit(
     }
   };
   auto transformAndRegisterTriple =
-      [&ctx, registerIfVariable](const SparqlTripleSimple& triple) {
+      [registerIfVariable](const SparqlTripleSimple& triple) {
         registerIfVariable(triple.s_);
         registerIfVariable(triple.p_);
         registerIfVariable(triple.o_);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -330,8 +330,7 @@ ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
   visit(ctx->prologue());
 
   if (ctx->update()) {
-    reportNotSupported(ctx->update(),
-                       "Multiple updates in one query are not supported.");
+    reportNotSupported(ctx->update(), "Multiple updates in one query are");
   }
   return visit(ctx->update1());
 }
@@ -360,37 +359,37 @@ ParsedQuery Visitor::visit(Parser::Update1Context* ctx) {
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::LoadContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Load is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Load is");
 }
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::ClearContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Clear is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Clear is");
 }
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::DropContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Drop is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Drop is");
 }
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::CreateContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Create is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Create is");
 }
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::AddContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Add is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Add is");
 }
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::MoveContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Move is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Move is");
 }
 
 // ____________________________________________________________________________________
 void Visitor::visit(Parser::CopyContext* ctx) {
-  reportNotSupported(ctx, "SPARQL 1.1 Update Copy is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update Copy is");
 }
 
 // ____________________________________________________________________________________
@@ -408,18 +407,18 @@ void Visitor::visit(Parser::DeleteWhereContext* ctx) {
   // DeleteData only deletes the specified triples. DeleteWhere matches the
   // given pattern and then deletes the matched triples. This is a shortcut for
   // a modify query.
-  reportNotSupported(ctx, "SPARQL 1.1 Update DeleteWhere is not supported.");
+  reportNotSupported(ctx, "SPARQL 1.1 Update DeleteWhere is");
 }
 
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
   if (ctx->iri()) {
     // Could also be default; disallow completely for now.
-    reportNotSupported(ctx->iri(), "Named graphs are not supported.");
+    reportNotSupported(ctx->iri(), "Named graphs are");
   }
   if (!ctx->usingClause().empty()) {
     reportNotSupported(ctx->usingClause(0),
-                       "Using is not supported in Update/Insert.");
+                       "USING inside an DELETE or INSERT is");
   }
 
   parsedQuery_._rootGraphPattern = visit(ctx->groupGraphPattern());
@@ -473,14 +472,14 @@ vector<SparqlTripleSimple> Visitor::visit(Parser::QuadDataContext* ctx) {
 vector<SparqlTripleSimple> Visitor::visit(Parser::QuadsContext* ctx) {
   if (!ctx->quadsNotTriples().empty()) {
     // Could also be default; disallow completely for now.
-    reportNotSupported(ctx->quadsNotTriples(0),
-                       "Named graphs are not supported.");
+    reportNotSupported(ctx->quadsNotTriples(0), "Named graphs are");
   }
 
   AD_CORRECTNESS_CHECK(ctx->triplesTemplate().size() == 1);
 
   auto convertAndRegisterTriple =
       [this](const std::array<GraphTerm, 3>& triple) -> SparqlTripleSimple {
+    // TODO:
     registerIfVariable(triple[0]);
     registerIfVariable(triple[1]);
     registerIfVariable(triple[2]);
@@ -489,9 +488,8 @@ vector<SparqlTripleSimple> Visitor::visit(Parser::QuadsContext* ctx) {
             visitGraphTerm(triple[2])};
   };
 
-  std::vector<SparqlTripleSimple> triples = {ad_utility::transform(
-      visit(ctx->triplesTemplate(0)), convertAndRegisterTriple)};
-  return triples;
+  return ad_utility::transform(visit(ctx->triplesTemplate(0)),
+                               convertAndRegisterTriple);
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -438,7 +438,7 @@ std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> Visitor::visit(
         if (triple.p_.isVariable() || triple.p_.isIri()) {
           return SparqlTriple::fromSimple(triple);
         } else {
-          reportError(ctx, "Predicate must a PropertyPath");
+          reportError(ctx, "Predicate must be a PropertyPath");
         }
       };
   GraphPattern pattern;
@@ -451,7 +451,6 @@ std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> Visitor::visit(
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
   if (ctx->iri()) {
-    // Could also be default; disallow completely for now.
     reportNotSupported(ctx->iri(), "Named graphs are");
   }
   if (!ctx->usingClause().empty()) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -345,11 +345,11 @@ ParsedQuery Visitor::visit(Parser::Update1Context* ctx) {
 
   parsedQuery_._clause = parsedQuery::UpdateClause();
 
-  if (ctx->insertData()) {
-    parsedQuery_.updateClause().toInsert_ = visit(ctx->insertData());
-  } else if (ctx->deleteData()) {
-    parsedQuery_.updateClause().toDelete_ = visit(ctx->deleteData());
-  } else if (ctx->deleteWhere()) {
+  // handles insertData and deleteData cases
+  visitIf(&parsedQuery_.updateClause().toInsert_, ctx->insertData());
+  visitIf(&parsedQuery_.updateClause().toDelete_, ctx->deleteData());
+
+  if (ctx->deleteWhere()) {
     auto [toDelete, pattern] = visit(ctx->deleteWhere());
     parsedQuery_.updateClause().toDelete_ = std::move(toDelete);
     parsedQuery_._rootGraphPattern = std::move(pattern);
@@ -463,12 +463,8 @@ ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
   parsedQuery_._rootGraphPattern = visit(ctx->groupGraphPattern());
 
   parsedQuery_._clause = parsedQuery::UpdateClause();
-  if (ctx->deleteClause()) {
-    parsedQuery_.updateClause().toDelete_ = visit(ctx->deleteClause());
-  }
-  if (ctx->insertClause()) {
-    parsedQuery_.updateClause().toInsert_ = visit(ctx->insertClause());
-  }
+  visitIf(&parsedQuery_.updateClause().toInsert_, ctx->insertClause());
+  visitIf(&parsedQuery_.updateClause().toDelete_, ctx->deleteClause());
 
   return parsedQuery_;
 }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -440,7 +440,9 @@ std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> Visitor::visit(
         if (triple.p_.isVariable() || triple.p_.isIri()) {
           return SparqlTriple::fromSimple(triple);
         } else {
-          reportError(ctx, "Predicate must be a PropertyPath");
+          // The predicate comes from a rule in the grammar (`verb`) which only
+          // allows variables and IRIs.
+          AD_FAIL();
         }
       };
   GraphPattern pattern;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -204,19 +204,19 @@ class SparqlQleverVisitor {
 
   [[nodiscard]] ParsedQuery visit(Parser::Update1Context* ctx);
 
-  [[noreturn]] void visit(Parser::LoadContext* ctx);
+  [[noreturn]] void visit(const Parser::LoadContext* ctx) const;
 
   [[nodiscard]] ParsedQuery visit(Parser::ClearContext* ctx);
 
-  [[noreturn]] void visit(Parser::DropContext* ctx);
+  [[noreturn]] void visit(const Parser::DropContext* ctx) const;
 
-  [[noreturn]] void visit(Parser::CreateContext* ctx);
+  [[noreturn]] void visit(const Parser::CreateContext* ctx) const;
 
-  [[noreturn]] void visit(Parser::AddContext* ctx);
+  [[noreturn]] void visit(const Parser::AddContext* ctx) const;
 
-  [[noreturn]] void visit(Parser::MoveContext* ctx);
+  [[noreturn]] void visit(const Parser::MoveContext* ctx) const;
 
-  [[noreturn]] void visit(Parser::CopyContext* ctx);
+  [[noreturn]] void visit(const Parser::CopyContext* ctx) const;
 
   [[nodiscard]] vector<SparqlTripleSimple> visit(
       Parser::InsertDataContext* ctx);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -19,6 +19,7 @@
 #include "parser/ParsedQuery.h"
 #include "parser/RdfEscaping.h"
 #include "parser/data/BlankNode.h"
+#include "parser/data/GraphRef.h"
 #include "parser/data/Iri.h"
 #include "parser/data/SolutionModifiers.h"
 #include "parser/data/Types.h"
@@ -205,7 +206,7 @@ class SparqlQleverVisitor {
 
   void visit(Parser::LoadContext* ctx);
 
-  void visit(Parser::ClearContext* ctx);
+  ParsedQuery visit(Parser::ClearContext* ctx);
 
   void visit(Parser::DropContext* ctx);
 
@@ -232,11 +233,11 @@ class SparqlQleverVisitor {
 
   void visit(Parser::UsingClauseContext* ctx);
 
-  void visit(Parser::GraphOrDefaultContext* ctx);
+  GraphOrDefault visit(Parser::GraphOrDefaultContext* ctx);
 
-  void visit(Parser::GraphRefContext* ctx);
+  GraphRef visit(Parser::GraphRefContext* ctx);
 
-  void visit(Parser::GraphRefAllContext* ctx);
+  GraphRefAll visit(Parser::GraphRefAllContext* ctx);
 
   vector<SparqlTripleSimple> visit(Parser::QuadPatternContext* ctx);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -200,52 +200,53 @@ class SparqlQleverVisitor {
   [[nodiscard]] std::optional<parsedQuery::Values> visit(
       Parser::ValuesClauseContext* ctx);
 
-  ParsedQuery visit(Parser::UpdateContext* ctx);
+  [[nodiscard]] ParsedQuery visit(Parser::UpdateContext* ctx);
 
-  ParsedQuery visit(Parser::Update1Context* ctx);
+  [[nodiscard]] ParsedQuery visit(Parser::Update1Context* ctx);
 
-  void visit(Parser::LoadContext* ctx);
+  [[noreturn]] void visit(Parser::LoadContext* ctx);
 
-  ParsedQuery visit(Parser::ClearContext* ctx);
+  [[nodiscard]] ParsedQuery visit(Parser::ClearContext* ctx);
 
-  void visit(Parser::DropContext* ctx);
+  [[noreturn]] void visit(Parser::DropContext* ctx);
 
-  void visit(Parser::CreateContext* ctx);
+  [[noreturn]] void visit(Parser::CreateContext* ctx);
 
-  void visit(Parser::AddContext* ctx);
+  [[noreturn]] void visit(Parser::AddContext* ctx);
 
-  void visit(Parser::MoveContext* ctx);
+  [[noreturn]] void visit(Parser::MoveContext* ctx);
 
-  void visit(Parser::CopyContext* ctx);
+  [[noreturn]] void visit(Parser::CopyContext* ctx);
 
-  vector<SparqlTripleSimple> visit(Parser::InsertDataContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(
+      Parser::InsertDataContext* ctx);
 
-  vector<SparqlTripleSimple> visit(Parser::DeleteDataContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(
+      Parser::DeleteDataContext* ctx);
 
-  std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> visit(
-      Parser::DeleteWhereContext* ctx);
+  [[nodiscard]] std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern>
+  visit(Parser::DeleteWhereContext* ctx);
 
-  ParsedQuery visit(Parser::ModifyContext* ctx);
+  [[nodiscard]] ParsedQuery visit(Parser::ModifyContext* ctx);
 
-  vector<SparqlTripleSimple> visit(Parser::DeleteClauseContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(
+      Parser::DeleteClauseContext* ctx);
 
-  vector<SparqlTripleSimple> visit(Parser::InsertClauseContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(
+      Parser::InsertClauseContext* ctx);
 
-  void visit(Parser::UsingClauseContext* ctx);
+  [[nodiscard]] GraphOrDefault visit(Parser::GraphOrDefaultContext* ctx);
 
-  GraphOrDefault visit(Parser::GraphOrDefaultContext* ctx);
+  [[nodiscard]] GraphRef visit(Parser::GraphRefContext* ctx);
 
-  GraphRef visit(Parser::GraphRefContext* ctx);
+  [[nodiscard]] GraphRefAll visit(Parser::GraphRefAllContext* ctx);
 
-  GraphRefAll visit(Parser::GraphRefAllContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(
+      Parser::QuadPatternContext* ctx);
 
-  vector<SparqlTripleSimple> visit(Parser::QuadPatternContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(Parser::QuadDataContext* ctx);
 
-  vector<SparqlTripleSimple> visit(Parser::QuadDataContext* ctx);
-
-  vector<SparqlTripleSimple> visit(Parser::QuadsContext* ctx);
-
-  void visit(Parser::QuadsNotTriplesContext* ctx);
+  [[nodiscard]] vector<SparqlTripleSimple> visit(Parser::QuadsContext* ctx);
 
   [[nodiscard]] Triples visit(Parser::TriplesTemplateContext* ctx);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -199,6 +199,52 @@ class SparqlQleverVisitor {
   [[nodiscard]] std::optional<parsedQuery::Values> visit(
       Parser::ValuesClauseContext* ctx);
 
+  ParsedQuery visit(Parser::UpdateContext* ctx);
+
+  ParsedQuery visit(Parser::Update1Context* ctx);
+
+  void visit(Parser::LoadContext* ctx);
+
+  void visit(Parser::ClearContext* ctx);
+
+  void visit(Parser::DropContext* ctx);
+
+  void visit(Parser::CreateContext* ctx);
+
+  void visit(Parser::AddContext* ctx);
+
+  void visit(Parser::MoveContext* ctx);
+
+  void visit(Parser::CopyContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::InsertDataContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::DeleteDataContext* ctx);
+
+  void visit(Parser::DeleteWhereContext* ctx);
+
+  ParsedQuery visit(Parser::ModifyContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::DeleteClauseContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::InsertClauseContext* ctx);
+
+  void visit(Parser::UsingClauseContext* ctx);
+
+  void visit(Parser::GraphOrDefaultContext* ctx);
+
+  void visit(Parser::GraphRefContext* ctx);
+
+  void visit(Parser::GraphRefAllContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::QuadPatternContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::QuadDataContext* ctx);
+
+  vector<SparqlTripleSimple> visit(Parser::QuadsContext* ctx);
+
+  void visit(Parser::QuadsNotTriplesContext* ctx);
+
   [[nodiscard]] Triples visit(Parser::TriplesTemplateContext* ctx);
 
   [[nodiscard]] ParsedQuery::GraphPattern visit(
@@ -578,4 +624,7 @@ class SparqlQleverVisitor {
   // part of the query result.
   void setMatchingWordAndScoreVisibleIfPresent(
       auto* ctx, const TripleWithPropertyPath& triple);
+
+  static TripleComponent visitGraphTerm(const GraphTerm& graphTerm);
+  void registerIfVariable(const auto& variant);
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -128,7 +128,7 @@ class SparqlQleverVisitor {
   ParsedQuery visit(Parser::QueryOrUpdateContext* ctx);
 
   // ___________________________________________________________________________
-  [[nodiscard]] ParsedQuery visit(Parser::QueryContext* ctx);
+  ParsedQuery visit(Parser::QueryContext* ctx);
 
   // ___________________________________________________________________________
   void visit(Parser::PrologueContext* ctx);
@@ -139,21 +139,19 @@ class SparqlQleverVisitor {
   // ___________________________________________________________________________
   void visit(Parser::PrefixDeclContext* ctx);
 
-  [[nodiscard]] ParsedQuery visit(Parser::SelectQueryContext* ctx);
+  ParsedQuery visit(Parser::SelectQueryContext* ctx);
 
-  [[nodiscard]] SubQueryAndMaybeValues visit(Parser::SubSelectContext* ctx);
+  SubQueryAndMaybeValues visit(Parser::SubSelectContext* ctx);
 
-  [[nodiscard]] parsedQuery::SelectClause visit(
-      Parser::SelectClauseContext* ctx);
+  parsedQuery::SelectClause visit(Parser::SelectClauseContext* ctx);
 
-  [[nodiscard]] std::variant<Variable, Alias> visit(
-      Parser::VarOrAliasContext* ctx);
+  std::variant<Variable, Alias> visit(Parser::VarOrAliasContext* ctx);
 
-  [[nodiscard]] Alias visit(Parser::AliasContext* ctx);
+  Alias visit(Parser::AliasContext* ctx);
 
-  [[nodiscard]] Alias visit(Parser::AliasWithoutBracketsContext* ctx);
+  Alias visit(Parser::AliasWithoutBracketsContext* ctx);
 
-  [[nodiscard]] ParsedQuery visit(Parser::ConstructQueryContext* ctx);
+  ParsedQuery visit(Parser::ConstructQueryContext* ctx);
 
   // The parser rules for which the visit overload is annotated [[noreturn]]
   // will always throw an exception because the corresponding feature is not
@@ -172,41 +170,39 @@ class SparqlQleverVisitor {
 
   [[noreturn]] static void visit(Parser::SourceSelectorContext* ctx);
 
-  [[nodiscard]] PatternAndVisibleVariables visit(
-      Parser::WhereClauseContext* ctx);
+  PatternAndVisibleVariables visit(Parser::WhereClauseContext* ctx);
 
-  [[nodiscard]] SolutionModifiers visit(Parser::SolutionModifierContext* ctx);
+  SolutionModifiers visit(Parser::SolutionModifierContext* ctx);
 
-  [[nodiscard]] vector<GroupKey> visit(Parser::GroupClauseContext* ctx);
+  vector<GroupKey> visit(Parser::GroupClauseContext* ctx);
 
-  [[nodiscard]] GroupKey visit(Parser::GroupConditionContext* ctx);
+  GroupKey visit(Parser::GroupConditionContext* ctx);
 
-  [[nodiscard]] vector<SparqlFilter> visit(Parser::HavingClauseContext* ctx);
+  vector<SparqlFilter> visit(Parser::HavingClauseContext* ctx);
 
-  [[nodiscard]] SparqlFilter visit(Parser::HavingConditionContext* ctx);
+  SparqlFilter visit(Parser::HavingConditionContext* ctx);
 
-  [[nodiscard]] OrderClause visit(Parser::OrderClauseContext* ctx);
+  OrderClause visit(Parser::OrderClauseContext* ctx);
 
-  [[nodiscard]] OrderKey visit(Parser::OrderConditionContext* ctx);
+  OrderKey visit(Parser::OrderConditionContext* ctx);
 
-  [[nodiscard]] LimitOffsetClause visit(Parser::LimitOffsetClausesContext* ctx);
+  LimitOffsetClause visit(Parser::LimitOffsetClausesContext* ctx);
 
-  [[nodiscard]] static uint64_t visit(Parser::LimitClauseContext* ctx);
+  static uint64_t visit(Parser::LimitClauseContext* ctx);
 
-  [[nodiscard]] static uint64_t visit(Parser::OffsetClauseContext* ctx);
+  static uint64_t visit(Parser::OffsetClauseContext* ctx);
 
-  [[nodiscard]] static uint64_t visit(Parser::TextLimitClauseContext* ctx);
+  static uint64_t visit(Parser::TextLimitClauseContext* ctx);
 
-  [[nodiscard]] std::optional<parsedQuery::Values> visit(
-      Parser::ValuesClauseContext* ctx);
+  std::optional<parsedQuery::Values> visit(Parser::ValuesClauseContext* ctx);
 
-  [[nodiscard]] ParsedQuery visit(Parser::UpdateContext* ctx);
+  ParsedQuery visit(Parser::UpdateContext* ctx);
 
-  [[nodiscard]] ParsedQuery visit(Parser::Update1Context* ctx);
+  ParsedQuery visit(Parser::Update1Context* ctx);
 
   [[noreturn]] void visit(const Parser::LoadContext* ctx) const;
 
-  [[nodiscard]] ParsedQuery visit(Parser::ClearContext* ctx);
+  ParsedQuery visit(Parser::ClearContext* ctx);
 
   [[noreturn]] void visit(const Parser::DropContext* ctx) const;
 
@@ -218,158 +214,136 @@ class SparqlQleverVisitor {
 
   [[noreturn]] void visit(const Parser::CopyContext* ctx) const;
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(
-      Parser::InsertDataContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::InsertDataContext* ctx);
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(
-      Parser::DeleteDataContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::DeleteDataContext* ctx);
 
-  [[nodiscard]] std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern>
-  visit(Parser::DeleteWhereContext* ctx);
+  std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> visit(
+      Parser::DeleteWhereContext* ctx);
 
-  [[nodiscard]] ParsedQuery visit(Parser::ModifyContext* ctx);
+  ParsedQuery visit(Parser::ModifyContext* ctx);
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(
-      Parser::DeleteClauseContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::DeleteClauseContext* ctx);
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(
-      Parser::InsertClauseContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::InsertClauseContext* ctx);
 
-  [[nodiscard]] GraphOrDefault visit(Parser::GraphOrDefaultContext* ctx);
+  GraphOrDefault visit(Parser::GraphOrDefaultContext* ctx);
 
-  [[nodiscard]] GraphRef visit(Parser::GraphRefContext* ctx);
+  GraphRef visit(Parser::GraphRefContext* ctx);
 
-  [[nodiscard]] GraphRefAll visit(Parser::GraphRefAllContext* ctx);
+  GraphRefAll visit(Parser::GraphRefAllContext* ctx);
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(
-      Parser::QuadPatternContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::QuadPatternContext* ctx);
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(Parser::QuadDataContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::QuadDataContext* ctx);
 
-  [[nodiscard]] vector<SparqlTripleSimple> visit(Parser::QuadsContext* ctx);
+  vector<SparqlTripleSimple> visit(Parser::QuadsContext* ctx);
 
-  [[nodiscard]] Triples visit(Parser::TriplesTemplateContext* ctx);
+  Triples visit(Parser::TriplesTemplateContext* ctx);
 
-  [[nodiscard]] ParsedQuery::GraphPattern visit(
-      Parser::GroupGraphPatternContext* ctx);
+  ParsedQuery::GraphPattern visit(Parser::GroupGraphPatternContext* ctx);
 
-  [[nodiscard]] OperationsAndFilters visit(
-      Parser::GroupGraphPatternSubContext* ctx);
+  OperationsAndFilters visit(Parser::GroupGraphPatternSubContext* ctx);
 
-  [[nodiscard]] OperationOrFilterAndMaybeTriples visit(
+  OperationOrFilterAndMaybeTriples visit(
       Parser::GraphPatternNotTriplesAndMaybeTriplesContext* ctx);
 
-  [[nodiscard]] parsedQuery::BasicGraphPattern visit(
-      Parser::TriplesBlockContext* graphTerm);
+  parsedQuery::BasicGraphPattern visit(Parser::TriplesBlockContext* graphTerm);
 
   // Filter clauses are no independent graph patterns themselves, but their
   // scope is always the complete graph pattern enclosing them.
-  [[nodiscard]] OperationOrFilter visit(
-      Parser::GraphPatternNotTriplesContext* ctx);
+  OperationOrFilter visit(Parser::GraphPatternNotTriplesContext* ctx);
 
-  [[nodiscard]] parsedQuery::GraphPatternOperation visit(
+  parsedQuery::GraphPatternOperation visit(
       Parser::OptionalGraphPatternContext* ctx);
 
   [[noreturn]] static parsedQuery::GraphPatternOperation visit(
       const Parser::GraphGraphPatternContext* ctx);
 
-  [[nodiscard]] parsedQuery::Service visit(
-      Parser::ServiceGraphPatternContext* ctx);
+  parsedQuery::Service visit(Parser::ServiceGraphPatternContext* ctx);
 
-  [[nodiscard]] parsedQuery::GraphPatternOperation visit(
-      Parser::BindContext* ctx);
+  parsedQuery::GraphPatternOperation visit(Parser::BindContext* ctx);
 
-  [[nodiscard]] parsedQuery::GraphPatternOperation visit(
-      Parser::InlineDataContext* ctx);
+  parsedQuery::GraphPatternOperation visit(Parser::InlineDataContext* ctx);
 
-  [[nodiscard]] parsedQuery::Values visit(Parser::DataBlockContext* ctx);
+  parsedQuery::Values visit(Parser::DataBlockContext* ctx);
 
-  [[nodiscard]] parsedQuery::SparqlValues visit(
-      Parser::InlineDataOneVarContext* ctx);
+  parsedQuery::SparqlValues visit(Parser::InlineDataOneVarContext* ctx);
 
-  [[nodiscard]] parsedQuery::SparqlValues visit(
-      Parser::InlineDataFullContext* ctx);
+  parsedQuery::SparqlValues visit(Parser::InlineDataFullContext* ctx);
 
-  [[nodiscard]] vector<TripleComponent> visit(
-      Parser::DataBlockSingleContext* ctx);
+  vector<TripleComponent> visit(Parser::DataBlockSingleContext* ctx);
 
-  [[nodiscard]] TripleComponent visit(Parser::DataBlockValueContext* ctx);
+  TripleComponent visit(Parser::DataBlockValueContext* ctx);
 
-  [[nodiscard]] GraphPatternOperation visit(
-      Parser::MinusGraphPatternContext* ctx);
+  GraphPatternOperation visit(Parser::MinusGraphPatternContext* ctx);
 
-  [[nodiscard]] GraphPatternOperation visit(
-      Parser::GroupOrUnionGraphPatternContext* ctx);
+  GraphPatternOperation visit(Parser::GroupOrUnionGraphPatternContext* ctx);
 
-  [[nodiscard]] SparqlFilter visit(Parser::FilterRContext* ctx);
+  SparqlFilter visit(Parser::FilterRContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::ConstraintContext* ctx);
+  ExpressionPtr visit(Parser::ConstraintContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::FunctionCallContext* ctx);
+  ExpressionPtr visit(Parser::FunctionCallContext* ctx);
 
-  [[nodiscard]] vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
+  vector<ExpressionPtr> visit(Parser::ArgListContext* ctx);
 
   std::vector<ExpressionPtr> visit(Parser::ExpressionListContext* ctx);
 
-  [[nodiscard]] std::optional<parsedQuery::ConstructClause> visit(
+  std::optional<parsedQuery::ConstructClause> visit(
       Parser::ConstructTemplateContext* ctx);
 
-  [[nodiscard]] Triples visit(Parser::ConstructTriplesContext* ctx);
+  Triples visit(Parser::ConstructTriplesContext* ctx);
 
-  [[nodiscard]] Triples visit(Parser::TriplesSameSubjectContext* ctx);
+  Triples visit(Parser::TriplesSameSubjectContext* ctx);
 
-  [[nodiscard]] PredicateObjectPairsAndTriples visit(
-      Parser::PropertyListContext* ctx);
+  PredicateObjectPairsAndTriples visit(Parser::PropertyListContext* ctx);
 
-  [[nodiscard]] PredicateObjectPairsAndTriples visit(
+  PredicateObjectPairsAndTriples visit(
       Parser::PropertyListNotEmptyContext* ctx);
 
-  [[nodiscard]] GraphTerm visit(Parser::VerbContext* ctx);
+  GraphTerm visit(Parser::VerbContext* ctx);
 
-  [[nodiscard]] ObjectsAndTriples visit(Parser::ObjectListContext* ctx);
+  ObjectsAndTriples visit(Parser::ObjectListContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndTriples visit(Parser::ObjectRContext* ctx);
+  SubjectOrObjectAndTriples visit(Parser::ObjectRContext* ctx);
 
-  [[nodiscard]] vector<TripleWithPropertyPath> visit(
+  vector<TripleWithPropertyPath> visit(
       Parser::TriplesSameSubjectPathContext* ctx);
 
-  [[nodiscard]] std::optional<PathObjectPairsAndTriples> visit(
+  std::optional<PathObjectPairsAndTriples> visit(
       Parser::PropertyListPathContext* ctx);
 
-  [[nodiscard]] PathObjectPairsAndTriples visit(
-      Parser::PropertyListPathNotEmptyContext* ctx);
+  PathObjectPairsAndTriples visit(Parser::PropertyListPathNotEmptyContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::VerbPathContext* ctx);
+  PropertyPath visit(Parser::VerbPathContext* ctx);
 
-  [[nodiscard]] static Variable visit(Parser::VerbSimpleContext* ctx);
+  static Variable visit(Parser::VerbSimpleContext* ctx);
 
-  [[nodiscard]] PathObjectPairsAndTriples visit(
-      Parser::TupleWithoutPathContext* term);
+  PathObjectPairsAndTriples visit(Parser::TupleWithoutPathContext* term);
 
-  [[nodiscard]] PathObjectPairsAndTriples visit(
-      Parser::TupleWithPathContext* ctx);
+  PathObjectPairsAndTriples visit(Parser::TupleWithPathContext* ctx);
 
-  [[nodiscard]] ad_utility::sparql_types::VarOrPath visit(
+  ad_utility::sparql_types::VarOrPath visit(
       Parser::VerbPathOrSimpleContext* ctx);
 
-  [[nodiscard]] ObjectsAndPathTriples visit(Parser::ObjectListPathContext* ctx);
+  ObjectsAndPathTriples visit(Parser::ObjectListPathContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndPathTriples visit(
-      Parser::ObjectPathContext* ctx);
+  SubjectOrObjectAndPathTriples visit(Parser::ObjectPathContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::PathContext* ctx);
+  PropertyPath visit(Parser::PathContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::PathAlternativeContext* ctx);
+  PropertyPath visit(Parser::PathAlternativeContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::PathSequenceContext* ctx);
+  PropertyPath visit(Parser::PathSequenceContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::PathEltContext* ctx);
+  PropertyPath visit(Parser::PathEltContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::PathEltOrInverseContext* ctx);
+  PropertyPath visit(Parser::PathEltOrInverseContext* ctx);
 
   [[noreturn]] static void visit(Parser::PathModContext* ctx);
 
-  [[nodiscard]] PropertyPath visit(Parser::PathPrimaryContext* ctx);
+  PropertyPath visit(Parser::PathPrimaryContext* ctx);
 
   [[noreturn]] static PropertyPath visit(
       const Parser::PathNegatedPropertySetContext*);
@@ -379,52 +353,47 @@ class SparqlQleverVisitor {
 
   /// Note that in the SPARQL grammar the INTEGER rule refers to positive
   /// integers without an explicit sign.
-  [[nodiscard]] static uint64_t visit(Parser::IntegerContext* ctx);
+  static uint64_t visit(Parser::IntegerContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndTriples visit(
-      Parser::TriplesNodeContext* ctx);
+  SubjectOrObjectAndTriples visit(Parser::TriplesNodeContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndTriples visit(
-      Parser::BlankNodePropertyListContext* ctx);
+  SubjectOrObjectAndTriples visit(Parser::BlankNodePropertyListContext* ctx);
 
   SubjectOrObjectAndPathTriples visit(Parser::TriplesNodePathContext* ctx);
 
   SubjectOrObjectAndPathTriples visit(
       Parser::BlankNodePropertyListPathContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndTriples visit(Parser::CollectionContext* ctx);
+  SubjectOrObjectAndTriples visit(Parser::CollectionContext* ctx);
 
   [[noreturn]] SubjectOrObjectAndPathTriples visit(
       Parser::CollectionPathContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndTriples visit(Parser::GraphNodeContext* ctx);
+  SubjectOrObjectAndTriples visit(Parser::GraphNodeContext* ctx);
 
-  [[nodiscard]] SubjectOrObjectAndPathTriples visit(
-      Parser::GraphNodePathContext* ctx);
+  SubjectOrObjectAndPathTriples visit(Parser::GraphNodePathContext* ctx);
 
-  [[nodiscard]] GraphTerm visit(Parser::VarOrTermContext* ctx);
+  GraphTerm visit(Parser::VarOrTermContext* ctx);
 
-  [[nodiscard]] GraphTerm visit(Parser::VarOrIriContext* ctx);
+  GraphTerm visit(Parser::VarOrIriContext* ctx);
 
-  [[nodiscard]] static Variable visit(Parser::VarContext* ctx);
+  static Variable visit(Parser::VarContext* ctx);
 
-  [[nodiscard]] GraphTerm visit(Parser::GraphTermContext* ctx);
+  GraphTerm visit(Parser::GraphTermContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::ExpressionContext* ctx);
+  ExpressionPtr visit(Parser::ExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(
-      Parser::ConditionalOrExpressionContext* ctx);
+  ExpressionPtr visit(Parser::ConditionalOrExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(
-      Parser::ConditionalAndExpressionContext* ctx);
+  ExpressionPtr visit(Parser::ConditionalAndExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::ValueLogicalContext* ctx);
+  ExpressionPtr visit(Parser::ValueLogicalContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::RelationalExpressionContext* ctx);
+  ExpressionPtr visit(Parser::RelationalExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::NumericExpressionContext* ctx);
+  ExpressionPtr visit(Parser::NumericExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::AdditiveExpressionContext* ctx);
+  ExpressionPtr visit(Parser::AdditiveExpressionContext* ctx);
 
   // Helper structs, needed in the following `visit` functions. Combine an
   // explicit operator (+ - * /) with an expression.
@@ -434,41 +403,35 @@ class SparqlQleverVisitor {
     ExpressionPtr expression_;
   };
 
-  [[nodiscard]] OperatorAndExpression visit(
+  OperatorAndExpression visit(
       Parser::MultiplicativeExpressionWithSignContext* ctx);
 
-  [[nodiscard]] OperatorAndExpression visit(
-      Parser::PlusSubexpressionContext* ctx);
+  OperatorAndExpression visit(Parser::PlusSubexpressionContext* ctx);
 
-  [[nodiscard]] OperatorAndExpression visit(
-      Parser::MinusSubexpressionContext* ctx);
+  OperatorAndExpression visit(Parser::MinusSubexpressionContext* ctx);
 
-  [[nodiscard]] OperatorAndExpression visit(
+  OperatorAndExpression visit(
       Parser::MultiplicativeExpressionWithLeadingSignButNoSpaceContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(
-      Parser::MultiplicativeExpressionContext* ctx);
+  ExpressionPtr visit(Parser::MultiplicativeExpressionContext* ctx);
 
-  [[nodiscard]] OperatorAndExpression visit(
-      Parser::MultiplyOrDivideExpressionContext* ctx);
+  OperatorAndExpression visit(Parser::MultiplyOrDivideExpressionContext* ctx);
 
-  [[nodiscard]] OperatorAndExpression visit(
-      Parser::MultiplyExpressionContext* ctx);
+  OperatorAndExpression visit(Parser::MultiplyExpressionContext* ctx);
 
-  [[nodiscard]] OperatorAndExpression visit(
-      Parser::DivideExpressionContext* ctx);
+  OperatorAndExpression visit(Parser::DivideExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::UnaryExpressionContext* ctx);
+  ExpressionPtr visit(Parser::UnaryExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::PrimaryExpressionContext* ctx);
+  ExpressionPtr visit(Parser::PrimaryExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::BrackettedExpressionContext* ctx);
+  ExpressionPtr visit(Parser::BrackettedExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::BuiltInCallContext* ctx);
+  ExpressionPtr visit(Parser::BuiltInCallContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::RegexExpressionContext* ctx);
+  ExpressionPtr visit(Parser::RegexExpressionContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::LangExpressionContext* ctx);
+  ExpressionPtr visit(Parser::LangExpressionContext* ctx);
 
   ExpressionPtr visit(Parser::SubstringExpressionContext* ctx);
 
@@ -478,39 +441,35 @@ class SparqlQleverVisitor {
 
   [[noreturn]] static void visit(const Parser::NotExistsFuncContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::AggregateContext* ctx);
+  ExpressionPtr visit(Parser::AggregateContext* ctx);
 
-  [[nodiscard]] ExpressionPtr visit(Parser::IriOrFunctionContext* ctx);
+  ExpressionPtr visit(Parser::IriOrFunctionContext* ctx);
 
-  [[nodiscard]] std::string visit(Parser::RdfLiteralContext* ctx);
+  std::string visit(Parser::RdfLiteralContext* ctx);
 
-  [[nodiscard]] IntOrDouble visit(Parser::NumericLiteralContext* ctx);
+  IntOrDouble visit(Parser::NumericLiteralContext* ctx);
 
-  [[nodiscard]] static IntOrDouble visit(
-      Parser::NumericLiteralUnsignedContext* ctx);
+  static IntOrDouble visit(Parser::NumericLiteralUnsignedContext* ctx);
 
-  [[nodiscard]] static IntOrDouble visit(
-      Parser::NumericLiteralPositiveContext* ctx);
+  static IntOrDouble visit(Parser::NumericLiteralPositiveContext* ctx);
 
-  [[nodiscard]] static IntOrDouble visit(
-      Parser::NumericLiteralNegativeContext* ctx);
+  static IntOrDouble visit(Parser::NumericLiteralNegativeContext* ctx);
 
-  [[nodiscard]] static bool visit(Parser::BooleanLiteralContext* ctx);
+  static bool visit(Parser::BooleanLiteralContext* ctx);
 
-  [[nodiscard]] static RdfEscaping::NormalizedRDFString visit(
-      Parser::StringContext* ctx);
+  static RdfEscaping::NormalizedRDFString visit(Parser::StringContext* ctx);
 
-  [[nodiscard]] TripleComponent::Iri visit(Parser::IriContext* ctx);
+  TripleComponent::Iri visit(Parser::IriContext* ctx);
 
-  [[nodiscard]] static string visit(Parser::IrirefContext* ctx);
+  static string visit(Parser::IrirefContext* ctx);
 
-  [[nodiscard]] string visit(Parser::PrefixedNameContext* ctx);
+  string visit(Parser::PrefixedNameContext* ctx);
 
-  [[nodiscard]] GraphTerm visit(Parser::BlankNodeContext* ctx);
+  GraphTerm visit(Parser::BlankNodeContext* ctx);
 
-  [[nodiscard]] string visit(Parser::PnameLnContext* ctx);
+  string visit(Parser::PnameLnContext* ctx);
 
-  [[nodiscard]] string visit(Parser::PnameNsContext* ctx);
+  string visit(Parser::PnameNsContext* ctx);
 
  private:
   template <typename Visitor, typename Ctx>
@@ -518,7 +477,7 @@ class SparqlQleverVisitor {
       std::is_void_v<decltype(std::declval<Visitor&>().visit(
           std::declval<Ctx*>()))>;
 
-  [[nodiscard]] BlankNode newBlankNode() {
+  BlankNode newBlankNode() {
     std::string label = std::to_string(_blankNodeCounter);
     _blankNodeCounter++;
     // true means automatically generated
@@ -536,7 +495,7 @@ class SparqlQleverVisitor {
 
   // Process an IRI function call. This is used in both `visitFunctionCall` and
   // `visitIriOrFunction`.
-  [[nodiscard]] static ExpressionPtr processIriFunctionCall(
+  static ExpressionPtr processIriFunctionCall(
       const TripleComponent::Iri& iri, std::vector<ExpressionPtr> argList,
       const antlr4::ParserRuleContext*);
 
@@ -549,11 +508,11 @@ class SparqlQleverVisitor {
   // Return the `SparqlExpressionPimpl` for a context that returns a
   // `ExpressionPtr` when visited. The descriptor is set automatically on the
   // `SparqlExpressionPimpl`.
-  [[nodiscard]] SparqlExpressionPimpl visitExpressionPimpl(
-      auto* ctx, bool allowLanguageFilters = false);
+  SparqlExpressionPimpl visitExpressionPimpl(auto* ctx,
+                                             bool allowLanguageFilters = false);
 
   template <typename Expr>
-  [[nodiscard]] ExpressionPtr createExpression(auto... children) {
+  ExpressionPtr createExpression(auto... children) {
     return std::make_unique<Expr>(
         std::array<ExpressionPtr, sizeof...(children)>{std::move(children)...});
   }
@@ -565,7 +524,7 @@ class SparqlQleverVisitor {
   // Call `visit` for each of the `childContexts` and return the results of
   // those calls as a `vector`.
   template <typename Ctx>
-  [[nodiscard]] auto visitVector(const std::vector<Ctx*>& childContexts)
+  auto visitVector(const std::vector<Ctx*>& childContexts)
       -> std::vector<decltype(visit(childContexts[0]))>
       requires(!voidWhenVisited<SparqlQleverVisitor, Ctx>);
 
@@ -573,13 +532,12 @@ class SparqlQleverVisitor {
   // cast the result to `Out` and return it. Requires that for all of the
   // `ctxs`, `visit(ctxs)` is convertible to `Out`.
   template <typename Out, typename... Contexts>
-  [[nodiscard]] Out visitAlternative(Contexts*... ctxs);
+  Out visitAlternative(Contexts*... ctxs);
 
   // Returns `std::nullopt` if the pointer is the `nullptr`. Otherwise return
   // `visit(ctx)`.
   template <typename Ctx>
-  [[nodiscard]] auto visitOptional(Ctx* ctx)
-      -> std::optional<decltype(visit(ctx))>;
+  auto visitOptional(Ctx* ctx) -> std::optional<decltype(visit(ctx))>;
 
   /// If `ctx` is not `nullptr`, visit it, convert the result to `Intermediate`
   /// and assign it to `*target`. The case where `Intermediate!=Target` is
@@ -618,7 +576,7 @@ class SparqlQleverVisitor {
   // Parse both `ConstructTriplesContext` and `TriplesTemplateContext` because
   // they have the same structure.
   template <typename Context>
-  [[nodiscard]] Triples parseTriplesConstruction(Context* ctx);
+  Triples parseTriplesConstruction(Context* ctx);
 
   // If the triple is a special triple for the text index (i.e. its predicate is
   // either `ql:contains-word` or `ql:contains-entity`, register the magic

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -221,7 +221,8 @@ class SparqlQleverVisitor {
 
   vector<SparqlTripleSimple> visit(Parser::DeleteDataContext* ctx);
 
-  void visit(Parser::DeleteWhereContext* ctx);
+  std::pair<vector<SparqlTripleSimple>, ParsedQuery::GraphPattern> visit(
+      Parser::DeleteWhereContext* ctx);
 
   ParsedQuery visit(Parser::ModifyContext* ctx);
 
@@ -625,6 +626,9 @@ class SparqlQleverVisitor {
   void setMatchingWordAndScoreVisibleIfPresent(
       auto* ctx, const TripleWithPropertyPath& triple);
 
+  // Constructs a TripleComponent from a GraphTerm.
   static TripleComponent visitGraphTerm(const GraphTerm& graphTerm);
+  // If argument is a variant that contains a Variable register that Variable as
+  // visible in the current scope.
   void registerIfVariable(const auto& variant);
 };

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -630,7 +630,4 @@ class SparqlQleverVisitor {
 
   // Constructs a TripleComponent from a GraphTerm.
   static TripleComponent visitGraphTerm(const GraphTerm& graphTerm);
-  // If argument is a variant that contains a Variable register that Variable as
-  // visible in the current scope.
-  void registerIfVariable(const auto& variant);
 };

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1683,6 +1683,8 @@ TEST(SparqlParser, UpdateQuery) {
           {{Var("?a"), Iri("<b>"), Iri("<c>")}},
           {{Iri("<a>"), Var("?a"), Iri("<c>")}},
           m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}}))));
+  expectUpdateFails("INSERT DATA { ?a ?b ?c }");
+  expectUpdateFails("DELETE WHERE { ?a \"foo\" ?c }");
   // Unsupported features.
   expectUpdateFails(
       "INSERT DATA { <a> <b> <c> } ; INSERT { ?a <b> <c> } WHERE { <d> <e> ?a "

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1654,7 +1654,7 @@ TEST(SparqlParser, updateQueryUnsupported) {
 TEST(SparqlParser, UpdateQuery) {
   auto expectUpdate = ExpectCompleteParse<&Parser::update>{
       {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
-  auto expectUpdateFails = ExpectParseFails<&Parser::query>{};
+  auto expectUpdateFails = ExpectParseFails<&Parser::update>{};
   auto Iri = [](std::string_view stringWithBrackets) {
     return TripleComponent::Iri::fromIriref(stringWithBrackets);
   };
@@ -1683,6 +1683,11 @@ TEST(SparqlParser, UpdateQuery) {
           {{Var("?a"), Iri("<b>"), Iri("<c>")}},
           {{Iri("<a>"), Var("?a"), Iri("<c>")}},
           m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}}))));
+  expectUpdate(
+      "DELETE WHERE { ?a <foo> ?c }",
+      m::UpdateQuery(
+          {{Var("?a"), Iri("<foo>"), Var("?c")}}, {},
+          m::GraphPattern(m::Triples({{Var{"?a"}, "<foo>", Var{"?c"}}}))));
   expectUpdateFails("INSERT DATA { ?a ?b ?c }");
   expectUpdateFails("DELETE WHERE { ?a \"foo\" ?c }");
   expectUpdateFails("WITH <foo> DELETE { ?a ?b ?c } WHERE { ?a ?b ?c }");
@@ -1698,8 +1703,8 @@ TEST(SparqlParser, UpdateQuery) {
   expectUpdateFails("CREATE GRAPH <foo>");
   expectUpdateFails("DROP GRAPH <foo>");
   expectUpdateFails("MOVE GRAPH <foo> TO DEFAULT");
-  expectUpdateFails("ADD GRAPH DEFAULT TO GRAPH <foo>");
-  expectUpdateFails("COPY GRAPH DEFAULT TO GRAPH <foo>");
+  expectUpdateFails("ADD DEFAULT TO GRAPH <foo>");
+  expectUpdateFails("COPY DEFAULT TO GRAPH <foo>");
   expectUpdateFails("DELETE { ?a <b> <c> } USING <foo> WHERE { <d> <e> ?a }");
   expectUpdateFails("WITH <foo> DELETE { ?a <b> <c> } WHERE { <d> <e> ?a }");
 }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1695,7 +1695,7 @@ TEST(SparqlParser, UpdateQuery) {
   expectUpdateFails("INSERT DATA { ?a ?b ?c }");
   expectUpdateFails("WITH <foo> DELETE { ?a ?b ?c } WHERE { ?a ?b ?c }");
   expectUpdateFails("DELETE { ?a ?b ?c } USING <foo> WHERE { ?a ?b ?c }");
-  expectUpdateFails("INSERT DATA { GRAPH <foo> }");
+  expectUpdateFails("INSERT DATA { GRAPH <foo> { } }");
   // Unsupported features.
   expectUpdateFails(
       "INSERT DATA { <a> <b> <c> } ; INSERT { ?a <b> <c> } WHERE { <d> <e> ?a "
@@ -1723,4 +1723,13 @@ TEST(SparqlParser, GraphOrDefault) {
       "GRAPH <foo>",
       testing::VariantWith<GraphRef>(AD_PROPERTY(
           TripleComponent::Iri, toStringRepresentation, testing::Eq("<foo>"))));
+}
+
+TEST(SparqlParser, GraphRef) {
+  auto expectGraphRefAll = ExpectCompleteParse<&Parser::graphRefAll>{
+      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+  expectGraphRefAll("DEFAULT", m::Variant<DEFAULT>());
+  expectGraphRefAll("NAMED", m::Variant<NAMED>());
+  expectGraphRefAll("ALL", m::Variant<ALL>());
+  expectGraphRefAll("GRAPH <foo>", m::GraphRefIri("<foo>"));
 }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1685,10 +1685,21 @@ TEST(SparqlParser, UpdateQuery) {
           m::GraphPattern(m::Triples({{Iri("<d>"), "<e>", Var{"?a"}}}))));
   expectUpdateFails("INSERT DATA { ?a ?b ?c }");
   expectUpdateFails("DELETE WHERE { ?a \"foo\" ?c }");
+  expectUpdateFails("WITH <foo> DELETE { ?a ?b ?c } WHERE { ?a ?b ?c }");
+  expectUpdateFails("DELETE { ?a ?b ?c } USING <foo> WHERE { ?a ?b ?c }");
+  expectUpdateFails("INSERT DATA { GRAPH <foo> }");
   // Unsupported features.
   expectUpdateFails(
       "INSERT DATA { <a> <b> <c> } ; INSERT { ?a <b> <c> } WHERE { <d> <e> ?a "
       "}");
+  expectUpdateFails("LOAD <foo>");
+  expectUpdateFails("CLEAR NAMED");
+  expectUpdateFails("CLEAR GRAPH <foo>");
+  expectUpdateFails("CREATE GRAPH <foo>");
+  expectUpdateFails("DROP GRAPH <foo>");
+  expectUpdateFails("MOVE GRAPH <foo> TO DEFAULT");
+  expectUpdateFails("ADD GRAPH DEFAULT TO GRAPH <foo>");
+  expectUpdateFails("COPY GRAPH DEFAULT TO GRAPH <foo>");
   expectUpdateFails("DELETE { ?a <b> <c> } USING <foo> WHERE { <d> <e> ?a }");
   expectUpdateFails("WITH <foo> DELETE { ?a <b> <c> } WHERE { <d> <e> ?a }");
 }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1666,8 +1666,8 @@ TEST(SparqlParser, UpdateQuery) {
                m::UpdateQuery({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>")}},
                               m::GraphPattern()));
   expectUpdate(
-      "INSERT DATA { \"foo:bar\" <b> <c> }",
-      m::UpdateQuery({}, {{Literal("\"foo:bar\""), Iri("<b>"), Iri("<c>")}},
+      "INSERT DATA { <a> <b> \"foo:bar\" }",
+      m::UpdateQuery({}, {{Iri("<a>"), Iri("<b>"), Literal("\"foo:bar\"")}},
                      m::GraphPattern()));
   expectUpdate("DELETE DATA { <a> <b> <c> }",
                m::UpdateQuery({{Iri("<a>"), Iri("<b>"), Iri("<c>")}}, {},

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -836,4 +836,20 @@ inline auto VisibleVariables =
   return AD_PROPERTY(ParsedQuery, getVisibleVariables, testing::Eq(elems));
 };
 
+inline auto UpdateQuery =
+    [](const std::vector<SparqlTripleSimple>& toDelete,
+       const std::vector<SparqlTripleSimple>& toInsert,
+       const Matcher<const p::GraphPattern&>& graphPatternMatcher)
+    -> Matcher<const ::ParsedQuery&> {
+  return testing::AllOf(
+      AD_PROPERTY(ParsedQuery, hasUpdateClause, testing::IsTrue()),
+      AD_PROPERTY(ParsedQuery, updateClause,
+                  AD_FIELD(parsedQuery::UpdateClause, toDelete_,
+                           testing::Eq(toDelete))),
+      AD_PROPERTY(ParsedQuery, updateClause,
+                  AD_FIELD(parsedQuery::UpdateClause, toInsert_,
+                           testing::Eq(toInsert))),
+      RootGraphPattern(graphPatternMatcher));
+};
+
 }  // namespace matchers

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -824,9 +824,9 @@ inline auto ConstructQuery(const std::vector<std::array<GraphTerm, 3>>& elems,
     -> Matcher<const ParsedQuery&> {
   return testing::AllOf(
       AD_PROPERTY(ParsedQuery, hasConstructClause, testing::IsTrue()),
-      AD_PROPERTY(
-          ParsedQuery, constructClause,
-          AD_FIELD(parsedQuery::ConstructClause, triples_, testing::Eq(elems))),
+      AD_PROPERTY(ParsedQuery, constructClause,
+                  AD_FIELD(parsedQuery::ConstructClause, triples_,
+                           testing::ElementsAreArray(elems))),
       RootGraphPattern(m));
 }
 
@@ -845,10 +845,10 @@ inline auto UpdateQuery =
       AD_PROPERTY(ParsedQuery, hasUpdateClause, testing::IsTrue()),
       AD_PROPERTY(ParsedQuery, updateClause,
                   AD_FIELD(parsedQuery::UpdateClause, toDelete_,
-                           testing::Eq(toDelete))),
+                           testing::ElementsAreArray(toDelete))),
       AD_PROPERTY(ParsedQuery, updateClause,
                   AD_FIELD(parsedQuery::UpdateClause, toInsert_,
-                           testing::Eq(toInsert))),
+                           testing::ElementsAreArray(toInsert))),
       RootGraphPattern(graphPatternMatcher));
 };
 

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -852,4 +852,12 @@ inline auto UpdateQuery =
       RootGraphPattern(graphPatternMatcher));
 };
 
+template <typename T>
+auto inline Variant = []() { return testing::VariantWith<T>(testing::_); };
+
+auto inline GraphRefIri = [](const string& iri) {
+  return testing::VariantWith<GraphRef>(AD_PROPERTY(
+      TripleComponent::Iri, toStringRepresentation, testing::Eq(iri)));
+};
+
 }  // namespace matchers


### PR DESCRIPTION
This commit extends SPARQL parser s.t. it can parse SPARQL UPDATE queries and store them as part of the `ParsedQuery`. The updates are not yet processed, but (as of now) still lead to an error message that updates are not yet supported. 