### PR TITLE
Warn instead of throwing when parsing invalid WKT `POINT`s

### DIFF
--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -469,7 +469,7 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
   std::string_view type = asStringViewUnsafe(typeIri.getContent());
 
   // Helper to handle literals that are invalid for the respective datatype
-  auto makeNormalLiteral = [parser, literal, normalizedLiteralContent,
+  auto makeNormalLiteral = [&parser, &literal, normalizedLiteralContent,
                             type](std::optional<std::exception> error =
                                       std::nullopt) {
     std::string_view errorMsg = error.has_value() ? error.value().what() : "";

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -8,6 +8,8 @@
 #include <absl/strings/charconv.h>
 
 #include <cstring>
+#include <exception>
+#include <optional>
 
 #include "global/Constants.h"
 #include "parser/GeoPoint.h"
@@ -466,6 +468,23 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
       asNormalizedStringViewUnsafe(normalizedLiteralContent));
   std::string_view type = asStringViewUnsafe(typeIri.getContent());
 
+  // Helper to handle literals that are invalid for the respective datatype
+  auto makeNormalLiteral = [parser, literal, normalizedLiteralContent,
+                            type](std::optional<std::exception> error =
+                                      std::nullopt) {
+    std::string errorMsg = "";
+    if (error.has_value()) {
+      errorMsg = error.value().what();
+    }
+    LOG(DEBUG) << normalizedLiteralContent
+               << " could not be parsed as an object of type " << type << ":"
+               << errorMsg
+               << ". It is treated as a plain string literal without datatype "
+                  "instead."
+               << std::endl;
+    parser->lastParseResult_ = std::move(literal);
+  };
+
   try {
     if (ad_utility::contains(integerDatatypes_, type)) {
       parser->parseIntegerConstant(normalizedLiteralContent);
@@ -475,13 +494,7 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
       } else if (normalizedLiteralContent == "false") {
         parser->lastParseResult_ = false;
       } else {
-        LOG(DEBUG)
-            << normalizedLiteralContent
-            << " could not be parsed as a boolean object of type " << type
-            << ". It is treated as a plain string literal without datatype "
-               "instead"
-            << std::endl;
-        parser->lastParseResult_ = std::move(literal);
+        makeNormalLiteral();
       }
     } else if (ad_utility::contains(floatDatatypes_, type)) {
       parser->parseDoubleConstant(normalizedLiteralContent);
@@ -513,47 +526,16 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
       literal.addDatatype(typeIri);
       parser->lastParseResult_ = std::move(literal);
     }
-  } catch (const DateParseException&) {
-    LOG(DEBUG) << normalizedLiteralContent
-               << " could not be parsed as a date object of type " << type
-               << ". It is treated as a plain string literal without datatype "
-                  "instead"
-               << std::endl;
-    parser->lastParseResult_ = std::move(literal);
+  } catch (const DateParseException& ex) {
+    makeNormalLiteral(ex);
   } catch (const DateOutOfRangeException& ex) {
-    LOG(DEBUG)
-        << normalizedLiteralContent
-        << " could not be parsed as a date object for the following reason: "
-        << ex.what()
-        << ". It is treated as a plain string literal without datatype "
-           "instead"
-        << std::endl;
-    parser->lastParseResult_ = std::move(literal);
-  } catch (const DurationParseException&) {
-    LOG(DEBUG) << normalizedLiteralContent
-               << " could not be parsed as a duration object of type " << type
-               << ". It is treated as a plain string literal without datatype "
-                  "instead"
-               << std::endl;
-    parser->lastParseResult_ = std::move(literal);
+    makeNormalLiteral(ex);
+  } catch (const DurationParseException& ex) {
+    makeNormalLiteral(ex);
   } catch (const DurationOverflowException& ex) {
-    LOG(DEBUG) << normalizedLiteralContent
-               << " could not be parsed as duration object for the following "
-                  "reason: "
-               << ex.what()
-               << ". It is treated as a plain string literal without datatype "
-                  "instead"
-               << std::endl;
-    parser->lastParseResult_ = std::move(literal);
+    makeNormalLiteral(ex);
   } catch (const CoordinateOutOfRangeException& ex) {
-    LOG(DEBUG) << normalizedLiteralContent
-               << " could not be parsed as GeoPoint object for the following "
-                  "reason: "
-               << ex.what()
-               << ". It is treated as a plain string literal without datatype "
-                  "instead"
-               << std::endl;
-    parser->lastParseResult_ = std::move(literal);
+    makeNormalLiteral(ex);
   } catch (const std::exception& e) {
     parser->raise(e.what());
   }

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -545,6 +545,15 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
                   "instead"
                << std::endl;
     parser->lastParseResult_ = std::move(literal);
+  } catch (const CoordinateOutOfRangeException& ex) {
+    LOG(DEBUG) << normalizedLiteralContent
+               << " could not be parsed as GeoPoint object for the following "
+                  "reason: "
+               << ex.what()
+               << ". It is treated as a plain string literal without datatype "
+                  "instead"
+               << std::endl;
+    parser->lastParseResult_ = std::move(literal);
   } catch (const std::exception& e) {
     parser->raise(e.what());
   }

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -472,12 +472,10 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
   auto makeNormalLiteral = [parser, literal, normalizedLiteralContent,
                             type](std::optional<std::exception> error =
                                       std::nullopt) {
-    std::string errorMsg = "";
-    if (error.has_value()) {
-      errorMsg = error.value().what();
-    }
+    std::string_view errorMsg = error.value_or("");
+    std::string_view sep = error.has_value() ? ": " : "";
     LOG(DEBUG) << normalizedLiteralContent
-               << " could not be parsed as an object of type " << type << ":"
+               << " could not be parsed as an object of type " << type << sep
                << errorMsg
                << ". It is treated as a plain string literal without datatype "
                   "instead."

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -472,7 +472,7 @@ TripleComponent TurtleParser<T>::literalAndDatatypeToTripleComponentImpl(
   auto makeNormalLiteral = [parser, literal, normalizedLiteralContent,
                             type](std::optional<std::exception> error =
                                       std::nullopt) {
-    std::string_view errorMsg = error.value_or("");
+    std::string_view errorMsg = error.has_value() ? error.value().what() : "";
     std::string_view sep = error.has_value() ? ": " : "";
     LOG(DEBUG) << normalizedLiteralContent
                << " could not be parsed as an object of type " << type << sep

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -267,6 +267,11 @@ TEST(RdfParserTest, literalAndDatatypeToTripleComponent) {
             "POLYGON(7.8 47.9, 40.0 40.5, 10.9 20.5)");
   EXPECT_EQ(asStringViewUnsafe(result2.getLiteral().getDatatype()),
             GEO_WKT_LITERAL);
+  // Invalid points should be converted to plain string literals
+  auto result3 = ladttc("POINT(0.0 99.9999)", fromIri(GEO_WKT_LITERAL));
+  ASSERT_FALSE(result3.getLiteral().hasDatatype());
+  ASSERT_EQ(asStringViewUnsafe(result3.getLiteral().getContent()),
+            "POINT(0.0 99.9999)");
 }
 
 TEST(RdfParserTest, blankNode) {


### PR DESCRIPTION
If the RDF parser encounters an invalid POINT (e.g. because it's coordinates are out of range), it will now convert it to a plain string literal without datatype. This behavior is consistent with the one for invalid `Date` values.