### PR TITLE
Improve `ad_utility::OwningView` + add `ad_utility::allView` and `AD_MOVE`

### DIFF
--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -32,8 +32,9 @@ inline auto getUniqueElements = []<typename OperandGenerator>(
                                     const EvaluationContext* context,
                                     size_t inputSize,
                                     OperandGenerator operandGenerator)
-    -> cppcoro::generator<typename OperandGenerator::value_type> {
-  ad_utility::HashSetWithMemoryLimit<typename OperandGenerator::value_type>
+    -> cppcoro::generator<std::ranges::range_value_t<OperandGenerator>> {
+  ad_utility::HashSetWithMemoryLimit<
+      std::ranges::range_value_t<OperandGenerator>>
       uniqueHashSet(inputSize, context->_allocator);
   for (auto& operand : operandGenerator) {
     if (uniqueHashSet.insert(operand).second) {

--- a/src/engine/sparqlExpressions/SetOfIntervals.h
+++ b/src/engine/sparqlExpressions/SetOfIntervals.h
@@ -77,7 +77,7 @@ struct SetOfIntervals {
   inline static std::vector<bool> toBitVector(const SetOfIntervals& a,
                                               size_t targetSize) {
     std::vector<bool> result(targetSize, false);
-    toBitVector(a, targetSize, begin(result));
+    toBitVector(a, targetSize, std::ranges::begin(result));
     return result;
   }
 };

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -1,8 +1,6 @@
 //  Copyright 2021, University of Freiburg, Chair of Algorithms and Data
 //  Structures. Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 
-//
-// Created by johannes on 15.09.21.
 // Several templated helper functions that are used for the Expression module
 
 #ifndef QLEVER_SPARQLEXPRESSIONGENERATORS_H
@@ -54,15 +52,10 @@ cppcoro::generator<const std::decay_t<std::invoke_result_t<Transformation, T>>> 
 }
 
 template <typename T, typename Transformation = std::identity>
-requires std::ranges::input_range<T>
-auto resultGenerator(T vector, size_t numItems, Transformation transformation = {})
-    -> cppcoro::generator<std::decay_t<
-        std::invoke_result_t<Transformation, std::remove_reference_t<decltype(*vector.begin())>>>> {
+requires(std::ranges::input_range<T>)
+auto resultGenerator(T&& vector, size_t numItems, Transformation transformation = {}) {
   AD_CONTRACT_CHECK(numItems == vector.size());
-  for (auto& element : vector) {
-    auto cpy = transformation(std::move(element));
-    co_yield cpy;
-  }
+  return ad_utility::allView(AD_FWD(vector)) | std::views::transform(std::move(transformation));
 }
 
 template <typename Transformation = std::identity>
@@ -97,7 +90,7 @@ auto makeGenerator(Input&& input, size_t numItems, const EvaluationContext* cont
         getIdsFromVariable(std::forward<Input>(input), context)};
     return resultGenerator(inputWithVariableResolved, numItems, transformation);
   } else {
-    return resultGenerator(std::forward<Input>(input), numItems, transformation);
+    return resultGenerator(AD_FWD(input), numItems, transformation);
   }
 }
 
@@ -119,7 +112,8 @@ inline auto valueGetterGenerator = []<typename ValueGetter, SingleExpressionResu
 /// generator.
 inline auto applyFunction = []<typename Function, typename... Generators>(
                                 Function&& function, size_t numItems, Generators... generators)
-    -> cppcoro::generator<std::invoke_result_t<Function, typename Generators::value_type...>> {
+    -> cppcoro::generator<
+        std::invoke_result_t<Function, std::ranges::range_value_t<Generators>...>> {
   // A tuple holding one iterator to each of the generators.
   std::tuple iterators{generators.begin()...};
 

--- a/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionGenerators.h
@@ -118,7 +118,7 @@ inline auto applyFunction = []<typename Function, typename... Generators>(
   std::tuple iterators{generators.begin()...};
 
   auto functionOnIterators = [&function](auto&&... iterators) {
-    return function(std::move(*iterators)...);
+    return function(AD_MOVE(*iterators)...);
   };
 
   for (size_t i = 0; i < numItems; ++i) {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -31,21 +31,21 @@ class VectorWithMemoryLimit
   using Allocator = ad_utility::AllocatorWithLimit<T>;
   using Base = std::vector<T, ad_utility::AllocatorWithLimit<T>>;
 
-  // The `AllocatorWithMemoryLimit`is not default-constructible. Unfortunately
-  // the support for such allocators is not really great in the standard
-  // library. In particular, the type_traits
+  // The `AllocatorWithMemoryLimit` is not default-constructible (on purpose).
+  // Unfortunately, the support for such allocators is not really great in the
+  // standard library. In particular, the type trait
   // `std::default_initializable<std::vector<T, Alloc>>` will be true, even if
-  // the `Alloc` is not default initializable, which leads to hard compile
+  // the `Alloc` is not default-initializable, which leads to hard compile
   // errors with the ranges library. For this reason we cannot simply inherit
   // all the constructors from `Base`, but explicitly have to forward all but
   // the default constructor. In particular, we only forward constructors that
   // have
   // * at least one argument
   // * the first argument must not be similar to `std::vector` or
-  // `VectorWithMemoryLimit` to not hide copy or move constructors.
+  // `VectorWithMemoryLimit` to not hide copy or move constructors
   // * the last argument must be `AllocatorWithMemoryLimit` (all constructors to
-  // `vector` take the allocator as a last parameter.
-  // * there must be a constructor of `std::vector` for the given arguments.
+  // `vector` take the allocator as a last parameter)
+  // * there must be a constructor of `Base` for the given arguments.
   template <typename... Args>
   requires(sizeof...(Args) > 0 &&
            !std::derived_from<std::remove_cvref_t<ad_utility::First<Args...>>,

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -28,8 +28,17 @@ template <typename T>
 class VectorWithMemoryLimit
     : public std::vector<T, ad_utility::AllocatorWithLimit<T>> {
  public:
+  using Allocator = ad_utility::AllocatorWithLimit<T>;
   using Base = std::vector<T, ad_utility::AllocatorWithLimit<T>>;
-  using Base::Base;
+  // using Base::Base;
+
+  template <typename... Args>
+  requires(sizeof...(Args) > 0 && std::constructible_from<Base, Args && ...>)
+  VectorWithMemoryLimit(Args&&... args) : Base{AD_FWD(args)...} {}
+
+  VectorWithMemoryLimit(std::initializer_list<T> init, const Allocator& alloc)
+      : Base(init, alloc){};
+
   // Disable copy constructor and copy assignment operator (copying is too
   // expensive in the setting where we want to use this class and not
   // necessary).
@@ -50,6 +59,7 @@ class VectorWithMemoryLimit
     return VectorWithMemoryLimit(*this);
   }
 };
+static_assert(!std::default_initializable<VectorWithMemoryLimit<int>>);
 
 // A class to store the results of expressions that can yield strings or IDs as
 // their result (for example IF and COALESCE). It is also used for expressions

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -225,7 +225,7 @@ struct LiteralFromIdGetter : Mixin<LiteralFromIdGetter> {
 struct RegexValueGetter {
   template <SingleExpressionResult S>
   requires std::invocable<StringValueGetter, S&&, const EvaluationContext*>
-  std::unique_ptr<re2::RE2> operator()(S&& input,
+  std::shared_ptr<re2::RE2> operator()(S&& input,
                                        const EvaluationContext* context) const {
     auto str = StringValueGetter{}(AD_FWD(input), context);
     if (!str.has_value()) {

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -225,7 +225,7 @@ struct LiteralFromIdGetter : Mixin<LiteralFromIdGetter> {
 struct RegexValueGetter {
   template <SingleExpressionResult S>
   requires std::invocable<StringValueGetter, S&&, const EvaluationContext*>
-  std::shared_ptr<re2::RE2> operator()(S&& input,
+  std::unique_ptr<re2::RE2> operator()(S&& input,
                                        const EvaluationContext* context) const {
     auto str = StringValueGetter{}(AD_FWD(input), context);
     if (!str.has_value()) {

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -357,8 +357,8 @@ void sortVocabVector(ItemVec* vecPtr, StringSortComparator comp,
   auto& els = *vecPtr;
   if constexpr (USE_PARALLEL_SORT) {
     if (doParallelSort) {
-      ad_utility::parallel_sort(begin(els), end(els), comp,
-                                ad_utility::parallel_tag(10));
+      ad_utility::parallel_sort(std::ranges::begin(els), std::ranges::end(els),
+                                comp, ad_utility::parallel_tag(10));
     } else {
       std::ranges::sort(els, comp);
     }

--- a/src/util/Forward.h
+++ b/src/util/Forward.h
@@ -9,4 +9,5 @@
 /// A simple macro that allows writing `AD_FWD(x)` instead of
 /// `std::forward<decltype(x)>(x)`.
 #define AD_FWD(x) std::forward<decltype(x)>(x)
+
 #endif  // QLEVER_FORWARD_H

--- a/src/util/Forward.h
+++ b/src/util/Forward.h
@@ -10,13 +10,20 @@
 /// `std::forward<decltype(x)>(x)`.
 #define AD_FWD(x) std::forward<decltype(x)>(x)
 
+// Needed for the implementation of `AD_MOVE` below.
 namespace ad_utility::detail {
 template <typename T>
 using MoveType =
     std::conditional_t<std::is_object_v<T>, T, std::remove_reference_t<T>&&>;
 }
 
-// TODO<joka921> Document and test.
+// `std::move(x)`, but only if `x` is not a temporary object. For example
+// `std::string x; AD_MOVE(x)` will move the string, while
+// `AD_MOVE(std::string{})` will not. This can be used in generic code where you
+// always want to move, but the pattern `auto x = std::move(genericFunction())`
+// should NOT move if the function returns an object, because that would prevent
+// copy elision. Using `AD_MOVE` in this case only moves if the
+// `genericFunction()` returns a reference.
 #define AD_MOVE(x) static_cast<ad_utility::detail::MoveType<decltype((x))>>(x)
 
 #endif  // QLEVER_FORWARD_H

--- a/src/util/Forward.h
+++ b/src/util/Forward.h
@@ -24,6 +24,10 @@ using MoveType =
 // should NOT move if the function returns an object, because that would prevent
 // copy elision. Using `AD_MOVE` in this case only moves if the
 // `genericFunction()` returns a reference.
+// Note: The double parentheses in `decltype((x))` are necessary, because
+// std::string x; // decltype(x) is string (which would not be moved by the
+// corresponding `MoveType`), but decltype((x)) is string&. For a temporary,
+// even e.g. `decltype((std::string{"hi"}))` is `std::string`.
 #define AD_MOVE(x) static_cast<ad_utility::detail::MoveType<decltype((x))>>(x)
 
 #endif  // QLEVER_FORWARD_H

--- a/src/util/Forward.h
+++ b/src/util/Forward.h
@@ -25,9 +25,10 @@ using MoveType =
 // copy elision. Using `AD_MOVE` in this case only moves if the
 // `genericFunction()` returns a reference.
 // Note: The double parentheses in `decltype((x))` are necessary, because
-// std::string x; // decltype(x) is string (which would not be moved by the
-// corresponding `MoveType`), but decltype((x)) is string&. For a temporary,
-// even e.g. `decltype((std::string{"hi"}))` is `std::string`.
+// for a normal lvalue `std::string x;`, `decltype(x)` is `std::string` (which
+// would not be moved by the corresponding `MoveType`), but `decltype((x))` is
+// `std::string&`. For a temporary, even e.g. `decltype((std::string{"hi"}))` is
+// `std::string`.
 #define AD_MOVE(x) static_cast<ad_utility::detail::MoveType<decltype((x))>>(x)
 
 #endif  // QLEVER_FORWARD_H

--- a/src/util/Forward.h
+++ b/src/util/Forward.h
@@ -10,4 +10,13 @@
 /// `std::forward<decltype(x)>(x)`.
 #define AD_FWD(x) std::forward<decltype(x)>(x)
 
+namespace ad_utility::detail {
+template <typename T>
+using MoveType =
+    std::conditional_t<std::is_object_v<T>, T, std::remove_reference_t<T>&&>;
+}
+
+// TODO<joka921> Document and test.
+#define AD_MOVE(x) static_cast<ad_utility::detail::MoveType<decltype((x))>>(x)
+
 #endif  // QLEVER_FORWARD_H

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -197,7 +197,7 @@ requires std::movable<UnderlyingRange> class OwningView
 namespace detail {
 template <typename Range>
 concept can_ref_view =
-    requires { std::ranges::ref_view{std::declval<Range>()}; };
+    requires(Range&& range) { std::ranges::ref_view{AD_FWD(range)}; };
 }
 
 // A simple drop-in replacement for `std::views::all` which is required because

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -201,9 +201,8 @@ concept can_ref_view =
 }
 
 // A simple drop-in replacement for `std::views::all` which is required because
-// GCC11 doesn't support `std::owning_view` (see above).
-// As soon as we don't support GCC11 anymore, we can throw out those
-// implementations.
+// GCC 11 doesn't support `std::owning_view` (see above). As soon as we don't
+// support GCC 11 anymore, we can throw out those implementations.
 template <typename Range>
 constexpr auto allView(Range&& range) {
   if constexpr (std::ranges::view<std::decay_t<Range>>) {
@@ -310,6 +309,7 @@ inline cppcoro::generator<std::span<ElementType>> reChunkAtSeparator(
 
 }  // namespace ad_utility
 
+// Enabling of "borrowed" ranges for `OwningView`.
 template <typename T>
 inline constexpr bool
     std::ranges::enable_borrowed_range<ad_utility::OwningView<T>> =

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -117,16 +117,95 @@ cppcoro::generator<typename SortedBlockView::value_type> uniqueBlockView(
 // replacement for `std::ranges::owning_view` which is not yet supported by
 // `GCC 11`.
 template <std::ranges::range UnderlyingRange>
-struct OwningView
+requires std::movable<UnderlyingRange> class OwningView
     : public std::ranges::view_interface<OwningView<UnderlyingRange>> {
  private:
-  UnderlyingRange value_;
+  UnderlyingRange underlyingRange_ = UnderlyingRange();
 
  public:
-  explicit OwningView(UnderlyingRange&& range) : value_{std::move(range)} {}
-  auto begin() { return value_.begin(); }
-  auto end() { return value_.end(); }
+  OwningView() requires std::default_initializable<UnderlyingRange> = default;
+
+  constexpr explicit OwningView(UnderlyingRange&& underlyingRange) noexcept(
+      std::is_nothrow_move_constructible_v<UnderlyingRange>)
+      : underlyingRange_(std::move(underlyingRange)) {}
+
+  OwningView(OwningView&&) = default;
+  OwningView& operator=(OwningView&&) = default;
+
+  constexpr UnderlyingRange& base() & noexcept { return underlyingRange_; }
+
+  constexpr const UnderlyingRange& base() const& noexcept {
+    return underlyingRange_;
+  }
+
+  constexpr UnderlyingRange&& base() && noexcept {
+    return std::move(underlyingRange_);
+  }
+
+  constexpr const UnderlyingRange&& base() const&& noexcept {
+    return std::move(underlyingRange_);
+  }
+
+  constexpr std::ranges::iterator_t<UnderlyingRange> begin() {
+    return std::ranges::begin(underlyingRange_);
+  }
+
+  constexpr std::ranges::sentinel_t<UnderlyingRange> end() {
+    return std::ranges::end(underlyingRange_);
+  }
+
+  constexpr auto begin() const
+      requires std::ranges::range<const UnderlyingRange> {
+    return std::ranges::begin(underlyingRange_);
+  }
+
+  constexpr auto end() const requires std::ranges::range<const UnderlyingRange>
+  {
+    return std::ranges::end(underlyingRange_);
+  }
+
+  constexpr bool empty()
+      requires requires { std::ranges::empty(underlyingRange_); } {
+    return std::ranges::empty(underlyingRange_);
+  }
+
+  constexpr bool empty() const
+      requires requires { std::ranges::empty(underlyingRange_); } {
+    return std::ranges::empty(underlyingRange_);
+  }
+
+  constexpr auto size() requires std::ranges::sized_range<UnderlyingRange> {
+    return std::ranges::size(underlyingRange_);
+  }
+
+  constexpr auto size() const
+      requires std::ranges::sized_range<const UnderlyingRange> {
+    return std::ranges::size(underlyingRange_);
+  }
+
+  constexpr auto data() requires std::ranges::contiguous_range<UnderlyingRange>
+  {
+    return std::ranges::data(underlyingRange_);
+  }
+
+  constexpr auto data() const
+      requires std::ranges::contiguous_range<const UnderlyingRange> {
+    return std::ranges::data(underlyingRange_);
+  }
 };
+
+template <typename Range>
+concept can_ref_view =
+    requires { std::ranges::ref_view{std::declval<Range>()}; };
+
+template <typename Range>
+constexpr auto allView(Range&& range) {
+  if constexpr (can_ref_view<Range>) {
+    return std::ranges::ref_view{AD_FWD(range)};
+  } else {
+    return ad_utility::OwningView{AD_FWD(range)};
+  }
+}
 
 // Returns a view that contains all the values in `[0, upperBound)`, similar to
 // Python's `range` function. Avoids the common pitfall in `std::views::iota`
@@ -222,5 +301,10 @@ inline cppcoro::generator<std::span<ElementType>> reChunkAtSeparator(
 }
 
 }  // namespace ad_utility
+
+template <typename _Tp>
+inline constexpr bool
+    std::ranges::enable_borrowed_range<ad_utility::OwningView<_Tp>> =
+        std::ranges::enable_borrowed_range<_Tp>;
 
 #endif  // QLEVER_VIEWS_H

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -200,7 +200,9 @@ concept can_ref_view =
 
 template <typename Range>
 constexpr auto allView(Range&& range) {
-  if constexpr (can_ref_view<Range>) {
+  if constexpr (std::ranges::view<std::decay_t<Range>>) {
+    return AD_FWD(range);
+  } else if constexpr (can_ref_view<Range>) {
     return std::ranges::ref_view{AD_FWD(range)};
   } else {
     return ad_utility::OwningView{AD_FWD(range)};

--- a/test/ViewsTest.cpp
+++ b/test/ViewsTest.cpp
@@ -142,6 +142,10 @@ TEST(Views, owningView) {
               ::testing::ElementsAre(
                   "4", "fourhundredseventythousandBlimbambum", "3", "1"));
 
+  ASSERT_THAT(toVec(std::as_const(vecView)),
+              ::testing::ElementsAre(
+                  "4", "fourhundredseventythousandBlimbambum", "3", "1"));
+
   auto generator = []() -> cppcoro::generator<std::string> {
     co_yield "4";
     co_yield "fourhundredseventythousandBlimbambum";


### PR DESCRIPTION
1. Extend `ad_utility::OwningView` (which so far had a simplistic implementation).
2. Implement `ad_utility::allView` (as a replacement for `std::views::all` becauce GCC 11 does not support std::owning_view).
3. Use `ad_utility::allView` instead of `cppcoro::generator` because the former is more efficient.
4. Add Macro `AD_MOVE`, which does not move temporaries (in order to ensure copy elision for something like `auto x = std::move(genericFuntionCall())`), but otherwise behaves just like `std::move`.