### PR TITLE
Implement `CopyableMutex` and `CopyableAtomic`

### DIFF
--- a/src/util/CopyableSynchronization.h
+++ b/src/util/CopyableSynchronization.h
@@ -1,0 +1,35 @@
+// Copyright 2024, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author:
+//   Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+
+#pragma once
+
+namespace ad_utility {
+// A mutex that can be "copied". The semantics are, that copying will create
+// a new mutex. This is sufficient for applications like in
+// `getInternallyVisibleVariableColumns()` where we just want to make a
+// `const` member function that modifies a `mutable` member threadsafe.
+struct CopyableMutex : std::mutex {
+  using std::mutex::mutex;
+  CopyableMutex(const CopyableMutex&) {}
+  CopyableMutex& operator=(const CopyableMutex&) { return *this; }
+};
+
+// A `std::atomic` that can be "copied". The semantics are, that copying will
+// create a new atomic that is initialized with the value being copied. This is
+// useful if we want to store an atomic as a class member, but still want the
+// class to be copyable.
+template <typename T>
+class CopyableAtomic : public std::atomic<T> {
+  using Base = std::atomic<T>;
+
+ public:
+  using Base::Base;
+  CopyableAtomic(const CopyableAtomic& rhs) : Base{rhs.load()} {}
+  CopyableAtomic& operator=(const CopyableAtomic& rhs) {
+    static_cast<Base&>(*this) = rhs.load();
+    return *this;
+  }
+};
+}  // namespace ad_utility

--- a/src/util/CopyableSynchronization.h
+++ b/src/util/CopyableSynchronization.h
@@ -10,6 +10,9 @@ namespace ad_utility {
 // a new mutex. This is sufficient for applications like in
 // `getInternallyVisibleVariableColumns()` where we just want to make a
 // `const` member function that modifies a `mutable` member threadsafe.
+// Note that a copy-constructed `CopyableMutex` will be unlocked, even if the
+// source was locked, and that copy assignment also never locks or unlocks any
+// of the involved atomics.
 struct CopyableMutex : std::mutex {
   using std::mutex::mutex;
   CopyableMutex(const CopyableMutex&) {}

--- a/src/util/CopyableSynchronization.h
+++ b/src/util/CopyableSynchronization.h
@@ -6,13 +6,11 @@
 #pragma once
 
 namespace ad_utility {
-// A mutex that can be "copied". The semantics are, that copying will create
-// a new mutex. This is sufficient for applications like in
-// `getInternallyVisibleVariableColumns()` where we just want to make a
+// A mutex that can be "copied". The semantics are that copying will create
+// a new mutex. This is useful when we just want to make a
 // `const` member function that modifies a `mutable` member threadsafe.
 // Note that a copy-constructed `CopyableMutex` will be unlocked, even if the
-// source was locked, and that copy assignment also never locks or unlocks any
-// of the involved atomics.
+// source was locked, and that copy assignment is a noop.
 struct CopyableMutex : std::mutex {
   using std::mutex::mutex;
   CopyableMutex(const CopyableMutex&) {}

--- a/src/util/CopyableSynchronization.h
+++ b/src/util/CopyableSynchronization.h
@@ -6,11 +6,11 @@
 #pragma once
 
 namespace ad_utility {
-// A mutex that can be "copied". The semantics are that copying will create
-// a new mutex. This is useful when we just want to make a
-// `const` member function that modifies a `mutable` member threadsafe.
-// Note that a copy-constructed `CopyableMutex` will be unlocked, even if the
-// source was locked, and that copy assignment is a noop.
+// A mutex that can be "copied". The semantics are that copying will create a
+// new mutex. This is useful when we just want to make a `const` member function
+// that modifies a `mutable` member threadsafe. Note that a copy-constructed
+// `CopyableMutex` will be unlocked, even if the source was locked, and that
+// copy assignment is a noop.
 struct CopyableMutex : std::mutex {
   using std::mutex::mutex;
   CopyableMutex(const CopyableMutex&) {}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -395,3 +395,5 @@ addLinkAndDiscoverTest(JThreadTest)
 addLinkAndDiscoverTest(ChunkedForLoopTest)
 
 addLinkAndDiscoverTest(FsstCompressorTest fsst)
+
+addLinkAndDiscoverTest(CopyableSynchronizationTest)

--- a/test/CopyableSynchronizationTest.cpp
+++ b/test/CopyableSynchronizationTest.cpp
@@ -13,12 +13,15 @@ using namespace ad_utility;
 TEST(CopyableSynchronization, CopyableMutex) {
   // Not much to test here.
   CopyableMutex m1;
-  [[maybe_unused]] CopyableMutex m2{m1};
-  m1 = m2;
   m1.lock();
+  [[maybe_unused]] CopyableMutex m2{m1};
+  // m2 is still unlocked.
   EXPECT_TRUE(m2.try_lock());
-  m1.unlock();
   m2.unlock();
+  m1 = m2;
+  // m1 is still locked;
+  EXPECT_FALSE(m1.try_lock());
+  m1.unlock();
 }
 
 // _________________________________________________

--- a/test/CopyableSynchronizationTest.cpp
+++ b/test/CopyableSynchronizationTest.cpp
@@ -1,0 +1,34 @@
+// Copyright 2024, University of Freiburg,
+// Chair of Algorithms and Data Structures.
+// Author:
+//   Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+
+#include <gmock/gmock.h>
+
+#include "util/CopyableSynchronization.h"
+
+using namespace ad_utility;
+
+// _________________________________________________
+TEST(CopyableSynchronization, CopyableMutex) {
+  // Not much to test here.
+  CopyableMutex m1;
+  [[maybe_unused]] CopyableMutex m2{m1};
+  m1 = m2;
+  m1.lock();
+  EXPECT_TRUE(m2.try_lock());
+  m1.unlock();
+  m2.unlock();
+}
+
+// _________________________________________________
+TEST(CopyableSynchronization, CopyableAtomic) {
+  CopyableAtomic<int> i1 = 42;
+  CopyableAtomic<int> i2{i1};
+  EXPECT_EQ(i2, 42);
+  ++i2;
+  EXPECT_EQ(i2, 43);
+  EXPECT_EQ(i1, 42);
+  i1 = i2;
+  EXPECT_EQ(i1, 43);
+}


### PR DESCRIPTION
`CopyableMutex` behaves like `std::mutex` and `CopyableAtomic` behaves like `std:atomic`, except that they also have a copy constructor and copy assignment. For `CopyableAtomic` the current value is copied, for `CopyableMutex` the copy constructor copies nothing and the copy assignment does nothing.