### PR TITLE
Fix the static initialization order fiasco for global constants

### DIFF
--- a/src/engine/CheckUsePatternTrick.cpp
+++ b/src/engine/CheckUsePatternTrick.cpp
@@ -118,7 +118,8 @@ static void rewriteTriplesForPatternTrick(const PatternTrickTuple& subAndPred,
   } else {
     // We could not find a suitable triple to append the additional column, we
     // therefore add an explicit triple `?s ql:has_pattern ?p`
-    triples.emplace_back(subAndPred.subject_, HAS_PATTERN_PREDICATE,
+    triples.emplace_back(subAndPred.subject_,
+                         std::string{HAS_PATTERN_PREDICATE},
                          subAndPred.predicate_);
   }
 }

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -34,7 +34,8 @@ static constexpr auto makeJoin =
       subtree->getVariableAndInfoByColumnIndex(subtreeColIndex).first;
   auto hasPatternScan = ad_utility::makeExecutionTree<IndexScan>(
       qec, Permutation::Enum::PSO,
-      SparqlTriple{subtreeVar, HAS_PATTERN_PREDICATE, objectVariable});
+      SparqlTriple{subtreeVar, std::string{HAS_PATTERN_PREDICATE},
+                   objectVariable});
   auto joinedSubtree = ad_utility::makeExecutionTree<Join>(
       qec, std::move(subtree), std::move(hasPatternScan), subtreeColIndex, 0);
   auto column =

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -37,9 +37,8 @@ constexpr inline size_t GALLOP_THRESHOLD = 1000;
 
 constexpr inline char INTERNAL_PREDICATE_PREFIX_NAME[] = "ql";
 
-constexpr ad_utility::detail::constexpr_str_cat_impl::ConstexprString
-    INTERNAL_PREDICATE_PREFIX =
-        "http://qlever.cs.uni-freiburg.de/builtin-functions/";
+constexpr inline char INTERNAL_PREDICATE_PREFIX[] =
+    "http://qlever.cs.uni-freiburg.de/builtin-functions/";
 
 // Return a IRI of the form
 // `<http://qlever.cs.uni-freiburg.de/builtin-functions/concatenationOfSuffixes>`

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -14,125 +14,146 @@
 #include <string_view>
 
 #include "util/MemorySize/MemorySize.h"
+#include "util/StringUtils.h"
 
 // For access to `memorySize` literals.
 using namespace ad_utility::memory_literals;
 
-static const ad_utility::MemorySize DEFAULT_MEMORY_LIMIT_INDEX_BUILDING = 5_GB;
-static const ad_utility::MemorySize STXXL_DISK_SIZE_INDEX_BUILDER = 1_GB;
+constexpr inline ad_utility::MemorySize DEFAULT_MEMORY_LIMIT_INDEX_BUILDING =
+    5_GB;
+constexpr inline ad_utility::MemorySize STXXL_DISK_SIZE_INDEX_BUILDER = 1_GB;
 
-static constexpr ad_utility::MemorySize DEFAULT_MEM_FOR_QUERIES = 4_GB;
+constexpr inline ad_utility::MemorySize DEFAULT_MEM_FOR_QUERIES = 4_GB;
 
-constexpr uint64_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
-static const size_t MIN_WORD_PREFIX_SIZE = 4;
-static const char PREFIX_CHAR = '*';
+constexpr inline uint64_t MAX_NOF_ROWS_IN_RESULT = 1'000'000;
+constexpr inline size_t MIN_WORD_PREFIX_SIZE = 4;
+constexpr inline char PREFIX_CHAR = '*';
 
-static const size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
+constexpr inline size_t BUFFER_SIZE_DOCSFILE_LINE = 100'000'000;
 
-static const size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
+constexpr inline size_t TEXT_PREDICATE_CARDINALITY_ESTIMATE = 1'000'000'000;
 
-static const size_t GALLOP_THRESHOLD = 1000;
+constexpr inline size_t GALLOP_THRESHOLD = 1000;
 
-static const char INTERNAL_PREDICATE_PREFIX_NAME[] = "ql";
+constexpr inline char INTERNAL_PREDICATE_PREFIX_NAME[] = "ql";
 
-static const std::string INTERNAL_PREDICATE_PREFIX =
-    "http://qlever.cs.uni-freiburg.de/builtin-functions/";
+constexpr ad_utility::detail::constexpr_str_cat_impl::ConstexprString
+    INTERNAL_PREDICATE_PREFIX =
+        "http://qlever.cs.uni-freiburg.de/builtin-functions/";
 
 // Return a IRI of the form
 // `<http://qlever.cs.uni-freiburg.de/builtin-functions/concatenationOfSuffixes>`
-constexpr auto makeInternalIri = [](auto&&... suffixes) {
-  return absl::StrCat("<", INTERNAL_PREDICATE_PREFIX, suffixes..., ">");
-};
-static const std::string INTERNAL_ENTITIES_URI_PREFIX =
-    absl::StrCat("<", INTERNAL_PREDICATE_PREFIX);
-static const std::string INTERNAL_PREDICATE_PREFIX_IRI = makeInternalIri("");
-static const std::string CONTAINS_ENTITY_PREDICATE =
-    makeInternalIri("contains-entity");
-static const std::string CONTAINS_WORD_PREDICATE =
-    makeInternalIri("contains-word");
+template <
+    ad_utility::detail::constexpr_str_cat_impl::ConstexprString... suffixes>
+constexpr std::string_view makeInternalIriConst() {
+  return ad_utility::constexprStrCat<"<", INTERNAL_PREDICATE_PREFIX,
+                                     suffixes..., ">">();
+}
 
-static const std::string INTERNAL_TEXT_MATCH_PREDICATE =
-    makeInternalIri("text");
-static const std::string HAS_PREDICATE_PREDICATE =
-    makeInternalIri("has-predicate");
-static const std::string HAS_PATTERN_PREDICATE = makeInternalIri("has-pattern");
-static const std::string DEFAULT_GRAPH_IRI = makeInternalIri("default-graph");
-static const std::string INTERNAL_GRAPH_IRI = makeInternalIri("internal-graph");
+inline std::string makeInternalIri(const auto&... suffixes) {
+  return absl::StrCat("<", std::string_view{INTERNAL_PREDICATE_PREFIX},
+                      suffixes..., ">");
+}
+constexpr inline std::string_view INTERNAL_ENTITIES_URI_PREFIX =
+    ad_utility::constexprStrCat<"<", INTERNAL_PREDICATE_PREFIX>();
+constexpr inline std::string_view INTERNAL_PREDICATE_PREFIX_IRI =
+    makeInternalIriConst<"">();
+constexpr inline std::string_view CONTAINS_ENTITY_PREDICATE =
+    makeInternalIriConst<"contains-entity">();
+constexpr inline std::string_view CONTAINS_WORD_PREDICATE =
+    makeInternalIriConst<"contains-word">();
 
-static constexpr std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
+constexpr inline std::string_view INTERNAL_TEXT_MATCH_PREDICATE =
+    makeInternalIriConst<"text">();
+constexpr inline std::string_view HAS_PREDICATE_PREDICATE =
+    makeInternalIriConst<"has-predicate">();
+constexpr inline std::string_view HAS_PATTERN_PREDICATE =
+    makeInternalIriConst<"has-pattern">();
+constexpr inline std::string_view DEFAULT_GRAPH_IRI =
+    makeInternalIriConst<"default-graph">();
+constexpr inline std::string_view INTERNAL_GRAPH_IRI =
+    makeInternalIriConst<"internal-graph">();
+
+constexpr inline std::pair<std::string_view, std::string_view> GEOF_PREFIX = {
     "geof:", "http://www.opengis.net/def/function/geosparql/"};
-static constexpr std::pair<std::string_view, std::string_view> MATH_PREFIX = {
+constexpr inline std::pair<std::string_view, std::string_view> MATH_PREFIX = {
     "math:", "http://www.w3.org/2005/xpath-functions/math#"};
-static constexpr std::pair<std::string_view, std::string_view> XSD_PREFIX = {
+constexpr inline std::pair<std::string_view, std::string_view> XSD_PREFIX = {
     "xsd", "http://www.w3.org/2001/XMLSchema#"};
 
-static const std::string INTERNAL_VARIABLE_PREFIX =
+constexpr inline std::string_view INTERNAL_VARIABLE_PREFIX =
     "?_QLever_internal_variable_";
 
-constexpr std::string_view INTERNAL_BLANKNODE_VARIABLE_PREFIX =
+constexpr inline std::string_view INTERNAL_BLANKNODE_VARIABLE_PREFIX =
     "?_QLever_internal_variable_bn_";
 
-constexpr std::string_view INTERNAL_VARIABLE_QUERY_PLANNER_PREFIX =
+constexpr inline std::string_view INTERNAL_VARIABLE_QUERY_PLANNER_PREFIX =
     "?_QLever_internal_variable_qp_";
 
-static constexpr std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
-static constexpr std::string_view MATCHINGWORD_VARIABLE_PREFIX =
+constexpr inline std::string_view SCORE_VARIABLE_PREFIX = "?ql_score_";
+constexpr inline std::string_view MATCHINGWORD_VARIABLE_PREFIX =
     "?ql_matchingword_";
 
-static const std::string LANGUAGE_PREDICATE = makeInternalIri("langtag");
+constexpr inline std::string_view LANGUAGE_PREDICATE =
+    makeInternalIriConst<"langtag">();
 
 // TODO<joka921> Move them to their own file, make them strings, remove
 // duplications, etc.
-static const char XSD_STRING[] = "http://www.w3.org/2001/XMLSchema#string";
-static const char XSD_DATETIME_TYPE[] =
+constexpr inline char XSD_STRING[] = "http://www.w3.org/2001/XMLSchema#string";
+constexpr inline char XSD_DATETIME_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#dateTime";
-static const char XSD_DATE_TYPE[] = "http://www.w3.org/2001/XMLSchema#date";
-static const char XSD_GYEAR_TYPE[] = "http://www.w3.org/2001/XMLSchema#gYear";
-static const char XSD_GYEARMONTH_TYPE[] =
+constexpr inline char XSD_DATE_TYPE[] = "http://www.w3.org/2001/XMLSchema#date";
+constexpr inline char XSD_GYEAR_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#gYear";
+constexpr inline char XSD_GYEARMONTH_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#gYearMonth";
-static const char XSD_DAYTIME_DURATION_TYPE[] =
+constexpr inline char XSD_DAYTIME_DURATION_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#dayTimeDuration";
 
 constexpr inline char XSD_INT_TYPE[] = "http://www.w3.org/2001/XMLSchema#int";
-static const char XSD_INTEGER_TYPE[] =
+constexpr inline char XSD_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#integer";
-static const char XSD_FLOAT_TYPE[] = "http://www.w3.org/2001/XMLSchema#float";
-static const char XSD_DOUBLE_TYPE[] = "http://www.w3.org/2001/XMLSchema#double";
+constexpr inline char XSD_FLOAT_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#float";
+constexpr inline char XSD_DOUBLE_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#double";
 constexpr inline char XSD_DECIMAL_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#decimal";
 
-static const char XSD_NON_POSITIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_NON_POSITIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#nonPositiveInteger";
-static const char XSD_NEGATIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_NEGATIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#negativeInteger";
-static const char XSD_LONG_TYPE[] = "http://www.w3.org/2001/XMLSchema#long";
-static const char XSD_SHORT_TYPE[] = "http://www.w3.org/2001/XMLSchema#short";
-static const char XSD_BYTE_TYPE[] = "http://www.w3.org/2001/XMLSchema#byte";
-static const char XSD_NON_NEGATIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_LONG_TYPE[] = "http://www.w3.org/2001/XMLSchema#long";
+constexpr inline char XSD_SHORT_TYPE[] =
+    "http://www.w3.org/2001/XMLSchema#short";
+constexpr inline char XSD_BYTE_TYPE[] = "http://www.w3.org/2001/XMLSchema#byte";
+constexpr inline char XSD_NON_NEGATIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
-static const char XSD_UNSIGNED_LONG_TYPE[] =
+constexpr inline char XSD_UNSIGNED_LONG_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedLong";
-static const char XSD_UNSIGNED_INT_TYPE[] =
+constexpr inline char XSD_UNSIGNED_INT_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedInt";
-static const char XSD_UNSIGNED_SHORT_TYPE[] =
+constexpr inline char XSD_UNSIGNED_SHORT_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#unsignedShort";
-static const char XSD_POSITIVE_INTEGER_TYPE[] =
+constexpr inline char XSD_POSITIVE_INTEGER_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#positiveInteger";
 constexpr inline char XSD_BOOLEAN_TYPE[] =
     "http://www.w3.org/2001/XMLSchema#boolean";
-static const char RDF_PREFIX[] = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
-static const char RDF_LANGTAG_STRING[] =
+constexpr inline char RDF_PREFIX[] =
+    "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+constexpr inline char RDF_LANGTAG_STRING[] =
     "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 
-static const std::string VOCAB_SUFFIX = ".vocabulary";
-static const std::string MMAP_FILE_SUFFIX = ".meta";
-static const std::string CONFIGURATION_FILE = ".meta-data.json";
+constexpr inline std::string_view VOCAB_SUFFIX = ".vocabulary";
+constexpr inline std::string_view MMAP_FILE_SUFFIX = ".meta";
+constexpr inline std::string_view CONFIGURATION_FILE = ".meta-data.json";
 
-static const std::string ERROR_IGNORE_CASE_UNSUPPORTED =
+constexpr inline std::string_view ERROR_IGNORE_CASE_UNSUPPORTED =
     "Key \"ignore-case\" is no longer supported. Please remove this key from "
     "your settings.json and rebuild your index. You can optionally specify the "
     "\"locale\" key, otherwise \"en.US\" will be used as default";
-static const std::string WARNING_ASCII_ONLY_PREFIXES =
+constexpr inline std::string_view WARNING_ASCII_ONLY_PREFIXES =
     "You specified \"ascii-prefixes-only = true\", which enables faster "
     "parsing for well-behaved TTL files";
 // " but only works correctly if there are no escape sequences in "
@@ -141,12 +162,12 @@ static const std::string WARNING_ASCII_ONLY_PREFIXES =
 // "Most Turtle files fulfill these properties (e.g. that from Wikidata), "
 // "but not all";
 
-static const std::string WARNING_PARALLEL_PARSING =
+constexpr inline std::string_view WARNING_PARALLEL_PARSING =
     "You specified \"parallel-parsing = true\", which enables faster parsing "
     "for TTL files with a well-behaved use of newlines";
-static const std::string LOCALE_DEFAULT_LANG = "en";
-static const std::string LOCALE_DEFAULT_COUNTRY = "US";
-static constexpr bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
+constexpr inline std::string_view LOCALE_DEFAULT_LANG = "en";
+constexpr inline std::string_view LOCALE_DEFAULT_COUNTRY = "US";
+constexpr inline bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
 
 // Constants for the range of valid compression prefixes
 // all ASCII- printable characters are left out.
@@ -155,20 +176,20 @@ static constexpr bool LOCALE_DEFAULT_IGNORE_PUNCTUATION = false;
 // All prefix codes have a most significant bit of 1. This means the prefix
 // codes are never valid UTF-8 and thus it is always able to determine, whether
 // this vocabulary was compressed or not.
-static constexpr uint8_t MIN_COMPRESSION_PREFIX = 129;
-static constexpr uint8_t NUM_COMPRESSION_PREFIXES = 126;
+constexpr inline uint8_t MIN_COMPRESSION_PREFIX = 129;
+constexpr inline uint8_t NUM_COMPRESSION_PREFIXES = 126;
 // if this is the first character of a compressed string, this means that no
 // compression has been applied to  a word
-static const uint8_t NO_PREFIX_CHAR =
+constexpr inline uint8_t NO_PREFIX_CHAR =
     MIN_COMPRESSION_PREFIX + NUM_COMPRESSION_PREFIXES;
 
 // When initializing a sort performance estimator, at most this percentage of
 // the number of triples in the index is being sorted at once.
-static constexpr size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
+constexpr inline size_t PERCENTAGE_OF_TRIPLES_FOR_SORT_ESTIMATE = 5;
 
 // When asked to make room for X ids in the cache, actually make room for X
 // times this factor.
-static constexpr size_t MAKE_ROOM_SLACK_FACTOR = 2;
+constexpr inline size_t MAKE_ROOM_SLACK_FACTOR = 2;
 
 // The maximal number of columns an `IdTable` (an intermediate result of
 // query evaluation) may have to be able to use the more efficient `static`
@@ -178,25 +199,26 @@ static constexpr size_t MAKE_ROOM_SLACK_FACTOR = 2;
 // more columns, but also increases compile times because more templates
 // have to be instantiated. It might also be necessary to increase some internal
 // compiler limits for the evaluation of constexpr functions and templates.
-static constexpr int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
+constexpr inline int DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE = 5;
 
 // Interval in which an enabled watchdog would check if
 // `CancellationHandle::throwIfCancelled` is called regularly.
-constexpr std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{50};
+constexpr inline std::chrono::milliseconds DESIRED_CANCELLATION_CHECK_INTERVAL{
+    50};
 
 // In all permutations, the graph ID of the triple is stored as the fourth
 // entry. During the index building it is important that this is the first
 // column after the "actual" triple.
-constexpr size_t ADDITIONAL_COLUMN_GRAPH_ID = 3;
+constexpr inline size_t ADDITIONAL_COLUMN_GRAPH_ID = 3;
 
 // In the PSO and PSO permutations the patterns of the subject and object are
 // stored at the following indices. Note that the col0 (the P) is not part of
 // the result, so the column order for PSO is S O PatternS PatternO.
-constexpr size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 4;
-constexpr size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 5;
+constexpr inline size_t ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN = 4;
+constexpr inline size_t ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN = 5;
 
 #ifdef _PARALLEL_SORT
-static constexpr bool USE_PARALLEL_SORT = true;
+constexpr inline bool USE_PARALLEL_SORT = true;
 #include <parallel/algorithm>
 namespace ad_utility {
 template <typename... Args>
@@ -208,7 +230,7 @@ using parallel_tag = __gnu_parallel::parallel_tag;
 }  // namespace ad_utility
 
 #else
-static constexpr bool USE_PARALLEL_SORT = false;
+constexpr inline bool USE_PARALLEL_SORT = false;
 namespace ad_utility {
 template <typename... Args>
 auto parallel_sort([[maybe_unused]] Args&&... args) {
@@ -219,8 +241,8 @@ auto parallel_sort([[maybe_unused]] Args&&... args) {
 using parallel_tag = int;
 }  // namespace ad_utility
 #endif
-constexpr size_t NUM_SORT_THREADS = 4;
+constexpr inline size_t NUM_SORT_THREADS = 4;
 /// ANSI escape sequence for bold text in the console
-constexpr std::string_view EMPH_ON = "\033[1m";
+constexpr inline std::string_view EMPH_ON = "\033[1m";
 /// ANSI escape sequence to print "normal" text again in the console.
-constexpr std::string_view EMPH_OFF = "\033[22m";
+constexpr inline std::string_view EMPH_OFF = "\033[22m";

--- a/src/global/SpecialIds.h
+++ b/src/global/SpecialIds.h
@@ -16,11 +16,12 @@ namespace qlever {
 // vocabulary to the IDs that are used to represent them. These IDs all have the
 // `Undefined` datatype s.t. they do not accidentally interfere with other IDs.
 static const inline ad_utility::HashMap<std::string, Id> specialIds = []() {
+  using S = std::string;
   ad_utility::HashMap<std::string, Id> result{
-      {HAS_PREDICATE_PREDICATE, Id::fromBits(1)},
-      {HAS_PATTERN_PREDICATE, Id::fromBits(2)},
-      {DEFAULT_GRAPH_IRI, Id::fromBits(3)},
-      {INTERNAL_GRAPH_IRI, Id::fromBits(4)}};
+      {S{HAS_PREDICATE_PREDICATE}, Id::fromBits(1)},
+      {S{HAS_PATTERN_PREDICATE}, Id::fromBits(2)},
+      {S{DEFAULT_GRAPH_IRI}, Id::fromBits(3)},
+      {S{INTERNAL_GRAPH_IRI}, Id::fromBits(4)}};
 
   // Perform the following checks: All the special IDs are unique, all of them
   // have the `Undefined` datatype, but none of them is equal to the "actual"

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -54,12 +54,12 @@ constexpr inline size_t BZIP2_MAX_TOTAL_BUFFER_SIZE = 1 << 30;
 constexpr inline size_t THRESHOLD_RELATION_CREATION = 2 << 20;
 
 // ________________________________________________________________
-constexpr inline std::string PARTIAL_VOCAB_FILE_NAME =
+constexpr inline std::string_view PARTIAL_VOCAB_FILE_NAME =
     ".tmp.partial-vocabulary.";
-constexpr inline std::string PARTIAL_MMAP_IDS = ".tmp.partial-ids-mmap.";
+constexpr inline std::string_view PARTIAL_MMAP_IDS = ".tmp.partial-ids-mmap.";
 
 // ________________________________________________________________
-constexpr inline std::string TMP_BASENAME_COMPRESSION =
+constexpr inline std::string_view TMP_BASENAME_COMPRESSION =
     ".tmp.for-prefix-compression";
 
 // _________________________________________________________________

--- a/src/index/ConstantsIndexBuilding.h
+++ b/src/index/ConstantsIndexBuilding.h
@@ -14,30 +14,31 @@
 // Determines the maximum number of bytes of an internal literal (before
 // compression). Every literal larger as this size is externalized regardless
 // of its language tag
-static const size_t MAX_INTERNAL_LITERAL_BYTES = 1'000'000;
+constexpr inline size_t MAX_INTERNAL_LITERAL_BYTES = 1'000'000;
 
 // How many lines are parsed at once during index creation.
 // Reduce to save RAM
-static const int NUM_TRIPLES_PER_PARTIAL_VOCAB = 10'000'000;
+constexpr inline int NUM_TRIPLES_PER_PARTIAL_VOCAB = 10'000'000;
 
 // How many Triples is the Buffer supposed to parse ahead.
 // If too big, the memory consumption is high, if too low we possibly lose speed
-static const size_t PARSER_BATCH_SIZE = 1'000'000;
+constexpr inline size_t PARSER_BATCH_SIZE = 1'000'000;
 
 // That many triples does the turtle parser have to buffer before the call to
 // getline returns (unless our input reaches EOF). This makes parsing from
 // streams faster.
-static const size_t PARSER_MIN_TRIPLES_AT_ONCE = 10'000;
+constexpr inline size_t PARSER_MIN_TRIPLES_AT_ONCE = 10'000;
 
 // When reading from a file, Chunks of this size will
 // be fed to the parser at once (10 MiB).
-inline std::atomic<size_t> FILE_BUFFER_SIZE = 10 * (1ul << 20);
+constinit inline std::atomic<size_t> FILE_BUFFER_SIZE = 10 * (1ul << 20);
 
-inline std::atomic<size_t> BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP = 50'000;
+constinit inline std::atomic<size_t> BUFFER_SIZE_JOIN_PATTERNS_WITH_OSP =
+    50'000;
 
 // When merging the vocabulary, this many finished words are buffered
 // before they are written to the output.
-inline std::atomic<size_t> BATCH_SIZE_VOCABULARY_MERGE = 10'000'000;
+constinit inline std::atomic<size_t> BATCH_SIZE_VOCABULARY_MERGE = 10'000'000;
 
 // When the BZIP2 parser encounters a parsing exception it will increase its
 // buffer and try again (we have no other way currently to determine if the
@@ -46,18 +47,19 @@ inline std::atomic<size_t> BATCH_SIZE_VOCABULARY_MERGE = 10'000'000;
 // Exception. (Only works safely if no Turtle statement is longer than this
 // size. I think currently 1 GB should be enough for this., this is 10MB per
 // triple average over 1000 triples.
-static const size_t BZIP2_MAX_TOTAL_BUFFER_SIZE = 1 << 30;
+constexpr inline size_t BZIP2_MAX_TOTAL_BUFFER_SIZE = 1 << 30;
 
 // If a single relation has more than this number of triples, it will be
 // buffered into an MmapVector during the creation of the relations;
-static const size_t THRESHOLD_RELATION_CREATION = 2 << 20;
+constexpr inline size_t THRESHOLD_RELATION_CREATION = 2 << 20;
 
 // ________________________________________________________________
-static const std::string PARTIAL_VOCAB_FILE_NAME = ".tmp.partial-vocabulary.";
-static const std::string PARTIAL_MMAP_IDS = ".tmp.partial-ids-mmap.";
+constexpr inline std::string PARTIAL_VOCAB_FILE_NAME =
+    ".tmp.partial-vocabulary.";
+constexpr inline std::string PARTIAL_MMAP_IDS = ".tmp.partial-ids-mmap.";
 
 // ________________________________________________________________
-static const std::string TMP_BASENAME_COMPRESSION =
+constexpr inline std::string TMP_BASENAME_COMPRESSION =
     ".tmp.for-prefix-compression";
 
 // _________________________________________________________________
@@ -65,38 +67,39 @@ static const std::string TMP_BASENAME_COMPRESSION =
 // unique elements of the vocabulary are identified via hash maps. Typically, 6
 // is a good value. On systems with very few CPUs, a lower value might be
 // beneficial.
-constexpr size_t NUM_PARALLEL_ITEM_MAPS = 10;
+constexpr inline size_t NUM_PARALLEL_ITEM_MAPS = 10;
 
 // The number of threads that are parsing in parallel, when the parallel Turtle
 // parser is used.
-constexpr size_t NUM_PARALLEL_PARSER_THREADS = 8;
+constexpr inline size_t NUM_PARALLEL_PARSER_THREADS = 8;
 
 // Increasing the following two constants increases the RAM usage without much
 // benefit to the performance.
 
 // The number of unparsed blocks of triples, that may wait for parsing at the
 // same time
-constexpr size_t QUEUE_SIZE_BEFORE_PARALLEL_PARSING = 10;
+constexpr inline size_t QUEUE_SIZE_BEFORE_PARALLEL_PARSING = 10;
 // The number of parsed blocks of triples, that may wait for parsing at the same
 // time
-constexpr size_t QUEUE_SIZE_AFTER_PARALLEL_PARSING = 10;
+constexpr inline size_t QUEUE_SIZE_AFTER_PARALLEL_PARSING = 10;
 
 // The blocksize parameter of the parallel vocabulary merging. Higher values
 // mean higher memory consumption, whereas a too low value will impact the
 // performance negatively.
-static constexpr size_t BLOCKSIZE_VOCABULARY_MERGING = 100;
+constexpr inline size_t BLOCKSIZE_VOCABULARY_MERGING = 100;
 
 // A buffer size used during the second pass of the Index build.
 // It is not const, so we can set it to a much lower value for unit tests to
 // increase the test coverage.
-inline size_t BUFFER_SIZE_PARTIAL_TO_GLOBAL_ID_MAPPINGS = 10'000;
+constinit inline std::atomic<size_t> BUFFER_SIZE_PARTIAL_TO_GLOBAL_ID_MAPPINGS =
+    10'000;
 
 // The uncompressed size in bytes of a block of a single column of the
 // permutations. If chosen too large, then we lose performance for very small
 // index scans which always have to read a complete block. If chosen too small,
 // the overhead of the metadata that has to be stored per block becomes
 // infeasible. 250K seems to be a reasonable tradeoff here.
-constexpr ad_utility::MemorySize
+constexpr inline ad_utility::MemorySize
     UNCOMPRESSED_BLOCKSIZE_COMPRESSED_METADATA_PER_COLUMN = 250_kB;
 
-static constexpr size_t NumColumnsIndexBuilding = 4;
+constexpr inline size_t NumColumnsIndexBuilding = 4;

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -134,12 +134,9 @@ struct alignas(256) ItemMapManager {
   /// Construct by assigning the minimum ID that should be returned by the map.
   explicit ItemMapManager(uint64_t minId, const TripleComponentComparator* cmp,
                           ItemAlloc alloc)
-      : map_(alloc), minId_(minId), comparator_(cmp) {
-    for (const auto& [iri, internalId] : qlever::specialIds) {
-      // TODO<joka921> Continue
-    }
+      : map_(alloc), minId_(minId), comparator_(cmp) {}
 
-    /// Move the held HashMap out as soon as we are done inserting and only need
+  /// Move the held HashMap out as soon as we are done inserting and only need
   /// the actual vocabulary.
   ItemMapAndBuffer&& moveMap() && { return std::move(map_); }
 
@@ -177,8 +174,6 @@ struct alignas(256) ItemMapManager {
     return std::apply(
         [this](const auto&... els) { return std::array{getId(els)...}; }, t);
   }
-
-  ad_utility::HashMap<Id, Id> internalIdMapping_;
   ItemMapAndBuffer map_;
   uint64_t minId_ = 0;
   const TripleComponentComparator* comparator_ = nullptr;

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -134,9 +134,12 @@ struct alignas(256) ItemMapManager {
   /// Construct by assigning the minimum ID that should be returned by the map.
   explicit ItemMapManager(uint64_t minId, const TripleComponentComparator* cmp,
                           ItemAlloc alloc)
-      : map_(alloc), minId_(minId), comparator_(cmp) {}
+      : map_(alloc), minId_(minId), comparator_(cmp) {
+    for (const auto& [iri, internalId] : qlever::specialIds) {
+      // TODO<joka921> Continue
+    }
 
-  /// Move the held HashMap out as soon as we are done inserting and only need
+    /// Move the held HashMap out as soon as we are done inserting and only need
   /// the actual vocabulary.
   ItemMapAndBuffer&& moveMap() && { return std::move(map_); }
 
@@ -174,6 +177,8 @@ struct alignas(256) ItemMapManager {
     return std::apply(
         [this](const auto&... els) { return std::array{getId(els)...}; }, t);
   }
+
+  ad_utility::HashMap<Id, Id> internalIdMapping_;
   ItemMapAndBuffer map_;
   uint64_t minId_ = 0;
   const TripleComponentComparator* comparator_ = nullptr;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1048,8 +1048,8 @@ void IndexImpl::readIndexBuilderSettingsFromFile() {
    */
 
   {
-    std::string lang = LOCALE_DEFAULT_LANG;
-    std::string country = LOCALE_DEFAULT_COUNTRY;
+    std::string lang{LOCALE_DEFAULT_LANG};
+    std::string country{LOCALE_DEFAULT_COUNTRY};
     bool ignorePunctuation = LOCALE_DEFAULT_IGNORE_PUNCTUATION;
     if (j.count("locale")) {
       lang = std::string{j["locale"]["language"]};

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -685,7 +685,7 @@ class IndexImpl {
         getVocab().prefixRanges(ad_utility::triple_component::literalPrefix);
     auto taggedPredicatesRanges =
         getVocab().prefixRanges(ad_utility::languageTaggedPredicatePrefix);
-    auto internal = INTERNAL_ENTITIES_URI_PREFIX;
+    std::string internal{INTERNAL_ENTITIES_URI_PREFIX};
     internal[0] = ad_utility::triple_component::iriPrefixChar;
     auto internalEntitiesRanges = getVocab().prefixRanges(internal);
 

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -93,7 +93,8 @@ class LocaleManager {
 
   /// Default constructor. Use the settings from "../global/Constants.h"
   LocaleManager()
-      : LocaleManager(LOCALE_DEFAULT_LANG, LOCALE_DEFAULT_COUNTRY,
+      : LocaleManager(std::string{LOCALE_DEFAULT_LANG},
+                      std::string{LOCALE_DEFAULT_COUNTRY},
                       LOCALE_DEFAULT_IGNORE_PUNCTUATION){};
 
   /**

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -77,7 +77,7 @@ struct VocabularyMetaData {
   size_t numBlankNodesTotal_ = 0;
   IdRangeForPrefix langTaggedPredicates_{
       std::string{ad_utility::languageTaggedPredicatePrefix}};
-  IdRangeForPrefix internalEntities_{INTERNAL_ENTITIES_URI_PREFIX};
+  IdRangeForPrefix internalEntities_{std::string{INTERNAL_ENTITIES_URI_PREFIX}};
 
   // Return true iff the `id` belongs to one of the two ranges that contain
   // the internal IDs that were added by QLever and were not part of the

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -302,7 +302,8 @@ void ParsedQuery::GraphPattern::addLanguageFilter(const Variable& variable,
                   ._triples;
 
     auto langEntity = ad_utility::convertLangtagToEntityUri(langTag);
-    SparqlTriple triple(variable, PropertyPath::fromIri(LANGUAGE_PREDICATE),
+    SparqlTriple triple(variable,
+                        PropertyPath::fromIri(std::string{LANGUAGE_PREDICATE}),
                         langEntity);
     t.push_back(std::move(triple));
   }

--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -11,9 +11,10 @@ using AntlrParser = SparqlAutomaticParser;
 // _____________________________________________________________________________
 ParsedQuery SparqlParser::parseQuery(std::string query) {
   // The second argument is the `PrefixMap` for QLever's internal IRIs.
+  using S = std::string;
   sparqlParserHelpers::ParserAndVisitor p{
       std::move(query),
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{S{INTERNAL_PREDICATE_PREFIX_NAME}, S{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   // Note: `AntlrParser::query` is a method of `AntlrParser` (which is an alias
   // for `SparqlAutomaticParser`) that returns the `QueryContext*` for the whole
   // query.

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -380,6 +380,7 @@ std::basic_string<Char> operator+(const std::basic_string_view<Char>& a,
   return strCatImpl(a, std::basic_string_view<Char>{b});
 }
 
-std::string operator+(char c, std::string_view b) {
+template <typename Char>
+std::string operator+(Char c, std::basic_string_view<Char> b) {
   return strCatImpl(std::string_view(&c, 1), b);
 }

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -336,7 +336,7 @@ constexpr auto constexprStrCatBufferImpl() {
 // TODO<C++26> This can be a `static constexpr` variable inside the
 // `constexprStrCatBufferImpl()` function above.
 template <ConstexprString... strings>
-constexpr auto constexprStrCatBufferVar =
+constexpr inline auto constexprStrCatBufferVar =
     constexprStrCatBufferImpl<strings...>();
 }  // namespace detail::constexpr_str_cat_impl
 
@@ -355,8 +355,8 @@ constexpr std::string_view constexprStrCat() {
 // these overloads are missing in the STL
 // TODO they can be constexpr once the compiler completely supports C++20
 template <typename Char>
-inline std::basic_string<Char> strCatImpl(const std::basic_string_view<Char>& a,
-                                          std::basic_string_view<Char> b) {
+std::basic_string<Char> strCatImpl(const std::basic_string_view<Char>& a,
+                                   std::basic_string_view<Char> b) {
   std::basic_string<Char> res;
   res.reserve(a.size() + b.size());
   res += a;

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -370,13 +370,13 @@ std::basic_string<Char> strCatImpl(const std::basic_string_view<Char>& a,
 // TODO they can be constexpr once the compiler completely supports C++20
 template <typename Char>
 std::basic_string<Char> operator+(const std::basic_string<Char>& a,
-                                         std::basic_string_view<Char> b) {
+                                  std::basic_string_view<Char> b) {
   return strCatImpl(std::basic_string_view<Char>{a}, b);
 }
 
 template <typename Char>
 std::basic_string<Char> operator+(const std::basic_string_view<Char>& a,
-                                         std::basic_string<Char> b) {
+                                  std::basic_string<Char> b) {
   return strCatImpl(a, std::basic_string_view<Char>{b});
 }
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <absl/strings/str_replace.h>
+#include <gmock/gmock-spec-builders.h>
 
 #include <string_view>
 
@@ -327,8 +328,9 @@ constexpr std::array<char, sz + 1> catImpl(
 // zero byte at the end.
 template <ConstexprString... strings>
 constexpr auto constexprStrCatBufferImpl() {
-  constexpr size_t sz = (... + strings.size());
-  constexpr auto innerResult = catImpl<sz>(std::array{strings...});
+  constexpr size_t sz = (size_t{0} + ... + strings.size());
+  constexpr auto innerResult =
+      catImpl<sz>(std::array<ConstexprString, sizeof...(strings)>{strings...});
   return innerResult;
 }
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -354,8 +354,7 @@ constexpr std::string_view constexprStrCat() {
 }
 }  // namespace ad_utility
 
-// these overloads are missing in the STL
-// TODO they can be constexpr once the compiler completely supports C++20
+// A helper function for the `operator+` overloads below.
 template <typename Char>
 std::basic_string<Char> strCatImpl(const std::basic_string_view<Char>& a,
                                    std::basic_string_view<Char> b) {
@@ -366,18 +365,21 @@ std::basic_string<Char> strCatImpl(const std::basic_string_view<Char>& a,
   return res;
 }
 
+// These overloads of `operator+` between a `string` and a `string_view`  are
+// missing in the STL.
+// TODO they can be constexpr once the compiler completely supports C++20
 template <typename Char>
-inline std::basic_string<Char> operator+(const std::basic_string<Char>& a,
+std::basic_string<Char> operator+(const std::basic_string<Char>& a,
                                          std::basic_string_view<Char> b) {
   return strCatImpl(std::basic_string_view<Char>{a}, b);
 }
 
 template <typename Char>
-inline std::basic_string<Char> operator+(const std::basic_string_view<Char>& a,
+std::basic_string<Char> operator+(const std::basic_string_view<Char>& a,
                                          std::basic_string<Char> b) {
   return strCatImpl(a, std::basic_string_view<Char>{b});
 }
 
-inline std::string operator+(char c, std::string_view b) {
+std::string operator+(char c, std::string_view b) {
   return strCatImpl(std::string_view(&c, 1), b);
 }

--- a/test/ConstantsTest.cpp
+++ b/test/ConstantsTest.cpp
@@ -25,3 +25,10 @@ TEST(Constants, testDefaultQueryTimeoutIsStriclyPositive) {
       std::runtime_error);
   EXPECT_NO_THROW(RuntimeParameters().set<"default-query-timeout">(1s));
 }
+
+TEST(Constants, makeInternalIri) {
+  EXPECT_EQ(makeInternalIri("hi", "-bye"),
+            (makeInternalIriConst<"hi", "-bye">()));
+  EXPECT_EQ(makeInternalIri("hi", "-bye"),
+            "<http://qlever.cs.uni-freiburg.de/builtin-functions/hi-bye>");
+}

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -65,7 +65,8 @@ class HasPredicateScanTest : public ::testing::Test {
 TEST_F(HasPredicateScanTest, freeS) {
   // ?x ql:has-predicate <p>, expected result : <x> and <y>
   auto scan = HasPredicateScan{
-      qec, SparqlTriple{Variable{"?x"}, HAS_PREDICATE_PREDICATE, iri("<p>")}};
+      qec, SparqlTriple{Variable{"?x"}, std::string{HAS_PREDICATE_PREDICATE},
+                        iri("<p>")}};
   runTest(scan, {{x}, {y}});
 }
 
@@ -73,7 +74,8 @@ TEST_F(HasPredicateScanTest, freeS) {
 TEST_F(HasPredicateScanTest, freeO) {
   // <x> ql:has-predicate ?p, expected result : <p> and <p2>
   auto scan = HasPredicateScan{
-      qec, SparqlTriple{iri("<x>"), HAS_PREDICATE_PREDICATE, Variable{"?p"}}};
+      qec, SparqlTriple{iri("<x>"), std::string{HAS_PREDICATE_PREDICATE},
+                        Variable{"?p"}}};
   runTest(scan, {{p}, {p2}});
 }
 
@@ -81,16 +83,16 @@ TEST_F(HasPredicateScanTest, freeO) {
 TEST_F(HasPredicateScanTest, fullScan) {
   // ?x ql:has-predicate ?y, expect the full mapping.
   auto scan = HasPredicateScan{
-      qec,
-      SparqlTriple{Variable{"?s"}, HAS_PREDICATE_PREDICATE, Variable{"?p"}}};
+      qec, SparqlTriple{Variable{"?s"}, std::string{HAS_PREDICATE_PREDICATE},
+                        Variable{"?p"}}};
   runTest(scan, {{x, p}, {x, p2}, {y, p}, {y, p3}, {z, p3}});
 
   // Full scans with the same variable in the subject and object are not
   // supported.
   auto makeIllegalScan = [this] {
     return HasPredicateScan{
-        qec,
-        SparqlTriple{Variable{"?s"}, HAS_PREDICATE_PREDICATE, Variable{"?s"}}};
+        qec, SparqlTriple{Variable{"?s"}, std::string{HAS_PREDICATE_PREDICATE},
+                          Variable{"?s"}}};
   };
   AD_EXPECT_THROW_WITH_MESSAGE(
       makeIllegalScan(),
@@ -100,7 +102,7 @@ TEST_F(HasPredicateScanTest, fullScan) {
   // Triples without any variables also aren't supported currently.
   auto makeIllegalScan2 = [this] {
     return HasPredicateScan{
-        qec, SparqlTriple{"<x>", HAS_PREDICATE_PREDICATE, "<y>"}};
+        qec, SparqlTriple{"<x>", std::string{HAS_PREDICATE_PREDICATE}, "<y>"}};
   };
   EXPECT_ANY_THROW(makeIllegalScan2());
 }
@@ -181,7 +183,8 @@ TEST_F(HasPredicateScanTest, patternTrickAllEntities) {
    *   ?x ?predicate ?o
    * } GROUP BY ?predicate
    */
-  auto triple = SparqlTriple{V{"?x"}, HAS_PATTERN_PREDICATE, V{"?predicate"}};
+  auto triple = SparqlTriple{V{"?x"}, std::string{HAS_PATTERN_PREDICATE},
+                             V{"?predicate"}};
   auto indexScan = ad_utility::makeExecutionTree<IndexScan>(
       qec, Permutation::Enum::PSO, triple);
   auto patternTrick =

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -31,6 +31,7 @@
 #include "util/AllocatorTestHelpers.h"
 #include "util/SourceLocation.h"
 
+namespace {
 using namespace sparqlParserHelpers;
 namespace m = matchers;
 using Parser = SparqlAutomaticParser;
@@ -39,6 +40,10 @@ using Var = Variable;
 auto iri = ad_utility::testing::iri;
 
 auto lit = ad_utility::testing::tripleComponentLiteral;
+
+const ad_utility::HashMap<std::string, std::string> defaultPrefixMap{
+    {std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+     std::string{INTERNAL_PREDICATE_PREFIX_IRI}}};
 
 template <auto F, bool testInsideConstructTemplate = false>
 auto parse =
@@ -146,6 +151,7 @@ using ::testing::IsEmpty;
 using ::testing::Pair;
 using ::testing::SizeIs;
 using ::testing::StrEq;
+}  // namespace
 
 TEST(SparqlParser, NumericLiterals) {
   auto expectNumericLiteral = ExpectCompleteParse<&Parser::numericLiteral>{};
@@ -869,9 +875,8 @@ TEST(SparqlParser, HavingCondition) {
 }
 
 TEST(SparqlParser, GroupGraphPattern) {
-  auto expectGraphPattern = ExpectCompleteParse<&Parser::groupGraphPattern>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectGraphPattern =
+      ExpectCompleteParse<&Parser::groupGraphPattern>{defaultPrefixMap};
   auto expectGroupGraphPatternFails =
       ExpectParseFails<&Parser::groupGraphPattern>{{}};
   auto DummyTriplesMatcher = m::Triples({{Var{"?x"}, "?y", Var{"?z"}}});
@@ -1023,9 +1028,8 @@ TEST(SparqlParser, RDFLiteral) {
 
 TEST(SparqlParser, SelectQuery) {
   auto contains = [](const std::string& s) { return ::testing::HasSubstr(s); };
-  auto expectSelectQuery = ExpectCompleteParse<&Parser::selectQuery>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectSelectQuery =
+      ExpectCompleteParse<&Parser::selectQuery>{defaultPrefixMap};
   auto expectSelectQueryFails = ExpectParseFails<&Parser::selectQuery>{};
   auto DummyGraphPatternMatcher =
       m::GraphPattern(m::Triples({{Var{"?x"}, "?y", Var{"?z"}}}));
@@ -1178,9 +1182,8 @@ TEST(SparqlParser, SelectQuery) {
 
 TEST(SparqlParser, ConstructQuery) {
   auto contains = [](const std::string& s) { return ::testing::HasSubstr(s); };
-  auto expectConstructQuery = ExpectCompleteParse<&Parser::constructQuery>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectConstructQuery =
+      ExpectCompleteParse<&Parser::constructQuery>{defaultPrefixMap};
   auto expectConstructQueryFails = ExpectParseFails<&Parser::constructQuery>{};
   expectConstructQuery(
       "CONSTRUCT { } WHERE { ?a ?b ?c }",
@@ -1227,9 +1230,7 @@ TEST(SparqlParser, ConstructQuery) {
 }
 
 TEST(SparqlParser, Query) {
-  auto expectQuery = ExpectCompleteParse<&Parser::query>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectQuery = ExpectCompleteParse<&Parser::query>{defaultPrefixMap};
   auto expectQueryFails = ExpectParseFails<&Parser::query>{};
   // Test that `_originalString` is correctly set.
   expectQuery(
@@ -1828,15 +1829,13 @@ TEST(SparqlParser, updateQueryUnsupported) {
 }
 
 TEST(SparqlParser, UpdateQuery) {
-  auto expectUpdate = ExpectCompleteParse<&Parser::update>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectUpdate = ExpectCompleteParse<&Parser::update>{defaultPrefixMap};
   auto expectUpdateFails = ExpectParseFails<&Parser::update>{};
   auto Iri = [](std::string_view stringWithBrackets) {
     return TripleComponent::Iri::fromIriref(stringWithBrackets);
   };
   auto Literal = [](std::string s) {
-    return TripleComponent::Literal::fromStringRepresentation(s);
+    return TripleComponent::Literal::fromStringRepresentation(std::move(s));
   };
 
   expectUpdate("INSERT DATA { <a> <b> <c> }",
@@ -1902,9 +1901,8 @@ TEST(SparqlParser, EmptyQuery) {
 TEST(SparqlParser, GraphOrDefault) {
   // Explicitly test this part, because all features that use it are not yet
   // supported.
-  auto expectGraphOrDefault = ExpectCompleteParse<&Parser::graphOrDefault>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectGraphOrDefault =
+      ExpectCompleteParse<&Parser::graphOrDefault>{defaultPrefixMap};
   expectGraphOrDefault("DEFAULT", testing::VariantWith<DEFAULT>(testing::_));
   expectGraphOrDefault(
       "GRAPH <foo>",
@@ -1913,9 +1911,8 @@ TEST(SparqlParser, GraphOrDefault) {
 }
 
 TEST(SparqlParser, GraphRef) {
-  auto expectGraphRefAll = ExpectCompleteParse<&Parser::graphRefAll>{
-      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
-        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
+  auto expectGraphRefAll =
+      ExpectCompleteParse<&Parser::graphRefAll>{defaultPrefixMap};
   expectGraphRefAll("DEFAULT", m::Variant<DEFAULT>());
   expectGraphRefAll("NAMED", m::Variant<NAMED>());
   expectGraphRefAll("ALL", m::Variant<ALL>());

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -870,7 +870,8 @@ TEST(SparqlParser, HavingCondition) {
 
 TEST(SparqlParser, GroupGraphPattern) {
   auto expectGraphPattern = ExpectCompleteParse<&Parser::groupGraphPattern>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   auto expectGroupGraphPatternFails =
       ExpectParseFails<&Parser::groupGraphPattern>{{}};
   auto DummyTriplesMatcher = m::Triples({{Var{"?x"}, "?y", Var{"?z"}}});
@@ -941,8 +942,9 @@ TEST(SparqlParser, GroupGraphPattern) {
           m::Triples(
               {{Var{"?x"}, "<is-a>", lit("\"Actor\"")},
                {Var{"?y"}, "<is-a>", iri("<Actor>")},
-               {Var{"?c"}, CONTAINS_ENTITY_PREDICATE, Var{"?x"}},
-               {Var{"?c"}, CONTAINS_WORD_PREDICATE, lit("\"coca* abuse\"")}})));
+               {Var{"?c"}, std::string{CONTAINS_ENTITY_PREDICATE}, Var{"?x"}},
+               {Var{"?c"}, std::string{CONTAINS_WORD_PREDICATE},
+                lit("\"coca* abuse\"")}})));
 
   // Scoping of variables in combination with a BIND clause.
   expectGraphPattern(
@@ -1022,7 +1024,8 @@ TEST(SparqlParser, RDFLiteral) {
 TEST(SparqlParser, SelectQuery) {
   auto contains = [](const std::string& s) { return ::testing::HasSubstr(s); };
   auto expectSelectQuery = ExpectCompleteParse<&Parser::selectQuery>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   auto expectSelectQueryFails = ExpectParseFails<&Parser::selectQuery>{};
   auto DummyGraphPatternMatcher =
       m::GraphPattern(m::Triples({{Var{"?x"}, "?y", Var{"?z"}}}));
@@ -1176,7 +1179,8 @@ TEST(SparqlParser, SelectQuery) {
 TEST(SparqlParser, ConstructQuery) {
   auto contains = [](const std::string& s) { return ::testing::HasSubstr(s); };
   auto expectConstructQuery = ExpectCompleteParse<&Parser::constructQuery>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   auto expectConstructQueryFails = ExpectParseFails<&Parser::constructQuery>{};
   expectConstructQuery(
       "CONSTRUCT { } WHERE { ?a ?b ?c }",
@@ -1224,7 +1228,8 @@ TEST(SparqlParser, ConstructQuery) {
 
 TEST(SparqlParser, Query) {
   auto expectQuery = ExpectCompleteParse<&Parser::query>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   auto expectQueryFails = ExpectParseFails<&Parser::query>{};
   // Test that `_originalString` is correctly set.
   expectQuery(
@@ -1824,7 +1829,8 @@ TEST(SparqlParser, updateQueryUnsupported) {
 
 TEST(SparqlParser, UpdateQuery) {
   auto expectUpdate = ExpectCompleteParse<&Parser::update>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   auto expectUpdateFails = ExpectParseFails<&Parser::update>{};
   auto Iri = [](std::string_view stringWithBrackets) {
     return TripleComponent::Iri::fromIriref(stringWithBrackets);
@@ -1897,7 +1903,8 @@ TEST(SparqlParser, GraphOrDefault) {
   // Explicitly test this part, because all features that use it are not yet
   // supported.
   auto expectGraphOrDefault = ExpectCompleteParse<&Parser::graphOrDefault>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   expectGraphOrDefault("DEFAULT", testing::VariantWith<DEFAULT>(testing::_));
   expectGraphOrDefault(
       "GRAPH <foo>",
@@ -1907,7 +1914,8 @@ TEST(SparqlParser, GraphOrDefault) {
 
 TEST(SparqlParser, GraphRef) {
   auto expectGraphRefAll = ExpectCompleteParse<&Parser::graphRefAll>{
-      {{INTERNAL_PREDICATE_PREFIX_NAME, INTERNAL_PREDICATE_PREFIX_IRI}}};
+      {{std::string{INTERNAL_PREDICATE_PREFIX_NAME},
+        std::string{INTERNAL_PREDICATE_PREFIX_IRI}}}};
   expectGraphRefAll("DEFAULT", m::Variant<DEFAULT>());
   expectGraphRefAll("NAMED", m::Variant<NAMED>());
   expectGraphRefAll("ALL", m::Variant<ALL>());

--- a/test/SparqlParserTest.cpp
+++ b/test/SparqlParserTest.cpp
@@ -1208,9 +1208,10 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
                                     "<label>", "en")),
                             Var{"?y"}}),
               triples[0]);
-    ASSERT_EQ((SparqlTriple{Var{"?text"},
-                            PropertyPath::fromIri(CONTAINS_ENTITY_PREDICATE),
-                            Var{"?y"}}),
+    ASSERT_EQ((SparqlTriple{
+                  Var{"?text"},
+                  PropertyPath::fromIri(std::string{CONTAINS_ENTITY_PREDICATE}),
+                  Var{"?y"}}),
               triples[1]);
   }
   {
@@ -1224,9 +1225,10 @@ TEST(ParserTest, LanguageFilterPostProcessing) {
     ASSERT_EQ((SparqlTriple{iri("<somebody>"), PropertyPath::fromIri("?p"),
                             Var{"?y"}}),
               triples[0]);
-    ASSERT_EQ((SparqlTriple{Var{"?text"},
-                            PropertyPath::fromIri(CONTAINS_ENTITY_PREDICATE),
-                            Var{"?y"}}),
+    ASSERT_EQ((SparqlTriple{
+                  Var{"?text"},
+                  PropertyPath::fromIri(std::string{CONTAINS_ENTITY_PREDICATE}),
+                  Var{"?y"}}),
               triples[1]);
     ASSERT_EQ(
         (SparqlTriple{

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -12,12 +12,14 @@
 #include <utility>
 
 #include "../test/util/GTestHelpers.h"
+#include "util/ConstexprSmallString.h"
 #include "util/ConstexprUtils.h"
 #include "util/Forward.h"
 #include "util/Generator.h"
 #include "util/StringUtils.h"
 
 using ad_utility::constantTimeEquals;
+using ad_utility::constexprStrCat;
 using ad_utility::getUTF8Substring;
 using ad_utility::strIsLangTag;
 using ad_utility::utf8ToLower;
@@ -343,4 +345,10 @@ TEST(StringUtilsTest, strLangTag) {
   ASSERT_TRUE(strIsLangTag("fr-BE-1606nict"));
   ASSERT_TRUE(strIsLangTag("de-CH-x-zh"));
   ASSERT_TRUE(strIsLangTag("en"));
+}
+
+TEST(StringUtilsTest, constexprStrCatLocal) {
+  using namespace std::string_view_literals;
+  ASSERT_EQ((constexprStrCat<"hello", " ", "World!">()), "hello World!"sv);
+  static_assert(constexprStrCat<"hello", " ", "World!">() == "hello World!"sv);
 }

--- a/test/StringUtilsTest.cpp
+++ b/test/StringUtilsTest.cpp
@@ -347,8 +347,26 @@ TEST(StringUtilsTest, strLangTag) {
   ASSERT_TRUE(strIsLangTag("en"));
 }
 
-TEST(StringUtilsTest, constexprStrCatLocal) {
+// _____________________________________________________________________________
+TEST(StringUtilsTest, constexprStrCat) {
   using namespace std::string_view_literals;
+  ASSERT_EQ((constexprStrCat<>()), ""sv);
+  ASSERT_EQ((constexprStrCat<"">()), ""sv);
+  ASSERT_EQ((constexprStrCat<"single">()), "single"sv);
+  ASSERT_EQ((constexprStrCat<"", "single", "">()), "single"sv);
   ASSERT_EQ((constexprStrCat<"hello", " ", "World!">()), "hello World!"sv);
   static_assert(constexprStrCat<"hello", " ", "World!">() == "hello World!"sv);
+}
+
+// _____________________________________________________________________________
+TEST(StringUtilsTest, constexprStrCatImpl) {
+  // The coverage tools don't track the compile time usages of these internal
+  // helper functions, so we test them manually.
+  using namespace ad_utility::detail::constexpr_str_cat_impl;
+  ASSERT_EQ((constexprStrCatBufferImpl<"h", "i">()),
+            (std::array{'h', 'i', '\0'}));
+
+  using C = ConstexprString;
+  ASSERT_EQ((catImpl<2>(std::array{C{"h"}, C{"i"}})),
+            (std::array{'h', 'i', '\0'}));
 }


### PR DESCRIPTION
QLever uses several global constants (in the Files `Constants.h` and `ConstantsIndexBuilding.h` .
Several of them were defined as ` static const` variables, which are prone to the so called "static initialization order fiasco". This is now fixed by making all these constants `constexpr`.
This commit also implements a utility to concatenate strings at compile time to initialize `static constexpr std::string_view` variables.