### PR TITLE
Implement functions `IRI` and `URI`

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -62,6 +62,7 @@ SparqlExpression::Ptr makeStrLangTagExpression(SparqlExpression::Ptr child1,
                                                SparqlExpression::Ptr child2);
 
 SparqlExpression::Ptr makeStrExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeIriOrUriExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeStrlenExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeSubstrExpression(SparqlExpression::Ptr string,
                                            SparqlExpression::Ptr start,

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -126,8 +126,8 @@ struct EffectiveBooleanValueGetter : Mixin<EffectiveBooleanValueGetter> {
   }
 };
 
-/// This class can be used as the `ValueGetter` argument of Expression
-/// templates. It produces a string value.
+// This class can be used as the `ValueGetter` argument of Expression
+// templates. It produces a string value.
 struct StringValueGetter : Mixin<StringValueGetter> {
   using Mixin<StringValueGetter>::operator();
   std::optional<string> operator()(ValueId, const EvaluationContext*) const;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -112,6 +112,28 @@ struct LiftStringFunction {
   }
 };
 
+// IRI or URI
+//
+// TODOs:
+//
+// 1. Check for `BASE` URL and if it exists, prepend it.
+// 2. What's the correct behavior for non-strings, like `1` or `true`?
+//
+// @1: Ignored by the implementation below.
+// @2: The implementation below converts all this to a string and then to an
+// IRI.
+[[maybe_unused]] auto iriOrUri =
+    [](std::optional<std::string> s) -> IdOrLiteralOrIri {
+  if (!s.has_value()) {
+    return Id::makeUndefined();
+  } else {
+    return IdOrLiteralOrIri{
+        LiteralOrIri{Iri::fromIrirefWithoutBrackets(s.value())}};
+  }
+};
+
+using IriOrUriExpression = NARY<1, FV<decltype(iriOrUri), StringValueGetter>>;
+
 // STRLEN
 [[maybe_unused]] auto strlen = [](std::string_view s) {
   return Id::makeFromInt(static_cast<int64_t>(s.size()));
@@ -485,6 +507,9 @@ Expr make(std::same_as<Expr> auto&... children) {
   return std::make_unique<T>(std::move(children)...);
 }
 Expr makeStrExpression(Expr child) { return make<StrExpression>(child); }
+Expr makeIriOrUriExpression(Expr child) {
+  return make<IriOrUriExpression>(child);
+}
 Expr makeStrlenExpression(Expr child) { return make<StrlenExpression>(child); }
 
 Expr makeSubstrExpression(Expr string, Expr start, Expr length) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1994,6 +1994,8 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
   };
   if (functionName == "str") {
     return createUnary(&makeStrExpression);
+  } else if (functionName == "iri" || functionName == "uri") {
+    return createUnary(&makeIriOrUriExpression);
   } else if (functionName == "strlang") {
     return createBinary(&makeStrLangTagExpression);
   } else if (functionName == "strdt") {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1405,6 +1405,8 @@ TEST(SparqlParser, builtInCall) {
   expectBuiltInCall("ucaSe(?x)", matchUnary(&makeUppercaseExpression));
   expectBuiltInCall("lCase(?x)", matchUnary(&makeLowercaseExpression));
   expectBuiltInCall("StR(?x)", matchUnary(&makeStrExpression));
+  expectBuiltInCall("iRI(?x)", matchUnary(&makeIriOrUriExpression));
+  expectBuiltInCall("uRI(?x)", matchUnary(&makeIriOrUriExpression));
   expectBuiltInCall("year(?x)", matchUnary(&makeYearExpression));
   expectBuiltInCall("month(?x)", matchUnary(&makeMonthExpression));
   expectBuiltInCall("tz(?x)", matchUnary(&makeTimezoneStrExpression));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -550,6 +550,7 @@ TEST(SparqlExpression, dateOperators) {
 // _____________________________________________________________________________________
 auto checkStrlen = testUnaryExpression<&makeStrlenExpression>;
 auto checkStr = testUnaryExpression<&makeStrExpression>;
+auto checkIriOrUri = testUnaryExpression<&makeIriOrUriExpression>;
 static auto makeStrlenWithStr = [](auto arg) {
   return makeStrlenExpression(makeStrExpression(std::move(arg)));
 };
@@ -578,6 +579,10 @@ TEST(SparqlExpression, stringOperators) {
            IdOrLiteralOrIriVec{lit("true"), lit("false"), lit("true")});
   checkStr(IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")},
            IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")});
+
+  // Test `iriOrUriExpression`.
+  checkIriOrUri(IdOrLiteralOrIriVec{lit("bim"), lit("bam")},
+                IdOrLiteralOrIriVec{iriref("<bim>"), iriref("<bam>")});
 
   // A simple test for uniqueness of the cache key.
   auto c1a = makeStrlenExpression(std::make_unique<IriExpression>(iri("<bim>")))

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -581,8 +581,8 @@ TEST(SparqlExpression, stringOperators) {
            IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")});
 
   // Test `iriOrUriExpression`.
-  checkIriOrUri(IdOrLiteralOrIriVec{lit("bim"), lit("bam")},
-                IdOrLiteralOrIriVec{iriref("<bim>"), iriref("<bam>")});
+  checkIriOrUri(IdOrLiteralOrIriVec{lit("bim"), lit("bam"), U},
+                IdOrLiteralOrIriVec{iriref("<bim>"), iriref("<bam>"), U});
 
   // A simple test for uniqueness of the cache key.
   auto c1a = makeStrlenExpression(std::make_unique<IriExpression>(iri("<bim>")))


### PR DESCRIPTION
This is a first draft. It does something meaningful already, but is not quite standard-conform yet.

Also, I am not sure whether the `StringValueGetter` is the right way to go here, since the argument can also be an `Iri`, in which case the function should be the identity.