### PR TITLE
Implement a `SingleUseExpression`

### DIFF
--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -179,8 +179,8 @@ class LiteralExpression : public SparqlExpression {
   std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
 
-// A simple expression that just returns an explicit result.
-// It can only be used once as the result is moved out.
+// A simple expression that just returns an explicit result. It can only be used
+// once as the result is moved out.
 struct SingleUseExpression : public SparqlExpression {
   explicit SingleUseExpression(ExpressionResult result)
       : result_{std::move(result)} {}

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -178,6 +178,34 @@ class LiteralExpression : public SparqlExpression {
   // Literal expressions don't have children
   std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
 };
+
+// A simple expression that just returns an explicit result.
+// It can only be used once as the result is moved out.
+struct SingleUseExpression : public SparqlExpression {
+  explicit SingleUseExpression(ExpressionResult result)
+      : result_{std::move(result)} {}
+  mutable ExpressionResult result_;
+  mutable std::atomic<bool> resultWasMoved_ = false;
+  ExpressionResult evaluate(EvaluationContext*) const override {
+    AD_CONTRACT_CHECK(!resultWasMoved_);
+    resultWasMoved_ = true;
+    return std::move(result_);
+  }
+
+  vector<Variable> getUnaggregatedVariables() override {
+    // This class should only be used as an implementation of other expressions,
+    // not as a "normal" part of an expression tree.
+    AD_FAIL();
+  }
+  string getCacheKey(
+      [[maybe_unused]] const VariableToColumnMap& varColMap) const override {
+    // This class should only be used as an implementation of other expressions,
+    // not as a "normal" part of an expression tree.
+    AD_FAIL();
+  }
+
+  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+};
 }  // namespace detail
 
 ///  The actual instantiations and aliases of LiteralExpressions.
@@ -188,4 +216,5 @@ using StringLiteralExpression =
 using IdExpression = detail::LiteralExpression<ValueId>;
 using VectorIdExpression =
     detail::LiteralExpression<VectorWithMemoryLimit<ValueId>>;
+using SingleUseExpression = detail::SingleUseExpression;
 }  // namespace sparqlExpression

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -39,7 +39,7 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
   auto trace = generateLocationTrace(l);
   VectorWithMemoryLimit<T> input(inputAsVector.begin(), inputAsVector.end(),
                                  makeAllocator());
-  auto d = std::make_unique<DummyExpression>(input.clone());
+  auto d = std::make_unique<SingleUseExpression>(input.clone());
   auto t = TestContext{};
   t.context._endIndex = input.size();
   AggregateExpressionT m{distinct, std::move(d)};

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -9,6 +9,7 @@
 #include "./util/AllocatorTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
+#include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/RelationalExpressions.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -42,8 +43,9 @@ const auto NaN = std::numeric_limits<double>::quiet_NaN();
 template <Comparison comp>
 auto makeExpression(SingleExpressionResult auto leftValue,
                     SingleExpressionResult auto rightValue) {
-  auto leftChild = std::make_unique<DummyExpression>(std::move(leftValue));
-  auto rightChild = std::make_unique<DummyExpression>(std::move(rightValue));
+  auto leftChild = std::make_unique<SingleUseExpression>(std::move(leftValue));
+  auto rightChild =
+      std::make_unique<SingleUseExpression>(std::move(rightValue));
 
   return relational::RelationalExpression<comp>(
       {std::move(leftChild), std::move(rightChild)});

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -883,6 +883,93 @@ TEST(SparqlExpression, isSomethingFunctions) {
 }
 
 // ____________________________________________________________________________
+TEST(SparqlExpression, DatatypeExpression) {
+  U = Id::makeUndefined();
+  auto d1 = DateOrLargeYear::parseXsdDatetime("1900-12-13T03:12:00.33Z");
+  auto d2 = DateOrLargeYear::parseGYear("-10000");
+  auto d3 = DateOrLargeYear::parseGYear("1900");
+  auto d4 = DateOrLargeYear::parseXsdDate("2024-06-13");
+  auto d5 = DateOrLargeYear::parseGYearMonth("2024-06");
+  Id DateId1 = Id::makeFromDate(d1);
+  Id DateId2 = Id::makeFromDate(d2);
+  Id DateId3 = Id::makeFromDate(d3);
+  Id DateId4 = Id::makeFromDate(d4);
+  Id DateId5 = Id::makeFromDate(d5);
+  auto checkGetDatatype = testUnaryExpression<&makeDatatypeExpression>;
+  checkGetDatatype(IdOrLiteralOrIriVec{testContext().x},
+                   IdOrLiteralOrIriVec{U});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{testContext().alpha},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{testContext().zz},
+      IdOrLiteralOrIriVec{
+          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{testContext().notInVocabB},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
+  checkGetDatatype(IdOrLiteralOrIriVec{testContext().notInVocabD},
+                   IdOrLiteralOrIriVec{U});
+  checkGetDatatype(IdOrLiteralOrIriVec{lit(
+                       "123", "^^<http://www.w3.org/2001/XMLSchema#integer>")},
+                   IdOrLiteralOrIriVec{
+                       iriref("<http://www.w3.org/2001/XMLSchema#integer>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{lit("Simple StrStr")},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{lit("english", "@en")},
+      IdOrLiteralOrIriVec{
+          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")});
+  checkGetDatatype(IdOrLiteralOrIriVec{U}, IdOrLiteralOrIriVec{U});
+  checkGetDatatype(IdOrLiteralOrIriVec{DateId1},
+                   IdOrLiteralOrIriVec{
+                       iriref("<http://www.w3.org/2001/XMLSchema#dateTime>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{DateId2},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#gYear>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{DateId3},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#gYear>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{DateId4},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#date>")});
+  checkGetDatatype(IdOrLiteralOrIriVec{DateId5},
+                   IdOrLiteralOrIriVec{iriref(
+                       "<http://www.w3.org/2001/XMLSchema#gYearMonth>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{Id::makeFromInt(212378233)},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#int>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{Id::makeFromDouble(2.3475)},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#double>")});
+  checkGetDatatype(IdOrLiteralOrIriVec{Id::makeFromBool(false)},
+                   IdOrLiteralOrIriVec{
+                       iriref("<http://www.w3.org/2001/XMLSchema#boolean>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{Id::makeFromInt(true)},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#int>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{lit("")},
+      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{lit(" ", "@de-LATN-de")},
+      IdOrLiteralOrIriVec{
+          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")});
+  checkGetDatatype(
+      IdOrLiteralOrIriVec{lit("testval", "^^<http://example/iri/test#test>")},
+      IdOrLiteralOrIriVec{iriref("<http://example/iri/test#test>")});
+  checkGetDatatype(IdOrLiteralOrIriVec{iriref("<http://example/iri/test>")},
+                   IdOrLiteralOrIriVec{U});
+
+  // test corner case DatatypeValueGetter
+  TestContext ctx;
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      sparqlExpression::detail::DatatypeValueGetter{}(Id::max(), &ctx.context),
+      ::testing::ContainsRegex("should be unreachable"));
+}
+
+// ____________________________________________________________________________
 TEST(SparqlExpression, testStrToHashExpressions) {
   auto checkGetMD5Expression = testUnaryExpression<&makeMD5Expression>;
   auto checkGetSHA1Expression = testUnaryExpression<&makeSHA1Expression>;

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -208,7 +208,7 @@ auto testNaryExpressionImpl =
       context._endIndex = resultSize;
 
       std::array<SparqlExpression::Ptr, sizeof...(operands)> children{
-          std::make_unique<DummyExpression>(
+          std::make_unique<SingleUseExpression>(
               ExpressionResult{clone(operands)})...};
 
       auto expressionPtr = std::apply(makeExpression, std::move(children));
@@ -883,93 +883,6 @@ TEST(SparqlExpression, isSomethingFunctions) {
 }
 
 // ____________________________________________________________________________
-TEST(SparqlExpression, DatatypeExpression) {
-  U = Id::makeUndefined();
-  auto d1 = DateOrLargeYear::parseXsdDatetime("1900-12-13T03:12:00.33Z");
-  auto d2 = DateOrLargeYear::parseGYear("-10000");
-  auto d3 = DateOrLargeYear::parseGYear("1900");
-  auto d4 = DateOrLargeYear::parseXsdDate("2024-06-13");
-  auto d5 = DateOrLargeYear::parseGYearMonth("2024-06");
-  Id DateId1 = Id::makeFromDate(d1);
-  Id DateId2 = Id::makeFromDate(d2);
-  Id DateId3 = Id::makeFromDate(d3);
-  Id DateId4 = Id::makeFromDate(d4);
-  Id DateId5 = Id::makeFromDate(d5);
-  auto checkGetDatatype = testUnaryExpression<&makeDatatypeExpression>;
-  checkGetDatatype(IdOrLiteralOrIriVec{testContext().x},
-                   IdOrLiteralOrIriVec{U});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{testContext().alpha},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{testContext().zz},
-      IdOrLiteralOrIriVec{
-          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{testContext().notInVocabB},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
-  checkGetDatatype(IdOrLiteralOrIriVec{testContext().notInVocabD},
-                   IdOrLiteralOrIriVec{U});
-  checkGetDatatype(IdOrLiteralOrIriVec{lit(
-                       "123", "^^<http://www.w3.org/2001/XMLSchema#integer>")},
-                   IdOrLiteralOrIriVec{
-                       iriref("<http://www.w3.org/2001/XMLSchema#integer>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{lit("Simple StrStr")},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{lit("english", "@en")},
-      IdOrLiteralOrIriVec{
-          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")});
-  checkGetDatatype(IdOrLiteralOrIriVec{U}, IdOrLiteralOrIriVec{U});
-  checkGetDatatype(IdOrLiteralOrIriVec{DateId1},
-                   IdOrLiteralOrIriVec{
-                       iriref("<http://www.w3.org/2001/XMLSchema#dateTime>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{DateId2},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#gYear>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{DateId3},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#gYear>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{DateId4},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#date>")});
-  checkGetDatatype(IdOrLiteralOrIriVec{DateId5},
-                   IdOrLiteralOrIriVec{iriref(
-                       "<http://www.w3.org/2001/XMLSchema#gYearMonth>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{Id::makeFromInt(212378233)},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#int>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{Id::makeFromDouble(2.3475)},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#double>")});
-  checkGetDatatype(IdOrLiteralOrIriVec{Id::makeFromBool(false)},
-                   IdOrLiteralOrIriVec{
-                       iriref("<http://www.w3.org/2001/XMLSchema#boolean>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{Id::makeFromInt(true)},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#int>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{lit("")},
-      IdOrLiteralOrIriVec{iriref("<http://www.w3.org/2001/XMLSchema#string>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{lit(" ", "@de-LATN-de")},
-      IdOrLiteralOrIriVec{
-          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")});
-  checkGetDatatype(
-      IdOrLiteralOrIriVec{lit("testval", "^^<http://example/iri/test#test>")},
-      IdOrLiteralOrIriVec{iriref("<http://example/iri/test#test>")});
-  checkGetDatatype(IdOrLiteralOrIriVec{iriref("<http://example/iri/test>")},
-                   IdOrLiteralOrIriVec{U});
-
-  // test corner case DatatypeValueGetter
-  TestContext ctx;
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      sparqlExpression::detail::DatatypeValueGetter{}(Id::max(), &ctx.context),
-      ::testing::ContainsRegex("should be unreachable"));
-}
-
-// ____________________________________________________________________________
 TEST(SparqlExpression, testStrToHashExpressions) {
   auto checkGetMD5Expression = testUnaryExpression<&makeMD5Expression>;
   auto checkGetSHA1Expression = testUnaryExpression<&makeSHA1Expression>;
@@ -1285,4 +1198,16 @@ TEST(SparqlExpression, isAggregateAndIsDistinct) {
 
   ASSERT_TRUE(groupConcatDistinctExpression.isAggregate());
   ASSERT_TRUE(groupConcatDistinctExpression.isDistinct());
+}
+
+// ___________________________________________________________________________
+TEST(SingleUseExpression, simpleMembersForTestCoverage) {
+  SingleUseExpression expression(Id::makeUndefined());
+  using namespace ::testing;
+  EXPECT_THAT(expression.evaluate(nullptr),
+              VariantWith<Id>(Eq(Id::makeUndefined())));
+  EXPECT_ANY_THROW(expression.evaluate(nullptr));
+  EXPECT_THAT(expression.childrenForTesting(), IsEmpty());
+  EXPECT_ANY_THROW(expression.getUnaggregatedVariables());
+  EXPECT_ANY_THROW(expression.getCacheKey({}));
 }

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -4,6 +4,7 @@
 
 #include "./util/IdTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
+#include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "global/ValueIdComparators.h"
 #include "gtest/gtest.h"
@@ -13,23 +14,6 @@
 #pragma once
 
 namespace sparqlExpression {
-// Dummy expression for testing, that for `evaluate` returns the `result` that
-// is specified in the constructor.
-struct DummyExpression : public SparqlExpression {
-  explicit DummyExpression(ExpressionResult result)
-      : _result{std::move(result)} {}
-  mutable ExpressionResult _result;
-  ExpressionResult evaluate(EvaluationContext*) const override {
-    return std::move(_result);
-  }
-  vector<Variable> getUnaggregatedVariables() override { return {}; }
-  string getCacheKey(
-      [[maybe_unused]] const VariableToColumnMap& varColMap) const override {
-    return "DummyDummyDummDumm";
-  }
-
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
-};
 
 // Make a `ValueId` from an int/ a double. Shorter name, as it will be used
 // often.


### PR DESCRIPTION
This is a cleaner version (with a better name) of the `DummyExpression` that we used so far. 