### PR TITLE
Implement lazy `Union` operation

### DIFF
--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -242,12 +242,12 @@ IdTable Union::computeUnion(
 
 // _____________________________________________________________________________
 template <bool left>
-std::vector<size_t> Union::computePermutation() const {
-  size_t startOfUndefColumns = _subtrees[left ? 0 : 1]->getResultWidth();
-  std::vector<size_t> permutation(_columnOrigins.size());
+std::vector<ColumnIndex> Union::computePermutation() const {
+  ColumnIndex startOfUndefColumns = _subtrees[left ? 0 : 1]->getResultWidth();
+  std::vector<ColumnIndex> permutation(_columnOrigins.size());
   for (size_t targetColIdx = 0; targetColIdx < _columnOrigins.size();
        ++targetColIdx) {
-    size_t originIndex = _columnOrigins.at(targetColIdx)[left ? 0 : 1];
+    ColumnIndex originIndex = _columnOrigins.at(targetColIdx)[left ? 0 : 1];
     if (originIndex == NO_COLUMN) {
       originIndex = startOfUndefColumns;
       startOfUndefColumns++;
@@ -259,7 +259,7 @@ std::vector<size_t> Union::computePermutation() const {
 
 // _____________________________________________________________________________
 IdTable Union::transformToCorrectColumnFormat(
-    IdTable idTable, const std::vector<size_t>& permutation) const {
+    IdTable idTable, const std::vector<ColumnIndex>& permutation) const {
   while (idTable.numColumns() < getResultWidth()) {
     idTable.addEmptyColumn();
     auto column = idTable.getColumn(idTable.numColumns() - 1);
@@ -275,7 +275,7 @@ cppcoro::generator<IdTable> Union::computeResultLazily(
     std::shared_ptr<const Result> result1,
     std::shared_ptr<const Result> result2,
     std::shared_ptr<LocalVocab> localVocab) const {
-  std::vector<size_t> permutation = computePermutation<true>();
+  std::vector<ColumnIndex> permutation = computePermutation<true>();
   if (result1->isFullyMaterialized()) {
     co_yield transformToCorrectColumnFormat(result1->idTable().clone(),
                                             permutation);

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -252,7 +252,7 @@ std::vector<size_t> Union::computePermutation() const {
       originIndex = startOfUndefColumns;
       startOfUndefColumns++;
     }
-    permutation[originIndex] = targetColIdx;
+    permutation[targetColIdx] = originIndex;
   }
   return permutation;
 }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -243,16 +243,17 @@ IdTable Union::computeUnion(
 // _____________________________________________________________________________
 template <bool left>
 std::vector<ColumnIndex> Union::computePermutation() const {
-  ColumnIndex startOfUndefColumns = _subtrees[left ? 0 : 1]->getResultWidth();
-  std::vector<ColumnIndex> permutation(_columnOrigins.size());
-  for (size_t targetColIdx = 0; targetColIdx < _columnOrigins.size();
-       ++targetColIdx) {
-    ColumnIndex originIndex = _columnOrigins.at(targetColIdx)[left ? 0 : 1];
+  constexpr size_t treeIndex = left ? 0 : 1;
+  ColumnIndex startOfUndefColumns = _subtrees[treeIndex]->getResultWidth();
+  std::vector<ColumnIndex> permutation{};
+  permutation.reserve(_columnOrigins.size());
+  for (const auto& columnOrigin : _columnOrigins) {
+    ColumnIndex originIndex = columnOrigin[treeIndex];
     if (originIndex == NO_COLUMN) {
       originIndex = startOfUndefColumns;
       startOfUndefColumns++;
     }
-    permutation[targetColIdx] = originIndex;
+    permutation.push_back(originIndex);
   }
   return permutation;
 }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -262,8 +262,8 @@ IdTable Union::transformToCorrectColumnFormat(
     IdTable idTable, const std::vector<size_t>& permutation) const {
   while (idTable.numColumns() < getResultWidth()) {
     idTable.addEmptyColumn();
-    std::ranges::fill(idTable.getColumn(idTable.numColumns() - 1),
-                      Id::makeUndefined());
+    auto column = idTable.getColumn(idTable.numColumns() - 1);
+    fillChunked(column.begin(), column.end(), Id::makeUndefined());
   }
 
   idTable.setColumnSubset(permutation);

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -164,11 +164,8 @@ ProtoResult Union::computeResult([[maybe_unused]] bool requestLaziness) {
   std::shared_ptr<const Result> subRes2 = _subtrees[1]->getResult();
   LOG(DEBUG) << "Union subresult computation done." << std::endl;
 
-  IdTable idTable{getExecutionContext()->getAllocator()};
-
-  idTable.setNumColumns(getResultWidth());
-  computeUnion(&idTable, subRes1->idTable(), subRes2->idTable(),
-                      _columnOrigins);
+  IdTable idTable =
+      computeUnion(subRes1->idTable(), subRes2->idTable(), _columnOrigins);
 
   LOG(DEBUG) << "Union result computation done" << std::endl;
   // If only one of the two operands has a non-empty local vocabulary, share
@@ -198,10 +195,10 @@ void Union::fillChunked(auto beg, auto end, const auto& value) const {
 };
 
 // _____________________________________________________________________________
-void Union::computeUnion(
-    IdTable* resPtr, const IdTable& left, const IdTable& right,
-    const std::vector<std::array<size_t, 2>>& columnOrigins) {
-  IdTable& res = *resPtr;
+IdTable Union::computeUnion(
+    const IdTable& left, const IdTable& right,
+    const std::vector<std::array<size_t, 2>>& columnOrigins) const {
+  IdTable res{getResultWidth(), getExecutionContext()->getAllocator()};
   res.resize(left.size() + right.size());
 
   // Write the column with the `inputColumnIndex` from the `inputTable` into the
@@ -230,4 +227,5 @@ void Union::computeUnion(
     writeColumn(left, targetColumn, leftCol, 0u);
     writeColumn(right, targetColumn, rightCol, left.size());
   }
+  return res;
 }

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -80,9 +80,14 @@ class Union : public Operation {
   template <bool left>
   std::vector<size_t> computePermutation() const;
 
+  // Take the given `IdTable`, add any missing columns to it (filled with
+  // undefined values) and permutate the columns to match the end result.
   IdTable transformToCorrectColumnFormat(
       IdTable idTable, const std::vector<size_t>& permutation) const;
 
+  // Create a generator that yields the `IdTable` for the left or right child
+  // one after another and apply a potential differing permutation to it. Write
+  // the merged LocalVocab to the given `LocalVocab` object at the end.
   cppcoro::generator<IdTable> computeResultLazily(
       std::shared_ptr<const Result> result1,
       std::shared_ptr<const Result> result2,

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -83,7 +83,7 @@ class Union : public Operation {
   // Take the given `IdTable`, add any missing columns to it (filled with
   // undefined values) and permutate the columns to match the end result.
   IdTable transformToCorrectColumnFormat(
-      IdTable idTable, const std::vector<size_t>& permutation) const;
+      IdTable idTable, const std::vector<ColumnIndex>& permutation) const;
 
   // Create a generator that yields the `IdTable` for the left or right child
   // one after another and apply a potential differing permutation to it. Write

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -70,8 +70,21 @@ class Union : public Operation {
   // A similar timeout-checking replacement for `std::fill`.
   void fillChunked(auto beg, auto end, const auto& value) const;
 
-  virtual ProtoResult computeResult(
-      [[maybe_unused]] bool requestLaziness) override;
+  virtual ProtoResult computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
+
+  // Compute the permutation of the `IdTable` being yielded for the left or
+  // right child depending on `left`. This permutation can then be used to swap
+  // the columns without any copy operations.
+  template <bool left>
+  std::vector<size_t> computePermutation() const;
+
+  IdTable transformToCorrectColumnFormat(
+      IdTable idTable, const std::vector<size_t>& permutation) const;
+
+  cppcoro::generator<IdTable> computeResultLazily(
+      std::shared_ptr<const Result> result1,
+      std::shared_ptr<const Result> result2,
+      std::shared_ptr<LocalVocab> localVocab) const;
 };

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -54,9 +54,9 @@ class Union : public Operation {
   static constexpr size_t chunkSize = 1'000'000;
 
   // The method is declared here to make it unit testable
-  void computeUnion(IdTable* inputTable, const IdTable& left,
-                    const IdTable& right,
-                    const std::vector<std::array<size_t, 2>>& columnOrigins);
+  IdTable computeUnion(
+      const IdTable& left, const IdTable& right,
+      const std::vector<std::array<size_t, 2>>& columnOrigins) const;
 
   vector<QueryExecutionTree*> getChildren() override {
     return {_subtrees[0].get(), _subtrees[1].get()};

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -70,7 +70,7 @@ class Union : public Operation {
   // A similar timeout-checking replacement for `std::fill`.
   void fillChunked(auto beg, auto end, const auto& value) const;
 
-  virtual ProtoResult computeResult(bool requestLaziness) override;
+  ProtoResult computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -78,7 +78,7 @@ class Union : public Operation {
   // right child depending on `left`. This permutation can then be used to swap
   // the columns without any copy operations.
   template <bool left>
-  std::vector<size_t> computePermutation() const;
+  std::vector<ColumnIndex> computePermutation() const;
 
   // Take the given `IdTable`, add any missing columns to it (filled with
   // undefined values) and permutate the columns to match the end result.

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -51,6 +51,8 @@ class Union : public Operation {
 
   const static size_t NO_COLUMN;
 
+  static constexpr size_t chunkSize = 1'000'000;
+
   // The method is declared here to make it unit testable
   void computeUnion(IdTable* inputTable, const IdTable& left,
                     const IdTable& right,
@@ -61,6 +63,13 @@ class Union : public Operation {
   }
 
  private:
+  // A drop-in replacement for `std::copy` that performs the copying in chunks
+  // of `chunkSize` and checks the timeout after each chunk.
+  void copyChunked(auto beg, auto end, auto target) const;
+
+  // A similar timeout-checking replacement for `std::fill`.
+  void fillChunked(auto beg, auto end, const auto& value) const;
+
   virtual ProtoResult computeResult(
       [[maybe_unused]] bool requestLaziness) override;
 

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -74,7 +74,7 @@ TEST(Union, computeUnionLarge) {
 
 // _____________________________________________________________________________
 TEST(Union, computeUnionLazy) {
-  auto runTest = [](bool nonLazyChilds,
+  auto runTest = [](bool nonLazyChildren,
                     ad_utility::source_location loc =
                         ad_utility::source_location::current()) {
     auto l = generateLocationTrace(loc);
@@ -83,12 +83,14 @@ TEST(Union, computeUnionLazy) {
     IdTable left = makeIdTableFromVector({{V(1)}, {V(2)}, {V(3)}});
     auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
         qec, std::move(left), Vars{Variable{"?x"}}, false,
-        std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt, nonLazyChilds);
+        std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt,
+        nonLazyChildren);
 
     IdTable right = makeIdTableFromVector({{V(4), V(5)}, {V(6), V(7)}});
     auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
         qec, std::move(right), Vars{Variable{"?u"}, Variable{"?x"}}, false,
-        std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt, nonLazyChilds);
+        std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt,
+        nonLazyChildren);
 
     Union u{qec, std::move(leftT), std::move(rightT)};
     auto resultTable = u.computeResultOnlyForTesting(true);

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -79,6 +79,7 @@ TEST(UnionTest, computeUnionLazy) {
                         ad_utility::source_location::current()) {
     auto l = generateLocationTrace(loc);
     auto* qec = ad_utility::testing::getQec();
+    qec->getQueryTreeCache().clearAll();
     IdTable left = makeIdTableFromVector({{V(1)}, {V(2)}, {V(3)}});
     auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
         qec, std::move(left), Vars{Variable{"?x"}}, false,

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -20,7 +20,7 @@ using Vars = std::vector<std::optional<Variable>>;
 }  // namespace
 
 // A simple test for computing a union.
-TEST(UnionTest, computeUnion) {
+TEST(Union, computeUnion) {
   auto* qec = ad_utility::testing::getQec();
   IdTable left = makeIdTableFromVector({{V(1)}, {V(2)}, {V(3)}});
   auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
@@ -30,7 +30,7 @@ TEST(UnionTest, computeUnion) {
   auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, right.clone(), Vars{Variable{"?u"}, Variable{"?x"}});
 
-  Union u{ad_utility::testing::getQec(), leftT, rightT};
+  Union u{qec, leftT, rightT};
   auto resultTable = u.computeResultOnlyForTesting();
   const auto& result = resultTable.idTable();
 
@@ -42,7 +42,7 @@ TEST(UnionTest, computeUnion) {
 
 // A test with large inputs to test the chunked writing that is caused by the
 // timeout checks.
-TEST(UnionTest, computeUnionLarge) {
+TEST(Union, computeUnionLarge) {
   auto* qec = ad_utility::testing::getQec();
   VectorTable leftInput, rightInput, expected;
   size_t numInputsL = 1'500'000u;
@@ -65,7 +65,7 @@ TEST(UnionTest, computeUnionLarge) {
   auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
       qec, makeIdTableFromVector(rightInput), Vars{Variable{"?u"}});
 
-  Union u{ad_utility::testing::getQec(), leftT, rightT};
+  Union u{qec, leftT, rightT};
   auto resultTable = u.computeResultOnlyForTesting();
   const auto& result = resultTable.idTable();
 
@@ -73,7 +73,7 @@ TEST(UnionTest, computeUnionLarge) {
 }
 
 // _____________________________________________________________________________
-TEST(UnionTest, computeUnionLazy) {
+TEST(Union, computeUnionLazy) {
   auto runTest = [](bool nonLazyChilds,
                     ad_utility::source_location loc =
                         ad_utility::source_location::current()) {
@@ -90,7 +90,7 @@ TEST(UnionTest, computeUnionLazy) {
         qec, std::move(right), Vars{Variable{"?u"}, Variable{"?x"}}, false,
         std::vector<ColumnIndex>{}, LocalVocab{}, std::nullopt, nonLazyChilds);
 
-    Union u{ad_utility::testing::getQec(), std::move(leftT), std::move(rightT)};
+    Union u{qec, std::move(leftT), std::move(rightT)};
     auto resultTable = u.computeResultOnlyForTesting(true);
     ASSERT_FALSE(resultTable.isFullyMaterialized());
     auto& result = resultTable.idTables();
@@ -112,4 +112,51 @@ TEST(UnionTest, computeUnionLazy) {
 
   runTest(false);
   runTest(true);
+}
+
+// _____________________________________________________________________________
+TEST(Union, ensurePermutationIsAppliedCorrectly) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 2, 3, 4, 5}}),
+      Vars{Var{"?a"}, Var{"?b"}, Var{"?c"}, Var{"?d"}, Var{"?e"}});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{6, 7, 8}}),
+      Vars{Var{"?b"}, Var{"?a"}, Var{"?e"}});
+
+  Union u{qec, std::move(leftT), std::move(rightT)};
+
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto resultTable = u.computeResultOnlyForTesting(true);
+    ASSERT_FALSE(resultTable.isFullyMaterialized());
+    auto& result = resultTable.idTables();
+
+    auto U = Id::makeUndefined();
+    auto expected1 = makeIdTableFromVector({{1, 2, 3, 4, 5}});
+    auto expected2 = makeIdTableFromVector({{V(7), V(6), U, U, V(8)}});
+
+    auto iterator = result.begin();
+    ASSERT_NE(iterator, result.end());
+    ASSERT_EQ(*iterator, expected1);
+
+    ++iterator;
+    ASSERT_NE(iterator, result.end());
+    ASSERT_EQ(*iterator, expected2);
+
+    ASSERT_EQ(++iterator, result.end());
+  }
+
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto resultTable = u.computeResultOnlyForTesting();
+    ASSERT_TRUE(resultTable.isFullyMaterialized());
+
+    auto U = Id::makeUndefined();
+    auto expected =
+        makeIdTableFromVector({{1, 2, 3, 4, 5}, {V(7), V(6), U, U, V(8)}});
+    EXPECT_EQ(resultTable.idTable(), expected);
+  }
 }


### PR DESCRIPTION
Allow the `Union` operation to lazily output its result.