### PR TITLE
Make some member functions of `GroupBy` `const` or even `static`

### DIFF
--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -572,7 +572,7 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
 }
 
 // _____________________________________________________________________________
-std::optional<IdTable> GroupBy::computeGroupByForSingleIndexScan() {
+std::optional<IdTable> GroupBy::computeGroupByForSingleIndexScan() const {
   // The child must be an `IndexScan` for this optimization.
   auto indexScan =
       std::dynamic_pointer_cast<const IndexScan>(_subtree->getRootOperation());
@@ -621,7 +621,7 @@ std::optional<IdTable> GroupBy::computeGroupByForSingleIndexScan() {
 }
 
 // ____________________________________________________________________________
-std::optional<IdTable> GroupBy::computeGroupByObjectWithCount() {
+std::optional<IdTable> GroupBy::computeGroupByObjectWithCount() const {
   // The child must be an `IndexScan` with exactly two variables.
   auto indexScan =
       std::dynamic_pointer_cast<IndexScan>(_subtree->getRootOperation());
@@ -671,7 +671,7 @@ std::optional<IdTable> GroupBy::computeGroupByObjectWithCount() {
 }
 
 // _____________________________________________________________________________
-std::optional<IdTable> GroupBy::computeGroupByForFullIndexScan() {
+std::optional<IdTable> GroupBy::computeGroupByForFullIndexScan() const {
   if (_groupByVariables.size() != 1) {
     return std::nullopt;
   }
@@ -766,7 +766,7 @@ std::optional<Permutation::Enum> GroupBy::getPermutationForThreeVariableTriple(
 
 // ____________________________________________________________________________
 std::optional<GroupBy::OptimizedGroupByData> GroupBy::checkIfJoinWithFullScan(
-    const Join& join) {
+    const Join& join) const {
   if (_groupByVariables.size() != 1) {
     return std::nullopt;
   }
@@ -809,7 +809,7 @@ std::optional<GroupBy::OptimizedGroupByData> GroupBy::checkIfJoinWithFullScan(
 }
 
 // ____________________________________________________________________________
-std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() {
+std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() const {
   auto join = std::dynamic_pointer_cast<Join>(_subtree->getRootOperation());
   if (!join) {
     return std::nullopt;
@@ -875,7 +875,7 @@ std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() {
 }
 
 // _____________________________________________________________________________
-std::optional<IdTable> GroupBy::computeOptimizedGroupByIfPossible() {
+std::optional<IdTable> GroupBy::computeOptimizedGroupByIfPossible() const {
   // TODO<C++23> Use `std::optional::or_else`.
   // TODO<RobinTF> Add runtime parameter to toggle index scan specific
   // optimizations for performance comparisons
@@ -897,7 +897,7 @@ std::optional<IdTable> GroupBy::computeOptimizedGroupByIfPossible() {
 // _____________________________________________________________________________
 std::optional<GroupBy::HashMapOptimizationData>
 GroupBy::computeUnsequentialProcessingMetadata(
-    std::vector<Aggregate>& aliases) {
+    std::vector<Aggregate>& aliases) const {
   // Get pointers to all aggregate expressions and their parents
   size_t numAggregates = 0;
   std::vector<HashMapAliasInformation> aliasesWithAggregateInfo;
@@ -933,7 +933,8 @@ GroupBy::computeUnsequentialProcessingMetadata(
 
 // _____________________________________________________________________________
 std::optional<GroupBy::HashMapOptimizationData>
-GroupBy::checkIfHashMapOptimizationPossible(std::vector<Aggregate>& aliases) {
+GroupBy::checkIfHashMapOptimizationPossible(
+    std::vector<Aggregate>& aliases) const {
   if (!RuntimeParameters().get<"group-by-hash-map-enabled">()) {
     return std::nullopt;
   }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1378,7 +1378,7 @@ template <size_t NUM_GROUP_COLUMNS>
 IdTable GroupBy::createResultFromHashMap(
     const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
     std::vector<HashMapAliasInformation>& aggregateAliases,
-    LocalVocab* localVocab) {
+    LocalVocab* localVocab) const {
   // Create result table, filling in the group values, since they might be
   // required in evaluation
   ad_utility::Timer sortingTimer{ad_utility::Timer::Started};
@@ -1449,7 +1449,7 @@ template <size_t NUM_GROUP_COLUMNS>
 IdTable GroupBy::computeGroupByForHashMapOptimization(
     std::vector<HashMapAliasInformation>& aggregateAliases,
     const IdTable& subresult, const std::vector<size_t>& columnIndices,
-    LocalVocab* localVocab) {
+    LocalVocab* localVocab) const {
   AD_CONTRACT_CHECK(columnIndices.size() == NUM_GROUP_COLUMNS ||
                     NUM_GROUP_COLUMNS == 0);
 

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -168,7 +168,7 @@ class GroupBy : public Operation {
   // This function checks whether such a case applies. In this case the result
   // is computed and returned wrapped in a optional. If no such case applies the
   // optional remains empty.
-  std::optional<IdTable> computeOptimizedGroupByIfPossible();
+  std::optional<IdTable> computeOptimizedGroupByIfPossible() const;
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -181,7 +181,7 @@ class GroupBy : public Operation {
   // The COUNT may be computed on any of the variables in the triple. If the
   // query has that form, the result of the query (which consists of one line)
   // is computed and returned. If not, an empty optional is returned.
-  std::optional<IdTable> computeGroupByForSingleIndexScan();
+  std::optional<IdTable> computeGroupByForSingleIndexScan() const;
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -192,7 +192,7 @@ class GroupBy : public Operation {
   // NOTE: This is exactly what we need for a context-sensitive object AC query
   // without connected triples. The GROUP BY variable can also be omitted in
   // the SELECT clause.
-  std::optional<IdTable> computeGroupByObjectWithCount();
+  std::optional<IdTable> computeGroupByObjectWithCount() const;
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -205,7 +205,7 @@ class GroupBy : public Operation {
   // or `?z`. In the SELECT clause, both of the elements may be omitted, so in
   // the example it is possible to only select `?x` or to only select the
   // `COUNT`.
-  std::optional<IdTable> computeGroupByForFullIndexScan();
+  std::optional<IdTable> computeGroupByForFullIndexScan() const;
 
   // Check if the query represented by this GROUP BY is of the following form:
   //
@@ -217,7 +217,7 @@ class GroupBy : public Operation {
   // Note that `?x` can also be the predicate or object of the three variable
   // triple, and that the COUNT may be by any of the variables `?x`, `?y`, or
   // `?z`.
-  std::optional<IdTable> computeGroupByForJoinWithFullScan();
+  std::optional<IdTable> computeGroupByForJoinWithFullScan() const;
 
   // Stores information required for substitution of an expression in an
   // expression tree.
@@ -436,14 +436,14 @@ class GroupBy : public Operation {
 
   // Reusable implementation of `checkIfHashMapOptimizationPossible`.
   std::optional<HashMapOptimizationData> computeUnsequentialProcessingMetadata(
-      std::vector<Aggregate>& aggregates);
+      std::vector<Aggregate>& aggregates) const;
 
   // Check if hash map optimization is applicable. This is the case when
   // the following conditions hold true:
   // - Runtime parameter is set
   // - Child operation is SORT
   std::optional<HashMapOptimizationData> checkIfHashMapOptimizationPossible(
-      std::vector<Aggregate>& aggregates);
+      std::vector<Aggregate>& aggregates) const;
 
   // Extract values from `expressionResult` and store them in the rows of
   // `resultTable` specified by the indices in `evaluationContext`, in column
@@ -474,12 +474,12 @@ class GroupBy : public Operation {
       sparqlExpression::SparqlExpression* expr);
 
   // Find all occurrences of grouped by variable for expression `expr`.
-  std::variant<std::vector<ParentAndChildIndex>, OccurAsRoot>
+  static std::variant<std::vector<ParentAndChildIndex>, OccurAsRoot>
   findGroupedVariable(sparqlExpression::SparqlExpression* expr,
                       const Variable& groupedVariable);
 
   // The recursive implementation of `findGroupedVariable` (see above).
-  void findGroupedVariableImpl(
+  static void findGroupedVariableImpl(
       sparqlExpression::SparqlExpression* expr,
       std::optional<ParentAndChildIndex> parentAndChildIndex,
       std::variant<std::vector<ParentAndChildIndex>, OccurAsRoot>&
@@ -521,7 +521,8 @@ class GroupBy : public Operation {
   // Check if the previously described optimization can be applied. The argument
   // Must be the single subtree of this GROUP BY, properly cast to a `const
   // Join*`.
-  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(const Join& join);
+  std::optional<OptimizedGroupByData> checkIfJoinWithFullScan(
+      const Join& join) const;
 
   // Check if the following is true: the `tree` represents a three variable
   // triple, that contains both `variableByWhichToSort` and

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -308,7 +308,7 @@ class GroupBy : public Operation {
   IdTable computeGroupByForHashMapOptimization(
       std::vector<HashMapAliasInformation>& aggregateAliases,
       const IdTable& subresult, const std::vector<size_t>& columnIndices,
-      LocalVocab* localVocab);
+      LocalVocab* localVocab) const;
 
   using AggregationData =
       std::variant<AvgAggregationData, CountAggregationData, MinAggregationData,
@@ -434,7 +434,7 @@ class GroupBy : public Operation {
   IdTable createResultFromHashMap(
       const HashMapAggregationData<NUM_GROUP_COLUMNS>& aggregationData,
       std::vector<HashMapAliasInformation>& aggregateAliases,
-      LocalVocab* localVocab);
+      LocalVocab* localVocab) const;
 
   // Reusable implementation of `checkIfHashMapOptimizationPossible`.
   static std::optional<HashMapOptimizationData>

--- a/src/engine/LazyGroupBy.cpp
+++ b/src/engine/LazyGroupBy.cpp
@@ -13,6 +13,7 @@ LazyGroupBy::LazyGroupBy(
     const ad_utility::AllocatorWithLimit<Id>& allocator, size_t numGroupColumns)
     : localVocab_{localVocab},
       aggregateAliases_{std::move(aggregateAliases)},
+      allocator_{allocator},
       aggregationData_{allocator, aggregateAliases_, numGroupColumns} {
   for (const auto& aggregateInfo : allAggregateInfoView()) {
     visitAggregate(
@@ -40,7 +41,7 @@ void LazyGroupBy::resetAggregationData() {
 void LazyGroupBy::commitRow(
     IdTable& resultTable,
     sparqlExpression::EvaluationContext& evaluationContext,
-    const GroupBy::GroupBlock& currentGroupBlock, const GroupBy& groupBy) {
+    const GroupBy::GroupBlock& currentGroupBlock) {
   resultTable.emplace_back();
   size_t colIdx = 0;
   for (const auto& [_, value] : currentGroupBlock) {
@@ -52,8 +53,8 @@ void LazyGroupBy::commitRow(
   evaluationContext._endIndex = resultTable.size();
 
   for (auto& alias : aggregateAliases_) {
-    groupBy.evaluateAlias(alias, &resultTable, evaluationContext,
-                          aggregationData_, &localVocab_);
+    GroupBy::evaluateAlias(alias, &resultTable, evaluationContext,
+                           aggregationData_, &localVocab_, allocator_);
   }
   resetAggregationData();
 }

--- a/src/engine/LazyGroupBy.h
+++ b/src/engine/LazyGroupBy.h
@@ -12,6 +12,7 @@
 class LazyGroupBy {
   LocalVocab& localVocab_;
   std::vector<GroupBy::HashMapAliasInformation> aggregateAliases_;
+  const ad_utility::AllocatorWithLimit<Id>& allocator_;
   GroupBy::HashMapAggregationData<0> aggregationData_;
 
  public:
@@ -30,8 +31,7 @@ class LazyGroupBy {
   // into the `resultTable` and reset the aggregation data for the next group.
   void commitRow(IdTable& resultTable,
                  sparqlExpression::EvaluationContext& evaluationContext,
-                 const GroupBy::GroupBlock& currentGroupBlock,
-                 const GroupBy& groupBy);
+                 const GroupBy::GroupBlock& currentGroupBlock);
 
   // Process the next potentially partial group as a block of rows. This
   // modifies the state of `aggregateData_`. Call `commitRow` to write the final

--- a/test/engine/LazyGroupByTest.cpp
+++ b/test/engine/LazyGroupByTest.cpp
@@ -43,16 +43,15 @@ class LazyGroupByTest : public ::testing::Test {
           std::make_shared<ValuesForTesting>(
               qec_, IdTable{2, ad_utility::makeAllocatorWithLimit<Id>(0_B)},
               std::vector{std::optional{xVar_}, std::optional{yVar_}}));
-  GroupBy groupBy_{qec_, {yVar_}, {}, subtree_};
 
   std::vector<GroupBy::Aggregate> aggregates_{
       {std::move(sparqlExpression_), 1}};
   LocalVocab localVocab_{};
   LazyGroupBy lazyGroupBy_{
       localVocab_,
-      groupBy_.computeUnsequentialProcessingMetadata(aggregates_)
+      GroupBy::computeUnsequentialProcessingMetadata(aggregates_, {yVar_})
           ->aggregateAliases_,
-      groupBy_.allocator(), 1};
+      ua, 1};
 
   sparqlExpression::EvaluationContext makeEvaluationContext(
       const IdTable& idTable) const {
@@ -60,7 +59,7 @@ class LazyGroupByTest : public ::testing::Test {
         *qec_,
         subtree_->getVariableColumns(),
         idTable,
-        groupBy_.allocator(),
+        ua,
         localVocab_,
         std::make_shared<ad_utility::CancellationHandle<>>(),
         std::chrono::steady_clock::time_point::max()};
@@ -80,13 +79,13 @@ TEST_F(LazyGroupByTest, verifyEmptyGroupsAreAggregatedCorrectly) {
   auto evaluationContext = makeEvaluationContext(idTable);
 
   lazyGroupBy_.processBlock(evaluationContext, 0, 0);
-  lazyGroupBy_.commitRow(resultTable, evaluationContext, block, groupBy_);
+  lazyGroupBy_.commitRow(resultTable, evaluationContext, block);
 
   // The grouped variable has the value 7 here + 0 is still 7.
   EXPECT_EQ(resultTable, makeIdTableFromVector({{7, 7}}, I));
 
   block.at(0).second = I(9);
-  lazyGroupBy_.commitRow(resultTable, evaluationContext, block, groupBy_);
+  lazyGroupBy_.commitRow(resultTable, evaluationContext, block);
 
   // The grouped variable has the value 9 here + 0 is still 9.
   EXPECT_EQ(resultTable, makeIdTableFromVector({{7, 7}, {9, 9}}, I));
@@ -100,7 +99,7 @@ TEST_F(LazyGroupByTest, verifyGroupsAreAggregatedCorrectly) {
   auto evaluationContext = makeEvaluationContext(idTable);
 
   lazyGroupBy_.processBlock(evaluationContext, 1, 3);
-  lazyGroupBy_.commitRow(resultTable, evaluationContext, block, groupBy_);
+  lazyGroupBy_.commitRow(resultTable, evaluationContext, block);
 
   // The `7` is the current group, and the aggregate computes the SUM between
   // the elements at index 1 and 2, which is  7 + 3 + 5 = 15.
@@ -112,7 +111,7 @@ TEST_F(LazyGroupByTest, verifyGroupsAreAggregatedCorrectly) {
   lazyGroupBy_.processBlock(evaluationContext, 3, 4);  // add 7 -> 17
   lazyGroupBy_.processBlock(evaluationContext, 4, 4);  // add 0 (empty) -> 17
   block.at(0).second = I(9);                           // add 9 -> 26
-  lazyGroupBy_.commitRow(resultTable, evaluationContext, block, groupBy_);
+  lazyGroupBy_.commitRow(resultTable, evaluationContext, block);
 
   EXPECT_EQ(resultTable, makeIdTableFromVector({{7, 15}, {9, 26}}, I));
 }
@@ -129,7 +128,7 @@ TEST_F(LazyGroupByTest, verifyCommitWorksWhenOriginalIdTableIsGone) {
   }
   IdTable idTable = makeIdTableFromVector({}, I);
   auto evaluationContext = makeEvaluationContext(idTable);
-  lazyGroupBy_.commitRow(resultTable, evaluationContext, block, groupBy_);
+  lazyGroupBy_.commitRow(resultTable, evaluationContext, block);
 
   // 3 + 3 + 5 = 11
   EXPECT_EQ(resultTable, makeIdTableFromVector({{3, 11}}, I));
@@ -149,14 +148,13 @@ TEST(LazyGroupBy, verifyGroupConcatIsCorrectlyInitialized) {
       qec, std::make_shared<ValuesForTesting>(
                qec, IdTable{1, ad_utility::makeAllocatorWithLimit<Id>(0_B)},
                std::vector{std::optional{variable}}));
-  GroupBy groupBy{qec, {variable}, {}, subtree};
   std::vector<GroupBy::Aggregate> aggregates{{std::move(sparqlExpression), 0}};
   LocalVocab localVocab{};
   LazyGroupBy lazyGroupBy{
       localVocab,
-      groupBy.computeUnsequentialProcessingMetadata(aggregates)
+      GroupBy::computeUnsequentialProcessingMetadata(aggregates, {variable})
           ->aggregateAliases_,
-      groupBy.allocator(), 1};
+      qec->getAllocator(), 1};
   using namespace ::testing;
   using Gc = GroupConcatAggregationData;
   EXPECT_THAT(lazyGroupBy.aggregationData_.getAggregationDataVariant(0),


### PR DESCRIPTION
This makes the static analysis happier and (in the case of the static methods) avoids the passing around of fully-fledged `GroupBy` objects.