### PR TITLE
Make `RAND` function conform to the standard

### DIFF
--- a/src/engine/sparqlExpressions/RandomExpression.h
+++ b/src/engine/sparqlExpressions/RandomExpression.h
@@ -22,19 +22,19 @@ class RandomExpression : public SparqlExpression {
     VectorWithMemoryLimit<Id> result{context->_allocator};
     const size_t numElements = context->_endIndex - context->_beginIndex;
     result.reserve(numElements);
-    ad_utility::FastRandomIntGenerator<int64_t> randInt;
+    ad_utility::RandomDoubleGenerator randDouble(0.0, 1.0);
 
     // As part of a GROUP BY we only return one value per group.
     if (context->_isPartOfGroupBy) {
-      return Id::makeFromInt(randInt() >> Id::numDatatypeBits);
+      return Id::makeFromDouble(randDouble());
     }
 
     // 1000 is an arbitrarily chosen interval at which to check for
     // cancellation.
     ad_utility::chunkedForLoop<1000>(
         0, numElements,
-        [&result, &randInt](size_t) {
-          result.push_back(Id::makeFromInt(randInt() >> Id::numDatatypeBits));
+        [&result, &randDouble](size_t) {
+          result.push_back(Id::makeFromDouble(randDouble()));
         },
         [context]() { context->cancellationHandle_->throwIfCancelled(); });
     return result;

--- a/test/RandomExpressionTest.cpp
+++ b/test/RandomExpressionTest.cpp
@@ -25,7 +25,9 @@ TEST(RandomExpression, evaluate) {
 
   std::vector<int64_t> histogram(10);
   for (auto rand : resultVector) {
-    ASSERT_EQ(rand.getDatatype(), Datatype::Int);
+    ASSERT_EQ(rand.getDatatype(), Datatype::Double);
+    ASSERT_GE(rand.getDouble(), 0.0);
+    ASSERT_LT(rand.getDouble(), 1.0);
     histogram[std::abs(rand.getInt()) % 10]++;
   }
 

--- a/test/RandomTest.cpp
+++ b/test/RandomTest.cpp
@@ -195,6 +195,38 @@ TEST(RandomNumberGeneratorTest, RandomDoubleGenerator) {
   testRange<RandomDoubleGenerator>(ranges);
 }
 
+// Test for the performance of `FastRandomIntGenerator` and
+// `RandomDoubleGenerator`.
+// NOTE: This does not actually test anything. It's just here to measure the
+// performance of the random number generators.
+TEST(RandomNumberGeneratorTest, PerformanceTes) {
+  // Create random number generators.
+  FastRandomIntGenerator<size_t> fastIntGenerator;
+  RandomDoubleGenerator doubleGenerator(0.0, 1.0);
+  size_t n = 1'000'000;
+  // Lambda for measuring the speed of a given random number generator.
+  auto measureAndShowSpeed = [&n](auto& generator, std::string name) {
+    auto start = std::chrono::high_resolution_clock::now();
+    decltype(generator()) sum = 0;
+    for (size_t i = 0; i < n; i++) {
+      sum += generator();
+    }
+    // Show in ns per number with one digit after the comma.
+    std::cout << "Speed of " << name << ": " << std::fixed
+              << std::setprecision(1)
+              << (static_cast<double>(
+                      std::chrono::duration_cast<std::chrono::nanoseconds>(
+                          std::chrono::high_resolution_clock::now() - start)
+                          .count()) /
+                  n)
+              << " ns per number" << std::setprecision(4)
+              << " [average value: " << (sum / n) << "]" << std::endl;
+  };
+  // Measure the time of our two random number generators.
+  measureAndShowSpeed(fastIntGenerator, "FastRandomIntGenerator");
+  measureAndShowSpeed(doubleGenerator, "RandomDoubleGenerator");
+}
+
 // Small test, if `randomShuffle` shuffles things the same way, if given the
 // same seed.
 TEST(RandomShuffleTest, Seed) {


### PR DESCRIPTION
So far, we used our `FastRandomIntGenerator` to generate values for `RAND`. However, the standard dictates that `RAND` returns an `xsd:double` from the range [0, 1). We now do this using our `RandomDoubleGenerator`. It is around six times slower than the previous generator, but still fast enough (4.8 ns / number vs. 0.8 ns / number). Fixes #1516

Also added a performance test to `RandomTest` to be able to check the speed of a random number generator quickly.