### PR TITLE
Don't even attempt to cache lazy results that will most likely never fit when fully aggregated

### DIFF
--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -93,9 +93,7 @@ class IndexScan final : public Operation {
 
   // Full index scans will never be able to fit in the cache on datasets the
   // size of wikidata, so we don't even need to try and waste performance.
-  [[nodiscard]] bool unlikelyToFitInCache() const override {
-    return numVariables_ == 3;
-  }
+  bool unlikelyToFitInCache() const override { return numVariables_ == 3; }
 
   // An index scan can directly and efficiently support LIMIT and OFFSET
   [[nodiscard]] bool supportsLimit() const override { return true; }

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -91,6 +91,12 @@ class IndexScan final : public Operation {
     return numVariables() == target;
   }
 
+  // Full index scans will never be able to fit in the cache on datasets the
+  // size of wikidata, so we don't even need to try and waste performance.
+  [[nodiscard]] bool unlikelyToFitInCache() const override {
+    return numVariables_ == 3;
+  }
+
   // An index scan can directly and efficiently support LIMIT and OFFSET
   [[nodiscard]] bool supportsLimit() const override { return true; }
 

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -93,7 +93,11 @@ class IndexScan final : public Operation {
 
   // Full index scans will never be able to fit in the cache on datasets the
   // size of wikidata, so we don't even need to try and waste performance.
-  bool unlikelyToFitInCache() const override { return numVariables_ == 3; }
+  bool unlikelyToFitInCache(
+      ad_utility::MemorySize maxCacheableSize) const override {
+    return ad_utility::MemorySize::bytes(getExactSize() * getResultWidth() *
+                                         sizeof(Id)) > maxCacheableSize;
+  }
 
   // An index scan can directly and efficiently support LIMIT and OFFSET
   [[nodiscard]] bool supportsLimit() const override { return true; }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -175,7 +175,8 @@ CacheValue Operation::runComputationAndPrepareForCache(
     const std::string& cacheKey, bool pinned) {
   auto& cache = _executionContext->getQueryTreeCache();
   auto result = runComputation(timer, computationMode);
-  if (!result.isFullyMaterialized() && !unlikelyToFitInCache()) {
+  if (!result.isFullyMaterialized() &&
+      !unlikelyToFitInCache(cache.getMaxSizeSingleEntry())) {
     AD_CONTRACT_CHECK(!pinned);
     result.cacheDuringConsumption(
         [maxSize = cache.getMaxSizeSingleEntry()](

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -175,7 +175,7 @@ CacheValue Operation::runComputationAndPrepareForCache(
     const std::string& cacheKey, bool pinned) {
   auto& cache = _executionContext->getQueryTreeCache();
   auto result = runComputation(timer, computationMode);
-  if (!result.isFullyMaterialized()) {
+  if (!result.isFullyMaterialized() && !unlikelyToFitInCache()) {
     AD_CONTRACT_CHECK(!pinned);
     result.cacheDuringConsumption(
         [maxSize = cache.getMaxSizeSingleEntry()](

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -406,4 +406,5 @@ class Operation {
               verifyLimitIsProperlyAppliedAndUpdatesRuntimeInfoCorrectly);
   FRIEND_TEST(Operation, ensureLazyOperationIsCachedIfSmallEnough);
   FRIEND_TEST(Operation, checkLazyOperationIsNotCachedIfTooLarge);
+  FRIEND_TEST(Operation, checkLazyOperationIsNotCachedIfUnlikelyToFitInCache);
 };

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -8,7 +8,6 @@
 
 #include <gtest/gtest_prod.h>
 
-#include <iomanip>
 #include <memory>
 
 #include "engine/QueryExecutionContext.h"
@@ -175,6 +174,10 @@ class Operation {
 
   void recursivelySetTimeConstraint(
       std::chrono::steady_clock::time_point deadline);
+
+  // Optimization for lazy operations where the very nature of the operation
+  // makes it unlikely to ever fit in cache when completely materialized.
+  [[nodiscard]] virtual bool unlikelyToFitInCache() const { return false; }
 
   // True iff this operation directly implement a `OFFSET` and `LIMIT` clause on
   // its result.

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -177,7 +177,10 @@ class Operation {
 
   // Optimization for lazy operations where the very nature of the operation
   // makes it unlikely to ever fit in cache when completely materialized.
-  [[nodiscard]] virtual bool unlikelyToFitInCache() const { return false; }
+  virtual bool unlikelyToFitInCache(
+      [[maybe_unused]] ad_utility::MemorySize maxCacheableSize) const {
+    return false;
+  }
 
   // True iff this operation directly implement a `OFFSET` and `LIMIT` clause on
   // its result.

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -21,6 +21,7 @@ class ValuesForTesting : public Operation {
   // Those can be manually overwritten for testing using the respective getters.
   size_t sizeEstimate_;
   size_t costEstimate_;
+  bool unlikelyToFitInCache_ = false;
 
  public:
   // Create an operation that has as its result the given `table` and the given
@@ -46,13 +47,15 @@ class ValuesForTesting : public Operation {
   }
   explicit ValuesForTesting(QueryExecutionContext* ctx,
                             std::vector<IdTable> tables,
-                            std::vector<std::optional<Variable>> variables)
+                            std::vector<std::optional<Variable>> variables,
+                            bool unlikelyToFitInCache = false)
       : Operation{ctx},
         tables_{std::move(tables)},
         variables_{std::move(variables)},
         supportsLimit_{false},
         sizeEstimate_{0},
         costEstimate_{0},
+        unlikelyToFitInCache_{unlikelyToFitInCache},
         resultSortedColumns_{},
         localVocab_{LocalVocab{}},
         multiplicity_{std::nullopt} {
@@ -108,6 +111,7 @@ class ValuesForTesting : public Operation {
     }
     return {std::move(table), resultSortedOn(), localVocab_.clone()};
   }
+  bool unlikelyToFitInCache() const override { return unlikelyToFitInCache_; }
   bool supportsLimit() const override { return supportsLimit_; }
 
  private:

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -111,7 +111,9 @@ class ValuesForTesting : public Operation {
     }
     return {std::move(table), resultSortedOn(), localVocab_.clone()};
   }
-  bool unlikelyToFitInCache() const override { return unlikelyToFitInCache_; }
+  bool unlikelyToFitInCache(ad_utility::MemorySize) const override {
+    return unlikelyToFitInCache_;
+  }
   bool supportsLimit() const override { return supportsLimit_; }
 
  private:


### PR DESCRIPTION
This adds a small optimization that prevents redundant copies of `IdTable`s in the case of large index scans (which can be extended for other operations in the future as well if necessary) 