### PR TITLE
Refactoring preliminaries for lazy operations (Part 2)

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -81,7 +81,7 @@ std::vector<QueryExecutionTree*> Bind::getChildren() {
 }
 
 // _____________________________________________________________________________
-Result Bind::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Bind::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Get input to BIND operation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult();

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -46,7 +46,7 @@ class Bind : public Operation {
   [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Implementation for the binding of arbitrary expressions.
   template <size_t IN_WIDTH, size_t OUT_WIDTH>

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -132,7 +132,7 @@ void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
   }
 }
 // ____________________________________________________________________________
-Result CartesianProductJoin::computeResult(
+ProtoResult CartesianProductJoin::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   IdTable result{getExecutionContext()->getAllocator()};
   result.setNumColumns(getResultWidth());

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -79,7 +79,7 @@ class CartesianProductJoin : public Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Copy each element from the `inputColumn` `groupSize` times to the
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -100,7 +100,7 @@ size_t CountAvailablePredicates::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-Result CountAvailablePredicates::computeResult(
+ProtoResult CountAvailablePredicates::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "CountAvailablePredicates result computation..." << std::endl;
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -103,6 +103,6 @@ class CountAvailablePredicates : public Operation {
   void computePatternTrickAllEntities(
       IdTable* result, const CompactVectorOfStrings<Id>& patterns) const;
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -37,7 +37,7 @@ VariableToColumnMap Distinct::computeVariableToColumnMap() const {
 }
 
 // _____________________________________________________________________________
-Result Distinct::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Distinct::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -54,7 +54,7 @@ class Distinct : public Operation {
   [[nodiscard]] string getCacheKeyImpl() const override;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -43,7 +43,7 @@ string Filter::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result Filter::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Filter::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult();
   LOG(DEBUG) << "Filter result computation..." << endl;

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -58,7 +58,7 @@ class Filter : public Operation {
     return _subtree->getVariableColumns();
   }
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   template <size_t WIDTH>
   void computeFilterImpl(IdTable* outputIdTable,

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -309,7 +309,7 @@ void GroupBy::doGroupBy(const IdTable& dynInput,
   *dynResult = std::move(result).toDynamic();
 }
 
-Result GroupBy::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult GroupBy::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -89,7 +89,7 @@ class GroupBy : public Operation {
  private:
   VariableToColumnMap computeVariableToColumnMap() const override;
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   template <size_t OUT_WIDTH>
   void processGroup(const Aggregate& expression,

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -254,7 +254,8 @@ size_t HasPredicateScan::getCostEstimate() {
 }
 
 // ___________________________________________________________________________
-Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult HasPredicateScan::computeResult(
+    [[maybe_unused]] bool requestLaziness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
 
@@ -365,7 +366,7 @@ void HasPredicateScan::computeFullScan(
 
 // ___________________________________________________________________________
 template <int WIDTH>
-Result HasPredicateScan::computeSubqueryS(
+ProtoResult HasPredicateScan::computeSubqueryS(
     IdTable* dynResult, const CompactVectorOfStrings<Id>& patterns) {
   auto subresult = subtree().getResult();
   auto patternCol = subtreeColIdx();

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -105,11 +105,11 @@ class HasPredicateScan : public Operation {
                               size_t resultSize);
 
   template <int WIDTH>
-  Result computeSubqueryS(IdTable* result,
-                          const CompactVectorOfStrings<Id>& patterns);
+  ProtoResult computeSubqueryS(IdTable* result,
+                               const CompactVectorOfStrings<Id>& patterns);
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -123,7 +123,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
   return variableToColumnMap;
 }
 // _____________________________________________________________________________
-Result IndexScan::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult IndexScan::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "IndexScan result computation...\n";
   IdTable idTable{getExecutionContext()->getAllocator()};
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -102,7 +102,7 @@ class IndexScan final : public Operation {
   std::array<const TripleComponent* const, 3> getPermutedTriple() const;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -90,7 +90,7 @@ string Join::getCacheKeyImpl() const {
 string Join::getDescriptor() const { return "Join on " + _joinVar.name(); }
 
 // _____________________________________________________________________________
-Result Join::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Join::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   size_t leftWidth = _left->getResultWidth();
   size_t rightWidth = _right->getResultWidth();

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -115,7 +115,7 @@ class Join : public Operation {
   virtual string getCacheKeyImpl() const override;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -32,7 +32,7 @@ string Minus::getCacheKeyImpl() const {
 string Minus::getDescriptor() const { return "Minus"; }
 
 // _____________________________________________________________________________
-Result Minus::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Minus::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Minus result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -72,7 +72,7 @@ class Minus : public Operation {
       const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
       size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -60,7 +60,8 @@ string MultiColumnJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult MultiColumnJoin::computeResult(
+    [[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -63,7 +63,7 @@ class MultiColumnJoin : public Operation {
       IdTable* resultMightBeUnsorted);
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -40,7 +40,7 @@ class NeutralElementOperation : public Operation {
   };
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override {
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
     IdTable idTable{getExecutionContext()->getAllocator()};
     idTable.setNumColumns(0);
     idTable.resize(1);

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -174,7 +174,8 @@ class Operation {
   void recursivelySetTimeConstraint(
       std::chrono::steady_clock::time_point deadline);
 
-  // True iff this operation directly implement a `LIMIT` clause on its result.
+  // True iff this operation directly implement a `OFFSET` and `LIMIT` clause on
+  // its result.
   [[nodiscard]] virtual bool supportsLimit() const { return false; }
 
   // Set the value of the `LIMIT` clause that will be applied to the result of
@@ -205,7 +206,7 @@ class Operation {
   // Direct access to the `computeResult()` method. This should be only used for
   // testing, otherwise the `getResult()` function should be used which also
   // sets the runtime info and uses the cache.
-  virtual Result computeResultOnlyForTesting(
+  virtual ProtoResult computeResultOnlyForTesting(
       bool requestLaziness = false) final {
     return computeResult(requestLaziness);
   }
@@ -257,7 +258,7 @@ class Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  virtual Result computeResult(bool requestLaziness) = 0;
+  virtual ProtoResult computeResult(bool requestLaziness) = 0;
 
   // Create and store the complete runtime information for this operation after
   // it has either been successfully computed or read from the cache.

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -89,7 +89,7 @@ string OptionalJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result OptionalJoin::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult OptionalJoin::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -75,7 +75,7 @@ class OptionalJoin : public Operation {
  private:
   void computeSizeEstimateAndMultiplicities();
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -63,7 +63,7 @@ std::string OrderBy::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -78,7 +78,7 @@ class OrderBy : public Operation {
   }
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override {
     return subtree_->getVariableColumns();

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -167,5 +167,5 @@ class Result {
   bool checkDefinedness(const VariableToColumnMap& varColMap);
 };
 
-// Temporary alias to keep PRs reviewable
+// In the future (as soon as we implement lazy operations) the `ProtoResult` and the `Result` will have different implementations. For now we simply use an alias to reduce the size of the diff in the PRs for lazy operations.
 using ProtoResult = Result;

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -166,3 +166,6 @@ class Result {
   // check is successful.
   bool checkDefinedness(const VariableToColumnMap& varColMap);
 };
+
+// Temporary alias to keep PRs reviewable
+using ProtoResult = Result;

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -167,5 +167,7 @@ class Result {
   bool checkDefinedness(const VariableToColumnMap& varColMap);
 };
 
-// In the future (as soon as we implement lazy operations) the `ProtoResult` and the `Result` will have different implementations. For now we simply use an alias to reduce the size of the diff in the PRs for lazy operations.
+// In the future (as soon as we implement lazy operations) the `ProtoResult` and
+// the `Result` will have different implementations. For now we simply use an
+// alias to reduce the size of the diff in the PRs for lazy operations.
 using ProtoResult = Result;

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -90,7 +90,7 @@ size_t Service::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-Result Service::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
   // Get the URL of the SPARQL endpoint.
   std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
   AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -97,7 +97,7 @@ class Service : public Operation {
   std::string getCacheKeyImpl() const override;
 
   // Compute the result using `getResultFunction_`.
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Get a VALUES clause that contains the values of the siblingTree's result.
   std::optional<std::string> getSiblingValuesClause() const;

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -51,7 +51,7 @@ std::string Sort::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Sort::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -67,7 +67,8 @@ class Sort : public Operation {
   }
 
  private:
-  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  virtual ProtoResult computeResult(
+      [[maybe_unused]] bool requestLaziness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()
       const override {

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -14,7 +14,7 @@ TextIndexScanForEntity::TextIndexScanForEntity(
       word_(std::move(word)) {}
 
 // _____________________________________________________________________________
-Result TextIndexScanForEntity::computeResult(
+ProtoResult TextIndexScanForEntity::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   IdTable idTable = getExecutionContext()->getIndex().getEntityMentionsForWord(
       word_, getExecutionContext()->getAllocator());

--- a/src/engine/TextIndexScanForEntity.h
+++ b/src/engine/TextIndexScanForEntity.h
@@ -101,7 +101,7 @@ class TextIndexScanForEntity : public Operation {
     return std::get<FixedEntity>(varOrFixed_.entity_).second;
   }
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -13,7 +13,7 @@ TextIndexScanForWord::TextIndexScanForWord(QueryExecutionContext* qec,
       isPrefix_(word_.ends_with('*')) {}
 
 // _____________________________________________________________________________
-Result TextIndexScanForWord::computeResult(
+ProtoResult TextIndexScanForWord::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   IdTable idTable = getExecutionContext()->getIndex().getWordPostingsForTerm(
       word_, getExecutionContext()->getAllocator());

--- a/src/engine/TextIndexScanForWord.h
+++ b/src/engine/TextIndexScanForWord.h
@@ -50,7 +50,7 @@ class TextIndexScanForWord : public Operation {
  private:
   // Returns a Result containing an IdTable with the columns being
   // the text variable and the completed word (if it was prefixed)
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextLimit.cpp
+++ b/src/engine/TextLimit.cpp
@@ -18,7 +18,7 @@ TextLimit::TextLimit(QueryExecutionContext* qec, const size_t limit,
       scoreColumns_(scoreColumns) {}
 
 // _____________________________________________________________________________
-Result TextLimit::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult TextLimit::computeResult([[maybe_unused]] bool requestLaziness) {
   std::shared_ptr<const Result> childRes = child_->getResult();
 
   if (limit_ == 0) {

--- a/src/engine/TextLimit.h
+++ b/src/engine/TextLimit.h
@@ -61,7 +61,7 @@ class TextLimit : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
  private:
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {child_.get()}; }
 };

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -142,7 +142,7 @@ class TransitivePathImpl : public TransitivePathBase {
    *
    * @return Result The result of the TransitivePath operation
    */
-  Result computeResult([[maybe_unused]] bool requestLaziness) override {
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -158,7 +158,7 @@ size_t Union::getCostEstimate() {
          getSizeEstimateBeforeLimit();
 }
 
-Result Union::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Union::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Union result computation..." << std::endl;
   std::shared_ptr<const Result> subRes1 = _subtrees[0]->getResult();
   std::shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();
@@ -173,8 +173,8 @@ Result Union::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Union result computation done" << std::endl;
   // If only one of the two operands has a non-empty local vocabulary, share
   // with that one (otherwise, throws an exception).
-  return Result{std::move(idTable), resultSortedOn(),
-                Result::getMergedLocalVocab(*subRes1, *subRes2)};
+  return {std::move(idTable), resultSortedOn(),
+          Result::getMergedLocalVocab(*subRes1, *subRes2)};
 }
 
 void Union::computeUnion(

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -61,7 +61,8 @@ class Union : public Operation {
   }
 
  private:
-  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  virtual ProtoResult computeResult(
+      [[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -108,7 +108,7 @@ void Values::computeMultiplicities() {
 }
 
 // ____________________________________________________________________________
-Result Values::computeResult([[maybe_unused]] bool requestLaziness) {
+ProtoResult Values::computeResult([[maybe_unused]] bool requestLaziness) {
   // Set basic properties of the result table.
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -48,7 +48,8 @@ class Values : public Operation {
 
  public:
   // These two are also used by class `Service`, hence public.
-  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  virtual ProtoResult computeResult(
+      [[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/util/UniqueCleanup.h
+++ b/src/util/UniqueCleanup.h
@@ -7,7 +7,6 @@
 
 #include <concepts>
 #include <functional>
-#include <memory>
 
 #include "util/ResetWhenMoved.h"
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -310,7 +310,7 @@ addLinkAndDiscoverTestSerial(OrderByTest engine)
 
 addLinkAndDiscoverTestSerial(ValuesForTestingTest index)
 
-addLinkAndDiscoverTestSerial(ExportQueryExecutionTreeTest index engine parser)
+addLinkAndDiscoverTestSerial(ExportQueryExecutionTreesTest index engine parser)
 
 addLinkAndDiscoverTestSerial(AggregateExpressionTest parser sparqlExpressions index engine)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,13 +6,13 @@ add_subdirectory(util)
 # Link binary ${basename} against `gmock_main`, the threading library, the
 # general test utilities and all libraries that are specified as additional
 # arguments.
-function (linkTest basename)
+function(linkTest basename)
     qlever_target_link_libraries(${basename} ${ARGN} GTest::gtest GTest::gmock_main testUtil ${CMAKE_THREAD_LIBS_INIT})
 endfunction()
 
 # Add the executable ${basename} that is compiled from the source file
 # "${basename}".cpp
-function (addTest basename)
+function(addTest basename)
     add_executable(${basename} "${basename}.cpp")
 endfunction()
 
@@ -43,23 +43,23 @@ if (SINGLE_TEST_BINARY)
     qlever_target_link_libraries(QLeverAllUnitTestsMain gtest gmock_main testUtil ${CMAKE_THREAD_LIBS_INIT})
     gtest_discover_tests(QLeverAllUnitTestsMain QLeverAllUnitTestsMain PROPERTIES RUN_SERIAL
             TRUE)
-else()
+else ()
     message(STATUS "The tests are split over multiple binaries")
 
-endif()
+endif ()
 # Usage: `addAndLinkTest(basename, [additionalLibraries...]`
 # Add a GTest/GMock test case that is called `basename` and compiled from a file called
 # `basename.cpp`. All tests are linked against `gmock_main` and the threading library.
 # additional libraries against which the test case has to be linked can be specified as
 # additional arguments after the `basename`
 function(addLinkAndDiscoverTest basename)
-  if (SINGLE_TEST_BINARY)
-      target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
-      qlever_target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
-  else()
-    addTest(${basename})
-    linkAndDiscoverTest(${basename} ${ARGN})
-  endif()
+    if (SINGLE_TEST_BINARY)
+        target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
+        qlever_target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
+    else ()
+        addTest(${basename})
+        linkAndDiscoverTest(${basename} ${ARGN})
+    endif ()
 
 endfunction()
 
@@ -68,13 +68,13 @@ endfunction()
 # (without any of the other test cases running in parallel). This can be
 # required e.g. if several tests cases write to the same file.
 function(addLinkAndDiscoverTestSerial basename)
-  if (SINGLE_TEST_BINARY)
-    target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
-    qlever_target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
-  else()
-    addTest(${basename})
-    linkAndDiscoverTestSerial(${basename} ${ARGN})
-  endif()
+    if (SINGLE_TEST_BINARY)
+        target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
+        qlever_target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
+    else ()
+        addTest(${basename})
+        linkAndDiscoverTestSerial(${basename} ${ARGN})
+    endif ()
 endfunction()
 
 # Only compile and link the test, but do not run it.
@@ -146,10 +146,10 @@ addLinkAndDiscoverTest(UnionTest engine)
 if (SINGLE_TEST_BINARY)
     target_sources(QLeverAllUnitTestsMain PUBLIC TokenTest.cpp TokenTestCtreHelper.cpp)
     qlever_target_link_libraries(QLeverAllUnitTestsMain parser re2 util)
-else()
+else ()
     add_executable(TokenTest TokenTest.cpp TokenTestCtreHelper.cpp)
     linkAndDiscoverTest(TokenTest parser re2 util)
-endif()
+endif ()
 
 addLinkAndDiscoverTestSerial(TurtleParserTest parser re2)
 

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -210,7 +210,7 @@ static std::string makeXMLHeader(
 static const std::string xmlTrailer = "\n</results>\n</sparql>";
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, Integers) {
+TEST(ExportQueryExecutionTrees, Integers) {
   std::string kg =
       "<s> <p> 42 . <s> <p> -42019234865781 . <s> <p> 4012934858173560";
   std::string query = "SELECT ?o WHERE {?s ?p ?o} ORDER BY ?o";
@@ -276,7 +276,7 @@ TEST(ExportQueryExecutionTree, Integers) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, Bool) {
+TEST(ExportQueryExecutionTrees, Bool) {
   std::string kg = "<s> <p> true . <s> <p> false.";
   std::string query = "SELECT ?o WHERE {?s ?p ?o} ORDER BY ?o";
 
@@ -330,7 +330,7 @@ TEST(ExportQueryExecutionTree, Bool) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, UnusedVariable) {
+TEST(ExportQueryExecutionTrees, UnusedVariable) {
   std::string kg = "<s> <p> true . <s> <p> false.";
   std::string query = "SELECT ?o WHERE {?s ?p ?x} ORDER BY ?s";
   std::string expectedXml = makeXMLHeader({"o"}) + R"(
@@ -366,7 +366,7 @@ TEST(ExportQueryExecutionTree, UnusedVariable) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, Floats) {
+TEST(ExportQueryExecutionTrees, Floats) {
   std::string kg =
       "<s> <p> 42.2 . <s> <p> -42019234865.781e12 . <s> <p> "
       "4.012934858173560e-12";
@@ -434,7 +434,7 @@ TEST(ExportQueryExecutionTree, Floats) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, Dates) {
+TEST(ExportQueryExecutionTrees, Dates) {
   std::string kg =
       "<s> <p> "
       "\"1950-01-01T00:00:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>.";
@@ -493,7 +493,7 @@ TEST(ExportQueryExecutionTree, Dates) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, Entities) {
+TEST(ExportQueryExecutionTrees, Entities) {
   std::string kg = "PREFIX qlever: <http://qlever.com/> \n <s> <p> qlever:o";
   std::string query = "SELECT ?o WHERE {?s ?p ?o} ORDER BY ?o";
   std::string expectedXml = makeXMLHeader({"o"}) +
@@ -540,7 +540,7 @@ TEST(ExportQueryExecutionTree, Entities) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, LiteralWithLanguageTag) {
+TEST(ExportQueryExecutionTrees, LiteralWithLanguageTag) {
   std::string kg = "<s> <p> \"\"\"Some\"Where\tOver,\"\"\"@en-ca.";
   std::string query = "SELECT ?o WHERE {?s ?p ?o} ORDER BY ?o";
   std::string expectedXml = makeXMLHeader({"o"}) +
@@ -589,7 +589,7 @@ TEST(ExportQueryExecutionTree, LiteralWithLanguageTag) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, LiteralWithDatatype) {
+TEST(ExportQueryExecutionTrees, LiteralWithDatatype) {
   std::string kg = "<s> <p> \"something\"^^<www.example.org/bim>";
   std::string query = "SELECT ?o WHERE {?s ?p ?o} ORDER BY ?o";
   std::string expectedXml = makeXMLHeader({"o"}) +
@@ -637,7 +637,7 @@ TEST(ExportQueryExecutionTree, LiteralWithDatatype) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, TestWithIriEscaped) {
+TEST(ExportQueryExecutionTrees, TestWithIriEscaped) {
   std::string kg = "<s> <p> <https://\\u0009:\\u0020)\\u000AtestIriKg>";
   std::string objectQuery = "SELECT ?o WHERE { ?s ?p ?o }";
   std::string expectedXml = makeXMLHeader({"o"}) +
@@ -681,7 +681,7 @@ testIriKg</uri></binding>
   runConstructQueryTestCase(testCaseConstruct);
 }
 
-TEST(ExportQueryExecutionTree, TestWithIriExtendedEscaped) {
+TEST(ExportQueryExecutionTrees, TestWithIriExtendedEscaped) {
   std::string kg =
       "<s> <p>"
       "<iriescaped\\u0001o\\u0002e\\u0003i\\u0004o\\u0005u\\u0006e\\u00"
@@ -754,7 +754,7 @@ TEST(ExportQueryExecutionTree, TestWithIriExtendedEscaped) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, TestIriWithEscapedIriString) {
+TEST(ExportQueryExecutionTrees, TestIriWithEscapedIriString) {
   std::string kg = "<s> <p> \" hallo\\n\\t welt\"";
   std::string objectQuery =
       "SELECT ?o WHERE { "
@@ -799,7 +799,7 @@ TEST(ExportQueryExecutionTree, TestIriWithEscapedIriString) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, UndefinedValues) {
+TEST(ExportQueryExecutionTrees, UndefinedValues) {
   std::string kg = "<s> <p> <o>";
   std::string query =
       "SELECT ?o WHERE {?s <p> <o> OPTIONAL {?s <p2> ?o}} ORDER BY ?o";
@@ -838,7 +838,7 @@ TEST(ExportQueryExecutionTree, UndefinedValues) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, BlankNode) {
+TEST(ExportQueryExecutionTrees, BlankNode) {
   std::string kg = "<s> <p> _:blank";
   std::string objectQuery = "SELECT ?o WHERE {?s ?p ?o } ORDER BY ?o";
   std::string expectedXml = makeXMLHeader({"o"}) +
@@ -864,7 +864,7 @@ TEST(ExportQueryExecutionTree, BlankNode) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, TextIndex) {
+TEST(ExportQueryExecutionTrees, TextIndex) {
   std::string kg = "<s> <p> \"alpha beta\". <s2> <p2> \"alphax betax\". ";
   std::string objectQuery =
       "SELECT ?o WHERE {<s> <p> ?t. ?text ql:contains-entity ?t .?text "
@@ -890,7 +890,7 @@ TEST(ExportQueryExecutionTree, TextIndex) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, MultipleVariables) {
+TEST(ExportQueryExecutionTrees, MultipleVariables) {
   std::string kg = "<s> <p> <o>";
   std::string objectQuery = "SELECT ?p ?o WHERE {<s> ?p ?o } ORDER BY ?p ?o";
   std::string expectedXml = makeXMLHeader({"p", "o"}) +
@@ -927,7 +927,7 @@ TEST(ExportQueryExecutionTree, MultipleVariables) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, BinaryExport) {
+TEST(ExportQueryExecutionTrees, BinaryExport) {
   std::string kg = "<s> <p> 31 . <s> <o> 42";
   std::string query = "SELECT ?p ?o WHERE {<s> ?p ?o } ORDER BY ?p ?o";
   std::string result =
@@ -952,7 +952,7 @@ TEST(ExportQueryExecutionTree, BinaryExport) {
 }
 
 // ____________________________________________________________________________
-TEST(ExportQueryExecutionTree, CornerCases) {
+TEST(ExportQueryExecutionTrees, CornerCases) {
   std::string kg = "<s> <p> <o>";
   std::string query = "SELECT ?p ?o WHERE {<s> ?p ?o } ORDER BY ?p ?o";
   std::string constructQuery =

--- a/test/engine/TextIndexScanTestHelpers.h
+++ b/test/engine/TextIndexScanTestHelpers.h
@@ -9,7 +9,7 @@ namespace textIndexScanTestHelpers {
 // obtain the textRecord using idToOptionalString.
 // TODO: Implement a more elegant/stable version
 inline string getTextRecordFromResultTable(const QueryExecutionContext* qec,
-                                           const Result& result,
+                                           const ProtoResult& result,
                                            const size_t& rowIndex) {
   return qec->getIndex()
       .idToOptionalString(
@@ -18,7 +18,7 @@ inline string getTextRecordFromResultTable(const QueryExecutionContext* qec,
 }
 
 inline string getEntityFromResultTable(const QueryExecutionContext* qec,
-                                       const Result& result,
+                                       const ProtoResult& result,
                                        const size_t& rowIndex) {
   return qec->getIndex()
       .idToOptionalString(
@@ -27,7 +27,7 @@ inline string getEntityFromResultTable(const QueryExecutionContext* qec,
 }
 
 inline string getWordFromResultTable(const QueryExecutionContext* qec,
-                                     const Result& result,
+                                     const ProtoResult& result,
                                      const size_t& rowIndex) {
   return qec->getIndex()
       .idToOptionalString(

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -49,7 +49,7 @@ class ValuesForTesting : public Operation {
   size_t& costEstimate() { return costEstimate_; }
 
   // ___________________________________________________________________________
-  Result computeResult([[maybe_unused]] bool requestLaziness) override {
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
     auto table = table_.clone();
     if (supportsLimit_) {
       table.erase(table.begin() + getLimit().upperBound(table.size()),

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -31,7 +31,7 @@ class StallForeverOperation : public Operation {
   using Operation::Operation;
   // Do-nothing operation that runs for 100ms without computing anything, but
   // which can be cancelled.
-  Result computeResult([[maybe_unused]] bool requestLaziness) override {
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
     auto end = std::chrono::steady_clock::now() + 100ms;
     while (std::chrono::steady_clock::now() < end) {
       checkCancellation();
@@ -73,7 +73,7 @@ class ShallowParentOperation : public Operation {
     return {child_.get()};
   }
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override {
+  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
     auto childResult = child_->getResult();
     return {childResult->idTable().clone(), resultSortedOn(),
             childResult->getSharedLocalVocab()};


### PR DESCRIPTION
`Operation:: computeResult()` now returns a type called `ProtoResult` (previously it returned `Result`.) Currently, `ProtoResult` is an alias for `Result`, but as soon as lazy operations are implemented, those two types will be different.
This PR makes the reviewing of the lazy operations PRs much easier, as it implements some of the very trivial changes which would otherwise clutter the diff.