### PR TITLE
Fix handling of exceptions and errors in lazy output

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -702,7 +702,7 @@ ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
     // that doesn't solve the problem for users of the plain HTTP 1.1 endpoint.
     if (exceptionMessage.has_value()) {
       std::string prefix =
-          "\n !!!! An error has occurred while exporting the query result. "
+          "\n !!!!>># An error has occurred while exporting the query result. "
           "Unfortunately due to limitations in the HTTP 1.1 protocol, there is "
           "no better way to report this than to append it to the incomplete "
           "result. The error message was:\n";

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -678,6 +678,41 @@ ExportQueryExecutionTrees::constructQueryResultToStream(
 }
 
 // _____________________________________________________________________________
+cppcoro::generator<std::string>
+ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
+    ad_utility::streams::stream_generator streamGenerator) {
+  // Immediately throw any exceptions that occur during the computation of the
+  // first block outside the actual generator. That way we get a proper HTTP
+  // response with error status codes etc. at least for those exceptions.
+  // Note: `begin` advances until the first block.
+  auto it = streamGenerator.begin();
+  return [](auto innerGenerator, auto it) -> cppcoro::generator<std::string> {
+    std::optional<std::string> exceptionMessage;
+    try {
+      for (; it != innerGenerator.end(); ++it) {
+        co_yield std::move(*it);
+      }
+    } catch (const std::exception& e) {
+      exceptionMessage = e.what();
+    } catch (...) {
+      exceptionMessage = "A very strange exception, please report this";
+    }
+    // TODO<joka921, RobinTF> Think of a better way to propagate and log those
+    // errors. We can additionally send them via the websocket connection, but
+    // that doesn't solve the problem for users of the plain HTTP 1.1 endpoint.
+    if (exceptionMessage.has_value()) {
+      std::string prefix =
+          "\n !!!! An error has occurred while exporting the query result. "
+          "Unfortunately due to limitations in the HTTP 1.1 protocol, there is "
+          "no better way to report this than to append it to the incomplete "
+          "result. The error message was:\n";
+      co_yield prefix;
+      co_yield exceptionMessage.value();
+    }
+  }(std::move(streamGenerator), std::move(it));
+}
+
+// _____________________________________________________________________________
 cppcoro::generator<std::string> ExportQueryExecutionTrees::computeResult(
     const ParsedQuery& parsedQuery, const QueryExecutionTree& qet,
     ad_utility::MediaType mediaType, const ad_utility::Timer& requestTimer,
@@ -706,35 +741,7 @@ cppcoro::generator<std::string> ExportQueryExecutionTrees::computeResult(
   auto inner =
       ad_utility::ConstexprSwitch<csv, tsv, octetStream, turtle, sparqlXml,
                                   sparqlJson, qleverJson>(compute, mediaType);
-  // Immediately throw any exceptions that occur during the computation of the
-  // first block outside the actual generator. That way we get a proper HTTP
-  // response with error status codes etc. at least for those exceptions.
-  // Note: `begin` advances until the first block.
-  auto it = inner.begin();
-  return [](auto innerGenerator, auto it) -> cppcoro::generator<std::string> {
-    std::optional<std::string> exceptionMessage;
-    try {
-      for (; it != innerGenerator.end(); ++it) {
-        co_yield std::move(*it);
-      }
-    } catch (const std::exception& e) {
-      exceptionMessage = e.what();
-    } catch (...) {
-      exceptionMessage = "A very strange exception, please report this";
-    }
-    // TODO<joka921, RobinTF> Think of a better way to propagate and log those
-    // errors. We can additionally send them via the websocket connection, but
-    // that doesn't solve the problem for users of the plain HTTP 1.1 endpoint.
-    if (exceptionMessage.has_value()) {
-      std::string prefix =
-          "\n !!!! An error has occurred while exporting the query result. "
-          "Unfortunately due to limitations in the HTTP 1.1 protocol, there is "
-          "no better way to report this than to append it to the incomplete "
-          "result. The error message was:\n";
-      co_yield prefix;
-      co_yield exceptionMessage.value();
-    }
-  }(std::move(inner), std::move(it));
+  return convertStreamGeneratorForChunkedTransfer(std::move(inner));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -706,14 +706,35 @@ cppcoro::generator<std::string> ExportQueryExecutionTrees::computeResult(
   auto inner =
       ad_utility::ConstexprSwitch<csv, tsv, octetStream, turtle, sparqlXml,
                                   sparqlJson, qleverJson>(compute, mediaType);
-  try {
-    for (auto& block : inner) {
-      co_yield std::move(block);
+  // Immediately throw any exceptions that occur during the computation of the
+  // first block outside the actual generator. That way we get a proper HTTP
+  // response with error status codes etc. at least for those exceptions.
+  // Note: `begin` advances until the first block.
+  auto it = inner.begin();
+  return [](auto innerGenerator, auto it) -> cppcoro::generator<std::string> {
+    std::optional<std::string> exceptionMessage;
+    try {
+      for (; it != innerGenerator.end(); ++it) {
+        co_yield std::move(*it);
+      }
+    } catch (const std::exception& e) {
+      exceptionMessage = e.what();
+    } catch (...) {
+      exceptionMessage = "A very strange exception, please report this";
     }
-  } catch (ad_utility::CancellationException& e) {
-    e.setOperation("Stream query export");
-    throw;
-  }
+    // TODO<joka921, RobinTF> Think of a better way to propagate and log those
+    // errors. We can additionally send them via the websocket connection, but
+    // that doesn't solve the problem for users of the plain HTTP 1.1 endpoint.
+    if (exceptionMessage.has_value()) {
+      std::string prefix =
+          "\n !!!! An error has occurred while exporting the query result. "
+          "Unfortunately due to limitations in the HTTP 1.1 protocol, there is "
+          "no better way to report this than to append it to the incomplete "
+          "result. The error message was:\n";
+      co_yield prefix;
+      co_yield exceptionMessage.value();
+    }
+  }(std::move(inner), std::move(it));
 }
 
 // _____________________________________________________________________________

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -92,7 +92,14 @@ class ExportQueryExecutionTrees {
   getLiteralOrIriFromVocabIndex(const Index& index, Id id,
                                 const LocalVocab& localVocab);
 
-  // TODO<joka921> Comment, this has very particular semantics.
+  // Convert a `stream_generator` to an "ordinary" `generator<string>` that
+  // yields exactly the same chunks as the `stream_generator`. Exceptions that
+  // happen during the creation of the first chunk (default chunk size is 1MB)
+  // will be immediately thrown when calling this function. Exceptions that
+  // happen later will be caught and their exception message will be  yielded by
+  // the resulting `generator<string>` together with a message, that explains,
+  // that there is no good mechanism for handling errors during a chunked HTTP
+  // response transfer.
   static cppcoro::generator<std::string>
   convertStreamGeneratorForChunkedTransfer(
       ad_utility::streams::stream_generator streamGenerator);

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -92,6 +92,11 @@ class ExportQueryExecutionTrees {
   getLiteralOrIriFromVocabIndex(const Index& index, Id id,
                                 const LocalVocab& localVocab);
 
+  // TODO<joka921> Comment, this has very particular semantics.
+  static cppcoro::generator<std::string>
+  convertStreamGeneratorForChunkedTransfer(
+      ad_utility::streams::stream_generator streamGenerator);
+
  private:
   // Similar to `computeResult` but returns a stream in
   // QLeverJSON-format.

--- a/src/util/http/HttpServer.h
+++ b/src/util/http/HttpServer.h
@@ -1,3 +1,4 @@
+
 //  Copyright 2021, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1322,14 +1322,15 @@ TEST(ExportQueryExecutionTrees, convertGeneratorForChunkedTransfer) {
   };
 
   cppcoro::generator<std::string> res;
+  using namespace ::testing;
   EXPECT_NO_THROW((
       res = ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
           throwLate(true))));
-  EXPECT_THAT(consume(std::move(res)), testing::HasSubstr("proper exception"));
+  EXPECT_THAT(consume(std::move(res)), AllOf(HasSubstr("!!!!>># An error has occurred"), HasSubstr("proper exception")));
 
   EXPECT_NO_THROW((
       res = ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
           throwLate(false))));
-  EXPECT_THAT(consume(std::move(res)),
-              testing::HasSubstr("A very strange exception"));
+  EXPECT_THAT(consume(std::move(res)), AllOf(HasSubstr("!!!!>># An error has occurred"),
+                    HasSubstr("A very strange")));
 }

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1100,13 +1100,12 @@ TEST_P(StreamableMediaTypesFixture, CancellationCancelsStream) {
 
   cancellationHandle->cancel(ad_utility::CancellationState::MANUAL);
   ad_utility::Timer timer(ad_utility::Timer::Started);
-  auto generator = ExportQueryExecutionTrees::computeResult(
-      pq, qet, GetParam(), timer, std::move(cancellationHandle));
-
-  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(generator.begin(),
-                                        HasSubstr("Stream query export"),
-                                        ad_utility::CancellationException);
+  EXPECT_ANY_THROW(([&]() {
+    [[maybe_unused]] auto generator = ExportQueryExecutionTrees::computeResult(
+        pq, qet, GetParam(), timer, std::move(cancellationHandle));
+  }()));
 }
+
 INSTANTIATE_TEST_SUITE_P(StreamableMediaTypes, StreamableMediaTypesFixture,
                          ::testing::Values(turtle, sparqlXml, tsv, csv,
                                            octetStream, sparqlJson,
@@ -1288,4 +1287,49 @@ TEST(ExportQueryExecutionTrees, ensureGeneratorIsNotConsumedWhenNotRequired) {
     EXPECT_NO_THROW({ tables = convertToVector(std::move(generator)); });
     EXPECT_THAT(tables, ElementsAre(Eq(std::cref(referenceTable1))));
   }
+}
+
+TEST(ExportQueryExecutionTrees, convertGeneratorForChunkedTransfer) {
+  using S = ad_utility::streams::stream_generator;
+  auto throwEarly = []() -> S {
+    co_yield " Hallo... Ups\n";
+    throw std::runtime_error{"failed"};
+  };
+  auto call = [](S stream) {
+    [[maybe_unused]] auto res =
+        ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
+            std::move(stream));
+  };
+  AD_EXPECT_THROW_WITH_MESSAGE(call(throwEarly()), std::string_view("failed"));
+  auto throwLate = [](bool throwProperException) -> S {
+    size_t largerThanBufferSize = (1ul << 20) + 4;
+    std::string largerThanBuffer;
+    largerThanBuffer.resize(largerThanBufferSize);
+    co_yield largerThanBuffer;
+    if (throwProperException) {
+      throw std::runtime_error{"proper exception"};
+    } else {
+      throw 424231;
+    }
+  };
+
+  auto consume = [](auto generator) {
+    std::string res;
+    for (const auto& el : generator) {
+      res.append(el);
+    }
+    return res;
+  };
+
+  cppcoro::generator<std::string> res;
+  EXPECT_NO_THROW((
+      res = ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
+          throwLate(true))));
+  EXPECT_THAT(consume(std::move(res)), testing::HasSubstr("proper exception"));
+
+  EXPECT_NO_THROW((
+      res = ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
+          throwLate(false))));
+  EXPECT_THAT(consume(std::move(res)),
+              testing::HasSubstr("A very strange exception"));
 }


### PR DESCRIPTION
So far, when an error occurred after the sending of the result began, the HTTP status code was OK but the result was not. This resulted in confusing behavior in the QLever UI. In particular, if no result was produced at all, the QLever UI would wait for the result until the timeout and then show some generic error message. Since #1438, this affected any query with an error message, with the effect that no more specific error messages were shown in the QLever UI. This is now fixed now as follows:

1.  When the error occurs *before* the sending of the result begins (the typical case), a non-200 HTTP code is sent just like before (this was broken by #1438).

2.  When the error occurs *after* the sending of the result has begun, a 200 HTTP code is sent (HTTP provides no way to change this code after sending has begun), but when the error occurs a message is sent that begins with a highly unusual character sequence (currently `!!!!>>#`). This message could then be detected by the QLever UI or other tools. It is important to understand that this is not a problem specific to QLever, but a problem of the simplistic HTTP 1.1 protocol.