### PR TITLE
Fix unescaped literals in SERVICE VALUES-clause

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -477,7 +477,7 @@ std::optional<std::string> Service::idToValueForValuesClause(
       return value;
     default:
       if (xsdType) {
-        return absl::StrCat("\"", value, "\"^^", xsdType);
+        return absl::StrCat("\"", value, "\"^^<", xsdType, ">");
       } else if (value.starts_with('<')) {
         return value;
       } else {

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -102,6 +102,9 @@ class Service : public Operation {
   static TripleComponent bindingToTripleComponent(
       const nlohmann::json& binding);
 
+  static std::optional<std::string> idToValueForValuesClause(
+      const Index& index, Id id, const LocalVocab& localVocab);
+
  private:
   // The string returned by this function is used as cache key.
   std::string getCacheKeyImpl() const override;

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -102,6 +102,8 @@ class Service : public Operation {
   static TripleComponent bindingToTripleComponent(
       const nlohmann::json& binding);
 
+  // Create a value for the VALUES-clause used in `getSiblingValuesClause` from
+  // id. If the id is of type blank node `std::nullopt` is returned.
   static std::optional<std::string> idToValueForValuesClause(
       const Index& index, Id id, const LocalVocab& localVocab);
 

--- a/src/parser/RdfEscaping.h
+++ b/src/parser/RdfEscaping.h
@@ -91,9 +91,6 @@ NormalizedRDFString normalizeRDFLiteral(std::string_view origLiteral);
  * and "be"ta"@en becomes "be\"ta"@en.
  *
  * If the `normLiteral` is not a literal, an AD_CONTRACT_CHECK will fail.
- *
- * TODO: This function currently only handles the escaping of " inside the
- * literal, no other characters. Is that enough?
  */
 std::string validRDFLiteralFromNormalized(std::string_view normLiteral);
 

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1110,7 +1110,7 @@ TEST(ExportQueryExecutionTrees, CornerCases) {
   std::string queryNoVariablesVisible = "SELECT ?not ?known WHERE {<s> ?p ?o}";
   auto resultNoColumns = runJSONQuery(kg, queryNoVariablesVisible,
                                       ad_utility::MediaType::sparqlJson);
-  ASSERT_TRUE(resultNoColumns["result"]["bindings"].empty());
+  ASSERT_TRUE(resultNoColumns["results"]["bindings"].empty());
 
   auto qec = ad_utility::testing::getQec(kg);
   AD_EXPECT_THROW_WITH_MESSAGE(

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -392,6 +392,7 @@ TEST_F(ServiceTest, computeResult) {
     // Check 5: When a siblingTree with variables common to the Service
     // Clause is passed, the Service Operation shall use the siblings result
     // to reduce its Query complexity by injecting them as Values Clause
+
     auto iri = ad_utility::testing::iri;
     using TC = TripleComponent;
     auto siblingTree = std::make_shared<QueryExecutionTree>(
@@ -402,7 +403,11 @@ TEST_F(ServiceTest, computeResult) {
                 {Variable{"?x"}, Variable{"?y"}, Variable{"?z"}},
                 {{TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z>"))},
                  {TC(iri("<x>")), TC(iri("<y>")), TC(iri("<z2>"))},
-                 {TC(iri("<blu>")), TC(iri("<bla>")), TC(iri("<blo>"))}}}));
+                 {TC(iri("<blu>")), TC(iri("<bla>")), TC(iri("<blo>"))},
+                 // This row will be ignored in the created Values Clause as it
+                 // contains a blank node.
+                 {TC(Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0))),
+                  TC(iri("<bl>")), TC(iri("<ank>"))}}}));
 
     auto parsedServiceClause5 = parsedServiceClause;
     parsedServiceClause5.graphPatternAsString_ =
@@ -610,16 +615,18 @@ TEST_F(ServiceTest, bindingToTripleComponent) {
       ::testing::HasSubstr("Type INVALID_TYPE is undefined"));
 }
 
+// ____________________________________________________________________________
 TEST_F(ServiceTest, idToValueForValuesClause) {
   auto idToVc = Service::idToValueForValuesClause;
   LocalVocab localVocab{};
   auto index = ad_utility::testing::makeIndexWithTestSettings();
 
-  // undefined, blanknode -> nullopt
+  // blanknode -> nullopt
   EXPECT_EQ(idToVc(index, Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0)),
                    localVocab),
             std::nullopt);
-  EXPECT_EQ(idToVc(index, Id::makeUndefined(), localVocab), std::nullopt);
+
+  EXPECT_EQ(idToVc(index, Id::makeUndefined(), localVocab), "UNDEF");
 
   // simple datatypes -> implicit string representation
   EXPECT_EQ(idToVc(index, Id::makeFromInt(42), localVocab), "42");

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -632,4 +632,10 @@ TEST_F(ServiceTest, idToValueForValuesClause) {
           "a\"b\"c"));
   EXPECT_EQ(idToVc(index, Id::makeFromLocalVocabIndex(&str), localVocab),
             "\"a\\\"b\\\"c\"");
+
+  // value with xsd-type
+  EXPECT_EQ(
+      idToVc(index, Id::makeFromGeoPoint(GeoPoint(70.5, 130.2)), localVocab)
+          .value(),
+      absl::StrCat("\"POINT(130.200000 70.500000)\"^^<", GEO_WKT_LITERAL, ">"));
 }


### PR DESCRIPTION
Fixes the bug where literals including unescaped quotes (or other characters non conform with the specification of Rdf-Literals, e.g. `"Abraham "Bram" Wiertz"@en`)  were passed unescaped to the `SERVICE` endpoint (using the `VALUES` clause optimization) causing the `SERVICE` clause to fail with a parsing error of the `SERVICE` query.
Also fixes the behavior of undefined values and blank nodes for this optimization.