### PR TITLE
Link `CompilationInfo` only to `ServerMain` and `IndexBuilderMain`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,12 +409,13 @@ add_subdirectory(test)
 # Add the library with the constants declared in `CompilationInfo.h` and defined
 # in `CompilationInfo.cpp` created by `CompilationInfo.cmake`.
 add_library(compilationInfo ${CMAKE_CURRENT_BINARY_DIR}/CompilationInfo.cpp)
+qlever_target_link_libraries(compilationInfo)
 
 add_executable(IndexBuilderMain src/index/IndexBuilderMain.cpp)
-qlever_target_link_libraries(IndexBuilderMain index ${CMAKE_THREAD_LIBS_INIT} Boost::program_options)
+qlever_target_link_libraries(IndexBuilderMain index ${CMAKE_THREAD_LIBS_INIT} Boost::program_options compilationInfo)
 
 add_executable(ServerMain src/ServerMain.cpp)
-qlever_target_link_libraries(ServerMain engine ${CMAKE_THREAD_LIBS_INIT} Boost::program_options)
+qlever_target_link_libraries(ServerMain engine ${CMAKE_THREAD_LIBS_INIT} Boost::program_options compilationInfo)
 target_precompile_headers(ServerMain REUSE_FROM engine)
 
 add_executable(VocabularyMergerMain src/VocabularyMergerMain.cpp)

--- a/CompilationInfo.cmake
+++ b/CompilationInfo.cmake
@@ -20,6 +20,11 @@ namespace qlever::version {
 constexpr std::string_view GitHash = ${GIT_HASH};
 constexpr std::string_view GitShortHash = GitHash.substr(0, 6);
 constexpr std::string_view DatetimeOfCompilation = ${DATETIME_OF_COMPILATION};
+
+void copyVersionInfo() {
+  *gitShortHashWithoutLinking.wlock() = GitShortHash;
+  *datetimeOfCompilationWithoutLinking.wlock() = DatetimeOfCompilation;
+}
 }")
 
 # For some reason `CMAKE_CURRENT_SOURCE_DIR` inside this script is

--- a/src/CompilationInfo.h
+++ b/src/CompilationInfo.h
@@ -6,10 +6,32 @@
 // File `CompilationInfo.cpp` which is created and linked by CMake.
 
 #pragma once
+#include <atomic>
 #include <string_view>
+
+#include "util/Synchronized.h"
 namespace qlever::version {
-// Short version of the hash of the commit that was used to QLever.
+
+// The following two constants require linking against the `compilationInfo`
+// library which is recreated on every compilation. Short version of the hash of
+
+// The commit that was used to compile QLever.
 extern const std::string_view GitShortHash;
 // The date and time at which QLever was compiled.
 extern const std::string_view DatetimeOfCompilation;
+
+// The following two versions of the above constants do NOT require linking
+// against the `compilationInfo` library, but only the inclusion of this header.
+// They only have meaningful values once the `copyVersionInfo` function (below)
+// was called. This is currently done in the `main` functions of
+// `IndexBuilderMain.cpp` and `ServerMain.cpp`.
+inline ad_utility::Synchronized<std::string_view> gitShortHashWithoutLinking{
+    std::string_view{"git short hash not set"}};
+inline ad_utility::Synchronized<std::string_view>
+    datetimeOfCompilationWithoutLinking{
+        std::string_view{"git short hash not set"}};
+
+// Copy the values from the constants that require linking to the `inline`
+// variables that don't require linking. For details see above.
+void copyVersionInfo();
 }  // namespace qlever::version

--- a/src/ServerMain.cpp
+++ b/src/ServerMain.cpp
@@ -25,6 +25,9 @@ namespace po = boost::program_options;
 
 // Main function.
 int main(int argc, char** argv) {
+  // Copy the git hash and datetime of compilation (which require relinking)
+  // to make them accessible to other parts of the code
+  qlever::version::copyVersionInfo();
   setlocale(LC_CTYPE, "");
 
   std::locale loc;

--- a/src/index/CMakeLists.txt
+++ b/src/index/CMakeLists.txt
@@ -6,4 +6,4 @@ add_library(index
         DocsDB.cpp FTSAlgorithms.cpp
         PrefixHeuristic.cpp CompressedRelation.cpp
         PatternCreator.cpp ScanSpecification.cpp)
-qlever_target_link_libraries(index util parser vocabulary compilationInfo ${STXXL_LIBRARIES})
+qlever_target_link_libraries(index util parser vocabulary ${STXXL_LIBRARIES})

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -51,6 +51,9 @@ void writeStxxlConfigFile(const string& location, const string& tail) {
 
 // Main function.
 int main(int argc, char** argv) {
+  // Copy the git hash and datetime of compilation (which require relinking)
+  // to make them accessible to other parts of the code
+  qlever::version::copyVersionInfo();
   setlocale(LC_CTYPE, "");
 
   std::locale loc;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -857,7 +857,8 @@ void IndexImpl::setSettingsFile(const std::string& filename) {
 void IndexImpl::writeConfiguration() const {
   // Copy the configuration and add the current commit hash.
   auto configuration = configurationJson_;
-  configuration["git-hash"] = qlever::version::GitShortHash;
+  configuration["git-hash"] =
+      *qlever::version::gitShortHashWithoutLinking.wlock();
   configuration["index-format-version"] = qlever::indexFormatVersion;
   auto f = ad_utility::makeOfstream(onDiskBase_ + CONFIGURATION_FILE);
   f << configuration;


### PR DESCRIPTION
Since #734, QLever uses `cmake` magic to generate a file `CompilationInfo.cpp` with information about the commit hash of the current code and the compilation date. This information was then linked to each binary that uses the `Index` class, which includes `ServerMain` and `IndexBuilderMain` as well as most of the test binaries. As a result, re-compilation took rather long even for minor code changes, which is annoying during development.

This is now fixed by only linking this information only to `ServerMain` and `IndexBuilderMain`. All other binaries get some default values, which is fine because they don't need this information anyway. 