### PR TITLE
Fix a small bug in the Turtle parser

### DIFF
--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -392,8 +392,8 @@ template <class T>
 TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
     std::string_view normalizedLiteralContent,
     const TripleComponent::Iri& typeIri, TurtleParser<T>* parser) {
-  auto literal =
-      TripleComponent::Literal::literalWithoutQuotes(normalizedLiteralContent);
+  auto literal = TripleComponent::Literal::literalWithNormalizedContent(
+      asNormalizedStringViewUnsafe(normalizedLiteralContent));
   std::string_view type = asStringViewUnsafe(typeIri.getContent());
 
   try {

--- a/test/RdfEscapingTest.cpp
+++ b/test/RdfEscapingTest.cpp
@@ -5,8 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include "./util/GTestHelpers.h"
 #include "parser/RdfEscaping.h"
-
 using namespace RdfEscaping;
 
 // ___________________________________________________________________________
@@ -43,6 +43,11 @@ TEST(RdfEscapingTest, normalizedContentFromLiteralOrIri) {
   ASSERT_EQ(f("\"bumm\"^^<http://www.mycustomiris.com/sometype>"), "bumm");
 }
 
+TEST(RdfEscapingTest, invalidEscapeThrows) {
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      normalizeRDFLiteral("\"invalid\\Escape\""),
+      ::testing::HasSubstr("Unsupported escape sequence"));
+}
 // ___________________________________________________________________________
 TEST(RdfEscapingTest, escapeForXml) {
   ASSERT_EQ(escapeForXml("abc\n\t;"), "abc\n\t;");

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -199,7 +199,8 @@ TEST(TurtleParserTest, rdfLiteral) {
   expected.emplace_back(lit(R"("simpleString")"));
   literals.emplace_back(R"("string\"with \\ escapes\n"^^<www.x.de>)");
   expected.emplace_back(TripleComponent::Literal::fromEscapedRdfLiteral(
-      R"("string\"with \\ escapes\n")"));
+      R"("string\"with \\ escapes\n")",
+      TripleComponent::Iri::fromIriref("<www.x.de>")));
   literals.emplace_back(R"("langtag"@en-gb)");
   expected.emplace_back(lit(R"("langtag")", "@en-gb"));
   literals.emplace_back("\"valueLong\"^^<www.someunknownType/integer>");

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -197,6 +197,9 @@ TEST(TurtleParserTest, rdfLiteral) {
   std::vector<TripleComponent> expected;
   literals.emplace_back(R"("simpleString")");
   expected.emplace_back(lit(R"("simpleString")"));
+  literals.emplace_back(R"("string\"with \\ escapes\n"^^<www.x.de>)");
+  expected.emplace_back(TripleComponent::Literal::fromEscapedRdfLiteral(
+      R"("string\"with \\ escapes\n")"));
   literals.emplace_back(R"("langtag"@en-gb)");
   expected.emplace_back(lit(R"("langtag")", "@en-gb"));
   literals.emplace_back("\"valueLong\"^^<www.someunknownType/integer>");


### PR DESCRIPTION
Fixes #1392 . The problem occurred for typed literals with escaped characters. 