### PR TITLE
Properly convert to milliseconds

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -710,7 +710,9 @@ nlohmann::json ExportQueryExecutionTrees::computeQueryResultAsQLeverJSON(
       nlohmann::ordered_json(runtimeInformation);
 
   auto timeResultComputation =
-      timeUntilFunctionCall + runtimeInformation.totalTime_;
+      timeUntilFunctionCall +
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          runtimeInformation.totalTime_);
 
   size_t resultSize = runtimeInformation.numRows_;
 


### PR DESCRIPTION
Just realised `std::chrono::milliseconds + std::chrono::microseconds` results in the latter, not the former, so the reported duration is off by a factor of 1000.