### PR TITLE
Fix query planning for join with `SERVICE` clause

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1779,33 +1779,41 @@ auto QueryPlanner::createJoinWithHasPredicateScan(
 
 // _____________________________________________________________________
 auto QueryPlanner::createJoinWithService(
-    SubtreePlan a, SubtreePlan b,
+    const SubtreePlan& a, const SubtreePlan& b,
     const std::vector<std::array<ColumnIndex, 2>>& jcs)
     -> std::optional<SubtreePlan> {
   auto aRootOp = std::dynamic_pointer_cast<Service>(a._qet->getRootOperation());
   auto bRootOp = std::dynamic_pointer_cast<Service>(b._qet->getRootOperation());
 
-  // Exactly one of the two Operations can be a service.
+  // Exactly one of the two Operations can be a serviceWithSibling.
   if (static_cast<bool>(aRootOp) == static_cast<bool>(bRootOp)) {
     return std::nullopt;
   }
 
-  auto serviceWithOutSibling = aRootOp ? aRootOp : bRootOp;
-  auto sibling = bRootOp ? a : b;
+  // Setup some variables that are agnostic of which of the two inputs is the
+  // serviceWithSibling clause, as these cases are completely symmetric.
+  const auto& [serviceIn, sibling, serviceIdx, siblingIdx] = [&]() {
+    static constexpr size_t zero = 0;
+    static constexpr size_t one = 1;
+    if (aRootOp) {
+      return std::tie(aRootOp, b, zero, one);
+    } else {
+      AD_CORRECTNESS_CHECK(bRootOp);
+      return std::tie(bRootOp, a, one, zero);
+    }
+  }();
 
-  auto service =
-      makeSubtreePlan(serviceWithOutSibling->addSiblingTree(sibling._qet));
-  auto qec = serviceWithOutSibling->getExecutionContext();
-
-  auto serviceIdx = aRootOp ? 0 : 1;
-  auto siblingIdx = aRootOp ? 1 : 0;
+  auto serviceWithSibling =
+      makeSubtreePlan(serviceIn->addSiblingTree(sibling._qet));
+  auto qec = serviceIn->getExecutionContext();
 
   SubtreePlan plan =
       jcs.size() == 1
-          ? makeSubtreePlan<Join>(qec, std::move(service._qet), sibling._qet,
-                                  jcs[0][serviceIdx], jcs[0][siblingIdx])
-          : makeSubtreePlan<MultiColumnJoin>(qec, std::move(service._qet),
-                                             sibling._qet);
+          ? makeSubtreePlan<Join>(qec, std::move(serviceWithSibling._qet),
+                                  sibling._qet, jcs[0][serviceIdx],
+                                  jcs[0][siblingIdx])
+          : makeSubtreePlan<MultiColumnJoin>(
+                qec, std::move(serviceWithSibling._qet), sibling._qet);
   mergeSubtreePlanIds(plan, a, b);
 
   return plan;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -330,7 +330,7 @@ class QueryPlanner {
       const std::vector<std::array<ColumnIndex, 2>>& jcs);
 
   [[nodiscard]] static std::optional<SubtreePlan> createJoinWithService(
-      SubtreePlan a, SubtreePlan b,
+      const SubtreePlan& a, const SubtreePlan& b,
       const std::vector<std::array<ColumnIndex, 2>>& jcs);
 
   [[nodiscard]] vector<SubtreePlan> getOrderByRow(

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -63,8 +63,11 @@ class Service : public Operation {
   // later be joined with the result of the `Service`. If the result of the
   // sibling is small, it will be used to constrain the SERVICE query using a
   // `VALUES` clause.
-  [[nodiscard]] std::shared_ptr<Service> addSiblingTree(
+  [[nodiscard]] std::shared_ptr<Service> createCopyWithSiblingTree(
       std::shared_ptr<QueryExecutionTree> siblingTree) const {
+    AD_CORRECTNESS_CHECK(siblingTree == nullptr);
+    // TODO<joka921> This copies the `parsedServiceClause_`. We could probably
+    // use a `shared_ptr` here to reduce the copying during QueryPlanning.
     return std::make_shared<Service>(getExecutionContext(),
                                      parsedServiceClause_, getResultFunction_,
                                      std::move(siblingTree));

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -65,7 +65,7 @@ class Service : public Operation {
   // `VALUES` clause.
   [[nodiscard]] std::shared_ptr<Service> createCopyWithSiblingTree(
       std::shared_ptr<QueryExecutionTree> siblingTree) const {
-    AD_CORRECTNESS_CHECK(siblingTree == nullptr);
+    AD_CORRECTNESS_CHECK(siblingTree_ == nullptr);
     // TODO<joka921> This copies the `parsedServiceClause_`. We could probably
     // use a `shared_ptr` here to reduce the copying during QueryPlanning.
     return std::make_shared<Service>(getExecutionContext(),

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -60,8 +60,11 @@ class Service : public Operation {
 
   // Set the siblingTree (subTree that will later be joined with the Result of
   // the Service Operation), used to reduce the Service Queries Complexity.
-  void setSiblingTree(std::shared_ptr<QueryExecutionTree> siblingTree) {
-    siblingTree_ = siblingTree;
+  [[nodiscard]] std::shared_ptr<Service> addSiblingTree(
+      std::shared_ptr<QueryExecutionTree> siblingTree) const {
+    return std::make_shared<Service>(getExecutionContext(),
+                                     parsedServiceClause_, getResultFunction_,
+                                     std::move(siblingTree));
   }
 
   // Methods inherited from base class `Operation`.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -58,8 +58,11 @@ class Service : public Operation {
           GetResultFunction getResultFunction = sendHttpOrHttpsRequest,
           std::shared_ptr<QueryExecutionTree> siblingTree = nullptr);
 
-  // Set the siblingTree (subTree that will later be joined with the Result of
-  // the Service Operation), used to reduce the Service Queries Complexity.
+  // Create a new `Service` operation, that is equal to `*this` but additionally
+  // respects the `siblingTree`. The sibling tree is a partial query that will
+  // later be joined with the result of the `Service`. If the result of the
+  // sibling is small, it will be used to constrain the SERVICE query using a
+  // `VALUES` clause.
   [[nodiscard]] std::shared_ptr<Service> addSiblingTree(
       std::shared_ptr<QueryExecutionTree> siblingTree) const {
     return std::make_shared<Service>(getExecutionContext(),

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -313,9 +313,8 @@ TEST_F(ServiceTest, getCacheKey) {
               {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
               {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))},
                {TC(iri("<blu>")), TC(iri("<bla>")), TC(iri("<blo>"))}}}));
-  service.setSiblingTree(siblingTree);
 
-  auto ck_sibling = service.getCacheKey();
+  auto ck_sibling = service.addSiblingTree(siblingTree)->getCacheKey();
   EXPECT_NE(ck_noSibling, ck_sibling);
 
   auto siblingTree2 = std::make_shared<QueryExecutionTree>(
@@ -325,9 +324,9 @@ TEST_F(ServiceTest, getCacheKey) {
                        {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
                        {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))}}}));
 
-  service.setSiblingTree(siblingTree2);
+  auto serviceWithSibling = service.addSiblingTree(siblingTree2);
 
-  auto ck_changedSibling = service.getCacheKey();
+  auto ck_changedSibling = serviceWithSibling->getCacheKey();
   EXPECT_NE(ck_sibling, ck_changedSibling);
 }
 

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -314,7 +314,8 @@ TEST_F(ServiceTest, getCacheKey) {
               {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))},
                {TC(iri("<blu>")), TC(iri("<bla>")), TC(iri("<blo>"))}}}));
 
-  auto ck_sibling = service.addSiblingTree(siblingTree)->getCacheKey();
+  auto ck_sibling =
+      service.createCopyWithSiblingTree(siblingTree)->getCacheKey();
   EXPECT_NE(ck_noSibling, ck_sibling);
 
   auto siblingTree2 = std::make_shared<QueryExecutionTree>(
@@ -324,7 +325,7 @@ TEST_F(ServiceTest, getCacheKey) {
                        {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
                        {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))}}}));
 
-  auto serviceWithSibling = service.addSiblingTree(siblingTree2);
+  auto serviceWithSibling = service.createCopyWithSiblingTree(siblingTree2);
 
   auto ck_changedSibling = serviceWithSibling->getCacheKey();
   EXPECT_NE(ck_sibling, ck_changedSibling);


### PR DESCRIPTION
There is a bug in the optimization introduced by #1341, which checks whether the sibling operand of a join with a `SERVICE` operations has a small result (and if yes, passes that result to the `SERVICE` clause as `VALUES` in order to reduce the result size of the `SERVICE` call). Instead of just adding the sibling operand to the existing `Service` operation (which led to an object that should have been `const` being changed), now a new `Service` operation that includes the sibling is created. In particular, this fixes https://qlever.cs.uni-freiburg.de/osm-planet, which worked before #1341 and now works again as it should.