### PR TITLE
Lazy import for SERVICE

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -164,7 +164,7 @@ ProtoResult Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
         static_cast<int>(response.status_), ", ",
         toStd(boost::beast::http::obsolete_reason(response.status_))));
   }
-  if (response.contentType_ != "application/sparql-results+json") {
+  if (!response.contentType_.starts_with("application/sparql-results+json")) {
     throwErrorWithContext(absl::StrCat(
         "QLever requires the endpoint of a SERVICE to send the result as "
         "'application/sparql-results+json' but the endpoint sent '",

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -116,6 +116,10 @@ class Service : public Operation {
   // Create result for silent fail.
   ProtoResult makeNeutralElementResultForSilentFail() const;
 
+  // Check that all visible variables of the SERVICE clause exist in the json
+  // object, otherwise throw an error.
+  void verifyVariables(const nlohmann::json& j);
+
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.
   //

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -123,6 +123,6 @@ class Service : public Operation {
   // parse JSON here and not a VALUES clause.
   template <size_t I>
   void writeJsonResult(const std::vector<std::string>& vars,
-                       const std::vector<nlohmann::json>& bindings,
+                       cppcoro::generator<nlohmann::json>& response,
                        IdTable* idTable, LocalVocab* localVocab);
 };

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -99,7 +99,8 @@ class Service : public Operation {
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 
   // Convert the given binding to TripleComponent.
-  static TripleComponent bindingToTripleComponent(const nlohmann::json& cell);
+  static TripleComponent bindingToTripleComponent(
+      const nlohmann::json& binding);
 
  private:
   // The string returned by this function is used as cache key.
@@ -119,13 +120,14 @@ class Service : public Operation {
 
   // Check that all visible variables of the SERVICE clause exist in the json
   // object, otherwise throw an error.
-  void verifyVariables(const nlohmann::json& j,
-                       const ad_utility::LazyJsonParser::Generator& gen) const;
+  void verifyVariables(const nlohmann::json& head,
+                       const ad_utility::LazyJsonParser::Details& gen) const;
 
   // Throws an error message, providing the first 100 bytes of the result as
   // context.
-  void throwErrorWithContext(std::string_view msg,
-                             std::string_view first100) const;
+  [[noreturn]] void throwErrorWithContext(
+      std::string_view msg, std::string_view first100,
+      std::string_view last100 = ""sv) const;
 
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -9,6 +9,7 @@
 #include "engine/Operation.h"
 #include "engine/Values.h"
 #include "parser/ParsedQuery.h"
+#include "util/LazyJsonParser.h"
 #include "util/http/HttpClient.h"
 
 // The SERVICE operation. Sends a query to the remote endpoint specified by the
@@ -118,7 +119,13 @@ class Service : public Operation {
 
   // Check that all visible variables of the SERVICE clause exist in the json
   // object, otherwise throw an error.
-  void verifyVariables(const nlohmann::json& j);
+  void verifyVariables(const nlohmann::json& j,
+                       const ad_utility::LazyJsonParser::Generator& gen) const;
+
+  // Throws an error message, providing the first 100 bytes of the result as
+  // context.
+  void throwErrorWithContext(std::string_view msg,
+                             std::string_view first100) const;
 
   // Write the given JSON result to the given result object. The `I` is the
   // width of the result table.
@@ -127,6 +134,6 @@ class Service : public Operation {
   // parse JSON here and not a VALUES clause.
   template <size_t I>
   void writeJsonResult(const std::vector<std::string>& vars,
-                       cppcoro::generator<nlohmann::json>& response,
+                       ad_utility::LazyJsonParser::Generator& response,
                        IdTable* idTable, LocalVocab* localVocab);
 };

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -30,6 +30,20 @@ cppcoro::generator<nlohmann::json> LazyJsonParser::parse(
 }
 
 // ____________________________________________________________________________
+cppcoro::generator<nlohmann::json> LazyJsonParser::parse(
+    cppcoro::generator<std::span<std::byte>> partialJson,
+    std::vector<std::string> arrayPath) {
+  return parse(
+      [](cppcoro::generator<std::span<std::byte>> partialJson)
+          -> cppcoro::generator<std::string> {
+        for (const auto& bytes : partialJson) {
+          co_yield reinterpret_cast<const char*>(bytes.data());
+        }
+      }(std::move(partialJson)),
+      std::move(arrayPath));
+}
+
+// ____________________________________________________________________________
 LazyJsonParser::LazyJsonParser(std::vector<std::string> arrayPath)
     : arrayPath_(std::move(arrayPath)),
       prefixInArray_(absl::StrCat(

--- a/src/util/LazyJsonParser.cpp
+++ b/src/util/LazyJsonParser.cpp
@@ -16,7 +16,7 @@ namespace ad_utility {
 
 // ____________________________________________________________________________
 cppcoro::generator<nlohmann::json> LazyJsonParser::parse(
-    cppcoro::generator<std::string> partialJson,
+    cppcoro::generator<std::string_view> partialJson,
     std::vector<std::string> arrayPath) {
   LazyJsonParser p(std::move(arrayPath));
   for (const auto& chunk : partialJson) {
@@ -35,9 +35,10 @@ cppcoro::generator<nlohmann::json> LazyJsonParser::parse(
     std::vector<std::string> arrayPath) {
   return parse(
       [](cppcoro::generator<std::span<std::byte>> partialJson)
-          -> cppcoro::generator<std::string> {
+          -> cppcoro::generator<std::string_view> {
         for (const auto& bytes : partialJson) {
-          co_yield reinterpret_cast<const char*>(bytes.data());
+          co_yield std::string(reinterpret_cast<const char*>(bytes.data()),
+                               bytes.size());
         }
       }(std::move(partialJson)),
       std::move(arrayPath));

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -30,7 +30,7 @@ class LazyJsonParser {
 
   class Error : public std::runtime_error {
    public:
-    Error(const std::string& msg) : std::runtime_error(msg) {}
+    explicit Error(const std::string& msg) : std::runtime_error(msg) {}
   };
 
   // Parse chunks of json-strings yielding them reconstructed.

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -22,7 +22,7 @@ class LazyJsonParser {
  public:
   // Parse chunks of json-strings yielding them reconstructed.
   static cppcoro::generator<nlohmann::json> parse(
-      cppcoro::generator<std::string> partialJson,
+      cppcoro::generator<std::string_view> partialJson,
       std::vector<std::string> arrayPath);
 
   // Convenient alternative for the function above using bytes.

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -20,15 +20,19 @@ namespace ad_utility {
  */
 class LazyJsonParser {
  public:
+  // Generator detail, the first 100 input characters for better error context.
+  struct Details {
+    std::string first100_;
+  };
+  using Generator = cppcoro::generator<nlohmann::json, Details>;
+
   // Parse chunks of json-strings yielding them reconstructed.
-  static cppcoro::generator<nlohmann::json> parse(
-      cppcoro::generator<std::string_view> partialJson,
-      std::vector<std::string> arrayPath);
+  static Generator parse(cppcoro::generator<std::string_view> partialJson,
+                         std::vector<std::string> arrayPath);
 
   // Convenient alternative for the function above using bytes.
-  static cppcoro::generator<nlohmann::json> parse(
-      cppcoro::generator<std::span<std::byte>> partialJson,
-      std::vector<std::string> arrayPath);
+  static Generator parse(cppcoro::generator<std::span<std::byte>> partialJson,
+                         std::vector<std::string> arrayPath);
 
  private:
   explicit LazyJsonParser(std::vector<std::string> arrayPath);

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -25,6 +25,11 @@ class LazyJsonParser {
       cppcoro::generator<std::string> partialJson,
       std::vector<std::string> arrayPath);
 
+  // Convenient alternative for the function above using bytes.
+  static cppcoro::generator<nlohmann::json> parse(
+      cppcoro::generator<std::span<std::byte>> partialJson,
+      std::vector<std::string> arrayPath);
+
  private:
   explicit LazyJsonParser(std::vector<std::string> arrayPath);
 

--- a/src/util/LazyJsonParser.h
+++ b/src/util/LazyJsonParser.h
@@ -20,11 +20,18 @@ namespace ad_utility {
  */
 class LazyJsonParser {
  public:
-  // Generator detail, the first 100 input characters for better error context.
+  // Generator detail, the first/last 100 input characters for better error
+  // context.
   struct Details {
     std::string first100_;
+    std::string last100_;
   };
   using Generator = cppcoro::generator<nlohmann::json, Details>;
+
+  class Error : public std::runtime_error {
+   public:
+    Error(const std::string& msg) : std::runtime_error(msg) {}
+  };
 
   // Parse chunks of json-strings yielding them reconstructed.
   static Generator parse(cppcoro::generator<std::string_view> partialJson,

--- a/test/LazyJsonParserTest.cpp
+++ b/test/LazyJsonParserTest.cpp
@@ -14,9 +14,9 @@ TEST(parseTest, parse) {
   const std::vector<std::string> arrayPath = {"results", "bindings"};
 
   auto yieldChars =
-      [](const std::string& s) -> cppcoro::generator<std::string> {
-    for (auto& c : s) {
-      co_yield std::string(1, c);
+      [](const std::string_view s) -> cppcoro::generator<std::string_view> {
+    for (size_t i = 0; i < s.size(); ++i) {
+      co_yield std::string_view(s.data() + i, 1);
     }
   };
   // Check if the parser yields the expected results when parsing each char

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -255,7 +255,10 @@ TEST_F(ServiceTest, computeResult) {
       "\"head\" section is not according to the SPARQL standard.");
 
   // Internal parser errors.
-  expectThrowOrSilence(std::string(1'000'000, '0'), "Ill formed JSON.");
+  expectThrowOrSilence(
+      std::string(1'000'000, '0'),
+      "QLever currently doesn't support SERVICE results where a single "
+      "result row is larger than 1MB");
 
   // CHECK 1b: Even if the SILENT-keyword is set, throw local errors.
   Service serviceSilent{

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -229,6 +229,20 @@ TEST_F(ServiceTest, computeResult) {
 
   expectThrowOrSilence("", "JSON result does not have the expected structure.");
 
+  // `head`/`vars` missing
+  expectThrowOrSilence(
+      "{\"results\": {\"bindings\": {{\"x\": {{\"type\": \"uri\"}, {\"value\": "
+      "\"a\"}}, \"y\": {{\"type\": \"uri\"}, {\"value\": \"b\"}}}}}}",
+      "JSON result does not have the expected structure.");
+  expectThrowOrSilence(
+      "{\"head\": {},"
+      "\"results\": {\"bindings\": {}}}",
+      "JSON result does not have the expected structure.");
+  // wrong variables type (array of strings expected)
+  expectThrowOrSilence(
+      "{\"head\": {\"vars\": 1},"
+      "\"results\": {\"bindings\": {}}}",
+      "JSON result does not have the expected structure.");
   expectThrowOrSilence(
       "{\"head\": {\"vars\": [1, 2, 3]},"
       "\"results\": {\"bindings\": {}}}",


### PR DESCRIPTION
Integrate the `LazyJsonParser` introduced in #1412 into the `SERVICE` Operation, which will help to reduce RAM usage for the import of large results. In particular, the (possibly large) JSON result of a SERVICE will not be fully materialized, but converted to a (possibly much smaller) `IdTable` on the fly. This is a preparation for making the SERVICE operation completely lazy.
