### PR TITLE
Refactor ConstructExportContext to use `IdTable` and `LocalVocab` instead of `Result`

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -32,7 +32,8 @@ ExportQueryExecutionTrees::constructQueryResultToTriples(
     LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> res,
     CancellationHandle cancellationHandle) {
   for (size_t i : getRowIndices(limitAndOffset, *res)) {
-    ConstructQueryExportContext context{i, *res, qet.getVariableColumns(),
+    ConstructQueryExportContext context{i, res->idTable(), res->localVocab(),
+                                        qet.getVariableColumns(),
                                         qet.getQec()->getIndex()};
     using enum PositionInTriple;
     for (const auto& triple : constructTriples) {

--- a/src/engine/TextLimit.h
+++ b/src/engine/TextLimit.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "engine/Operation.h"
+#include "engine/QueryExecutionTree.h"
 
 // This class implements the TextLimit operation. It limits the number of texts
 // that are returned for each unique entity combination. The texts are selected

--- a/src/parser/data/ConstructQueryExportContext.h
+++ b/src/parser/data/ConstructQueryExportContext.h
@@ -18,7 +18,8 @@ enum struct PositionInTriple : int { SUBJECT, PREDICATE, OBJECT };
 // All the data that is needed to evaluate an element in a construct query.
 struct ConstructQueryExportContext {
   const size_t _row;
-  const Result& _res;
+  const IdTable& idTable_;
+  const LocalVocab& localVocab_;
   const VariableToColumnMap& _variableColumns;
   const Index& _qecIndex;
 };

--- a/src/parser/data/Variable.cpp
+++ b/src/parser/data/Variable.cpp
@@ -29,15 +29,14 @@ Variable::Variable(std::string name) : _name{std::move(name)} {
   // Call stack. Most notably the check which columns belongs to this variable
   // should be much further up in the call stack.
   size_t row = context._row;
-  const Result& res = context._res;
   const auto& variableColumns = context._variableColumns;
   const Index& qecIndex = context._qecIndex;
-  const auto& idTable = res.idTable();
+  const auto& idTable = context.idTable_;
   if (variableColumns.contains(*this)) {
     size_t index = variableColumns.at(*this).columnIndex_;
     auto id = idTable(row, index);
     auto optionalStringAndType = ExportQueryExecutionTrees::idToStringAndType(
-        qecIndex, id, res.localVocab());
+        qecIndex, id, context.localVocab_);
     if (!optionalStringAndType.has_value()) {
       return std::nullopt;
     }

--- a/test/SparqlDataTypesTest.cpp
+++ b/test/SparqlDataTypesTest.cpp
@@ -22,7 +22,8 @@ struct ContextWrapper {
   VariableToColumnMap _hashMap{};
 
   ConstructQueryExportContext createContextForRow(size_t row) const {
-    return {row, _resultTable, _hashMap, _index};
+    return {row, _resultTable.idTable(), _resultTable.localVocab(), _hashMap,
+            _index};
   }
 
   void setIdTable(IdTable&& table) {


### PR DESCRIPTION
This is a small preparation for lazy operations (see #1350)