### PR TITLE
Make the constructors of `IdTable` SFINAE-friendly

### DIFF
--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -181,8 +181,9 @@ class IdTable {
   // dynamic number of columns) must be equal, else a runtime check fails.
   // Note: this also allows to create an empty view.
   explicit IdTable(size_t numColumns)
-      requires (columnsAreAllocatable && std::is_default_constructible_v<Allocator>)
-      : IdTable(numColumns, Allocator {}){}
+      requires(columnsAreAllocatable &&
+               std::is_default_constructible_v<Allocator>)
+      : IdTable(numColumns, Allocator{}) {}
   explicit IdTable(size_t numColumns, Allocator allocator)
       requires columnsAreAllocatable
       : numColumns_{numColumns}, allocator_{std::move(allocator)} {
@@ -227,7 +228,6 @@ class IdTable {
   explicit IdTable(Allocator allocator)
       requires(!isView && columnsAreAllocatable)
       : IdTable{NumColumns, std::move(allocator)} {};
-
 
   // `IdTables` are expensive to copy, so we disable accidental copies as they
   // are most likely bugs. To explicitly copy an `IdTable`, the `clone()` member

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -180,7 +180,10 @@ class IdTable {
   // Then the argument `numColumns` and `NumColumns` (the static and the
   // dynamic number of columns) must be equal, else a runtime check fails.
   // Note: this also allows to create an empty view.
-  explicit IdTable(size_t numColumns, Allocator allocator = {})
+  explicit IdTable(size_t numColumns)
+      requires (columnsAreAllocatable && std::is_default_constructible_v<Allocator>)
+      : IdTable(numColumns, Allocator {}){}
+  explicit IdTable(size_t numColumns, Allocator allocator)
       requires columnsAreAllocatable
       : numColumns_{numColumns}, allocator_{std::move(allocator)} {
     if constexpr (!isDynamic) {
@@ -218,9 +221,13 @@ class IdTable {
   // already set up with the correct number of columns and can be used directly.
   // If `NumColumns == 0` then the number of columns has to be specified via
   // `setNumColumns()`.
-  explicit IdTable(Allocator allocator = {})
+  IdTable() requires(!isView && columnsAreAllocatable &&
+                     std::is_default_constructible_v<Allocator>)
+      : IdTable{NumColumns, Allocator{}} {};
+  explicit IdTable(Allocator allocator)
       requires(!isView && columnsAreAllocatable)
       : IdTable{NumColumns, std::move(allocator)} {};
+
 
   // `IdTables` are expensive to copy, so we disable accidental copies as they
   // are most likely bugs. To explicitly copy an `IdTable`, the `clone()` member

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1078,6 +1078,16 @@ TEST(IdTable, staticAsserts) {
   static_assert(std::ranges::random_access_range<IdTableStatic<1>>);
 }
 
+TEST(IdTable, constructorsAreSfinaeFriendly) {
+  // Check, that constructors that take no allocator are disabled if the
+  // allocator is not default-constructible.
+  static_assert(!std::is_default_constructible_v<IdTable>);
+  static_assert(!std::is_constructible_v<IdTable, size_t>);
+  using IntTable = columnBasedIdTable::IdTable<int, 0>;
+  static_assert(std::is_default_constructible_v<IntTable>);
+  static_assert(std::is_constructible_v<IntTable, size_t>);
+}
+
 // Check that we can completely instantiate `IdTable`s with a different value
 // type and a different underlying storage.
 

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -1081,9 +1081,14 @@ TEST(IdTable, staticAsserts) {
 TEST(IdTable, constructorsAreSfinaeFriendly) {
   // Check, that constructors that take no allocator are disabled if the
   // allocator is not default-constructible.
+
+  // `IdTable` (in the public namespace) is templated on an
+  // `AllocatorWithMemoryLimit` which is not default-constructible.
   static_assert(!std::is_default_constructible_v<IdTable>);
   static_assert(!std::is_constructible_v<IdTable, size_t>);
+
   using IntTable = columnBasedIdTable::IdTable<int, 0>;
+  //`IntTable` uses `std::allocator`, which is default-constructible.
   static_assert(std::is_default_constructible_v<IntTable>);
   static_assert(std::is_constructible_v<IntTable, size_t>);
 }


### PR DESCRIPTION
Previously `std::is_default_constructible<IdTable>` was `true`, but trying to default-construct an `IdTable` led to a hard compiler error, as the used allocator (the `AllocatorWithLimit`) was not default constructible. This is now fixed by adding the proper constraints to the constructors of the `IdTable` class.