### PR TITLE
Minor refactoring changes to `GroupBy` and related classes

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -24,7 +24,7 @@
 #include "util/HashSet.h"
 #include "util/Timer.h"
 
-using sparqlExpression::SupportedAggregates;
+using groupBy::detail::VectorOfAggregationData;
 
 // _______________________________________________________________________________________________
 GroupBy::GroupBy(QueryExecutionContext* qec, vector<Variable> groupByVariables,
@@ -1029,7 +1029,7 @@ GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
   }
 
   auto resizeVectors =
-      []<SupportedAggregates T>(
+      []<VectorOfAggregationData T>(
           T& arg, size_t numberOfGroups,
           [[maybe_unused]] const HashMapAggregateTypeWithData& info) {
         if constexpr (std::same_as<typename T::value_type,
@@ -1049,7 +1049,7 @@ GroupBy::HashMapAggregationData<NUM_GROUP_COLUMNS>::getHashEntries(
 
     std::visit(
         [&resizeVectors, &aggregationTypeWithData,
-         numberOfGroups]<SupportedAggregates T>(T& arg) {
+         numberOfGroups]<VectorOfAggregationData T>(T& arg) {
           resizeVectors(arg, numberOfGroups, aggregationTypeWithData);
         },
         aggregation);
@@ -1240,8 +1240,8 @@ static constexpr auto makeProcessGroupsVisitor =
        const std::vector<size_t>& hashEntries) {
       return [blockSize, evaluationContext,
               &hashEntries]<sparqlExpression::SingleExpressionResult T,
-                            SupportedAggregates A>(T&& singleResult,
-                                                   A& aggregationDataVector) {
+                            VectorOfAggregationData A>(
+                 T&& singleResult, A& aggregationDataVector) {
         auto generator = sparqlExpression::detail::makeGenerator(
             std::forward<T>(singleResult), blockSize, evaluationContext);
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -860,7 +860,7 @@ GroupBy::isSupportedAggregate(sparqlExpression::SparqlExpression* expr) {
 bool GroupBy::findAggregatesImpl(
     sparqlExpression::SparqlExpression* expr,
     std::optional<ParentAndChildIndex> parentAndChildIndex,
-    std::vector<GroupBy::HashMapAggregateInformation>& info) {
+    std::vector<HashMapAggregateInformation>& info) {
   if (expr->isAggregate()) {
     if (auto aggregateType = isSupportedAggregate(expr)) {
       info.emplace_back(expr, 0, aggregateType.value(), parentAndChildIndex);

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -24,6 +24,8 @@
 #include "util/HashSet.h"
 #include "util/Timer.h"
 
+using sparqlExpression::SupportedAggregates;
+
 // _______________________________________________________________________________________________
 GroupBy::GroupBy(QueryExecutionContext* qec, vector<Variable> groupByVariables,
                  std::vector<Alias> aliases,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -509,6 +509,8 @@ class GroupBy : public Operation {
 };
 
 // _____________________________________________________________________________
+namespace sparqlExpression {
 template <typename A>
 concept SupportedAggregates =
     ad_utility::SameAsAnyTypeIn<A, GroupBy::AggregationDataVectors>;
+}

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -509,8 +509,8 @@ class GroupBy : public Operation {
 };
 
 // _____________________________________________________________________________
-namespace sparqlExpression {
+namespace groupBy::detail {
 template <typename A>
-concept SupportedAggregates =
+concept VectorOfAggregationData =
     ad_utility::SameAsAnyTypeIn<A, GroupBy::AggregationDataVectors>;
 }

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -14,26 +14,22 @@
 #include <vector>
 
 #include "engine/GroupByHashMapOptimization.h"
+#include "engine/Join.h"
 #include "engine/Operation.h"
 #include "engine/QueryExecutionTree.h"
-#include "engine/sparqlExpressions/RelationalExpressionHelpers.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "parser/Alias.h"
-#include "parser/ParsedQuery.h"
 #include "util/TypeIdentity.h"
-
-using std::string;
-using std::vector;
-
-// Forward declarations for internal member function
-class IndexScan;
-class Join;
 
 // Block size for when using the hash map optimization
 static constexpr size_t GROUP_BY_HASH_MAP_BLOCK_SIZE = 262144;
 
 class GroupBy : public Operation {
+  using string = std::string;
+  template <typename T>
+  using vector = std::vector<T>;
+
  private:
   std::shared_ptr<QueryExecutionTree> _subtree;
   vector<Variable> _groupByVariables;
@@ -364,7 +360,7 @@ class GroupBy : public Operation {
       IdTable* resultTable,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
       size_t dataIndex, size_t beginIndex, size_t endIndex,
-      LocalVocab* localVocab);
+      LocalVocab* localVocab) const;
 
   // Substitute away any occurrences of the grouped variable and of aggregate
   // results, if necessary, and subsequently evaluate the expression of an
@@ -374,7 +370,7 @@ class GroupBy : public Operation {
       HashMapAliasInformation& alias, IdTable* result,
       sparqlExpression::EvaluationContext& evaluationContext,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-      LocalVocab* localVocab);
+      LocalVocab* localVocab) const;
 
   // Sort the HashMap by key and create result table.
   template <size_t NUM_GROUP_COLUMNS>
@@ -383,6 +379,12 @@ class GroupBy : public Operation {
       std::vector<HashMapAliasInformation>& aggregateAliases,
       LocalVocab* localVocab);
 
+ private:
+  // Reusable implementation of `checkIfHashMapOptimizationPossible`.
+  std::optional<HashMapOptimizationData> computeHashMapOptimizationMetadata(
+      std::vector<Aggregate>& aggregates);
+
+ public:
   // Check if hash map optimization is applicable. This is the case when
   // the following conditions hold true:
   // - Runtime parameter is set
@@ -400,9 +402,8 @@ class GroupBy : public Operation {
 
   // Substitute the group values for all occurrences of a group variable.
   void substituteGroupVariable(
-      const std::vector<GroupBy::ParentAndChildIndex>& occurrences,
-      IdTable* resultTable, size_t beginIndex, size_t count,
-      size_t columnIndex) const;
+      const std::vector<ParentAndChildIndex>& occurrences, IdTable* resultTable,
+      size_t beginIndex, size_t count, size_t columnIndex) const;
 
   // Substitute the results for all aggregates in `info`. The values of the
   // grouped variable should be at column 0 in `groupValues`.
@@ -411,7 +412,7 @@ class GroupBy : public Operation {
       std::vector<HashMapAggregateInformation>& info, size_t beginIndex,
       size_t endIndex,
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
-      IdTable* resultTable, LocalVocab* localVocab);
+      IdTable* resultTable, LocalVocab* localVocab) const;
 
   // Check if an expression is of a certain type.
   template <class T>
@@ -422,8 +423,8 @@ class GroupBy : public Operation {
   static bool hasAnyType(const auto& expr);
 
   // Check if an expression is a currently supported aggregate.
-  static std::optional<GroupBy::HashMapAggregateTypeWithData>
-  isSupportedAggregate(sparqlExpression::SparqlExpression* expr);
+  static std::optional<HashMapAggregateTypeWithData> isSupportedAggregate(
+      sparqlExpression::SparqlExpression* expr);
 
   // Find all occurrences of grouped by variable for expression `expr`.
   std::variant<std::vector<ParentAndChildIndex>, OccurAsRoot>
@@ -506,3 +507,8 @@ class GroupBy : public Operation {
   // TODO<joka921> Also inform the query planner (via the cost estimate)
   // that the optimization can be done.
 };
+
+// _____________________________________________________________________________
+template <typename A>
+concept SupportedAggregates =
+    ad_utility::SameAsAnyTypeIn<A, GroupBy::AggregationDataVectors>;

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "engine/sparqlExpressions/AggregateExpression.h"
-#include "engine/sparqlExpressions/RelationalExpressionHelpers.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 
 // _____________________________________________________________________________
@@ -42,10 +41,15 @@ struct AvgAggregationData {
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
       [[maybe_unused]] const LocalVocab* localVocab) const {
-    if (error_)
+    if (error_) {
       return ValueId::makeUndefined();
-    else
-      return ValueId::makeFromDouble(sum_ / static_cast<double>(count_));
+    }
+    // AVG(empty group) = 0
+    if (count_ == 0) {
+      return ValueId::makeFromInt(0);
+    }
+
+    return ValueId::makeFromDouble(sum_ / static_cast<double>(count_));
   }
 };
 
@@ -136,12 +140,13 @@ struct SumAggregationData {
   // _____________________________________________________________________________
   [[nodiscard]] ValueId calculateResult(
       [[maybe_unused]] const LocalVocab* localVocab) const {
-    if (error_)
+    if (error_) {
       return ValueId::makeUndefined();
-    else if (intSumValid_)
+    }
+    if (intSumValid_) {
       return ValueId::makeFromInt(intSum_);
-    else
-      return ValueId::makeFromDouble(sum_);
+    }
+    return ValueId::makeFromDouble(sum_);
   }
 };
 
@@ -149,7 +154,7 @@ struct SumAggregationData {
 struct GroupConcatAggregationData {
   using ValueGetter = sparqlExpression::detail::StringValueGetter;
   std::string currentValue_;
-  std::string separator_;
+  std::string_view separator_;
 
   // _____________________________________________________________________________
   void addValue(auto&& value, const sparqlExpression::EvaluationContext* ctx) {
@@ -171,7 +176,7 @@ struct GroupConcatAggregationData {
   }
 
   // _____________________________________________________________________________
-  explicit GroupConcatAggregationData(std::string separator)
+  explicit GroupConcatAggregationData(std::string_view separator)
       : separator_{std::move(separator)} {
     currentValue_.reserve(20000);
   }

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -177,7 +177,7 @@ struct GroupConcatAggregationData {
 
   // _____________________________________________________________________________
   explicit GroupConcatAggregationData(std::string_view separator)
-      : separator_{std::move(separator)} {
+      : separator_{separator} {
     currentValue_.reserve(20000);
   }
 };

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -44,7 +44,7 @@ struct AvgAggregationData {
     if (error_) {
       return ValueId::makeUndefined();
     }
-    // AVG(empty group) = 0
+    // AVG(empty group) = 0, this is mandated by the SPARQL 1.1 standard.
     if (count_ == 0) {
       return ValueId::makeFromInt(0);
     }

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -95,6 +95,12 @@ Result::Result(cppcoro::generator<IdTable> idTables,
              SharedLocalVocabWrapper{std::move(localVocab)}} {}
 
 // _____________________________________________________________________________
+Result::Result(cppcoro::generator<IdTable> idTables,
+               std::vector<ColumnIndex> sortedBy, LocalVocabPtr localVocab)
+    : Result{std::move(idTables), std::move(sortedBy),
+             SharedLocalVocabWrapper{std::move(localVocab)}} {}
+
+// _____________________________________________________________________________
 // Apply `LimitOffsetClause` to given `IdTable`.
 void resizeIdTable(IdTable& idTable, const LimitOffsetClause& limitOffset) {
   std::ranges::for_each(

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -96,6 +96,8 @@ class Result {
          std::vector<ColumnIndex> sortedBy, SharedLocalVocabWrapper localVocab);
   Result(cppcoro::generator<IdTable> idTables,
          std::vector<ColumnIndex> sortedBy, LocalVocab&& localVocab);
+  Result(cppcoro::generator<IdTable> idTables,
+         std::vector<ColumnIndex> sortedBy, LocalVocabPtr localVocab);
   // Prevent accidental copying of a result table.
   Result(const Result& other) = delete;
   Result& operator=(const Result& other) = delete;

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -164,9 +164,7 @@ using AvgExpressionBase =
     AggregateExpression<AvgOperation, decltype(avgFinalOperation)>;
 class AvgExpression : public AvgExpressionBase {
   using AvgExpressionBase::AvgExpressionBase;
-  ValueId resultForEmptyGroup() const override {
-    return Id::makeFromDouble(0.0);
-  }
+  ValueId resultForEmptyGroup() const override { return Id::makeFromInt(0); }
 };
 
 // Compare two arbitrary values (each of which can be an ID, a literal, or an

--- a/test/AggregateExpressionTest.cpp
+++ b/test/AggregateExpressionTest.cpp
@@ -87,7 +87,7 @@ TEST(AggregateExpression, avg) {
   testAvgId({D(2), D(2), I(2)}, D(2), true);
   testAvgId({I(3), U}, U);
   testAvgId({I(3), NaN}, NaN);
-  testAvgId({}, D(0));
+  testAvgId({}, I(0));
 
   auto testAvgString = testAggregate<AvgExpression, IdOrLiteralOrIri, Id>;
   testAvgString({lit("alpha"), lit("äpfel"), lit("Beta"), lit("unfug")}, U);


### PR DESCRIPTION
These include improvements like
* Adding `const` qualifiers to functions
* Extracting subfunctions that will be reused in the future.
* Increasing readability by dropping redundant namespace qualifiers