### PR TITLE
implement specific value getter for `IRI()` / `URI()`

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -22,6 +22,7 @@ namespace sparqlExpression::detail {
 
 using LiteralOrIri = ad_utility::triple_component::LiteralOrIri;
 using Iri = ad_utility::triple_component::Iri;
+using IdOrLiteralOrIri = std::variant<ValueId, LiteralOrIri>;
 
 // An empty struct to represent a non-numeric value in a context where only
 // numeric values make sense.
@@ -297,4 +298,14 @@ struct LanguageTagValueGetter : Mixin<LanguageTagValueGetter> {
     }
   }
 };
+
+// Value getter for implementing the expressions `IRI()`/`URI()`.
+struct IriOrUriValueGetter : Mixin<IriOrUriValueGetter> {
+  using Mixin<IriOrUriValueGetter>::operator();
+  IdOrLiteralOrIri operator()(ValueId id,
+                              const EvaluationContext* context) const;
+  IdOrLiteralOrIri operator()(const LiteralOrIri& litOrIri,
+                              const EvaluationContext* context) const;
+};
+
 }  // namespace sparqlExpression::detail

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -118,7 +118,7 @@ struct LiftStringFunction {
 // 2. What's the correct behavior for non-strings, like `1` or `true`?
 //
 // @1: Added static method `fromIrirefWithBasicUrlCheck` for `Iri` which checks
-// if the provided iri string satisifies basic URL pattern.
+// if the provided iri string satisfies basic URL pattern.
 // @2: Only a `LiteralOrIri` or an `Id` from `Vocab`/`LocalVocab` is in
 // consideration within the `IriOrUriValueGetter`, hence automatically
 // ignores values like `1`, `true`, `Date` etc.

--- a/src/parser/Iri.cpp
+++ b/src/parser/Iri.cpp
@@ -4,6 +4,7 @@
 
 #include "parser/Iri.h"
 
+#include <ctre.hpp>
 #include <utility>
 
 #include "parser/LiteralOrIri.h"
@@ -39,6 +40,20 @@ Iri Iri::fromIrirefWithoutBrackets(std::string_view stringWithoutBrackets) {
   AD_CORRECTNESS_CHECK(!stringWithoutBrackets.starts_with('<') &&
                        !stringWithoutBrackets.ends_with('>'));
   return Iri{absl::StrCat("<"sv, stringWithoutBrackets, ">"sv)};
+}
+
+// ____________________________________________________________________________
+std::optional<Iri> Iri::fromIrirefWithBasicUrlCheck(
+    std::string_view stringWithoutBrackets) {
+  AD_CORRECTNESS_CHECK(!stringWithoutBrackets.starts_with('<') &&
+                       !stringWithoutBrackets.ends_with('>'));
+  // Pattern to check for valid base Url, ignores path.
+  constexpr static ctll::fixed_string patternUrlBase =
+      "^((https|http|ftp)://[a-zA-Z0-9.\\-]+(:[0-9]+)?)(.*)$";
+  if (ctre::match<patternUrlBase>(stringWithoutBrackets)) {
+    return Iri{absl::StrCat("<"sv, stringWithoutBrackets, ">"sv)};
+  }
+  return std::nullopt;
 }
 
 // ____________________________________________________________________________

--- a/src/parser/Iri.h
+++ b/src/parser/Iri.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string_view>
 
 #include "parser/NormalizedString.h"
@@ -36,11 +37,16 @@ class Iri {
   const std::string& toStringRepresentation() const;
   std::string& toStringRepresentation();
 
-  // Create a new iri given an iri with brackets
+  // Create a new `Iri` given an iri string with brackets.
   static Iri fromIriref(std::string_view stringWithBrackets);
 
-  // create a new iri given an iri without brackets
+  // Create a new `Iri` given an iri string without brackets.
   static Iri fromIrirefWithoutBrackets(std::string_view stringWithoutBrackets);
+
+  // Creat a new `Iri` if the provided iri string (without brackets) passes
+  // the basic `URL` pattern check.
+  static std::optional<Iri> fromIrirefWithBasicUrlCheck(
+      std::string_view stringWithoutBrackets);
 
   // Create a new iri given a prefix iri and its suffix
   static Iri fromPrefixAndSuffix(const Iri& prefix, std::string_view suffix);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -580,9 +580,34 @@ TEST(SparqlExpression, stringOperators) {
   checkStr(IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")},
            IdOrLiteralOrIriVec{lit("one"), lit("two"), lit("three")});
 
+  auto T = Id::makeFromBool(true);
+  auto F = Id::makeFromBool(false);
+  auto date = Id::makeFromDate(DateOrLargeYear::parseXsdDate("2025-01-01"));
   // Test `iriOrUriExpression`.
-  checkIriOrUri(IdOrLiteralOrIriVec{lit("bim"), lit("bam"), U},
-                IdOrLiteralOrIriVec{iriref("<bim>"), iriref("<bam>"), U});
+  // test invalid
+  checkIriOrUri(
+      IdOrLiteralOrIriVec{lit("bim"), lit("bam"), U, IntId(2), DoubleId(12.99),
+                          date, T, F, testContext().x, testContext().aelpha,
+                          testContext().notInVocabAelpha,
+                          iriref("<h://bimbam>"), iriref("<a>")},
+      IdOrLiteralOrIriVec{U, U, U, U, U, U, U, U, U, U, U, U, U});
+  // test valid
+  checkIriOrUri(
+      IdOrLiteralOrIriVec{lit("https://www.bimbimbam/2001/bamString"),
+                          lit("http://www.w3.org/2001/XMLSchema#unsignedShort"),
+                          lit("http://www.w3.org/2001/XMLSchema#string"),
+                          iriref("<http://www.w3.org/2001/XMLSchema#string>"),
+                          testContext().notInVocabIri,
+                          testContext().notInVocabIriLit,
+                          lit("http://example/"), iriref("<http://example/>")},
+      IdOrLiteralOrIriVec{
+          iriref("<https://www.bimbimbam/2001/bamString>"),
+          iriref("<http://www.w3.org/2001/XMLSchema#unsignedShort>"),
+          iriref("<http://www.w3.org/2001/XMLSchema#string>"),
+          iriref("<http://www.w3.org/2001/XMLSchema#string>"),
+          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>"),
+          iriref("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>"),
+          iriref("<http://example/>"), iriref("<http://example/>")});
 
   // A simple test for uniqueness of the cache key.
   auto c1a = makeStrlenExpression(std::make_unique<IriExpression>(iri("<bim>")))

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -55,7 +55,8 @@ struct TestContext {
   Id x, label, alpha, aelpha, A, Beta, zz, blank;
   // IDs of literals (the first two) and entities (the latter two) in the local
   // vocab.
-  Id notInVocabA, notInVocabB, notInVocabC, notInVocabD, notInVocabAelpha;
+  Id notInVocabA, notInVocabB, notInVocabC, notInVocabD, notInVocabAelpha,
+      notInVocabIri, notInVocabIriLit;
   TestContext() {
     // First get some IDs for strings from the vocabulary to later reuse them.
     // Note the `u_` inserted for the blank node (see 'BlankNode.cpp').
@@ -85,6 +86,12 @@ struct TestContext {
         localVocab.getIndexAndAddIfNotContained(iri("<notInVocabD>")));
     notInVocabAelpha = Id::makeFromLocalVocabIndex(
         localVocab.getIndexAndAddIfNotContained(lit("notInVocabÄlpha")));
+    notInVocabIri =
+        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+            iri("<http://www.w3.org/1999/02/22-rdf-syntax-ns#langString>")));
+    notInVocabIriLit =
+        Id::makeFromLocalVocabIndex(localVocab.getIndexAndAddIfNotContained(
+            lit("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString")));
 
     // Set up the `table` that represents the previous partial query results. It
     // has five columns/variables: ?ints (only integers), ?doubles (only


### PR DESCRIPTION
- Added value getter `IriOrUriValueGetter`, which allows to use `std::identity` w.r.t. NaryExpressionImpl.
- Added check for valid base URL over static method in `Iri`