### PR TITLE
Apply SERVICE optimization for OPTIONAL and MINUS

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1825,8 +1825,9 @@ auto QueryPlanner::createJoinWithService(
 }
 
 // _____________________________________________________________________
-auto QueryPlanner::createOptionalJoinWithService(
-    const SubtreePlan& a, const SubtreePlan& b) -> std::optional<SubtreePlan> {
+auto QueryPlanner::createOptionalJoinWithService(const SubtreePlan& a,
+                                                 const SubtreePlan& b)
+    -> std::optional<SubtreePlan> {
   // We can only proceed if (only) the right subtree is a `SERVICE`.
   auto aRootOp = std::dynamic_pointer_cast<Service>(a._qet->getRootOperation());
   auto bRootOp = std::dynamic_pointer_cast<Service>(b._qet->getRootOperation());

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1626,17 +1626,22 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
         " another graph pattern.");
   }
 
+  // This case shouldn't happen. If the first pattern is OPTIONAL, it
+  // is made non optional earlier. If a minus occurs after an optional
+  // further into the query that optional should be resolved by now.
+  AD_CONTRACT_CHECK(a.type != SubtreePlan::OPTIONAL);
   if (b.type == SubtreePlan::MINUS) {
-    // This case shouldn't happen. If the first pattern is OPTIONAL, it
-    // is made non optional earlier. If a minus occurs after an optional
-    // further into the query that optional should be resolved by now.
-    AD_CONTRACT_CHECK(a.type != SubtreePlan::OPTIONAL);
     return {makeSubtreePlan<Minus>(_qec, a._qet, b._qet)};
   }
 
   // OPTIONAL JOINS are not symmetric!
-  AD_CONTRACT_CHECK(a.type != SubtreePlan::OPTIONAL);
   if (b.type == SubtreePlan::OPTIONAL) {
+    // If the OPTIONAL subtree's rootOperation is a SERVICE, try to simplify it
+    // using the result of the first subtree.
+    if (auto opt = createOptionalJoinWithService(a, b)) {
+      return {opt.value()};
+    }
+
     // Join the two optional columns using an optional join
     return {makeSubtreePlan<OptionalJoin>(_qec, a._qet, b._qet)};
   }
@@ -1814,6 +1819,27 @@ auto QueryPlanner::createJoinWithService(
                                   jcs[0][siblingIdx])
           : makeSubtreePlan<MultiColumnJoin>(
                 qec, std::move(serviceWithSibling._qet), sibling._qet);
+  mergeSubtreePlanIds(plan, a, b);
+
+  return plan;
+}
+
+// _____________________________________________________________________
+auto QueryPlanner::createOptionalJoinWithService(
+    const SubtreePlan& a, const SubtreePlan& b) -> std::optional<SubtreePlan> {
+  // We can only proceed if (only) the right subtree is a `SERVICE`.
+  auto aRootOp = std::dynamic_pointer_cast<Service>(a._qet->getRootOperation());
+  auto bRootOp = std::dynamic_pointer_cast<Service>(b._qet->getRootOperation());
+  if (static_cast<bool>(aRootOp) || !static_cast<bool>(bRootOp)) {
+    return std::nullopt;
+  }
+
+  auto serviceWithSibling =
+      makeSubtreePlan(bRootOp->createCopyWithSiblingTree(a._qet));
+  auto qec = bRootOp->getExecutionContext();
+
+  SubtreePlan plan = makeSubtreePlan<OptionalJoin>(
+      qec, a._qet, std::move(serviceWithSibling._qet));
   mergeSubtreePlanIds(plan, a, b);
 
   return plan;

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -329,11 +329,14 @@ class QueryPlanner {
       SubtreePlan a, SubtreePlan b,
       const std::vector<std::array<ColumnIndex, 2>>& jcs);
 
+  // The following two functions are used to provide a Service-operation with
+  // it's siblingTree, allowing us to optimize the service-query.
   [[nodiscard]] static std::optional<SubtreePlan> createJoinWithService(
       const SubtreePlan& a, const SubtreePlan& b,
       const std::vector<std::array<ColumnIndex, 2>>& jcs);
 
-  [[nodiscard]] static std::optional<SubtreePlan> createOptionalJoinWithService(
+  template <typename Operation>
+  [[nodiscard]] static std::optional<SubtreePlan> createSubtreeWithService(
       const SubtreePlan& a, const SubtreePlan& b);
 
   [[nodiscard]] vector<SubtreePlan> getOrderByRow(

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -333,6 +333,9 @@ class QueryPlanner {
       const SubtreePlan& a, const SubtreePlan& b,
       const std::vector<std::array<ColumnIndex, 2>>& jcs);
 
+  [[nodiscard]] static std::optional<SubtreePlan> createOptionalJoinWithService(
+      const SubtreePlan& a, const SubtreePlan& b);
+
   [[nodiscard]] vector<SubtreePlan> getOrderByRow(
       const ParsedQuery& pq,
       const std::vector<std::vector<SubtreePlan>>& dpTab) const;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1087,7 +1087,7 @@ TEST(QueryPlanner, JoinWithService) {
 }
 
 // ___________________________________________________________________________
-TEST(QueryPlanner, OptionalJoinWithService) {
+TEST(QueryPlanner, SubtreeWithService) {
   auto scan = h::IndexScanFromStrings;
   auto sibling = scan("?x", "<is-a>", "?y");
 
@@ -1104,4 +1104,9 @@ TEST(QueryPlanner, OptionalJoinWithService) {
       h::OptionalJoin(
           sibling,
           h::Sort(h::Service(sibling, "{ ?x <is-a> ?z . ?y <is-a> ?a . }"))));
+
+  h::expect(
+      "SELECT * WHERE { ?x <is-a> ?y MINUS{SERVICE <https://endpoint.com> { ?x "
+      "<is-a> ?z . }}}",
+      h::Minus(sibling, h::Sort(h::Service(sibling, "{ ?x <is-a> ?z . }"))));
 }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1065,9 +1065,7 @@ TEST(QueryPlanner, CancellationCancelsQueryPlanning) {
 // ___________________________________________________________________________
 TEST(QueryPlanner, JoinWithService) {
   auto scan = h::IndexScanFromStrings;
-
   auto sibling = scan("?x", "<is-a>", "?y");
-
   std::string_view graphPatternAsString = "{ ?x <is-a> ?z . }";
 
   h::expect(
@@ -1084,6 +1082,26 @@ TEST(QueryPlanner, JoinWithService) {
       "SELECT * WHERE { ?x <is-a> ?y . "
       "SERVICE <https://endpoint.com> { ?x <is-a> ?z . ?y <is-a> ?a . }}",
       h::MultiColumnJoin(
+          sibling,
+          h::Sort(h::Service(sibling, "{ ?x <is-a> ?z . ?y <is-a> ?a . }"))));
+}
+
+// ___________________________________________________________________________
+TEST(QueryPlanner, OptionalJoinWithService) {
+  auto scan = h::IndexScanFromStrings;
+  auto sibling = scan("?x", "<is-a>", "?y");
+
+  h::expect(
+      "SELECT * WHERE { ?x <is-a> ?y ."
+      "OPTIONAL{SERVICE <https://endpoint.com> { ?x <is-a> ?z . }}}",
+      h::OptionalJoin(sibling,
+                      h::Sort(h::Service(sibling, "{ ?x <is-a> ?z . }"))));
+
+  h::expect(
+      "SELECT * WHERE { ?x <is-a> ?y . "
+      "OPTIONAL{"
+      "SERVICE <https://endpoint.com> { ?x <is-a> ?z . ?y <is-a> ?a . }}}",
+      h::OptionalJoin(
           sibling,
           h::Sort(h::Service(sibling, "{ ?x <is-a> ?z . ?y <is-a> ?a . }"))));
 }

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -14,6 +14,7 @@
 #include "engine/Filter.h"
 #include "engine/IndexScan.h"
 #include "engine/Join.h"
+#include "engine/Minus.h"
 #include "engine/MultiColumnJoin.h"
 #include "engine/NeutralElementOperation.h"
 #include "engine/OptionalJoin.h"
@@ -206,6 +207,8 @@ inline auto MultiColumnJoin = MatchTypeAndUnorderedChildren<::MultiColumnJoin>;
 inline auto Join = MatchTypeAndUnorderedChildren<::Join>;
 
 constexpr auto OptionalJoin = MatchTypeAndOrderedChildren<::OptionalJoin>;
+
+constexpr auto Minus = MatchTypeAndOrderedChildren<::Minus>;
 
 // Return a matcher that matches a query execution tree that consists of
 // multiple JOIN operations that join the `children`. The `INTERNAL SORT BY`


### PR DESCRIPTION
With this commit, the optimization that constrains a `SERVICE` query using a `VALUES` clause when the sibling of the `SERVICE` is small (originally introduced in #1341) is also applied for `OPTIONAL` and `MINUS` clauses when the right operand is a `SERVICE`.