### PR TITLE
Clamp `POINT` literals that are out of bound

### DIFF
--- a/src/parser/GeoPoint.cpp
+++ b/src/parser/GeoPoint.cpp
@@ -13,12 +13,14 @@
 #include "util/GeoSparqlHelpers.h"
 
 // _____________________________________________________________________________
-GeoPoint::GeoPoint(double lat, double lng) : lat_{lat}, lng_{lng} {
-  // Ensure valid lat and lng values
-  if (lat < -COORDINATE_LAT_MAX || lat > COORDINATE_LAT_MAX || std::isnan(lat))
-    throw CoordinateOutOfRangeException(lat, true);
-  if (lng < -COORDINATE_LNG_MAX || lng > COORDINATE_LNG_MAX || std::isnan(lng))
-    throw CoordinateOutOfRangeException(lng, false);
+GeoPoint::GeoPoint(double lat, double lng) {
+  // Clamp latitudes and longitudes to valid ranges.
+  lat_ = std::clamp(lat, -COORDINATE_LAT_MAX, COORDINATE_LAT_MAX);
+  lng_ = std::clamp(lng, -COORDINATE_LNG_MAX, COORDINATE_LNG_MAX);
+  if (lat_ != lat || lng_ != lng) {
+    LOG(WARN) << "POINT(" << lng << " " << lat << ") out of range, "
+              << "clamped to POINT(" << lng_ << " " << lat_ << ")" << std::endl;
+  }
 };
 
 // _____________________________________________________________________________

--- a/src/parser/GeoPoint.h
+++ b/src/parser/GeoPoint.h
@@ -12,24 +12,6 @@
 #include "util/BitUtils.h"
 #include "util/SourceLocation.h"
 
-/// Exception type for construction of GeoPoints that have invalid values
-struct CoordinateOutOfRangeException : public std::exception {
- private:
-  std::string errorMessage_;
-
- public:
-  explicit CoordinateOutOfRangeException(
-      double value, bool isLat,
-      ad_utility::source_location s = ad_utility::source_location::current()) {
-    errorMessage_ =
-        absl::StrCat(s.file_name(), ", line ", s.line(), ": The given value ",
-                     value, " is out of range for ",
-                     isLat ? "latitude" : "longitude", " coordinates.");
-  }
-
-  const char* what() const noexcept override { return errorMessage_.c_str(); }
-};
-
 /// A GeoPoint represents a pair of geographical coordinates on earth consisting
 /// of latitude (lat) and longitude (lng).
 class GeoPoint {


### PR DESCRIPTION
So far, the index build exits when a `POINT` literal (of type `geo:wktLiteral`) is encountered, where the latitude or longitude is out of bounds. Unfortunately, Wikidata has several such points. This is a simple way to address this: the latitude and longitude are clamped to the permitted range and a warning is printed for each point for which that happens.

Alternative solutions: drop the triple altogether or leave the literal value as it is, but remove the datatype or change it to `xsd:string`.