### PR TITLE
Automatically identify and fix spelling errors using `codespell`.

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -5,4 +5,4 @@ check-hidden = true
 # Ignore mixedCase variables, lines with latin, lines with codespell-ignore pragma, etc
 ignore-regex = \b([A-Z]*[a-z]+[A-Z][a-zA-Z]*)\b|.*(Lorem ipsum|eleifend|feugait|codespell-ignore).*
 # alph - is used frequently in tests, just ignore altogether
-ignore-words-list = ser,alph
+ignore-words-list = ser,alph,inbetween,interm

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,8 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,.codespellrc
+skip = .git*,.codespellrc,*.pdf,generated
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+# Ignore mixedCase variables, lines with latin, lines with codespell-ignore pragma, etc
+ignore-regex = \b([A-Z]*[a-z]+[A-Z][a-zA-Z]*)\b|.*(Lorem ipsum|eleifend|feugait|codespell-ignore).*
+# alph - is used frequently in tests, just ignore altogether
+ignore-words-list = ser,alph

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config-local.yaml
+++ b/.pre-commit-config-local.yaml
@@ -14,3 +14,9 @@ repos:
         args: [ "-style=file" ]
         require_serial: false
 
+
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .codespellrc
+    rev: v2.2.6
+    hooks:
+    - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@ repos:
     hooks:
       - id: clang-format
         'types_or': [ c++, c ]
+
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in .codespellrc
+    rev: v2.2.6
+    hooks:
+    - id: codespell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ message(STATUS ---)
 include_directories(src)
 
 # Run the script `CompilationInfo.cmake` that creates the file `CompilationInfo.cpp`
-# with the current git hash and the curent time and date. When specifying
+# with the current git hash and the current time and date. When specifying
 # `-DDONT_UPDATE_COMPILATION_INFO=true` as an argument to `cmake`, the compilation info is
 # never updated. This is useful during development to avoid a relinking of the binaries for
 # every compilation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV MEMORY_FOR_QUERIES 70
 ENV CACHE_MAX_SIZE_GB 30
 ENV CACHE_MAX_SIZE_GB_SINGLE_ENTRY 5
 ENV CACHE_MAX_NUM_ENTRIES 1000
-# Need the shell to get the INDEX_PREFIX envirionment variable
+# Need the shell to get the INDEX_PREFIX environment variable
 ENTRYPOINT ["/bin/sh", "-c", "exec ServerMain -i \"/index/${INDEX_PREFIX}\" -j 8 -m ${MEMORY_FOR_QUERIES} -c ${CACHE_MAX_SIZE_GB} -e ${CACHE_MAX_SIZE_GB_SINGLE_ENTRY} -k ${CACHE_MAX_NUM_ENTRIES} -p 7001 \"$@\"", "--"]
 
 # Build image:  docker build -t qlever.master .

--- a/Dockerfiles/Dockerfile.Ubuntu18.04
+++ b/Dockerfiles/Dockerfile.Ubuntu18.04
@@ -49,7 +49,7 @@ ENV MEMORY_FOR_QUERIES 70
 ENV CACHE_MAX_SIZE_GB 30
 ENV CACHE_MAX_SIZE_GB_SINGLE_ENTRY 5
 ENV CACHE_MAX_NUM_ENTRIES 1000
-# Need the shell to get the INDEX_PREFIX envirionment variable
+# Need the shell to get the INDEX_PREFIX environment variable
 ENTRYPOINT ["/bin/sh", "-c", "exec ServerMain -i \"/index/${INDEX_PREFIX}\" -j 8 -m ${MEMORY_FOR_QUERIES} -c ${CACHE_MAX_SIZE_GB} -e ${CACHE_MAX_SIZE_GB_SINGLE_ENTRY} -k ${CACHE_MAX_NUM_ENTRIES} -p 7001 \"$@\"", "--"]
 
 # Build image:  docker build -t qlever.master .

--- a/Dockerfiles/Dockerfile.Ubuntu20.04
+++ b/Dockerfiles/Dockerfile.Ubuntu20.04
@@ -45,7 +45,7 @@ ENV MEMORY_FOR_QUERIES 70
 ENV CACHE_MAX_SIZE_GB 30
 ENV CACHE_MAX_SIZE_GB_SINGLE_ENTRY 5
 ENV CACHE_MAX_NUM_ENTRIES 1000
-# Need the shell to get the INDEX_PREFIX envirionment variable
+# Need the shell to get the INDEX_PREFIX environment variable
 ENTRYPOINT ["/bin/sh", "-c", "exec ServerMain -i \"/index/${INDEX_PREFIX}\" -j 8 -m ${MEMORY_FOR_QUERIES} -c ${CACHE_MAX_SIZE_GB} -e ${CACHE_MAX_SIZE_GB_SINGLE_ENTRY} -k ${CACHE_MAX_NUM_ENTRIES} -p 7001 \"$@\"", "--"]
 
 # Build image:  docker build -t qlever.master .

--- a/benchmark/BenchmarkExamples.cpp
+++ b/benchmark/BenchmarkExamples.cpp
@@ -62,7 +62,7 @@ class ConfigOptions : public BenchmarkInterface {
                          "allowed for the configuration option \"num-signs\".",
                          numSigns);
 
-    manager.addOption("coin-flip-try", "The number of succesful coin flips.",
+    manager.addOption("coin-flip-try", "The number of successful coin flips.",
                       &wonOnTryX_, {false, false, false, false, false});
 
     // Sub manager can be used to organize things better. They are basically
@@ -94,7 +94,7 @@ class BMSingleMeasurements : public ConfigOptions {
       exponentiate(number);
     });
     auto& multipleTimes = results.addMeasurement(
-        "Recursivly exponentiate multiple times", [&number, &exponentiate]() {
+        "Recursively exponentiate multiple times", [&number, &exponentiate]() {
           size_t toExponentiate = number;
           for (size_t i = 0; i < 10'000'000'000; i++) {
             toExponentiate = exponentiate(toExponentiate);

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -338,8 +338,8 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
 }
 
 /*
-The columns of the automatically generated benchmark tables contain the following
-information:
+The columns of the automatically generated benchmark tables contain the
+following information:
 - The parameter, that changes with every row.
 - Time needed for sorting `IdTable`s.
 - Time needed for merge/galloping join.
@@ -1931,7 +1931,8 @@ class BmSampleSizeRatio final : public GeneralInterfaceImplementation {
     generation of all other row entries.
     - The join column entries of the bigger table have a uniform distribution,
     are made up out of only the elements of the bigger tables and the generation
-    of one row entry is independent from the generation of all other row entries.
+    of one row entry is independent from the generation of all other row
+    entries.
     - The generation of join column entries in the smaller table is independent
     from the generation in the bigger table.
 

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -130,7 +130,7 @@ struct SetOfIdTableColumnElements {
 /*
 @brief Create an overlap between the join columns of the IdTables, by randomly
 choosing distinct elements from the join column of the smaller table and
-overiding all their occurrences in the join column with randomly choosen
+overriding all their occurrences in the join column with randomly chosen
 distinct elements from the join column of the bigger table.
 
 @param smallerTable The table, where distinct join column elements will be
@@ -167,7 +167,7 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
   // Collect and count the table elements.
   SetOfIdTableColumnElements biggerTableJoinColumnSet(biggerTableJoinColumnRef);
 
-  // Seeds for the random generators, so that things are less similiar.
+  // Seeds for the random generators, so that things are less similar.
   const std::array<ad_utility::RandomSeed, 2> seeds =
       createArrayOfRandomSeeds<2>(std::move(randomSeed));
 
@@ -229,7 +229,7 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
           Assign the value to itself.
           This is needed, because so we can indirectly track the first
           'encounter' with an distinct element in the smaller table and save
-          ressources.
+          resources.
           */
           smallerTableElementToNewElement.emplace(id, id);
         }
@@ -275,7 +275,7 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
   SetOfIdTableColumnElements smallerTableJoinColumnSet(
       smallerTableJoinColumnRef);
 
-  // Seeds for the random generators, so that things are less similiar.
+  // Seeds for the random generators, so that things are less similar.
   const std::array<ad_utility::RandomSeed, 2> seeds =
       createArrayOfRandomSeeds<2>(std::move(randomSeed));
 
@@ -304,7 +304,7 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
         const auto& biggerTableId{biggerTableJoinColumnSet.uniqueElements_.at(
             randomBiggerTableElement())};
 
-        // Skip this possibilty, if we have an overflow.
+        // Skip this possibility, if we have an overflow.
         size_t newMatches{
             smallerTableJoinColumnSet.numOccurrences_.at(smallerTableId)};
         if (const size_t numOccurencesBiggerTable{
@@ -338,12 +338,12 @@ static size_t createOverlapRandomly(IdTableAndJoinColumn* const smallerTable,
 }
 
 /*
-The columns of the automaticly generated benchmark tables contain the following
-informations:
+The columns of the automatically generated benchmark tables contain the following
+information:
 - The parameter, that changes with every row.
 - Time needed for sorting `IdTable`s.
 - Time needed for merge/galloping join.
-- Time needed for sorting and merge/galloping added togehter.
+- Time needed for sorting and merge/galloping added together.
 - Time needed for the hash join.
 - How many rows the result of joining the tables has.
 - How much faster the hash join is. For example: Two times faster.
@@ -390,7 +390,7 @@ concept exactlyOneGrowthFunction =
     ((growthFunction<Ts, size_t> || growthFunction<Ts, float>)+...) == 1;
 
 /*
-@brief Calculates the smalles whole exponent $n$, so that $base^n$ is equal, or
+@brief Calculates the smallest whole exponent $n$, so that $base^n$ is equal, or
 bigger, than the `startingPoint`.
 */
 template <std::convertible_to<double> T>
@@ -530,7 +530,7 @@ struct ConfigVariables {
   `IdTables` gets bigger with every row, while the other attributes stay the
   same.
   For the attributes, that don't stay the same, inclusive boundaries are
-  defined. Sometimes implicitely via other configuration option. (With the
+  defined. Sometimes implicitly via other configuration option. (With the
   exception of the sample size ratios for the special benchmarking class
   `BmSampleSizeRatio`.)
 
@@ -1107,7 +1107,7 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
   - Return values of the parameter, you gave a function for.
   - Time needed for sorting `IdTable`s.
   - Time needed for merge/galloping join.
-  - Time needed for sorting and merge/galloping added togehter.
+  - Time needed for sorting and merge/galloping added together.
   - Time needed for the hash join.
   - How many rows the result of joining the tables has.
   - How much faster the hash join is. For example: Two times faster.
@@ -1145,7 +1145,7 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
   to be exactly the same.
   @param randomSeed Seed for the random generators.
   @param smallerTableSorted, biggerTableSorted Should the bigger/smaller table
-  be sorted by his join column before being joined? More specificly, some
+  be sorted by his join column before being joined? More specifically, some
   join algorithm require one, or both, of the IdTables to be sorted. If this
   argument is false, the time needed for sorting the required table will
   added to the time of the join algorithm.
@@ -1200,7 +1200,7 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
     // Returns the first argument, that is a growth function.
     auto returnFirstGrowthFunction =
         [&isGrowthFunction]<typename... Ts>(Ts&... args) -> auto& {
-      // Put them into a tuple, so that we can easly look them up.
+      // Put them into a tuple, so that we can easily look them up.
       auto tup = std::tuple<Ts&...>{AD_FWD(args)...};
 
       // Get the index of the first growth function.
@@ -1479,7 +1479,7 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
                       biggerTableJoinColumnSampleSizeRatio)) -
         1;
 
-    // Seeds for the random generators, so that things are less similiar
+    // Seeds for the random generators, so that things are less similar
     // between the tables.
     const std::array<ad_utility::RandomSeed, 5> seeds =
         createArrayOfRandomSeeds<5>(std::move(randomSeed));
@@ -1891,7 +1891,7 @@ class BmSampleSizeRatio final : public GeneralInterfaceImplementation {
           "'max-memory' and 'bigger-table-num-columns'";
     } else {
       smallerTableNumRowsDescription =
-          "divison of 'max-bigger-table-rows' with 'min-ratio-rows'";
+          "division of 'max-bigger-table-rows' with 'min-ratio-rows'";
       smallerTableNumRowsConfigurationOptions = "'max-bigger-table-rows'";
     }
 
@@ -1918,7 +1918,7 @@ class BmSampleSizeRatio final : public GeneralInterfaceImplementation {
     };
 
     /*
-    Calculate the expexcted number of rows in the result for the simplified
+    Calculate the expected number of rows in the result for the simplified
     creation model of input tables join columns and overlaps, with the biggest
     sample size ratio used for both input tables. The simplified creation model
     assumes, that:
@@ -1927,12 +1927,12 @@ class BmSampleSizeRatio final : public GeneralInterfaceImplementation {
     overlaps are inserted later.
     - The join column entries of the smaller table have a uniform distribution,
     are made up out of the join column elements of both tables (smaller and
-    bigger) and the generation of one row entry is independet from the
+    bigger) and the generation of one row entry is independent from the
     generation of all other row entries.
     - The join column entries of the bigger table have a uniform distribution,
     are made up out of only the elements of the bigger tables and the generation
-    of one row entry is independet from the generation of all other row entries.
-    - The generation of join column entries in the smaller table is independet
+    of one row entry is independent from the generation of all other row entries.
+    - The generation of join column entries in the smaller table is independent
     from the generation in the bigger table.
 
     Note: In reality, the set of possible join column entries for the smaller
@@ -2155,7 +2155,7 @@ class BmSmallerTableGrowsBiggerTableRemainsSameSize final
   - Number of rows in the smaller table.
   - Time needed for sorting `IdTable`s.
   - Time needed for merge/galloping join.
-  - Time needed for sorting and merge/galloping added togehter.
+  - Time needed for sorting and merge/galloping added together.
   - Time needed for the hash join.
   - How many rows the result of joining the tables has.
   - How much faster the hash join is. For example: Two times faster.
@@ -2165,7 +2165,7 @@ class BmSmallerTableGrowsBiggerTableRemainsSameSize final
   @param tableDescriptor A identifier for the to be created benchmark table, so
   that it can be easier identified later.
   @param smallerTableSorted, biggerTableSorted Should the bigger/smaller table
-  be sorted by his join column before being joined? More specificly, some
+  be sorted by his join column before being joined? More specifically, some
   join algorithm require one, or both, of the IdTables to be sorted. If this
   argument is false, the time needed for sorting the required table will
   added to the time of the join algorithm.

--- a/benchmark/JoinAlgorithmBenchmark.cpp
+++ b/benchmark/JoinAlgorithmBenchmark.cpp
@@ -759,7 +759,7 @@ class GeneralInterfaceImplementation : public BenchmarkInterface {
     @brief The generated lambda returns true, iff if it is called with a value,
     that is bigger than the given minimum value
 
-    @param canBeEqual If true, the generated lamba also returns true, if the
+    @param canBeEqual If true, the generated lambda also returns true, if the
     values are equal.
     */
     auto generateBiggerEqualLambda = []<typename T>(const T& minimumValue,

--- a/benchmark/Usage.md
+++ b/benchmark/Usage.md
@@ -68,7 +68,7 @@ BenchmarkResults runAllBenchmarks(){
   /*
   Create an empty table with a number of rows and columns. Doesn't measure anything.
   The number of columns can not be changed after creation, but the number of rows can.
-  Important: The row names aren't saved in a seperate container, but INSIDE the
+  Important: The row names aren't saved in a separate container, but INSIDE the
   first column of the table.
   */
   auto& table = results.addTable(identifier, {"rowName1", "rowName2", "etc."},

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -98,7 +98,7 @@ class BenchmarkResults {
   }
 
   /*
-   * @brief Returns a vector of all the singe measurements.
+   * @brief Returns a vector of all the single measurements.
    */
   std::vector<ResultEntry> getSingleMeasurements() const;
 
@@ -185,7 +185,7 @@ class BenchmarkInterface {
   const ad_utility::ConfigManager& getConfigManager() const;
 
   /*
-  @brief Only used for manipulaton via the infrastructure. Is called directly
+  @brief Only used for manipulation via the infrastructure. Is called directly
   before `runAllBenchmarks`.
 
   Add/update the default metadata of the benchmark class. Currently
@@ -216,7 +216,7 @@ class BenchmarkRegister {
    *  implemented the `BenchmarkInterface`. Shouldn't take up much space
    *  and I couldn't find a better way of doing it.
    *
-   * @param benchmarkClasseInstance The memory managment of the passed
+   * @param benchmarkClasseInstance The memory management of the passed
    *  instances will be taken over by `BenchmarkRegister`.
    */
   explicit BenchmarkRegister(BenchmarkPointer&& benchmarkClasseInstance);
@@ -230,9 +230,9 @@ class BenchmarkRegister {
   /*
   @brief For each registered benchmark:
   - Update the default class metadata.
-  - Run the measurments.
+  - Run the measurements.
 
-  @return Every benchmark class get's measured with their own
+  @return Every benchmark class gets measured with their own
   `BenchmarkResults`. They should be in the same order as the registrations.
   */
   static std::vector<BenchmarkResults> runAllRegisteredBenchmarks();
@@ -247,7 +247,7 @@ class BenchmarkRegister {
 Macros for easier registering of benchmark classes.
 `declareRegisterVariable` and `declareRegisterVariableHidden` are needed for
 the implementation. Only `registerBenchmark` needs to be 'called', when one
-want's to register a benchmark class.
+wants to register a benchmark class.
 */
 #define AD_DECLARE_REGISTER_VARIABLE_HIDDEN(line, benchmarkClass, ...) \
   static BenchmarkRegister gRegisterVariable##benchmarkClass##line{    \

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -205,7 +205,7 @@ class BenchmarkRegister {
   using BenchmarkPointer = std::unique_ptr<BenchmarkInterface>;
 
   /*
-  Static vector of all registered benchmark classe instances.
+  Static vector of all registered benchmark class instances.
    */
   inline static std::vector<BenchmarkPointer> registeredBenchmarks{};
 

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -55,7 +55,7 @@ static void writeBenchmarkClassAndBenchmarkResultsToJsonFile(
   AD_CORRECTNESS_CHECK(benchmarkClassAndBenchmarkResultsAsJson.is_array());
 
   /*
-  Add the old json arry entries to the new json array entries, if a non empty
+  Add the old json array entries to the new json array entries, if a non empty
   file exists. Otherwise, we create/fill the file.
   */
   if (appendToJsonInFile && std::filesystem::exists(jsonFileName) &&
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
       "Writes the benchmarks as json to a json file, overriding the previous"
       " content of the file.")(
       "append,a",
-      "Causes the json option to append to the end of the json arry in the "
+      "Causes the json option to append to the end of the json array in the "
       "json file, if there is one, instead of overriding the previous content "
       "of "
       "the file.")(

--- a/benchmark/infrastructure/BenchmarkMain.cpp
+++ b/benchmark/infrastructure/BenchmarkMain.cpp
@@ -33,7 +33,7 @@ using namespace ad_benchmark;
 @brief Transform the given benchmark classes and corresponding results to
 json, and write them to the specified json file.
 
-@param benchmarkClassAndResults The benchmark classes togehter with their
+@param benchmarkClassAndResults The benchmark classes together with their
 results of running `runAllBenchmarks`.
 @param jsonFileName The name of the json file, where the json informationen
 should be written in.
@@ -107,7 +107,7 @@ static __attribute__((noreturn)) void printConfigurationOptionsAndExit() {
  * and prints their measured time in a fitting format.
  */
 int main(int argc, char** argv) {
-  // The filename, should the write option be choosen.
+  // The filename, should the write option be chosen.
   std::string writeFileName = "";
   // The short hand, for the benchmark configuration.
   std::string shortHandConfigurationString = "";
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
   po::store(po::parse_command_line(argc, argv, options), vm);
   po::notify(vm);
 
-  // If write was choosen, then the given file must be a json file.
+  // If write was chosen, then the given file must be a json file.
   if (vm.count("write") && !writeFileName.ends_with(".json")) {
     std::cerr << "The file defined via `--write` must be a `.json` file.\n";
     printUsageAndExit();
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
   Pairing the measured times up together with the the benchmark classes,
   that created them. Note: All the classes registered in `BenchmarkRegister`
   are always ran in the same order. So the benchmark class and benchmark
-  results are always at the same index position, and are grouped togehter
+  results are always at the same index position, and are grouped together
   correctly.
   */
   const auto& benchmarkClassAndResults{ad_utility::zipVectors(

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -163,11 +163,11 @@ void ResultTable::setEntry(const size_t& row, const size_t& column,
 
 // ____________________________________________________________________________
 ResultTable::operator std::string() const {
-  // Used for the formating of floats in the table. They will always be
-  // formated as having 4 values after the decimal point.
+  // Used for the formatting of floats in the table. They will always be
+  // formatted as having 4 values after the decimal point.
   static constexpr absl::string_view floatFormatSpecifier = "%.4f";
 
-  // What should be printed between columns. Used for nicer formating.
+  // What should be printed between columns. Used for nicer formatting.
   const std::string columnSeperator = " | ";
 
   // Convert an `EntryType` of `ResultTable` to a screen friendly
@@ -175,7 +175,7 @@ ResultTable::operator std::string() const {
   auto entryToStringVisitor = []<typename T>(const T& entry) {
     /*
     `EntryType` has multiple distinct possible types, that all need different
-    handeling. Fortunaly, we can decide the handeling at compile time and
+    handling. Fortunately, we can decide the handling at compile time and
     throw the others away, using `if constexpr(std::is_same<...,...>::value)`.
     */
     if constexpr (std::is_same_v<T, std::monostate>) {
@@ -276,11 +276,11 @@ ResultTable::operator std::string() const {
                         ad_utility::addIndentation(stream.str(), "    "));
   }
 
-  // For formating: What is the maximum string width of a column, if you
+  // For formatting: What is the maximum string width of a column, if you
   // compare all it's entries?
   std::vector<size_t> columnMaxStringWidth(numColumns(), 0);
   for (size_t column = 0; column < numColumns(); column++) {
-    // How long is the string representation of a colum entry in a wanted row?
+    // How long is the string representation of a column entry in a wanted row?
     auto stringWidthOfRow = std::views::transform(
         entries_, [&column, &entryToString](const std::vector<EntryType>& row) {
           return entryToString(row.at(column)).length();
@@ -317,7 +317,7 @@ ResultTable::operator std::string() const {
 
 // ____________________________________________________________________________
 void ResultTable::addRow() {
-  // Create an emptry row of the same size as every other row.
+  // Create an empty row of the same size as every other row.
   entries_.emplace_back(numColumns());
 }
 

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -271,7 +271,7 @@ class ResultTable : public BenchmarkMetadataGetter {
 
  private:
   /*
-  @brief Sets the member variables for the constructure functions.
+  @brief Sets the member variables for the constructor functions.
 
   @param descriptor A string to identify this instance in json format later.
   @param descriptorForLog A string to identify this instance in the log.

--- a/benchmark/infrastructure/BenchmarkMetadata.h
+++ b/benchmark/infrastructure/BenchmarkMetadata.h
@@ -13,7 +13,7 @@ namespace ad_benchmark {
  */
 class BenchmarkMetadata {
   // No real reason, to really build everything ourselves, when the
-  // nlohmann::ordered_json object already containes everything, that we could
+  // nlohmann::ordered_json object already contains everything, that we could
   // need.
   nlohmann::ordered_json data_;
 

--- a/benchmark/infrastructure/BenchmarkToJson.h
+++ b/benchmark/infrastructure/BenchmarkToJson.h
@@ -13,14 +13,14 @@
 
 namespace ad_benchmark {
 /*
- * @brief Create a nlohmann::ordered_json array with all relevant informations
- *  about the measurments taken by all the `BenchmarkResults`.
+ * @brief Create a nlohmann::ordered_json array with all relevant information
+ *  about the measurements taken by all the `BenchmarkResults`.
  */
 nlohmann::ordered_json benchmarkResultsToJson(
     const std::vector<BenchmarkResults>& results);
 
 /*
-@brief Create a nlohmann::ordered_json array with all relevant informations
+@brief Create a nlohmann::ordered_json array with all relevant information
 given by the pairs.
 */
 nlohmann::ordered_json zipBenchmarkClassAndBenchmarkResultsToJson(

--- a/benchmark/infrastructure/BenchmarkToString.cpp
+++ b/benchmark/infrastructure/BenchmarkToString.cpp
@@ -42,7 +42,7 @@ std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
 }
 
 /*
-@brief Return a string containing a titel version of `categoryName` and a string
+@brief Return a string containing a title version of `categoryName` and a string
 list representation of all the given category entries.
 Note: This function converts `CategoryType` objects by trying to cast them as
 `std::string`.
@@ -97,7 +97,7 @@ std::string benchmarkResultsToString(
     }
   };
 
-  // Visualization for single measurments, if there are any.
+  // Visualization for single measurements, if there are any.
   addNonEmptyCategoryToStringSteam("Single measurement benchmarks",
                                    results.getSingleMeasurements());
 

--- a/benchmark/infrastructure/BenchmarkToString.h
+++ b/benchmark/infrastructure/BenchmarkToString.h
@@ -36,7 +36,7 @@ std::string getMetadataPrettyString(const BenchmarkMetadata& meta,
                                     std::string_view suffix);
 
 /*
- * @brief Returns a formated string containing all the benchmark information.
+ * @brief Returns a formatted string containing all the benchmark information.
  */
 std::string benchmarkResultsToString(
     const BenchmarkInterface* const benchmarkClass,

--- a/benchmark/util/ResultTableColumnOperations.h
+++ b/benchmark/util/ResultTableColumnOperations.h
@@ -69,12 +69,12 @@ requires(sizeof...(ColumnInputTypes) > 1) void sumUpColumns(
 }
 
 /*
-@brief Reads two floating point columns, calculates the relativ speedup between
+@brief Reads two floating point columns, calculates the relative speedup between
 their entries and writes it in a third column.
 
 @param columnToCalculateFor, columnToCompareAgainst The columns, with which
 the question "How much faster than the entries of `columnToCompareAgainst`
-are the entires of `columnToCalculateFor`?".
+are the entries of `columnToCalculateFor`?".
 @param columnToPlaceResultIn This is where the speedup calculation results
 will be placed in.
 */

--- a/docs/quickstart.md.DEPRECATED
+++ b/docs/quickstart.md.DEPRECATED
@@ -37,7 +37,7 @@ for known issues such as problems with Docker on Mac.
 
 Then open [http://localhost:7001/](http://localhost:7001/) in your browser.
 
-For example, all female scientists occuring in the text corpus with the regex
+For example, all female scientists occurring in the text corpus with the regex
 "algo.*" can be obtained with the following query
 
     SELECT ?x TEXT(?t) SCORE(?t) WHERE {

--- a/docs/sparql_plus_text.md
+++ b/docs/sparql_plus_text.md
@@ -1,7 +1,7 @@
 # SPARQL+Text support in QLever
 
 QLever allows the combination of SPARQL and full-text search. The text input
-consists of text records, where passages of the text are annotated by entitites
+consists of text records, where passages of the text are annotated by entities
 from the RDF data. The format of the required input files is described below.
 In SPARQL+Text queries you can then specify co-occurrence of words from the text
 with entities from the RDF data. This is a very powerful concept: it contains

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -129,6 +129,6 @@ if [ $i -ge 60 ]; then
   exit 1
 fi
 
-echo "ServerMain was succesfully started, running queries ..."
+echo "ServerMain was successfully started, running queries ..."
 $PYTHON_BINARY "$PROJECT_DIR/e2e/queryit.py" "$PROJECT_DIR/e2e/scientists_queries.yaml" "http://localhost:9099" | tee "$BINARY_DIR/query_log.txt" || bail "Querying Server failed"
 popd

--- a/master.Makefile
+++ b/master.Makefile
@@ -17,7 +17,7 @@ SHELL = /bin/bash
 # clear-unpinned: Clear all unpinned results from the cache. This is exactly
 #                 what happens when clicking "Clear cache" in the QLever UI.
 #
-# show-all-ac-queries: Show the AC queries for subject, predicat, object for
+# show-all-ac-queries: Show the AC queries for subject, predicate, object for
 #                      copy&paste in the QLever UI backend settings.
 
 # This Makefile should be used as follows:
@@ -112,7 +112,7 @@ show-config-default:
 CAT_TTL = cat $(DB).ttl
 
 index:
-	@if ls $(DB).index.* 1> /dev/null 2>&1; then echo -e "\033[31mIndex exists, delete it first with make remove_index, which would exeucte the following:\033[0m"; echo; make -sn remove_index; echo; else \
+	@if ls $(DB).index.* 1> /dev/null 2>&1; then echo -e "\033[31mIndex exists, delete it first with make remove_index, which would execute the following:\033[0m"; echo; make -sn remove_index; echo; else \
 	time ( docker run -it --rm -v $(shell pwd):/index --entrypoint bash --name qlever.$(DB)-index $(DOCKER_IMAGE) -c "cd /index && $(CAT_TTL) | IndexBuilderMain -F ttl -f - -l -i $(DB) -K $(DB) $(TEXT_OPTIONS_INDEX) -s $(DB_BASE).settings.json | tee $(DB).index-log.txt"; rm -f $(DB)*tmp* ) \
 	fi
 

--- a/master.Makefile
+++ b/master.Makefile
@@ -8,7 +8,7 @@ SHELL = /bin/bash
 # This Makefile provides the following targets:
 #
 # pin: Pin queries to cache, so that all autocompletion queries are fast, even
-#      when "Clear cache" is clicked in the QLever UI (ther results for pinned 
+#      when "Clear cache" is clicked in the QLever UI (the results for pinned 
 #      queries will never be removed, unless ... see target clear).
 #
 # clear: Clear the cache completely (including pinned results). Note that this
@@ -57,7 +57,7 @@ CACHE_MAX_NUM_ENTRIES = 1000
 # The URL of the QLever backend.
 QLEVER_API = https://qlever.cs.uni-freiburg.de/api/$(SLUG)
 
-# The URL of the QLever UI istance ... TODO: it's confusing that this also has
+# The URL of the QLever UI instance ... TODO: it's confusing that this also has
 # /api/ in the name, it actually has nothing to do with the URLs from the QLever
 # backends (which are defined in the Apache configuration of QLever).
 WARMUP_API = $(subst /api/,/api/warmup/,$(QLEVER_API))

--- a/misc/multiplicity-problem.txt
+++ b/misc/multiplicity-problem.txt
@@ -38,7 +38,7 @@ this changes multiplicities from
 the join column is does not change in multiplicity, size and #distinct change equally:
 2/2=1
 the next column will also have the size lowered to 2, but the #distincts may or may not be lowered
-in the last column, the size is lowered ot 2 and the #distincts HAS to be lowered, either to 2 or possibly even to 1
+in the last column, the size is lowered to 2 and the #distincts HAS to be lowered, either to 2 or possibly even to 1
 
 what happen's in B:
 We keep every 500th row.

--- a/misc/query_planning_and_text.txt
+++ b/misc/query_planning_and_text.txt
@@ -4,7 +4,7 @@ IN-CONTEXT:
 
 The query planner creates a node for each triple and a scan for each node.
 This is not necessary for each in-context relation because several triples are worded in one operation.
-The only pyhsical scan for a relation is the scan of the wordlists.
+The only physical scan for a relation is the scan of the wordlists.
 Thus, only triples of the form in-context <WORDS> need a SCAN.
 Where WORDS can be literals, prefixes and also concrete entities.
 TODO: This will change when there is support for text without words.

--- a/misc/reduce_ram_and_startup_time.txt
+++ b/misc/reduce_ram_and_startup_time.txt
@@ -1,21 +1,21 @@
 1. We can reduce RAM and startup time by not keeping all meta data in RAM. In general, but especially for OXX and also SXX permutation.
 
 Downside:
-noticeable overhead for queries that are otherwise very fast (e.g. 1-5ms). We might end up with abotu as much overhead as well.
+noticeable overhead for queries that are otherwise very fast (e.g. 1-5ms). We might end up with about as much overhead as well.
 higher overhead for joins with ?s ?p ?o triples, because there a larger number metadata objects many have to be read.
 
 HOWTO:
 The meta-data structure has to change:
 BlockMetaData has to be moved to its own area on disk to make RelationMetaData objects fixed-size.
 This should not have much downsides but requires significant rewriting effort.
-From there, it should be rather striaghtforward and IndexMetaData->getRmd(...)
-will now do the reading and construction of meta data objects too. Since we use them throughout hte query planning a LRU cache may be useful once again.
+From there, it should be rather straightforward and IndexMetaData->getRmd(...)
+will now do the reading and construction of meta data objects too. Since we use them throughout the query planning a LRU cache may be useful once again.
 
 IS THERE AN EASIER WAY TO SAVE RAM?:
 What happens if i just skip all literals in OXX permutations?
 --> not possible because I still want to do ?x ?p "Albert Einstein"
 
-I could reduce usage of blocks even more, but there are already very few blocks in OXX permutations, the #obejct is simply so high.
+I could reduce usage of blocks even more, but there are already very few blocks in OXX permutations, the #object is simply so high.
 --> not useful
 
 I could try to decrease the ID size

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -72,7 +72,7 @@ class CartesianProductJoin : public Operation {
  protected:
   // Don't promise any sorting of the result.
   // TODO<joka921> Depending on the implementation we could propagate sorted
-  // columsn from either the first or the last input, but it is questionable if
+  // columns from either the first or the last input, but it is questionable if
   // there would be any real benefit from this and it would only increase the
   // complexity of the query planning and required testing.
   vector<ColumnIndex> resultSortedOn() const override { return {}; }
@@ -82,7 +82,7 @@ class CartesianProductJoin : public Operation {
   Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Copy each element from the `inputColumn` `groupSize` times to the
-  // `targetColumn`. Repeat until the `targetColumn` is copletely filled. Skip
+  // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip
   // the first `offset` write operations to the `targetColumn`. Call
   // `checkCancellation` after each write. If `StaticGroupSize != 0`, then the
   // group size is known at compile time which allows for more efficient loop

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -90,7 +90,7 @@ uint64_t CountAvailablePredicates::getSizeEstimateBeforeLimit() {
 size_t CountAvailablePredicates::getCostEstimate() {
   if (subtree_.get() != nullptr) {
     // Without knowing the ratio of elements that will have a pattern assuming
-    // constant cost per entry should be reasonable (altough non distinct
+    // constant cost per entry should be reasonable (although non distinct
     // entries are of course actually cheaper).
     return subtree_->getCostEstimate() + subtree_->getSizeEstimate();
   } else {

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -125,7 +125,7 @@ vector<ColumnIndex> GroupBy::computeSortColumns(
 // ____________________________________________________________________
 VariableToColumnMap GroupBy::computeVariableToColumnMap() const {
   VariableToColumnMap result;
-  // The returned columns are all groupByVariables followed by aggregrates.
+  // The returned columns are all groupByVariables followed by aggregates.
   const auto& subtreeVars = _subtree->getVariableColumns();
   size_t colIndex = 0;
   for (const auto& var : _groupByVariables) {

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -142,7 +142,7 @@ class GroupBy : public Operation {
   //   } GROUP BY ?y
   //
   // NOTE: This is exactly what we need for a context-sensitive object AC query
-  // without connected triples. The GROUP BY variable can also be ommitted in
+  // without connected triples. The GROUP BY variable can also be omitted in
   // the SELECT clause.
   bool computeGroupByObjectWithCount(IdTable* result);
 

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -81,7 +81,7 @@ class Join : public Operation {
    * @brief Joins IdTables a and b on join column jc2, returning
    * the result in dynRes. Creates a cross product for matching rows.
    *
-   * This should be a switch, which shoud decide which algorithm to use for
+   * This should be a switch, which should decide which algorithm to use for
    * joining two IdTables.
    * The possible algorithms should be:
    * - The normal merge join.
@@ -100,8 +100,8 @@ class Join : public Operation {
    * the result in dynRes. Creates a cross product for matching rows by putting
    * the smaller IdTable in a hash map and using that, to faster find the
    * matching rows.
-   * Needed to be a seperate function from the actual implementation, because
-   * compiler optimization keept inlining it, which make testing impossible,
+   * Needed to be a separate function from the actual implementation, because
+   * compiler optimization kept inlining it, which make testing impossible,
    * because you couldn't call the function after linking and just got
    * 'undefined reference' errors.
    *

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -14,9 +14,9 @@
 #include "global/Id.h"
 #include "parser/LiteralOrIri.h"
 
-// A class for maintaining a local vocabulary with contiguous (local) IDs. This is
-// meant for words that are not part of the normal vocabulary (constructed from
-// the input data at indexing time).
+// A class for maintaining a local vocabulary with contiguous (local) IDs. This
+// is meant for words that are not part of the normal vocabulary (constructed
+// from the input data at indexing time).
 //
 class LocalVocab {
  private:

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -14,7 +14,7 @@
 #include "global/Id.h"
 #include "parser/LiteralOrIri.h"
 
-// A class for maintaing a local vocabulary with contiguous (local) IDs. This is
+// A class for maintaining a local vocabulary with contiguous (local) IDs. This is
 // meant for words that are not part of the normal vocabulary (constructed from
 // the input data at indexing time).
 //

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -99,7 +99,7 @@ void Minus::computeMinus(
     const IdTable& dynA, const IdTable& dynB,
     const std::vector<std::array<ColumnIndex, 2>>& joinColumns,
     IdTable* dynResult) const {
-  // Substract dynB from dynA. The result should be all result mappings mu
+  // Subtract dynB from dynA. The result should be all result mappings mu
   // for which all result mappings mu' in dynB are not compatible (one value
   // for a variable defined in both differs) or the domain of mu and mu' are
   // disjoint (mu' defines no solution for any variables for which mu defines a

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<const Result> Operation::getResult(
   ad_utility::Timer timer{ad_utility::Timer::Started};
 
   if (isRoot) {
-    // Reset runtime info, tests may re-use Operation objects.
+    // Reset runtime info, tests may reuse Operation objects.
     _runtimeInfo = std::make_shared<RuntimeInformation>();
     // Start with an estimated runtime info which will be updated as we go.
     createRuntimeInfoFromEstimates(getRuntimeInfoPointer());
@@ -150,7 +150,7 @@ std::shared_ptr<const Result> Operation::getResult(
       // `QueryPlanner` does currently only set the limit for operations that
       // support it natively, except for operations in subqueries. This means
       // that a lot of the time the limit is only artificially applied during
-      // export, allowing the cache to re-use the same operation for different
+      // export, allowing the cache to reuse the same operation for different
       // limits and offsets.
       if (!supportsLimit()) {
         ad_utility::timer::Timer limitTimer{ad_utility::timer::Timer::Started};

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -216,7 +216,7 @@ std::shared_ptr<const Result> Operation::getResult(
     // Rethrow as QUERY_ABORTED allowing us to print the Operation
     // only at innermost failure of a recursive call
     throw ad_utility::AbortException(
-        "Unexpected expection that is not a subclass of std::exception");
+        "Unexpected exception that is not a subclass of std::exception");
   }
 }
 

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -259,7 +259,7 @@ class Operation {
   virtual Result computeResult(bool requestLaziness) = 0;
 
   // Create and store the complete runtime information for this operation after
-  // it has either been succesfully computed or read from the cache.
+  // it has either been successfully computed or read from the cache.
   virtual void updateRuntimeInformationOnSuccess(
       const ConcurrentLruCache::ResultAndCacheStatus& resultAndCacheStatus,
       Milliseconds duration) final;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1161,8 +1161,8 @@ void QueryPlanner::applyTextLimitsIfPossible(
       if (((plan._idsOfIncludedNodes &
             textLimit.idsOfMustBeFinishedOperations_) ^
            textLimit.idsOfMustBeFinishedOperations_) != 0) {
-        // Ther is still an operation that needs to be finished before this text
-        // limit can be applied
+        // There is still an operation that needs to be finished before this
+        // text limit can be applied
         i++;
         continue;
       }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1532,7 +1532,7 @@ bool QueryPlanner::TripleGraph::isSimilar(
     LOG(INFO) << asString() << std::endl;
     LOG(INFO) << other.asString() << std::endl;
     LOG(INFO) << "Two nodes in this graph were matches to the same node in "
-                 "the other grap"
+                 "the other graph"
               << std::endl;
     return false;
   }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -893,7 +893,7 @@ QueryPlanner::SubtreePlan QueryPlanner::getTextLeafPlan(
   if (node.triple_.p_._iri == CONTAINS_ENTITY_PREDICATE) {
     if (node._variables.size() == 2) {
       // TODO<joka921>: This is not nice, refactor the whole TripleGraph class
-      // to make these checks more explicity.
+      // to make these checks more explicitly.
       Variable evar = *(node._variables.begin()) == cvar
                           ? *(++node._variables.begin())
                           : *(node._variables.begin());

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -144,7 +144,7 @@ class QueryPlanner {
     size_t getSizeEstimate() const;
   };
 
-  // A helper class to find connected componenents of an RDF query using DFS.
+  // A helper class to find connected components of an RDF query using DFS.
   class QueryGraph {
    private:
     // A simple class to represent a graph node as well as some data for a DFS.

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -163,6 +163,6 @@ class Result {
   // Check that if the `varColMap` guarantees that a column is always defined
   // (i.e. that is contains no single undefined value) that there are indeed no
   // undefined values in the `_idTable` of this result. Return `true` iff the
-  // check is succesful.
+  // check is successful.
   bool checkDefinedness(const VariableToColumnMap& varColMap);
 };

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -330,7 +330,7 @@ Awaitable<void> Server::process(
     response = createJsonResponse(json, request);
   }
 
-  // Ping with or without messsage.
+  // Ping with or without message.
   if (urlPathAndParameters._path == "/ping") {
     if (auto msg = checkParameter("msg", std::nullopt)) {
       LOG(INFO) << "Alive check with message \"" << msg.value() << "\""
@@ -568,7 +568,7 @@ Awaitable<void> Server::sendStreamableResponse(
     // propagate it, and log it directly, so the code doesn't try to send
     // an HTTP response containing the error message onto a HTTP stream
     // that is already partially written. The only way to pass metadata
-    // after the beginning is by using the trailer mechanism as decribed
+    // after the beginning is by using the trailer mechanism as described
     // here:
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer#chunked_transfer_encoding_using_a_trailing_header
     // This won't be treated as an error by any regular HTTP client, so

--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -43,7 +43,7 @@ class SortPerformanceEstimator {
       size_t maxNumberOfElementsToSort);
 
   /// Set up the sort estimates. This will take some time. Only samples, that
-  /// can be allocated by the allocator and that have less thatn
+  /// can be allocated by the allocator and that have less than
   /// `maxNumberOfElementsToSort` elements will actually be measured.
   void computeEstimatesExpensively(
       const ad_utility::AllocatorWithLimit<Id>& allocator,

--- a/src/engine/SortPerformanceEstimator.h
+++ b/src/engine/SortPerformanceEstimator.h
@@ -61,7 +61,7 @@ class SortPerformanceEstimator {
   static constexpr size_t NUM_SAMPLES_COLS = sampleValuesCols.size();
   static constexpr size_t NUM_SAMPLES_ROWS = sampleValuesRows.size();
 
-  // The time in seconds for the samples that are sorted during initializtion.
+  // The time in seconds for the samples that are sorted during initialization.
   // _samples[i][j] is the measured time it takes to sort an IdTable with
   // sampleValuesRows[i] rows and sampleValuesCols[j] columns.
   // The values are default-initialized to 0.

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -20,7 +20,7 @@ struct TransitivePathSide {
   // Column of the sub table where the Ids of this side are located
   size_t subCol_;
   std::variant<Id, Variable> value_;
-  // The column in the ouput table where this side Ids are written to.
+  // The column in the output table where this side Ids are written to.
   // This member is set by the TransitivePath class
   size_t outputCol_ = 0;
 
@@ -270,7 +270,7 @@ class TransitivePathBase : public Operation {
 
   // Return a set of subtrees that can be used alternatively when the left or
   // right side is bound. This is used by the `TransitivePathBinSearch` class,
-  // which keeps both possible sortings of the predicate of which transitivity
+  // which keeps both possible sorting of the predicate of which transitivity
   // is computed.
   virtual std::span<const std::shared_ptr<QueryExecutionTree>>
   alternativeSubtrees() const {

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -270,8 +270,8 @@ class TransitivePathBase : public Operation {
 
   // Return a set of subtrees that can be used alternatively when the left or
   // right side is bound. This is used by the `TransitivePathBinSearch` class,
-  // which keeps both possible sorting of the predicate of which transitivity
-  // is computed.
+  // which has to store both ways to sort the subtree until it knows which side
+  // becomes bound.
   virtual std::span<const std::shared_ptr<QueryExecutionTree>>
   alternativeSubtrees() const {
     return {};

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -146,7 +146,8 @@ class TransitivePathImpl : public TransitivePathBase {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(
-          "This query might have to evaluate the empty path, which is currently "
+          "This query might have to evaluate the empty path, which is "
+          "currently "
           "not supported");
     }
     auto [startSide, targetSide] = decideDirection();

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -146,7 +146,7 @@ class TransitivePathImpl : public TransitivePathBase {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(
-          "This query might have to evalute the empty path, which is currently "
+          "This query might have to evaluate the empty path, which is currently "
           "not supported");
     }
     auto [startSide, targetSide] = decideDirection();

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -469,7 +469,7 @@ class CompressedExternalIdTable
   // exactly once.
   auto getRows() {
     if (!this->transformAndPushLastBlock()) {
-      // For the case of only a single block we have to mimick the exact same
+      // For the case of only a single block we have to mimic the exact same
       // return type as that of `writer_.getGeneratorForAllRows()`, that's why
       // there are the seemingly redundant multiple calls to
       // join(OwningView(vector(...))).
@@ -538,7 +538,7 @@ struct BlockSorter {
 #endif
   }
 };
-// Deduction guide for the implicit aggregate initializtion (its  "constructor")
+// Deduction guide for the implicit aggregate initialization (its  "constructor")
 // in the aggregate above. Is actually not needed in C++20, but GCC 11 requires
 // it.
 template <typename Comparator>

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -538,7 +538,7 @@ struct BlockSorter {
 #endif
   }
 };
-// Deduction guide for the implicit aggregate initialization (its  "constructor")
+// Deduction guide for the implicit aggregate initialization (its "constructor")
 // in the aggregate above. Is actually not needed in C++20, but GCC 11 requires
 // it.
 template <typename Comparator>

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -618,7 +618,7 @@ class IdTable {
   // first copies the sorted input completely, and then calls `std::unique`,
   // followed by `erase` at the end. `DISTINCT` should be implemented via an
   // out-of-place algorithm that only writes the distinct elements. The the
-  // follwing two functions can be deleted.
+  // following two functions can be deleted.
   void erase(const iterator& beginIt, const iterator& endIt) requires(!isView) {
     AD_EXPENSIVE_CHECK(begin() <= beginIt && beginIt <= endIt &&
                        endIt <= end());

--- a/src/engine/raw_thoughts.txt
+++ b/src/engine/raw_thoughts.txt
@@ -3,7 +3,7 @@ Thoughts on open TODOS:
 TODO: Evaluate filters as early as possible.
 - A filter with one variable is essentially another relation on that var.
 - A filter with two variables will be applied as soon as both nodes are collapsed
-Right now Filters with two varibales are implemented but they are processed in the end.
+Right now Filters with two variables are implemented but they are processed in the end.
 This is possibly not optimal. Think of:
 
 ?x mother ?m
@@ -78,7 +78,7 @@ FOR THE SIMPLE CASE
 
 ?x -- ?c [word]
 
-SOLUTION: no longer as weired semantics.
+SOLUTION: no longer as weird semantics.
 need to collapse the smallest subtrees behind the variable first,
 then use the words as extra info during the final consume.
 
@@ -131,7 +131,7 @@ PROBLEM3: Two different results. With co-occurring entity and without depending 
 I WANT:
 Due to problem3, I do NOT create execution trees for context nodes (easy to detect).
 Depending on the rest of the query graph / tree, there cannot be one optimal operation to compute the context node's result.
-When consuming a context node, into a higher up, I create a TEXT OEPRATION forEntity.
+When consuming a context node, into a higher up, I create a TEXT OPERATION forEntity.
 This will be a consumption of an <in-context> edge with target context-node.
 I will later add <has-context> relations that can also consume context nodes.
 Those will create a TEXT OPERATION forContexts and a context->document mapping (easy Broccoli style with ranges).

--- a/src/engine/sparqlExpressions/LangExpression.h
+++ b/src/engine/sparqlExpressions/LangExpression.h
@@ -28,8 +28,8 @@ class LangExpression : public SparqlExpression {
 
   // The following methods are required for the virtual interface of
   // `SparqlExpression`, but they will always fail at runtime when executed. All
-  // occurrences of `LanguageExpression` should be detected and dealt with by the
-  // parser before any of these methods is ever called.
+  // occurrences of `LanguageExpression` should be detected and dealt with by
+  // the parser before any of these methods is ever called.
   ExpressionResult evaluate(EvaluationContext*) const override { AD_FAIL(); }
 
   std::string getCacheKey(const VariableToColumnMap&) const override {

--- a/src/engine/sparqlExpressions/LangExpression.h
+++ b/src/engine/sparqlExpressions/LangExpression.h
@@ -28,7 +28,7 @@ class LangExpression : public SparqlExpression {
 
   // The following methods are required for the virtual interface of
   // `SparqlExpression`, but they will always fail at runtime when executed. All
-  // occurences of `LanguageExpression` should be detected and dealt with by the
+  // occurrences of `LanguageExpression` should be detected and dealt with by the
   // parser before any of these methods is ever called.
   ExpressionResult evaluate(EvaluationContext*) const override { AD_FAIL(); }
 

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -65,7 +65,7 @@ class RegexExpression : public SparqlExpression {
 namespace detail {
 // Check if `regex` is a prefix regex which means that it starts with `^` and
 // contains no other "special" regex characters like `*` or `.`. If this check
-// suceeds, the prefix is returned without the leading `^` and with all escaping
+// succeeds, the prefix is returned without the leading `^` and with all escaping
 // undone. Else, `std::nullopt` is returned.
 std::optional<std::string> getPrefixRegex(std::string regex);
 }  // namespace detail

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -65,8 +65,8 @@ class RegexExpression : public SparqlExpression {
 namespace detail {
 // Check if `regex` is a prefix regex which means that it starts with `^` and
 // contains no other "special" regex characters like `*` or `.`. If this check
-// succeeds, the prefix is returned without the leading `^` and with all escaping
-// undone. Else, `std::nullopt` is returned.
+// succeeds, the prefix is returned without the leading `^` and with all
+// escaping undone. Else, `std::nullopt` is returned.
 std::optional<std::string> getPrefixRegex(std::string regex);
 }  // namespace detail
 }  // namespace sparqlExpression

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -125,7 +125,7 @@ class ValueId {
   // NOTE: (Also for the operator<=> below: These comparisons only work
   // correctly if we only store entries in the local vocab that are NOT part of
   // the vocabulary. This is currently not true for expression results from
-  // GROUP BY and BIND operations (for performance reaons). So a join with such
+  // GROUP BY and BIND operations (for performance reasons). So a join with such
   // results will currently lead to wrong results.
   constexpr bool operator==(const ValueId& other) const {
     if (getDatatype() == Datatype::LocalVocabIndex &&

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -522,7 +522,7 @@ class CompressedRelationReader {
   // Get the first and the last triple that the result of a `scan` with the
   // given arguments would lead to. Throw an exception if the scan result would
   // be empty. This function is used to more efficiently filter the blocks of
-  // index scans between joining them to get better estimates for the begginning
+  // index scans between joining them to get better estimates for the beginning
   // and end of incomplete blocks.
   MetadataAndBlocks::FirstAndLastTriple getFirstAndLastTriple(
       const MetadataAndBlocks& metadataAndBlocks) const;

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -39,7 +39,7 @@ inline std::atomic<size_t> BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP = 50'000;
 // before they are written to the output.
 inline std::atomic<size_t> BATCH_SIZE_VOCABULARY_MERGE = 10'000'000;
 
-// When the BZIP2 parser encouters a parsing exception it will increase its
+// When the BZIP2 parser encounters a parsing exception it will increase its
 // buffer and try again (we have no other way currently to determine if the
 // exception was "real" or only because we cut a statement in the middle. Once
 // it holds this many bytes in total, it will assume that there was indeed an
@@ -82,7 +82,7 @@ constexpr size_t QUEUE_SIZE_BEFORE_PARALLEL_PARSING = 10;
 constexpr size_t QUEUE_SIZE_AFTER_PARALLEL_PARSING = 10;
 
 // The blocksize parameter of the parallel vocabulary merging. Higher values
-// mean higher memory consumption, wherease a too low value will impact the
+// mean higher memory consumption, whereas a too low value will impact the
 // performance negatively.
 static constexpr size_t BLOCKSIZE_VOCABULARY_MERGING = 100;
 

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -134,8 +134,8 @@ class Index {
 
   [[nodiscard]] const CompactVectorOfStrings<Id>& getPatterns() const;
   /**
-   * @return The multiplicity of the entities column (0) of the full has-relation
-   *         relation after unrolling the patterns.
+   * @return The multiplicity of the entities column (0) of the full
+   * has-relation relation after unrolling the patterns.
    */
   [[nodiscard]] double getAvgNumDistinctPredicatesPerSubject() const;
 

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -134,7 +134,7 @@ class Index {
 
   [[nodiscard]] const CompactVectorOfStrings<Id>& getPatterns() const;
   /**
-   * @return The multiplicity of the entites column (0) of the full has-relation
+   * @return The multiplicity of the entities column (0) of the full has-relation
    *         relation after unrolling the patterns.
    */
   [[nodiscard]] double getAvgNumDistinctPredicatesPerSubject() const;

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -56,8 +56,8 @@ cppcoro::generator<ContextFileParser::Line> IndexImpl::wordsInTextRecords(
       contextId = contextId.incremented();
     }
   }
-  // ROUND 2: Optionally, consider each literal from the internal vocabulary as a
-  // text record.
+  // ROUND 2: Optionally, consider each literal from the internal vocabulary as
+  // a text record.
   if (addWordsFromLiterals) {
     for (VocabIndex index = VocabIndex::make(0); index.get() < vocab_.size();
          index = index.incremented()) {

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -25,7 +25,7 @@ namespace {
 
 // Custom delimiter class for tokenization of literals using `absl::StrSplit`.
 // The `Find` function returns the next delimiter in `text` after the given
-// `pos` or an empty subtring if there is no next delimiter.
+// `pos` or an empty substring if there is no next delimiter.
 struct LiteralsTokenizationDelimiter {
   absl::string_view Find(absl::string_view text, size_t pos) {
     auto isWordChar = [](char c) -> bool { return std::isalnum(c); };

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -56,7 +56,7 @@ cppcoro::generator<ContextFileParser::Line> IndexImpl::wordsInTextRecords(
       contextId = contextId.incremented();
     }
   }
-  // ROUND 2: Optionally, consider each literal from the interal vocabulary as a
+  // ROUND 2: Optionally, consider each literal from the internal vocabulary as a
   // text record.
   if (addWordsFromLiterals) {
     for (VocabIndex index = VocabIndex::make(0); index.get() < vocab_.size();

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1418,7 +1418,7 @@ namespace {
 // Return a lambda that is called repeatedly with triples that are sorted by the
 // `idx`-th column and counts the number of distinct entities that occur in a
 // triple where none of the elements fulfills the `isQleverInternalId`
-// predicate. This is used to cound the number of distinct subjects, objects,
+// predicate. This is used to count the number of distinct subjects, objects,
 // and predicates during the index building.
 template <size_t idx>
 auto makeNumDistinctIdsCounter =

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -33,7 +33,7 @@
 using std::array;
 using namespace ad_utility::memory_literals;
 
-// During the index building we typically have two permutation sortings present
+// During the index building we typically have two permutation sorting present
 // at the same time, as we directly push the triples from the first sorting to
 // the second sorting. We therefore have to adjust the amount of memory per
 // external sorter.
@@ -152,7 +152,7 @@ std::unique_ptr<ExternalSorter<SortByPSO, 5>> IndexImpl::buildOspWithPatterns(
   // the additional permutation.
   hasPatternPredicateSortedByPSO->moveResultOnMerge() = false;
   // The column with index 1 always is `has-predicate` and is not needed here.
-  // Note that the order of the columns during index building  is alwasy `SPO`,
+  // Note that the order of the columns during index building  is always `SPO`,
   // but the sorting might be different (PSO in this case).
   auto lazyPatternScan = lazyScanWithPermutedColumns(
       hasPatternPredicateSortedByPSO, std::array<ColumnIndex, 2>{0, 2});

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -33,10 +33,10 @@
 using std::array;
 using namespace ad_utility::memory_literals;
 
-// During the index building we typically have two permutation sorting present
-// at the same time, as we directly push the triples from the first sorting to
-// the second sorting. We therefore have to adjust the amount of memory per
-// external sorter.
+// During the index building we typically have two permutations present at the
+// same time, as we directly push the triples from the first sorting to the
+// second sorting. We therefore have to adjust the amount of memory per external
+// sorter.
 static constexpr size_t NUM_EXTERNAL_SORTERS_AT_SAME_TIME = 2u;
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -272,8 +272,8 @@ class IndexImpl {
 
   const CompactVectorOfStrings<Id>& getPatterns() const;
   /**
-   * @return The multiplicity of the Entities column (0) of the full has-relation
-   *         relation after unrolling the patterns.
+   * @return The multiplicity of the Entities column (0) of the full
+   * has-relation relation after unrolling the patterns.
    */
   double getAvgNumDistinctPredicatesPerSubject() const;
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -272,7 +272,7 @@ class IndexImpl {
 
   const CompactVectorOfStrings<Id>& getPatterns() const;
   /**
-   * @return The multiplicity of the Entites column (0) of the full has-relation
+   * @return The multiplicity of the Entities column (0) of the full has-relation
    *         relation after unrolling the patterns.
    */
   double getAvgNumDistinctPredicatesPerSubject() const;
@@ -611,7 +611,7 @@ class IndexImpl {
  private:
   /**
    * @brief Throws an exception if no patterns are loaded. Should be called from
-   *        whithin any index method that returns data requiring the patterns
+   *        within any index method that returns data requiring the patterns
    *        file.
    */
   void throwExceptionIfNoPatterns() const;

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -110,8 +110,8 @@ class IndexMetaData {
 
   // `isPersistentMetaData` is true when we do not need to add relation meta
   // data to data_, but assume that it is already contained in data_. This must
-  // be a compile time parameter because we have to avoid instantiation of member
-  // function set() when `MapType` is read only  (e.g., when based on
+  // be a compile time parameter because we have to avoid instantiation of
+  // member function set() when `MapType` is read only  (e.g., when based on
   // MmapVectorView).
   template <bool isPersistentMetaData = false>
   void add(AddType addedValue);

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -110,7 +110,7 @@ class IndexMetaData {
 
   // `isPersistentMetaData` is true when we do not need to add relation meta
   // data to data_, but assume that it is already contained in data_. This must
-  // be a compile time parameter because we have to avoid instantation of member
+  // be a compile time parameter because we have to avoid instantiation of member
   // function set() when `MapType` is read only  (e.g., when based on
   // MmapVectorView).
   template <bool isPersistentMetaData = false>
@@ -132,7 +132,7 @@ class IndexMetaData {
     static const bool value = std::is_same<MetaWrapperMmap, T>::value ||
                               std::is_same<MetaWrapperMmapView, T>::value;
   };
-  // Compile time information whether this instatiation if MMapBased or not
+  // Compile time information whether this instantiation if MMapBased or not
   static constexpr bool isMmapBased_ = IsMmapBased<MapType>::value;
 
   // This magic number is written when serializing the IndexMetaData to a file.

--- a/src/index/MetaDataHandler.h
+++ b/src/index/MetaDataHandler.h
@@ -68,7 +68,7 @@ class MetaDataWrapperDense {
   MetaDataWrapperDense& operator=(MetaDataWrapperDense<M>&& other) = default;
 
   // Templated setup version
-  // Arguments are passsed through to template argument M.
+  // Arguments are passed through to template argument M.
   // TODO<joka921>: enable_if  for better error messages
   template <typename... Args>
   void setup(Args... args) {

--- a/src/index/PatternCreator.h
+++ b/src/index/PatternCreator.h
@@ -111,8 +111,8 @@ class PatternCreator {
   ad_utility::BufferedVector<TripleAndIsInternal> tripleBuffer_;
   TripleSorter tripleSorter_;
 
-  // The predicates which have already occurred in one of the patterns. Needed to
-  // count the number of distinct predicates.
+  // The predicates which have already occurred in one of the patterns. Needed
+  // to count the number of distinct predicates.
   ad_utility::HashSet<Pattern::value_type> distinctPredicates_;
 
   // The number of distinct subjects and distinct subject-predicate pairs.

--- a/src/index/PatternCreator.h
+++ b/src/index/PatternCreator.h
@@ -111,7 +111,7 @@ class PatternCreator {
   ad_utility::BufferedVector<TripleAndIsInternal> tripleBuffer_;
   TripleSorter tripleSorter_;
 
-  // The predicates which have already occured in one of the patterns. Needed to
+  // The predicates which have already occurred in one of the patterns. Needed to
   // count the number of distinct predicates.
   ad_utility::HashSet<Pattern::value_type> distinctPredicates_;
 

--- a/src/index/PrefixHeuristic.cpp
+++ b/src/index/PrefixHeuristic.cpp
@@ -84,7 +84,7 @@ TreeNode* TreeNode::insert(string_view value) {
 
 // ___________________________________________________________________________
 std::pair<size_t, TreeNode*> TreeNode::getMaximum(size_t codelength) {
-  // _sharedCount = _ownCount + sum over children's _sharedCount
+  // _sharedCount = _ownCount + sum over childrens' _sharedCount
   _sharedCount = _ownCount;
 
   // get Maximum score and node from all the children
@@ -118,7 +118,7 @@ std::pair<size_t, TreeNode*> TreeNode::getMaximum(size_t codelength) {
 
   _score = _sharedCount * relevantLength;
 
-  // Check if our own score is greater than any of the children
+  // Check if our own score is greater than the score any of the childrens'
   // we choose >= so we get a valid pointer when there is only the root with
   // score 0 left.
   if (_score >= maxScore) {

--- a/src/index/PrefixHeuristic.cpp
+++ b/src/index/PrefixHeuristic.cpp
@@ -118,7 +118,7 @@ std::pair<size_t, TreeNode*> TreeNode::getMaximum(size_t codelength) {
 
   _score = _sharedCount * relevantLength;
 
-  // Check if our own score is greater than any of the childrens
+  // Check if our own score is greater than any of the children
   // we choose >= so we get a valid pointer when there is only the root with
   // score 0 left.
   if (_score >= maxScore) {

--- a/src/index/PrefixHeuristic.cpp
+++ b/src/index/PrefixHeuristic.cpp
@@ -84,7 +84,7 @@ TreeNode* TreeNode::insert(string_view value) {
 
 // ___________________________________________________________________________
 std::pair<size_t, TreeNode*> TreeNode::getMaximum(size_t codelength) {
-  // _sharedCount = _ownCount + sum over childrens _sharedCount
+  // _sharedCount = _ownCount + sum over children's _sharedCount
   _sharedCount = _ownCount;
 
   // get Maximum score and node from all the children

--- a/src/index/PrefixHeuristic.h
+++ b/src/index/PrefixHeuristic.h
@@ -21,7 +21,7 @@
 //                            be added to every word, no matter if it is
 //                            actually compressed. (This is true for the
 //                            vocabulary in QLever). The Algorithm has to know
-//                            this in order to chosse the correct prefixes.
+//                            this in order to choose the correct prefixes.
 //
 // Returns:   Vector of suitable prefixes which have been selected by the
 //            algorithm

--- a/src/index/vocabulary/CombinedVocabulary.h
+++ b/src/index/vocabulary/CombinedVocabulary.h
@@ -136,7 +136,7 @@ class CombinedVocabulary {
   }
 
   // Return a global ID (sometimes just an index) that is the largest global ID
-  // occuring in either of the underlying vocabularies plus 1. This ID can be
+  // occurring in either of the underlying vocabularies plus 1. This ID can be
   // used as the "end" ID to indicate "not found".
   [[nodiscard]] uint64_t getEndIndex() const {
     uint64_t endA = _firstVocab.size() == 0

--- a/src/parser/ParallelBuffer.h
+++ b/src/parser/ParallelBuffer.h
@@ -39,7 +39,7 @@ class ParallelBuffer {
    */
   virtual void open(const string& filename) = 0;
   /**
-   * @brief Get (approximately) the next blocksize_ bytes from the inut stream.
+   * @brief Get (approximately) the next blocksize_ bytes from the input stream.
    *
    * Only valid after a call to open().
    *

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -292,7 +292,7 @@ void ParsedQuery::GraphPattern::addLanguageFilter(const Variable& variable,
     // If necessary create an empty `BasicGraphPattern` at the end to which we
     // can append a triple.
     // TODO<joka921> It might be beneficial to place this triple not at the
-    // end but close to other occurences of `variable`.
+    // end but close to other occurrences of `variable`.
     if (_graphPatterns.empty() ||
         !std::holds_alternative<parsedQuery::BasicGraphPattern>(
             _graphPatterns.back())) {

--- a/src/parser/SelectClause.cpp
+++ b/src/parser/SelectClause.cpp
@@ -103,6 +103,6 @@ void SelectClause::deleteAliasesButKeepVariables() {
   }
   auto& varsAndAliases = std::get<VarsAndAliases>(varsAndAliasesOrAsterisk_);
   // The variables that the aliases are bound to have previously been stored
-  // seperately in `varsAndAliases.vars_`, so we can simply delete the aliases.
+  // separately in `varsAndAliases.vars_`, so we can simply delete the aliases.
   varsAndAliases.aliases_.clear();
 }

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -211,7 +211,7 @@ struct SkipWhitespaceAndCommentsMixin {
   void skipWhitespaceAndComments() {
     // Call `skipWhitespace` and `skipComments` in a loop until no more input
     // was consumed. This is necessary because we might have multiple lines of
-    // comments that are spearated by whitespace.
+    // comments that are separated by whitespace.
     while (true) {
       bool a = skipWhitespace();
       bool b = skipComments();

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -330,10 +330,10 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
   }
 
   /*
-   * The helper struct used for the intenal apply function
+   * The helper struct used for the internal apply function
    * Its static function process<regex>(string_view)
    * tries to match a prefix of the string_view with the regex and returns
-   * <true, matchContent> on sucess and <false, emptyStringView> on failure
+   * <true, matchContent> on success and <false, emptyStringView> on failure
    */
   struct Matcher {
     template <auto& regex>

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -734,7 +734,7 @@ bool TurtleStreamParser<T>::getLine(TurtleTriple* triple) {
            !isParserExhausted_) {
       bool parsedStatement;
       std::optional<ParseException> ex;
-      // If this buffer reads from an mapped file, then exceptions are
+      // If this buffer reads from a memory-mapped file, then exceptions are
       // immediately rethrown. If we are reading from a stream in chunks of
       // bytes, we can try again with a larger buffer.
       try {

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -697,7 +697,7 @@ bool TurtleStreamParser<T>::resetStateAndRead(
   byteVec_ = std::move(buf);
   tok_.reset(byteVec_.data(), byteVec_.size());
 
-  LOG(TRACE) << "Succesfully decompressed next batch of " << nextBytes.size()
+  LOG(TRACE) << "Successfully decompressed next batch of " << nextBytes.size()
              << " << bytes to parser\n";
 
   // repair the backup state, its pointers might have changed due to
@@ -734,7 +734,7 @@ bool TurtleStreamParser<T>::getLine(TurtleTriple* triple) {
            !isParserExhausted_) {
       bool parsedStatement;
       std::optional<ParseException> ex;
-      // If this buffer reads from an mmaped file, then exceptions are
+      // If this buffer reads from an mapped file, then exceptions are
       // immediately rethrown. If we are reading from a stream in chunks of
       // bytes, we can try again with a larger buffer.
       try {
@@ -751,7 +751,7 @@ bool TurtleStreamParser<T>::getLine(TurtleTriple* triple) {
         // try to parse with a larger buffer and repeat the reading process
         // (maybe the failure was due to statements crossing our block).
         if (resetStateAndRead(&b)) {
-          // we have succesfully extended our buffer
+          // we have successfully extended our buffer
           if (byteVec_.size() > BZIP2_MAX_TOTAL_BUFFER_SIZE) {
             auto d = tok_.view();
             LOG(ERROR) << "Could not parse " << PARSER_MIN_TRIPLES_AT_ONCE

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1109,7 +1109,7 @@ vector<Visitor::ExpressionPtr> Visitor::visit(Parser::ArgListContext* ctx) {
   if (ctx->NIL()) {
     return std::vector<ExpressionPtr>{};
   }
-  // The grammar allows an optional DISTICT before the argument list (the
+  // The grammar allows an optional DISTINCT before the argument list (the
   // whole list, not the individual arguments), but we currently don't support
   // it.
   if (ctx->DISTINCT()) {

--- a/src/util/AsyncStream.h
+++ b/src/util/AsyncStream.h
@@ -45,8 +45,8 @@ cppcoro::generator<typename Range::value_type> runStreamAsync(
     queue.finish();
   }};
 
-  // Only rethrow an exception from the `thread` if no exception occurred in this
-  // thread to avoid crashes because of multiple active exceptions.
+  // Only rethrow an exception from the `thread` if no exception occurred in
+  // this thread to avoid crashes because of multiple active exceptions.
   auto cleanup = ad_utility::makeOnDestructionDontThrowDuringStackUnwinding(
       [&queue, &thread, &exception] {
         queue.finish();

--- a/src/util/AsyncStream.h
+++ b/src/util/AsyncStream.h
@@ -45,7 +45,7 @@ cppcoro::generator<typename Range::value_type> runStreamAsync(
     queue.finish();
   }};
 
-  // Only rethrow an exception from the `thread` if no exception occured in this
+  // Only rethrow an exception from the `thread` if no exception occurred in this
   // thread to avoid crashes because of multiple active exceptions.
   auto cleanup = ad_utility::makeOnDestructionDontThrowDuringStackUnwinding(
       [&queue, &thread, &exception] {

--- a/src/util/Cache.h
+++ b/src/util/Cache.h
@@ -478,7 +478,7 @@ class TreeBasedLRUCache
 };
 
 /// typedef for the simple name LRUCache that is fixed to one of the possible
-/// implementations at compiletime
+/// implementations at compile time
 #ifdef _QLEVER_USE_TREE_BASED_CACHE
 template <typename Key, typename Value, ValueSizeGetter<Value> ValueSizeGetter>
 using LRUCache = TreeBasedLRUCache<Key, Value, ValueSizeGetter>;

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -64,7 +64,7 @@ AD_ALWAYS_INLINE constexpr bool isCancelled(
 
 /// Helper struct to allow to conditionally compile fields into a class.
 struct Empty {
-  // Ignore potential assigment
+  // Ignore potential assignment
   template <typename... Args>
   explicit Empty(const Args&...) {}
 };

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -298,7 +298,7 @@ std::string ConfigManager::createJsonPointerString(
   std::ostringstream pointerString;
 
   // We don't use a `lazyStrJoin` here, so that an empty `keys` produces an
-  // emptry string.
+  // empty string.
   std::ranges::for_each(
       keys, [&escapeSpecialCharacters, &pointerString](std::string_view key) {
         pointerString << "/" << escapeSpecialCharacters(key);
@@ -386,7 +386,7 @@ void ConfigManager::verifyPath(const std::vector<std::string>& path) const {
           `some/options/optionA` in json pointer terms, but in string terms,
           because `"option"` is a prefix of `"options"`.
 
-          This can be fixed, by adding the seperator `/` at the end of both
+          This can be fixed, by adding the separator `/` at the end of both
           string representation. Because the symbol `/` is not allowed in
           `xi`, for `any i in [0, N]`, but must be between them, it forces all
           the `xi` and `yi` to be equal.

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -44,7 +44,7 @@ class ConfigManager {
   Our hash map always saves either a configuration option, or a sub manager
   (another `ConfigManager`).
 
-  This class makes the handeling more explicit and allows for more information
+  This class makes the handling more explicit and allows for more information
   to be saved alongside the configuration options and sub managers.
   For example: The order, in which they were created.
   */
@@ -285,13 +285,13 @@ class ConfigManager {
 
   /*
   @brief Returns a string containing a json configuration and, optionally, the
-  string representations of all added configuration options, togehter with the
+  string representations of all added configuration options, together with the
   validator invariants.
 
   @param detailed Iff false, only print the json configuration. Otherwise, print
   the json configuration, followed by the string representations of all added
   configuration options, which contain more detailed information about the
-  configuration options, togehter with the validator invariants
+  configuration options, together with the validator invariants
   */
   std::string printConfigurationDoc(bool detailed) const;
 
@@ -552,7 +552,7 @@ class ConfigManager {
     /*
     We can't just create a `ConfigOption` variable, pass it and return it,
     because the hash map has ownership of the newly added `ConfigOption`.
-    Which was transfered via creating a new internal `ConfigOption` with move
+    Which was transferred via creating a new internal `ConfigOption` with move
     constructors.
     Which would mean, that our local `ConfigOption` isn't the `ConfigOption` we
     want to return a reference to.

--- a/src/util/ConfigManager/ConfigManager.h
+++ b/src/util/ConfigManager/ConfigManager.h
@@ -309,7 +309,7 @@ class ConfigManager {
   get thrown, if the `validatorFunction` returns false.
   @param validatorDescriptor A description of the invariant, that
   `validatorFunction` imposes.
-  @param configOptionsToBeChecked Proxies for the configuration options, whos
+  @param configOptionsToBeChecked Proxies for the configuration options, whose
   values will be passed to the validator function as function arguments. Will
   keep the same order.
   */

--- a/src/util/ConfigManager/ConfigOption.cpp
+++ b/src/util/ConfigManager/ConfigOption.cpp
@@ -70,7 +70,7 @@ bool ConfigOption::wasSet() const {
 void ConfigOption::setValueWithJson(const nlohmann::json& json) {
   // TODO<C++23> Use "deducing this" for simpler recursive lambdas.
   /*
-  Manually checks, if the json represents one of the possibilites of
+  Manually checks, if the json represents one of the possibilities of
   `AvailableTypes`.
   */
   auto isValueTypeSubType = []<typename T>(const nlohmann::json& j,

--- a/src/util/ConfigManager/ConfigOption.h
+++ b/src/util/ConfigManager/ConfigOption.h
@@ -42,7 +42,7 @@ class ConfigOption {
 
  private:
   /*
-  Holds the type dependant data of the class, because the class is not a
+  Holds the type dependent data of the class, because the class is not a
   templated class, but sometimes behaves like one.
   */
   template <typename T>

--- a/src/util/ConfigManager/Validator.h
+++ b/src/util/ConfigManager/Validator.h
@@ -30,7 +30,7 @@ concept ValidatorFunction =
     RegularInvocableWithSimilarReturnType<Func, bool, const ParameterTypes&...>;
 
 // Simple struct, that holds an error message. For use as the return type of
-// invocable object, that fullfill `ExceptionValidator`.
+// invocable object, that fulfill `ExceptionValidator`.
 struct ErrorMessage {
  private:
   std::string message_;

--- a/src/util/ConfigManager/Validator.h
+++ b/src/util/ConfigManager/Validator.h
@@ -100,7 +100,7 @@ class ConfigOptionValidatorManager {
   */
   std::function<void(void)> wrappedValidatorFunction_;
 
-  // A descripton of the invariant, this validator imposes.
+  // A description of the invariant, this validator imposes.
   std::string descriptor_;
 
   // Pointer to the `configOption`, that will be checked.

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -18,7 +18,7 @@ namespace ad_utility {
 // Compute `base ^ exponent` where `^` denotes exponentiation. This is consteval
 // because for all runtime calls, a better optimized algorithm from the standard
 // library should be chosen.
-// TODO<joka921> why can't this be consteval when the result is boudn to a
+// TODO<joka921> why can't this be consteval when the result is bound to a
 // `constexpr` variable?
 constexpr auto pow(auto base, int exponent) {
   if (exponent < 0) {

--- a/src/util/CopyableUniquePtr.h
+++ b/src/util/CopyableUniquePtr.h
@@ -14,8 +14,8 @@
 namespace ad_utility {
 
 /*
-A version of `std::unique_ptr` with a copy assigment operator and a copy
-constructor, which both copy the dereferenced pointer to create a new instace
+A version of `std::unique_ptr` with a copy assignment operator and a copy
+constructor, which both copy the dereferenced pointer to create a new instance
 of the object for the `unique_ptr`.
 Currently not written with support for dynamically-allocated array of objects
 in mind, so that may not work.

--- a/src/util/CryptographicHashUtils.h
+++ b/src/util/CryptographicHashUtils.h
@@ -35,23 +35,23 @@ inline constexpr auto hexFormatter = [](std::string* out, char c) {
   return absl::AlphaNumFormatter()(out, absl::Hex(c, absl::kZeroPad2));
 };
 
-// `HashMd5` takes an arguement of type `std::string_view` and provides
+// `HashMd5` takes an argument of type `std::string_view` and provides
 // a Hex value by applying `EVP_md5()` from the openssl library as a result.
 constexpr auto hashMd5 = hashImpl<&EVP_md5, MD5_DIGEST_LENGTH>;
 
-// `HashSha1` takes an arguement of type `std::string_view` and provides
+// `HashSha1` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha1()` from the openssl library as a result.
 constexpr auto hashSha1 = hashImpl<&EVP_sha1, SHA_DIGEST_LENGTH>;
 
-// `HashSha256` takes an arguement of type `std::string_view` and provides
+// `HashSha256` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha256()` from the openssl library as a result.
 constexpr auto hashSha256 = hashImpl<&EVP_sha256, SHA256_DIGEST_LENGTH>;
 
-// `HashSha384` takes an arguement of type `std::string_view` and provides
+// `HashSha384` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha384()` from the openssl library as a result.
 constexpr auto hashSha384 = hashImpl<&EVP_sha384, SHA384_DIGEST_LENGTH>;
 
-// `HashSha512` takes an arguement of type `std::string_view` and provides
+// `HashSha512` takes an argument of type `std::string_view` and provides
 // a Hex by applying `EVP_sha512()` from the openssl library as a result.
 constexpr auto hashSha512 = hashImpl<&EVP_sha512, SHA512_DIGEST_LENGTH>;
 

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -192,7 +192,7 @@ class Date {
 
   /// Convert a `uint64_t` to a `Date`. This is only valid if the `uint64_t` was
   /// obtained via a call to `Date::toBits()`. This just casts the underlying
-  /// representaion.
+  /// representation.
   static constexpr Date fromBits(uint64_t bytes) {
     return std::bit_cast<Date>(bytes);
   }
@@ -413,7 +413,7 @@ class DateOrLargeYear {
   // format used by Wikidata).
   std::pair<std::string, const char*> toStringAndType() const;
 
-  // The bitwise comparison also correpsonds to the semantic ordering of years
+  // The bitwise comparison also corresponds to the semantic ordering of years
   // and dates.
   auto operator<=>(const DateOrLargeYear&) const = default;
 

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -102,7 +102,7 @@ std::string getMessageImpl(
 }
 
 // Helper function used to format the arguments passed to `AD_CONTRACT_CHECK`
-// etc. Return "<concatentation of `getMessageImpl(messages)...`>" followed by
+// etc. Return "<concatenation of `getMessageImpl(messages)...`>" followed by
 // a full stop and space if there is at least one message.
 std::string concatMessages(auto&&... messages) {
   if constexpr (sizeof...(messages) == 0) {

--- a/src/util/File.h
+++ b/src/util/File.h
@@ -222,7 +222,7 @@ Stream makeFilestream(const std::filesystem::path& path, auto&&... args) {
 }  // namespace detail
 
 // Open and return a std::ifstream from a given filename and optional
-// additionals `args`. Throw an exception stating the filename and the absolute
+// additional `args`. Throw an exception stating the filename and the absolute
 // path when the file can't be opened.
 std::ifstream makeIfstream(const std::filesystem::path& path, auto&&... args) {
   return detail::makeFilestream<std::ifstream, false>(path, AD_FWD(args)...);

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -662,7 +662,7 @@ class BlockAndSubrange {
 
 // A helper struct for the zipper join on blocks algorithm (see below). It
 // combines the current iterator, then end iterator, the relevant projection to
-// obtain the input to the comparsion, and a buffer for blocks that are
+// obtain the input to the comparison, and a buffer for blocks that are
 // currently required by the join algorithm for one side of the join.
 template <typename Iterator, typename End, typename Projection>
 struct JoinSide {

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -158,7 +158,7 @@ template <std::ranges::random_access_range Range1,
   };
 
   // This function returns true if and only if the given `row` (which is an
-  // element of `left` or `right`) constains no UNDEF values. It is used inside
+  // element of `left` or `right`) contains no UNDEF values. It is used inside
   // the following `mergeWithUndefRight` function.
   auto containsNoUndefined = []<typename T>(const T& row) {
     if constexpr (isSimilar<FindSmallerUndefRangesLeft, Noop> &&

--- a/src/util/MemorySize/MemorySize.h
+++ b/src/util/MemorySize/MemorySize.h
@@ -66,7 +66,7 @@ class MemorySize {
 
   /*
   Factory functions for creating an instance of this class with the wanted
-  memory size saved internally. Always requries the exact memory size unit and
+  memory size saved internally. Always requires the exact memory size unit and
   size wanted.
   */
   template <std::integral T>
@@ -175,7 +175,7 @@ constexpr ConstexprMap<std::string_view, size_t, 5> numBytesPerUnit(
 /*
 Helper function for dividing two instances of `size_t`.
 Needed, because there is no `std` division function, that takes unconverted
-`size_t`.This tends to lead to error and unprecise results. This function
+`size_t`.This tends to lead to error and imprecise results. This function
 however, should be about as precise as possible, when having the return type
 `double`.
 */
@@ -222,7 +222,7 @@ template <Arithmetic T>
 constexpr size_t convertMemoryUnitsToBytes(const T amountOfUnits,
                                            std::string_view unitName) {
   if constexpr (std::is_signed_v<T>) {
-    // Negativ values makes no sense.
+    // Negative values makes no sense.
     AD_CONTRACT_CHECK(amountOfUnits >= 0);
   }
 
@@ -267,7 +267,7 @@ multiplied/divied with.
 `MemorySize` records. It will be given the amount of bytes in `m`, followed by
 `c` for this calculation. Both will either have been cast to `size_t`, or
 `double.` Note, that the rounding and casting to `size_t` for floating point
-return types will be automaticly done, and can be ignored by `func`.
+return types will be automatically done, and can be ignored by `func`.
  */
 template <Arithmetic T, typename Func>
 requires std::invocable<Func, const double, const double> ||
@@ -289,7 +289,7 @@ constexpr MemorySize magicImplForDivAndMul(const MemorySize& m, const T c,
 template <std::integral T>
 constexpr MemorySize MemorySize::bytes(T numBytes) {
   if constexpr (std::is_signed_v<T>) {
-    // Doesn't make much sense to a negativ amount of memory.
+    // Doesn't make much sense to a negative amount of memory.
     AD_CONTRACT_CHECK(numBytes >= 0);
   }
 

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -161,13 +161,13 @@ class MmapVector {
   }
 
   // create Array of given size  fill with default value
-  // file contents will be overriden if existing!
+  // file contents will be overridden if existing!
   // allows read and write access
   void open(size_t size, const T& defaultValue, string filename,
             AccessPattern pattern = AccessPattern::None);
 
-  // create unititialized array of given size at path specified by filename
-  // file will be created or overriden!
+  // create uninitialized array of given size at path specified by filename
+  // file will be created or overridden!
   // allows read and write access
   void open(size_t size, string filename,
             AccessPattern pattern = AccessPattern::None);
@@ -305,7 +305,7 @@ class MmapVectorView : private MmapVector<T> {
   // ____________________________________________________
   size_t size() const { return MmapVector<T>::size(); }
 
-  // default constructor, leaves an unitialized vector that will throw until a
+  // default constructor, leaves an uninitialized vector that will throw until a
   // valid call to open()
   MmapVectorView() = default;
 
@@ -342,8 +342,8 @@ class MmapVectorView : private MmapVector<T> {
     open(filename, pattern);
   }
 
-  // explicitly close the vector to an unitialized state and free the associated
-  // ressources
+  // explicitly close the vector to an uninitialized state and free the associated
+  // resources
   void close();
 
   // destructor

--- a/src/util/MmapVector.h
+++ b/src/util/MmapVector.h
@@ -342,8 +342,8 @@ class MmapVectorView : private MmapVector<T> {
     open(filename, pattern);
   }
 
-  // explicitly close the vector to an uninitialized state and free the associated
-  // resources
+  // explicitly close the vector to an uninitialized state and free the
+  // associated resources
   void close();
 
   // destructor

--- a/src/util/MmapVectorImpl.h
+++ b/src/util/MmapVectorImpl.h
@@ -82,7 +82,7 @@ template <class T>
 void MmapVector<T>::mapForReading() {
   // open to get valid file descriptor
   int orig_fd = ::open(_filename.c_str(), O_RDONLY);
-  // TODO: check if MAP_SHARED is necessary/usefule
+  // TODO: check if MAP_SHARED is necessary/useful
   void* ptr = mmap(nullptr, _bytesize, PROT_READ, MAP_SHARED, orig_fd, 0);
   AD_CONTRACT_CHECK(ptr != MAP_FAILED);
 

--- a/src/util/PriorityQueue.h
+++ b/src/util/PriorityQueue.h
@@ -153,7 +153,7 @@ class TreeBasedPQ {
   /**
    * Update the key of a value in the HeapBasedPQ
    * @param newKey
-   * @param handle inout parameter, will be changed to be a valid handle after
+   * @param handle in/out parameter, will be changed to be a valid handle after
    * the operation has finished.
    * @throws NotInPQException if the handle does not point into the PQ (because
    * of pop or erase operations)
@@ -370,7 +370,7 @@ class HeapBasedPQ {
    * associated with the handle
    *
    * @param newKey
-   * @param handle Inout parameter: Updated s.t. it stays valid.
+   * @param handle in/out parameter: Updated s.t. it stays valid.
    * @throws NotInPQException if the handle does not point into the PQ (because
    * of pop or erase operations)
    */

--- a/src/util/PriorityQueue.h
+++ b/src/util/PriorityQueue.h
@@ -241,7 +241,7 @@ class HeapBasedPQ {
     const Value& value() const { return mData->mValue; }
     Value& value() { return mData->mValue; }
 
-    // was the value asociated with this handle already deleted because of an
+    // was the value associated with this handle already deleted because of an
     // erase operation
     bool isValid() const { return (mData->mScore).index() == 1; };
 

--- a/src/util/Serializer/Serializer.h
+++ b/src/util/Serializer/Serializer.h
@@ -144,7 +144,7 @@ static constexpr bool SerializerMatchesConstness =
   requires(Constraint) void serialize(S& serializer, T&& arg)
 
 /// Similar to `AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT` but only for
-/// `WriteSerializer`s. For an exmple usage see `SerializeVector.h`
+/// `WriteSerializer`s. For an example usage see `SerializeVector.h`
 #define AD_SERIALIZE_FUNCTION_WITH_CONSTRAINT_WRITE(Constraint)       \
   template <ad_utility::serialization::WriteSerializer S, typename T> \
   requires(Constraint) void serialize(S& serializer, T&& arg)

--- a/src/util/Simple8bCode.h
+++ b/src/util/Simple8bCode.h
@@ -127,7 +127,7 @@ class Simple8bCode {
         }
         // Check that the max value (60 bit) is not exceeded.
         // I put it here to same some for this check, otherwise we must
-        // for each elements in hte plaintext do this check.
+        // for each elements in the plaintext do this check.
         assert(get(nofElementsEncoded + nofItemsInWord) <= 0x0FFFFFFFFFFFFFFF);
       }
     }

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -147,7 +147,7 @@ size_t findLiteralEnd(const std::string_view input,
     }
   }
 
-  // if we have found any unescaped occurence of literalEnd, return the last
+  // if we have found any unescaped occurrence of literalEnd, return the last
   // of these positions
   if (lastFoundPos != size_t(-1)) {
     return lastFoundPos;

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -105,7 +105,7 @@ size_t findLiteralEnd(std::string_view input, std::string_view literalEnd);
 @brief Add elements of the range to a stream, with the `separator` between the
 elements.
 
-@tparam Range An input range, whos dereferenced iterators can be inserted into
+@tparam Range An input range, whose dereferenced iterators can be inserted into
 streams.
 
 @param separator Will be put between each of the string representations

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -202,7 +202,7 @@ void lazyStrJoin(std::ostream* stream, Range&& r, std::string_view separator) {
     return;
   }
 
-  // Add the first entry without a seperator.
+  // Add the first entry without a separator.
   *stream << *begin;
 
   // Add the remaining entries.
@@ -270,7 +270,7 @@ std::string insertThousandSeparator(const std::string_view str,
     /*
     For walking over the string view.
     Our initialization value skips the leading digits, so that only the digits
-    remain, where we have to put the seperator in front of every three chars.
+    remain, where we have to put the separator in front of every three chars.
     */
     size_t currentIdx{s.length() % 3 == 0 ? 3 : s.length() % 3};
     ostream << s.substr(0, currentIdx);

--- a/src/util/SuppressWarnings.h
+++ b/src/util/SuppressWarnings.h
@@ -12,7 +12,7 @@
 // really sure that the suppressed warnings are false positives and that there
 // is no feasible way to avoid them.
 
-// Macros to disable and reenable certain warnings on GCC13. Currently some
+// Macros to disable and re-enable certain warnings on GCC13. Currently some
 // (valid) uses of `std::sort` trigger a false positive `-Warray-bounds`
 // warning. It is important that there is a corresponding `ENABLE_...` macro
 // issued for every `DISABLE_...` macro.

--- a/src/util/Synchronized.h
+++ b/src/util/Synchronized.h
@@ -107,7 +107,7 @@ class Synchronized {
    * type, return the result.
    *
    * Note that return type deduction is done via auto which means,
-   * that no references are passed out. This happens deliberatly as
+   * that no references are passed out. This happens deliberately as
    * passing out references to the underlying type would ignore the locking.
    */
   template <typename F>
@@ -146,7 +146,7 @@ class Synchronized {
    * return the result.
    *
    * Note that return type deduction is done via auto which means,
-   * that no references are passed out. This happens deliberatly as
+   * that no references are passed out. This happens deliberately as
    * passing out references to the underlying type would ignore the locking.
    * Only supported if the mutex allows shared locking and the
    * function type F only treats its object as const.

--- a/src/util/TaskQueue.h
+++ b/src/util/TaskQueue.h
@@ -58,7 +58,7 @@ class TaskQueue {
   /// "pusher" is faster for many tasks, the queue will grow too large to fit
   /// into memory. The task queue will work optimally, when on the average the
   /// workers are at least as fast as the "pusher", but the pusher is faster
-  /// sometimes (which the queue can then accomodate).
+  /// sometimes (which the queue can then accommodate).
   TaskQueue(size_t maxQueueSize, size_t numThreads, std::string name = "")
       : queueMaxSize_{maxQueueSize}, name_{std::move(name)} {
     AD_CONTRACT_CHECK(queueMaxSize_ > 0);

--- a/src/util/TupleForEach.h
+++ b/src/util/TupleForEach.h
@@ -16,7 +16,7 @@ void forEachInTuple(Tuple&& tuple, Function&& function) {
   std::apply(forEachInParamPack, std::forward<Tuple>(tuple));
 }
 
-/// Apply the `function` to each element of the `tuple`. Retur an `array` of
+/// Apply the `function` to each element of the `tuple`. Return an `array` of
 /// the results. The function is applied on the tuple elements sequentially
 /// from left to right.
 /// \param tuple must be a std::tuple<...>.

--- a/src/util/TupleHelpers.h
+++ b/src/util/TupleHelpers.h
@@ -44,7 +44,7 @@ auto setupTupleFromCallable(F&& f) {
  * toUniquePtrTuple(int(3), std::string("foo")) ==
  * std::tuple(std::make_unique<int>(3), std::make_unique<std::string>("foo")) It
  * can take an arbitrary positive number of arguments. Currently this template
- * is linearly expanded, if this becomes a bottleneck at compiletime (e.g. for
+ * is linearly expanded, if this becomes a bottleneck at compile time (e.g. for
  * very long parameter packs) we could do something more intelligent.
  * @return std::tuple(std::make_unique<First>(std::forward<First>(l),
  * std::make_unique<FirstOfRem.....

--- a/src/util/TypeTraits.h
+++ b/src/util/TypeTraits.h
@@ -115,7 +115,7 @@ constexpr static bool isArray = false;
 template <typename T, size_t N>
 constexpr static bool isArray<std::array<T, N>> = true;
 
-// `SimilarToArray` is also true for `std::aray<...>&`, etc.
+// `SimilarToArray` is also true for `std::array<...>&`, etc.
 template <typename T>
 concept SimilarToArray = isArray<std::decay_t<T>>;
 

--- a/src/util/http/HttpClient.cpp
+++ b/src/util/http/HttpClient.cpp
@@ -21,7 +21,7 @@ namespace net = boost::asio;
 using tcp = boost::asio::ip::tcp;
 using ad_utility::httpUtils::Url;
 
-// Implemented using Boost.Beast, code apapted from
+// Implemented using Boost.Beast, code adapted from
 // https://www.boost.org/doc/libs/master/libs/beast/example/http/client/sync/http_client_sync.cpp
 // https://www.boost.org/doc/libs/master/libs/beast/example/http/client/sync-ssl/http_client_sync_ssl.cpp
 

--- a/src/util/http/HttpClient.h
+++ b/src/util/http/HttpClient.h
@@ -40,7 +40,7 @@ class HttpClientImpl {
   ~HttpClientImpl();
 
   // Send a request (the first argument must be either `http::verb::get` or
-  // `http::verb::post`) and return the body of the reponse (possibly very
+  // `http::verb::post`) and return the body of the response (possibly very
   // large) as an `cppcoro::generator<std::string_view>`. The same connection
   // can be used for multiple requests in a row.
   cppcoro::generator<std::span<std::byte>> sendRequest(

--- a/src/util/http/HttpUtils.cpp
+++ b/src/util/http/HttpUtils.cpp
@@ -13,7 +13,7 @@
 namespace ad_utility::httpUtils {
 
 // The regex for parsing the components of a URL. We need it also as a string
-// (for error messagin) and CTRE has no function for printing a regex as a
+// (for error messaging) and CTRE has no function for printing a regex as a
 // a string, hence the two variables.
 static constexpr char urlRegexString[] =
     "^(http|https)://([^:/]+)(:([0-9]+))?(/.*)?$";

--- a/src/util/http/MediaTypes.h
+++ b/src/util/http/MediaTypes.h
@@ -47,7 +47,7 @@ struct MediaTypeWithQuality {
   float _qualityValue;
   Variant _mediaType;
 
-  // Order first by the qualities, and then by the specifity of the type.
+  // Order first by the qualities, and then by the specificity of the type.
   std::partial_ordering operator<=>(const MediaTypeWithQuality& rhs) const {
     if (auto cmp = _qualityValue <=> rhs._qualityValue; cmp != 0) {
       return cmp;

--- a/src/util/http/websocket/WebSocketSession.cpp
+++ b/src/util/http/websocket/WebSocketSession.cpp
@@ -122,7 +122,7 @@ net::awaitable<void> WebSocketSession::handleSession(
                                     queryRegistry, std::move(queryId)};
   // There is currently no safe way of which we know that allows us to respawn
   // the coroutine onto another thread AND make it safely cancellable at the
-  // same time. Therfore we just assert that the cancellation slot is not
+  // same time. Therefore we just assert that the cancellation slot is not
   // connected.
   auto slot = (co_await net::this_coro::cancellation_state).slot();
   AD_CORRECTNESS_CHECK(!slot.is_connected());

--- a/test/AlgorithmTest.cpp
+++ b/test/AlgorithmTest.cpp
@@ -31,7 +31,8 @@ TEST(Algorithm, Contains) {
       std::vector<std::string> substrings{"h", "a", "l", "ha", "al", "hal"};
       ASSERT_TRUE(std::ranges::all_of(
           substrings, [&s](const auto& el) { return contains(s, el); }));
-      std::vector<std::string> noSubstrings{"x", "hl", "hel"};
+      std::vector<std::string> noSubstrings{"x", "hl",
+                                            "hel"};  // codespell-ignore
       ASSERT_TRUE(std::ranges::none_of(
           noSubstrings, [&s](const auto& el) { return contains(s, el); }));
     }
@@ -40,7 +41,8 @@ TEST(Algorithm, Contains) {
                                                "ha", "al", "hal"};
       ASSERT_TRUE(std::ranges::all_of(
           substrings, [&s](const auto& el) { return contains(s, el); }));
-      std::vector<std::string_view> noSubstrings{"x", "hl", "hel"};
+      std::vector<std::string_view> noSubstrings{"x", "hl",
+                                                 "hel"};  // codespell-ignore
       ASSERT_TRUE(std::ranges::none_of(
           noSubstrings, [&s](const auto& el) { return contains(s, el); }));
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,7 @@ function (linkTest basename)
     qlever_target_link_libraries(${basename} ${ARGN} GTest::gtest GTest::gmock_main testUtil ${CMAKE_THREAD_LIBS_INIT})
 endfunction()
 
-# Add the exectutable ${basename} that is compiled from the source file
+# Add the executable ${basename} that is compiled from the source file
 # "${basename}".cpp
 function (addTest basename)
     add_executable(${basename} "${basename}.cpp")

--- a/test/CacheTest.cpp
+++ b/test/CacheTest.cpp
@@ -69,7 +69,7 @@ TEST(LRUCacheTest, testSimpleMapUsage) {
   ASSERT_EQ(*cache["5"], "xxxxx");
   // Non-existing elements must yield shared_ptr<const Value>(nullptr)
   // this bool converts to false
-  ASSERT_FALSE(cache["non-existant"]);
+  ASSERT_FALSE(cache["non-existent"]);
 }
 // _____________________________________________________________________________
 TEST(LRUCacheTest, testSimpleMapUsageWithDrop) {

--- a/test/CacheTest.cpp
+++ b/test/CacheTest.cpp
@@ -133,7 +133,7 @@ TEST(LRUCacheTest, testDecreasingCapacity) {
   cache.insert("9", "xxxxxxxxx");
   cache.setMaxNumEntries(2);
   ASSERT_EQ(*cache["9"], "xxxxxxxxx");  // freshly inserted
-  ASSERT_EQ(*cache["5"], "xxxxx");      // second leat recently used
+  ASSERT_EQ(*cache["5"], "xxxxx");      // second least recently used
   ASSERT_FALSE(cache["1"]);
   ASSERT_FALSE(cache["2"]);
   ASSERT_FALSE(cache["3"]);

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -129,7 +129,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
   path of an already added sub manager, should cause an exception. After all,
-  this would imply, that the sub manger is part of this new option. Which is not
+  this would imply, that the sub manager is part of this new option. Which is not
   supported at the moment.
   */
   config.addSubManager({"sub"s, "manager"s})
@@ -139,7 +139,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   /*
   Trying to add a configuration option, who contains the entire path of an
-  already added sub manger as prefix, should cause an exception. After all, such
+  already added sub manager as prefix, should cause an exception. After all, such
   recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
@@ -148,7 +148,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   /*
   Trying to add a configuration option, whose path is the path of an already
-  added sub manger, should cause an exception.
+  added sub manager, should cause an exception.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.addOption({"sub"s, "manager"s}, "", &notUsed, 42),
@@ -178,7 +178,7 @@ TEST(ConfigManagerTest, AddConfigurationOptionFalseExceptionTest) {
   The reasons, why it's not allowed, are basically the same.
 
   In the past, it was possible to cause path collisions even though there
-  weren't any, by having paths, which json pointer representation fullfilled the
+  weren't any, by having paths, which json pointer representation fulfilled the
   conditions for one of the cases. For example: It should be possible, to have
   one option under `[prefixes]` and one under
   `[prefixes-eternal]`. But, because `/prefixes` is a prefix of
@@ -261,7 +261,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
-  already added sub manger, should cause an exception. After all, such recursive
+  already added sub manager, should cause an exception. After all, such recursive
   builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
@@ -280,7 +280,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
           R"('\[Shared_part\]\[Unique_part_1\]\[Sense_of_existence\]\[Answer\]\[42\]')"));
 
   /*
-  Trying to add a sub manger, whose entire path is a prefix of the path of an
+  Trying to add a sub manager, whose entire path is a prefix of the path of an
   already added config option, should cause an exception. After all, such
   recursive builds should have been done on `C++` level, not json level.
   */
@@ -291,7 +291,7 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   /*
   Trying to add a sub manager, who contains the entire path of an already added
   config option as prefix, should cause an exception.
-  After all, this would imply, that the sub manger is part of this option. Which
+  After all, this would imply, that the sub manager is part of this option. Which
   is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
@@ -330,7 +330,7 @@ TEST(ConfigManagerTest, AddSubManagerFalseExceptionTest) {
   The reasons, why it's not allowed, are basically the same.
 
   In the past, it was possible to cause path collisions even though there
-  weren't any, by having paths, which json pointer representation fullfilled the
+  weren't any, by having paths, which json pointer representation fulfilled the
   conditions for one of the cases. For example: It should be possible, to have
   one sub manager under `[prefixes]` and one under
   `[prefixes-eternal]`. But, because `/prefixes` is a prefix of
@@ -1034,7 +1034,7 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
         return (one && !two && !three) || (!one && two && !three) ||
                (!one && !two && three);
       },
-      "Exactly one bool must be choosen.", "", boolOneOption, boolTwoOption,
+      "Exactly one bool must be chosen.", "", boolOneOption, boolTwoOption,
       boolThreeOption);
   checkValidator(
       m,
@@ -1042,7 +1042,7 @@ TEST(ConfigManagerTest, HumanReadableAddValidator) {
           R"--({"numberInRange" : 60, "boolOne": true, "boolTwo": false, "boolThree": false})--"),
       nlohmann::json::parse(
           R"--({"numberInRange" : 60, "boolOne": true, "boolTwo": true, "boolThree": false})--"),
-      "Exactly one bool must be choosen.");
+      "Exactly one bool must be chosen.");
 }
 
 // Human readable examples for `addOptionValidator` with `Validator` functions.
@@ -1094,7 +1094,7 @@ TEST(ConfigManagerTest, HumanReadableAddOptionValidator) {
 /*
 @brief Generate an informative validator name in the form of `Config manager
 validator<x> y`. With `x` being the list of function argument types and `y` an
-unqiue number id.
+unique number id.
 
 @tparam Ts The types of the function arguments of the validator function.
 
@@ -1167,7 +1167,7 @@ void doValidatorTest(
   /*
   @brief Adjust `variant` argument for `createDummyValueForValidator` and
   `generateDummyNonExceptionValidatorFunction`.
-  The bool type in those helper functions needs special handeling, because it
+  The bool type in those helper functions needs special handling, because it
   only has two values and can't fulfill the invariant, that
   `createDummyValueForValidator` and
   `generateDummyNonExceptionValidatorFunction` should fulfill.
@@ -1218,7 +1218,7 @@ void doValidatorTest(
   /*
   @brief Test all validator functions generated by `addValidatorToConfigManager`
   for a given range of `variant` and a specific configuration of `Ts`. Note:
-  This is for specificly for testing the validators generated by calling
+  This is for specifically for testing the validators generated by calling
   `addValidatorToConfigManager` with a all values in `[variantStart,
   variantEnd)` as `variant` and all other arguments unchanged.
 
@@ -1633,7 +1633,7 @@ void doValidatorTest(
           ConfigManager& managerToAddValidatorTo,
           ConstConfigOptionProxy<std::string> option,
           const nlohmann::json::json_pointer& pathToOption) {
-        // The value, which causes the automaticly generated validator with the
+        // The value, which causes the automatically generated validator with the
         // given variant to fail.
         const std::string& failValue =
             createDummyValueForValidator<std::string>(variantNumber);
@@ -1695,7 +1695,7 @@ void doValidatorTest(
       nlohmann::json::json_pointer("/some/manager/someValue1"));
 
   /*
-  Reseting `mValidatorSubValidatorOption1`, so that the validator, that was
+  Resetting `mValidatorSubValidatorOption1`, so that the validator, that was
   added via `doExceptionMessageTest`, not longer fails.
 
   We can not use an r-value nlohmann json object for this, because there is no
@@ -2475,7 +2475,7 @@ TEST(ConfigManagerTest, ConfigurationDocValidatorAssignment) {
 
   /*
   Generate the `ConfigOption`, together with their validators. Note: We do not
-  need working `ConfigOption`. As long as they exists, everythings fine.
+  need working `ConfigOption`. As long as they exists, everything fine.
   */
   const auto configOptionKeysAndValidators{createKeyAndValidatorPairVector(
       []() {
@@ -2486,7 +2486,7 @@ TEST(ConfigManagerTest, ConfigurationDocValidatorAssignment) {
 
   /*
   Generate the `ConfigManager`, together with their validators. Note: We do not
-  need working `ConfigManager`. As long as they exists, everythings fine.
+  need working `ConfigManager`. As long as they exists, everything fine.
   */
   const auto configManagerKeysAndValidators{createKeyAndValidatorPairVector(
       []() { return ConfigManager{}; }, NUM_CONFIG_MANAGER)};

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -129,8 +129,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
   /*
   Trying to add a configuration option, whose entire path is a prefix of the
   path of an already added sub manager, should cause an exception. After all,
-  this would imply, that the sub manager is part of this new option. Which is not
-  supported at the moment.
+  this would imply, that the sub manager is part of this new option. Which is
+  not supported at the moment.
   */
   config.addSubManager({"sub"s, "manager"s})
       .addOption("someOpt"s, "", &notUsed, 42);
@@ -139,8 +139,8 @@ TEST(ConfigManagerTest, AddConfigurationOptionExceptionTest) {
 
   /*
   Trying to add a configuration option, who contains the entire path of an
-  already added sub manager as prefix, should cause an exception. After all, such
-  recursive builds should have been done on `C++` level, not json level.
+  already added sub manager as prefix, should cause an exception. After all,
+  such recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.addOption({"sub"s, "manager"s, "someOption"s}, "", &notUsed, 42),
@@ -261,8 +261,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
 
   /*
   Trying to add a sub manager, whose entire path is a prefix of the path of an
-  already added sub manager, should cause an exception. After all, such recursive
-  builds should have been done on `C++` level, not json level.
+  already added sub manager, should cause an exception. After all, such
+  recursive builds should have been done on `C++` level, not json level.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.addSubManager({"Shared_part"s, "Unique_part_1"s}),
@@ -291,8 +291,8 @@ TEST(ConfigManagerTest, addSubManagerExceptionTest) {
   /*
   Trying to add a sub manager, who contains the entire path of an already added
   config option as prefix, should cause an exception.
-  After all, this would imply, that the sub manager is part of this option. Which
-  is not supported at the moment.
+  After all, this would imply, that the sub manager is part of this option.
+  Which is not supported at the moment.
   */
   AD_EXPECT_THROW_WITH_MESSAGE(
       config.addSubManager({"some"s, "option"s, "manager"s}),
@@ -1633,8 +1633,8 @@ void doValidatorTest(
           ConfigManager& managerToAddValidatorTo,
           ConstConfigOptionProxy<std::string> option,
           const nlohmann::json::json_pointer& pathToOption) {
-        // The value, which causes the automatically generated validator with the
-        // given variant to fail.
+        // The value, which causes the automatically generated validator with
+        // the given variant to fail.
         const std::string& failValue =
             createDummyValueForValidator<std::string>(variantNumber);
 

--- a/test/CopyableUniquePtrTest.cpp
+++ b/test/CopyableUniquePtrTest.cpp
@@ -75,7 +75,7 @@ TEST(CopyableUniquePtr, CopyAndMoveConstructor) {
   {
     ad_utility::CopyableUniquePtr<int> nonEmptyPointer(
         ad_utility::make_copyable_unique<int>(42));
-    // Saving the adress of the int object, so that we can later check, that
+    // Saving the address of the int object, so that we can later check, that
     // it was actually moved.
     int* const intAdress = nonEmptyPointer.get();
 

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -454,10 +454,10 @@ struct GroupByOptimizations : ::testing::Test {
   }
 
   static SparqlExpressionPimpl makeGroupConcatPimpl(
-      const Variable& var, const std::string& seperator = " ") {
+      const Variable& var, const std::string& separator = " ") {
     return SparqlExpressionPimpl{
         std::make_unique<GroupConcatExpression>(
-            false, makeVariableExpression(var), seperator),
+            false, makeVariableExpression(var), separator),
         "GROUP_CONCAT(?someVariable)"};
   }
 
@@ -1226,7 +1226,7 @@ TEST_F(GroupByOptimizations, hashMapOptimizationGroupConcatIndex) {
   auto groupConcatExpression2 = makeGroupConcatPimpl(varY, ",");
   auto aliasGC2 = Alias{groupConcatExpression2, varW};
 
-  // SELECT (GROUP_CONCAT(?y) as ?z) (GROUP_CONCAT(?y;seperator=",") as ?w)
+  // SELECT (GROUP_CONCAT(?y) as ?z) (GROUP_CONCAT(?y;separator=",") as ?w)
   // WHERE {...} GROUP BY ?x
   GroupBy groupBy{qec, variablesOnlyX, {aliasGC1, aliasGC2}, subtreeWithSort};
   auto result = groupBy.getResult();

--- a/test/IdTableHelpersTest.cpp
+++ b/test/IdTableHelpersTest.cpp
@@ -187,7 +187,7 @@ TEST(IdTableHelpersTest, createRandomlyFilledIdTableWithoutGenerators) {
 // The overloads that take generators for creating the content of the join
 // columns.
 TEST(IdTableHelpersTest, createRandomlyFilledIdTableWithGeneratos) {
-  // Creates a 'generator', that counts one up, everytime it's called.
+  // Creates a 'generator', that counts one up, every time it's called.
   auto createCountUpGenerator = []() {
     return [i = 0]() mutable { return ad_utility::testing::VocabId(i++); };
   };
@@ -284,7 +284,7 @@ TEST(IdTableHelpersTest, createRandomlyFilledIdTableWithGeneratos) {
 
 TEST(IdTableHelpersTest, generateIdTable) {
   /*
-  Creates a 'generator', that returns a row of the given lenght, were every
+  Creates a 'generator', that returns a row of the given length, were every
   entry contains the same number. The number starts with 0 and goes on up
   with every call.
   */

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -67,7 +67,7 @@ TEST(IdTable, DocumentationOfIteratorUsage) {
   // The following calls do not change the table, but are also not expected to
   // do so because we explicitly bind to a `value_type`.
   {
-    IdTable::row_type row = t[0];  // Explitly copy/materialize the full row.
+    IdTable::row_type row = t[0];  // Explicitly copy/materialize the full row.
     row[0] = V(50);
     // We have changed the copied row, but not the table.
     ASSERT_EQ(V(50), row[0]);
@@ -76,7 +76,7 @@ TEST(IdTable, DocumentationOfIteratorUsage) {
   {
     // Exactly the same example, but with `iterator`s and `iterator_traits`.
     std::iterator_traits<IdTable::iterator>::value_type row =
-        *t.begin();  // Explitly copy/materialize the full row.
+        *t.begin();  // Explicitly copy/materialize the full row.
     row[0] = V(51);
     // We have changed the copied row, but not the table.
     ASSERT_EQ(V(51), row[0]);
@@ -254,7 +254,7 @@ void runTestForDifferentTypes(auto testCase, std::string testCaseName) {
 // to be made. It is necessary because for some `IdTable` instantiations
 // (for example when the data is stored in a `BufferedVector`) the `clone`
 // member function needs additional arguments. Currently, the only additional
-// argument is the filenmae for the copy for `IdTables` that store their data in
+// argument is the filename for the copy for `IdTables` that store their data in
 // a `BufferedVector`. For an example usage see the test cases below.
 auto clone(const auto& table, auto... args) {
   if constexpr (requires { table.clone(); }) {

--- a/test/JsonCustomConverterForThirdPartyTest.cpp
+++ b/test/JsonCustomConverterForThirdPartyTest.cpp
@@ -121,7 +121,7 @@ TEST(JsonCustomConverterForThirdParty, StdVariant) {
   doSimpleTest(std::monostate{}, (int)42);
   doSimpleTest((float)4.2777422, std::monostate{});
 
-  // There is a custom exception, should the index for a value tpye be not
+  // There is a custom exception, should the index for a value type be not
   // valid. That is, to big, or to small.
   j["index"] = -1;
   ASSERT_THROW(variant = j.get<VariantType>(), nlohmann::detail::out_of_range);
@@ -160,11 +160,11 @@ TEST(JsonCustomConverterForThirdParty,
     pointer = j.get<PointerType>();
   };
 
-  // Uniqe pointer doesn't own an object.
+  // Unique pointer doesn't own an object.
   doCheckPreparation(nullptr, std::make_unique<PointerObjectType>(42));
   ASSERT_EQ(pointer.get(), nullptr);
 
-  // Uniqe pointer owns an object.
+  // Unique pointer owns an object.
   doCheckPreparation(std::make_unique<int>(42), nullptr);
   ASSERT_NE(pointer.get(), nullptr);
   ASSERT_EQ(*pointer, 42);

--- a/test/NBitIntegerTest.cpp
+++ b/test/NBitIntegerTest.cpp
@@ -93,7 +93,7 @@ auto testTranslationNearLimits = []<size_t N>() {
 // to(b))))`, when `to` is `NBitInteger<N>::toNBit` and `from` is the
 // corresponding `fromNBit`. This tests the (well-defined) behavior of the
 // `NBitInteger`s in the presence of overflows. The `wouldOverflow(a, b)`
-// function must return `true` if `f(a, b)` would overlow, leading to undefined
+// function must return `true` if `f(a, b)` would overflow, leading to undefined
 // behavior. In those cases, the result `i(f(u(a), u(b))` is evaluated instead
 // of `f(a, b)`, where `i` is a cast to int64_t and `u` is a cast to `uint64_t`.
 // The behavior of this operation is well-defined because unsigned integer

--- a/test/PriorityQueueTest.cpp
+++ b/test/PriorityQueueTest.cpp
@@ -96,11 +96,11 @@ TEST(PqTest, TreeUpdateReinsert) {
     ASSERT_EQ(pq.size(), 0ul);
     ASSERT_THROW(pq.updateKey(15, &h), ad_utility::NotInPQException);
     ASSERT_EQ(pq.size(), 0ul);
-    auto h2 = pq.insert(500, "alot"s);
+    auto h2 = pq.insert(500, "alot"s);  // codespell-ignore
     ASSERT_EQ(pq.size(), 1ul);
     h = pq.pop();
     ASSERT_EQ(h.score(), 500);
-    ASSERT_EQ(h.value(), "alot"s);
+    ASSERT_EQ(h.value(), "alot"s);  // codespell-ignore
   };
   TreeBasedPQ<int, string> pq;
   test(pq);

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -160,7 +160,7 @@ TEST(RandomNumberGeneratorTest, SlowRandomIntGenerator) {
                                           seed};
   });
 
-  // For use withing the range tests.
+  // For use within the range tests.
   const std::vector<NumericalRange<size_t>> ranges{
       {4ul, 7ul}, {200ul, 70171ul}, {71747ul, 1936556173ul}};
 
@@ -179,7 +179,7 @@ TEST(RandomNumberGeneratorTest, RandomDoubleGenerator) {
                                  std::numeric_limits<double>::max(), seed};
   });
 
-  // For use withing the range tests.
+  // For use within the range tests.
   const std::vector<NumericalRange<double>> ranges{
       {4.74717, 7.4}, {-200.0771370, -70.77713}, {-71747.6666, 1936556173.}};
 

--- a/test/ResultTableColumnOperationsTest.cpp
+++ b/test/ResultTableColumnOperationsTest.cpp
@@ -61,7 +61,7 @@ static void compareToColumn(
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "compareToColumn")};
 
-  // Compare every entry with the fitting comparsion function.
+  // Compare every entry with the fitting comparison function.
   AD_CONTRACT_CHECK(expectedContent.size() == tableToCompareAgainst.numRows());
   for (size_t i = 0; i < expectedContent.size(); i++) {
     if constexpr (std::floating_point<T>) {
@@ -333,7 +333,7 @@ TEST(ResultTableColumnOperations, calculateSpeedupOfColumn) {
         ad_utility::SlowRandomIntGenerator<size_t> rowGenerator(
             0, table.numRows() - 1);
 
-        // Test things trough for all possible input and output columns.
+        // Test things through for all possible input and output columns.
         for (size_t outputColumn = 0; outputColumn < table.numColumns();
              outputColumn++) {
           for (size_t firstInputColumn = 0;

--- a/test/SelectClauseTest.cpp
+++ b/test/SelectClauseTest.cpp
@@ -1,6 +1,6 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Autor:
+// Author:
 //   2022 -     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
 
 #include "engine/sparqlExpressions/LiteralExpression.h"

--- a/test/SerializerTest.cpp
+++ b/test/SerializerTest.cpp
@@ -165,7 +165,7 @@ TEST(Serializer, SimpleExample) {
     A a{};  // Uninitialized, we will read into it;
     serialization::FileReadSerializer reader{filename};
     reader >> a;
-    // We have succesfully restored the values.
+    // We have successfully restored the values.
     ASSERT_EQ(a.a, 42);
     ASSERT_EQ(a.b, -5);
   }
@@ -425,7 +425,7 @@ TEST(Serializer, Array) {
   testWithAllSerializers(testNonTriviallyCopyableDatatype);
 }
 
-// Test that we can succesfully write `string_view`s to a serializer and
+// Test that we can successfully write `string_view`s to a serializer and
 // correctly read them as `string`s.
 TEST(Serializer, StringViewToString) {
   auto testString = [](auto&& writer, auto makeReaderFromWriter) {

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -794,7 +794,7 @@ inline auto SelectQuery =
 
 namespace pq {
 
-// This is implemented as a separater Matcher because it generates some overhead
+// This is implemented as a separated Matcher because it generates some overhead
 // in the tests.
 inline auto OriginalString =
     [](const std::string& originalString) -> Matcher<const ::ParsedQuery&> {

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1035,7 +1035,7 @@ TEST(SparqlExpression, ReplaceExpression) {
                           IdOrLiteralOrIri{lit("(?i)[ei]")},
                           IdOrLiteralOrIri{lit("x")}});
 
-  // Multiple matches withing the same string
+  // Multiple matches within the same string
   checkReplace(
       IdOrLiteralOrIri{lit("wEeDEflE")},
       std::tuple{IdOrLiteralOrIri{lit("weeeDeeflee")},

--- a/test/StringSortComparatorTest.cpp
+++ b/test/StringSortComparatorTest.cpp
@@ -90,7 +90,7 @@ TEST(StringSortComparatorTest, TripleComponentComparatorQuarternary) {
 
   ASSERT_TRUE(comp("\"Hannibal\"@en", "\"HanNibal\"@en"));
 
-  // something is not smaller thant itself
+  // something is not smaller than itself
   ASSERT_FALSE(comp("\"beta\"", "\"beta\""));
 
   // Testing that latin and Hindi numbers mean exactly the same up to the
@@ -170,7 +170,7 @@ TEST(StringSortComparatorTest, TripleComponentComparatorTotal) {
 
   assertTrue("\"Hannibal\"@en", "\"HanNibal\"@en");
 
-  // something is not smaller thant itself
+  // something is not smaller than itself
   assertFalse("\"beta\"", "\"beta\"");
 
   // Testing that latin and Hindi numbers mean exactly the same up to the
@@ -205,7 +205,7 @@ TEST(StringSortComparatorTest, SimpleStringComparator) {
   ASSERT_TRUE(comp("alpha", "ALPHA"));
   ASSERT_FALSE(comp("ALPHA", "alpha"));
 
-  // something is not smaller thant itself
+  // something is not smaller than itself
   ASSERT_FALSE(comp("beta", "beta"));
 
   ASSERT_TRUE(comp("\"@u2", "@u2"));

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -318,6 +318,6 @@ TEST(StringUtilsTest, findLiteralEnd) {
   using namespace ad_utility;
   EXPECT_EQ(findLiteralEnd("nothing", "\""), std::string_view::npos);
   EXPECT_EQ(findLiteralEnd("no\"thing", "\""), 2u);
-  EXPECT_EQ(findLiteralEnd("no\\\"thi\"ng", "\""), 7u);
+  EXPECT_EQ(findLiteralEnd("no\\\"thi\"ng", "\""), 7u);  // codespell-ignore
   EXPECT_EQ(findLiteralEnd("no\\\\\"thing", "\""), 4u);
 }

--- a/test/SynchronizedTest.cpp
+++ b/test/SynchronizedTest.cpp
@@ -249,8 +249,9 @@ TEST(Synchronized, SFINAE) {
 
   // Outcommenting this does not compile and cannot be brought to compile
   // without making usage of the Synchronized classes "withWriteLock" method
-  // unnecessarily hard. static_assert(!AllowsNonConstExclusiveAccessLambda<const
-  // Synchronized<Vec, std::shared_mutex>>::value);
+  // unnecessarily hard.
+  // static_assert(!AllowsNonConstExclusiveAccessLambda<const Synchronized<Vec,
+  // std::shared_mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 const Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(AllowsConstSharedAccessLambda<
@@ -269,8 +270,9 @@ TEST(Synchronized, SFINAE) {
 
   // Outcommenting this does not compile and cannot be brought to compile
   // without making usage of the Synchronized classes "withWriteLock" method
-  // unnecessarily hard. static_assert(!AllowsNonConstExclusiveAccessLambda<const
-  // Synchronized<Vec, std::mutex>>::value);
+  // unnecessarily hard.
+  // static_assert(!AllowsNonConstExclusiveAccessLambda<const Synchronized<Vec,
+  // std::mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 const Synchronized<Vec, std::mutex>>::value);
   static_assert(!AllowsConstSharedAccessLambda<

--- a/test/SynchronizedTest.cpp
+++ b/test/SynchronizedTest.cpp
@@ -249,7 +249,7 @@ TEST(Synchronized, SFINAE) {
 
   // Outcommenting this does not compile and cannot be brought to compile
   // without making usage of the Synchronized classes "withWriteLock" method
-  // unecessarily hard. static_assert(!AllowsNonConstExclusiveAccessLambda<const
+  // unnecessarily hard. static_assert(!AllowsNonConstExclusiveAccessLambda<const
   // Synchronized<Vec, std::shared_mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 const Synchronized<Vec, std::shared_mutex>>::value);
@@ -269,7 +269,7 @@ TEST(Synchronized, SFINAE) {
 
   // Outcommenting this does not compile and cannot be brought to compile
   // without making usage of the Synchronized classes "withWriteLock" method
-  // unecessarily hard. static_assert(!AllowsNonConstExclusiveAccessLambda<const
+  // unnecessarily hard. static_assert(!AllowsNonConstExclusiveAccessLambda<const
   // Synchronized<Vec, std::mutex>>::value);
   static_assert(AllowsConstExclusiveAccessLambda<
                 const Synchronized<Vec, std::mutex>>::value);

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -476,9 +476,9 @@ TEST_P(TransitivePathTest, zeroLengthException) {
                       left, right, 0, std::numeric_limits<size_t>::max());
   AD_EXPECT_THROW_WITH_MESSAGE(
       T->computeResultOnlyForTesting(),
-      ::testing::ContainsRegex(
-          "This query might have to evaluate the empty path, which is currently "
-          "not supported"));
+      ::testing::ContainsRegex("This query might have to evaluate the empty "
+                               "path, which is currently "
+                               "not supported"));
 }
 
 INSTANTIATE_TEST_SUITE_P(TransitivePathTestSuite, TransitivePathTest,

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -477,7 +477,7 @@ TEST_P(TransitivePathTest, zeroLengthException) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       T->computeResultOnlyForTesting(),
       ::testing::ContainsRegex(
-          "This query might have to evalute the empty path, which is currently "
+          "This query might have to evaluate the empty path, which is currently "
           "not supported"));
 }
 

--- a/test/VocabularyGeneratorTest.cpp
+++ b/test/VocabularyGeneratorTest.cpp
@@ -34,7 +34,7 @@ bool vocabTestCompare(const IdPairMMapVecView& a,
 auto V = ad_utility::testing::VocabId;
 }  // namespace
 
-// Test fixture that sets up the binary files vor partial vocabulary and
+// Test fixture that sets up the binary files for partial vocabulary and
 // everything else connected with vocabulary merging.
 class MergeVocabularyTest : public ::testing::Test {
  protected:
@@ -71,7 +71,7 @@ class MergeVocabularyTest : public ::testing::Test {
                    "lead to test failures\n";
     }
 
-    // make paths abolute under created tmp directory
+    // make paths absolute under created tmp directory
     _path0 = _basePath + _path0;
     _path1 = _basePath + _path1;
     _pathVocabExp = _basePath + std::string(".vocabExp");

--- a/test/VocabularyTestHelpers.h
+++ b/test/VocabularyTestHelpers.h
@@ -102,7 +102,7 @@ void testUpperAndLowerBoundContiguousIDs(const auto& vocab, auto makeWordLarger,
                          words, ids);
 }
 
-// Same as the previous function, but explictly state, which IDs are expected in
+// Same as the previous function, but explicitly state, which IDs are expected in
 // the vocabulary.
 void testUpperAndLowerBoundWithStdLessFromWordsAndIds(auto vocabulary,
                                                       const auto& words,
@@ -183,7 +183,7 @@ void testUpperAndLowerBoundWithNumericComparator(auto createVocabulary) {
 // Checks that vocabulary[ids[i]] == words[i].
 auto testAccessOperatorFromWordsAndIds(auto vocabulary, const auto& words,
                                        const auto& ids) {
-  // Not in any particulary order.
+  // Not in any particularly order.
   AD_CONTRACT_CHECK(words.size() == ids.size());
   ASSERT_EQ(words.size(), vocabulary.size());
   for (size_t i = 0; i < words.size(); ++i) {
@@ -193,7 +193,7 @@ auto testAccessOperatorFromWordsAndIds(auto vocabulary, const auto& words,
 // Check that the `operator[]` works as expected for an unordered vocabulary,
 // created via `createVocabulary(std::vector<std::string>)`.
 auto testAccessOperatorForUnorderedVocabulary(auto createVocabulary) {
-  // Not in any particulary order.
+  // Not in any particularly order.
   const std::vector<std::string> words{"alpha", "delta", "ALPHA", "beta", "42",
                                        "31",    "0a",    "a0",    "al"};
   std::vector<uint64_t> ids;

--- a/test/VocabularyTestHelpers.h
+++ b/test/VocabularyTestHelpers.h
@@ -102,8 +102,8 @@ void testUpperAndLowerBoundContiguousIDs(const auto& vocab, auto makeWordLarger,
                          words, ids);
 }
 
-// Same as the previous function, but explicitly state, which IDs are expected in
-// the vocabulary.
+// Same as the previous function, but explicitly state, which IDs are expected
+// in the vocabulary.
 void testUpperAndLowerBoundWithStdLessFromWordsAndIds(auto vocabulary,
                                                       const auto& words,
                                                       const auto& ids) {

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -115,7 +115,7 @@ TEST(CartesianProductJoin, computeResult) {
                         {1, 3, 5}},
                        {{{0}, {1}}, {{2}, {3}}, {{4}, {5}}});
 
-  // Heterogenous sizes.
+  // Heterogeneous sizes.
   testCartesianProduct(
       {{0, 2, 4}, {1, 2, 4}, {0, 2, 5}, {1, 2, 5}, {0, 2, 6}, {1, 2, 6}},
       {{{0}, {1}}, {{2}}, {{4}, {5}, {6}}});

--- a/test/engine/TextIndexScanForEntityTest.cpp
+++ b/test/engine/TextIndexScanForEntityTest.cpp
@@ -124,7 +124,7 @@ TEST(TextIndexScanForEntity, CacheKeys) {
 
   TextIndexScanForEntity s8{qec, Variable{"?text7"}, newFixedEntity,
                             "sentences"};
-  // Same text var, same fixed entitiy, different words
+  // Same text var, same fixed entity, different words
   ASSERT_NE(s7.getCacheKeyImpl(), s8.getCacheKeyImpl());
 }
 

--- a/test/util/AsyncTestHelpers.h
+++ b/test/util/AsyncTestHelpers.h
@@ -93,7 +93,7 @@ void runAsyncTest(Func innerRun, size_t numThreads) {
 
 // Drop-in replacement for gtest's TEST() macro, but for tests that make
 // use of boost asio's awaitable coroutines. Note that this prevents you
-// from using ASSERT_* macros unless you redefine the return keword with
+// from using ASSERT_* macros unless you redefine the return keyword with
 // co_return so it works nicely with the coroutine.
 #define ASYNC_TEST(test_suite_name, test_name) \
   ASYNC_TEST_N(test_suite_name, test_name, 1)

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -1,6 +1,6 @@
 // Copyright 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Author: Andre Schlegel (Januar of 2023, schlegea@informatik.uni-freiburg.de)
+// Author: Andre Schlegel (January of 2023, schlegea@informatik.uni-freiburg.de)
 
 #include "../test/util/IdTableHelpers.h"
 
@@ -42,7 +42,7 @@ void compareIdTableWithExpectedContent(
   auto trace{generateLocationTrace(l, traceMessage.str())};
 
   // Because we compare tables later by sorting them, so that every table has
-  // one definit form, we need to create local copies.
+  // one definite form, we need to create local copies.
   IdTable localTable{table.clone()};
   IdTable localExpectedContent{expectedContent.clone()};
 
@@ -131,7 +131,7 @@ IdTable createRandomlyFilledIdTable(
     return ad_utility::testing::VocabId(randomNumberGenerator());
   };
 
-  // Assiging the column number to a generator function.
+  // Assigning the column number to a generator function.
   std::vector<const std::function<ValueId()>*> columnToGenerator(
       numberColumns, &normalEntryGenerator);
   std::ranges::for_each(joinColumnWithGenerator,

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -104,7 +104,7 @@ void compareIdTableWithExpectedContent(
 
 /*
  * @brief Sorts an IdTable in place, in the same way, that we sort them during
- * normal programm usage.
+ * normal program usage.
  */
 void sortIdTableByJoinColumnInPlace(IdTableAndJoinColumn& table);
 

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -1,6 +1,6 @@
 // Copyright 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
-// Author: Andre Schlegel (Januar of 2023, schlegea@informatik.uni-freiburg.de)
+// Author: Andre Schlegel (January of 2023, schlegea@informatik.uni-freiburg.de)
 
 #pragma once
 
@@ -84,7 +84,7 @@ IdTable makeIdTableFromVector(const VectorTable& content,
 
 /*
  * @brief Tests, whether the given IdTable has the same content as the sample
- * solution and, if the option was choosen, if the IdTable is sorted by
+ * solution and, if the option was chosen, if the IdTable is sorted by
  * the join column.
  *
  * @param table The IdTable that should be tested.
@@ -205,7 +205,7 @@ IdTable createRandomlyFilledIdTable(
         ad_utility::FastRandomIntGenerator<unsigned int>{}()));
 
 /*
-@brief Return a IdTable, that is completly randomly filled.
+@brief Return a IdTable, that is completely randomly filled.
 
 @param numberRows, numberColumns The size of the IdTable, that is to be
 returned.

--- a/test/util/JoinHelpers.h
+++ b/test/util/JoinHelpers.h
@@ -42,7 +42,7 @@ IdTable useJoinFunctionOnIdTables(const IdTableAndJoinColumn& tableA,
 
   // You need to use this special function for executing lambdas. The normal
   // function for functions won't work.
-  // Additionaly, we need to cast the two size_t, because callFixedSize only
+  // Additionally, we need to cast the two size_t, because callFixedSize only
   // takes arrays of int.
   ad_utility::callFixedSize(
       (std::array{static_cast<int>(tableA.idTable.numColumns()),

--- a/test/util/ValidatorHelpers.h
+++ b/test/util/ValidatorHelpers.h
@@ -52,7 +52,7 @@ auto generateDummyNonExceptionValidatorFunction(size_t variant) {
   return [... dummyValuesToCompareTo =
               createDummyValueForValidator<ParameterTypes>(variant)](
              const ParameterTypes&... args) {
-    // Special handeling for `args` of type bool is needed. For the reasoning:
+    // Special handling for `args` of type bool is needed. For the reasoning:
     // See the doc string.
     auto compare = []<typename T>(const T& arg,
                                   const T& dummyValueToCompareTo) {


### PR DESCRIPTION
Add a GitHub action and a locally installable pre-commit hook that runs the spell checker `codespell` on the codebase and fails if codespell identifies possible spelling errors. Also fix all the errors that the initial run of codespell detected. 
Should the tool have too many false positives in the future, we can stell deactivate it and run it manually every now and then, but after a review of the initial suggestions I (@joka921) don't consider that to be likely.