### PR TITLE
Make the HttpTest run serially.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -273,7 +273,7 @@ addLinkAndDiscoverTestSerial(ValuesTest engine)
 
 addLinkAndDiscoverTestSerial(ServiceTest engine)
 
-addLinkAndDiscoverTest(HttpTest Boost::iostreams http)
+addLinkAndDiscoverTestSerial(HttpTest Boost::iostreams http)
 
 addLinkAndDiscoverTest(CallFixedSizeTest)
 


### PR DESCRIPTION
This hopefully fixes the spurious failures on `GitHub Actions`. The current assumption is that there is a data race on the resetting of the global logging, which is required for those tests.