### PR TITLE
Better interface for aggregate expressions

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -832,7 +832,9 @@ GroupBy::isSupportedAggregate(sparqlExpression::SparqlExpression* expr) {
   using namespace sparqlExpression;
 
   // `expr` is not a distinct aggregate
-  if (expr->isDistinct()) return std::nullopt;
+  if (expr->isAggregate() !=
+      SparqlExpression::AggregateStatus::NonDistinctAggregate)
+    return std::nullopt;
 
   // `expr` is not a nested aggregated
   if (std::ranges::any_of(expr->children(), [](const auto& ptr) {
@@ -861,7 +863,8 @@ bool GroupBy::findAggregatesImpl(
     sparqlExpression::SparqlExpression* expr,
     std::optional<ParentAndChildIndex> parentAndChildIndex,
     std::vector<HashMapAggregateInformation>& info) {
-  if (expr->isAggregate()) {
+  if (expr->isAggregate() !=
+      sparqlExpression::SparqlExpression::AggregateStatus::NoAggregate) {
     if (auto aggregateType = isSupportedAggregate(expr)) {
       info.emplace_back(expr, 0, aggregateType.value(), parentAndChildIndex);
       return true;

--- a/src/engine/sparqlExpressions/AggregateExpression.cpp
+++ b/src/engine/sparqlExpressions/AggregateExpression.cpp
@@ -157,14 +157,6 @@ AggregateExpression<AggregateOperation, FinalOperation>::childrenImpl() {
   return {&_child, 1};
 }
 
-// _________________________________________________________________________
-template <typename AggregateOperation, typename FinalOperation>
-vector<Variable> AggregateExpression<
-    AggregateOperation, FinalOperation>::getUnaggregatedVariables() {
-  // This is an aggregate, so it never leaves any unaggregated variables.
-  return {};
-}
-
 // __________________________________________________________________________
 template <typename AggregateOperation, typename FinalOperation>
 [[nodiscard]] string

--- a/src/engine/sparqlExpressions/AggregateExpression.h
+++ b/src/engine/sparqlExpressions/AggregateExpression.h
@@ -68,19 +68,15 @@ class AggregateExpression : public SparqlExpression {
   // (needed only for implicit GROUP BYs).
   virtual ValueId resultForEmptyGroup() const = 0;
 
-  // Get the unaggregated variables of the expression (can be empty).
-  vector<Variable> getUnaggregatedVariables() override;
-
   // Yes, this is an aggregate expression.
-  bool isAggregate() const override { return true; }
+  AggregateStatus isAggregate() const override {
+    return _distinct ? AggregateStatus::DistinctAggregate
+                     : AggregateStatus::NonDistinctAggregate;
+  }
 
   // Get the cache key for this expression.
   [[nodiscard]] string getCacheKey(
       const VariableToColumnMap& varColMap) const override;
-
-  // This is only used for aggregate expressions, and then it's exactly the
-  // value of the `distinct` parameter in the constructor.
-  bool isDistinct() const override { return _distinct; }
 
   // Needed for the pattern trick, see `SparqlExpression.h`.
   [[nodiscard]] std::optional<SparqlExpressionPimpl::VariableAndDistinctness>

--- a/src/engine/sparqlExpressions/CountStarExpression.cpp
+++ b/src/engine/sparqlExpressions/CountStarExpression.cpp
@@ -68,13 +68,10 @@ class CountStarExpression : public SparqlExpression {
   }
 
   // COUNT * technically is an aggregate.
-  bool isAggregate() const override { return true; }
-
-  // No variables.
-  std::vector<Variable> getUnaggregatedVariables() override { return {}; }
-
-  // __________________________________________________________________
-  bool isDistinct() const override { return distinct_; }
+  AggregateStatus isAggregate() const override {
+    return distinct_ ? AggregateStatus::DistinctAggregate
+                     : AggregateStatus::NonDistinctAggregate;
+  }
 
   // __________________________________________________________________
   string getCacheKey(

--- a/src/engine/sparqlExpressions/CountStarExpression.cpp
+++ b/src/engine/sparqlExpressions/CountStarExpression.cpp
@@ -16,7 +16,9 @@ class CountStarExpression : public SparqlExpression {
 
  public:
   // _________________________________________________________________________
-  explicit CountStarExpression(bool distinct) : distinct_{distinct} {}
+  explicit CountStarExpression(bool distinct) : distinct_{distinct} {
+    setIsInsideAggregate();
+  }
 
   // _________________________________________________________________________
   ExpressionResult evaluate(

--- a/src/engine/sparqlExpressions/GroupConcatExpression.h
+++ b/src/engine/sparqlExpressions/GroupConcatExpression.h
@@ -65,14 +65,11 @@ class GroupConcatExpression : public SparqlExpression {
   // Required when using the hash map optimization.
   [[nodiscard]] const std::string& getSeparator() const { return separator_; }
 
-  // A `GroupConcatExpression` is an aggregate, so it never leaves any
-  // unaggregated variables.
-  vector<Variable> getUnaggregatedVariables() override { return {}; }
-
   // A `GroupConcatExpression` is an aggregate.
-  bool isAggregate() const override { return true; }
-
-  bool isDistinct() const override { return distinct_; }
+  AggregateStatus isAggregate() const override {
+    return distinct_ ? AggregateStatus::DistinctAggregate
+                     : AggregateStatus::NonDistinctAggregate;
+  }
 
   [[nodiscard]] string getCacheKey(
       const VariableToColumnMap& varColMap) const override {

--- a/src/engine/sparqlExpressions/LiteralExpression.h
+++ b/src/engine/sparqlExpressions/LiteralExpression.h
@@ -83,7 +83,7 @@ class LiteralExpression : public SparqlExpression {
   }
 
   // _________________________________________________________________________
-  vector<Variable> getUnaggregatedVariables() override {
+  vector<Variable> getUnaggregatedVariables() const override {
     if constexpr (std::is_same_v<T, ::Variable>) {
       return {_value};
     } else {
@@ -192,7 +192,7 @@ struct SingleUseExpression : public SparqlExpression {
     return std::move(result_);
   }
 
-  vector<Variable> getUnaggregatedVariables() override {
+  vector<Variable> getUnaggregatedVariables() const override {
     // This class should only be used as an implementation of other expressions,
     // not as a "normal" part of an expression tree.
     AD_FAIL();

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -27,7 +27,7 @@ std::vector<const Variable*> SparqlExpression::containedVariables() const {
 // _____________________________________________________________________________
 std::vector<Variable> SparqlExpression::getUnaggregatedVariables() const {
   // Aggregates always aggregate over all variables, so no variables remain
-  // unaggregated
+  // unaggregated.
   if (isAggregate() != AggregateStatus::NoAggregate) {
     return {};
   }

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -25,7 +25,12 @@ std::vector<const Variable*> SparqlExpression::containedVariables() const {
 }
 
 // _____________________________________________________________________________
-std::vector<Variable> SparqlExpression::getUnaggregatedVariables() {
+std::vector<Variable> SparqlExpression::getUnaggregatedVariables() const {
+  // Aggregates always aggregate over all variables, so no variables remain
+  // unaggregated
+  if (isAggregate() != AggregateStatus::NoAggregate) {
+    return {};
+  }
   // Default implementation: This expression adds no variables, but all
   // unaggregated variables from the children remain unaggregated.
   std::vector<Variable> result;
@@ -39,20 +44,14 @@ std::vector<Variable> SparqlExpression::getUnaggregatedVariables() {
 
 // _____________________________________________________________________________
 bool SparqlExpression::containsAggregate() const {
-  if (isAggregate()) return true;
+  if (isAggregate() != AggregateStatus::NoAggregate) return true;
   return std::ranges::any_of(
       children(), [](const Ptr& child) { return child->containsAggregate(); });
 }
 
 // _____________________________________________________________________________
-bool SparqlExpression::isAggregate() const { return false; }
-
-// _____________________________________________________________________________
-bool SparqlExpression::isDistinct() const {
-  AD_THROW(
-      "isDistinct() maybe only called for aggregate expressions. If this is "
-      "an aggregate expression, then the implementation of isDistinct() is "
-      "missing for this expression. Please report this to the developers.");
+auto SparqlExpression::isAggregate() const -> AggregateStatus {
+  return AggregateStatus::NoAggregate;
 }
 
 // _____________________________________________________________________________
@@ -155,5 +154,13 @@ void SparqlExpression::setIsInsideAggregate() {
 }
 
 // _____________________________________________________________________________
-bool SparqlExpression::isInsideAggregate() const { return isInsideAggregate_; }
+bool SparqlExpression::isInsideAggregate() const {
+  if (isAggregate() != AggregateStatus::NoAggregate) {
+    AD_CORRECTNESS_CHECK(
+        isInsideAggregate_,
+        "This indicates a missing call to `setIsInsideAggregate()` inside the "
+        "constructor of an aggregate expression");
+  }
+  return isInsideAggregate_;
+}
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -47,7 +47,7 @@ bool SparqlExpression::containsAggregate() const {
   if (isAggregate() != AggregateStatus::NoAggregate) {
     AD_CORRECTNESS_CHECK(isInsideAggregate());
     return true;
-  };
+  }
 
   return std::ranges::any_of(
       children(), [](const Ptr& child) { return child->containsAggregate(); });

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -44,7 +44,11 @@ std::vector<Variable> SparqlExpression::getUnaggregatedVariables() const {
 
 // _____________________________________________________________________________
 bool SparqlExpression::containsAggregate() const {
-  if (isAggregate() != AggregateStatus::NoAggregate) return true;
+  if (isAggregate() != AggregateStatus::NoAggregate) {
+    AD_CORRECTNESS_CHECK(isInsideAggregate());
+    return true
+  };
+
   return std::ranges::any_of(
       children(), [](const Ptr& child) { return child->containsAggregate(); });
 }

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -36,18 +36,20 @@ class SparqlExpression {
 
   /// Return all the variables that occur in the expression, but are not
   /// aggregated.
-  virtual std::vector<Variable> getUnaggregatedVariables();
+  virtual std::vector<Variable> getUnaggregatedVariables() const;
 
   // Return true iff this expression contains an aggregate like SUM, COUNT etc.
   // This information is needed to check if there is an implicit GROUP BY in a
   // query because any of the selected aliases contains an aggregate.
   virtual bool containsAggregate() const final;
 
+  enum struct AggregateStatus {
+    NoAggregate,
+    DistinctAggregate,
+    NonDistinctAggregate
+  };
   // Check if expression is aggregate
-  virtual bool isAggregate() const;
-
-  // Check if an expression is distinct (only applies to aggregates)
-  virtual bool isDistinct() const;
+  virtual AggregateStatus isAggregate() const;
 
   // Replace child at index `childIndex` with `newExpression`
   virtual void replaceChild(size_t childIndex,

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -29,8 +29,7 @@ class SparqlExpression {
   // Evaluate a Sparql expression.
   virtual ExpressionResult evaluate(EvaluationContext*) const = 0;
 
-  // Return all variables and IRIs, needed for certain parser methods.
-  // TODO<joka921> should be called getStringLiteralsAndVariables
+  // Return all variables, needed for certain parser methods.
   virtual std::vector<const Variable*> containedVariables() const final;
 
   // Return all the variables that occur in the expression, but are not

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -2,8 +2,7 @@
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
-#ifndef QLEVER_SPARQLEXPRESSION_H
-#define QLEVER_SPARQLEXPRESSION_H
+#pragma once
 
 #include <memory>
 #include <span>
@@ -35,11 +34,12 @@ class SparqlExpression {
   virtual std::vector<const Variable*> containedVariables() const final;
 
   // Return all the variables that occur in the expression, but are not
-  // aggregated. The default implementation works for aggregate expressions
-  // (which never have unaggregated variables) and for expressions that only
-  // combine other expressions and therefore propagate their unaggregated
-  // variables. Leaf operations (in particular the `VariableExpression` need to
-  // override this method.
+  // aggregated. These variables must be grouped in a GROUP BY. The default
+  // implementation works for aggregate expressions (which never have
+  // unaggregated variables) and for expressions that only combine other
+  // expressions and therefore propagate their unaggregated variables. Leaf
+  // operations (in particular the `VariableExpression`) need to override this
+  // method.
   virtual std::vector<Variable> getUnaggregatedVariables() const;
 
   // Return true iff this expression contains an aggregate like SUM, COUNT etc.
@@ -118,8 +118,9 @@ class SparqlExpression {
   virtual std::span<SparqlExpression::Ptr> children() final;
   virtual std::span<const SparqlExpression::Ptr> children() const final;
 
-  // Return true if this class or any of its ancestors in the expression tree is
-  // an aggregate. For an example usage see the `LiteralExpression` class.
+  // Return true if this expression or any of its ancestors in the expression
+  // tree is an aggregate. For an example usage see the `LiteralExpression`
+  // class.
   bool isInsideAggregate() const;
 
  private:
@@ -137,5 +138,3 @@ class SparqlExpression {
   virtual void setIsInsideAggregate() final;
 };
 }  // namespace sparqlExpression
-
-#endif  // QLEVER_SPARQLEXPRESSION_H

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -15,27 +15,31 @@
 
 namespace sparqlExpression {
 
-/// Virtual base class for an arbitrary Sparql Expression which holds the
-/// structure of the expression as well as the logic to evaluate this expression
-/// on a given intermediate result
+// Virtual base class for an arbitrary Sparql Expression which holds the
+// structure of the expression as well as the logic to evaluate this expression
+// on a given intermediate result
 class SparqlExpression {
  private:
   std::string _descriptor;
   bool isInsideAggregate_ = false;
 
  public:
-  /// ________________________________________________________________________
+  // ________________________________________________________________________
   using Ptr = std::unique_ptr<SparqlExpression>;
 
-  /// Evaluate a Sparql expression.
+  // Evaluate a Sparql expression.
   virtual ExpressionResult evaluate(EvaluationContext*) const = 0;
 
-  /// Return all variables and IRIs, needed for certain parser methods.
-  /// TODO<joka921> should be called getStringLiteralsAndVariables
+  // Return all variables and IRIs, needed for certain parser methods.
+  // TODO<joka921> should be called getStringLiteralsAndVariables
   virtual std::vector<const Variable*> containedVariables() const final;
 
-  /// Return all the variables that occur in the expression, but are not
-  /// aggregated.
+  // Return all the variables that occur in the expression, but are not
+  // aggregated. The default implementation works for aggregate expressions
+  // (which never have unaggregated variables) and for expressions that only
+  // combine other expressions and therefore propagate their unaggregated
+  // variables. Leaf operations (in particular the `VariableExpression` need to
+  // override this method.
   virtual std::vector<Variable> getUnaggregatedVariables() const;
 
   // Return true iff this expression contains an aggregate like SUM, COUNT etc.
@@ -43,34 +47,35 @@ class SparqlExpression {
   // query because any of the selected aliases contains an aggregate.
   virtual bool containsAggregate() const final;
 
+  // Check if expression is an aggregate. If true, then the return type also
+  // specifies, whether the aggregate is `DISTINCT` or not.
   enum struct AggregateStatus {
     NoAggregate,
     DistinctAggregate,
     NonDistinctAggregate
   };
-  // Check if expression is aggregate
   virtual AggregateStatus isAggregate() const;
 
   // Replace child at index `childIndex` with `newExpression`
   virtual void replaceChild(size_t childIndex,
                             std::unique_ptr<SparqlExpression> newExpression);
 
-  /// Get a unique identifier for this expression, used as cache key.
+  // Get a unique identifier for this expression, used as cache key.
   virtual string getCacheKey(const VariableToColumnMap& varColMap) const = 0;
 
-  /// Get a short, human readable identifier for this expression.
+  // Get a short, human-readable identifier for this expression.
   virtual const string& descriptor() const final;
   virtual string& descriptor() final;
 
-  /// For the pattern trick we need to know, whether this expression
-  /// is a non-distinct count of a single variable. In this case we return
-  /// the variable. Otherwise we return std::nullopt.
+  // For the pattern trick we need to know, whether this expression
+  // is a non-distinct count of a single variable. In this case we return
+  // the variable. Otherwise we return std::nullopt.
   virtual std::optional<SparqlExpressionPimpl::VariableAndDistinctness>
   getVariableForCount() const;
 
-  /// Helper function for getVariableForCount() : If this
-  /// expression is a single variable, return the name of this variable.
-  /// Otherwise, return std::nullopt.
+  // Helper function for getVariableForCount() : If this
+  // expression is a single variable, return the name of this variable.
+  // Otherwise, return std::nullopt.
   virtual std::optional<::Variable> getVariableOrNullopt() const;
 
   // For the following three functions (`containsLangExpression`,
@@ -113,6 +118,10 @@ class SparqlExpression {
   virtual std::span<SparqlExpression::Ptr> children() final;
   virtual std::span<const SparqlExpression::Ptr> children() const final;
 
+  // Return true if this class or any of its ancestors in the expression tree is
+  // an aggregate. For an example usage see the `LiteralExpression` class.
+  bool isInsideAggregate() const;
+
  private:
   virtual std::span<SparqlExpression::Ptr> childrenImpl() = 0;
 
@@ -126,10 +135,6 @@ class SparqlExpression {
   // this expression as well as for all its descendants. This function must be
   // called by all child classes that are aggregate expressions.
   virtual void setIsInsideAggregate() final;
-
-  // Return true if this class or any of its ancestors in the expression tree is
-  // an aggregate. For an example usage see the `LiteralExpression` class.
-  bool isInsideAggregate() const;
 };
 }  // namespace sparqlExpression
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1738,8 +1738,10 @@ template <typename AggregateExpr>
       return ::testing::_;
     }
   }();
+  using enum SparqlExpression::AggregateStatus;
+  auto aggregateStatus = distinct ? DistinctAggregate : NonDistinctAggregate;
   return Pointee(AllOf(
-      AD_PROPERTY(Exp, isDistinct, Eq(distinct)),
+      AD_PROPERTY(Exp, isAggregate, Eq(aggregateStatus)),
       AD_PROPERTY(Exp, children, ElementsAre(variableExpressionMatcher(child))),
       WhenDynamicCastTo<const AggregateExpr&>(innerMatcher)));
 }
@@ -1766,8 +1768,10 @@ TEST(SparqlParser, aggregateExpressions) {
       [&typeIdLambda, typeIdxCountStar](
           bool distinct) -> ::testing::Matcher<const SparqlExpression::Ptr&> {
     using namespace ::testing;
+    using enum SparqlExpression::AggregateStatus;
+    auto aggregateStatus = distinct ? DistinctAggregate : NonDistinctAggregate;
     return Pointee(
-        AllOf(AD_PROPERTY(SparqlExpression, isDistinct, Eq(distinct)),
+        AllOf(AD_PROPERTY(SparqlExpression, isAggregate, Eq(aggregateStatus)),
               ResultOf(typeIdLambda, Eq(typeIdxCountStar))));
   };
 
@@ -1775,7 +1779,10 @@ TEST(SparqlParser, aggregateExpressions) {
   expectAggregate("COUNT(DISTINCT *)", matchCountStar(true));
 
   expectAggregate("SAMPLE(?x)",
-                  matchPtrWithVariables<SampleExpression>(V{"?x"}));
+                  matchAggregate<SampleExpression>(false, V{"?x"}));
+  expectAggregate("SAMPLE(DISTINCT ?x)",
+                  matchAggregate<SampleExpression>(false, V{"?x"}));
+
   expectAggregate("Min(?x)", matchAggregate<MinExpression>(false, V{"?x"}));
   expectAggregate("Min(DISTINCT ?x)",
                   matchAggregate<MinExpression>(true, V{"?x"}));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1320,8 +1320,9 @@ TEST(SparqlExpression, isAggregateAndIsDistinct) {
   // aggregate with the given distinctness. In particular, the expression itself
   // as well as its child must return `true` for the `isInsideAggregate()`
   // function, and the distinctness of the aggregate itself must match.
-  // If `hasChild` is `false`, then the aggregate is expected to have no
-  // children. This is the case for the `CountStarExpression`.
+  // If `hasChild` is `true`, then the aggregate is expected to have at least
+  // one child. This is the case for all aggregates except the
+  // `CountStarExpression`.
   auto match = [](bool distinct, bool hasChild = true) {
     auto aggStatus = distinct ? DistinctAggregate : NonDistinctAggregate;
     auto distinctMatcher =


### PR DESCRIPTION
Preparation for #1476 (lazy `GROUP BY`), which, in particular, has not worked with `SAMPLE` so far. While at it, clean up the code and the documentation.