### PR TITLE
Fix result duration computation for lazy results

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -188,4 +188,5 @@ class ExportQueryExecutionTrees {
               ensureCorrectSlicingOfIdTablesWhenFirstAndLastArePartial);
   FRIEND_TEST(ExportQueryExecutionTrees,
               ensureGeneratorIsNotConsumedWhenNotRequired);
+  FRIEND_TEST(ExportQueryExecutionTrees, verifyQleverJsonContainsValidMetadata);
 };

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1349,8 +1349,7 @@ TEST(ExportQueryExecutionTrees, verifyQleverJsonContainsValidMetadata) {
   EXPECT_LT(
       toChrono(timingInformation["computeResult"].get<std::string_view>()),
       100ms);
-  // These should be at least 1ms apart because of our sleep in this test.
-  EXPECT_GT(
+  EXPECT_GE(
       toChrono(timingInformation["total"].get<std::string_view>()),
       toChrono(timingInformation["computeResult"].get<std::string_view>()));
 }

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -12,12 +12,16 @@
 #include "util/IdTableHelpers.h"
 #include "util/IdTestHelpers.h"
 #include "util/IndexTestHelpers.h"
+#include "util/ParseableDuration.h"
 
 using namespace std::string_literals;
+using namespace std::chrono_literals;
 using ::testing::ElementsAre;
+using ::testing::EndsWith;
 using ::testing::Eq;
 using ::testing::HasSubstr;
 
+namespace {
 // Run the given SPARQL `query` on the given Turtle `kg` and export the result
 // as the `mediaType`. `mediaType` must be TSV or CSV.
 std::string runQueryStreamableResult(const std::string& kg,
@@ -241,6 +245,13 @@ std::vector<IdTable> convertToVector(cppcoro::generator<T> generator) {
   }
   return result;
 }
+
+std::chrono::milliseconds toChrono(std::string_view string) {
+  EXPECT_THAT(string, EndsWith("ms"));
+  return ad_utility::ParseableDuration<std::chrono::milliseconds>::fromString(
+      string);
+}
+}  // namespace
 
 // ____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, Integers) {
@@ -1288,4 +1299,58 @@ TEST(ExportQueryExecutionTrees, ensureGeneratorIsNotConsumedWhenNotRequired) {
     EXPECT_NO_THROW({ tables = convertToVector(std::move(generator)); });
     EXPECT_THAT(tables, ElementsAre(Eq(std::cref(referenceTable1))));
   }
+}
+
+// _____________________________________________________________________________
+TEST(ExportQueryExecutionTrees, verifyQleverJsonContainsValidMetadata) {
+  std::string_view query =
+      "SELECT * WHERE { ?x ?y ?z . FILTER(?y != <p2>) } OFFSET 1 LIMIT 4";
+  auto cancellationHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+
+  auto* qec = ad_utility::testing::getQec(
+      "<s> <p1> 40,41,42,43,44,45,46,47,48,49"
+      " ; <p2> 50,51,52,53,54,55,56,57,58,59");
+  QueryPlanner qp{qec, cancellationHandle};
+  auto pq = SparqlParser::parseQuery(std::string{query});
+  auto qet = qp.createExecutionTree(pq);
+
+  ad_utility::Timer timer{ad_utility::Timer::Started};
+
+  // Verify this is accounted for for time calculation.
+  std::this_thread::sleep_for(1ms);
+
+  auto jsonStream = ExportQueryExecutionTrees::computeResultAsQLeverJSON(
+      pq, qet, timer, std::move(cancellationHandle));
+
+  std::string aggregateString{};
+  for (std::string& chunk : jsonStream) {
+    aggregateString += chunk;
+  }
+  nlohmann::json json = nlohmann::json::parse(aggregateString);
+  auto originalRuntimeInfo = qet.getRootOperation()->runtimeInfo();
+
+  EXPECT_EQ(json["query"], query);
+  EXPECT_EQ(json["status"], "OK");
+  EXPECT_THAT(json["warnings"], ElementsAre());
+  EXPECT_THAT(json["selected"], ElementsAre(Eq("?x"), Eq("?y"), Eq("?z")));
+  EXPECT_EQ(json["res"].size(), 4);
+  auto& runtimeInformationWrapper = json["runtimeInformation"];
+  EXPECT_TRUE(runtimeInformationWrapper.contains("meta"));
+  ASSERT_TRUE(runtimeInformationWrapper.contains("query_execution_tree"));
+  auto& runtimeInformation = runtimeInformationWrapper["query_execution_tree"];
+  EXPECT_EQ(runtimeInformation["result_cols"], 3);
+  EXPECT_EQ(runtimeInformation["result_rows"], 4);
+  EXPECT_EQ(json["resultsize"], 4);
+  auto& timingInformation = json["time"];
+  EXPECT_GE(toChrono(timingInformation["total"].get<std::string_view>()), 1ms);
+  // Ensure result is not returned in microseconds and subsequently interpreted
+  // in milliseconds
+  EXPECT_LT(
+      toChrono(timingInformation["computeResult"].get<std::string_view>()),
+      100ms);
+  // These should be at least 1ms apart because of our sleep in this test.
+  EXPECT_GT(
+      toChrono(timingInformation["total"].get<std::string_view>()),
+      toChrono(timingInformation["computeResult"].get<std::string_view>()));
 }


### PR DESCRIPTION
This fixes a regression introduced in #1438 that I didn't notice wasn't fixed as part of #1470. The runtime information was wrong for lazy operations (wrong number of rows and wrong times).
This is now fixed + a unit tests is added that would have prevented this regression in the first place.