### PR TITLE
Add runtime parameter to toggle index scan optimizations

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -877,13 +877,13 @@ std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() {
 // _____________________________________________________________________________
 std::optional<IdTable> GroupBy::computeOptimizedGroupByIfPossible() {
   // TODO<C++23> Use `std::optional::or_else`.
-  // TODO<RobinTF> Add runtime parameter to toggle index scan specific
-  // optimizations for performance comparisons
-  if (auto result = computeGroupByForSingleIndexScan()) {
-    return result;
-  }
-  if (auto result = computeGroupByForFullIndexScan()) {
-    return result;
+  if (!RuntimeParameters().get<"group-by-disable-index-scan-optimizations">()) {
+    if (auto result = computeGroupByForSingleIndexScan()) {
+      return result;
+    }
+    if (auto result = computeGroupByForFullIndexScan()) {
+      return result;
+    }
   }
   if (auto result = computeGroupByForJoinWithFullScan()) {
     return result;

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -47,6 +47,7 @@ inline auto& RuntimeParameters() {
         SizeT<"lazy-index-scan-max-size-materialization">{1'000'000},
         Bool<"use-binsearch-transitive-path">{true},
         Bool<"group-by-hash-map-enabled">{false},
+        Bool<"group-by-disable-index-scan-optimizations">{false},
         SizeT<"service-max-value-rows">{100}};
   }();
   return params;


### PR DESCRIPTION
This is just to compare performance of the index specific implementation and the general lazy case