### PR TITLE
Prepare the url parser for SPARQL Update 

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -168,7 +168,7 @@ ad_utility::url_parser::ParsedRequest Server::parseHttpRequest(
     const ad_utility::httpUtils::HttpRequest auto& request) {
   // For an HTTP request, `request.target()` yields the HTTP Request-URI.
   // This is a concatenation of the URL path and the query strings.
-  using namespace ad_utility::url_parser::Operation;
+  using namespace ad_utility::url_parser::sparqlOperation;
   auto parsedUrl = ad_utility::url_parser::parseRequestTarget(request.target());
   ad_utility::url_parser::ParsedRequest parsedRequest{
       std::move(parsedUrl.path_), std::move(parsedUrl.parameters_), None{}};
@@ -452,14 +452,14 @@ Awaitable<void> Server::process(
   }
 
   // Process the two operation types.
-  if (std::holds_alternative<ad_utility::url_parser::Operation::Query>(
+  if (std::holds_alternative<ad_utility::url_parser::sparqlOperation::Query>(
           parsedHttpRequest.operation_)) {
     if (auto timeLimit = co_await verifyUserSubmittedQueryTimeout(
             checkParameter("timeout", std::nullopt), accessTokenOk, request,
             send)) {
       co_return co_await processQuery(
           parameters,
-          std::get<ad_utility::url_parser::Operation::Query>(
+          std::get<ad_utility::url_parser::sparqlOperation::Query>(
               parsedHttpRequest.operation_)
               .query_,
           requestTimer, std::move(request), send, timeLimit.value());
@@ -469,7 +469,8 @@ Awaitable<void> Server::process(
       // sent to the client already. We can stop here.
       co_return;
     }
-  } else if (std::holds_alternative<ad_utility::url_parser::Operation::Update>(
+  } else if (std::holds_alternative<
+                 ad_utility::url_parser::sparqlOperation::Update>(
                  parsedHttpRequest.operation_)) {
     throw std::runtime_error(
         "SPARQL 1.1 Update is  currently not supported by QLever.");

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -276,10 +276,10 @@ ad_utility::url_parser::ParsedRequest Server::parseHttpRequest(
       parsedRequest.operation_ = Update{request.body()};
       return parsedRequest;
     }
-    throw std::runtime_error(
-        absl::StrCat("POST request with content type \"", contentType,
-                     "\" not supported (must be \"", contentTypeUrlEncoded,
-                     "\" or \"", contentTypeSparqlQuery, "\")"));
+    throw std::runtime_error(absl::StrCat(
+        "POST request with content type \"", contentType,
+        "\" not supported (must be \"", contentTypeUrlEncoded, "\", \"",
+        contentTypeSparqlQuery, "\" or \"", contentTypeSparqlUpdate, "\")"));
   }
   std::ostringstream requestMethodName;
   requestMethodName << request.method();

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -693,7 +693,7 @@ boost::asio::awaitable<void> Server::processQuery(
   try {
     auto containsParam = [&params](const std::string& param,
                                    const std::string& expected) {
-      auto parameterValue =
+      auto& parameterValue =
           ad_utility::url_parser::getParameterCheckAtMostOnce(params, param);
       return parameterValue.has_value() && parameterValue.value() == expected;
     };
@@ -735,7 +735,7 @@ boost::asio::awaitable<void> Server::processQuery(
 
     // TODO<c++23> use std::optional::transform
     std::optional<uint64_t> maxSend = std::nullopt;
-    auto parameterValue =
+    auto& parameterValue =
         ad_utility::url_parser::getParameterCheckAtMostOnce(params, "send");
     if (parameterValue.has_value()) {
       maxSend = std::stoul(parameterValue.value());
@@ -968,12 +968,12 @@ std::optional<std::string_view> Server::checkParameter(
     const ad_utility::url_parser::ParamValueMap& parameters,
     std::string_view key, std::optional<std::string_view> value,
     bool accessAllowed) {
-  auto param =
+  auto& param =
       ad_utility::url_parser::getParameterCheckAtMostOnce(parameters, key);
   if (!param.has_value()) {
     return std::nullopt;
   }
-  std::string parameterValue = param.value();
+  const std::string& parameterValue = param.value();
 
   // If value is given, but not equal to param value, return std::nullopt. If
   // no value is given, set it to param value.

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -177,7 +177,7 @@ ad_utility::url_parser::ParsedRequest Server::parseHttpRequest(
   // statistics) don't have a query. So an empty operation is not necessarily an
   // error.
   auto setOperationIfSpecifiedInParams =
-      [&]<typename Operation>(string_view paramName) {
+      [&parsedRequest]<typename Operation>(string_view paramName) {
         auto operation = ad_utility::url_parser::getParameterCheckAtMostOnce(
             parsedRequest.parameters_, paramName);
         if (operation.has_value()) {
@@ -459,8 +459,8 @@ Awaitable<void> Server::process(
       co_return;
     }
   };
-  auto visitUpdate =
-      [](ad_utility::url_parser::sparqlOperation::Update) -> Awaitable<void> {
+  auto visitUpdate = [](const ad_utility::url_parser::sparqlOperation::Update&)
+      -> Awaitable<void> {
     throw std::runtime_error(
         "SPARQL 1.1 Update is  currently not supported by QLever.");
   };

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -697,10 +697,7 @@ boost::asio::awaitable<void> Server::processQuery(
                                    const std::string& expected) {
       auto parameterValue =
           ad_utility::url_parser::getParameterCheckAtMostOnce(params, param);
-      if (!parameterValue.has_value()) {
-        return false;
-      }
-      return parameterValue.value() == expected;
+     return parameterValue.has_value() && parameterValue.value() == expected;
     };
     const bool pinSubtrees = containsParam("pinsubtrees", "true");
     const bool pinResult = containsParam("pinresult", "true");

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -182,7 +182,7 @@ class Server {
   /// or throws an exception. We still need to return an `optional` though for
   /// technical reasons that are described in the definition of this function.
   net::awaitable<std::optional<PlannedQuery>> parseAndPlan(
-      const std::string& query, const vector<DatasetClause>& additionalDatasets,
+      const std::string& query, const vector<DatasetClause>& queryDatasets,
       QueryExecutionContext& qec, SharedCancellationHandle handle,
       TimeLimit timeLimit);
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -182,8 +182,10 @@ class Server {
   /// or throws an exception. We still need to return an `optional` though for
   /// technical reasons that are described in the definition of this function.
   net::awaitable<std::optional<PlannedQuery>> parseAndPlan(
-      const std::string& query, QueryExecutionContext& qec,
-      SharedCancellationHandle handle, TimeLimit timeLimit);
+      const std::string& query,
+      const vector<SparqlQleverVisitor::DatasetClause>& additionalDatasets,
+      QueryExecutionContext& qec, SharedCancellationHandle handle,
+      TimeLimit timeLimit);
 
   /// Acquire the `CancellationHandle` for the given `QueryId`, start the
   /// watchdog and call `cancelAfterDeadline` to set the timeout after

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -213,9 +213,9 @@ class Server {
   /// the key determines the kind of action. If the key is not found, always
   /// return `std::nullopt`. If `accessAllowed` is false and a value is present,
   /// throw an exception.
-  static std::optional<std::string_view> checkParameter(
+  static std::optional<std::string> checkParameter(
       const ad_utility::url_parser::ParamValueMap& parameters,
-      std::string_view key, std::optional<std::string_view> value,
+      std::string_view key, std::optional<std::string> value,
       bool accessAllowed);
   FRIEND_TEST(ServerTest, checkParameter);
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -38,8 +38,6 @@ class Server {
 
   virtual ~Server() = default;
 
-  using ParamValueMap = ad_utility::HashMap<string, string>;
-
  private:
   //! Initialize the server.
   void initialize(const string& indexBaseName, bool useText,
@@ -131,7 +129,7 @@ class Server {
   /// \param timeLimit Duration in seconds after which the query will be
   ///                  cancelled.
   Awaitable<void> processQuery(
-      const ParamValueMap& params, const string& query,
+      const ad_utility::url_parser::ParamValueMap& params, const string& query,
       ad_utility::Timer& requestTimer,
       const ad_utility::httpUtils::HttpRequest auto& request, auto&& send,
       TimeLimit timeLimit);
@@ -215,7 +213,7 @@ class Server {
   /// return `std::nullopt`. If `accessAllowed` is false and a value is present,
   /// throw an exception.
   static std::optional<std::string_view> checkParameter(
-      const ad_utility::HashMap<std::string, std::string>& parameters,
+      const ad_utility::url_parser::ParamValueMap& parameters,
       std::string_view key, std::optional<std::string_view> value,
       bool accessAllowed);
 

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -217,6 +217,7 @@ class Server {
       const ad_utility::url_parser::ParamValueMap& parameters,
       std::string_view key, std::optional<std::string_view> value,
       bool accessAllowed);
+  FRIEND_TEST(ServerTest, checkParameter);
 
   /// Check if user-provided timeout is authorized with a valid access-token or
   /// lower than the server default. Return an empty optional and send a 403

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -182,8 +182,7 @@ class Server {
   /// or throws an exception. We still need to return an `optional` though for
   /// technical reasons that are described in the definition of this function.
   net::awaitable<std::optional<PlannedQuery>> parseAndPlan(
-      const std::string& query,
-      const vector<SparqlQleverVisitor::DatasetClause>& additionalDatasets,
+      const std::string& query, const vector<DatasetClause>& additionalDatasets,
       QueryExecutionContext& qec, SharedCancellationHandle handle,
       TimeLimit timeLimit);
 

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -23,15 +23,17 @@ using std::string;
 using std::vector;
 
 // _____________________________________________________________________________
-void parsedQuery::DatasetClauses::addClauses(
+parsedQuery::DatasetClauses parsedQuery::DatasetClauses::fromClauses(
     const std::vector<DatasetClause>& clauses) {
+  DatasetClauses result;
   for (auto& [dataset, isNamed] : clauses) {
-    auto& graphs = isNamed ? namedGraphs_ : defaultGraphs_;
+    auto& graphs = isNamed ? result.namedGraphs_ : result.defaultGraphs_;
     if (!graphs.has_value()) {
       graphs.emplace();
     }
     graphs.value().insert(dataset);
   }
+  return result;
 }
 
 // _____________________________________________________________________________

--- a/src/parser/ParsedQuery.cpp
+++ b/src/parser/ParsedQuery.cpp
@@ -15,11 +15,24 @@
 
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/RdfEscaping.h"
+#include "parser/sparqlParser/SparqlQleverVisitor.h"
 #include "util/Conversions.h"
 #include "util/TransparentFunctors.h"
 
 using std::string;
 using std::vector;
+
+// _____________________________________________________________________________
+void parsedQuery::DatasetClauses::addClauses(
+    const std::vector<DatasetClause>& clauses) {
+  for (auto& [dataset, isNamed] : clauses) {
+    auto& graphs = isNamed ? namedGraphs_ : defaultGraphs_;
+    if (!graphs.has_value()) {
+      graphs.emplace();
+    }
+    graphs.value().insert(dataset);
+  }
+}
 
 // _____________________________________________________________________________
 string SparqlPrefix::asString() const {

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -37,6 +37,9 @@
 using std::string;
 using std::vector;
 
+// Forward declaration
+struct DatasetClause;
+
 namespace parsedQuery {
 // A struct for the FROM and FROM NAMED clauses;
 struct DatasetClauses {
@@ -44,6 +47,8 @@ struct DatasetClauses {
   ScanSpecificationAsTripleComponent::Graphs defaultGraphs_{};
   // FROM NAMED clauses.
   ScanSpecificationAsTripleComponent::Graphs namedGraphs_{};
+
+  void addClauses(const std::vector<DatasetClause>& clauses);
 };
 }  // namespace parsedQuery
 

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -48,7 +48,7 @@ struct DatasetClauses {
   // FROM NAMED clauses.
   ScanSpecificationAsTripleComponent::Graphs namedGraphs_{};
 
-  void addClauses(const std::vector<DatasetClause>& clauses);
+  static DatasetClauses fromClauses(const std::vector<DatasetClause>& clauses);
 };
 }  // namespace parsedQuery
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -236,7 +236,8 @@ Alias Visitor::visit(Parser::AliasWithoutBracketsContext* ctx) {
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::ConstructQueryContext* ctx) {
   ParsedQuery query;
-  query.datasetClauses_.addClauses(visitVector(ctx->datasetClause()));
+  query.datasetClauses_ = parsedQuery::DatasetClauses::fromClauses(
+      visitVector(ctx->datasetClause()));
   if (ctx->constructTemplate()) {
     query._clause = visit(ctx->constructTemplate())
                         .value_or(parsedQuery::ConstructClause{});
@@ -930,7 +931,8 @@ void Visitor::visit(Parser::PrefixDeclContext* ctx) {
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::SelectQueryContext* ctx) {
   parsedQuery_._clause = visit(ctx->selectClause());
-  parsedQuery_.datasetClauses_.addClauses(visitVector(ctx->datasetClause()));
+  parsedQuery_.datasetClauses_ = parsedQuery::DatasetClauses::fromClauses(
+      visitVector(ctx->datasetClause()));
   auto [pattern, visibleVariables] = visit(ctx->whereClause());
   parsedQuery_._rootGraphPattern = std::move(pattern);
   parsedQuery_.registerVariablesVisibleInQueryBody(visibleVariables);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -233,26 +233,10 @@ Alias Visitor::visit(Parser::AliasWithoutBracketsContext* ctx) {
   return {visitExpressionPimpl(ctx->expression()), visit(ctx->var())};
 }
 
-namespace {
-// Add the `datasetClauses` to the `targetClauses`.
-void addDatasetClauses(
-    ParsedQuery::DatasetClauses& targetClauses,
-    const std::vector<SparqlQleverVisitor::DatasetClause>& datasetClauses) {
-  for (auto& [dataset, isNamed] : datasetClauses) {
-    auto& graphs =
-        isNamed ? targetClauses.namedGraphs_ : targetClauses.defaultGraphs_;
-    if (!graphs.has_value()) {
-      graphs.emplace();
-    }
-    graphs.value().insert(std::move(dataset));
-  }
-}
-}  // namespace
-
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::ConstructQueryContext* ctx) {
   ParsedQuery query;
-  addDatasetClauses(query.datasetClauses_, visitVector(ctx->datasetClause()));
+  query.datasetClauses_.addClauses(visitVector(ctx->datasetClause()));
   if (ctx->constructTemplate()) {
     query._clause = visit(ctx->constructTemplate())
                         .value_or(parsedQuery::ConstructClause{});
@@ -279,7 +263,7 @@ ParsedQuery Visitor::visit(const Parser::AskQueryContext* ctx) {
 }
 
 // ____________________________________________________________________________________
-Visitor::DatasetClause Visitor::visit(Parser::DatasetClauseContext* ctx) {
+DatasetClause Visitor::visit(Parser::DatasetClauseContext* ctx) {
   if (ctx->defaultGraphClause()) {
     return {.dataset_ = visit(ctx->defaultGraphClause()), .isNamed_ = false};
   } else {
@@ -946,8 +930,7 @@ void Visitor::visit(Parser::PrefixDeclContext* ctx) {
 // ____________________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::SelectQueryContext* ctx) {
   parsedQuery_._clause = visit(ctx->selectClause());
-  addDatasetClauses(parsedQuery_.datasetClauses_,
-                    visitVector(ctx->datasetClause()));
+  parsedQuery_.datasetClauses_.addClauses(visitVector(ctx->datasetClause()));
   auto [pattern, visibleVariables] = visit(ctx->whereClause());
   parsedQuery_._rootGraphPattern = std::move(pattern);
   parsedQuery_.registerVariablesVisibleInQueryBody(visibleVariables);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -31,6 +31,9 @@ class Reversed {
 struct DatasetClause {
   TripleComponent::Iri dataset_;
   bool isNamed_;
+
+  // For testing
+  bool operator==(const DatasetClause& other) const = default;
 };
 
 /**

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -27,6 +27,12 @@ class Reversed {
   auto end() { return _iterable.rend(); }
 };
 
+// A named or default graph
+struct DatasetClause {
+  TripleComponent::Iri dataset_;
+  bool isNamed_;
+};
+
 /**
  * This is a visitor that takes the parse tree from ANTLR and transforms it into
  * a `ParsedQuery`.
@@ -146,11 +152,6 @@ class SparqlQleverVisitor {
       const Parser::DescribeQueryContext* ctx);
 
   [[noreturn]] static ParsedQuery visit(const Parser::AskQueryContext* ctx);
-
-  struct DatasetClause {
-    TripleComponent::Iri dataset_;
-    bool isNamed_;
-  };
 
   DatasetClause visit(Parser::DatasetClauseContext* ctx);
 

--- a/src/util/http/CMakeLists.txt
+++ b/src/util/http/CMakeLists.txt
@@ -6,4 +6,4 @@ add_library(http HttpServer.h HttpClient.h HttpClient.cpp HttpUtils.h HttpUtils.
         websocket/WebSocketSession.cpp websocket/MessageSender.cpp websocket/QueryToSocketDistributor.cpp
         websocket/QueryHub.cpp websocket/UpdateFetcher.cpp)
 
-qlever_target_link_libraries(http util mediaTypes httpParser OpenSSL::SSL OpenSSL::Crypto)
+qlever_target_link_libraries(http parser util mediaTypes httpParser OpenSSL::SSL OpenSSL::Crypto)

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -25,14 +25,7 @@ ParamValueMap ad_utility::url_parser::paramsToMap(
     boost::urls::params_view params) {
   ParamValueMap result;
   for (const auto& [key, value, _] : params) {
-    if (result.contains(key)) {
-      result[key].push_back(value);
-    } else {
-      auto [blockingElement, wasInserted] = result.insert({key, {value}});
-      if (!wasInserted) {
-        AD_FAIL();
-      }
-    }
+    result[key].push_back(value);
   }
   return result;
 }

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -21,15 +21,17 @@ ParsedUrl ad_utility::url_parser::parseRequestTarget(std::string_view target) {
 }
 
 // _____________________________________________________________________________
-ad_utility::HashMap<std::string, std::string>
-ad_utility::url_parser::paramsToMap(boost::urls::params_view params) {
-  ad_utility::HashMap<std::string, std::string> result;
+ParamValueMap ad_utility::url_parser::paramsToMap(
+    boost::urls::params_view params) {
+  ParamValueMap result;
   for (const auto& [key, value, _] : params) {
-    auto [blockingElement, wasInserted] = result.insert({key, value});
-    if (!wasInserted) {
-      throw std::runtime_error(
-          absl::StrCat("HTTP parameter \"", key, "\" is set twice. It is \"",
-                       blockingElement->second, "\" and \"", value, "\""));
+    if (result.contains(key)) {
+      result[key].push_back(value);
+    } else {
+      auto [blockingElement, wasInserted] = result.insert({key, {value}});
+      if (!wasInserted) {
+        AD_FAIL();
+      }
     }
   }
   return result;

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -2,6 +2,7 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 
 #include "UrlParser.h"
 

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -8,6 +8,19 @@
 
 using namespace ad_utility::url_parser;
 
+std::optional<std::string> ad_utility::url_parser::getParameterCheckAtMostOnce(
+    const ParamValueMap& map, string_view key) {
+  if (!map.contains(key)) {
+    return std::nullopt;
+  }
+  auto& value = map.at(key);
+  if (value.size() != 1) {
+    throw std::runtime_error(
+        absl::StrCat("Parameter \"", key,
+                     "\" must be specified exactly once. Is: ", value.size()));
+  }
+  return value.front();
+}
 // _____________________________________________________________________________
 ParsedUrl ad_utility::url_parser::parseRequestTarget(std::string_view target) {
   auto urlResult = boost::urls::parse_origin_form(target);

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -8,8 +8,9 @@
 
 using namespace ad_utility::url_parser;
 
-std::optional<std::string> ad_utility::url_parser::getParameterCheckAtMostOnce(
-    const ParamValueMap& map, string_view key) {
+const std::optional<std::string>&
+ad_utility::url_parser::getParameterCheckAtMostOnce(const ParamValueMap& map,
+                                                    string_view key) {
   if (!map.contains(key)) {
     return std::nullopt;
   }

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -38,9 +38,9 @@ ParamValueMap ad_utility::url_parser::paramsToMap(
 }
 
 // _____________________________________________________________________________
-std::vector<SparqlQleverVisitor::DatasetClause>
-ad_utility::url_parser::parseDatasetClauses(const ParamValueMap& params) {
-  std::vector<SparqlQleverVisitor::DatasetClause> datasetClauses;
+std::vector<DatasetClause> ad_utility::url_parser::parseDatasetClauses(
+    const ParamValueMap& params) {
+  std::vector<DatasetClause> datasetClauses;
   auto readDatasetClauses = [&params, &datasetClauses](const std::string& key,
                                                        bool isNamed) {
     if (params.contains(key)) {

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -36,3 +36,22 @@ ParamValueMap ad_utility::url_parser::paramsToMap(
   }
   return result;
 }
+
+// _____________________________________________________________________________
+std::vector<SparqlQleverVisitor::DatasetClause>
+ad_utility::url_parser::parseDatasetClauses(const ParamValueMap& params) {
+  std::vector<SparqlQleverVisitor::DatasetClause> datasetClauses;
+  auto readDatasetClauses = [&params, &datasetClauses](const std::string& key,
+                                                       bool isNamed) {
+    if (params.contains(key)) {
+      for (const auto& uri : params.at(key)) {
+        datasetClauses.emplace_back(
+            ad_utility::triple_component::Iri::fromIrirefWithoutBrackets(uri),
+            isNamed);
+      }
+    }
+  };
+  readDatasetClauses("default-graph-uri", false);
+  readDatasetClauses("named-graph-uri", true);
+  return datasetClauses;
+}

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -8,9 +8,8 @@
 
 using namespace ad_utility::url_parser;
 
-const std::optional<std::string>&
-ad_utility::url_parser::getParameterCheckAtMostOnce(const ParamValueMap& map,
-                                                    string_view key) {
+std::optional<std::string> ad_utility::url_parser::getParameterCheckAtMostOnce(
+    const ParamValueMap& map, string_view key) {
   if (!map.contains(key)) {
     return std::nullopt;
   }

--- a/src/util/http/UrlParser.cpp
+++ b/src/util/http/UrlParser.cpp
@@ -17,7 +17,7 @@ std::optional<std::string> ad_utility::url_parser::getParameterCheckAtMostOnce(
   if (value.size() != 1) {
     throw std::runtime_error(
         absl::StrCat("Parameter \"", key,
-                     "\" must be specified exactly once. Is: ", value.size()));
+                     "\" must be given exactly once. Is: ", value.size()));
   }
   return value.front();
 }

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -64,11 +64,11 @@ struct ParsedRequest {
   std::variant<Operation::Query, Operation::Update, Operation::None> operation_;
 };
 
-// Parse the URL path and the URL query parameters of a HTTP Request target.
+// Parse the URL path and the URL query parameters of an HTTP Request target.
 ParsedUrl parseRequestTarget(std::string_view target);
 
-// Convert the HTTP Query parameters `params` to a hashmap. Throw an error
-// if a key is included twice.
+// Convert the HTTP Query parameters `params` to a ParamValueMap (a map from
+// string to vectors of strings).
 ParamValueMap paramsToMap(boost::urls::params_view params);
 
 // Parse default and named graphs URIs from the parameters.

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -32,7 +32,7 @@ struct ParsedUrl {
 };
 
 // The different SPARQL operations that a `ParsedRequest` can represent.
-namespace Operation {
+namespace sparqlOperation {
 // A SPARQL 1.1 Query
 struct Query {
   std::string query_;
@@ -52,7 +52,7 @@ struct Update {
 struct None {
   bool operator==(const None& rhs) const = default;
 };
-}  // namespace Operation
+}  // namespace sparqlOperation
 
 // Representation of parsed HTTP request.
 // - `path_` is the URL path
@@ -61,7 +61,9 @@ struct None {
 struct ParsedRequest {
   std::string path_;
   ParamValueMap parameters_;
-  std::variant<Operation::Query, Operation::Update, Operation::None> operation_;
+  std::variant<sparqlOperation::Query, sparqlOperation::Update,
+               sparqlOperation::None>
+      operation_;
 };
 
 // Parse the URL path and the URL query parameters of an HTTP Request target.

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -72,8 +72,7 @@ ParsedUrl parseRequestTarget(std::string_view target);
 ParamValueMap paramsToMap(boost::urls::params_view params);
 
 // Parse default and named graphs URIs from the parameters.
-std::vector<SparqlQleverVisitor::DatasetClause> parseDatasetClauses(
-    const ParamValueMap& params);
+std::vector<DatasetClause> parseDatasetClauses(const ParamValueMap& params);
 }  // namespace ad_utility::url_parser
 
 #endif  // QLEVER_URLPARSER_H

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -23,6 +23,12 @@ namespace ad_utility::url_parser {
 // multiple times with different values.
 using ParamValueMap = ad_utility::HashMap<string, std::vector<string>>;
 
+// Extracts a parameter that must be present exactly once. If the parameter is
+// not present std::nullopt is returned. If the parameter is present multiple
+// times an exception is thrown.
+std::optional<std::string> getParameterCheckAtMostOnce(const ParamValueMap& map,
+                                                       string_view key);
+
 // A parsed URL.
 // - `path_` is the URL path
 // - `parameters_` is a map of the HTTP Query parameters

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -17,16 +17,17 @@
  * /brief Some helpers to parse request URLs in QLever.
  */
 namespace ad_utility::url_parser {
-// TODO: There can be multiple values for a HTTP query parameter. Some SPARQL
-// features require setting a parameter multiple times. Change the interface
-// s.t. this is supported.
+
+// A map that stores the values for parameters. Parameters can be specified
+// multiple times with different values.
+using ParamValueMap = ad_utility::HashMap<string, std::vector<string>>;
 
 // A parsed URL.
 // - `path_` is the URL path
-// - `parameters_` is a hashmap of the HTTP Query parameters
+// - `parameters_` is a map of the HTTP Query parameters
 struct ParsedUrl {
   std::string path_;
-  ad_utility::HashMap<std::string, std::string> parameters_;
+  ParamValueMap parameters_;
 };
 
 // The different SPARQL operations that a `ParsedRequest` can represent.
@@ -58,7 +59,7 @@ struct None {
 // - `operation_` the operation that should be performed
 struct ParsedRequest {
   std::string path_;
-  ad_utility::HashMap<std::string, std::string> parameters_;
+  ParamValueMap parameters_;
   std::variant<Operation::Query, Operation::Update, Operation::None> operation_;
 };
 
@@ -67,8 +68,7 @@ ParsedUrl parseRequestTarget(std::string_view target);
 
 // Convert the HTTP Query parameters `params` to a hashmap. Throw an error
 // if a key is included twice.
-ad_utility::HashMap<std::string, std::string> paramsToMap(
-    boost::urls::params_view params);
+ParamValueMap paramsToMap(boost::urls::params_view params);
 }  // namespace ad_utility::url_parser
 
 #endif  // QLEVER_URLPARSER_H

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -29,30 +29,37 @@ struct ParsedUrl {
   ad_utility::HashMap<std::string, std::string> parameters_;
 };
 
-struct QueryOp {
+// The different SPARQL operations that a `ParsedRequest` can represent.
+namespace Operation {
+// A SPARQL 1.1 Query
+struct Query {
   std::string query_;
 
-  bool operator==(const QueryOp& rhs) const = default;
+  bool operator==(const Query& rhs) const = default;
 };
 
-struct UpdateOp {
+// A SPARQL 1.1 Update
+struct Update {
   std::string update_;
 
-  bool operator==(const UpdateOp& rhs) const = default;
+  bool operator==(const Update& rhs) const = default;
 };
 
-struct UndefinedOp {
-  bool operator==(const UndefinedOp& rhs) const = default;
+// No operation. This can happen for QLever's custom operations (e.g.
+// `cache-stats`). These requests have no operation but are still valid.
+struct None {
+  bool operator==(const None& rhs) const = default;
 };
+}  // namespace Operation
 
 // Representation of parsed HTTP request.
 // - `path_` is the URL path
 // - `parameters_` is a hashmap of the parameters
-// - `query_` contains the Query
+// - `operation_` the operation that should be performed
 struct ParsedRequest {
   std::string path_;
   ad_utility::HashMap<std::string, std::string> parameters_;
-  std::variant<QueryOp, UpdateOp, UndefinedOp> operation_;
+  std::variant<Operation::Query, Operation::Update, Operation::None> operation_;
 };
 
 // Parse the URL path and the URL query parameters of a HTTP Request target.

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -26,8 +26,8 @@ using ParamValueMap = ad_utility::HashMap<string, std::vector<string>>;
 // Extracts a parameter that must be present exactly once. If the parameter is
 // not present std::nullopt is returned. If the parameter is present multiple
 // times an exception is thrown.
-std::optional<std::string> getParameterCheckAtMostOnce(const ParamValueMap& map,
-                                                       string_view key);
+const std::optional<std::string>& getParameterCheckAtMostOnce(
+    const ParamValueMap& map, string_view key);
 
 // A parsed URL.
 // - `path_` is the URL path

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -11,7 +11,8 @@
 #include <string>
 #include <string_view>
 
-#include "../HashMap.h"
+#include "parser/sparqlParser/SparqlQleverVisitor.h"
+#include "util/HashMap.h"
 
 /**
  * /brief Some helpers to parse request URLs in QLever.
@@ -69,6 +70,10 @@ ParsedUrl parseRequestTarget(std::string_view target);
 // Convert the HTTP Query parameters `params` to a hashmap. Throw an error
 // if a key is included twice.
 ParamValueMap paramsToMap(boost::urls::params_view params);
+
+// Parse default and named graphs URIs from the parameters.
+std::vector<SparqlQleverVisitor::DatasetClause> parseDatasetClauses(
+    const ParamValueMap& params);
 }  // namespace ad_utility::url_parser
 
 #endif  // QLEVER_URLPARSER_H

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -2,12 +2,12 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 
 #ifndef QLEVER_URLPARSER_H
 #define QLEVER_URLPARSER_H
 
 #include <boost/url.hpp>
-#include <optional>
 #include <string>
 #include <string_view>
 
@@ -29,6 +29,22 @@ struct ParsedUrl {
   ad_utility::HashMap<std::string, std::string> parameters_;
 };
 
+struct QueryOp {
+  std::string query_;
+
+  bool operator==(const QueryOp& rhs) const = default;
+};
+
+struct UpdateOp {
+  std::string update_;
+
+  bool operator==(const UpdateOp& rhs) const = default;
+};
+
+struct UndefinedOp {
+  bool operator==(const UndefinedOp& rhs) const = default;
+};
+
 // Representation of parsed HTTP request.
 // - `path_` is the URL path
 // - `parameters_` is a hashmap of the parameters
@@ -36,7 +52,7 @@ struct ParsedUrl {
 struct ParsedRequest {
   std::string path_;
   ad_utility::HashMap<std::string, std::string> parameters_;
-  std::optional<std::string> query_;
+  std::variant<QueryOp, UpdateOp, UndefinedOp> operation_;
 };
 
 // Parse the URL path and the URL query parameters of a HTTP Request target.

--- a/src/util/http/UrlParser.h
+++ b/src/util/http/UrlParser.h
@@ -26,8 +26,8 @@ using ParamValueMap = ad_utility::HashMap<string, std::vector<string>>;
 // Extracts a parameter that must be present exactly once. If the parameter is
 // not present std::nullopt is returned. If the parameter is present multiple
 // times an exception is thrown.
-const std::optional<std::string>& getParameterCheckAtMostOnce(
-    const ParamValueMap& map, string_view key);
+std::optional<std::string> getParameterCheckAtMostOnce(const ParamValueMap& map,
+                                                       string_view key);
 
 // A parsed URL.
 // - `path_` is the URL path

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -79,6 +79,17 @@ TEST(ServerTest, parseHttpRequest) {
   EXPECT_THAT(parse(MakePostRequest("/", URLENCODED,
                                     "query=SELECT%20%2A%20WHERE%20%7B%7D")),
               ParsedRequestIs("/", {}, Query{"SELECT * WHERE {}"}));
+  EXPECT_THAT(
+      parse(MakePostRequest(
+          "/", URLENCODED,
+          "query=SELECT%20%2A%20WHERE%20%7B%7D&default-graph-uri=https%3A%2F%"
+          "2Fw3.org%2Fdefault&named-graph-uri=https%3A%2F%2Fw3.org%2F1&named-"
+          "graph-uri=https%3A%2F%2Fw3.org%2F2")),
+      ParsedRequestIs(
+          "/",
+          {{"default-graph-uri", {"https://w3.org/default"}},
+           {"named-graph-uri", {"https://w3.org/1", "https://w3.org/2"}}},
+          Query{"SELECT * WHERE {}"}));
   AD_EXPECT_THROW_WITH_MESSAGE(
       parse(MakePostRequest("/?send=100", URLENCODED,
                             "query=SELECT%20%2A%20WHERE%20%7B%7D")),

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -159,4 +159,16 @@ TEST(ServerTest, checkParameter) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       Server::checkParameter(exampleParams, "baz", "qux", false),
       testing::StrEq("Parameter \"baz\" must be given exactly once. Is: 2"));
+  EXPECT_THAT(Server::checkParameter(exampleParams, "foo", std::nullopt, true),
+              testing::Optional(testing::StrEq("bar")));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      Server::checkParameter(exampleParams, "foo", std::nullopt, false),
+      testing::StrEq("Access to \"foo=bar\" denied (requires a valid access "
+                     "token), processing of request aborted"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      Server::checkParameter(exampleParams, "baz", std::nullopt, false),
+      testing::StrEq("Parameter \"baz\" must be given exactly once. Is: 2"));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      Server::checkParameter(exampleParams, "baz", std::nullopt, true),
+      testing::StrEq("Parameter \"baz\" must be given exactly once. Is: 2"));
 }

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -13,7 +13,7 @@
 #include "util/http/UrlParser.h"
 
 using namespace ad_utility::url_parser;
-using namespace ad_utility::url_parser::Operation;
+using namespace ad_utility::url_parser::sparqlOperation;
 
 namespace {
 auto ParsedRequestIs = [](const std::string& path,

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -75,8 +75,8 @@ TEST(ServerTest, parseHttpRequest) {
   AD_EXPECT_THROW_WITH_MESSAGE(
       parse(MakeGetRequest("/?query=SELECT%20%2A%20WHERE%20%7B%7D&query=SELECT%"
                            "20%3Ffoo%20WHERE%20%7B%7D")),
-      ::testing::HasSubstr(
-          "The parameter \"query\" must be set exactly once."));
+      ::testing::StrEq(
+          "Parameter \"query\" must be given exactly once. Is: 2"));
   AD_EXPECT_THROW_WITH_MESSAGE(
       parse(MakePostRequest("/", URLENCODED,
                             "query=SELECT%20%2A%20WHERE%20%7B%7D&update=DELETE%"
@@ -87,8 +87,8 @@ TEST(ServerTest, parseHttpRequest) {
       parse(MakePostRequest("/", URLENCODED,
                             "update=DELETE%20%7B%7D%20WHERE%20%7B%7D&update="
                             "DELETE%20%7B%7D%20WHERE%20%7B%7D")),
-      ::testing::HasSubstr(
-          "The parameter \"update\" must be set exactly once."));
+      ::testing::StrEq(
+          "Parameter \"update\" must be given exactly once. Is: 2"));
   EXPECT_THAT(
       parse(MakePostRequest("/", "application/x-www-form-urlencoded",
                             "query=SELECT%20%2A%20WHERE%20%7B%7D&send=100")),

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -83,3 +83,33 @@ TEST(UrlParserTest, parseRequestTarget) {
       parseRequestTarget("file://more-than-target"),
       testing::StrEq("Failed to parse URL: \"file://more-than-target\"."));
 }
+
+TEST(UrlParserTest, parseDatasetClauses) {
+  using namespace ad_utility::url_parser;
+  using Iri = ad_utility::triple_component::Iri;
+
+  // Construct the vector from an initializer list without specifying the type.
+  auto IsDatasets = [](const std::vector<DatasetClause>& datasetClauses)
+      -> testing::Matcher<const std::vector<DatasetClause>&> {
+    return testing::ContainerEq(datasetClauses);
+  };
+
+  EXPECT_THAT(parseDatasetClauses({}), IsDatasets({}));
+  EXPECT_THAT(
+      parseDatasetClauses({{"default-graph-uri", {"https://w3.org/1"}}}),
+      IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), false}}));
+  EXPECT_THAT(parseDatasetClauses({{"named-graph-uri", {"https://w3.org/1"}}}),
+              IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), true}}));
+  EXPECT_THAT(parseDatasetClauses({{"default-graph-uri", {"https://w3.org/1"}},
+                                   {"named-graph-uri", {"https://w3.org/2"}}}),
+              IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), false},
+                          {Iri::fromIriref("<https://w3.org/2>"), true}}));
+  EXPECT_THAT(
+      parseDatasetClauses(
+          {{"default-graph-uri", {"https://w3.org/1", "https://w3.org/2"}},
+           {"named-graph-uri", {"https://w3.org/3", "https://w3.org/4"}}}),
+      IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), false},
+                  {Iri::fromIriref("<https://w3.org/2>"), false},
+                  {Iri::fromIriref("<https://w3.org/3>"), true},
+                  {Iri::fromIriref("<https://w3.org/4>"), true}}));
+}

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -11,6 +11,20 @@
 
 using namespace ad_utility;
 
+TEST(UrlParserTest, getParameterCheckAtMostOnce) {
+  const url_parser::ParamValueMap map = {{"once", {"a"}},
+                                         {"multiple_times", {"b", "c"}}};
+
+  EXPECT_THAT(url_parser::getParameterCheckAtMostOnce(map, "absent"),
+              testing::Eq(std::nullopt));
+  EXPECT_THAT(url_parser::getParameterCheckAtMostOnce(map, "once"),
+              testing::Optional(testing::StrEq("a")));
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      url_parser::getParameterCheckAtMostOnce(map, "multiple_times"),
+      testing::HasSubstr("Parameter \"multiple_times\" must be specified "
+                         "exactly once. Is: 2"));
+}
+
 TEST(UrlParserTest, paramsToMap) {
   auto parseParams =
       [](const string& queryString) -> url_parser::ParamValueMap {

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -26,6 +26,14 @@ TEST(UrlParserTest, paramsToMap) {
   EXPECT_THAT(parseParams("?&"), HashMapEq({{"", {"", ""}}}));
   EXPECT_THAT(parseParams("?query=SELECT%20%2A%20WHERE%20%7B%7D"),
               HashMapEq({{"query", {"SELECT * WHERE {}"}}}));
+  EXPECT_THAT(
+      parseParams("?query=SELECT%20%2A%20WHERE%20%7B%7D&default-graph-uri="
+                  "https%3A%2F%2Fw3.org%2Fdefault&named-graph-uri=https%3A%2F%"
+                  "2Fw3.org%2F1&named-graph-uri=https%3A%2F%2Fw3.org%2F2"),
+      HashMapEq(
+          {{"query", {"SELECT * WHERE {}"}},
+           {"default-graph-uri", {"https://w3.org/default"}},
+           {"named-graph-uri", {"https://w3.org/1", "https://w3.org/2"}}}));
   EXPECT_THAT(parseParams("?cmd=stats"), HashMapEq({{"cmd", {"stats"}}}));
   EXPECT_THAT(parseParams("/ping"), HashMapEq({}));
   EXPECT_THAT(parseParams(""), HashMapEq({}));

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -23,8 +23,8 @@ TEST(UrlParserTest, getParameterCheckAtMostOnce) {
               ::testing::Optional(::testing::StrEq("a")));
   AD_EXPECT_THROW_WITH_MESSAGE(
       url_parser::getParameterCheckAtMostOnce(map, "multiple_times"),
-      ::testing::HasSubstr("Parameter \"multiple_times\" must be specified "
-                           "exactly once. Is: 2"));
+      ::testing::StrEq("Parameter \"multiple_times\" must be given "
+                       "exactly once. Is: 2"));
 }
 
 TEST(UrlParserTest, paramsToMap) {

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -102,7 +102,6 @@ TEST(UrlParserTest, parseRequestTarget) {
 
 TEST(UrlParserTest, parseDatasetClauses) {
   using namespace ad_utility::url_parser;
-  using Iri = ad_utility::triple_component::Iri;
 
   // Construct the vector from an initializer list without specifying the type.
   auto IsDatasets = [](const std::vector<DatasetClause>& datasetClauses)

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -6,23 +6,25 @@
 #include <gtest/gtest.h>
 
 #include "util/GTestHelpers.h"
+#include "util/TripleComponentTestHelpers.h"
 #include "util/http/HttpUtils.h"
 #include "util/http/UrlParser.h"
 
 using namespace ad_utility;
+using namespace ad_utility::testing;
 
 TEST(UrlParserTest, getParameterCheckAtMostOnce) {
   const url_parser::ParamValueMap map = {{"once", {"a"}},
                                          {"multiple_times", {"b", "c"}}};
 
   EXPECT_THAT(url_parser::getParameterCheckAtMostOnce(map, "absent"),
-              testing::Eq(std::nullopt));
+              ::testing::Eq(std::nullopt));
   EXPECT_THAT(url_parser::getParameterCheckAtMostOnce(map, "once"),
-              testing::Optional(testing::StrEq("a")));
+              ::testing::Optional(::testing::StrEq("a")));
   AD_EXPECT_THROW_WITH_MESSAGE(
       url_parser::getParameterCheckAtMostOnce(map, "multiple_times"),
-      testing::HasSubstr("Parameter \"multiple_times\" must be specified "
-                         "exactly once. Is: 2"));
+      ::testing::HasSubstr("Parameter \"multiple_times\" must be specified "
+                           "exactly once. Is: 2"));
 }
 
 TEST(UrlParserTest, paramsToMap) {
@@ -32,8 +34,8 @@ TEST(UrlParserTest, paramsToMap) {
     return url_parser::paramsToMap(url.params());
   };
   auto HashMapEq = [](const url_parser::ParamValueMap& hashMap)
-      -> testing::Matcher<const url_parser::ParamValueMap> {
-    return testing::ContainerEq(hashMap);
+      -> ::testing::Matcher<const url_parser::ParamValueMap> {
+    return ::testing::ContainerEq(hashMap);
   };
 
   EXPECT_THAT(parseParams("?foo=a&foo=b"), HashMapEq({{"foo", {"a", "b"}}}));
@@ -73,10 +75,10 @@ TEST(UrlParserTest, parseRequestTarget) {
 
   auto IsParsedUrl = [](const string& path,
                         const url_parser::ParamValueMap& parameters)
-      -> testing::Matcher<const ParsedUrl&> {
-    return testing::AllOf(
-        AD_FIELD(ParsedUrl, path_, testing::Eq(path)),
-        AD_FIELD(ParsedUrl, parameters_, testing::ContainerEq(parameters)));
+      -> ::testing::Matcher<const ParsedUrl&> {
+    return ::testing::AllOf(
+        AD_FIELD(ParsedUrl, path_, ::testing::Eq(path)),
+        AD_FIELD(ParsedUrl, parameters_, ::testing::ContainerEq(parameters)));
   };
 
   EXPECT_THAT(parseRequestTarget("/"), IsParsedUrl("/", {}));
@@ -95,7 +97,7 @@ TEST(UrlParserTest, parseRequestTarget) {
   // This a complete URL and not only the request target
   AD_EXPECT_THROW_WITH_MESSAGE(
       parseRequestTarget("file://more-than-target"),
-      testing::StrEq("Failed to parse URL: \"file://more-than-target\"."));
+      ::testing::StrEq("Failed to parse URL: \"file://more-than-target\"."));
 }
 
 TEST(UrlParserTest, parseDatasetClauses) {
@@ -104,26 +106,26 @@ TEST(UrlParserTest, parseDatasetClauses) {
 
   // Construct the vector from an initializer list without specifying the type.
   auto IsDatasets = [](const std::vector<DatasetClause>& datasetClauses)
-      -> testing::Matcher<const std::vector<DatasetClause>&> {
-    return testing::ContainerEq(datasetClauses);
+      -> ::testing::Matcher<const std::vector<DatasetClause>&> {
+    return ::testing::ContainerEq(datasetClauses);
   };
 
   EXPECT_THAT(parseDatasetClauses({}), IsDatasets({}));
   EXPECT_THAT(
       parseDatasetClauses({{"default-graph-uri", {"https://w3.org/1"}}}),
-      IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), false}}));
+      IsDatasets({{iri("<https://w3.org/1>"), false}}));
   EXPECT_THAT(parseDatasetClauses({{"named-graph-uri", {"https://w3.org/1"}}}),
-              IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), true}}));
+              IsDatasets({{iri("<https://w3.org/1>"), true}}));
   EXPECT_THAT(parseDatasetClauses({{"default-graph-uri", {"https://w3.org/1"}},
                                    {"named-graph-uri", {"https://w3.org/2"}}}),
-              IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), false},
-                          {Iri::fromIriref("<https://w3.org/2>"), true}}));
+              IsDatasets({{iri("<https://w3.org/1>"), false},
+                          {iri("<https://w3.org/2>"), true}}));
   EXPECT_THAT(
       parseDatasetClauses(
           {{"default-graph-uri", {"https://w3.org/1", "https://w3.org/2"}},
            {"named-graph-uri", {"https://w3.org/3", "https://w3.org/4"}}}),
-      IsDatasets({{Iri::fromIriref("<https://w3.org/1>"), false},
-                  {Iri::fromIriref("<https://w3.org/2>"), false},
-                  {Iri::fromIriref("<https://w3.org/3>"), true},
-                  {Iri::fromIriref("<https://w3.org/4>"), true}}));
+      IsDatasets({{iri("<https://w3.org/1>"), false},
+                  {iri("<https://w3.org/2>"), false},
+                  {iri("<https://w3.org/3>"), true},
+                  {iri("<https://w3.org/4>"), true}}));
 }

--- a/test/UrlParserTest.cpp
+++ b/test/UrlParserTest.cpp
@@ -13,48 +13,44 @@ using namespace ad_utility;
 
 TEST(UrlParserTest, paramsToMap) {
   auto parseParams =
-      [](const string& queryString) -> HashMap<std::string, std::string> {
-    boost::urls::url_view url(queryString);
+      [](const string& queryString) -> url_parser::ParamValueMap {
+    const boost::urls::url_view url(queryString);
     return url_parser::paramsToMap(url.params());
   };
-  auto HashMapEq = [](const HashMap<std::string, std::string>& hashMap)
-      -> testing::Matcher<HashMap<std::string, std::string>> {
+  auto HashMapEq = [](const url_parser::ParamValueMap& hashMap)
+      -> testing::Matcher<const url_parser::ParamValueMap> {
     return testing::ContainerEq(hashMap);
   };
 
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      parseParams("?foo=a&foo=b"),
-      testing::StrEq(
-          "HTTP parameter \"foo\" is set twice. It is \"a\" and \"b\""));
-  // Parameter with key "" is set twice.
-  EXPECT_THROW(parseParams("?&"), std::runtime_error);
-
+  EXPECT_THAT(parseParams("?foo=a&foo=b"), HashMapEq({{"foo", {"a", "b"}}}));
+  EXPECT_THAT(parseParams("?&"), HashMapEq({{"", {"", ""}}}));
   EXPECT_THAT(parseParams("?query=SELECT%20%2A%20WHERE%20%7B%7D"),
-              HashMapEq({{"query", "SELECT * WHERE {}"}}));
-  EXPECT_THAT(parseParams("?cmd=stats"), HashMapEq({{"cmd", "stats"}}));
+              HashMapEq({{"query", {"SELECT * WHERE {}"}}}));
+  EXPECT_THAT(parseParams("?cmd=stats"), HashMapEq({{"cmd", {"stats"}}}));
   EXPECT_THAT(parseParams("/ping"), HashMapEq({}));
   EXPECT_THAT(parseParams(""), HashMapEq({}));
   // Producing a sequence with one empty param here is a design decision by
   // Boost.URL to make it distinguishable from the case where there is no query
   // string.
-  EXPECT_THAT(parseParams("?"), HashMapEq({{"", ""}}));
+  EXPECT_THAT(parseParams("?"), HashMapEq({{"", {""}}}));
   EXPECT_THAT(parseParams("/ping?a=b&c=d"),
-              HashMapEq({{"a", "b"}, {"c", "d"}}));
-  EXPECT_THAT(parseParams("?foo=a"), HashMapEq({{"foo", "a"}}));
+              HashMapEq({{"a", {"b"}}, {"c", {"d"}}}));
+  EXPECT_THAT(parseParams("?foo=a"), HashMapEq({{"foo", {"a"}}}));
   EXPECT_THAT(parseParams("?a=b&c=d&e=f"),
-              HashMapEq({{"a", "b"}, {"c", "d"}, {"e", "f"}}));
-  EXPECT_THAT(parseParams("?=foo"), HashMapEq({{"", "foo"}}));
-  EXPECT_THAT(parseParams("?=foo&a=b"), HashMapEq({{"", "foo"}, {"a", "b"}}));
-  EXPECT_THAT(parseParams("?foo="), HashMapEq({{"foo", ""}}));
+              HashMapEq({{"a", {"b"}}, {"c", {"d"}}, {"e", {"f"}}}));
+  EXPECT_THAT(parseParams("?=foo"), HashMapEq({{"", {"foo"}}}));
+  EXPECT_THAT(parseParams("?=foo&a=b"),
+              HashMapEq({{"", {"foo"}}, {"a", {"b"}}}));
+  EXPECT_THAT(parseParams("?foo="), HashMapEq({{"foo", {""}}}));
   EXPECT_THAT(parseParams("?foo=&bar=baz"),
-              HashMapEq({{"foo", ""}, {"bar", "baz"}}));
+              HashMapEq({{"foo", {""}}, {"bar", {"baz"}}}));
 }
 
 TEST(UrlParserTest, parseRequestTarget) {
   using namespace ad_utility::url_parser;
 
   auto IsParsedUrl = [](const string& path,
-                        const HashMap<std::string, std::string>& parameters)
+                        const url_parser::ParamValueMap& parameters)
       -> testing::Matcher<const ParsedUrl&> {
     return testing::AllOf(
         AD_FIELD(ParsedUrl, path_, testing::Eq(path)),
@@ -63,17 +59,17 @@ TEST(UrlParserTest, parseRequestTarget) {
 
   EXPECT_THAT(parseRequestTarget("/"), IsParsedUrl("/", {}));
   EXPECT_THAT(parseRequestTarget("/?cmd=stats"),
-              IsParsedUrl("/", {{"cmd", "stats"}}));
+              IsParsedUrl("/", {{"cmd", {"stats"}}}));
   EXPECT_THAT(parseRequestTarget("/?cmd=clear-cache"),
-              IsParsedUrl("/", {{"cmd", "clear-cache"}}));
+              IsParsedUrl("/", {{"cmd", {"clear-cache"}}}));
   EXPECT_THAT(parseRequestTarget(
                   "/?query=SELECT%20%2A%20WHERE%20%7B%7D&action=csv_export"),
-              IsParsedUrl("/", {{"query", "SELECT * WHERE {}"},
-                                {"action", "csv_export"}}));
+              IsParsedUrl("/", {{"query", {"SELECT * WHERE {}"}},
+                                {"action", {"csv_export"}}}));
   EXPECT_THAT(parseRequestTarget("/ping?foo=bar"),
-              IsParsedUrl("/ping", {{"foo", "bar"}}));
+              IsParsedUrl("/ping", {{"foo", {"bar"}}}));
   EXPECT_THAT(parseRequestTarget("/foo??update=bar"),
-              IsParsedUrl("/foo", {{"?update", "bar"}}));
+              IsParsedUrl("/foo", {{"?update", {"bar"}}}));
   // This a complete URL and not only the request target
   AD_EXPECT_THROW_WITH_MESSAGE(
       parseRequestTarget("file://more-than-target"),


### PR DESCRIPTION
HTTP requests via GET and POST are now handled according to the SPARQL standard, in particular:
1. `UPDATE`s have to be sent via `POST` requests.
2. Url parameters can now be specified multiple times. In particular, there can be multiple values for the parameters `default-graph-uri` and `named-graph-uri` which are an alternative to `FROM` and `FROM NAMED` clauses in a query.
3. The above-mentioned parameters are now correctly forwarded to the query processing.

Note that this commit doesn't implement the necessary functionality of `SPARQL UPDATE`, all `UPDATE` request will lead to a `not supported error` being reported.