### PR TITLE
Avoid no-op generator wrapper when limit is no-op

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -157,7 +157,7 @@ ProtoResult Operation::runComputation(const ad_utility::Timer& timer,
   if (!supportsLimit()) {
     runtimeInfo().addLimitOffsetRow(_limit, true);
     AD_CONTRACT_CHECK(!externalLimitApplied_);
-    externalLimitApplied_ = _limit._limit.has_value() || _limit._offset != 0;
+    externalLimitApplied_ = !_limit.isUnconstrained();
     result.applyLimitOffset(_limit, [this](std::chrono::microseconds limitTime,
                                            const IdTable& idTable) {
       updateRuntimeStats(true, idTable.numRows(), idTable.numColumns(),

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -120,7 +120,7 @@ void Result::applyLimitOffset(
   // than the size of the `IdTable`, then this has no effect and runtime
   // `O(1)` (see the docs for `std::shift_left`).
   AD_CONTRACT_CHECK(limitTimeCallback);
-  if (!limitOffset._limit.has_value() && limitOffset._offset == 0) {
+  if (limitOffset.isUnconstrained()) {
     return;
   }
   if (isFullyMaterialized()) {

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -120,6 +120,9 @@ void Result::applyLimitOffset(
   // than the size of the `IdTable`, then this has no effect and runtime
   // `O(1)` (see the docs for `std::shift_left`).
   AD_CONTRACT_CHECK(limitTimeCallback);
+  if (!limitOffset._limit.has_value() && limitOffset._offset == 0) {
+    return;
+  }
   if (isFullyMaterialized()) {
     ad_utility::timer::Timer limitTimer{ad_utility::timer::Timer::Started};
     resizeIdTable(std::get<IdTable>(data_), limitOffset);

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -8,9 +8,11 @@
 #include "util/IdTableHelpers.h"
 
 using namespace std::chrono_literals;
-using testing::Combine;
+using ::testing::AnyOf;
+using ::testing::Combine;
 using ::testing::HasSubstr;
-using testing::Values;
+using ::testing::Not;
+using ::testing::Values;
 
 namespace {
 // Helper function to generate all possible splits of an IdTable in order to
@@ -352,12 +354,8 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
             ASSERT_EQ(row.size(), 2);
             // Make sure we never get values that were supposed to be filtered
             // out.
-            EXPECT_NE(row[0].getVocabIndex().get(), 0);
-            EXPECT_NE(row[0].getVocabIndex().get(), 1);
-            EXPECT_NE(row[0].getVocabIndex().get(), 4);
-            EXPECT_NE(row[1].getVocabIndex().get(), 9);
-            EXPECT_NE(row[1].getVocabIndex().get(), 8);
-            EXPECT_NE(row[1].getVocabIndex().get(), 5);
+            EXPECT_THAT(row[0].getVocabIndex().get(), Not(AnyOf(0, 1, 4)));
+            EXPECT_THAT(row[1].getVocabIndex().get(), Not(AnyOf(9, 8, 5)));
           }
           totalRows += innerTable.size();
           colSizes.push_back(innerTable.numColumns());
@@ -371,12 +369,8 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
         ASSERT_EQ(row.size(), 2);
         // Make sure we never get values that were supposed to be filtered
         // out.
-        EXPECT_NE(row[0].getVocabIndex().get(), 0);
-        EXPECT_NE(row[0].getVocabIndex().get(), 1);
-        EXPECT_NE(row[0].getVocabIndex().get(), 4);
-        EXPECT_NE(row[1].getVocabIndex().get(), 9);
-        EXPECT_NE(row[1].getVocabIndex().get(), 8);
-        EXPECT_NE(row[1].getVocabIndex().get(), 5);
+        EXPECT_THAT(row[0].getVocabIndex().get(), Not(AnyOf(0, 1, 4)));
+        EXPECT_THAT(row[1].getVocabIndex().get(), Not(AnyOf(9, 8, 5)));
       }
     }
 


### PR DESCRIPTION
Currently the `Result` class wraps lazy results in a generator if the corresponding `Operation` does not support limits natively in order to trim the result sizes in post processing. If the limit is empty however this generator wrapper is completely redundant. This commit removes this extra generator if neither a LIMIT nor an OFFSET exists. This possibly makes it easier to debug such queries, the runtime overhead should be negligible if the lazy blocks are large enough.