### PR TITLE
SPARQL Update Part 1: Located Triples

### DIFF
--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -2,7 +2,7 @@ add_subdirectory(vocabulary)
 add_library(index
         Index.cpp IndexImpl.cpp IndexImpl.Text.cpp
         Vocabulary.cpp VocabularyOnDisk.cpp
-        Permutation.cpp TextMetaData.cpp
+        LocatedTriples.cpp Permutation.cpp TextMetaData.cpp
         DocsDB.cpp FTSAlgorithms.cpp
         PrefixHeuristic.cpp CompressedRelation.cpp
         PatternCreator.cpp)

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -1,0 +1,240 @@
+// Copyright 2023 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors:
+//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
+//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+
+#include "index/LocatedTriples.h"
+
+#include <algorithm>
+
+#include "absl/strings/str_join.h"
+#include "index/CompressedRelation.h"
+#include "index/IndexMetaData.h"
+#include "index/Permutation.h"
+
+IdTriple permute(const IdTriple& triple,
+                 const std::array<size_t, 3>& keyOrder) {
+  return {triple[keyOrder[0]], triple[keyOrder[1]], triple[keyOrder[2]]};
+}
+
+std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
+    const std::vector<IdTriple>& triples, const Permutation& permutation,
+    bool shouldExist) {
+  const Permutation::MetaData& meta = permutation.metaData();
+  const vector<CompressedBlockMetadata>& blocks = meta.blockData();
+
+  vector<LocatedTriple> out;
+  out.reserve(triples.size());
+  size_t currentBlockIndex;
+  for (auto triple : triples) {
+    triple = permute(triple, permutation.keyOrder());
+    currentBlockIndex =
+        std::ranges::lower_bound(
+            blocks, triple,
+            [&](const IdTriple& block, const IdTriple& triple) {
+              return block < triple;
+            },
+            [](const CompressedBlockMetadata& block) {
+              const auto& perm = block.lastTriple_;
+              return IdTriple{perm.col0Id_, perm.col1Id_, perm.col2Id_};
+            }) -
+        blocks.begin();
+    out.emplace_back(currentBlockIndex, triple, shouldExist);
+  }
+
+  return out;
+}
+
+// ____________________________________________________________________________
+std::pair<size_t, size_t> LocatedTriplesPerBlock::numTriples(
+    size_t blockIndex) const {
+  // If no located triples for `blockIndex_` exist, there is no entry in `map_`.
+  if (!map_.contains(blockIndex)) {
+    return {0, 0};
+  }
+
+  auto blockUpdateTriples = map_.at(blockIndex);
+  size_t countDeletes = std::ranges::count_if(
+      blockUpdateTriples,
+      [](const LocatedTriple& elem) { return !elem.shouldTripleExist_; });
+  size_t countInserts = blockUpdateTriples.size() - countDeletes;
+
+  return {countInserts, countDeletes};
+}
+
+size_t LocatedTriplesPerBlock::mergeTriples(size_t blockIndex, IdTable block,
+                                            IdTable& result,
+                                            size_t offsetInResult,
+                                            size_t numIndexColumns) const {
+  // This method should only be called if there are located triples in the
+  // specified block.
+  AD_CONTRACT_CHECK(map_.contains(blockIndex));
+
+  // TODO<qup42>: We're assuming that the index columns are always {0, 1, 2},
+  // {1, 2} or {2}. Is this true?
+  AD_CONTRACT_CHECK(numIndexColumns <= block.numColumns());
+  AD_CONTRACT_CHECK(result.numColumns() == block.numColumns());
+  AD_CONTRACT_CHECK(result.numColumns() >= 1);
+
+  auto resultEntry = result.begin() + offsetInResult;
+  const auto& locatedTriples = map_.at(blockIndex);
+  auto locatedTriple = locatedTriples.begin();
+
+  // Advance to the first located triple in the specified range.
+  auto cmpLt = [&numIndexColumns](auto lt, auto& row) {
+    if (numIndexColumns == 3) {
+      return (row[0] > lt->triple_[0] ||
+              (row[0] == lt->triple_[0] &&
+               (row[1] > lt->triple_[1] ||
+                (row[1] == lt->triple_[1] && row[2] > lt->triple_[2]))));
+    } else if (numIndexColumns == 2) {
+      return (row[0] > lt->triple_[1] ||
+              (row[0] == lt->triple_[1] && (row[1] > lt->triple_[2])));
+    } else {
+      AD_CORRECTNESS_CHECK(numIndexColumns == 1);
+      return (row[0] > lt->triple_[2]);
+    }
+  };
+  auto cmpEq = [&numIndexColumns](auto lt, auto& row) {
+    if (numIndexColumns == 3) {
+      return (row[0] == lt->triple_[0] && row[1] == lt->triple_[1] &&
+              row[2] == lt->triple_[2]);
+    } else if (numIndexColumns == 2) {
+      return (row[0] == lt->triple_[1] && row[1] == lt->triple_[2]);
+    } else {
+      AD_CORRECTNESS_CHECK(numIndexColumns == 1);
+      return (row[0] == lt->triple_[2]);
+    }
+  };
+  auto writeTripleToResult = [&numIndexColumns, &result](auto resultEntry,
+                                                         auto& locatedTriple) {
+    for (size_t i = 0; i < numIndexColumns; i++) {
+      (*resultEntry)[i] = locatedTriple->triple_[3 - numIndexColumns + i];
+    }
+    // Write UNDEF to any additional columns.
+    for (size_t i = numIndexColumns; i < result.numColumns(); i++) {
+      (*resultEntry)[i] = ValueId::makeUndefined();
+    }
+  };
+
+  for (auto row : block) {
+    // Append triples that are marked for insertion at this `rowIndex` to the
+    // result.
+    while (locatedTriple != locatedTriples.end() && cmpLt(locatedTriple, row)) {
+      if (locatedTriple->shouldTripleExist_ == true) {
+        // Adding an inserted Triple between two triples.
+        writeTripleToResult(resultEntry, locatedTriple);
+        ++resultEntry;
+        ++locatedTriple;
+      } else {
+        // Deletion of a triple that does not exist in the index has no effect.
+        ++locatedTriple;
+      }
+    }
+
+    // Append the triple at this position to the result if and only if it is not
+    // marked for deletion and matches (also skip it if it does not match).
+    bool deleteThisEntry = false;
+    if (locatedTriple != locatedTriples.end() && cmpEq(locatedTriple, row)) {
+      if (locatedTriple->shouldTripleExist_ == false) {
+        // A deletion of a triple that exists in the index.
+        deleteThisEntry = true;
+
+        ++locatedTriple;
+      } else {
+        // An insertion of a triple that already exists in the index has no
+        // effect.
+        ++locatedTriple;
+      }
+    }
+    if (!deleteThisEntry) {
+      *resultEntry++ = row;
+    }
+  }
+  while (locatedTriple != locatedTriples.end() &&
+         locatedTriple->shouldTripleExist_ == true) {
+    writeTripleToResult(resultEntry, locatedTriple);
+    ++resultEntry;
+    ++locatedTriple;
+  }
+
+  // Return the number of rows written to `result`.
+  return resultEntry - (result.begin() + offsetInResult);
+}
+
+// ____________________________________________________________________________
+std::vector<LocatedTriples::iterator> LocatedTriplesPerBlock::add(
+    const std::vector<LocatedTriple>& locatedTriples) {
+  std::vector<LocatedTriples::iterator> handles;
+  handles.reserve(locatedTriples.size());
+  for (auto triple : locatedTriples) {
+    LocatedTriples& locatedTriples = map_[triple.blockIndex_];
+    auto [handle, wasInserted] = locatedTriples.emplace(triple);
+    AD_CORRECTNESS_CHECK(wasInserted == true);
+    AD_CORRECTNESS_CHECK(handle != locatedTriples.end());
+    ++numTriples_;
+    handles.emplace_back(handle);
+  }
+  return handles;
+};
+
+// ____________________________________________________________________________
+void LocatedTriplesPerBlock::erase(size_t blockIndex,
+                                   LocatedTriples::iterator iter) {
+  AD_CONTRACT_CHECK(map_.contains(blockIndex));
+  map_[blockIndex].erase(iter);
+  numTriples_--;
+  if (map_[blockIndex].empty()) {
+    map_.erase(blockIndex);
+  }
+}
+
+// ____________________________________________________________________________
+std::ostream& operator<<(std::ostream& os, const LocatedTriples& lts) {
+  os << "{ ";
+  std::ranges::copy(lts, std::ostream_iterator<LocatedTriple>(os, " "));
+  os << "}";
+  return os;
+}
+
+// ____________________________________________________________________________
+std::ostream& operator<<(std::ostream& os,
+                         const columnBasedIdTable::Row<Id>& idTableRow) {
+  os << "(";
+  for (size_t i = 0; i < idTableRow.numColumns(); ++i) {
+    os << idTableRow[i] << (i < idTableRow.numColumns() - 1 ? " " : ")");
+  }
+  return os;
+}
+
+// ____________________________________________________________________________
+std::ostream& operator<<(std::ostream& os, const IdTable& idTable) {
+  os << "{ ";
+  std::ranges::copy(
+      idTable, std::ostream_iterator<columnBasedIdTable::Row<Id>>(os, " "));
+  os << "}";
+  return os;
+}
+
+// ____________________________________________________________________________
+template <typename T, std::size_t N>
+std::ostream& operator<<(std::ostream& os, const std::array<T, N>& v) {
+  os << "(";
+  std::ranges::copy(v, std::ostream_iterator<T>(os, ", "));
+  os << ")";
+  return os;
+}
+
+template std::ostream& operator<< <ValueId, 3ul>(
+    std::ostream& os, const std::array<ValueId, 3ul>& v);
+
+// ____________________________________________________________________________
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
+  std::ranges::copy(v, std::ostream_iterator<T>(os, ", "));
+  return os;
+}
+
+template std::ostream& operator<< <std::array<ValueId, 3>>(
+    std::ostream& os, const std::vector<std::array<ValueId, 3ul>>& v);

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -1,0 +1,174 @@
+// Copyright 2023 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors:
+//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
+//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+
+#pragma once
+
+#include "engine/idTable/IdTable.h"
+#include "global/IdTriple.h"
+#include "index/CompressedRelation.h"
+#include "util/HashMap.h"
+
+class Permutation;
+
+IdTriple permute(const IdTriple& triple, const std::array<size_t, 3>& keyOrder);
+
+// A triple and its block in a particular permutation.
+// For a detailed definition of all border cases, see the definition at
+// the end of this file.
+struct LocatedTriple {
+  // The index of the block, according to the definition above.
+  size_t blockIndex_;
+  // The `Id`s of the triple in the order of the permutation. For example,
+  // for an object pertaining to the OPS permutation: `id1` is the object,
+  // `id2` is the predicate, and `id3` is the subject.
+  IdTriple triple_;
+
+  // Flag that is true if the given triple is inserted and false if it
+  // is deleted.
+  bool shouldTripleExist_;
+
+  // Locate the given triples in the given permutation.
+  static std::vector<LocatedTriple> locateTriplesInPermutation(
+      const std::vector<IdTriple>& triples, const Permutation& permutation,
+      bool shouldExist);
+
+  bool operator==(const LocatedTriple&) const = default;
+
+  friend std::ostream& operator<<(std::ostream& os, const LocatedTriple& lt) {
+    os << "LT(" << lt.blockIndex_ << " " << lt.triple_[0] << " "
+       << lt.triple_[1] << " " << lt.triple_[2] << " " << lt.shouldTripleExist_
+       << ")";
+    return os;
+  }
+};
+
+// A sorted set of located triples. In `LocatedTriplesPerBlock` below, we use
+// this to store all located triples with the same `blockIndex_`.
+//
+// NOTE: We could also overload `std::less` here, but the explicit specification
+// of the order makes it clearer.
+struct LocatedTripleCompare {
+  bool operator()(const LocatedTriple& x, const LocatedTriple& y) const {
+    return x.triple_ < y.triple_;
+  }
+};
+using LocatedTriples = std::set<LocatedTriple, LocatedTripleCompare>;
+
+std::ostream& operator<<(std::ostream& os, const LocatedTriples& lts);
+
+// Sorted sets of located triples, grouped by block. We use this to store all
+// located triples for a permutation.
+class LocatedTriplesPerBlock {
+ private:
+  // The total number of `LocatedTriple` objects stored (for all blocks).
+  size_t numTriples_ = 0;
+
+ public:
+  // For each block with a non-empty set of located triples, the located triples
+  // in that block.
+  //
+  // NOTE: This is currently not private because we want access to
+  // `map_.size()`, `map_.clear()`, `map_.contains(...)`, and `map_.at(...)`.
+  // We could also make `LocatedTriplesPerBlock` a subclass of `HashMap<size_t,
+  // LocatedTriples>`, but not sure whether that is good style.
+  ad_utility::HashMap<size_t, LocatedTriples> map_;
+
+  // Get upper limits for the number of located triples for the given block. The
+  // return value is a pair of numbers: first, the number of existing triples
+  // ("to be deleted") and second, the number of new triples ("to be inserted").
+  // The numbers are only upper limits because there may be triples that have no
+  // effect (like adding an already existing triple and deleting a non-existent
+  // triple).
+  std::pair<size_t, size_t> numTriples(size_t blockIndex) const;
+
+  // Merge located triples for `blockIndex_` with the given index `block` and
+  // write to `result`, starting from position `offsetInResult`. Return the
+  // number of rows written to `result`.
+  //
+  // PRECONDITIONS:
+  //
+  // 1. The set of located triples for `blockIndex_` must be non-empty.
+  // Otherwise, there is no need for merging and this method shouldn't be
+  // called for efficiency reasons.
+  //
+  // 2. It is the responsibility of the caller that there is enough space for
+  // the result of the merge in `result` starting from `offsetInResult`.
+  size_t mergeTriples(size_t blockIndex, IdTable block, IdTable& result,
+                      size_t offsetInResult, size_t numIndexColumns) const;
+
+  // Add `locatedTriples` to the `LocatedTriplesPerBlock`.
+  // Return handles to where they were added (`LocatedTriples` is a sorted set,
+  // see above). We need the handles so that we can easily remove the
+  // `locatedTriples` from the set again in case we need to.
+  //
+  // PRECONDITIONS:
+  //
+  // 1. The `locatedTriples` must not already exist in
+  // `LocatedTriplesPerBlock`.
+  std::vector<LocatedTriples::iterator> add(
+      const std::vector<LocatedTriple>& locatedTriples);
+
+  void erase(size_t blockIndex, LocatedTriples::iterator iter);
+
+  // Get the total number of `LocatedTriple`s (for all blocks).
+  size_t numTriples() const { return numTriples_; }
+
+  // Get the number of blocks with a non-empty set of located triples.
+  size_t numBlocks() const { return map_.size(); }
+
+  // Remove all located triples.
+  void clear() {
+    map_.clear();
+    numTriples_ = 0;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const LocatedTriplesPerBlock& ltpb) {
+    // Get the block indices in sorted order.
+    std::vector<size_t> blockIndices;
+    std::ranges::transform(ltpb.map_, std::back_inserter(blockIndices),
+                           [](const auto& entry) { return entry.first; });
+    std::ranges::sort(blockIndices);
+    for (auto blockIndex : blockIndices) {
+      os << "LTs in Block #" << blockIndex << ": " << ltpb.map_.at(blockIndex)
+         << std::endl;
+    }
+    return os;
+  }
+};
+
+// Human-readable representation , which are very useful for debugging.
+// TODO<qup42>: find a better place for these definitions
+std::ostream& operator<<(std::ostream& os,
+                         const columnBasedIdTable::Row<Id>& idTableRow);
+std::ostream& operator<<(std::ostream& os, const IdTable& idTable);
+template <typename T, std::size_t N>
+std::ostream& operator<<(std::ostream& os, const std::array<T, N>& v);
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::vector<T>& v);
+
+// DEFINITION OF THE POSITION OF A LOCATED TRIPLE IN A PERMUTATION
+//
+// 1. The position is defined by the index of a block in the permutation and the
+// index of a row within that block.
+//
+// 2. If the triple is contained in the permutation, it is contained exactly
+// once and so there is a well defined block and position in that block.
+//
+// 2. If there is a block, where the first triple is smaller and the last triple
+// is larger, then that is the block and the position in that block is that of
+// the first triple that is (not smaller and hence) larger.
+//
+// 3. If the triple falls "between two blocks" (the last triple of the previous
+// block is smaller and the first triple of the next block is larger), then the
+// position is the first position in that next block.
+//
+// 4. As a special case of 3, if the triple is smaller than all triples in the
+// permutation, the position is the first position of the first block.
+//
+// 5. If the triple is larger than all triples in the permutation, the block
+// index is one after the largest block index and the position within that
+// non-existing block is arbitrary.

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -8,6 +8,7 @@
 
 #include "global/Constants.h"
 #include "index/IndexMetaData.h"
+#include "index/LocatedTriples.h"
 #include "util/CancellationHandle.h"
 #include "util/File.h"
 #include "util/Log.h"
@@ -126,6 +127,8 @@ class Permutation {
   // _______________________________________________________
   const bool& isLoaded() const { return isLoaded_; }
 
+  const MetaData& metaData() const { return meta_; }
+
  private:
   // for Log output, e.g. "POS"
   std::string readableName_;
@@ -135,7 +138,6 @@ class Permutation {
   // sorted, for example {1, 0, 2} for PSO.
   array<size_t, 3> keyOrder_;
 
-  const MetaData& metaData() const { return meta_; }
   MetaData meta_;
 
   // This member is `optional` because we initialize it in a deferred way in the

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -1,0 +1,704 @@
+// Copyright 2023 - 2024, University of Freiburg
+//  Chair of Algorithms and Data Structures.
+//  Authors:
+//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
+//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include "./util/AllocatorTestHelpers.h"
+#include "./util/IdTableHelpers.h"
+#include "./util/IdTestHelpers.h"
+#include "index/CompressedRelation.h"
+#include "index/IndexImpl.h"
+#include "index/LocatedTriples.h"
+#include "index/Permutation.h"
+
+// TODO: Why the namespace here? (copied from `test/IndexMetaDataTest.cpp`)
+namespace {
+auto V = ad_utility::testing::VocabId;
+}
+
+namespace Matchers {
+inline auto numBlocks =
+    [](size_t numBlocks) -> testing::Matcher<const LocatedTriplesPerBlock&> {
+  return AD_PROPERTY(LocatedTriplesPerBlock, LocatedTriplesPerBlock::numBlocks,
+                     testing::Eq(numBlocks));
+};
+
+inline auto numTriplesTotal =
+    [](size_t numTriples) -> testing::Matcher<const LocatedTriplesPerBlock&> {
+  return AD_PROPERTY(LocatedTriplesPerBlock, LocatedTriplesPerBlock::numTriples,
+                     testing::Eq(numTriples));
+};
+
+inline auto numTriplesBlockwise =
+    [](size_t blockIndex, std::pair<size_t, size_t> insertsAndDeletes)
+    -> testing::Matcher<const LocatedTriplesPerBlock&> {
+  return testing::ResultOf(
+      absl::StrCat(".numTriplesTotal(", std::to_string(blockIndex), ")"),
+      [blockIndex](const LocatedTriplesPerBlock& ltpb) {
+        return ltpb.numTriples(blockIndex);
+      },
+      testing::Eq(insertsAndDeletes));
+};
+
+// A Matcher to check `numBlocks`, `numTriplesTotal` and
+// `numTriplesTotal(blockIndex_)` for all blocks.
+auto allNums = [](size_t blocks, size_t triples,
+                  const ad_utility::HashMap<size_t, std::pair<size_t, size_t>>&
+                      numTriplesPerBlock)
+    -> testing::Matcher<const LocatedTriplesPerBlock&> {
+  auto blockMatchers = ad_utility::transform(
+      numTriplesPerBlock,
+      [](auto p) -> testing::Matcher<const LocatedTriplesPerBlock&> {
+        auto [blockIndex, insertsAndDeletes] = p;
+        return numTriplesBlockwise(blockIndex, insertsAndDeletes);
+      });
+  return testing::AllOf(numBlocks(blocks), numTriplesTotal(triples),
+                        testing::AllOfArray(blockMatchers));
+};
+}  // namespace Matchers
+namespace m = Matchers;
+
+// Fixture with helper functions.
+class LocatedTriplesTest : public ::testing::Test {
+ protected:
+  // Make `LocatedTriplesPerBlock` from a list of `LocatedTriple` objects (the
+  // order in which the objects are given does not matter).
+  LocatedTriplesPerBlock makeLocatedTriplesPerBlock(
+      const std::vector<LocatedTriple>& locatedTriples) {
+    LocatedTriplesPerBlock result;
+    result.add(locatedTriples);
+    return result;
+  }
+};
+
+auto IT = [](const auto& c1, const auto& c2, const auto& c3) {
+  return IdTriple{V(c1), V(c2), V(c3)};
+};
+
+// Test the method that counts the number of `LocatedTriple's in a block.
+TEST_F(LocatedTriplesTest, numTriplesInBlock) {
+  using LT = LocatedTriple;
+  // Set up lists of located triples for three blocks.
+  auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock(
+      {LT{1, IT(10, 1, 0), false}, LT{1, IT(10, 2, 1), false},
+       LT{1, IT(11, 3, 0), true}, LT{2, IT(20, 4, 0), true},
+       LT{2, IT(21, 5, 0), true}, LT{4, IT(30, 6, 0), true},
+       LT{4, IT(32, 7, 0), false}});
+
+  EXPECT_THAT(
+      locatedTriplesPerBlock,
+      m::allNums(3, 7, {{1, {1, 2}}, {2, {2, 0}}, {3, {0, 0}}, {4, {1, 1}}}));
+
+  auto handles = locatedTriplesPerBlock.add(
+      {LT{3, IT(25, 5, 0), true}, LT{4, IT(31, 6, 1), false}});
+
+  EXPECT_THAT(
+      locatedTriplesPerBlock,
+      m::allNums(4, 9, {{1, {1, 2}}, {2, {2, 0}}, {3, {1, 0}}, {4, {1, 2}}}));
+
+  locatedTriplesPerBlock.erase(3, handles[0]);
+
+  EXPECT_THAT(
+      locatedTriplesPerBlock,
+      m::allNums(3, 8, {{1, {1, 2}}, {2, {2, 0}}, {3, {0, 0}}, {4, {1, 2}}}));
+
+  locatedTriplesPerBlock.erase(4, handles[1]);
+
+  EXPECT_THAT(
+      locatedTriplesPerBlock,
+      m::allNums(3, 7, {{1, {1, 2}}, {2, {2, 0}}, {3, {0, 0}}, {4, {1, 1}}}));
+
+  locatedTriplesPerBlock.clear();
+
+  EXPECT_THAT(
+      locatedTriplesPerBlock,
+      m::allNums(0, 0, {{1, {0, 0}}, {2, {0, 0}}, {3, {0, 0}}, {4, {0, 0}}}));
+}
+
+TEST_F(LocatedTriplesTest, erase) {
+  using LT = LocatedTriple;
+  // Set up lists of located triples for three blocks.
+  auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock(
+      {LT{1, IT(10, 1, 0), false}, LT{1, IT(10, 2, 1), false},
+       LT{1, IT(11, 3, 0), true}, LT{2, IT(20, 4, 0), true},
+       LT{2, IT(21, 5, 0), true}, LT{4, IT(30, 6, 0), true},
+       LT{4, IT(32, 7, 0), false}});
+
+  auto handles = locatedTriplesPerBlock.add({LT{1, IT(15, 15, 15), false}});
+  EXPECT_THROW(locatedTriplesPerBlock.erase(5, handles[0]),
+               ad_utility::Exception);
+}
+
+// Test the method that merges the matching `LocatedTriple`s from a block into
+// an `IdTable`.
+TEST_F(LocatedTriplesTest, mergeTriples) {
+  using LT = LocatedTriple;
+
+  auto merge = [](size_t resultCols, size_t numIndexColumns, size_t resultRows,
+                  IdTable block, const LocatedTriplesPerBlock& locatedTriples) {
+    IdTable result(resultCols, ad_utility::testing::makeAllocator());
+    result.resize(resultRows);
+    locatedTriples.mergeTriples(1, std::move(block), result, 0,
+                                numIndexColumns);
+    return result;
+  };
+
+  // Merge the `LocatesTriples` into a block with 3 index columns.
+  {
+    IdTable block = makeIdTableFromVector({
+        {1, 10, 10},  // Row 0
+        {2, 15, 20},  // Row 1
+        {2, 15, 30},  // Row 2
+        {2, 20, 10},  // Row 3
+        {2, 30, 20},  // Row 4
+        {3, 30, 30}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 5, 10), true},    // Insert before row 0
+        LT{1, IT(1, 10, 10), false},  // Delete row 0
+        LT{1, IT(1, 10, 11), true},   // Insert before row 1
+        LT{1, IT(2, 11, 10), true},   // Insert before row 1
+        LT{1, IT(2, 30, 10), true},   // Insert before row 4
+        LT{1, IT(2, 30, 20), false},  // Delete row 4
+        LT{1, IT(3, 30, 25), false},  // Delete non-existent row
+        LT{1, IT(3, 30, 30), false},  // Delete row 5
+        LT{1, IT(4, 10, 10), true},   // Insert after row 5
+    });
+    IdTable resultExpected = makeIdTableFromVector({
+        {1, 5, 10},   // LT 1
+        {1, 10, 11},  // LT 2
+        {2, 11, 10},  // LT 3
+        {2, 15, 20},  // orig. Row 1
+        {2, 15, 30},  // orig. Row 2
+        {2, 20, 10},  // orig. Row 3
+        {2, 30, 10},  // LT 4
+        {4, 10, 10}   // LT 7
+    });
+
+    auto merged =
+        merge(resultExpected.numColumns(), 3, resultExpected.numRows(),
+              std::move(block), locatedTriplesPerBlock);
+    EXPECT_EQ(merged, resultExpected);
+  }
+
+  // Merge the `LocatesTriples` into a block with 2 index columns. This may
+  // happen if all triples in a block have the same value for the first column.
+  {
+    IdTable block = makeIdTableFromVector({
+        {10, 10},  // Row 0
+        {15, 20},  // Row 1
+        {15, 30},  // Row 2
+        {20, 10},  // Row 3
+        {30, 20},  // Row 4
+        {30, 30}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 10, 10), false},  // Delete row 0
+        LT{1, IT(1, 10, 11), true},   // Insert before row 1
+        LT{1, IT(1, 11, 10), true},   // Insert before row 1
+        LT{1, IT(1, 21, 11), true},   // Insert before row 4
+        LT{1, IT(1, 30, 10), true},   // Insert before row 4
+        LT{1, IT(1, 30, 20), false},  // Delete row 4
+        LT{1, IT(1, 30, 25), false},  // Delete non-existent row
+        LT{1, IT(1, 30, 30), false}   // Delete row 5
+    });
+    IdTable resultExpected = makeIdTableFromVector({
+        {10, 11},  // LT 2
+        {11, 10},  // LT 3
+        {15, 20},  // orig. Row 1
+        {15, 30},  // orig. Row 2
+        {20, 10},  // orig. Row 3
+        {21, 11},  // LT 4
+        {30, 10}   // LT 5
+    });
+
+    auto merged =
+        merge(resultExpected.numColumns(), 2, resultExpected.numRows(),
+              std::move(block), locatedTriplesPerBlock);
+    EXPECT_EQ(merged, resultExpected);
+  }
+
+  // Merge the `LocatesTriples` into a block with 1 index columns.
+  {
+    IdTable block = makeIdTableFromVector({
+        {10},  // Row 0
+        {11},  // Row 1
+        {12},  // Row 2
+        {20},  // Row 3
+        {23},  // Row 4
+        {30}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 10, 12), false},  // Delete row 2
+        LT{1, IT(1, 10, 13), true},   // Insert before row 3
+    });
+    IdTable resultExpected = makeIdTableFromVector({
+        {10},  // orig. Row 0
+        {11},  // orig. Row 1
+        {13},  // LT 2
+        {20},  // orig. Row 3
+        {23},  // orig. Row 4
+        {30}   // orig. Row 5
+    });
+
+    auto merged =
+        merge(resultExpected.numColumns(), 1, resultExpected.numRows(),
+              std::move(block), locatedTriplesPerBlock);
+    EXPECT_EQ(merged, resultExpected);
+  }
+
+  // Inserting a Triple that already exists should have no effect.
+  {
+    IdTable block = makeIdTableFromVector({{1, 2, 3}, {1, 3, 5}, {1, 7, 9}});
+    auto locatedTriplesPerBlock =
+        makeLocatedTriplesPerBlock({LT{1, IT(1, 3, 5), true}});
+    IdTable resultExpected = block.clone();
+
+    auto merged =
+        merge(resultExpected.numColumns(), 3, resultExpected.numRows(),
+              std::move(block), locatedTriplesPerBlock);
+    EXPECT_EQ(merged, resultExpected);
+  }
+  // Inserting a Triple that already exists should have no effect.
+  {
+    IdTable block = makeIdTableFromVector({{1, 2, 3}, {1, 3, 5}, {1, 7, 9}});
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock(
+        {LT{1, IT(1, 2, 4), false}, LT{1, IT(1, 2, 5), false},
+         LT{1, IT(1, 3, 5), false}});
+    IdTable resultExpected = makeIdTableFromVector({{1, 2, 3}, {1, 7, 9}});
+
+    auto merged =
+        merge(resultExpected.numColumns(), 3, resultExpected.numRows(),
+              std::move(block), locatedTriplesPerBlock);
+    EXPECT_EQ(merged, resultExpected);
+  }
+
+  // Merging if the block has additional columns.
+  {
+    IdTable block =
+        makeIdTableFromVector({{1, 2, 3, ad_utility::testing::IntId(10),
+                                ad_utility::testing::IntId(11)},
+                               {1, 3, 5, ad_utility::testing::IntId(12),
+                                ad_utility::testing::IntId(11)},
+                               {1, 7, 9, ad_utility::testing::IntId(13),
+                                ad_utility::testing::IntId(14)}});
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock(
+        {LT{1, IT(1, 3, 5), false}, LT{1, IT(1, 3, 6), true}});
+    IdTable resultExpected =
+        makeIdTableFromVector({{1, 2, 3, ad_utility::testing::IntId(10),
+                                ad_utility::testing::IntId(11)},
+                               {1, 3, 6, ad_utility::testing::UndefId(),
+                                ad_utility::testing::UndefId()},
+                               {1, 7, 9, ad_utility::testing::IntId(13),
+                                ad_utility::testing::IntId(14)}});
+
+    auto merged =
+        merge(resultExpected.numColumns(), 3, resultExpected.numRows(),
+              std::move(block), locatedTriplesPerBlock);
+    EXPECT_EQ(merged, resultExpected);
+  }
+
+  // Merging for a block that has no located triples returns an error.
+  {
+    IdTable block = makeIdTableFromVector({
+        {4, 10, 10},  // Row 0
+        {5, 15, 20},  // Row 1
+        {5, 15, 30},  // Row 2
+        {5, 20, 10},  // Row 3
+        {5, 30, 20},  // Row 4
+        {6, 30, 30}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 5, 10), true},    // Insert before row 0
+        LT{1, IT(1, 10, 10), false},  // Delete row 0
+        LT{1, IT(1, 10, 11), true},   // Insert before row 1
+        LT{1, IT(2, 11, 10), true},   // Insert before row 1
+        LT{1, IT(2, 30, 10), true},   // Insert before row 4
+        LT{1, IT(2, 30, 20), false},  // Delete row 4
+        LT{1, IT(3, 30, 30), false},  // Delete row 5
+        LT{1, IT(4, 10, 10), true},   // Insert after row 5
+    });
+
+    IdTable result(3, ad_utility::testing::makeAllocator());
+    result.resize(locatedTriplesPerBlock.numTriples());
+    EXPECT_THROW(
+        locatedTriplesPerBlock.mergeTriples(2, std::move(block), result, 0, 3),
+        ad_utility::Exception);
+  }
+
+  {
+    IdTable block = makeIdTableFromVector({
+        {1, 10, 10},  // Row 0
+        {2, 15, 20},  // Row 1
+        {2, 15, 30},  // Row 2
+        {2, 20, 10},  // Row 3
+        {2, 30, 20},  // Row 4
+        {3, 30, 30}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 5, 10), true},    // Insert before row 0
+        LT{1, IT(1, 10, 10), false},  // Delete row 0
+        LT{1, IT(1, 10, 11), true},   // Insert before row 1
+        LT{1, IT(2, 11, 10), true},   // Insert before row 1
+        LT{1, IT(2, 30, 10), true},   // Insert before row 4
+        LT{1, IT(2, 30, 20), false},  // Delete row 4
+        LT{1, IT(3, 30, 25), false},  // Delete non-existent row
+        LT{1, IT(3, 30, 30), false},  // Delete row 5
+        LT{1, IT(4, 10, 10), true},   // Insert after row 5
+    });
+    IdTable result(3, ad_utility::testing::makeAllocator());
+    result.resize(locatedTriplesPerBlock.numTriples());
+    EXPECT_THROW(
+        locatedTriplesPerBlock.mergeTriples(1, std::move(block), result, 0, 4),
+        ad_utility::Exception);
+  }
+
+  {
+    IdTable block = makeIdTableFromVector({
+        {1, 10, 10},  // Row 0
+        {2, 15, 20},  // Row 1
+        {2, 15, 30},  // Row 2
+        {2, 20, 10},  // Row 3
+        {2, 30, 20},  // Row 4
+        {3, 30, 30}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 5, 10), true},    // Insert before row 0
+        LT{1, IT(1, 10, 10), false},  // Delete row 0
+        LT{1, IT(1, 10, 11), true},   // Insert before row 1
+        LT{1, IT(2, 11, 10), true},   // Insert before row 1
+        LT{1, IT(2, 30, 10), true},   // Insert before row 4
+        LT{1, IT(2, 30, 20), false},  // Delete row 4
+        LT{1, IT(3, 30, 25), false},  // Delete non-existent row
+        LT{1, IT(3, 30, 30), false},  // Delete row 5
+        LT{1, IT(4, 10, 10), true},   // Insert after row 5
+    });
+    IdTable result(1, ad_utility::testing::makeAllocator());
+    result.resize(locatedTriplesPerBlock.numTriples());
+    EXPECT_THROW(
+        locatedTriplesPerBlock.mergeTriples(1, std::move(block), result, 0, 3),
+        ad_utility::Exception);
+  }
+
+  {
+    IdTable block = makeIdTableFromVector({
+        {},  // Row 0
+        {},  // Row 1
+        {},  // Row 2
+        {},  // Row 3
+        {},  // Row 4
+        {}   // Row 5
+    });
+    auto locatedTriplesPerBlock = makeLocatedTriplesPerBlock({
+        LT{1, IT(1, 5, 10), true},   // Insert before row 0
+        LT{1, IT(2, 11, 10), true},  // Insert before row 1
+    });
+    IdTable result(0, ad_utility::testing::makeAllocator());
+    result.resize(locatedTriplesPerBlock.numTriples());
+    EXPECT_THROW(
+        locatedTriplesPerBlock.mergeTriples(1, std::move(block), result, 0, 0),
+        ad_utility::Exception);
+  }
+}
+
+// Test the locating of triples in a permutation using `locatedTriple`.
+TEST_F(LocatedTriplesTest, locatedTriple) {
+  using LT = LocatedTriple;
+
+  auto checkRelationsForPermutation =
+      [](const Permutation& permutation,
+         const std::vector<Id>& expectedRelations) {
+        auto cancellationHandle =
+            std::make_shared<ad_utility::CancellationHandle<>>();
+        // TODO<qup42,cpp23>: use zip
+        auto relationsAndCounts =
+            permutation.getDistinctCol0IdsAndCounts(cancellationHandle);
+        ASSERT_EQ(relationsAndCounts.numRows(), expectedRelations.size())
+            << "Expected and real number of relations differ";
+        for (size_t i = 0; i < expectedRelations.size(); i++) {
+          auto relationId = expectedRelations[i];
+          IdTable relationEntries =
+              permutation.scan(CompressedRelationReader::ScanSpecification(
+                                   relationId, std::nullopt, std::nullopt),
+                               {}, cancellationHandle);
+          // std::cout << "Relation: " << relationId << " -> " <<
+          // relationEntries << std::endl;
+          ASSERT_EQ(relationsAndCounts.at(i, 0), relationId);
+          // ASSERT_EQ(relationsAndCounts.at(i, 1), ??);
+          ASSERT_FALSE(relationEntries.empty())
+              << "Relation " << relationId << " is empty in Permutation "
+              << permutation.readableName();
+        }
+      };
+  // TODO<qup42> use or delete; keep for now
+  (void)checkRelationsForPermutation;
+  auto displayBlocks =
+      [](const vector<CompressedBlockMetadata>& blockMetadata) {
+        for (size_t i = 0; i < blockMetadata.size(); i++) {
+          const auto& block = blockMetadata[i];
+          std::cout << "Block #" << i << "(n=" << block.numRows_
+                    << "): " << block.firstTriple_ << " -> "
+                    << block.lastTriple_ << std::endl;
+        }
+      };
+  auto checkTripleLocationForPermutation =
+      [](const Permutation& permutation,
+         const std::vector<IdTriple>& triplesToLocate,
+         const ad_utility::HashMap<size_t, std::vector<LT>>&
+             expectedLocatedTriplesPerBlock) {
+        LocatedTriplesPerBlock locatedTriplesPerBlock;
+        // TODO<qup42> test for adding/deleting (and not only deletion)
+        locatedTriplesPerBlock.add(LT::locateTriplesInPermutation(
+            triplesToLocate, permutation, false));
+
+        std::cout << locatedTriplesPerBlock;
+
+        // Extract the sorted keys (block indices) from the map
+        std::vector<size_t> blockIndices;
+        for (const auto& [blockIndex, expectedLocatedTriples] :
+             expectedLocatedTriplesPerBlock) {
+          blockIndices.push_back(blockIndex);
+        }
+        std::sort(blockIndices.begin(), blockIndices.end());
+        // Check that all expected blocks are present and contain the expected
+        // Triples
+        for (auto blockIndex : blockIndices) {
+          ASSERT_TRUE(locatedTriplesPerBlock.map_.contains(blockIndex))
+              << "blockIndex = " << blockIndex << " not found";
+          auto locatedTriplesSet = locatedTriplesPerBlock.map_.at(blockIndex);
+          std::vector<LT> computedLocatedTriples(locatedTriplesSet.begin(),
+                                                 locatedTriplesSet.end());
+          std::vector<LT> expectedLocatedTriples =
+              expectedLocatedTriplesPerBlock.at(blockIndex);
+          std::vector<LT> expectedPermutedLocatedTriples =
+              ad_utility::transform(
+                  std::move(expectedLocatedTriples), [&permutation](LT&& lt) {
+                    return LT{lt.blockIndex_,
+                              permute(lt.triple_, permutation.keyOrder()),
+                              lt.shouldTripleExist_};
+                  });
+          ASSERT_EQ(computedLocatedTriples, expectedPermutedLocatedTriples)
+              << "blockIndex = " << blockIndex
+              << " doesn't have the expected LocatedTriples";
+        }
+        ASSERT_EQ(locatedTriplesPerBlock.numBlocks(),
+                  expectedLocatedTriplesPerBlock.size());
+      };
+  auto createIndexFromIdTable = [](const IdTable& triplesInIndex,
+                                   ad_utility::AllocatorWithLimit<Id> allocator,
+                                   const std::string& indexBasename,
+                                   const ad_utility::MemorySize& blockSize) {
+    IndexImpl indexBuilder(allocator);
+    indexBuilder.setOnDiskBase(indexBasename);
+    indexBuilder.blocksizePermutationPerColumn() = blockSize;
+
+    // This is still not a complete index. `Index::createFromOnDiskIndex`
+    // cannot be used, because the vocabulary is not generated.
+    // `IndexImpl::readIndexBuilderSettingsFromFile` also has to be called
+    // before building the index in this case.
+    std::function<bool(const ValueId&)> isInternalId = [](const ValueId&) {
+      return false;
+    };
+    auto firstSorter = indexBuilder.makeSorter<FirstPermutation>("first");
+    ad_utility::CompressedExternalIdTableSorterTypeErased&
+        typeErasedFirstSorter = firstSorter;
+    firstSorter.pushBlock(triplesInIndex.clone());
+    auto firstSorterWithUnique =
+        ad_utility::uniqueBlockView(typeErasedFirstSorter.getSortedOutput());
+    auto secondSorter = indexBuilder.makeSorter<SecondPermutation>("second");
+    indexBuilder.createSPOAndSOP(3, isInternalId,
+                                 std::move(firstSorterWithUnique),
+                                 std::move(secondSorter));
+    typeErasedFirstSorter.clearUnderlying();
+    auto thirdSorter = indexBuilder.makeSorter<ThirdPermutation>("third");
+    indexBuilder.createOSPAndOPS(3, isInternalId,
+                                 secondSorter.getSortedBlocks<0>(),
+                                 std::move(thirdSorter));
+    secondSorter.clear();
+    indexBuilder.createPSOAndPOS(3, isInternalId,
+                                 thirdSorter.getSortedBlocks<0>());
+    thirdSorter.clear();
+  };
+  auto deletePermutation = [](const std::string& indexBasename,
+                              const Permutation& permutation) {
+    std::string name = indexBasename + ".index" + permutation.fileSuffix();
+    ad_utility::deleteFile(name);
+    ad_utility::deleteFile(name + MMAP_FILE_SUFFIX);
+  };
+  // The actual test, for a given block size.
+  auto testWithGivenBlockSizeAll =
+      [&displayBlocks, &checkTripleLocationForPermutation,
+       &createIndexFromIdTable, &deletePermutation](
+          const IdTable& triplesInIndex,
+          const std::vector<IdTriple>& triplesToLocate,
+          const ad_utility::MemorySize& blockSize,
+          const ad_utility::HashMap<
+              Permutation::Enum, ad_utility::HashMap<size_t, std::vector<LT>>>&
+              expectedLocatedTriplesPerBlock) {
+        std::string testIndexBasename = "LocatedTriplesTest.locatedTriple";
+
+        const auto& testAllocator = ad_utility::testing::makeAllocator();
+        createIndexFromIdTable(triplesInIndex, testAllocator, testIndexBasename,
+                               blockSize);
+
+        using enum Permutation::Enum;
+        for (auto& perm : {SPO, SOP, OSP, OPS, PSO, POS}) {
+          Permutation permutation{perm, {}, testAllocator};
+          permutation.loadFromDisk(testIndexBasename);
+
+          if (expectedLocatedTriplesPerBlock.contains(perm)) {
+            displayBlocks(permutation.metaData().blockData());
+
+            checkTripleLocationForPermutation(
+                permutation, triplesToLocate,
+                expectedLocatedTriplesPerBlock.at(perm));
+          } else {
+            std::cout << "Skipping permutation " << Permutation::toString(perm)
+                      << std::endl;
+          }
+
+          deletePermutation(testIndexBasename, permutation);
+        }
+      };
+
+  {
+    // Triples in the index.
+    IdTable triplesInIndex = makeIdTableFromVector({{1, 10, 10},    // Row 0
+                                                    {2, 10, 10},    // Row 1
+                                                    {2, 15, 20},    // Row 2
+                                                    {2, 15, 30},    // Row 3
+                                                    {2, 20, 10},    // Row 4
+                                                    {2, 30, 20},    // Row 5
+                                                    {2, 30, 30},    // Row 6
+                                                    {3, 10, 10}});  // Row 7
+
+    // Locate the following triples, some of which exist in the relation and
+    // some of which do not, and which cover a variety of positions, including
+    // triples that are larger than all existing triples.
+    std::vector<IdTriple> triplesToLocate{IT(1, 5, 10),    // Before Row 0
+                                          IT(1, 15, 10),   // Before Row 1
+                                          IT(2, 10, 10),   // Equals Row 1
+                                          IT(2, 14, 20),   // Before Row 2
+                                          IT(2, 20, 10),   // Equals Row 4
+                                          IT(2, 30, 30),   // Equals Row 6
+                                          IT(2, 30, 31),   // Before Row 7
+                                          IT(9, 30, 32)};  // Larger than all.
+
+    // Now test for multiple block sizes (8 bytes is the minimum; number
+    // determined experimentally).
+    std::cout << "Index triples: " << triplesInIndex << std::endl;
+    std::cout << "Delta triples: " << triplesToLocate << std::endl;
+
+    // With block size 8, we have each triple in its own block.
+    testWithGivenBlockSizeAll(
+        triplesInIndex, triplesToLocate, 8_B,
+        {{Permutation::SPO,
+          {{0, {LT(0, IT(1, 5, 10), false)}},
+           {1, {LT(1, IT(1, 15, 10), false), LT(1, IT(2, 10, 10), false)}},
+           {2, {LT(2, IT(2, 14, 20), false)}},
+           {4, {LT(4, IT(2, 20, 10), false)}},
+           {6, {LT(6, IT(2, 30, 30), false)}},
+           {7, {LT(7, IT(2, 30, 31), false)}},
+           {8, {LT(8, IT(9, 30, 32), false)}}}}});
+
+    // With block size 16, we have five blocks (Block 0 = Row 0, Block 1 = Row
+    // 1+2, Block 2 = Row 3+4, Block 3 = Row 5+6, Block 4 = Row 7).
+    testWithGivenBlockSizeAll(
+        triplesInIndex, triplesToLocate, 16_B,
+        {{Permutation::SPO,
+          {{0, {LT(0, IT(1, 5, 10), false)}},
+           {1,
+            {LT(1, IT(1, 15, 10), false), LT(1, IT(2, 10, 10), false),
+             LT(1, IT(2, 14, 20), false)}},
+           {2, {LT(2, IT(2, 20, 10), false)}},
+           {3, {LT(3, IT(2, 30, 30), false)}},
+           {4, {LT(4, IT(2, 30, 31), false)}},
+           {5, {LT(5, IT(9, 30, 32), false)}}}}});
+
+    // With block size 32, we have four blocks (Block 0 = Row 0, Block 1 = Row
+    // 1+2+3+4, Block 2 = Row 5+6, Block 3 = Row 7). Note that a
+    // relation that spans multiple blocks has these blocks on its own.
+    testWithGivenBlockSizeAll(
+        triplesInIndex, triplesToLocate, 32_B,
+        {{Permutation::SPO,
+          {{0, {LT(0, IT(1, 5, 10), false)}},
+           {1,
+            {LT(1, IT(1, 15, 10), false), LT(1, IT(2, 10, 10), false),
+             LT(1, IT(2, 14, 20), false), LT(1, IT(2, 20, 10), false)}},
+           {2, {LT(2, IT(2, 30, 30), false)}},
+           {3, {LT(3, IT(2, 30, 31), false)}},
+           {4, {LT(4, IT(9, 30, 32), false)}}}}});
+
+    // With block size 48, we have three blocks (Block 0 = Row 0, Block 1 = Row
+    // 1+2+3+4+5+6, Block 2 = Row 7).
+    testWithGivenBlockSizeAll(
+        triplesInIndex, triplesToLocate, 48_B,
+        {{Permutation::SPO,
+          {{0, {LT(0, IT(1, 5, 10), false)}},
+           {1,
+            {LT(1, IT(1, 15, 10), false), LT(1, IT(2, 10, 10), false),
+             LT(1, IT(2, 14, 20), false), LT(1, IT(2, 20, 10), false),
+             LT(1, IT(2, 30, 30), false)}},
+           {2, {LT(2, IT(2, 30, 31), false)}},
+           {3, {LT(3, IT(9, 30, 32), false)}}}}});
+
+    // With block size 100'000, we have one block.
+    testWithGivenBlockSizeAll(
+        triplesInIndex, triplesToLocate, 100'000_B,
+        {{Permutation::SPO,
+          {{0,
+            {LT(0, IT(1, 5, 10), false), LT(0, IT(1, 15, 10), false),
+             LT(0, IT(2, 10, 10), false), LT(0, IT(2, 14, 20), false),
+             LT(0, IT(2, 20, 10), false), LT(0, IT(2, 30, 30), false),
+             LT(0, IT(2, 30, 31), false)}},
+           {1, {LT(1, IT(9, 30, 32), false)}}}}});
+  }
+
+  {
+    // Test more thoroughly in an index that consists of a single block.
+    IdTable triplesInIndex = makeIdTableFromVector({{1, 10, 10},    // Row 0
+                                                    {3, 10, 10},    // Row 1
+                                                    {3, 15, 20},    // Row 2
+                                                    {3, 15, 30},    // Row 3
+                                                    {3, 20, 10},    // Row 4
+                                                    {3, 30, 20},    // Row 5
+                                                    {3, 30, 30},    // Row 6
+                                                    {5, 10, 10},    // Row 7
+                                                    {7, 10, 10},    // Row 8
+                                                    {7, 15, 20},    // Row 9
+                                                    {7, 15, 30},    // Row 10
+                                                    {7, 20, 10},    // Row 11
+                                                    {7, 30, 20},    // Row 12
+                                                    {7, 30, 30}});  // Row 13
+
+    std::vector<IdTriple> triplesToLocate{
+        IT(1, 5, 20),    // Before Row 0
+        IT(1, 10, 10),   // Equal Row 0 (a small relation)
+        IT(2, 20, 10),   // Before Row 1
+        IT(3, 15, 30),   // Equal Row 3
+        IT(3, 20, 15),   // Before Row 5
+        IT(4, 30, 30),   // Before Row 7
+        IT(5, 5, 10),    // Before Row 7
+        IT(5, 10, 10),   // Equal Row 7
+        IT(6, 10, 10),   // Before Row 8
+        IT(7, 20, 5),    // Before Row 11
+        IT(7, 30, 20),   // Equal Row 12
+        IT(7, 30, 30),   // Equal Row 13
+        IT(9, 30, 32)};  // Larger than all.
+
+    testWithGivenBlockSizeAll(
+        triplesInIndex, triplesToLocate, 100'000_B,
+        {{Permutation::SPO,
+          {{0,
+            {LT(0, IT(1, 5, 20), false), LT(0, IT(1, 10, 10), false),
+             LT(0, IT(2, 20, 10), false), LT(0, IT(3, 15, 30), false),
+             LT(0, IT(3, 20, 15), false), LT(0, IT(4, 30, 30), false),
+             LT(0, IT(5, 5, 10), false), LT(0, IT(5, 10, 10), false),
+             LT(0, IT(6, 10, 10), false), LT(0, IT(7, 20, 5), false),
+             LT(0, IT(7, 30, 20), false), LT(0, IT(7, 30, 30), false)}},
+           {1, {LT(1, IT(9, 30, 32), false)}}}}});
+  }
+}


### PR DESCRIPTION
This is the first PR in a series of PRs that will come from #1351.

Changes:
- `LocatedTriple` is a triple that is to be deleted/inserted and has been assigned to a block in the index.
  - An operation to locate a batch of Triples: `locateTriplesInPermutation`
- `LocatedTriples` are an ordered set of `LocatedTriple`s.
- `LocatedTriplesPerBlock` are `LocatedTriples` for different blocks. This data structure will later exist once per Permutation.
  - An operation to add and remove `LocatedTriple`s: `add` and `erase`
  - An operation to update `IdTable` by the changes: `mergeTriples`
