### PR TITLE
Improve `ScanSpecification` + fix empty index scan bugs

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -164,8 +164,7 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
       ScanSpecificationAsTripleComponent{
           TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE), std::nullopt,
           std::nullopt}
-          .toScanSpecification(index)
-          .value();
+          .toScanSpecification(index);
   auto fullHasPattern =
       index.getPermutation(Permutation::Enum::PSO)
           .lazyScan(scanSpec, std::nullopt, {}, cancellationHandle_);

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -266,8 +266,7 @@ ProtoResult HasPredicateScan::computeResult(
       ScanSpecificationAsTripleComponent{
           TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE), std::nullopt,
           std::nullopt}
-          .toScanSpecification(index)
-          .value();
+          .toScanSpecification(index);
   auto hasPattern =
       index.getPermutation(Permutation::Enum::PSO)
           .lazyScan(scanSpec, std::nullopt, {}, cancellationHandle_);
@@ -339,8 +338,7 @@ void HasPredicateScan::computeFreeO(
       ScanSpecificationAsTripleComponent{
           TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE), subjectAsId,
           std::nullopt}
-          .toScanSpecification(index)
-          .value();
+          .toScanSpecification(index);
   auto hasPattern = index.getPermutation(Permutation::Enum::PSO)
                         .scan(std::move(scanSpec), {}, cancellationHandle_);
   AD_CORRECTNESS_CHECK(hasPattern.numRows() <= 1);

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -259,7 +259,13 @@ std::array<const TripleComponent* const, 3> IndexScan::getPermutedTriple()
 }
 
 // ___________________________________________________________________________
-ScanSpecificationAsTripleComponent IndexScan::getScanSpecification() const {
+ScanSpecification IndexScan::getScanSpecification() const {
+  const IndexImpl& index = getIndex().getImpl();
+  return getScanSpecificationTc().toScanSpecification(index);
+}
+
+// ___________________________________________________________________________
+ScanSpecificationAsTripleComponent IndexScan::getScanSpecificationTc() const {
   auto permutedTriple = getPermutedTriple();
   return {*permutedTriple[0], *permutedTriple[1], *permutedTriple[2]};
 }
@@ -267,11 +273,6 @@ ScanSpecificationAsTripleComponent IndexScan::getScanSpecification() const {
 // ___________________________________________________________________________
 Permutation::IdTableGenerator IndexScan::getLazyScan(
     std::vector<CompressedBlockMetadata> blocks) const {
-  const IndexImpl& index = getIndex().getImpl();
-  auto scanSpecification = getScanSpecification().toScanSpecification(index);
-  if (!scanSpecification.has_value()) {
-    return {};
-  }
   // If there is a LIMIT or OFFSET clause that constrains the scan
   // (which can happen with an explicit subquery), we cannot use the prefiltered
   // blocks, as we currently have no mechanism to include limits and offsets
@@ -280,8 +281,10 @@ Permutation::IdTableGenerator IndexScan::getLazyScan(
                           ? std::optional{std::move(blocks)}
                           : std::nullopt;
 
-  return index.getPermutation(permutation())
-      .lazyScan(std::move(scanSpecification).value(), std::move(actualBlocks),
+  return getIndex()
+      .getImpl()
+      .getPermutation(permutation())
+      .lazyScan(getScanSpecification(), std::move(actualBlocks),
                 additionalColumns(), cancellationHandle_, getLimit());
 };
 
@@ -289,12 +292,8 @@ Permutation::IdTableGenerator IndexScan::getLazyScan(
 std::optional<Permutation::MetadataAndBlocks> IndexScan::getMetadataForScan()
     const {
   const auto& index = getExecutionContext()->getIndex().getImpl();
-  auto scanSpec = getScanSpecification().toScanSpecification(index);
-  if (!scanSpec.has_value()) {
-    return std::nullopt;
-  }
   return index.getPermutation(permutation())
-      .getMetadataAndBlocks(scanSpec.value());
+      .getMetadataAndBlocks(getScanSpecification());
 };
 
 // ________________________________________________________________

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -108,7 +108,8 @@ class IndexScan final : public Operation {
   // `permutation_`. For example if `permutation_ == PSO` then the result is
   // {&predicate_, &subject_, &object_}
   std::array<const TripleComponent* const, 3> getPermutedTriple() const;
-  ScanSpecificationAsTripleComponent getScanSpecification() const;
+  ScanSpecification getScanSpecification() const;
+  ScanSpecificationAsTripleComponent getScanSpecificationTc() const;
 
  private:
   ProtoResult computeResult(bool requestLaziness) override;

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -331,9 +331,16 @@ class CompressedRelationWriter {
 
   // This is the function in `CompressedRelationsTest.cpp` that tests the
   // internals of this class and therefore needs private access.
+  /*
   friend void testCompressedRelations(const auto& inputs,
                                       std::string testCaseName,
                                       ad_utility::MemorySize blocksize);
+                                      */
+  friend std::pair<std::vector<CompressedBlockMetadata>,
+                   std::vector<CompressedRelationMetadata>>
+  compressedRelationTestWriteCompressedRelations(
+      const auto& inputs, std::string filename,
+      ad_utility::MemorySize blocksize);
 };
 
 using namespace std::string_view_literals;

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -295,8 +295,7 @@ IdTable Index::scan(
 }
 
 // ____________________________________________________________________________
-size_t Index::getResultSizeOfScan(
-    const ScanSpecificationAsTripleComponent& scanSpecification,
-    const Permutation::Enum& permutation) const {
+size_t Index::getResultSizeOfScan(const ScanSpecification& scanSpecification,
+                                  const Permutation::Enum& permutation) const {
   return pimpl_->getResultSizeOfScan(scanSpecification, permutation);
 }

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -252,9 +252,8 @@ class Index {
 
   // Similar to the previous overload of `scan`, but only get the exact size of
   // the scan result.
-  size_t getResultSizeOfScan(
-      const ScanSpecificationAsTripleComponent& scanSpecification,
-      const Permutation::Enum& permutation) const;
+  size_t getResultSizeOfScan(const ScanSpecification& scanSpecification,
+                             const Permutation::Enum& permutation) const;
 
   // Get access to the implementation. This should be used rarely as it
   // requires including the rather expensive `IndexImpl.h` header

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1421,13 +1421,7 @@ IdTable IndexImpl::scan(
     const ad_utility::SharedCancellationHandle& cancellationHandle,
     const LimitOffsetClause& limitOffset) const {
   auto scanSpecification = scanSpecificationAsTc.toScanSpecification(*this);
-  if (!scanSpecification.has_value()) {
-    cancellationHandle->throwIfCancelled();
-    return IdTable{
-        scanSpecificationAsTc.numColumns() + additionalColumns.size(),
-        allocator_};
-  }
-  return scan(scanSpecification.value(), permutation, additionalColumns,
+  return scan(scanSpecification, permutation, additionalColumns,
               cancellationHandle, limitOffset);
 }
 // _____________________________________________________________________________
@@ -1442,14 +1436,9 @@ IdTable IndexImpl::scan(
 
 // _____________________________________________________________________________
 size_t IndexImpl::getResultSizeOfScan(
-    const ScanSpecificationAsTripleComponent& scanSpecificationAsTc,
+    const ScanSpecification& scanSpecification,
     const Permutation::Enum& permutation) const {
-  const Permutation& p = getPermutation(permutation);
-  auto scanSpecification = scanSpecificationAsTc.toScanSpecification(*this);
-  if (!scanSpecification.has_value()) {
-    return 0;
-  }
-  return p.getResultSizeOfScan(scanSpecification.value());
+  return getPermutation(permutation).getResultSizeOfScan(scanSpecification);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -437,9 +437,8 @@ class IndexImpl {
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
-  size_t getResultSizeOfScan(
-      const ScanSpecificationAsTripleComponent& scanSpecification,
-      const Permutation::Enum& permutation) const;
+  size_t getResultSizeOfScan(const ScanSpecification& scanSpecification,
+                             const Permutation::Enum& permutation) const;
 
  private:
   // Private member functions

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -124,7 +124,7 @@ std::optional<CompressedRelationMetadata> Permutation::getMetadata(
 // _____________________________________________________________________
 std::optional<Permutation::MetadataAndBlocks> Permutation::getMetadataAndBlocks(
     const ScanSpecification& scanSpec) const {
-  CompressedRelationReader::MetadataAndBlocksBase mb{
+  CompressedRelationReader::ScanSpecAndBlocks mb{
       scanSpec,
       CompressedRelationReader::getRelevantBlocks(scanSpec, meta_.blockData())};
 

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -124,13 +124,16 @@ std::optional<CompressedRelationMetadata> Permutation::getMetadata(
 // _____________________________________________________________________
 std::optional<Permutation::MetadataAndBlocks> Permutation::getMetadataAndBlocks(
     const ScanSpecification& scanSpec) const {
-  MetadataAndBlocks result{
+  CompressedRelationReader::MetadataAndBlocksBase mb{
       scanSpec,
-      CompressedRelationReader::getRelevantBlocks(scanSpec, meta_.blockData()),
-      std::nullopt};
+      CompressedRelationReader::getRelevantBlocks(scanSpec, meta_.blockData())};
 
-  result.firstAndLastTriple_ = reader().getFirstAndLastTriple(result);
-  return result;
+  auto firstAndLastTriple = reader().getFirstAndLastTriple(mb);
+  if (!firstAndLastTriple.has_value()) {
+    return std::nullopt;
+  }
+  return MetadataAndBlocks{std::move(mb),
+                           std::move(firstAndLastTriple.value())};
 }
 
 // _____________________________________________________________________

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -70,7 +70,8 @@ class Permutation {
       const CancellationHandle& cancellationHandle) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
-  using MetadataAndBlocks = CompressedRelationReader::MetadataAndBlocks;
+  using MetadataAndBlocks =
+      CompressedRelationReader::ScanSpecAndBlocksAndBounds;
 
   using IdTableGenerator = CompressedRelationReader::IdTableGenerator;
 
@@ -84,7 +85,7 @@ class Permutation {
   //   with the `col1Id` if specified), else the behavior is
   //   undefined.
   // TODO<joka921> We should only communicate this interface via the
-  // `MetadataAndBlocks` class and make this a strong class that always
+  // `ScanSpecAndBlocksAndBounds` class and make this a strong class that always
   // maintains its invariants.
   IdTableGenerator lazyScan(
       const ScanSpecification& scanSpec,

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -94,10 +94,10 @@ class Permutation {
 
   std::optional<CompressedRelationMetadata> getMetadata(Id col0Id) const;
 
-  // Return the metadata for the relation specified by the `col0Id`
-  // along with the metadata for all the blocks that contain this relation (also
-  // prefiltered by the `col1Id` if specified). If the `col0Id` does not exist
-  // in this permutation, `nullopt` is returned.
+  // Return the metadata for the scan specified by the `scanSpecification`
+  // along with the metadata for all the blocks that are relevant for this scan.
+  // If there are no matching blocks (meaning that the scan result will be
+  // empty) return `nullopt`.
   std::optional<MetadataAndBlocks> getMetadataAndBlocks(
       const ScanSpecification& scanSpec) const;
 

--- a/src/index/ScanSpecification.cpp
+++ b/src/index/ScanSpecification.cpp
@@ -8,46 +8,43 @@
 #include "index/IndexImpl.h"
 
 // ____________________________________________________________________________
-std::optional<ScanSpecification>
-ScanSpecificationAsTripleComponent::toScanSpecification(
+ScanSpecification ScanSpecificationAsTripleComponent::toScanSpecification(
     const Index& index) const {
   return toScanSpecification(index.getImpl());
 }
 
 // ____________________________________________________________________________
-std::optional<ScanSpecification>
-ScanSpecificationAsTripleComponent::toScanSpecification(
+ScanSpecification ScanSpecificationAsTripleComponent::toScanSpecification(
     const IndexImpl& index) const {
-  // TODO<C++23> Use `std::optional::transform`.
-  // TODO<SPARQL UPDATE>: We can also have LocalVocab entries is the
-  // ScanSpecification.
-  bool nonexistingVocabEntryFound = false;
+  LocalVocab localVocab;
   auto getId =
-      [&index, &nonexistingVocabEntryFound](
+      [&index, &localVocab](
           const std::optional<TripleComponent>& tc) -> std::optional<Id> {
+    // TODO<C++23> Use `std::optional::transform`.
     if (!tc.has_value()) {
       return std::nullopt;
     }
-    auto id = tc.value().toValueId(index.getVocab());
-    if (!id.has_value()) {
-      nonexistingVocabEntryFound = true;
-    }
-    return id;
+    return TripleComponent{tc.value()}.toValueId(index.getVocab(), localVocab);
   };
   std::optional<Id> col0Id = getId(col0_);
   std::optional<Id> col1Id = getId(col1_);
   std::optional<Id> col2Id = getId(col2_);
 
-  if (nonexistingVocabEntryFound) {
-    return std::nullopt;
+  ScanSpecification::Graphs graphsToFilter = std::nullopt;
+  if (graphsToFilter_.has_value()) {
+    graphsToFilter.emplace();
+    for (const auto& graph : graphsToFilter_.value()) {
+      graphsToFilter->insert(getId(graph).value());
+    }
   }
-  return ScanSpecification{col0Id, col1Id, col2Id};
+  return {col0Id, col1Id, col2Id, std::move(localVocab),
+          std::move(graphsToFilter)};
 }
 
 // ____________________________________________________________________________
-ScanSpecificationAsTripleComponent::ScanSpecificationAsTripleComponent(T col0,
-                                                                       T col1,
-                                                                       T col2) {
+ScanSpecificationAsTripleComponent::ScanSpecificationAsTripleComponent(
+    T col0, T col1, T col2, Graphs graphsToFilter)
+    : graphsToFilter_{std::move(graphsToFilter)} {
   auto toNulloptIfVariable = [](T& tc) -> std::optional<TripleComponent> {
     if (tc.has_value() && tc.value().isVariable()) {
       return std::nullopt;

--- a/src/index/ScanSpecification.cpp
+++ b/src/index/ScanSpecification.cpp
@@ -74,13 +74,18 @@ size_t ScanSpecificationAsTripleComponent::numColumns() const {
 
 // _____________________________________________________________________________
 void ScanSpecification::validate() const {
-  bool c0 = col0Id_.has_value();
-  bool c1 = col1Id_.has_value();
-  bool c2 = col2Id_.has_value();
-  if (!c0) {
-    AD_CORRECTNESS_CHECK(!c1 && !c2);
-  }
-  if (!c1) {
-    AD_CORRECTNESS_CHECK(!c2);
-  }
+  auto forEach = [this](auto f) {
+    f(col0Id_);
+    f(col1Id_);
+    f(col2Id_);
+  };
+
+  auto checkNulloptImpliesFollowingNullopt = [nulloptFound =
+                                                  false](const T& id) mutable {
+    if (nulloptFound) {
+      AD_CONTRACT_CHECK(!id.has_value());
+    }
+    nulloptFound = !id.has_value();
+  };
+  forEach(checkNulloptImpliesFollowingNullopt);
 }

--- a/src/index/ScanSpecification.h
+++ b/src/index/ScanSpecification.h
@@ -20,14 +20,22 @@ class Index;
 // the knowledge graph at all. The values which are `nullopt` become variables
 // and are returned as columns in the result of the scan.
 class ScanSpecification {
- private:
+ public:
   using T = std::optional<Id>;
   using Graphs = std::optional<ad_utility::HashSet<Id>>;
 
+ private:
   T col0Id_;
   T col1Id_;
   T col2Id_;
+  // A local vocab that is needed in case at least one of the `colXIds_` has
+  // type `LocalVocabIndex`. Note that this doesn't automatically mean that the
+  // scan result will be empty, because local vocab entries might also be
+  // created by SPARQL UPDATE requests.
   std::shared_ptr<const LocalVocab> localVocab_;
+
+  // If specified (i.e. not `nullopt`) then the result of the scan only consists
+  // of triples that belong to one of the graphs.
   Graphs graphsToFilter_{};
   friend class ScanSpecificationAsTripleComponent;
 
@@ -48,13 +56,6 @@ class ScanSpecification {
   const T& col2Id() const { return col2Id_; }
 
   const Graphs& graphsToFilter() const { return graphsToFilter_; }
-
-  bool operator==(const ScanSpecification& s) const {
-    auto tie = [](const ScanSpecification& x) {
-      return std::tie(x.col0Id_, x.col1Id_, x.col2Id_, x.graphsToFilter_);
-    };
-    return tie(*this) == tie(s);
-  }
 
   // Only used in tests.
   void setCol1Id(T col1Id) {

--- a/src/index/ScanSpecification.h
+++ b/src/index/ScanSpecification.h
@@ -32,10 +32,16 @@ class ScanSpecification {
   // type `LocalVocabIndex`. Note that this doesn't automatically mean that the
   // scan result will be empty, because local vocab entries might also be
   // created by SPARQL UPDATE requests.
+  // Note: This `localVocab` keeps the `colXIds` alive in that case. It is a
+  // serious bug, to copy the `colXIds` out of this class. The only valid usage
+  // is to compare them with other IDs as long as the `ScanSpecification` is
+  // still alive.
+  // TODO<joka921> This can be enforced by the type system, but that requires
+  // several intrusive changes in other parts of QLever.
   std::shared_ptr<const LocalVocab> localVocab_;
 
   // If specified (i.e. not `nullopt`) then the result of the scan only consists
-  // of triples that belong to one of the graphs.
+  // of triples that belong to the union of these graphs.
   Graphs graphsToFilter_{};
   friend class ScanSpecificationAsTripleComponent;
 

--- a/src/index/ScanSpecification.h
+++ b/src/index/ScanSpecification.h
@@ -22,24 +22,34 @@ class Index;
 class ScanSpecification {
  private:
   using T = std::optional<Id>;
+  using Graphs = std::optional<ad_utility::HashSet<Id>>;
 
   T col0Id_;
   T col1Id_;
   T col2Id_;
+  std::shared_ptr<const LocalVocab> localVocab_;
+  Graphs graphsToFilter_;
   friend class ScanSpecificationAsTripleComponent;
 
   void validate() const;
 
  public:
-  ScanSpecification(T col0Id, T col1Id, T col2Id)
-      : col0Id_{col0Id}, col1Id_{col1Id}, col2Id_{col2Id} {
+  ScanSpecification(T col0Id, T col1Id, T col2Id, LocalVocab localVocab = {},
+                    Graphs graphsToFilter = std::nullopt)
+      : col0Id_{col0Id},
+        col1Id_{col1Id},
+        col2Id_{col2Id},
+        localVocab_{std::make_shared<LocalVocab>(std::move(localVocab))},
+        graphsToFilter_(std::move(graphsToFilter)) {
     validate();
   }
   const T& col0Id() const { return col0Id_; }
   const T& col1Id() const { return col1Id_; }
   const T& col2Id() const { return col2Id_; }
 
-  bool operator==(const ScanSpecification&) const = default;
+  const Graphs& graphsToFilter() const { return graphsToFilter_; }
+
+  // bool operator==(const ScanSpecification&) const = default;
 
   // Only used in tests.
   void setCol1Id(T col1Id) {
@@ -51,30 +61,28 @@ class ScanSpecification {
 // Same as `ScanSpecification` (see above), but stores `TripleComponent`s
 // instead of `Id`s.
 class ScanSpecificationAsTripleComponent {
+ public:
   using T = std::optional<TripleComponent>;
+  using Graphs = std::optional<ad_utility::HashSet<TripleComponent>>;
 
  private:
-  std::optional<TripleComponent> col0_;
-  std::optional<TripleComponent> col1_;
-  std::optional<TripleComponent> col2_;
+  T col0_;
+  T col1_;
+  T col2_;
+  Graphs graphsToFilter_;
 
  public:
   // Construct from three optional `TripleComponent`s. If any of the three
   // entries is unbound (`nullopt` or of type `Variable`), then all subsequent
   // entries also have to be unbound. For example if `col0` is bound, but `col1`
   // isn't, then `col2` also has to be unbound.
-  ScanSpecificationAsTripleComponent(T col0, T col1, T col2);
+  ScanSpecificationAsTripleComponent(T col0, T col1, T col2,
+                                     Graphs graphsToFilter = std::nullopt);
 
   // Convert to a `ScanSpecification`. The `index` is used to convert the
-  // `TripleComponent` to `Id`s by looking them up in the vocabulary. Return
-  // `nullopt` if and only if one of the vocab lookup fails (then the result of
-  // the corresponding scan will be empty).
-  // TODO<joka921> Once we implement SPARQL UPDATE, we possibly also to use the
-  // `LocalVocab` of the UPDATE triples here.
-  std::optional<ScanSpecification> toScanSpecification(
-      const IndexImpl& index) const;
-  std::optional<ScanSpecification> toScanSpecification(
-      const Index& index) const;
+  // `TripleComponent` to `Id`s by looking them up in the vocabulary.
+  ScanSpecification toScanSpecification(const IndexImpl& index) const;
+  ScanSpecification toScanSpecification(const Index& index) const;
 
   // The number of columns that the corresponding index scan will have.
   size_t numColumns() const;

--- a/src/index/ScanSpecification.h
+++ b/src/index/ScanSpecification.h
@@ -28,7 +28,7 @@ class ScanSpecification {
   T col1Id_;
   T col2Id_;
   std::shared_ptr<const LocalVocab> localVocab_;
-  Graphs graphsToFilter_;
+  Graphs graphsToFilter_{};
   friend class ScanSpecificationAsTripleComponent;
 
   void validate() const;
@@ -49,7 +49,12 @@ class ScanSpecification {
 
   const Graphs& graphsToFilter() const { return graphsToFilter_; }
 
-  // bool operator==(const ScanSpecification&) const = default;
+  bool operator==(const ScanSpecification& s) const {
+    auto tie = [](const ScanSpecification& x) {
+      return std::tie(x.col0Id_, x.col1Id_, x.col2Id_, x.graphsToFilter_);
+    };
+    return tie(*this) == tie(s);
+  }
 
   // Only used in tests.
   void setCol1Id(T col1Id) {
@@ -69,7 +74,7 @@ class ScanSpecificationAsTripleComponent {
   T col0_;
   T col1_;
   T col2_;
-  Graphs graphsToFilter_;
+  Graphs graphsToFilter_{};
 
  public:
   // Construct from three optional `TripleComponent`s. If any of the three

--- a/test/index/ScanSpecificationTest.cpp
+++ b/test/index/ScanSpecificationTest.cpp
@@ -8,6 +8,27 @@
 #include "../util/IndexTestHelpers.h"
 #include "index/ScanSpecification.h"
 
+TEST(ScanSpecification, getters) {
+  Id i = Id::makeFromInt(42);
+  Id j = Id::makeFromInt(47);
+  Id k = Id::makeFromInt(49);
+  auto s = ScanSpecification{i, j, k};
+  EXPECT_EQ(s.col0Id(), i);
+  EXPECT_EQ(s.col1Id(), j);
+  EXPECT_EQ(s.col2Id(), k);
+  AD_EXPECT_NULLOPT(s.graphsToFilter());
+
+  auto graphsToFilter = ad_utility::HashSet<Id>{i, k};
+
+  auto n = std::nullopt;
+  s = ScanSpecification{n, n, n, {}, graphsToFilter};
+  AD_EXPECT_NULLOPT(s.col0Id());
+  AD_EXPECT_NULLOPT(s.col1Id());
+  AD_EXPECT_NULLOPT(s.col2Id());
+  EXPECT_THAT(s.graphsToFilter(),
+              ::testing::Optional(
+                  ::testing::UnorderedElementsAreArray(graphsToFilter)));
+}
 // _____________________________________________________________________________
 TEST(ScanSpecification, validate) {
   Id i = Id::makeFromInt(42);
@@ -45,24 +66,39 @@ TEST(ScanSpecification, ScanSpecificationAsTripleComponent) {
   // Match that a `ScanSpecificationAsTripleComponent` has the expected number
   // of columns, and yields the expected `ScanSpecification` when
   // `toScanSpecification` is called on it.
-  auto matchScanSpec =
-      [&toScanSpec](const std::optional<ScanSpecification> spec,
-                    size_t numColumns = 0) -> ::testing::Matcher<const STc&> {
+  auto matchScanSpec = [&toScanSpec](const ScanSpecification spec,
+                                     size_t numColumns =
+                                         0) -> ::testing::Matcher<const STc&> {
     auto innerMatcher = [&toScanSpec, &spec] {
-      return ::testing::ResultOf(toScanSpec, ::testing::Eq(spec));
+      using namespace ::testing;
+      auto graphMatcher = [&spec]() -> Matcher<const S::Graphs&> {
+        if (!spec.graphsToFilter().has_value()) {
+          return Eq(std::nullopt);
+        } else {
+          return Optional(
+              UnorderedElementsAreArray(spec.graphsToFilter().value()));
+        }
+      };
+      return ResultOf(toScanSpec,
+                      AllOf(AD_PROPERTY(S, col0Id, spec.col0Id()),
+                            AD_PROPERTY(S, col1Id, spec.col1Id()),
+                            AD_PROPERTY(S, col2Id, spec.col2Id()),
+                            AD_PROPERTY(S, graphsToFilter, graphMatcher())));
     };
-    if (!spec.has_value()) {
-      return innerMatcher();
-    } else {
-      return ::testing::AllOf(
-          innerMatcher(),
-          AD_PROPERTY(STc, numColumns, ::testing::Eq(numColumns)));
-    }
+    return AllOf(AD_PROPERTY(STc, numColumns, numColumns), innerMatcher());
   };
   EXPECT_THAT(STc(iTc, iTc, iTc), matchScanSpec(S(i, i, i), 0));
   EXPECT_THAT(STc(iTc, iTc, n), matchScanSpec(S(i, i, n), 1));
   EXPECT_THAT(STc(iTc, n, n), matchScanSpec(S(i, n, n), 2));
   EXPECT_THAT(STc(n, n, n), matchScanSpec(S(n, n, n), 3));
+  // An Example with graph Ids
+  using GIri = ad_utility::HashSet<TripleComponent>;
+  using G = ad_utility::HashSet<Id>;
+  ad_utility::HashSet<Id> graphs{i};
+  EXPECT_THAT(STc(n, n, n, GIri{iTc}), matchScanSpec(S(n, n, n, {}, G{i}), 3));
+  // Test that the matcher is in fact sensitive to the Graph ID.
+  EXPECT_THAT(STc(n, n, n, GIri{iTc}),
+              ::testing::Not(matchScanSpec(S(n, n, n), 3)));
 
   // Test the resolution of vocab entries.
   auto getId = ad_utility::testing::makeGetId(index);
@@ -81,6 +117,8 @@ TEST(ScanSpecification, ScanSpecificationAsTripleComponent) {
               matchScanSpec(S(localVocabId, x, x)));
   EXPECT_THAT(STc(xIri, notInVocab, xIri),
               matchScanSpec(S(x, localVocabId, x)));
-  EXPECT_THAT(STc(xIri, xIri, notInVocab),
-              matchScanSpec(S(x, x, localVocabId)));
+  EXPECT_THAT(STc(xIri, xIri, notInVocab, GIri{xIri, notInVocab}),
+              matchScanSpec(S(x, x, localVocabId, {}, G{x, localVocabId})));
+  EXPECT_THAT(STc(xIri, xIri, notInVocab, GIri{xIri, notInVocab}),
+              ::testing::Not(matchScanSpec(S(x, x, localVocabId))));
 }

--- a/test/index/ScanSpecificationTest.cpp
+++ b/test/index/ScanSpecificationTest.cpp
@@ -75,7 +75,12 @@ TEST(ScanSpecification, ScanSpecificationAsTripleComponent) {
   // `toScanSpecification` is `nullopt`.
   TripleComponent notInVocab =
       TripleComponent::Iri::fromIriref("<thisIriIsNotContained>");
-  EXPECT_THAT(STc(notInVocab, xIri, xIri), matchScanSpec(std::nullopt));
-  EXPECT_THAT(STc(xIri, notInVocab, xIri), matchScanSpec(std::nullopt));
-  EXPECT_THAT(STc(xIri, xIri, notInVocab), matchScanSpec(std::nullopt));
+  LocalVocabEntry localVocabEntry{notInVocab.getIri()};
+  auto localVocabId = Id::makeFromLocalVocabIndex(&localVocabEntry);
+  EXPECT_THAT(STc(notInVocab, xIri, xIri),
+              matchScanSpec(S(localVocabId, x, x)));
+  EXPECT_THAT(STc(xIri, notInVocab, xIri),
+              matchScanSpec(S(x, localVocabId, x)));
+  EXPECT_THAT(STc(xIri, xIri, notInVocab),
+              matchScanSpec(S(x, x, localVocabId)));
 }

--- a/test/util/GTestHelpers.h
+++ b/test/util/GTestHelpers.h
@@ -76,6 +76,7 @@ https://github.com/google/googletest/blob/main/docs/reference/matchers.md#matche
 
 // `EXPECT` that the `argument` is equal to `std::nullopt`.
 #define AD_EXPECT_NULLOPT(argument) EXPECT_EQ(argument, std::nullopt)
+
 // _____________________________________________________________________________
 // Add the given `source_location`  to all gtest failure messages that occur,
 // while the return value is still in scope. It is important to bind the return


### PR DESCRIPTION
The `ScanSpecification` class now has two additional members: a `LocalVocab` and a set of graphs. The `LocalVocab` enables that one or several of the `col0Id`, `col1Id`, `col2Id` can be new IRIs or literals (note that our comparators work fine even exactly the same IRI or literal is contained in different `LocalVocab`s). This is important for SPARQL Update. The set of graphs enables filtering of the scan result by one or severval graph IRIs.

Also convert `ScanSpecificationAsTripelComponent` to `ScanSpecification` already in the `IndexScan` class (where we already have an `Index` available to convert the `TripleComponent`s to `Id`s). In a future change, we might want to get rid of `ScanSpecificationAsTripelComponent` altogether and produce a `ScanSpecification` right away.

On the side, clean up the code and fix several bugs for empty results of index scan operations that only occur with lazy operations.