### PR TITLE
Use return values instead of output variables in the `GroupBy` class

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -603,7 +603,7 @@ std::optional<Permutation::Enum> GroupBy::getPermutationForThreeVariableTriple(
 
 // ____________________________________________________________________________
 std::optional<GroupBy::OptimizedGroupByData> GroupBy::checkIfJoinWithFullScan(
-    const Operation& join) {
+    const Join& join) {
   if (_groupByVariables.size() != 1) {
     return std::nullopt;
   }
@@ -616,8 +616,8 @@ std::optional<GroupBy::OptimizedGroupByData> GroupBy::checkIfJoinWithFullScan(
 
   // Determine if any of the two children of the join operation is a
   // triple with three variables that fulfills the condition.
-  auto* child1 = join.getChildren().at(0);
-  auto* child2 = join.getChildren().at(1);
+  auto* child1 = static_cast<const Operation&>(join).getChildren().at(0);
+  auto* child2 = static_cast<const Operation&>(join).getChildren().at(1);
 
   // TODO<joka921, C++23> Use `optional::or_else`
   auto permutation = getPermutationForThreeVariableTriple(
@@ -713,6 +713,7 @@ std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() {
 
 // _____________________________________________________________________________
 std::optional<IdTable> GroupBy::computeOptimizedGroupByIfPossible() {
+  // TODO<C++23> Use `std::optional::or_else`.
   if (auto result = computeGroupByForSingleIndexScan()) {
     return result;
   }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -473,8 +473,7 @@ class GroupBy : public Operation {
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Join*`.
-  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(
-      const Operation& join);
+  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(const Join& join);
 
   // Check if the following is true: the `tree` represents a three variable
   // triple, that contains both `variableByWhichToSort` and

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -99,10 +99,9 @@ class GroupBy : public Operation {
                     size_t resultColumn, LocalVocab* localVocab) const;
 
   template <size_t IN_WIDTH, size_t OUT_WIDTH>
-  void doGroupBy(const IdTable& dynInput, const vector<size_t>& groupByCols,
-                 const vector<GroupBy::Aggregate>& aggregates,
-                 IdTable* dynResult, const IdTable* inTable,
-                 LocalVocab* outLocalVocab) const;
+  IdTable doGroupBy(const IdTable& dynInput, const vector<size_t>& groupByCols,
+                    const vector<Aggregate>& aggregates, const IdTable* inTable,
+                    LocalVocab* outLocalVocab) const;
 
   FRIEND_TEST(GroupByTest, doGroupBy);
 
@@ -254,8 +253,8 @@ class GroupBy : public Operation {
   // Create result IdTable by using a HashMap mapping groups to aggregation data
   // and subsequently calling `createResultFromHashMap`.
   template <size_t NUM_GROUP_COLUMNS>
-  void computeGroupByForHashMapOptimization(
-      IdTable* result, std::vector<HashMapAliasInformation>& aggregateAliases,
+  IdTable computeGroupByForHashMapOptimization(
+      std::vector<HashMapAliasInformation>& aggregateAliases,
       const IdTable& subresult, const std::vector<size_t>& columnIndices,
       LocalVocab* localVocab);
 
@@ -379,8 +378,7 @@ class GroupBy : public Operation {
 
   // Sort the HashMap by key and create result table.
   template <size_t NUM_GROUP_COLUMNS>
-  void createResultFromHashMap(
-      IdTable* result,
+  IdTable createResultFromHashMap(
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
       std::vector<HashMapAliasInformation>& aggregateAliases,
       LocalVocab* localVocab);

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -115,11 +115,10 @@ class GroupBy : public Operation {
   // result of the GROUP BY can be computed directly from the index meta data.
   // See the functions below for examples and details.
   //
-  // This function takes an empty `result` as input and checks whether such a
-  // case applies. In this case the result is computed and stored in `result`
-  // and `true` is returned. If no such case applies, `false` is returned and
-  // `result` remains empty.
-  bool computeOptimizedGroupByIfPossible(IdTable* result);
+  // This function checks whether such a case applies. In this case the result
+  // is computed and returned wrapped in a optional. If no such case applies the
+  // optional remains empty.
+  std::optional<IdTable> computeOptimizedGroupByIfPossible();
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -131,9 +130,8 @@ class GroupBy : public Operation {
   // in the two variable case might also be the subject or object of the triple.
   // The COUNT may be computed on any of the variables in the triple. If the
   // query has that form, the result of the query (which consists of one line)
-  // is computed and stored in the `result` and `true` is returned. If not, the
-  // `result` is left untouched, and `false` is returned.
-  bool computeGroupByForSingleIndexScan(IdTable* result);
+  // is computed and returned. If not, an empty optional is returned.
+  std::optional<IdTable> computeGroupByForSingleIndexScan();
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -144,7 +142,7 @@ class GroupBy : public Operation {
   // NOTE: This is exactly what we need for a context-sensitive object AC query
   // without connected triples. The GROUP BY variable can also be omitted in
   // the SELECT clause.
-  bool computeGroupByObjectWithCount(IdTable* result);
+  std::optional<IdTable> computeGroupByObjectWithCount();
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -157,7 +155,7 @@ class GroupBy : public Operation {
   // or `?z`. In the SELECT clause, both of the elements may be omitted, so in
   // the example it is possible to only select `?x` or to only select the
   // `COUNT`.
-  bool computeGroupByForFullIndexScan(IdTable* result);
+  std::optional<IdTable> computeGroupByForFullIndexScan();
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -169,7 +167,7 @@ class GroupBy : public Operation {
   // Note that `?x` can also be the predicate or object of the three variable
   // triple, and that the COUNT may be by any of the variables `?x`, `?y`, or
   // `?z`.
-  bool computeGroupByForJoinWithFullScan(IdTable* result);
+  std::optional<IdTable> computeGroupByForJoinWithFullScan();
 
   // Stores information required for substitution of an expression in an
   // expression tree.

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -477,7 +477,8 @@ class GroupBy : public Operation {
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Join*`.
-  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(const Join* join);
+  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(
+      const Operation& join);
 
   // Check if the following is true: the `tree` represents a three variable
   // triple, that contains both `variableByWhichToSort` and

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -99,8 +99,8 @@ class GroupBy : public Operation {
                     size_t resultColumn, LocalVocab* localVocab) const;
 
   template <size_t IN_WIDTH, size_t OUT_WIDTH>
-  IdTable doGroupBy(const IdTable& dynInput, const vector<size_t>& groupByCols,
-                    const vector<Aggregate>& aggregates, const IdTable* inTable,
+  IdTable doGroupBy(const IdTable& inTable, const vector<size_t>& groupByCols,
+                    const vector<Aggregate>& aggregates,
                     LocalVocab* outLocalVocab) const;
 
   FRIEND_TEST(GroupByTest, doGroupBy);

--- a/test/GroupByTest.cpp
+++ b/test/GroupByTest.cpp
@@ -1529,8 +1529,7 @@ TEST_F(GroupByOptimizations, computeGroupByForJoinWithFullScan) {
             : validForOptimization.computeOptimizedGroupByIfPossible();
     EXPECT_THAT(
         optional,
-        Optional(Eq(W{makeIdTableFromVector(
-            {{idOfX, Id::makeFromInt(7)}, {idOfY, Id::makeFromInt(1)}})})));
+        Optional(Eq(W{makeIdTableFromVector({{idOfX, I(7)}, {idOfY, I(1)}})})));
   };
   testWithBothInterfaces(true);
   testWithBothInterfaces(false);
@@ -1577,9 +1576,7 @@ TEST_F(GroupByOptimizations, computeGroupByForSingleIndexScan) {
                         : groupBy.computeOptimizedGroupByIfPossible();
 
     // The test index currently consists of 15 triples.
-    EXPECT_THAT(
-        optional,
-        Optional(Eq(W{makeIdTableFromVector({{Id::makeFromInt(15)}})})));
+    EXPECT_THAT(optional, Optional(Eq(W{makeIdTableFromVector({{I(15)}})})));
   };
   testWithBothInterfaces(true);
   testWithBothInterfaces(false);
@@ -1589,8 +1586,7 @@ TEST_F(GroupByOptimizations, computeGroupByForSingleIndexScan) {
     auto optional = groupBy.computeGroupByForSingleIndexScan();
     // The test index currently consists of 5 triples that have the predicate
     // `<label>`
-    ASSERT_THAT(optional,
-                Optional(Eq(W{makeIdTableFromVector({{Id::makeFromInt(5)}})})));
+    ASSERT_THAT(optional, Optional(Eq(W{makeIdTableFromVector({{I(5)}})})));
   }
   {
     auto groupBy =
@@ -1598,8 +1594,7 @@ TEST_F(GroupByOptimizations, computeGroupByForSingleIndexScan) {
     auto optional = groupBy.computeGroupByForSingleIndexScan();
     // The test index currently consists of six distinct subjects:
     // <x>, <y>, <z>, <a>, <b> and <c>.
-    ASSERT_THAT(optional,
-                Optional(Eq(W{makeIdTableFromVector({{Id::makeFromInt(6)}})})));
+    ASSERT_THAT(optional, Optional(Eq(W{makeIdTableFromVector({{I(6)}})})));
   }
 }
 // _____________________________________________________________________________

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -131,9 +131,6 @@ class CopyShield {
   std::shared_ptr<T> pointer_;
 
  public:
-  explicit CopyShield(T data)
-      : pointer_{std::make_shared<T>(std::move(data))} {}
-
   template <typename... Ts>
   explicit CopyShield(Ts&&... args)
       : pointer_{std::make_shared<T>(AD_FWD(args)...)} {}
@@ -143,7 +140,7 @@ class CopyShield {
     return *pointer_ <=> other;
   }
 
-  auto operator==(const T& other) const
+  bool operator==(const T& other) const
       requires(requires { std::declval<T>() == std::declval<T>(); }) {
     return *pointer_ == other;
   }

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -134,7 +134,7 @@ class CopyShield {
 
  public:
   template <typename... Ts>
-  explicit CopyShield(Ts&&... args)
+  explicit CopyShield(Ts&&... args) requires(std::constructible_from<T, Ts...>)
       : pointer_{std::make_shared<T>(AD_FWD(args)...)} {}
 
   auto operator<=>(const T& other) const requires(std::three_way_comparable<T>)

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -6,6 +6,8 @@
 
 #include <gmock/gmock.h>
 
+#include <concepts>
+
 #include "util/SourceLocation.h"
 #include "util/TypeTraits.h"
 #include "util/json.h"
@@ -135,13 +137,12 @@ class CopyShield {
   explicit CopyShield(Ts&&... args)
       : pointer_{std::make_shared<T>(AD_FWD(args)...)} {}
 
-  auto operator<=>(const T& other) const
-      requires(requires { std::declval<T>() <=> std::declval<T>(); }) {
+  auto operator<=>(const T& other) const requires(std::three_way_comparable<T>)
+  {
     return *pointer_ <=> other;
   }
 
-  bool operator==(const T& other) const
-      requires(requires { std::declval<T>() == std::declval<T>(); }) {
+  bool operator==(const T& other) const requires(std::equality_comparable<T>) {
     return *pointer_ == other;
   }
 };

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -124,3 +124,27 @@ MATCHER_P(InsertIntoStream, matcher,
   *result_listener << "that yields \"" << output << "\"";
   return testing::ExplainMatchResult(matcher, output, result_listener);
 }
+
+// Helper type that allows to use non-copyable types in gtest matchers.
+template <typename T>
+class CopyShield {
+  std::shared_ptr<T> pointer_;
+
+ public:
+  explicit CopyShield(T data)
+      : pointer_{std::make_shared<T>(std::move(data))} {}
+
+  template <typename... Ts>
+  explicit CopyShield(Ts&&... args)
+      : pointer_{std::make_shared<T>(AD_FWD(args)...)} {}
+
+  auto operator<=>(const T& other) const
+      requires(requires { std::declval<T>() <=> std::declval<T>(); }) {
+    return *pointer_ <=> other;
+  }
+
+  auto operator==(const T& other) const
+      requires(requires { std::declval<T>() == std::declval<T>(); }) {
+    return *pointer_ == other;
+  }
+};


### PR DESCRIPTION
Previously, several functions inside the `GroupBy` class had a signature similar to `void doSomething(IdTable* result, otherArguments...)` where the `result` argument was a pure output argument that was always expected to be empty.
These functions are now refactored to follow the more idiomatic `IdTable doSomething(otherArguments...)` style.