### PR TITLE
Prevent segfault for `COUNT(*)` where the expression has no child

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -857,7 +857,10 @@ GroupBy::isSupportedAggregate(sparqlExpression::SparqlExpression* expr) {
   if (expr->isDistinct()) return std::nullopt;
 
   // `expr` is not a nested aggregated
-  if (expr->children().front()->containsAggregate()) return std::nullopt;
+  if (!expr->children().empty() &&
+      expr->children().front()->containsAggregate()) {
+    return std::nullopt;
+  }
 
   using H = HashMapAggregateTypeWithData;
 


### PR DESCRIPTION
This is a bug I encountered when messing around queries like [this](https://qlever.cs.uni-freiburg.de/wikidata/nBDpRk) 
```sparql
PREFIX p: <http://www.wikidata.org/prop/>
SELECT (COUNT(*) as ?c) WHERE {
  ?x p:P2860  ?z
}
GROUP BY ?x
```
would result in a segfault when hash map optimizations for group by are enabled because the code assumed exactly one child of any expression which isn't the case for `COUNT(*)`