### PR TITLE
Fix link in example folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,2 +1,2 @@
-See the [quickstart guide](docs/quickstart.md) for how to make use of this
+See the [quickstart guide](../docs/quickstart.md) for how to make use of this
 example data.


### PR DESCRIPTION
This link wasn't working. I believe this is the correct quick start guide link.