### PR TITLE
More relaxed parsing of IRIs

### DIFF
--- a/src/parser/Tokenizer.cpp
+++ b/src/parser/Tokenizer.cpp
@@ -88,6 +88,8 @@ const RE2& Tokenizer::idToRegex(const TurtleTokenId reg) {
       return _tokens.Double;
     case Iriref:
       return _tokens.Iriref;
+    case IrirefRelaxed:
+      return _tokens.IrirefRelaxed;
     case PnameNS:
       return _tokens.PnameNS;
     case PnameLN:

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -56,6 +56,7 @@ struct TurtleToken {
         StringLiteralLongQuote(grp(StringLiteralLongQuoteString)),
 
         Iriref(grp(IrirefString)),
+        IrirefRelaxed(grp(IrirefStringRelaxed)),
         PnameNS(grp(PnameNSString)),
         PnameLN(grp(PnameLNString)),
         PnLocal(grp(PnLocalString)),
@@ -126,6 +127,9 @@ struct TurtleToken {
   const string IrirefString =
       "<([^\\x00-\\x20<>\"{}|^`\\\\]|"s + UcharString + ")*>";
   const RE2 Iriref;
+  const string IrirefStringRelaxed =
+      "<([^\\x00-\\x19<>\"{}|^`\\\\]|"s + UcharString + ")*>";
+  const RE2 IrirefRelaxed;
 
   const string PercentString = "%" + cls(HexString) + "{2}";
   // const RE2 Percent;

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -128,7 +128,7 @@ struct TurtleToken {
       "<([^\\x00-\\x20<>\"{}|^`\\\\]|"s + UcharString + ")*>";
   const RE2 Iriref;
   const string IrirefStringRelaxed =
-      "<([^\\x00-\\x19<>\"{}|^`\\\\]|"s + UcharString + ")*>";
+      "<([^\\x00-\\x19<>\"\\\\]|"s + UcharString + ")*>";
   const RE2 IrirefRelaxed;
 
   const string PercentString = "%" + cls(HexString) + "{2}";

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -666,7 +666,9 @@ bool TurtleParser<T>::iriref() {
   }
   auto endPos = view.find_first_of("<>\"\n", 1);
   if (endPos == string::npos || view[endPos] != '>') {
-    return false;
+    raise(
+        "Unterminated IRI reference (found '<' but no '>' before "
+        "one of the following characters: <, \", newline)");
   }
   // In relaxed mode, that is all we check. Otherwise, we check if the IRI is
   // standard-conform. If not, we output a warning and try to parse it in a more

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -656,28 +656,33 @@ bool TurtleParser<T>::pnameLnRelaxed() {
 // _____________________________________________________________________
 template <class T>
 bool TurtleParser<T>::iriref() {
+  // First make a cheap and simple check if we find `<...>` in the current
+  // line (we don't care about the characters in between). If not, this is
+  // certainly not an IRI reference.
+  tok_.skipWhitespaceAndComments();
+  auto view = tok_.view();
+  if (!view.starts_with('<')) {
+    return false;
+  }
+  auto endPos = view.find_first_of(">\n");
+  if (endPos == string::npos || view[endPos] != '>') {
+    return false;
+  }
+  // In relaxed mode, that is all we check. Otherwise, we check if the IRI is
+  // standard-conform. If not, we output a warning and try to parse it in a more
+  // relaxed way.
   if constexpr (UseRelaxedParsing) {
-    // Manually check if the input starts with "<" and then find the next ">"
-    // this might accept invalid irirefs but is faster than checking the
-    // complete regexes.
-    tok_.skipWhitespaceAndComments();
-    auto view = tok_.view();
-    if (view.starts_with('<')) {
-      auto endPos = view.find_first_of("> \n");
-      if (endPos == string::npos || view[endPos] != '>') {
-        raise("Parsing IRI ref (IRI without prefix) failed");
-      } else {
-        tok_.remove_prefix(endPos + 1);
-        lastParseResult_ =
-            TripleComponent::Iri::fromIriref(view.substr(0, endPos + 1));
-        return true;
-      }
-    } else {
-      return false;
-    }
+    tok_.remove_prefix(endPos + 1);
+    lastParseResult_ =
+        TripleComponent::Iri::fromIriref(view.substr(0, endPos + 1));
+    return true;
   } else {
     if (!parseTerminal<TurtleTokenId::Iriref>()) {
-      return false;
+      LOG(WARN) << "IRI ref not standard-conform: "
+                << view.substr(0, endPos + 1) << std::endl;
+      if (!parseTerminal<TurtleTokenId::IrirefRelaxed>()) {
+        return false;
+      }
     }
     lastParseResult_ =
         TripleComponent::Iri::fromIriref(lastParseResult_.getString());

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -671,8 +671,8 @@ bool TurtleParser<T>::iriref() {
         "one of the following characters: <, \", newline)");
   }
   // In relaxed mode, that is all we check. Otherwise, we check if the IRI is
-  // standard-conform. If not, we output a warning and try to parse it in a more
-  // relaxed way.
+  // standard-compliant. If not, we output a warning and try to parse it in a
+  // more relaxed way.
   if constexpr (UseRelaxedParsing) {
     tok_.remove_prefix(endPos + 1);
     lastParseResult_ =
@@ -680,7 +680,7 @@ bool TurtleParser<T>::iriref() {
     return true;
   } else {
     if (!parseTerminal<TurtleTokenId::Iriref>()) {
-      LOG(WARN) << "IRI ref not standard-conform: "
+      LOG(WARN) << "IRI ref not standard-compliant: "
                 << view.substr(0, endPos + 1) << std::endl;
       if (!parseTerminal<TurtleTokenId::IrirefRelaxed>()) {
         return false;

--- a/src/parser/TurtleParser.cpp
+++ b/src/parser/TurtleParser.cpp
@@ -664,7 +664,7 @@ bool TurtleParser<T>::iriref() {
   if (!view.starts_with('<')) {
     return false;
   }
-  auto endPos = view.find_first_of(">\n");
+  auto endPos = view.find_first_of("<>\"\n", 1);
   if (endPos == string::npos || view[endPos] != '>') {
     return false;
   }

--- a/src/parser/TurtleParser.h
+++ b/src/parser/TurtleParser.h
@@ -392,6 +392,7 @@ class TurtleParser : public TurtleParserBase {
   FRIEND_TEST(TurtleParserTest, booleanLiteral);
   FRIEND_TEST(TurtleParserTest, booleanLiteralLongForm);
   FRIEND_TEST(TurtleParserTest, collection);
+  FRIEND_TEST(TurtleParserTest, iriref);
 };
 
 /**

--- a/src/parser/TurtleTokenId.h
+++ b/src/parser/TurtleTokenId.h
@@ -27,6 +27,7 @@ enum class TurtleTokenId : int {
   Exponent,
   Double,
   Iriref,
+  IrirefRelaxed,
   PnameNS,
   PnameLN,
   PnLocal,

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -187,14 +187,30 @@ TEST(TokenizerTest, Entities) {
   string iriref2 = "<simple>";
   string iriref3 = "<unicode\uAA34\U000ABC34end>";
   string iriref4 = "<escaped\\uAA34\\U000ABC34end>";
-  string noIriref1 = "<\n>";
-  string noIriref2 = "< >";
+  string noIriref1 = "< >";
+  string noIriref2 = "<{}|^`>";
+  string noIriref4 = "<\">";
+  string noIriref3 = "<\n>";
+
+  // Strict Iriref parsing.
   ASSERT_TRUE(RE2::FullMatch(iriref1, t.Iriref, nullptr));
   ASSERT_TRUE(RE2::FullMatch(iriref2, t.Iriref, nullptr));
   ASSERT_TRUE(RE2::FullMatch(iriref3, t.Iriref, nullptr));
   ASSERT_TRUE(RE2::FullMatch(iriref4, t.Iriref, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noIriref1, t.Iriref, nullptr));
   ASSERT_FALSE(RE2::FullMatch(noIriref2, t.Iriref, nullptr));
+  ASSERT_FALSE(RE2::FullMatch(noIriref3, t.Iriref, nullptr));
+  ASSERT_FALSE(RE2::FullMatch(noIriref4, t.Iriref, nullptr));
+
+  // Relaxed Iriref parsing.
+  ASSERT_TRUE(RE2::FullMatch(iriref1, t.IrirefRelaxed, nullptr));
+  ASSERT_TRUE(RE2::FullMatch(iriref2, t.IrirefRelaxed, nullptr));
+  ASSERT_TRUE(RE2::FullMatch(iriref3, t.IrirefRelaxed, nullptr));
+  ASSERT_TRUE(RE2::FullMatch(iriref4, t.IrirefRelaxed, nullptr));
+  ASSERT_TRUE(RE2::FullMatch(noIriref1, t.IrirefRelaxed, nullptr));
+  ASSERT_TRUE(RE2::FullMatch(noIriref2, t.IrirefRelaxed, nullptr));
+  ASSERT_FALSE(RE2::FullMatch(noIriref3, t.IrirefRelaxed, nullptr));
+  ASSERT_FALSE(RE2::FullMatch(noIriref4, t.IrirefRelaxed, nullptr));
 
   using H = TokenTestCtreHelper;
   ASSERT_TRUE(H::matchIriref(iriref1));

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -700,8 +700,9 @@ TEST(TurtleParserTest, iriref) {
   auto runTestsForParser = [](auto parser) {
     std::string iriref_1 = "<fine>";
     std::string iriref_2 = "<okay ish>";
-    std::string iriref_3 = "<throws\"exception>";
-    std::string iriref_4 = "no iriref at all";
+    std::string iriref_3 = "<not\x19okay>";
+    std::string iriref_4 = "<throws\"exception>";
+    std::string iriref_5 = "no iriref at all";
     // The first IRI ref is fine for both parsers.
     parser.setInputStream(iriref_1);
     ASSERT_TRUE(parser.iriref());
@@ -719,11 +720,15 @@ TEST(TurtleParserTest, iriref) {
     } else {
       EXPECT_EQ(warning, "");
     }
-    // The third IRI ref throws a exception when parsed.
+    // The third IRI ref is not accepted by either parser.
     parser.setInputStream(iriref_3);
-    ASSERT_THROW(parser.iriref(), TurtleParser<Tokenizer>::ParseException);
-    // The fourth IRI ref is not recognized as an IRI ref.
+    ASSERT_FALSE(parser.iriref());
+    // The fourth IRI ref throws an exception when parsed (because " is
+    // encountered before the closing >).
     parser.setInputStream(iriref_4);
+    ASSERT_THROW(parser.iriref(), TurtleParser<Tokenizer>::ParseException);
+    // The fifth IRI ref is not recognized as an IRI ref.
+    parser.setInputStream(iriref_5);
     ASSERT_FALSE(parser.iriref());
   };
   // Run tests for both parsers and reset std::cout.

--- a/test/TurtleParserTest.cpp
+++ b/test/TurtleParserTest.cpp
@@ -717,7 +717,7 @@ TEST(TurtleParserTest, iriref) {
     if constexpr (std::is_same_v<decltype(parser), CtreParser>) {
       EXPECT_EQ(warning, "");
     } else {
-      EXPECT_THAT(warning, ::testing::HasSubstr("not standard-conform"));
+      EXPECT_THAT(warning, ::testing::HasSubstr("not standard-compliant"));
       EXPECT_THAT(warning, ::testing::HasSubstr(iriref_2));
     }
     // The third IRI ref is accepted by the CtreParser, but not by the


### PR DESCRIPTION
So far, our Turtle parser (with `"ascii-prefixes-only": false` requires that IRIs are standard-conform, and halts with an error otherwise. But even Apache Jena (which implements the standard rather scrupulously) is more forgiving. For example, when the input format is Turtle and an IRI contains a space, Apache Jena just outputs a warning and not an error.

This change now does the same: It first tries strict parsing, and if that does not work, it outputs a warning and tries more relaxed parsing. The additionally allowed characters are space, backtick, or any one of `{}|^`. I checked that this does not slow down parsing.

NOTE: So far, spaces in IRIs didn't work with `"ascii-prefixes-only": true` either. That way, the PubChem data (which has a few IRIs with spaces), could not be parsed with either option. The reason that it didn't work with `"ascii-prefixes-only": true` either is that with this option, the parsing simply looks for the next `>`, however only as far as the next *space* or newline. This has now been changed to look as far as the next `<`, `>`, `"`, or newline. This excludes that any of these four characters occur inside of an IRI, but that is reasonable.