### PR TITLE
Make `Filter` request its subresult lazily even if the filtered result is materialized

### DIFF
--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -65,10 +65,10 @@ ProtoResult Filter::computeResult(bool requestLaziness) {
             resultSortedOn(), std::move(localVocab)};
   }
 
-  IdTable result = ad_utility::callFixedSize(
-      getSubtree().get()->getResultWidth(),
-      [this, subRes = std::move(subRes)]<int WIDTH>() {
-        IdTable result{WIDTH, getExecutionContext()->getAllocator()};
+  size_t width = getSubtree().get()->getResultWidth();
+  IdTable result =
+      ad_utility::callFixedSize(width, [this, &subRes, width]<int WIDTH>() {
+        IdTable result{width, getExecutionContext()->getAllocator()};
         IdTableStatic<WIDTH> output =
             std::move(result).toStatic<static_cast<size_t>(WIDTH)>();
 
@@ -112,9 +112,9 @@ IdTable Filter::filterIdTable(const std::shared_ptr<const Result>& subRes,
   evaluationContext._columnsByWhichResultIsSorted = subRes->sortedBy();
 
   size_t width = evaluationContext._inputTable.numColumns();
-  IdTable result =
-      ad_utility::callFixedSize(width, [this, &evaluationContext]<int WIDTH>() {
-        IdTable result{WIDTH, getExecutionContext()->getAllocator()};
+  IdTable result = ad_utility::callFixedSize(
+      width, [this, &evaluationContext, width]<int WIDTH>() {
+        IdTable result{width, getExecutionContext()->getAllocator()};
         IdTableStatic<WIDTH> output =
             std::move(result).toStatic<static_cast<size_t>(WIDTH)>();
         computeFilterImpl(output, evaluationContext);

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -7,7 +7,6 @@
 #include "./Filter.h"
 
 #include <algorithm>
-#include <optional>
 #include <sstream>
 
 #include "engine/CallFixedSize.h"

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -87,7 +87,7 @@ IdTable Filter::filterIdTable(const std::shared_ptr<const Result>& subRes,
                               const IdTable& idTable) const {
   size_t width = idTable.numColumns();
   IdTable result{width, getExecutionContext()->getAllocator()};
-  CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, result, idTable,
+  CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this, result, idTable,
                   subRes->localVocab(), subRes->sortedBy());
   return result;
 }
@@ -100,7 +100,7 @@ void Filter::computeFilterImpl(IdTable& dynamicResultTable,
                                std::vector<ColumnIndex> sortedBy) const {
   AD_CONTRACT_CHECK(inputTable.numColumns() == WIDTH || WIDTH == 0);
   IdTableStatic<WIDTH> resultTable =
-      dynamicResultTable.toStatic<static_cast<size_t>(WIDTH)>();
+      std::move(dynamicResultTable).toStatic<static_cast<size_t>(WIDTH)>();
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), _subtree->getVariableColumns(), inputTable,
       getExecutionContext()->getAllocator(), localVocab, cancellationHandle_,

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -45,24 +45,59 @@ string Filter::getDescriptor() const {
 // _____________________________________________________________________________
 ProtoResult Filter::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
-  std::shared_ptr<const Result> subRes = _subtree->getResult(requestLaziness);
+  std::shared_ptr<const Result> subRes = _subtree->getResult(true);
   LOG(DEBUG) << "Filter result computation..." << endl;
   checkCancellation();
 
+  auto localVocab = subRes->getSharedLocalVocab();
   if (subRes->isFullyMaterialized()) {
     IdTable result = filterIdTable(subRes, subRes->idTable());
     LOG(DEBUG) << "Filter result computation done." << endl;
 
-    return {std::move(result), resultSortedOn(), subRes->getSharedLocalVocab()};
+    return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }
-  auto localVocab = subRes->getSharedLocalVocab();
-  return {[](auto subRes, auto* self) -> cppcoro::generator<IdTable> {
-            for (IdTable& idTable : subRes->idTables()) {
-              IdTable result = self->filterIdTable(subRes, idTable);
-              co_yield result;
-            }
-          }(std::move(subRes), this),
-          resultSortedOn(), std::move(localVocab)};
+  if (requestLaziness) {
+    return {[](auto subRes, auto* self) -> cppcoro::generator<IdTable> {
+              for (IdTable& idTable : subRes->idTables()) {
+                IdTable result = self->filterIdTable(subRes, idTable);
+                co_yield result;
+              }
+            }(std::move(subRes), this),
+            resultSortedOn(), std::move(localVocab)};
+  }
+
+  IdTable result = ad_utility::callFixedSize(
+      getSubtree().get()->getResultWidth(),
+      [this, subRes = std::move(subRes)]<size_t WIDTH>() {
+        IdTable result{WIDTH, getExecutionContext()->getAllocator()};
+        constexpr int intWidth = static_cast<int>(WIDTH);
+        IdTableStatic<intWidth> output = std::move(result).toStatic<intWidth>();
+
+        std::vector<ColumnIndex> sortedOn = subRes->sortedBy();
+
+        for (IdTable& idTable : subRes->idTables()) {
+          sparqlExpression::EvaluationContext evaluationContext(
+              *getExecutionContext(), _subtree->getVariableColumns(), idTable,
+              getExecutionContext()->getAllocator(), subRes->localVocab(),
+              cancellationHandle_, deadline_);
+
+          // TODO<joka921> This should be a mandatory argument to the
+          // EvaluationContext constructor.
+          evaluationContext._columnsByWhichResultIsSorted = std::move(sortedOn);
+
+          computeFilterImpl<WIDTH>(output, evaluationContext);
+
+          // Reuse vector
+          sortedOn = std::move(evaluationContext._columnsByWhichResultIsSorted);
+          checkCancellation();
+        }
+
+        return std::move(output).toDynamic();
+      });
+
+  LOG(DEBUG) << "Filter result computation done." << endl;
+
+  return {std::move(result), resultSortedOn(), std::move(localVocab)};
 }
 
 // _____________________________________________________________________________
@@ -78,45 +113,46 @@ IdTable Filter::filterIdTable(const std::shared_ptr<const Result>& subRes,
   evaluationContext._columnsByWhichResultIsSorted = subRes->sortedBy();
 
   size_t width = evaluationContext._inputTable.numColumns();
-  IdTable result = CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this,
-                                   evaluationContext);
+  IdTable result = ad_utility::callFixedSize(
+      width, [this, &evaluationContext]<size_t WIDTH>() {
+        constexpr int intWidth = static_cast<int>(WIDTH);
+        IdTable result{WIDTH, getExecutionContext()->getAllocator()};
+        IdTableStatic<intWidth> output = std::move(result).toStatic<intWidth>();
+        computeFilterImpl<WIDTH>(output, evaluationContext);
+
+        return std::move(output).toDynamic();
+      });
   checkCancellation();
   return result;
 }
 
 // _____________________________________________________________________________
 template <size_t WIDTH>
-IdTable Filter::computeFilterImpl(
+void Filter::computeFilterImpl(
+    IdTableStatic<WIDTH>& resultTable,
     sparqlExpression::EvaluationContext& evaluationContext) {
-  IdTable idTable{getExecutionContext()->getAllocator()};
-  idTable.setNumColumns(evaluationContext._inputTable.numColumns());
-
+  const auto input = evaluationContext._inputTable.asStaticView<WIDTH>();
   sparqlExpression::ExpressionResult expressionResult =
       _expression.getPimpl()->evaluate(&evaluationContext);
 
-  const auto input = evaluationContext._inputTable.asStaticView<WIDTH>();
-  auto output = std::move(idTable).toStatic<WIDTH>();
-  // Clang 17 seems to incorrectly deduce the type, so try to trick it
-  std::remove_const_t<decltype(output)>& output2 = output;
-
   auto visitor =
-      [this, &output2, &input,
+      [this, &resultTable, &input,
        &evaluationContext]<sparqlExpression::SingleExpressionResult T>(
           T&& singleResult) {
         if constexpr (std::is_same_v<T, ad_utility::SetOfIntervals>) {
           auto totalSize = std::accumulate(
               singleResult._intervals.begin(), singleResult._intervals.end(),
-              0ul, [](const auto& sum, const auto& interval) {
+              resultTable.size(), [](const auto& sum, const auto& interval) {
                 return sum + (interval.second - interval.first);
               });
-          output2.reserve(totalSize);
+          resultTable.reserve(totalSize);
           checkCancellation();
           for (auto [beg, end] : singleResult._intervals) {
             AD_CONTRACT_CHECK(end <= input.size());
-            output2.insertAtEnd(input.cbegin() + beg, input.cbegin() + end);
+            resultTable.insertAtEnd(input.cbegin() + beg, input.cbegin() + end);
             checkCancellation();
           }
-          AD_CONTRACT_CHECK(output2.size() == totalSize);
+          AD_CONTRACT_CHECK(resultTable.size() == totalSize);
         } else {
           // All other results are converted to boolean values via the
           // `EffectiveBooleanValueGetter`. This means for example, that zero,
@@ -131,7 +167,7 @@ IdTable Filter::computeFilterImpl(
           using EBV = sparqlExpression::detail::EffectiveBooleanValueGetter;
           for (auto&& resultValue : resultGenerator) {
             if (EBV{}(resultValue, &evaluationContext) == EBV::Result::True) {
-              output2.push_back(input[i]);
+              resultTable.push_back(input[i]);
             }
             checkCancellation();
             ++i;
@@ -140,8 +176,6 @@ IdTable Filter::computeFilterImpl(
       };
 
   std::visit(visitor, std::move(expressionResult));
-
-  return std::move(output).toDynamic();
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -158,7 +158,7 @@ void Filter::computeFilterImpl(IdTable& dynamicResultTable,
 
   // Clang 17 seems to incorrectly deduce the type.
   dynamicResultTable =
-      std::move(const_cast<IdTableStatic<WIDTH>>(resultTable)).toDynamic();
+      std::move(const_cast<IdTableStatic<WIDTH>&>(resultTable)).toDynamic();
   checkCancellation();
 }
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -156,7 +156,9 @@ void Filter::computeFilterImpl(IdTable& dynamicResultTable,
 
   std::visit(visitor, std::move(expressionResult));
 
-  dynamicResultTable = std::move(resultTable).toDynamic();
+  // Clang 17 seems to incorrectly deduce the type.
+  dynamicResultTable =
+      std::move<IdTableStatic<WIDTH>&>(resultTable).toDynamic();
   checkCancellation();
 }
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -158,7 +158,7 @@ void Filter::computeFilterImpl(IdTable& dynamicResultTable,
 
   // Clang 17 seems to incorrectly deduce the type.
   dynamicResultTable =
-      std::move<IdTableStatic<WIDTH>&>(resultTable).toDynamic();
+      std::move(const_cast<IdTableStatic<WIDTH>>(resultTable)).toDynamic();
   checkCancellation();
 }
 

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -63,7 +63,8 @@ class Filter : public Operation {
   // Perform the actual filter operation of the data provided by
   // `evaluationContext`.
   template <size_t WIDTH>
-  IdTable computeFilterImpl(
+  void computeFilterImpl(
+      IdTableStatic<WIDTH>& resultTable,
       sparqlExpression::EvaluationContext& evaluationContext);
 
   // Run `computeFilterImpl` on the provided IdTable

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -62,8 +62,8 @@ class Filter : public Operation {
 
   // Perform the actual filter operation of the data provided.
   template <int WIDTH>
-  void computeFilterImpl(IdTableStatic<WIDTH>& resultTable,
-                         const IdTable& input, const LocalVocab& localVocab,
+  void computeFilterImpl(IdTable& dynamicResultTable, const IdTable& input,
+                         const LocalVocab& localVocab,
                          std::vector<ColumnIndex> sortedBy) const;
 
   // Run `computeFilterImpl` on the provided IdTable

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -60,14 +60,13 @@ class Filter : public Operation {
 
   ProtoResult computeResult(bool requestLaziness) override;
 
-  // Perform the actual filter operation of the data provided by
-  // `evaluationContext`.
+  // Perform the actual filter operation of the data provided.
   template <int WIDTH>
-  void computeFilterImpl(
-      IdTableStatic<WIDTH>& resultTable,
-      sparqlExpression::EvaluationContext& evaluationContext);
+  void computeFilterImpl(IdTableStatic<WIDTH>& resultTable,
+                         const IdTable& input, const LocalVocab& localVocab,
+                         std::vector<ColumnIndex> sortedBy) const;
 
   // Run `computeFilterImpl` on the provided IdTable
   IdTable filterIdTable(const std::shared_ptr<const Result>& subRes,
-                        const IdTable& idTable);
+                        const IdTable& idTable) const;
 };

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -62,7 +62,7 @@ class Filter : public Operation {
 
   // Perform the actual filter operation of the data provided by
   // `evaluationContext`.
-  template <size_t WIDTH>
+  template <int WIDTH>
   void computeFilterImpl(
       IdTableStatic<WIDTH>& resultTable,
       sparqlExpression::EvaluationContext& evaluationContext);

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -22,6 +22,7 @@ class ValuesForTesting : public Operation {
   size_t sizeEstimate_;
   size_t costEstimate_;
   bool unlikelyToFitInCache_ = false;
+  bool forceFullyMaterialized_ = false;
 
  public:
   // Create an operation that has as its result the given `table` and the given
@@ -32,7 +33,8 @@ class ValuesForTesting : public Operation {
                             bool supportsLimit = false,
                             std::vector<ColumnIndex> sortedColumns = {},
                             LocalVocab localVocab = LocalVocab{},
-                            std::optional<float> multiplicity = std::nullopt)
+                            std::optional<float> multiplicity = std::nullopt,
+                            bool forceFullyMaterialized = false)
       : Operation{ctx},
         tables_{},
         variables_{std::move(variables)},
@@ -41,7 +43,8 @@ class ValuesForTesting : public Operation {
         costEstimate_{table.numRows()},
         resultSortedColumns_{std::move(sortedColumns)},
         localVocab_{std::move(localVocab)},
-        multiplicity_{multiplicity} {
+        multiplicity_{multiplicity},
+        forceFullyMaterialized_{forceFullyMaterialized} {
     AD_CONTRACT_CHECK(variables_.size() == table.numColumns());
     tables_.push_back(std::move(table));
   }
@@ -77,7 +80,7 @@ class ValuesForTesting : public Operation {
 
   // ___________________________________________________________________________
   ProtoResult computeResult(bool requestLaziness) override {
-    if (requestLaziness) {
+    if (requestLaziness && !forceFullyMaterialized_) {
       // Not implemented yet
       AD_CORRECTNESS_CHECK(!supportsLimit_);
       std::vector<IdTable> clones;

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -22,7 +22,6 @@ class ValuesForTesting : public Operation {
   size_t sizeEstimate_;
   size_t costEstimate_;
   bool unlikelyToFitInCache_ = false;
-  bool forceFullyMaterialized_ = false;
 
  public:
   // Create an operation that has as its result the given `table` and the given
@@ -199,6 +198,7 @@ class ValuesForTesting : public Operation {
   std::vector<ColumnIndex> resultSortedColumns_;
   LocalVocab localVocab_;
   std::optional<float> multiplicity_;
+  bool forceFullyMaterialized_ = false;
 };
 
 // Similar to `ValuesForTesting` above, but `knownEmptyResult()` always returns


### PR DESCRIPTION
Because `Filter` is an operation that can only reduce the result size (often drastically) there are plenty of occasions where the input of the filter is too large to be materialized, but the output of the filter can be materialized. As of this commit we thus always try to compute this input of a FILTER lazily.