### PR TITLE
Correctly handle `GROUP BY` inside a `GRAPH ?var` clause

### DIFF
--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -86,6 +86,10 @@ class GroupBy : public Operation {
     return {_subtree.get()};
   }
 
+  // Getters for testing
+  const auto& groupByVariables() const { return _groupByVariables; }
+  const auto& aliases() const { return _aliases; }
+
   struct HashMapAliasInformation;
 
  private:

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -351,8 +351,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
       aliases = pq.selectClause().getAliases();
     }
 
-    // The GroupBy constructor automatically takes care of sorting the input if
-    // necessary.
+    // Inside a `GRAPH ?var {....}` clause,  a `GROUP BY` must implicitly group
+    // by the graph variable.
     auto groupVariables = pq._groupByVariables;
     if (activeGraphVariable_.has_value()) {
       AD_CORRECTNESS_CHECK(
@@ -361,6 +361,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
           "should have thrown an exception earlier");
       groupVariables.push_back(activeGraphVariable_.value());
     }
+    // The GroupBy constructor automatically takes care of sorting the input if
+    // necessary.
     groupByPlan._qet = makeExecutionTree<GroupBy>(
         _qec, groupVariables, std::move(aliases), parent._qet);
     added.push_back(groupByPlan);

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -355,14 +355,14 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
     // necessary.
     auto groupVariables = pq._groupByVariables;
     if (activeGraphVariable_.has_value()) {
-      AD_CORRECTNESS_CHECK(!ad_utility::contains(groupVariables,
-                           activeGraphVariable_.value()),
-                           "Graph variable used inside the GRAPH clause, this "
-                           "should have thrown an exception earlier");
+      AD_CORRECTNESS_CHECK(
+          !ad_utility::contains(groupVariables, activeGraphVariable_.value()),
+          "Graph variable used inside the GRAPH clause, this "
+          "should have thrown an exception earlier");
       groupVariables.push_back(activeGraphVariable_.value());
     }
     groupByPlan._qet = makeExecutionTree<GroupBy>(
-        _qec, pq._groupByVariables, std::move(aliases), parent._qet);
+        _qec, groupVariables, std::move(aliases), parent._qet);
     added.push_back(groupByPlan);
   }
   return added;

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -351,8 +351,8 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
       aliases = pq.selectClause().getAliases();
     }
 
-    // Inside a `GRAPH ?var {....}` clause,  a `GROUP BY` must implicitly group
-    // by the graph variable.
+    // Inside a `GRAPH ?var {....}` clause,  a `GROUP BY` must implicitly (also)
+    // group by the graph variable.
     auto groupVariables = pq._groupByVariables;
     if (activeGraphVariable_.has_value()) {
       AD_CORRECTNESS_CHECK(

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -353,6 +353,14 @@ vector<QueryPlanner::SubtreePlan> QueryPlanner::getGroupByRow(
 
     // The GroupBy constructor automatically takes care of sorting the input if
     // necessary.
+    auto groupVariables = pq._groupByVariables;
+    if (activeGraphVariable_.has_value()) {
+      AD_CORRECTNESS_CHECK(!ad_utility::contains(groupVariables,
+                           activeGraphVariable_.value()),
+                           "Graph variable used inside the GRAPH clause, this "
+                           "should have thrown an exception earlier");
+      groupVariables.push_back(activeGraphVariable_.value());
+    }
     groupByPlan._qet = makeExecutionTree<GroupBy>(
         _qec, pq._groupByVariables, std::move(aliases), parent._qet);
     added.push_back(groupByPlan);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -21,6 +21,10 @@ class QueryPlanner {
   using vector = std::vector<T>;
 
   ParsedQuery::DatasetClauses activeDatasetClauses_;
+  // The variable of the innermost `GRAPH ?var` clause that the planner
+  // currently is planning.
+  // Note: The behavior of only taking the innermost graph variable into account
+  // for nested `GRAPH` clauses is compliant with SPARQL 1.1.
   std::optional<Variable> activeGraphVariable_;
 
  public:


### PR DESCRIPTION
A `GROUP BY` inside a`GRAPH ?var` clause should implicitly also group by `?var`. This is now fixed.