### PR TITLE
More tests, i.p. for error thrown in HTTP request handler

### DIFF
--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -23,6 +23,36 @@
 using std::endl;
 using std::string;
 
+namespace {
+class JoinImpl {
+ public:
+  /*
+   * @brief Combines 2 rows like in a join and inserts the result in the
+   * given table.
+   *
+   *@tparam The amount of columns in the rows and the table.
+   *
+   * @param[in] The left row of the join.
+   * @param[in] The right row of the join.
+   * @param[in] The numerical position of the join column of row b.
+   * @param[in] The table, in which the new combined row should be inserted.
+   * Must be static.
+   */
+  template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
+  static void addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
+                                      const ColumnIndex jcRowB,
+                                      IdTableStatic<TABLE_WIDTH>* table);
+
+  /*
+   * @brief The implementation of hashJoin.
+   */
+  template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
+  static void hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
+                           const IdTable& dynB, ColumnIndex jc2,
+                           IdTable* dynRes);
+};
+}  // namespace
+
 // _____________________________________________________________________________
 Join::Join(QueryExecutionContext* qec, std::shared_ptr<QueryExecutionTree> t1,
            std::shared_ptr<QueryExecutionTree> t2, ColumnIndex t1JoinCol,
@@ -409,8 +439,9 @@ void Join::join(const IdTable& a, ColumnIndex jc1, const IdTable& b,
 
 // ______________________________________________________________________________
 template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
-void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
-                        const IdTable& dynB, ColumnIndex jc2, IdTable* dynRes) {
+void JoinImpl::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
+                            const IdTable& dynB, ColumnIndex jc2,
+                            IdTable* dynRes) {
   const IdTableView<L_WIDTH> a = dynA.asStaticView<L_WIDTH>();
   const IdTableView<R_WIDTH> b = dynB.asStaticView<R_WIDTH>();
 
@@ -479,11 +510,11 @@ void Join::hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
         // branch gets discarded at compile time, which makes this
         // condition have constant runtime.
         if constexpr (leftIsLarger) {
-          addCombinedRowToIdTable(largerTable[i], row, smallerTableJoinColumn,
-                                  &result);
+          JoinImpl::addCombinedRowToIdTable(largerTable[i], row,
+                                            smallerTableJoinColumn, &result);
         } else {
-          addCombinedRowToIdTable(row, largerTable[i], largerTableJoinColumn,
-                                  &result);
+          JoinImpl::addCombinedRowToIdTable(row, largerTable[i],
+                                            largerTableJoinColumn, &result);
         }
       }
     }
@@ -510,14 +541,14 @@ void Join::hashJoin(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
                     ColumnIndex jc2, IdTable* dynRes) {
   CALL_FIXED_SIZE(
       (std::array{dynA.numColumns(), dynB.numColumns(), dynRes->numColumns()}),
-      &Join::hashJoinImpl, this, dynA, jc1, dynB, jc2, dynRes);
+      &JoinImpl::hashJoinImpl, dynA, jc1, dynB, jc2, dynRes);
 }
 
 // ___________________________________________________________________________
 template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
-void Join::addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
-                                   const ColumnIndex jcRowB,
-                                   IdTableStatic<TABLE_WIDTH>* table) {
+void JoinImpl::addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
+                                       const ColumnIndex jcRowB,
+                                       IdTableStatic<TABLE_WIDTH>* table) {
   // Add a new, empty row.
   const size_t backIndex = table->size();
   table->emplace_back();

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -95,8 +95,6 @@ class Join : public Operation {
   void join(const IdTable& a, ColumnIndex jc1, const IdTable& b,
             ColumnIndex jc2, IdTable* result) const;
 
-  friend class JoinImpl;
-
   /**
    * @brief Joins IdTables dynA and dynB on join column jc2, returning
    * the result in dynRes. Creates a cross product for matching rows by putting
@@ -135,4 +133,31 @@ class Join : public Operation {
                                               ColumnIndex joinColTable,
                                               IndexScan& scan,
                                               ColumnIndex joinColScan);
+
+  using ScanMethodType = std::function<IdTable(Id)>;
+
+  /*
+   * @brief Combines 2 rows like in a join and inserts the result in the
+   * given table.
+   *
+   *@tparam The amount of columns in the rows and the table.
+   *
+   * @param[in] The left row of the join.
+   * @param[in] The right row of the join.
+   * @param[in] The numerical position of the join column of row b.
+   * @param[in] The table, in which the new combined row should be inserted.
+   * Must be static.
+   */
+  template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
+  static void addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
+                                      const ColumnIndex jcRowB,
+                                      IdTableStatic<TABLE_WIDTH>* table);
+
+  /*
+   * @brief The implementation of hashJoin.
+   */
+  template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
+  static void hashJoinImpl(const IdTable& dynA, ColumnIndex jc1,
+                           const IdTable& dynB, ColumnIndex jc2,
+                           IdTable* dynRes);
 };

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -95,6 +95,8 @@ class Join : public Operation {
   void join(const IdTable& a, ColumnIndex jc1, const IdTable& b,
             ColumnIndex jc2, IdTable* result) const;
 
+  friend class JoinImpl;
+
   /**
    * @brief Joins IdTables dynA and dynB on join column jc2, returning
    * the result in dynRes. Creates a cross product for matching rows by putting
@@ -133,38 +135,4 @@ class Join : public Operation {
                                               ColumnIndex joinColTable,
                                               IndexScan& scan,
                                               ColumnIndex joinColScan);
-
-  using ScanMethodType = std::function<IdTable(Id)>;
-
-  ScanMethodType getScanMethod(
-      std::shared_ptr<QueryExecutionTree> fullScanDummyTree) const;
-
-  void appendCrossProduct(const IdTable::const_iterator& leftBegin,
-                          const IdTable::const_iterator& leftEnd,
-                          const IdTable::const_iterator& rightBegin,
-                          const IdTable::const_iterator& rightEnd,
-                          IdTable* res) const;
-  /*
-   * @brief Combines 2 rows like in a join and inserts the result in the
-   * given table.
-   *
-   *@tparam The amount of columns in the rows and the table.
-   *
-   * @param[in] The left row of the join.
-   * @param[in] The right row of the join.
-   * @param[in] The numerical position of the join column of row b.
-   * @param[in] The table, in which the new combined row should be inserted.
-   * Must be static.
-   */
-  template <typename ROW_A, typename ROW_B, int TABLE_WIDTH>
-  static void addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
-                                      const ColumnIndex jcRowB,
-                                      IdTableStatic<TABLE_WIDTH>* table);
-
-  /*
-   * @brief The implementation of hashJoin.
-   */
-  template <int L_WIDTH, int R_WIDTH, int OUT_WIDTH>
-  void hashJoinImpl(const IdTable& dynA, ColumnIndex jc1, const IdTable& dynB,
-                    ColumnIndex jc2, IdTable* dynRes);
 };

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -62,32 +62,6 @@ std::string OrderBy::getDescriptor() const {
   return "OrderBy on" + orderByVars;
 }
 
-static auto sortImpl(const auto& sortIndices, auto& idTable, auto width) {
-  // Return true iff `rowA` comes before `rowB` in the sort order specified by
-  // `sortIndices_`.
-  auto comparison = [&sortIndices](const auto& row1, const auto& row2) -> bool {
-    for (auto& [column, isDescending] : sortIndices) {
-      if (row1[column] == row2[column]) {
-        continue;
-      }
-      bool isLessThan =
-          toBoolNotUndef(valueIdComparators::compareIds<
-                         valueIdComparators::ComparisonForIncompatibleTypes::
-                             CompareByType>(
-              row1[column], row2[column], valueIdComparators::Comparison::LT));
-      return isLessThan != isDescending;
-    }
-    return false;
-  };
-
-  // We cannot use the `CALL_FIXED_SIZE` macro here because the `sort` function
-  // is templated not only on the integer `I` (which the `callFixedSize`
-  // function deals with) but also on the `comparison`.
-  ad_utility::callFixedSize(width, [&idTable, &comparison]<size_t I>() {
-    Engine::sort<I>(&idTable, comparison);
-  });
-}
-
 // _____________________________________________________________________________
 ProtoResult OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
@@ -125,8 +99,6 @@ ProtoResult OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   // only contains a single datatype, then we can use more efficient
   // implementations here.
 
-  sortImpl(sortIndices_, idTable, width);
-  /*
   // Return true iff `rowA` comes before `rowB` in the sort order specified by
   // `sortIndices_`.
   auto comparison = [this](const auto& row1, const auto& row2) -> bool {
@@ -150,7 +122,6 @@ ProtoResult OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   ad_utility::callFixedSize(width, [&idTable, &comparison]<size_t I>() {
     Engine::sort<I>(&idTable, comparison);
   });
-   */
   // We can't check during sort, so reset status here
   cancellationHandle_->resetWatchDogState();
   checkCancellation();

--- a/src/util/AsyncStream.h
+++ b/src/util/AsyncStream.h
@@ -73,8 +73,8 @@ cppcoro::generator<typename Range::value_type> runStreamAsync(
   }
   ifTiming([&t] {
     t->stop();
-    LOG(INFO) << "Waiting time for async stream was " << t->msecs().count()
-              << "ms" << std::endl;
+    LOG(TRACE) << "Waiting time for async stream was " << t->msecs().count()
+               << "ms" << std::endl;
   });
 }
 }  // namespace ad_utility::streams

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -553,3 +553,13 @@ TEST(DateYearOrDuration, Order) {
   ASSERT_LT(d7, d4);
   ASSERT_LT(d7, d6);
 }
+
+// _____________________________________________________________________________
+TEST(DateYearOrDuration, Hashing) {
+  DateYearOrDuration d1{
+      DayTimeDuration{DayTimeDuration::Type::Positive, 0, 23, 23, 62.44}};
+  DateYearOrDuration d2{
+      DayTimeDuration{DayTimeDuration::Type::Positive, 1, 24, 23, 62.44}};
+  ad_utility::HashSet<DateYearOrDuration> set{d1, d2};
+  EXPECT_THAT(set, ::testing::UnorderedElementsAre(d1, d2));
+}

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -148,15 +148,22 @@ TEST(HttpServer, HttpTest) {
   }
 }
 
+// Test the various `catch` clauses in `HttpServer::session`.
 TEST(HttpServer, ErrorHandlingInSession) {
+  // We will interfere with the logging to test it, so we have to reset the
+  // logging after we are done.
   absl::Cleanup cleanup{
       []() { ad_utility::setGlobalLoggingStream(&std::cout); }};
   ad_utility::SharedCancellationHandle handle =
       std::make_shared<ad_utility::CancellationHandle<>>();
-  // Create and run an HTTP server, which replies to each request with three
+
+  // Create an HTTP server, which replies to each request with three
   // lines: the request method (GET, POST, or OTHER), a copy of the request
   // target (might be empty), and a copy of the request body (might be empty).
-
+  // After sending the response, the exception denoted by the `exceptionPtr`
+  // will be thrown. This exception will be propagated to the
+  // `HttpServer::session` method, the exception behavior of which we want to
+  // test.
   auto makeHttpServer = [](std::exception_ptr exceptionPtr) {
     AD_CORRECTNESS_CHECK(exceptionPtr);
     return TestHttpServer([exception = std::move(exceptionPtr)](
@@ -186,20 +193,36 @@ TEST(HttpServer, ErrorHandlingInSession) {
       // First send a response, to make the client happy.
       co_await send(createOkResponse(std::move(response), request,
                                      ad_utility::MediaType::textPlain));
+      // Then throw an exception.
       AD_CORRECTNESS_CHECK(exception);
       std::rethrow_exception(exception);
     });
   };
 
-  auto setExceptionPtr = [&makeHttpServer, &handle](auto exceptionObject) {
+  // Do the following: Create an HtttpServer using the above method that throws
+  // the `exceptionObject` after sending the response. Then send an HTTP request
+  // to that server to trigger the exception. Capture the log of the server and
+  // return it, s.t. it can be tested.
+  auto throwAndCaptureLog = [&makeHttpServer, &handle](auto exceptionObject) {
+    // Redirect the log, s.t. we can return it later.
     std::stringstream logStream;
     ad_utility::setGlobalLoggingStream(&logStream);
+
+    // Convert the `exceptionObject` to an `exception_ptr`
     std::exception_ptr exception;
     try {
       throw exceptionObject;
     } catch (...) {
       exception = std::current_exception();
     }
+
+    // Create and run a server and send a request to it. The exception will be
+    // caught by the `session` method, and a log statement will be issued
+    // depending on the exception. Note: We need a separate server for each
+    // test, because we need to shut down the server before extracting its log,
+    // otherwise we have a race condition on the logging. An alternative would
+    // be to implement a threadsafe `stringstream`, but the chosen approach also
+    // works for our purposes.
     auto httpServer = makeHttpServer(exception);
     httpServer.runInOwnThread();
     auto httpClient = std::make_unique<HttpClient>(
@@ -207,21 +230,28 @@ TEST(HttpServer, ErrorHandlingInSession) {
 
     auto response = HttpClient::sendRequest(std::move(httpClient), verb::get,
                                             "localhost", "target1", handle);
+    // Check the response.
     EXPECT_EQ(response.status_, boost::beast::http::status::ok);
     EXPECT_EQ(response.contentType_, "text/plain");
     EXPECT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
+
+    // We need to shut down the server first to not have a race condition on the
+    // logging stream.
     httpServer.shutDown();
     // logStream.emit();
     return logStream.str();
   };
 
   using namespace ::testing;
-  auto s = setExceptionPtr(
+  // Logging of a general `boost` exception.
+  auto s = throwAndCaptureLog(
       beast::system_error{boost::asio::error::host_not_found_try_again});
   EXPECT_THAT(s, HasSubstr("Host not found"));
 
-  s = setExceptionPtr(beast::system_error{beast::error::timeout});
-  s += setExceptionPtr(beast::system_error{boost::asio::error::eof});
+  // The `timeout`and `eof` exceptions are only logged in the `TRACE` level,
+  // normally they are silently caught and ignored.
+  s = throwAndCaptureLog(beast::system_error{beast::error::timeout});
+  s += throwAndCaptureLog(beast::system_error{boost::asio::error::eof});
   if (LOGLEVEL >= TRACE) {
     EXPECT_THAT(s,
                 AllOf(HasSubstr("due to a timeout"), HasSubstr("End of file")));
@@ -229,10 +259,12 @@ TEST(HttpServer, ErrorHandlingInSession) {
     EXPECT_THAT(s, Eq(""));
   }
 
-  s = setExceptionPtr(std::runtime_error{"The runtime error for testing"});
+  // Handling of `std::exception`.
+  s = throwAndCaptureLog(std::runtime_error{"The runtime error for testing"});
   EXPECT_THAT(s, HasSubstr("The runtime error for testing"));
 
-  s = setExceptionPtr(47);
+  // Thrown object that is not a `std::exception`.
+  s = throwAndCaptureLog(47);
   EXPECT_THAT(s,
               HasSubstr("Weird exception not inheriting from std::exception"));
 }

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -147,3 +147,87 @@ TEST(HttpServer, HttpTest) {
         HttpClient("localhost", std::to_string(httpServer.getPort())));
   }
 }
+
+TEST(HttpServer, ErrorHandlingInSession) {
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  // Create and run an HTTP server, which replies to each request with three
+  // lines: the request method (GET, POST, or OTHER), a copy of the request
+  // target (might be empty), and a copy of the request body (might be empty).
+
+  std::exception_ptr exception;
+  std::stringstream logStream;
+  ad_utility::setGlobalLoggingStream(&logStream);
+  TestHttpServer httpServer(
+      [&exception](auto request, auto&& send) -> boost::asio::awaitable<void> {
+        std::string methodName;
+        switch (request.method()) {
+          case boost::beast::http::verb::get:
+            methodName = "GET";
+            break;
+          case boost::beast::http::verb::post:
+            methodName = "POST";
+            break;
+          default:
+            methodName = "OTHER";
+        }
+
+        auto response =
+            [](std::string methodName, std::string target,
+               std::string body) -> cppcoro::generator<std::string> {
+          co_yield methodName;
+          co_yield "\n";
+          co_yield target;
+          co_yield "\n";
+          co_yield body;
+        }(methodName, std::string(toStd(request.target())), request.body());
+
+        // First send a response, to make the client happy.
+        co_await send(createOkResponse(std::move(response), request,
+                                       ad_utility::MediaType::textPlain));
+        AD_CORRECTNESS_CHECK(exception);
+        std::rethrow_exception(exception);
+      });
+  httpServer.runInOwnThread();
+
+  auto setExceptionPtr = [&exception, &httpServer,
+                          &handle](auto exceptionObject) {
+    try {
+      throw exceptionObject;
+    } catch (...) {
+      exception = std::current_exception();
+    }
+    auto httpClient = std::make_unique<HttpClient>(
+        "localhost", std::to_string(httpServer.getPort()));
+
+    auto response = HttpClient::sendRequest(std::move(httpClient), verb::get,
+                                            "localhost", "target1", handle);
+    ASSERT_EQ(response.status_, boost::beast::http::status::ok);
+    ASSERT_EQ(response.contentType_, "text/plain");
+    ASSERT_EQ(toString(std::move(response.body_)), "GET\ntarget1\n");
+  };
+
+  using namespace ::testing;
+  setExceptionPtr(
+      beast::system_error{boost::asio::error::host_not_found_try_again});
+  EXPECT_THAT(logStream.str(), HasSubstr("Host not found"));
+  logStream.str("");
+
+  setExceptionPtr(beast::system_error{beast::error::timeout});
+  setExceptionPtr(beast::system_error{boost::asio::error::eof});
+  if (LOGLEVEL >= TRACE) {
+    EXPECT_THAT(logStream.str(),
+                AllOf(HasSubstr("due to a timeout"), HasSubstr("End of file")));
+  } else {
+    EXPECT_THAT(logStream.str(), Eq(""));
+  }
+
+  logStream.str("");
+  setExceptionPtr(std::runtime_error{"The runtime error for testing"});
+  EXPECT_THAT(logStream.str(), HasSubstr("The runtime error for testing"));
+
+  logStream.str("");
+  setExceptionPtr(47);
+  EXPECT_THAT(logStream.str(),
+              HasSubstr("Weird exception not inheriting from std::exception"));
+}


### PR DESCRIPTION
The code in the `catch` clauses of `HttpServer::session` in `HttpServer.h` was untested so far. It is now cleverly tested by creating a test `HttpServer` with a request handler that throws an expection after its reponse, redirecting the log, and then checking the log messages. Also test the hashing of `DateYearOrDuration` + make some other minor changes.