### PR TITLE
Fix the Codecov upload action for PRs

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -108,7 +108,7 @@ jobs:
         mv ${{ github.workspace}}/build/test/coverage.lcov coverage-report
     - name: Upload coverage artifact
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage-report/

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,7 +26,7 @@ jobs:
         echo ${GITHUB_REF} > ./sonarcloud-report/github_ref
     - name: Upload sonarcloud artifact
       if: github.event_name == 'pull_request'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sonarcloud-report
         path: sonarcloud-report/

--- a/.github/workflows/upload-coverage.yml
+++ b/.github/workflows/upload-coverage.yml
@@ -71,11 +71,15 @@ jobs:
           ref: ${{env.original_github_ref}}
           path: qlever-source
       - name: "Move qlever sources up"
-        run: mv qlever-source/* .
+        run: shopt -s dotglob && mv qlever-source/* .
+      # For the new version of the codecov action we have to move the coverage file back to its original location,
+      # else several things don't work...
+      - name: "Move coverage file to original location"
+        run: mkdir build && mkdir build/test && mv coverage.lcov build/test
       - name: "Upload coverage report"
         uses: codecov/codecov-action@v4
         with:
-          file: coverage.lcov
+          file: ${{github.workspace}}/build/test/coverage.lcov
           # Note: technically, a `token` is not required for codecov.io when
           # uploading from a public repository, but specifying it avoids the
           # nasty spurious failures due to Github's rate limit for codecov's


### PR DESCRIPTION
There were some changes required to make the coverage for pull requests work with the new version of the `codecov/action`.
Also bump the version of the `upload-artifact` action from `v3` to `v4` to get rid of another warning.