### PR TITLE
Make `IndexScan` helper functions non-static

### DIFF
--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -125,7 +125,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
 
 // _____________________________________________________________________________
 cppcoro::generator<IdTable> IndexScan::scanInChunks() const {
-  auto metadata = getMetadataForScan(*this);
+  auto metadata = getMetadataForScan();
   if (!metadata.has_value()) {
     co_return;
   }
@@ -133,7 +133,7 @@ cppcoro::generator<IdTable> IndexScan::scanInChunks() const {
       CompressedRelationReader::getBlocksFromMetadata(metadata.value());
   std::vector<CompressedBlockMetadata> blocks{blocksSpan.begin(),
                                               blocksSpan.end()};
-  for (IdTable& idTable : getLazyScan(*this, std::move(blocks))) {
+  for (IdTable& idTable : getLazyScan(std::move(blocks))) {
     co_yield std::move(idTable);
   }
 }
@@ -266,43 +266,43 @@ ScanSpecificationAsTripleComponent IndexScan::getScanSpecification() const {
 
 // ___________________________________________________________________________
 Permutation::IdTableGenerator IndexScan::getLazyScan(
-    const IndexScan& s, std::vector<CompressedBlockMetadata> blocks) {
-  const IndexImpl& index = s.getIndex().getImpl();
+    std::vector<CompressedBlockMetadata> blocks) const {
+  const IndexImpl& index = getIndex().getImpl();
   std::optional<Id> col0Id;
-  if (s.numVariables_ < 3) {
-    col0Id = s.getPermutedTriple()[0]->toValueId(index.getVocab()).value();
+  if (numVariables_ < 3) {
+    col0Id = getPermutedTriple()[0]->toValueId(index.getVocab()).value();
   }
   std::optional<Id> col1Id;
-  if (s.numVariables_ < 2) {
-    col1Id = s.getPermutedTriple()[1]->toValueId(index.getVocab()).value();
+  if (numVariables_ < 2) {
+    col1Id = getPermutedTriple()[1]->toValueId(index.getVocab()).value();
   }
 
   // This function is currently only called by the `getLazyScanForJoin...`
   // functions. In these cases we always have at least one variable in each of
   // the scans, because otherwise there would be no join column.
-  AD_CORRECTNESS_CHECK(s.numVariables_ >= 1);
+  AD_CORRECTNESS_CHECK(numVariables_ >= 1);
   // If there is a LIMIT or OFFSET clause that constrains the scan
   // (which can happen with an explicit subquery), we cannot use the prefiltered
   // blocks, as we currently have no mechanism to include limits and offsets
   // into the prefiltering (`std::nullopt` means `scan all blocks`).
-  auto actualBlocks = s.getLimit().isUnconstrained()
+  auto actualBlocks = getLimit().isUnconstrained()
                           ? std::optional{std::move(blocks)}
                           : std::nullopt;
 
-  return index.getPermutation(s.permutation())
+  return index.getPermutation(permutation())
       .lazyScan({col0Id, col1Id, std::nullopt}, std::move(actualBlocks),
-                s.additionalColumns(), s.cancellationHandle_, s.getLimit());
+                additionalColumns(), cancellationHandle_, getLimit());
 };
 
 // ________________________________________________________________
-std::optional<Permutation::MetadataAndBlocks> IndexScan::getMetadataForScan(
-    const IndexScan& s) {
-  const auto& index = s.getExecutionContext()->getIndex().getImpl();
-  auto scanSpec = s.getScanSpecification().toScanSpecification(index);
+std::optional<Permutation::MetadataAndBlocks> IndexScan::getMetadataForScan()
+    const {
+  const auto& index = getExecutionContext()->getIndex().getImpl();
+  auto scanSpec = getScanSpecification().toScanSpecification(index);
   if (!scanSpec.has_value()) {
     return std::nullopt;
   }
-  return index.getPermutation(s.permutation())
+  return index.getPermutation(permutation())
       .getMetadataAndBlocks(scanSpec.value());
 };
 
@@ -340,8 +340,8 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
   }
   AD_CONTRACT_CHECK(other2.size() == numTotal);
 
-  auto metaBlocks1 = getMetadataForScan(s1);
-  auto metaBlocks2 = getMetadataForScan(s2);
+  auto metaBlocks1 = s1.getMetadataForScan();
+  auto metaBlocks2 = s2.getMetadataForScan();
 
   if (!metaBlocks1.has_value() || !metaBlocks2.has_value()) {
     return {{}};
@@ -349,7 +349,7 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
   auto [blocks1, blocks2] = CompressedRelationReader::getBlocksForJoin(
       metaBlocks1.value(), metaBlocks2.value());
 
-  std::array result{getLazyScan(s1, blocks1), getLazyScan(s2, blocks2)};
+  std::array result{s1.getLazyScan(blocks1), s2.getLazyScan(blocks2)};
   result[0].details().numBlocksAll_ = metaBlocks1.value().blockMetadata_.size();
   result[1].details().numBlocksAll_ = metaBlocks2.value().blockMetadata_.size();
   return result;
@@ -357,11 +357,11 @@ IndexScan::lazyScanForJoinOfTwoScans(const IndexScan& s1, const IndexScan& s2) {
 
 // ________________________________________________________________
 Permutation::IdTableGenerator IndexScan::lazyScanForJoinOfColumnWithScan(
-    std::span<const Id> joinColumn, const IndexScan& s) {
+    std::span<const Id> joinColumn) const {
   AD_EXPENSIVE_CHECK(std::ranges::is_sorted(joinColumn));
-  AD_CORRECTNESS_CHECK(s.numVariables_ <= 3 && s.numVariables_ > 0);
+  AD_CORRECTNESS_CHECK(numVariables_ <= 3 && numVariables_ > 0);
 
-  auto metaBlocks1 = getMetadataForScan(s);
+  auto metaBlocks1 = getMetadataForScan();
 
   if (!metaBlocks1.has_value()) {
     return {};
@@ -369,7 +369,7 @@ Permutation::IdTableGenerator IndexScan::lazyScanForJoinOfColumnWithScan(
   auto blocks = CompressedRelationReader::getBlocksForJoin(joinColumn,
                                                            metaBlocks1.value());
 
-  auto result = getLazyScan(s, blocks);
+  auto result = getLazyScan(blocks);
   result.details().numBlocksAll_ = metaBlocks1.value().blockMetadata_.size();
   return result;
 }

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -60,12 +60,12 @@ class IndexScan final : public Operation {
   static std::array<Permutation::IdTableGenerator, 2> lazyScanForJoinOfTwoScans(
       const IndexScan& s1, const IndexScan& s2);
 
-  // Return a generator that lazily yields the result of `s` in blocks, but only
+  // Return a generator that lazily yields the result in blocks, but only
   // the blocks that can theoretically contain matching rows when performing a
-  // join between the first column of the result of `s`  with the `joinColumn`.
+  // join between the first column of the result with the `joinColumn`.
   // Requires that the `joinColumn` is sorted, else the behavior is undefined.
-  static Permutation::IdTableGenerator lazyScanForJoinOfColumnWithScan(
-      std::span<const Id> joinColumn, const IndexScan& s);
+  Permutation::IdTableGenerator lazyScanForJoinOfColumnWithScan(
+      std::span<const Id> joinColumn) const;
 
  private:
   // TODO<joka921> Make the `getSizeEstimateBeforeLimit()` function `const` for
@@ -118,8 +118,7 @@ class IndexScan final : public Operation {
   cppcoro::generator<IdTable> scanInChunks() const;
 
   //  Helper functions for the public `getLazyScanFor...` functions (see above).
-  static Permutation::IdTableGenerator getLazyScan(
-      const IndexScan& s, std::vector<CompressedBlockMetadata> blocks);
-  static std::optional<Permutation::MetadataAndBlocks> getMetadataForScan(
-      const IndexScan& s);
+  Permutation::IdTableGenerator getLazyScan(
+      std::vector<CompressedBlockMetadata> blocks) const;
+  std::optional<Permutation::MetadataAndBlocks> getMetadataForScan() const;
 };

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -633,8 +633,8 @@ IdTable Join::computeResultForIndexScanAndIdTable(const IdTable& idTable,
                               : joinColMap.permutationLeft())};
 
   ad_utility::Timer timer{ad_utility::timer::Timer::InitialStatus::Started};
-  auto rightBlocksInternal = IndexScan::lazyScanForJoinOfColumnWithScan(
-      permutationIdTable.col(), scan);
+  auto rightBlocksInternal =
+      scan.lazyScanForJoinOfColumnWithScan(permutationIdTable.col());
   auto rightBlocks = convertGenerator(std::move(rightBlocksInternal));
 
   runtimeInfo().addDetail("time-for-filtering-blocks", timer.msecs());

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -140,7 +140,7 @@ void testLazyScanForJoinWithColumn(
     column.push_back(entry.toValueId(qec->getIndex().getVocab()).value());
   }
 
-  auto lazyScan = IndexScan::lazyScanForJoinOfColumnWithScan(column, scan);
+  auto lazyScan = scan.lazyScanForJoinOfColumnWithScan(column);
   testLazyScan(std::move(lazyScan), scan, expectedRows);
 }
 
@@ -161,8 +161,7 @@ void testLazyScanWithColumnThrows(
   // We need this to suppress the warning about a [[nodiscard]] return value
   // being unused.
   auto makeScan = [&column, &s1]() {
-    [[maybe_unused]] auto scan =
-        IndexScan::lazyScanForJoinOfColumnWithScan(column, s1);
+    [[maybe_unused]] auto scan = s1.lazyScanForJoinOfColumnWithScan(column);
   };
   EXPECT_ANY_THROW(makeScan());
 }


### PR DESCRIPTION
For historical reasons there were some functions in the `IndexScan` class that followed the "c-style object oriented programming pattern " `const IndexScan::function(const IndexScan& self, ...);`. This commit refactors makes these functions ordinary member functions which makes using them easier and more idiomatic.