### PR TITLE
Fix result for implicit `GROUP BY` without matches

### DIFF
--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -10,9 +10,11 @@ namespace sparqlExpression {
 namespace detail {
 
 // __________________________________________________________________________
-template <typename AggregateOperation, typename FinalOp>
-AggregateExpression<AggregateOperation, FinalOp>::AggregateExpression(
-    bool distinct, Ptr&& child, AggregateOperation aggregateOp)
+template <typename AggregateOperation, typename NeutralElement,
+          typename FinalOperation>
+AggregateExpression<AggregateOperation, NeutralElement, FinalOperation>::
+    AggregateExpression(bool distinct, Ptr&& child,
+                        AggregateOperation aggregateOp)
     : _distinct(distinct),
       _child{std::move(child)},
       _aggregateOp{std::move(aggregateOp)} {
@@ -20,65 +22,75 @@ AggregateExpression<AggregateOperation, FinalOp>::AggregateExpression(
 }
 
 // __________________________________________________________________________
-template <typename AggregateOperation, typename FinalOperation>
-ExpressionResult
-AggregateExpression<AggregateOperation, FinalOperation>::evaluate(
-    EvaluationContext* context) const {
+template <typename AggregateOperation, typename NeutralElement,
+          typename FinalOperation>
+ExpressionResult AggregateExpression<
+    AggregateOperation, NeutralElement,
+    FinalOperation>::evaluate(EvaluationContext* context) const {
   auto childResult = _child->evaluate(context);
 
   return std::visit(
       [this, context](auto&& arg) {
-        return evaluateOnChildOperand(_aggregateOp, FinalOperation{}, context,
-                                      _distinct, AD_FWD(arg));
+        return evaluateOnChildOperand(_aggregateOp, this->getNeutralElement(),
+                                      FinalOperation{}, context, _distinct,
+                                      AD_FWD(arg));
       },
       std::move(childResult));
 }
 
 // _________________________________________________________________________
-template <typename AggregateOperation, typename FinalOperation>
-std::span<SparqlExpression::Ptr>
-AggregateExpression<AggregateOperation, FinalOperation>::childrenImpl() {
+template <typename AggregateOperation, typename NeutralElement,
+          typename FinalOperation>
+std::span<SparqlExpression::Ptr> AggregateExpression<
+    AggregateOperation, NeutralElement, FinalOperation>::childrenImpl() {
   return {&_child, 1};
 }
 
 // _________________________________________________________________________
-template <typename AggregateOperation, typename FinalOperation>
-vector<Variable> AggregateExpression<
-    AggregateOperation, FinalOperation>::getUnaggregatedVariables() {
+template <typename AggregateOperation, typename NeutralElement,
+          typename FinalOperation>
+vector<Variable>
+AggregateExpression<AggregateOperation, NeutralElement,
+                    FinalOperation>::getUnaggregatedVariables() {
   // This is an aggregate, so it never leaves any unaggregated variables.
   return {};
 }
 
 // __________________________________________________________________________
-template <typename AggregateOperation, typename FinalOperation>
-[[nodiscard]] string
-AggregateExpression<AggregateOperation, FinalOperation>::getCacheKey(
-    const VariableToColumnMap& varColMap) const {
+template <typename AggregateOperation, typename NeutralElement,
+          typename FinalOperation>
+[[nodiscard]] string AggregateExpression<
+    AggregateOperation, NeutralElement,
+    FinalOperation>::getCacheKey(const VariableToColumnMap& varColMap) const {
   return std::string(typeid(*this).name()) + std::to_string(_distinct) + "(" +
          _child->getCacheKey(varColMap) + ")";
 }
 
 // __________________________________________________________________________
-template <typename AggregateOperation, typename FinalOperation>
+template <typename AggregateOperation, typename NeutralElement,
+          typename FinalOperation>
 [[nodiscard]] std::optional<SparqlExpressionPimpl::VariableAndDistinctness>
-AggregateExpression<AggregateOperation, FinalOperation>::getVariableForCount()
-    const {
+AggregateExpression<AggregateOperation, NeutralElement,
+                    FinalOperation>::getVariableForCount() const {
   // This behavior is not correct for the `COUNT` aggregate. The count is
   // therefore implemented in a separate `CountExpression` class, which
   // overrides this function.
   return std::nullopt;
 }
 
-#define INSTANTIATE_AGG_EXP(...)      \
+// Explicit instantiatio for the AVG expression.
+template class AggregateExpression<AvgOperation, NumericValue,
+                                   decltype(avgFinalOperation)>;
+
+// Explicit instantiations for the other aggregate expressions.
+#define INSTANTIATE_AGG_EXP(F, V, N)  \
   template class AggregateExpression< \
-      Operation<2, FunctionAndValueGetters<__VA_ARGS__>>>;
-INSTANTIATE_AGG_EXP(decltype(addForSum), NumericValueGetter);
-
-template class AggregateExpression<
-    AGG_OP<decltype(addForSum), NumericValueGetter>, decltype(averageFinalOp)>;
-
-INSTANTIATE_AGG_EXP(decltype(count), IsValidValueGetter);
-INSTANTIATE_AGG_EXP(decltype(minLambdaForAllTypes), ActualValueGetter);
-INSTANTIATE_AGG_EXP(decltype(maxLambdaForAllTypes), ActualValueGetter);
+      Operation<2, FunctionAndValueGetters<F, V>>, N>;
+INSTANTIATE_AGG_EXP(decltype(addForSum), NumericValueGetter, NumericValue);
+INSTANTIATE_AGG_EXP(decltype(count), IsValidValueGetter, long int);
+INSTANTIATE_AGG_EXP(decltype(minLambdaForAllTypes), ActualValueGetter,
+                    ValueId);
+INSTANTIATE_AGG_EXP(decltype(maxLambdaForAllTypes), ActualValueGetter,
+                    ValueId);
 }  // namespace detail
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -3,8 +3,7 @@
 
 // Several helper types needed for the SparqlExpression module
 
-#ifndef QLEVER_SPARQLEXPRESSIONTYPES_H
-#define QLEVER_SPARQLEXPRESSIONTYPES_H
+#pragma once
 
 #include <vector>
 
@@ -21,9 +20,9 @@
 
 namespace sparqlExpression {
 
-/// A std::vector<T, AllocatorWithLimit> with deleted copy constructor
-/// and copy assignment. Used in the SparqlExpression module, where we want
-/// no accidental copies of large intermediate results.
+// A std::vector<T, AllocatorWithLimit> with deleted copy constructor
+// and copy assignment. Used in the SparqlExpression module, where we want
+// no accidental copies of large intermediate results.
 template <typename T>
 class VectorWithMemoryLimit
     : public std::vector<T, ad_utility::AllocatorWithLimit<T>> {
@@ -313,20 +312,27 @@ std::optional<ExpressionResult> evaluateOnSpecializedFunctionsIfPossible(
   return result;
 }
 
-/// An Operation that consists of a `FunctionAndValueGetters` that takes
-/// `NumOperands` parameters. The `FunctionForSetOfIntervalsType` is a function,
-/// that can efficiently perform the operation when all the operands are
-/// `SetOfInterval`s.
-/// It is necessary to use the `FunctionAndValueGetters` struct to allow for
-/// multiple `ValueGetters` (a parameter pack, that has to appear at the end of
-/// the template declaration) and the default parameter for the
-/// `FunctionForSetOfIntervals` (which also has to appear at the end).
+// Class for an operation used in a `SparqlExpression`, consisting of the
+// function for computing the operation and the value getters for the operands.
+// The number of operands is fixed.
+//
+// NOTE: This class is defined in the namespace `sparqlExpression` and is
+// different from the class with the same name defined in `Operation.h`
+//
+// TODO: The rest of this comment seems to be outdated. Please check, Johannes.
+//
+// An Operation that consists of a `FunctionAndValueGetters` that takes
+// `NumOperands` parameters. The `FunctionForSetOfIntervalsType` is a function,
+// that can efficiently perform the operation when all the operands are
+// `SetOfInterval`s. It is necessary to use the `FunctionAndValueGetters`
+// struct to allow for multiple `ValueGetters` (a parameter pack, that has to
+// appear at the end of the template declaration) and the default parameter for
+// the `FunctionForSetOfIntervals` (which also has to appear at the end).
 template <
     size_t NumOperands,
     ad_utility::isInstantiation<FunctionAndValueGetters>
         FunctionAndValueGettersT,
     ad_utility::isInstantiation<SpecializedFunction>... SpecializedFunctions>
-
 struct Operation {
  private:
   using OriginalValueGetters = typename FunctionAndValueGettersT::ValueGetters;
@@ -361,5 +367,3 @@ size_t getResultSize(const EvaluationContext& context, const Inputs&...) {
 
 }  // namespace detail
 }  // namespace sparqlExpression
-
-#endif  // QLEVER_SPARQLEXPRESSIONTYPES_H

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -48,26 +48,53 @@ auto testAggregate = [](std::vector<T> inputAsVector, U expectedResult,
   EXPECT_EQ(res, expectedResult);
 };
 
-// ______________________________________________________________________________
-TEST(AggregateExpression, max) {
-  auto testMaxId = testAggregate<MaxExpression, Id>;
-  testMaxId({I(3), U, I(0), I(4), U, (I(-1))}, I(4));
-  testMaxId({V(7), U, V(2), V(4)}, V(7));
-  testMaxId({I(3), U, V(0), L(3), U, (I(-1))}, L(3));
+// Test `CountExpression`.
+TEST(AggregateExpression, count) {
+  auto testCountId = testAggregate<CountExpression, Id>;
+  testCountId({I(3), D(23.3), I(0), I(4), (I(-1))}, I(5));
+  testCountId({D(2), D(2), I(2), V(17)}, I(3), true);
+  testCountId({U, I(3), U}, I(1));
+  testCountId({I(3), NaN, NaN}, I(2), true);
+  testCountId({}, I(0));
 
-  auto testMaxString = testAggregate<MaxExpression, IdOrLiteralOrIri>;
-  // TODO<joka921> Implement correct comparison on strings
-  testMaxString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")},
-                lit("äpfel"));
+  auto testCountString = testAggregate<CountExpression, IdOrLiteralOrIri, Id>;
+  testCountString({lit("alpha"), lit("äpfel"), lit(""), lit("unfug")}, I(4));
 }
 
-// ______________________________________________________________________________
+// Test `SumExpression`.
+TEST(AggregateExpression, sum) {
+  auto testSumId = testAggregate<SumExpression, Id>;
+  testSumId({I(3), D(23.3), I(0), I(4), (I(-1))}, D(29.3));
+  testSumId({D(2), D(2), I(2)}, D(4), true);
+  testSumId({I(3), U}, U);
+  testSumId({I(3), NaN}, NaN);
+  testSumId({}, I(0));
+
+  auto testSumString = testAggregate<SumExpression, IdOrLiteralOrIri, Id>;
+  testSumString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);
+}
+
+// Test `AvgExpression`.
+TEST(AggregateExpression, avg) {
+  auto testAvgId = testAggregate<AvgExpression, Id>;
+  testAvgId({I(3), D(0), I(0), I(4), (I(-2))}, D(1));
+  testAvgId({D(2), D(2), I(2)}, D(2), true);
+  testAvgId({I(3), U}, U);
+  testAvgId({I(3), NaN}, NaN);
+  testAvgId({}, D(0));
+
+  auto testAvgString = testAggregate<AvgExpression, IdOrLiteralOrIri, Id>;
+  testAvgString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);
+}
+
+// Test `MinExpression`.
 TEST(AggregateExpression, min) {
   auto testMinId = testAggregate<MinExpression, Id>;
   testMinId({I(3), I(0), I(4), (I(-1))}, I(-1));
   testMinId({V(7), V(2), V(4)}, V(2));
   testMinId({V(7), U, V(2), V(4)}, U);
   testMinId({I(3), V(0), L(3), (I(-1))}, I(-1));
+  testMinId({}, U);
 
   auto testMinString = testAggregate<MinExpression, IdOrLiteralOrIri>;
   // TODO<joka921> Implement correct comparison on strings
@@ -75,28 +102,16 @@ TEST(AggregateExpression, min) {
                 lit("Beta"));
 }
 
-// ______________________________________________________________________________
-TEST(AggregateExpression, sum) {
-  auto testSumId = testAggregate<SumExpression, Id>;
-  testSumId({I(3), D(23.3), I(0), I(4), (I(-1))}, D(29.3));
-  testSumId({D(2), D(2), I(2)}, D(4), true);
+// Test `MaxExpression`.
+TEST(AggregateExpression, max) {
+  auto testMaxId = testAggregate<MaxExpression, Id>;
+  testMaxId({I(3), U, I(0), I(4), U, (I(-1))}, I(4));
+  testMaxId({V(7), U, V(2), V(4)}, V(7));
+  testMaxId({I(3), U, V(0), L(3), U, (I(-1))}, L(3));
+  testMaxId({}, U);
 
-  testSumId({I(3), U}, U);
-  testSumId({I(3), NaN}, NaN);
-
-  auto testSumString = testAggregate<SumExpression, IdOrLiteralOrIri, Id>;
-  testSumString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);
-}
-
-// ______________________________________________________________________________
-TEST(AggregateExpression, count) {
-  auto testCountId = testAggregate<CountExpression, Id>;
-  testCountId({I(3), D(23.3), I(0), I(4), (I(-1))}, I(5));
-  testCountId({D(2), D(2), I(2), V(17)}, I(3), true);
-
-  testCountId({U, I(3), U}, I(1));
-  testCountId({I(3), NaN, NaN}, I(2), true);
-
-  auto testCountString = testAggregate<CountExpression, IdOrLiteralOrIri, Id>;
-  testCountString({lit("alpha"), lit("äpfel"), lit(""), lit("unfug")}, I(4));
+  auto testMaxString = testAggregate<MaxExpression, IdOrLiteralOrIri>;
+  // TODO<joka921> Implement correct comparison on strings
+  testMaxString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")},
+                lit("äpfel"));
 }


### PR DESCRIPTION
For an implicit `GROUP BY`, the standard dictates that there should be a result (a single line) even when there are no matches. The aggregate value then depends on the aggregate function: 0 for `COUNT`, `SUM`, `AVG`, undefined for `MIN` and `MAX`, empty string for `GROUP_CONCAT`. This is now properly implemented and tested. Here is an example query: https://qlever.cs.uni-freiburg.de/olympics/iq1oph .

Along the way, improve the documentation in `src/engine/sparqlExpressions/AggregateExpression.{h,cpp}` considerably, which makes the really complex code there a bit easier to follow and extend.