### PR TITLE
Fix URL-decoding bug from previous commit 

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -219,7 +219,7 @@ ad_utility::url_parser::ParsedRequest Server::parseHttpRequest(
             "URL-encoded POST requests must not contain query parameters in "
             "the URL.");
       }
-      
+
       // Set the url-encoded parameters from the request body.
       // Note: previously we used `boost::urls::parse_query`, but that function
       // doesn't unescape the `+` which encodes a space character. The following

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -225,11 +225,14 @@ ad_utility::url_parser::ParsedRequest Server::parseHttpRequest(
       // doesn't unescape the `+` which encodes a space character. The following
       // workaround of making the url-encoded parameters a complete relative url
       // and parsing this URL seems to work.
-      auto query =
-          boost::urls::parse_origin_form(absl::StrCat("/?", request.body()));
+      // Note: We have to bind the result of `StrCat` to an explicit variable,
+      // as the `boost::urls` parsing routines only give back a view, which
+      // otherwise would be dangling.
+      auto bodyAsQuery = absl::StrCat("/?", request.body());
+      auto query = boost::urls::parse_origin_form(bodyAsQuery);
       if (!query) {
         throw std::runtime_error(
-            "Invalid URL-endoded POST request, body was: " + request.body());
+            "Invalid URL-encoded POST request, body was: " + request.body());
       }
       parsedRequest.parameters_ =
           ad_utility::url_parser::paramsToMap(query->params());

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -64,7 +64,7 @@ TEST(ServerTest, parseHttpRequest) {
       ParsedRequest("/", {{"action", "csv_export"}}, "SELECT * WHERE {}"));
   EXPECT_THAT(
       parse(MakePostRequest("/", URLENCODED,
-                            "query=SELECT%20%2A%20WHERE%20%7B%7D&send=100")),
+                            "query=SELECT+%2A%20WHERE%20%7B%7D&send=100")),
       ParsedRequest("/", {{"send", "100"}}, "SELECT * WHERE {}"));
   EXPECT_THAT(
       parse(MakePostRequest("/", "application/x-www-form-urlencoded",

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -66,6 +66,10 @@ TEST(ServerTest, parseHttpRequest) {
       parse(MakePostRequest("/", URLENCODED,
                             "query=SELECT+%2A%20WHERE%20%7B%7D&send=100")),
       ParsedRequest("/", {{"send", "100"}}, "SELECT * WHERE {}"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      parse(MakePostRequest("/", URLENCODED,
+                            "ääär y=SELECT+%2A%20WHERE%20%7B%7D&send=100")),
+      ::testing::HasSubstr("Invalid URL-encoded POST request"));
   EXPECT_THAT(
       parse(MakePostRequest("/", "application/x-www-form-urlencoded",
                             "query=SELECT%20%2A%20WHERE%20%7B%7D&send=100")),

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -60,7 +60,7 @@ TEST(ServerTest, parseHttpRequest) {
               ParsedRequest("/", {{"cmd", "stats"}}, std::nullopt));
   EXPECT_THAT(
       parse(MakeGetRequest(
-          "/?query=SELECT%20%2A%20WHERE%20%7B%7D&action=csv_export")),
+          "/?query=SELECT+%2A%20WHERE%20%7B%7D&action=csv_export")),
       ParsedRequest("/", {{"action", "csv_export"}}, "SELECT * WHERE {}"));
   EXPECT_THAT(
       parse(MakePostRequest("/", URLENCODED,


### PR DESCRIPTION
For URL-decoding, now use (the well documented) `boost::urls::parse_origin_form` instead of the (internal and poorly documented) `boost::urls::parse_query` because the latter turned out to not unescape `+` to space.

TODO for a separate PR: When the URL path is malformed, currently a Boost-internal error message is returned, like `leftover [boost.url.grammar:4]`. Instead an exception should be thrown and caught and a proper error message displayed.