### PR TITLE
Implement `SILENT` keyword for `SERVICE` clause

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -35,7 +35,7 @@ std::string Service::getCacheKeyImpl() const {
   if (parsedServiceClause_.silent_) {
     os << "SILENT ";
   }
-  os << parsedServiceClause_.serviceIri_.toSparql() << " {\n"
+  os << parsedServiceClause_.serviceIri_.toStringRepresentation() << " {\n"
      << parsedServiceClause_.prologue_ << "\n"
      << parsedServiceClause_.graphPatternAsString_ << "\n";
   if (siblingTree_ != nullptr) {
@@ -47,8 +47,9 @@ std::string Service::getCacheKeyImpl() const {
 
 // ____________________________________________________________________________
 std::string Service::getDescriptor() const {
-  return absl::StrCat("Service with IRI ",
-                      parsedServiceClause_.serviceIri_.toSparql());
+  return absl::StrCat(
+      "Service with IRI ",
+      parsedServiceClause_.serviceIri_.toStringRepresentation());
 }
 
 // ____________________________________________________________________________
@@ -117,14 +118,11 @@ ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
   }
 }
 
+// ____________________________________________________________________________
 ProtoResult Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   // Get the URL of the SPARQL endpoint.
-  std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
-  AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&
-                    serviceIriString.ends_with(">"));
-  serviceIriString.remove_prefix(1);
-  serviceIriString.remove_suffix(1);
-  ad_utility::httpUtils::Url serviceUrl{serviceIriString};
+  ad_utility::httpUtils::Url serviceUrl{
+      asStringViewUnsafe(parsedServiceClause_.serviceIri_.getContent())};
 
   // Construct the query to be sent to the SPARQL endpoint.
   std::string variablesForSelectClause = absl::StrJoin(

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -343,7 +343,7 @@ TripleComponent Service::bindingToTripleComponent(const nlohmann::json& cell) {
 }
 
 // ____________________________________________________________________________
-ProtoResult Service::makeNeutralElementResultForSilentFail() {
+ProtoResult Service::makeNeutralElementResultForSilentFail() const {
   IdTable idTable{getResultWidth(), getExecutionContext()->getAllocator()};
   idTable.emplace_back();
   for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -343,7 +343,7 @@ TripleComponent Service::bindingToTripleComponent(const nlohmann::json& cell) {
 }
 
 // ____________________________________________________________________________
-ProtoResult Service::makeNeutralElementResultForSilentFail() const{
+ProtoResult Service::makeNeutralElementResultForSilentFail() const {
   IdTable idTable{getResultWidth(), getExecutionContext()->getAllocator()};
   idTable.emplace_back();
   for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -16,7 +16,6 @@
 #include "parser/TokenizerCtre.h"
 #include "util/Exception.h"
 #include "util/HashSet.h"
-#include "util/Views.h"
 #include "util/http/HttpUtils.h"
 
 // ____________________________________________________________________________
@@ -94,14 +93,6 @@ size_t Service::getCostEstimate() {
 
 // ____________________________________________________________________________
 ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
-  // Get the URL of the SPARQL endpoint.
-  std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
-  AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&
-                    serviceIriString.ends_with(">"));
-  serviceIriString.remove_prefix(1);
-  serviceIriString.remove_suffix(1);
-  ad_utility::httpUtils::Url serviceUrl{serviceIriString};
-
   // Try to simplify the Service Query using it's sibling Operation.
   if (auto valuesClause = getSiblingValuesClause(); valuesClause.has_value()) {
     auto openBracketPos = parsedServiceClause_.graphPatternAsString_.find('{');
@@ -109,6 +100,31 @@ ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
         "{\n" + valuesClause.value() + '\n' +
         parsedServiceClause_.graphPatternAsString_.substr(openBracketPos + 1);
   }
+
+  try {
+    return computeResultImpl(requestLaziness);
+  } catch (const ad_utility::CancellationException&) {
+    throw;
+  } catch (const ad_utility::detail::AllocationExceedsLimitException&) {
+    throw;
+  } catch (const std::exception&) {
+    // if the `SILENT` keyword is set in the service clause, catch the error and
+    // return a neutral Element.
+    if (parsedServiceClause_.silent_) {
+      return makeNeutralElementResultForSilentFail();
+    }
+    throw;
+  }
+}
+
+ProtoResult Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
+  // Get the URL of the SPARQL endpoint.
+  std::string_view serviceIriString = parsedServiceClause_.serviceIri_.iri();
+  AD_CONTRACT_CHECK(serviceIriString.starts_with("<") &&
+                    serviceIriString.ends_with(">"));
+  serviceIriString.remove_prefix(1);
+  serviceIriString.remove_suffix(1);
+  ad_utility::httpUtils::Url serviceUrl{serviceIriString};
 
   // Construct the query to be sent to the SPARQL endpoint.
   std::string variablesForSelectClause = absl::StrJoin(
@@ -143,76 +159,58 @@ ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
         std::string_view{jsonStr.data()}.substr(0, 100)));
   };
 
-  try {
-    // Verify status and content-type of the response.
-    if (response.status_ != boost::beast::http::status::ok) {
-      throwErrorWithContext(absl::StrCat(
-          "SERVICE responded with HTTP status code: ",
-          static_cast<int>(response.status_), ", ",
-          toStd(boost::beast::http::obsolete_reason(response.status_))));
-    }
-    if (response.contentType_ != "application/sparql-results+json") {
-      throwErrorWithContext(absl::StrCat(
-          "QLever requires the endpoint of a SERVICE to send the result as "
-          "'application/sparql-results+json' but the endpoint sent '",
-          response.contentType_, "'"));
-    }
-
-    // Parse the received result.
-    std::vector<std::string> resVariables;
-    std::vector<nlohmann::json> resBindings;
-    try {
-      auto jsonResult = nlohmann::json::parse(jsonStr);
-
-      if (jsonResult.empty()) {
-        throwErrorWithContext("Response from SPARQL endpoint is empty");
-      }
-
-      resVariables = jsonResult["head"]["vars"].get<std::vector<std::string>>();
-      resBindings =
-          jsonResult["results"]["bindings"].get<std::vector<nlohmann::json>>();
-    } catch (const nlohmann::json::parse_error&) {
-      throwErrorWithContext("Failed to parse the SERVICE result as JSON");
-    } catch (const nlohmann::json::type_error&) {
-      throwErrorWithContext("JSON result does not have the expected structure");
-    }
-
-    // Check if result header row is expected.
-    std::string headerRow =
-        absl::StrCat("?", absl::StrJoin(resVariables, " ?"));
-    std::string expectedHeaderRow = absl::StrJoin(
-        parsedServiceClause_.visibleVariables_, " ", Variable::AbslFormatter);
-    if (headerRow != expectedHeaderRow) {
-      throwErrorWithContext(absl::StrCat(
-          "Header row of JSON result for SERVICE query is \"", headerRow,
-          "\", but expected \"", expectedHeaderRow, "\""));
-    }
-
-    // Set basic properties of the result table.
-    IdTable idTable{getExecutionContext()->getAllocator()};
-    idTable.setNumColumns(getResultWidth());
-    LocalVocab localVocab{};
-    // Fill the result table using the `writeJsonResult` method below.
-    size_t resWidth = getResultWidth();
-    CALL_FIXED_SIZE(resWidth, &Service::writeJsonResult, this, resVariables,
-                    resBindings, &idTable, &localVocab);
-
-    return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
-  } catch (const std::runtime_error& e) {
-    // if the `SILENT` keyword is set in the service clause, catch the error and
-    // return a neutral IdTable
-    if (parsedServiceClause_.silent_) {
-      IdTable idTable{getExecutionContext()->getAllocator()};
-      idTable.setNumColumns(getResultWidth());
-      idTable.emplace_back();
-      for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {
-        idTable(0, colIdx) = Id::makeUndefined();
-      }
-      return {std::move(idTable), resultSortedOn(), LocalVocab{}};
-    }
-    // otherwise rethrow the error.
-    throw;
+  // Verify status and content-type of the response.
+  if (response.status_ != boost::beast::http::status::ok) {
+    throwErrorWithContext(absl::StrCat(
+        "SERVICE responded with HTTP status code: ",
+        static_cast<int>(response.status_), ", ",
+        toStd(boost::beast::http::obsolete_reason(response.status_))));
   }
+  if (response.contentType_ != "application/sparql-results+json") {
+    throwErrorWithContext(absl::StrCat(
+        "QLever requires the endpoint of a SERVICE to send the result as "
+        "'application/sparql-results+json' but the endpoint sent '",
+        response.contentType_, "'"));
+  }
+
+  // Parse the received result.
+  std::vector<std::string> resVariables;
+  std::vector<nlohmann::json> resBindings;
+  try {
+    auto jsonResult = nlohmann::json::parse(jsonStr);
+
+    if (jsonResult.empty()) {
+      throwErrorWithContext("Response from SPARQL endpoint is empty");
+    }
+
+    resVariables = jsonResult["head"]["vars"].get<std::vector<std::string>>();
+    resBindings =
+        jsonResult["results"]["bindings"].get<std::vector<nlohmann::json>>();
+  } catch (const nlohmann::json::parse_error&) {
+    throwErrorWithContext("Failed to parse the SERVICE result as JSON");
+  } catch (const nlohmann::json::type_error&) {
+    throwErrorWithContext("JSON result does not have the expected structure");
+  }
+
+  // Check if result header row is expected.
+  std::string headerRow = absl::StrCat("?", absl::StrJoin(resVariables, " ?"));
+  std::string expectedHeaderRow = absl::StrJoin(
+      parsedServiceClause_.visibleVariables_, " ", Variable::AbslFormatter);
+  if (headerRow != expectedHeaderRow) {
+    throwErrorWithContext(absl::StrCat(
+        "Header row of JSON result for SERVICE query is \"", headerRow,
+        "\", but expected \"", expectedHeaderRow, "\""));
+  }
+
+  // Set basic properties of the result table.
+  IdTable idTable{getResultWidth(), getExecutionContext()->getAllocator()};
+  LocalVocab localVocab{};
+  // Fill the result table using the `writeJsonResult` method below.
+  size_t resWidth = getResultWidth();
+  CALL_FIXED_SIZE(resWidth, &Service::writeJsonResult, this, resVariables,
+                  resBindings, &idTable, &localVocab);
+
+  return {std::move(idTable), resultSortedOn(), std::move(localVocab)};
 }
 
 // ____________________________________________________________________________
@@ -344,4 +342,14 @@ TripleComponent Service::bindingToTripleComponent(const nlohmann::json& cell) {
     throw std::runtime_error(absl::StrCat("Type ", type, " is undefined."));
   }
   return tc;
+}
+
+// ____________________________________________________________________________
+ProtoResult Service::makeNeutralElementResultForSilentFail() {
+  IdTable idTable{getResultWidth(), getExecutionContext()->getAllocator()};
+  idTable.emplace_back();
+  for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {
+    idTable(0, colIdx) = Id::makeUndefined();
+  }
+  return {std::move(idTable), resultSortedOn(), LocalVocab{}};
 }

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -343,7 +343,7 @@ TripleComponent Service::bindingToTripleComponent(const nlohmann::json& cell) {
 }
 
 // ____________________________________________________________________________
-ProtoResult Service::makeNeutralElementResultForSilentFail() const {
+ProtoResult Service::makeNeutralElementResultForSilentFail() const{
   IdTable idTable{getResultWidth(), getExecutionContext()->getAllocator()};
   idTable.emplace_back();
   for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -104,11 +104,17 @@ class Service : public Operation {
   // The string returned by this function is used as cache key.
   std::string getCacheKeyImpl() const override;
 
-  // Compute the result using `getResultFunction_`.
+  // Compute the result using `getResultFunction_` and the siblingTree.
   ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+
+  // Actually compute the result for the function above.
+  ProtoResult computeResultImpl([[maybe_unused]] bool requestLaziness);
 
   // Get a VALUES clause that contains the values of the siblingTree's result.
   std::optional<std::string> getSiblingValuesClause() const;
+
+  // Create result for silent fail.
+  ProtoResult makeNeutralElementResultForSilentFail();
 
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -114,7 +114,7 @@ class Service : public Operation {
   std::optional<std::string> getSiblingValuesClause() const;
 
   // Create result for silent fail.
-  ProtoResult makeNeutralElementResultForSilentFail();
+  ProtoResult makeNeutralElementResultForSilentFail() const;
 
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -114,7 +114,7 @@ class Service : public Operation {
   std::optional<std::string> getSiblingValuesClause() const;
 
   // Create result for silent fail.
-  ProtoResult makeNeutralElementResultForSilentFail() const;
+  ProtoResult makeNeutralElementResultForSilentFail()const;
 
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -114,7 +114,7 @@ class Service : public Operation {
   std::optional<std::string> getSiblingValuesClause() const;
 
   // Create result for silent fail.
-  ProtoResult makeNeutralElementResultForSilentFail()const;
+  ProtoResult makeNeutralElementResultForSilentFail() const;
 
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -48,7 +48,7 @@ struct Service {
   // The visible variables of the service clause.
   std::vector<Variable> visibleVariables_;
   // The URL of the service clause.
-  Iri serviceIri_;
+  TripleComponent::Iri serviceIri_;
   // The prologue (prefix definitions).
   std::string prologue_;
   // The body of the SPARQL query for the remote endpoint.

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -53,6 +53,8 @@ struct Service {
   std::string prologue_;
   // The body of the SPARQL query for the remote endpoint.
   std::string graphPatternAsString_;
+  // The existence of the `SILENT`-keyword.
+  bool silent_;
 };
 
 /// A `BasicGraphPattern` represents a consecutive block of triples.

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -720,7 +720,9 @@ parsedQuery::Service Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
     reportNotSupported(ctx->varOrIri(), "Variable endpoint in SERVICE is");
   }
   AD_CONTRACT_CHECK(std::holds_alternative<Iri>(varOrIri));
-  Iri serviceIri = std::get<Iri>(varOrIri);
+  auto serviceIri =
+      TripleComponent::Iri::fromIriref(std::get<Iri>(varOrIri).iri());
+
   // Parse the body of the SERVICE query. Add the visible variables from the
   // SERVICE clause to the visible variables so far, but also remember them
   // separately (with duplicates removed) because we need them in `Service.cpp`

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -705,14 +705,6 @@ GraphPatternOperation Visitor::visit(Parser::OptionalGraphPatternContext* ctx) {
 
 // Parsing for the `serviceGraphPattern` rule.
 parsedQuery::Service Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
-  // If SILENT is specified, report that we do not support it yet.
-  //
-  // TODO: Support it, it's not hard. The semantics of SILENT is that if no
-  // result can be obtained from the remote endpoint, then do as if the SERVICE
-  // clause would not be there = the result is the neutral element.
-  if (ctx->SILENT()) {
-    reportNotSupported(ctx, "SILENT modifier in SERVICE is");
-  }
   // Get the IRI and if a variable is specified, report that we do not support
   // it yet.
   //
@@ -745,8 +737,8 @@ parsedQuery::Service Visitor::visit(Parser::ServiceGraphPatternContext* ctx) {
                            visibleVariablesServiceQuery.end());
   // Create suitable `parsedQuery::Service` object and return it.
   return {std::move(visibleVariablesServiceQuery), std::move(serviceIri),
-          prologueString_,
-          getOriginalInputForContext(ctx->groupGraphPattern())};
+          prologueString_, getOriginalInputForContext(ctx->groupGraphPattern()),
+          static_cast<bool>(ctx->SILENT())};
 }
 
 // ____________________________________________________________________________

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1392,11 +1392,14 @@ TEST(ExportQueryExecutionTrees, convertGeneratorForChunkedTransfer) {
   EXPECT_NO_THROW((
       res = ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
           throwLate(true))));
-  EXPECT_THAT(consume(std::move(res)), AllOf(HasSubstr("!!!!>># An error has occurred"), HasSubstr("proper exception")));
+  EXPECT_THAT(consume(std::move(res)),
+              AllOf(HasSubstr("!!!!>># An error has occurred"),
+                    HasSubstr("proper exception")));
 
   EXPECT_NO_THROW((
       res = ExportQueryExecutionTrees::convertStreamGeneratorForChunkedTransfer(
           throwLate(false))));
-  EXPECT_THAT(consume(std::move(res)), AllOf(HasSubstr("!!!!>># An error has occurred"),
+  EXPECT_THAT(consume(std::move(res)),
+              AllOf(HasSubstr("!!!!>># An error has occurred"),
                     HasSubstr("A very strange")));
 }

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -123,11 +123,12 @@ TEST_F(ServiceTest, basicMethods) {
   // body (empty in this case because this test is not about evaluating a
   // query). The fourth argument plays no role in our test (and isn't really
   // used in `parsedQuery::Service` either).
-  parsedQuery::Service parsedServiceClause{{Variable{"?x"}, Variable{"?y"}},
-                                           Iri{"<http://localhorst/api>"},
-                                           "PREFIX doof: <http://doof.org>",
-                                           "{ }",
-                                           false};
+  parsedQuery::Service parsedServiceClause{
+      {Variable{"?x"}, Variable{"?y"}},
+      TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
+      "PREFIX doof: <http://doof.org>",
+      "{ }",
+      false};
   // Create an operation from this.
   Service serviceOp{testQec, parsedServiceClause};
 
@@ -154,14 +155,15 @@ TEST_F(ServiceTest, basicMethods) {
 // Tests that `computeResult` behaves as expected.
 TEST_F(ServiceTest, computeResult) {
   // Construct a parsed SERVICE clause by hand, see `basicMethods` test above.
-  parsedQuery::Service parsedServiceClause{{Variable{"?x"}, Variable{"?y"}},
-                                           Iri{"<http://localhorst/api>"},
-                                           "PREFIX doof: <http://doof.org>",
-                                           "{ }",
-                                           false};
+  parsedQuery::Service parsedServiceClause{
+      {Variable{"?x"}, Variable{"?y"}},
+      TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
+      "PREFIX doof: <http://doof.org>",
+      "{ }",
+      false};
   parsedQuery::Service parsedServiceClauseSilent{
       {Variable{"?x"}, Variable{"?y"}},
-      Iri{"<http://localhorst/api>"},
+      TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
       "PREFIX doof: <http://doof.org>",
       "{ }",
       true};
@@ -337,11 +339,12 @@ TEST_F(ServiceTest, computeResult) {
 }
 
 TEST_F(ServiceTest, getCacheKey) {
-  parsedQuery::Service parsedServiceClause{{Variable{"?x"}, Variable{"?y"}},
-                                           Iri{"<http://localhorst/api>"},
-                                           "PREFIX doof: <http://doof.org>",
-                                           "{ }",
-                                           false};
+  parsedQuery::Service parsedServiceClause{
+      {Variable{"?x"}, Variable{"?y"}},
+      TripleComponent::Iri::fromIriref("<http://localhorst/api>"),
+      "PREFIX doof: <http://doof.org>",
+      "{ }",
+      false};
 
   // The cacheKey of the Service Operation has to depend on the cacheKey
   // of the siblingTree, as it might alter the Service Query.

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -186,7 +186,7 @@ TEST_F(ServiceTest, computeResult) {
   };
 
   // Checks that a given result throws a specific error message, however when
-  // the `SILENT` keyword is set it will be catched.
+  // the `SILENT` keyword is set it will be caught.
   auto expectThrowOrSilence =
       [&](const std::string& result, std::string_view errorMsg,
           boost::beast::http::status status = boost::beast::http::status::ok,

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -8,7 +8,6 @@
 #include <ctre-unicode.hpp>
 #include <regex>
 
-#include "QueryPlannerTestHelpers.h"
 #include "engine/Service.h"
 #include "global/RuntimeParameters.h"
 #include "parser/GraphPatternOperation.h"

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -191,7 +191,7 @@ TEST_F(ServiceTest, computeResult) {
           boost::beast::http::status status = boost::beast::http::status::ok,
           std::string contentType = "application/sparql-results+json") {
         AD_EXPECT_THROW_WITH_MESSAGE(
-            runComputeResult(result, status, contentType),
+            runComputeResult(result, status, contentType, false),
             ::testing::HasSubstr(errorMsg));
         EXPECT_NO_THROW(runComputeResult(result, status, contentType, true));
       };

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1000,6 +1000,12 @@ TEST(SparqlParser, GroupGraphPattern) {
       m::GraphPattern(m::Service(Iri{"<ep>"}, {Var{"?s"}, Var{"?o"}},
                                  "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }")));
 
+  expectGraphPattern(
+      "{ SERVICE SILENT <ep> { { SELECT ?s ?o WHERE { ?s ?p ?o } } } }",
+      m::GraphPattern(m::Service(Iri{"<ep>"}, {Var{"?s"}, Var{"?o"}},
+                                 "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }", "",
+                                 true)));
+
   // SERVICE with a variable endpoint is not yet supported.
   expectGroupGraphPatternFails("{ SERVICE ?endpoint { ?s ?p ?o } }");
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -993,18 +993,19 @@ TEST(SparqlParser, GroupGraphPattern) {
           m::InlineData({Var{"?a"}}, {{iri("<a>")}, {iri("<b>")}})));
   expectGraphPattern("{ SERVICE <endpoint> { ?s ?p ?o } }",
                      m::GraphPattern(m::Service(
-                         Iri{"<endpoint>"}, {Var{"?s"}, Var{"?p"}, Var{"?o"}},
-                         "{ ?s ?p ?o }")));
+                         TripleComponent::Iri::fromIriref("<endpoint>"),
+                         {Var{"?s"}, Var{"?p"}, Var{"?o"}}, "{ ?s ?p ?o }")));
   expectGraphPattern(
       "{ SERVICE <ep> { { SELECT ?s ?o WHERE { ?s ?p ?o } } } }",
-      m::GraphPattern(m::Service(Iri{"<ep>"}, {Var{"?s"}, Var{"?o"}},
+      m::GraphPattern(m::Service(TripleComponent::Iri::fromIriref("<ep>"),
+                                 {Var{"?s"}, Var{"?o"}},
                                  "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }")));
 
   expectGraphPattern(
       "{ SERVICE SILENT <ep> { { SELECT ?s ?o WHERE { ?s ?p ?o } } } }",
-      m::GraphPattern(m::Service(Iri{"<ep>"}, {Var{"?s"}, Var{"?o"}},
-                                 "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }", "",
-                                 true)));
+      m::GraphPattern(m::Service(
+          TripleComponent::Iri::fromIriref("<ep>"), {Var{"?s"}, Var{"?o"}},
+          "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }", "", true)));
 
   // SERVICE with a variable endpoint is not yet supported.
   expectGroupGraphPatternFails("{ SERVICE ?endpoint { ?s ?p ?o } }");
@@ -1293,8 +1294,9 @@ TEST(SparqlParser, Query) {
       "SELECT * WHERE { SERVICE <endpoint> { ?s ?p ?o } }",
       m::SelectQuery(m::AsteriskSelect(),
                      m::GraphPattern(m::Service(
-                         Iri{"<endpoint>"}, {Var{"?s"}, Var{"?p"}, Var{"?o"}},
-                         "{ ?s ?p ?o }", "PREFIX doof: <http://doof.org/>"))));
+                         TripleComponent::Iri::fromIriref("<endpoint>"),
+                         {Var{"?s"}, Var{"?p"}, Var{"?o"}}, "{ ?s ?p ?o }",
+                         "PREFIX doof: <http://doof.org/>"))));
 
   // Describe and Ask Queries are not supported.
   expectQueryFails("DESCRIBE *");

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1000,8 +1000,7 @@ TEST(SparqlParser, GroupGraphPattern) {
       m::GraphPattern(m::Service(Iri{"<ep>"}, {Var{"?s"}, Var{"?o"}},
                                  "{ { SELECT ?s ?o WHERE { ?s ?p ?o } } }")));
 
-  // SERVICE with SILENT or a variable endpoint is not yet supported.
-  expectGroupGraphPatternFails("{ SERVICE SILENT <ep> { ?s ?p ?o } }");
+  // SERVICE with a variable endpoint is not yet supported.
   expectGroupGraphPatternFails("{ SERVICE ?endpoint { ?s ?p ?o } }");
 
   // graphGraphPattern is not supported.

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -495,17 +495,17 @@ inline auto InlineData = [](const std::vector<::Variable>& vars,
   return detail::GraphPatternOperation<p::Values>(Values(vars, values));
 };
 
-inline auto Service = [](const ::Iri& iri,
-                         const std::vector<::Variable>& variables,
-                         const std::string& graphPattern,
-                         const std::string& prologue =
-                             "") -> Matcher<const p::GraphPatternOperation&> {
+inline auto Service =
+    [](const ::Iri& iri, const std::vector<::Variable>& variables,
+       const std::string& graphPattern, const std::string& prologue = "",
+       bool silent = false) -> Matcher<const p::GraphPatternOperation&> {
   auto serviceMatcher = testing::AllOf(
       AD_FIELD(p::Service, serviceIri_, testing::Eq(iri)),
       AD_FIELD(p::Service, visibleVariables_,
                testing::UnorderedElementsAreArray(variables)),
       AD_FIELD(p::Service, graphPatternAsString_, testing::Eq(graphPattern)),
-      AD_FIELD(p::Service, prologue_, testing::Eq(prologue)));
+      AD_FIELD(p::Service, prologue_, testing::Eq(prologue)),
+      AD_FIELD(p::Service, silent_, testing::Eq(silent)));
   return detail::GraphPatternOperation<p::Service>(serviceMatcher);
 };
 

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -496,7 +496,8 @@ inline auto InlineData = [](const std::vector<::Variable>& vars,
 };
 
 inline auto Service =
-    [](const ::Iri& iri, const std::vector<::Variable>& variables,
+    [](const TripleComponent::Iri& iri,
+       const std::vector<::Variable>& variables,
        const std::string& graphPattern, const std::string& prologue = "",
        bool silent = false) -> Matcher<const p::GraphPatternOperation&> {
   auto serviceMatcher = testing::AllOf(


### PR DESCRIPTION
Adds the `SILENT` keyword to be used within the `SERVICE` clause.
The SPARQL standard defines this keyword as follows:
> The SILENT keyword indicates that errors encountered while accessing a remote SPARQL endpoint should be ignored while processing the query. The failed SERVICE clause is treated as if it had a result of a single solution with no bindings.