### PR TITLE
Implement `math:pow()`

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -42,6 +42,8 @@ SparqlExpression::Ptr makeSqrtExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeSinExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeCosExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeTanExpression(SparqlExpression::Ptr child);
+SparqlExpression::Ptr makePowExpression(SparqlExpression::Ptr child1,
+                                        SparqlExpression::Ptr child2);
 
 SparqlExpression::Ptr makeDistExpression(SparqlExpression::Ptr child1,
                                          SparqlExpression::Ptr child2);

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -2,6 +2,7 @@
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
+#include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 
 namespace sparqlExpression {
 namespace detail {
@@ -32,6 +33,15 @@ NARY_EXPRESSION(AddExpression, 2, FV<decltype(add), NumericValueGetter>);
 inline auto subtract = makeNumericExpression<std::minus<>>();
 NARY_EXPRESSION(SubtractExpression, 2,
                 FV<decltype(subtract), NumericValueGetter>);
+
+// Power
+struct powOp {
+  constexpr double operator()(const double base, const double exp) {
+    return std::pow(base, exp);
+  }
+};
+inline auto pow = makeNumericExpression<powOp>();
+NARY_EXPRESSION(PowExpression, 2, FV<decltype(pow), NumericValueGetter>);
 
 // Or
 inline auto orLambda = [](TernaryBool a, TernaryBool b) {
@@ -95,5 +105,10 @@ SparqlExpression::Ptr makeAndExpression(SparqlExpression::Ptr child1,
 SparqlExpression::Ptr makeOrExpression(SparqlExpression::Ptr child1,
                                        SparqlExpression::Ptr child2) {
   return std::make_unique<OrExpression>(std::move(child1), std::move(child2));
+}
+
+SparqlExpression::Ptr makePowExpression(SparqlExpression::Ptr child1,
+                                        SparqlExpression::Ptr child2) {
+  return std::make_unique<PowExpression>(std::move(child1), std::move(child2));
 }
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
+++ b/src/engine/sparqlExpressions/NumericBinaryExpressions.cpp
@@ -34,13 +34,11 @@ inline auto subtract = makeNumericExpression<std::minus<>>();
 NARY_EXPRESSION(SubtractExpression, 2,
                 FV<decltype(subtract), NumericValueGetter>);
 
-// Power
-struct powOp {
-  constexpr double operator()(const double base, const double exp) {
-    return std::pow(base, exp);
-  }
+// Power.
+inline auto powImpl = [](double base, double exp) {
+  return std::pow(base, exp);
 };
-inline auto pow = makeNumericExpression<powOp>();
+inline auto pow = makeNumericExpression<decltype(powImpl)>();
 NARY_EXPRESSION(PowExpression, 2, FV<decltype(pow), NumericValueGetter>);
 
 // Or

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -17,6 +17,7 @@
 #include "engine/sparqlExpressions/CountStarExpression.h"
 #include "engine/sparqlExpressions/GroupConcatExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
+#include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/NowDatetimeExpression.h"
 #include "engine/sparqlExpressions/RandomExpression.h"
 #include "engine/sparqlExpressions/RegexExpression.h"
@@ -131,6 +132,10 @@ ExpressionPtr Visitor::processIriFunctionCall(
     } else if (functionName == "tan") {
       checkNumArgs(1);
       return sparqlExpression::makeTanExpression(std::move(argList[0]));
+    } else if (functionName == "pow") {
+      checkNumArgs(2);
+      return sparqlExpression::makePowExpression(std::move(argList[0]),
+                                                 std::move(argList[1]));
     }
   } else if (checkPrefix(XSD_PREFIX)) {
     if (functionName == "integer" || functionName == "int") {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1683,14 +1683,14 @@ TEST(SparqlParser, FunctionCall) {
                      matchUnary(&makeConvertToDoubleExpression));
 
   // Wrong number of arguments.
-  expectFunctionCallFails(
-      "<http://www.opengis.net/def/function/geosparql/distance>(?a)");
-  // Unknown function with the `geof:` prefix.
-  expectFunctionCallFails(
-      "<http://www.opengis.net/def/function/geosparql/notExisting>()");
+  expectFunctionCallFails(absl::StrCat(geof, "distance>(?a)"));
+  // Unknown function with `geof:`, `math:`, or `xsd:` prefix.
+  expectFunctionCallFails(absl::StrCat(geof, "nada>(?x)"));
+  expectFunctionCallFails(absl::StrCat(math, "nada>(?x)"));
+  expectFunctionCallFails(absl::StrCat(xsd, "nada>(?x)"));
   // Prefix for which no function is known.
-  expectFunctionCallFails(
-      "<http://www.no-existing-prefixes.com/notExisting>()");
+  std::string prefixNexistepas = "<http://nexiste.pas/>";
+  expectFunctionCallFails(absl::StrCat(prefixNexistepas, "nada>(?x)"));
 }
 
 // ______________________________________________________________________________

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -19,6 +19,7 @@
 #include "engine/sparqlExpressions/CountStarExpression.h"
 #include "engine/sparqlExpressions/GroupConcatExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
+#include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/NowDatetimeExpression.h"
 #include "engine/sparqlExpressions/RandomExpression.h"
 #include "engine/sparqlExpressions/RegexExpression.h"
@@ -1669,6 +1670,9 @@ TEST(SparqlParser, FunctionCall) {
                      matchUnary(&makeCosExpression));
   expectFunctionCall(absl::StrCat(math, "tan>(?x)"),
                      matchUnary(&makeTanExpression));
+  expectFunctionCall(
+      absl::StrCat(math, "pow>(?a, ?b)"),
+      matchNary(&makePowExpression, Variable{"?a"}, Variable{"?b"}));
   expectFunctionCall(absl::StrCat(xsd, "int>(?x)"),
                      matchUnary(&makeConvertToIntExpression));
   expectFunctionCall(absl::StrCat(xsd, "integer>(?x)"),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -910,6 +910,9 @@ TEST(SparqlExpression, customNumericFunctions) {
   testUnaryExpression<makeTanExpression>(
       std::vector<Id>{I(0), D(1), D(2), D(-1)},
       std::vector<Id>{D(0), D(tan(1)), D(tan(2)), D(tan(-1))});
+  auto checkPow = std::bind_front(testNaryExpression, &makePowExpression);
+  checkPow(Ids{D(1), D(32), U, U}, Ids{I(5), D(2), U, D(0)},
+           IdOrLiteralOrIriVec{I(0), D(5), I(0), lit("abc")});
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
Many functions from <http://www.w3.org/2005/xpath-functions/math#>, like `sqrt`, `sin`, `cos`, ... are already implemented in Qlever, but not `pow`. This PR implements `math:pow(base, exp)`.