### PR TITLE
Use one `LocalVocab` for each block during lazy evaluation

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -99,26 +99,25 @@ ProtoResult Bind::computeResult(bool requestLaziness) {
 
   auto applyBind = [this, subRes](IdTable idTable, LocalVocab* localVocab) {
     return computeExpressionBind(localVocab, std::move(idTable),
-                                 subRes->localVocab(),
                                  _bind._expression.getPimpl());
   };
 
   if (subRes->isFullyMaterialized()) {
     if (requestLaziness && subRes->idTable().size() > CHUNK_SIZE) {
-      auto localVocab =
-          std::make_shared<LocalVocab>(subRes->getCopyOfLocalVocab());
-      auto generator = [](std::shared_ptr<LocalVocab> vocab, auto applyBind,
-                          std::shared_ptr<const Result> result)
-          -> cppcoro::generator<IdTable> {
-        size_t size = result->idTable().size();
-        for (size_t offset = 0; offset < size; offset += CHUNK_SIZE) {
-          co_yield applyBind(
-              cloneSubView(result->idTable(),
-                           {offset, std::min(size, offset + CHUNK_SIZE)}),
-              vocab.get());
-        }
-      }(localVocab, std::move(applyBind), std::move(subRes));
-      return {std::move(generator), resultSortedOn(), std::move(localVocab)};
+      return {
+          [](auto applyBind, std::shared_ptr<const Result> result)
+              -> cppcoro::generator<Result::IdTableVocabPair> {
+            size_t size = result->idTable().size();
+            for (size_t offset = 0; offset < size; offset += CHUNK_SIZE) {
+              LocalVocab outVocab = result->getCopyOfLocalVocab();
+              IdTable idTable = applyBind(
+                  cloneSubView(result->idTable(),
+                               {offset, std::min(size, offset + CHUNK_SIZE)}),
+                  &outVocab);
+              co_yield {std::move(idTable), std::move(outVocab)};
+            }
+          }(std::move(applyBind), std::move(subRes)),
+          resultSortedOn()};
     }
     // Make a deep copy of the local vocab from `subRes` and then add to it (in
     // case BIND adds a new word or words).
@@ -133,27 +132,24 @@ ProtoResult Bind::computeResult(bool requestLaziness) {
     return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }
   auto localVocab = std::make_shared<LocalVocab>();
-  auto generator =
-      [](std::shared_ptr<LocalVocab> vocab, auto applyBind,
-         std::shared_ptr<const Result> result) -> cppcoro::generator<IdTable> {
-    for (IdTable& idTable : result->idTables()) {
-      co_yield applyBind(std::move(idTable), vocab.get());
+  auto generator = [](auto applyBind, std::shared_ptr<const Result> result)
+      -> cppcoro::generator<Result::IdTableVocabPair> {
+    for (Result::IdTableVocabPair& pair : result->idTables()) {
+      IdTable idTable = applyBind(std::move(pair.idTable_), &pair.localVocab_);
+      co_yield {std::move(idTable), std::move(pair.localVocab_)};
     }
-    std::array<const LocalVocab*, 2> vocabs{vocab.get(), &result->localVocab()};
-    *vocab = LocalVocab::merge(std::span{vocabs});
-  }(localVocab, std::move(applyBind), std::move(subRes));
-  return {std::move(generator), resultSortedOn(), std::move(localVocab)};
+  }(std::move(applyBind), std::move(subRes));
+  return {std::move(generator), resultSortedOn()};
 }
 
 // _____________________________________________________________________________
 IdTable Bind::computeExpressionBind(
-    LocalVocab* outputLocalVocab, IdTable idTable,
-    const LocalVocab& inputLocalVocab,
+    LocalVocab* localVocab, IdTable idTable,
     const sparqlExpression::SparqlExpression* expression) const {
   sparqlExpression::EvaluationContext evaluationContext(
       *getExecutionContext(), _subtree->getVariableColumns(), idTable,
-      getExecutionContext()->getAllocator(), inputLocalVocab,
-      cancellationHandle_, deadline_);
+      getExecutionContext()->getAllocator(), *localVocab, cancellationHandle_,
+      deadline_);
 
   sparqlExpression::ExpressionResult expressionResult =
       expression->evaluate(&evaluationContext);
@@ -188,7 +184,7 @@ IdTable Bind::computeExpressionBind(
         if (it != resultGenerator.end()) {
           Id constantId =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(*it), *outputLocalVocab);
+                  std::move(*it), *localVocab);
           checkCancellation();
           ad_utility::chunkedFill(outputColumn, constantId, CHUNK_SIZE,
                                   [this]() { checkCancellation(); });
@@ -199,7 +195,7 @@ IdTable Bind::computeExpressionBind(
         for (auto& resultValue : resultGenerator) {
           outputColumn[i] =
               sparqlExpression::detail::constantExpressionResultToId(
-                  std::move(resultValue), *outputLocalVocab);
+                  std::move(resultValue), *localVocab);
           i++;
           checkCancellation();
         }

--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -131,13 +131,12 @@ ProtoResult Bind::computeResult(bool requestLaziness) {
     LOG(DEBUG) << "BIND result computation done." << std::endl;
     return {std::move(result), resultSortedOn(), std::move(localVocab)};
   }
-  auto localVocab = std::make_shared<LocalVocab>();
   auto generator =
       [](auto applyBind,
          std::shared_ptr<const Result> result) -> Result::Generator {
-    for (Result::IdTableVocabPair& pair : result->idTables()) {
-      IdTable idTable = applyBind(std::move(pair.idTable_), &pair.localVocab_);
-      co_yield {std::move(idTable), std::move(pair.localVocab_)};
+    for (auto& [idTable, localVocab] : result->idTables()) {
+      IdTable resultTable = applyBind(std::move(idTable), &localVocab);
+      co_yield {std::move(resultTable), std::move(localVocab)};
     }
   }(std::move(applyBind), std::move(subRes));
   return {std::move(generator), resultSortedOn()};

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -49,8 +49,7 @@ class Bind : public Operation {
 
   // Implementation for the binding of arbitrary expressions.
   IdTable computeExpressionBind(
-      LocalVocab* outputLocalVocab, IdTable idTable,
-      const LocalVocab& inputLocalVocab,
+      LocalVocab* localVocab, IdTable idTable,
       const sparqlExpression::SparqlExpression* expression) const;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -37,7 +37,7 @@ ExportQueryExecutionTrees::getRowIndices(LimitOffsetClause limitOffset,
   if (limitOffset._limit.value_or(1) == 0) {
     co_return;
   }
-  for (const TableConstRefWithVocab& tableWithVocab : getIdTables(result)) {
+  for (TableConstRefWithVocab& tableWithVocab : getIdTables(result)) {
     uint64_t currentOffset =
         limitOffset.actualOffset(tableWithVocab.idTable_.numRows());
     uint64_t upperBound =

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -13,13 +13,17 @@
 #include "util/http/MediaTypes.h"
 
 // __________________________________________________________________________
-cppcoro::generator<const IdTable&> ExportQueryExecutionTrees::getIdTables(
-    const Result& result) {
+cppcoro::generator<ExportQueryExecutionTrees::TableConstRefWithVocab>
+ExportQueryExecutionTrees::getIdTables(const Result& result) {
   if (result.isFullyMaterialized()) {
-    co_yield result.idTable();
+    ExportQueryExecutionTrees::TableConstRefWithVocab pair{result.idTable(),
+                                                           result.localVocab()};
+    co_yield pair;
   } else {
-    for (const IdTable& idTable : result.idTables()) {
-      co_yield idTable;
+    for (const Result::IdTableVocabPair& pair : result.idTables()) {
+      ExportQueryExecutionTrees::TableConstRefWithVocab tableWithVocab{
+          pair.idTable_, pair.localVocab_};
+      co_yield tableWithVocab;
     }
   }
 }
@@ -33,11 +37,14 @@ ExportQueryExecutionTrees::getRowIndices(LimitOffsetClause limitOffset,
   if (limitOffset._limit.value_or(1) == 0) {
     co_return;
   }
-  for (const IdTable& idTable : getIdTables(result)) {
-    uint64_t currentOffset = limitOffset.actualOffset(idTable.numRows());
-    uint64_t upperBound = limitOffset.upperBound(idTable.numRows());
+  for (const TableConstRefWithVocab& tableWithVocab : getIdTables(result)) {
+    uint64_t currentOffset =
+        limitOffset.actualOffset(tableWithVocab.idTable_.numRows());
+    uint64_t upperBound =
+        limitOffset.upperBound(tableWithVocab.idTable_.numRows());
     if (currentOffset != upperBound) {
-      co_yield {idTable, std::views::iota(currentOffset, upperBound)};
+      co_yield {std::move(tableWithVocab),
+                std::views::iota(currentOffset, upperBound)};
     }
     limitOffset._offset -= currentOffset;
     if (limitOffset._limit.has_value()) {
@@ -57,9 +64,10 @@ ExportQueryExecutionTrees::constructQueryResultToTriples(
     const ad_utility::sparql_types::Triples& constructTriples,
     LimitOffsetClause limitAndOffset, std::shared_ptr<const Result> result,
     CancellationHandle cancellationHandle) {
-  for (const auto& [idTable, range] : getRowIndices(limitAndOffset, *result)) {
+  for (const auto& [pair, range] : getRowIndices(limitAndOffset, *result)) {
+    auto& idTable = pair.idTable_;
     for (uint64_t i : range) {
-      ConstructQueryExportContext context{i, idTable, result->localVocab(),
+      ConstructQueryExportContext context{i, idTable, pair.localVocab_,
                                           qet.getVariableColumns(),
                                           qet.getQec()->getIndex()};
       using enum PositionInTriple;
@@ -172,10 +180,10 @@ ExportQueryExecutionTrees::idTableToQLeverJSONBindings(
     std::shared_ptr<const Result> result,
     CancellationHandle cancellationHandle) {
   AD_CORRECTNESS_CHECK(result != nullptr);
-  for (const auto& [idTable, range] : getRowIndices(limitAndOffset, *result)) {
+  for (const auto& [pair, range] : getRowIndices(limitAndOffset, *result)) {
     for (uint64_t rowIndex : range) {
-      co_yield idTableToQLeverJSONRow(qet, columns, result->localVocab(),
-                                      rowIndex, idTable)
+      co_yield idTableToQLeverJSONRow(qet, columns, pair.localVocab_, rowIndex,
+                                      pair.idTable_)
           .dump();
       cancellationHandle->throwIfCancelled();
     }
@@ -405,14 +413,14 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
 
   // special case : binary export of IdTable
   if constexpr (format == MediaType::octetStream) {
-    for (const auto& [idTable, range] :
-         getRowIndices(limitAndOffset, *result)) {
+    for (const auto& [pair, range] : getRowIndices(limitAndOffset, *result)) {
       for (uint64_t i : range) {
         for (const auto& columnIndex : selectedColumnIndices) {
           if (columnIndex.has_value()) {
-            co_yield std::string_view{reinterpret_cast<const char*>(&idTable(
-                                          i, columnIndex.value().columnIndex_)),
-                                      sizeof(Id)};
+            co_yield std::string_view{
+                reinterpret_cast<const char*>(
+                    &pair.idTable_(i, columnIndex.value().columnIndex_)),
+                sizeof(Id)};
           }
         }
         cancellationHandle->throwIfCancelled();
@@ -436,15 +444,15 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
   constexpr auto& escapeFunction = format == MediaType::tsv
                                        ? RdfEscaping::escapeForTsv
                                        : RdfEscaping::escapeForCsv;
-  for (const auto& [idTable, range] : getRowIndices(limitAndOffset, *result)) {
+  for (const auto& [pair, range] : getRowIndices(limitAndOffset, *result)) {
     for (uint64_t i : range) {
       for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
         if (selectedColumnIndices[j].has_value()) {
           const auto& val = selectedColumnIndices[j].value();
-          Id id = idTable(i, val.columnIndex_);
+          Id id = pair.idTable_(i, val.columnIndex_);
           auto optionalStringAndType =
               idToStringAndType<format == MediaType::csv>(
-                  qet.getQec()->getIndex(), id, result->localVocab(),
+                  qet.getQec()->getIndex(), id, pair.localVocab_,
                   escapeFunction);
           if (optionalStringAndType.has_value()) [[likely]] {
             co_yield optionalStringAndType.value().first;
@@ -561,15 +569,15 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   auto selectedColumnIndices =
       qet.selectedVariablesToColumnIndices(selectClause, false);
   // TODO<joka921> we could prefilter for the nonexisting variables.
-  for (const auto& [idTable, range] : getRowIndices(limitAndOffset, *result)) {
+  for (const auto& [pair, range] : getRowIndices(limitAndOffset, *result)) {
     for (uint64_t i : range) {
       co_yield "\n  <result>";
       for (size_t j = 0; j < selectedColumnIndices.size(); ++j) {
         if (selectedColumnIndices[j].has_value()) {
           const auto& val = selectedColumnIndices[j].value();
-          Id id = idTable(i, val.columnIndex_);
+          Id id = pair.idTable_(i, val.columnIndex_);
           co_yield idToXMLBinding(val.variable_, id, qet.getQec()->getIndex(),
-                                  result->localVocab());
+                                  pair.localVocab_);
         }
       }
       co_yield "\n  </result>";
@@ -611,12 +619,13 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
     co_return;
   }
 
-  auto getBinding = [&](const IdTable& idTable, const uint64_t& i) {
+  auto getBinding = [&](const IdTable& idTable, const uint64_t& i,
+                        const LocalVocab& localVocab) {
     nlohmann::ordered_json binding = {};
     for (const auto& column : columns) {
-      auto optionalStringAndType = idToStringAndType(
-          qet.getQec()->getIndex(), idTable(i, column->columnIndex_),
-          result->localVocab());
+      auto optionalStringAndType =
+          idToStringAndType(qet.getQec()->getIndex(),
+                            idTable(i, column->columnIndex_), localVocab);
       if (optionalStringAndType.has_value()) [[likely]] {
         const auto& [stringValue, xsdType] = optionalStringAndType.value();
         binding[column->variable_] =
@@ -627,12 +636,12 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   };
 
   bool isFirstRow = true;
-  for (const auto& [idTable, range] : getRowIndices(limitAndOffset, *result)) {
+  for (const auto& [pair, range] : getRowIndices(limitAndOffset, *result)) {
     for (uint64_t i : range) {
       if (!isFirstRow) [[likely]] {
         co_yield ",";
       }
-      co_yield getBinding(idTable, i);
+      co_yield getBinding(pair.idTable_, i, pair.localVocab_);
       cancellationHandle->throwIfCancelled();
       isFirstRow = false;
     }

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -16,13 +16,11 @@
 cppcoro::generator<ExportQueryExecutionTrees::TableConstRefWithVocab>
 ExportQueryExecutionTrees::getIdTables(const Result& result) {
   if (result.isFullyMaterialized()) {
-    ExportQueryExecutionTrees::TableConstRefWithVocab pair{result.idTable(),
-                                                           result.localVocab()};
+    TableConstRefWithVocab pair{result.idTable(), result.localVocab()};
     co_yield pair;
   } else {
     for (const Result::IdTableVocabPair& pair : result.idTables()) {
-      ExportQueryExecutionTrees::TableConstRefWithVocab tableWithVocab{
-          pair.idTable_, pair.localVocab_};
+      TableConstRefWithVocab tableWithVocab{pair.idTable_, pair.localVocab_};
       co_yield tableWithVocab;
     }
   }

--- a/src/engine/ExportQueryExecutionTrees.h
+++ b/src/engine/ExportQueryExecutionTrees.h
@@ -171,15 +171,23 @@ class ExportQueryExecutionTrees {
       const parsedQuery::SelectClause& selectClause,
       LimitOffsetClause limitAndOffset, CancellationHandle cancellationHandle);
 
+  // Public for testing.
+ public:
+  struct TableConstRefWithVocab {
+    const IdTable& idTable_;
+    const LocalVocab& localVocab_;
+  };
   // Helper type that contains an `IdTable` and a view with related indices to
   // access the `IdTable` with.
   struct TableWithRange {
-    const IdTable& idTable_;
+    TableConstRefWithVocab tableWithVocab_;
     std::ranges::iota_view<uint64_t, uint64_t> view_;
   };
 
+ private:
   // Yield all `IdTables` provided by the given `result`.
-  static cppcoro::generator<const IdTable&> getIdTables(const Result& result);
+  static cppcoro::generator<ExportQueryExecutionTrees::TableConstRefWithVocab>
+  getIdTables(const Result& result);
 
   // Return a range that contains the indices of the rows that have to be
   // exported from the `idTable` given the `LimitOffsetClause`. It takes into

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -57,8 +57,7 @@ ProtoResult Filter::computeResult(bool requestLaziness) {
   }
 
   if (requestLaziness) {
-    return {[](auto subRes,
-               auto* self) -> cppcoro::generator<Result::IdTableVocabPair> {
+    return {[](auto subRes, auto* self) -> Result::Generator {
               for (Result::IdTableVocabPair& pair : subRes->idTables()) {
                 IdTable result = self->filterIdTable(
                     subRes->sortedBy(), pair.idTable_, pair.localVocab_);

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -48,47 +48,56 @@ ProtoResult Filter::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "Filter result computation..." << endl;
   checkCancellation();
 
-  auto localVocab = subRes->getSharedLocalVocab();
   if (subRes->isFullyMaterialized()) {
-    IdTable result = filterIdTable(subRes, subRes->idTable());
+    IdTable result = filterIdTable(subRes->sortedBy(), subRes->idTable(),
+                                   subRes->localVocab());
     LOG(DEBUG) << "Filter result computation done." << endl;
 
-    return {std::move(result), resultSortedOn(), std::move(localVocab)};
+    return {std::move(result), resultSortedOn(), subRes->getSharedLocalVocab()};
   }
 
   if (requestLaziness) {
-    return {[](auto subRes, auto* self) -> cppcoro::generator<IdTable> {
-              for (IdTable& idTable : subRes->idTables()) {
-                IdTable result = self->filterIdTable(subRes, idTable);
-                co_yield result;
+    return {[](auto subRes,
+               auto* self) -> cppcoro::generator<Result::IdTableVocabPair> {
+              for (Result::IdTableVocabPair& pair : subRes->idTables()) {
+                IdTable result = self->filterIdTable(
+                    subRes->sortedBy(), pair.idTable_, pair.localVocab_);
+                co_yield {std::move(result), std::move(pair.localVocab_)};
               }
             }(std::move(subRes), this),
-            resultSortedOn(), std::move(localVocab)};
+            resultSortedOn()};
   }
 
   // If we receive a generator of IdTables, we need to materialize it into a
   // single IdTable.
   size_t width = getSubtree().get()->getResultWidth();
   IdTable result{width, getExecutionContext()->getAllocator()};
-  ad_utility::callFixedSize(width, [this, &subRes, &result]<int WIDTH>() {
-    for (IdTable& idTable : subRes->idTables()) {
-      computeFilterImpl<WIDTH>(result, idTable, subRes->localVocab(),
-                               subRes->sortedBy());
-    }
-  });
+  std::vector<LocalVocab> localVocabs;
+  ad_utility::callFixedSize(
+      width, [this, &subRes, &result, &localVocabs]<int WIDTH>() {
+        for (Result::IdTableVocabPair& pair : subRes->idTables()) {
+          computeFilterImpl<WIDTH>(result, pair.idTable_, pair.localVocab_,
+                                   subRes->sortedBy());
+          localVocabs.emplace_back(std::move(pair.localVocab_));
+        }
+      });
+
+  LocalVocab resultLocalVocab{};
+  resultLocalVocab.mergeWith(localVocabs);
 
   LOG(DEBUG) << "Filter result computation done." << endl;
 
-  return {std::move(result), resultSortedOn(), std::move(localVocab)};
+  return {std::move(result), resultSortedOn(), std::move(resultLocalVocab)};
 }
 
 // _____________________________________________________________________________
-IdTable Filter::filterIdTable(const std::shared_ptr<const Result>& subRes,
-                              const IdTable& idTable) const {
+IdTable Filter::filterIdTable(std::vector<ColumnIndex> sortedBy,
+                              const IdTable& idTable,
+                              const LocalVocab& localVocab) const {
   size_t width = idTable.numColumns();
   IdTable result{width, getExecutionContext()->getAllocator()};
   CALL_FIXED_SIZE(width, &Filter::computeFilterImpl, this, result, idTable,
-                  subRes->localVocab(), subRes->sortedBy());
+                  localVocab, std::move(sortedBy));
   return result;
 }
 

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -58,10 +58,10 @@ ProtoResult Filter::computeResult(bool requestLaziness) {
 
   if (requestLaziness) {
     return {[](auto subRes, auto* self) -> Result::Generator {
-              for (Result::IdTableVocabPair& pair : subRes->idTables()) {
-                IdTable result = self->filterIdTable(
-                    subRes->sortedBy(), pair.idTable_, pair.localVocab_);
-                co_yield {std::move(result), std::move(pair.localVocab_)};
+              for (auto& [idTable, localVocab] : subRes->idTables()) {
+                IdTable result = self->filterIdTable(subRes->sortedBy(),
+                                                     idTable, localVocab);
+                co_yield {std::move(result), std::move(localVocab)};
               }
             }(std::move(subRes), this),
             resultSortedOn()};

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -67,6 +67,7 @@ class Filter : public Operation {
                          std::vector<ColumnIndex> sortedBy) const;
 
   // Run `computeFilterImpl` on the provided IdTable
-  IdTable filterIdTable(const std::shared_ptr<const Result>& subRes,
-                        const IdTable& idTable) const;
+  IdTable filterIdTable(std::vector<ColumnIndex> sortedBy,
+                        const IdTable& idTable,
+                        const LocalVocab& localVocab) const;
 };

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -533,7 +533,8 @@ Result::Generator GroupBy::computeResultLazily(
       // Reuse buffer if not moved out
       resultTable = std::move(outputPair.idTable_);
       resultTable.clear();
-      currentLocalVocab = LocalVocab{};
+      // Keep last local vocab for next commit.
+      currentLocalVocab = std::move(storedLocalVocabs.back());
       storedLocalVocabs.clear();
     }
   }

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -391,13 +391,8 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
 
   AD_CORRECTNESS_CHECK(subresult->idTable().numColumns() == inWidth);
 
-  // Make a deep copy of the local vocab from `subresult` and then add to it (in
-  // case GROUP_CONCAT adds a new word or words).
-  //
-  // TODO: In most GROUP BY operations, nothing is added to the local
-  // vocabulary, so it would be more efficient to first share the pointer here
-  // (like with `shareLocalVocabFrom`) and only copy it when a new word is about
-  // to be added. Same for BIND.
+  // Make a copy of the local vocab. Note: the LocalVocab has reference
+  // semantics via `shared_ptr`, so no actual strings are copied here.
 
   auto localVocab = subresult->getCopyOfLocalVocab();
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -339,16 +339,6 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
 
   LOG(DEBUG) << "GroupBy subresult computation done" << std::endl;
 
-  // Make a deep copy of the local vocab from `subresult` and then add to it (in
-  // case GROUP_CONCAT adds a new word or words).
-  //
-  // TODO: In most GROUP BY operations, nothing is added to the local
-  // vocabulary, so it would be more efficient to first share the pointer here
-  // (like with `shareLocalVocabFrom`) and only copy it when a new word is about
-  // to be added. Same for BIND.
-
-  auto localVocab = subresult->getCopyOfLocalVocab();
-
   std::vector<size_t> groupByColumns;
 
   // parse the group by columns
@@ -369,6 +359,7 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
   }
 
   if (useHashMapOptimization) {
+    auto localVocab = subresult->getCopyOfLocalVocab();
     IdTable idTable = CALL_FIXED_SIZE(
         groupByCols.size(), &GroupBy::computeGroupByForHashMapOptimization,
         this, metadataForUnsequentialData->aggregateAliases_,
@@ -383,22 +374,32 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
   if (!subresult->isFullyMaterialized()) {
     AD_CORRECTNESS_CHECK(metadataForUnsequentialData.has_value());
 
-    auto localVocabPointer =
-        std::make_shared<LocalVocab>(std::move(localVocab));
-    cppcoro::generator<IdTable> generator = CALL_FIXED_SIZE(
+    cppcoro::generator<Result::IdTableVocabPair> generator = CALL_FIXED_SIZE(
         (std::array{inWidth, outWidth}), &GroupBy::computeResultLazily, this,
         std::move(subresult), std::move(aggregates),
         std::move(metadataForUnsequentialData).value().aggregateAliases_,
-        std::move(groupByCols), localVocabPointer, !requestLaziness);
+        std::move(groupByCols), !requestLaziness);
 
-    return requestLaziness
-               ? ProtoResult{std::move(generator), resultSortedOn(),
-                             std::move(localVocabPointer)}
-               : ProtoResult{cppcoro::getSingleElement(std::move(generator)),
-                             resultSortedOn(), std::move(*localVocabPointer)};
+    if (requestLaziness) {
+      return ProtoResult{std::move(generator), resultSortedOn()};
+    }
+    Result::IdTableVocabPair pair =
+        cppcoro::getSingleElement(std::move(generator));
+    return ProtoResult{std::move(pair.idTable_), resultSortedOn(),
+                       std::move(pair.localVocab_)};
   }
 
   AD_CORRECTNESS_CHECK(subresult->idTable().numColumns() == inWidth);
+
+  // Make a deep copy of the local vocab from `subresult` and then add to it (in
+  // case GROUP_CONCAT adds a new word or words).
+  //
+  // TODO: In most GROUP BY operations, nothing is added to the local
+  // vocabulary, so it would be more efficient to first share the pointer here
+  // (like with `shareLocalVocabFrom`) and only copy it when a new word is about
+  // to be added. Same for BIND.
+
+  auto localVocab = subresult->getCopyOfLocalVocab();
 
   IdTable idTable = CALL_FIXED_SIZE(
       (std::array{inWidth, outWidth}), &GroupBy::doGroupBy, this,
@@ -474,14 +475,15 @@ void GroupBy::processEmptyImplicitGroup(
 
 // _____________________________________________________________________________
 template <size_t IN_WIDTH, size_t OUT_WIDTH>
-cppcoro::generator<IdTable> GroupBy::computeResultLazily(
+cppcoro::generator<Result::IdTableVocabPair> GroupBy::computeResultLazily(
     std::shared_ptr<const Result> subresult, std::vector<Aggregate> aggregates,
     std::vector<HashMapAliasInformation> aggregateAliases,
-    std::vector<size_t> groupByCols, std::shared_ptr<LocalVocab> localVocab,
-    bool singleIdTable) const {
+    std::vector<size_t> groupByCols, bool singleIdTable) const {
   size_t inWidth = _subtree->getResultWidth();
   AD_CONTRACT_CHECK(inWidth == IN_WIDTH || IN_WIDTH == 0);
-  LazyGroupBy lazyGroupBy{*localVocab, std::move(aggregateAliases),
+  LocalVocab currentLocalVocab{};
+  std::vector<LocalVocab> storedLocalVocabs;
+  LazyGroupBy lazyGroupBy{currentLocalVocab, std::move(aggregateAliases),
                           getExecutionContext()->getAllocator(),
                           groupByCols.size()};
 
@@ -491,12 +493,14 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
 
   GroupBlock currentGroupBlock;
 
-  for (IdTable& idTable : subresult->idTables()) {
+  for (Result::IdTableVocabPair& pair : subresult->idTables()) {
+    auto& idTable = pair.idTable_;
     if (idTable.empty()) {
       continue;
     }
     AD_CORRECTNESS_CHECK(idTable.numColumns() == inWidth);
     checkCancellation();
+    storedLocalVocabs.emplace_back(std::move(pair.localVocab_));
 
     if (currentGroupBlock.empty()) {
       for (size_t col : groupByCols) {
@@ -505,11 +509,11 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
     }
 
     sparqlExpression::EvaluationContext evaluationContext =
-        createEvaluationContext(*localVocab, idTable);
+        createEvaluationContext(currentLocalVocab, idTable);
 
     size_t lastBlockStart = searchBlockBoundaries(
         [this, &groupSplitAcrossTables, &lazyGroupBy, &evaluationContext,
-         &resultTable, &currentGroupBlock, &aggregates, &localVocab,
+         &resultTable, &currentGroupBlock, &aggregates, &currentLocalVocab,
          &groupByCols](size_t blockStart, size_t blockEnd) {
           if (groupSplitAcrossTables) {
             lazyGroupBy.processBlock(evaluationContext, blockStart, blockEnd);
@@ -521,7 +525,7 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
             IdTableStatic<OUT_WIDTH> table =
                 std::move(resultTable).toStatic<OUT_WIDTH>();
             processBlock<OUT_WIDTH>(table, aggregates, evaluationContext,
-                                    blockStart, blockEnd, localVocab.get(),
+                                    blockStart, blockEnd, &currentLocalVocab,
                                     groupByCols);
             resultTable = std::move(table).toDynamic();
           }
@@ -530,8 +534,15 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
     groupSplitAcrossTables = true;
     lazyGroupBy.processBlock(evaluationContext, lastBlockStart, idTable.size());
     if (!singleIdTable && !resultTable.empty()) {
-      co_yield resultTable;
+      currentLocalVocab.mergeWith(storedLocalVocabs);
+      Result::IdTableVocabPair pair{std::move(resultTable),
+                                    std::move(currentLocalVocab)};
+      co_yield pair;
+      // Re-use buffer if not moved out
+      resultTable = std::move(pair.idTable_);
       resultTable.clear();
+      currentLocalVocab = LocalVocab{};
+      storedLocalVocabs.clear();
     }
   }
   // No need for final commit when loop was never entered.
@@ -539,11 +550,11 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
     // If we have an implicit group by we need to produce one result row
     if (groupByCols.empty()) {
       processEmptyImplicitGroup<OUT_WIDTH>(resultTable, aggregates,
-                                           localVocab.get());
-      co_yield resultTable;
+                                           &currentLocalVocab);
+      co_yield {std::move(resultTable), std::move(currentLocalVocab)};
     } else if (singleIdTable) {
       // Yield at least a single empty table if requested.
-      co_yield resultTable;
+      co_yield {std::move(resultTable), std::move(currentLocalVocab)};
     }
     co_return;
   }
@@ -560,9 +571,10 @@ cppcoro::generator<IdTable> GroupBy::computeResultLazily(
   }
 
   sparqlExpression::EvaluationContext evaluationContext =
-      createEvaluationContext(*localVocab, idTable);
+      createEvaluationContext(currentLocalVocab, idTable);
   lazyGroupBy.commitRow(resultTable, evaluationContext, currentGroupBlock);
-  co_yield resultTable;
+  currentLocalVocab.mergeWith(storedLocalVocabs);
+  co_yield {std::move(resultTable), std::move(currentLocalVocab)};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -374,7 +374,7 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
   if (!subresult->isFullyMaterialized()) {
     AD_CORRECTNESS_CHECK(metadataForUnsequentialData.has_value());
 
-    cppcoro::generator<Result::IdTableVocabPair> generator = CALL_FIXED_SIZE(
+    Result::Generator generator = CALL_FIXED_SIZE(
         (std::array{inWidth, outWidth}), &GroupBy::computeResultLazily, this,
         std::move(subresult), std::move(aggregates),
         std::move(metadataForUnsequentialData).value().aggregateAliases_,
@@ -467,7 +467,7 @@ void GroupBy::processEmptyImplicitGroup(
 
 // _____________________________________________________________________________
 template <size_t IN_WIDTH, size_t OUT_WIDTH>
-cppcoro::generator<Result::IdTableVocabPair> GroupBy::computeResultLazily(
+Result::Generator GroupBy::computeResultLazily(
     std::shared_ptr<const Result> subresult, std::vector<Aggregate> aggregates,
     std::vector<HashMapAliasInformation> aggregateAliases,
     std::vector<size_t> groupByCols, bool singleIdTable) const {

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -380,13 +380,10 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
         std::move(metadataForUnsequentialData).value().aggregateAliases_,
         std::move(groupByCols), !requestLaziness);
 
-    if (requestLaziness) {
-      return ProtoResult{std::move(generator), resultSortedOn()};
-    }
-    Result::IdTableVocabPair pair =
-        cppcoro::getSingleElement(std::move(generator));
-    return ProtoResult{std::move(pair.idTable_), resultSortedOn(),
-                       std::move(pair.localVocab_)};
+    return requestLaziness
+               ? ProtoResult{std::move(generator), resultSortedOn()}
+               : ProtoResult{cppcoro::getSingleElement(std::move(generator)),
+                             resultSortedOn()};
   }
 
   AD_CORRECTNESS_CHECK(subresult->idTable().numColumns() == inWidth);

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -535,11 +535,11 @@ cppcoro::generator<Result::IdTableVocabPair> GroupBy::computeResultLazily(
     lazyGroupBy.processBlock(evaluationContext, lastBlockStart, idTable.size());
     if (!singleIdTable && !resultTable.empty()) {
       currentLocalVocab.mergeWith(storedLocalVocabs);
-      Result::IdTableVocabPair pair{std::move(resultTable),
-                                    std::move(currentLocalVocab)};
-      co_yield pair;
-      // Re-use buffer if not moved out
-      resultTable = std::move(pair.idTable_);
+      Result::IdTableVocabPair outputPair{std::move(resultTable),
+                                          std::move(currentLocalVocab)};
+      co_yield outputPair;
+      // Reuse buffer if not moved out
+      resultTable = std::move(outputPair.idTable_);
       resultTable.clear();
       currentLocalVocab = LocalVocab{};
       storedLocalVocabs.clear();

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -140,12 +140,11 @@ class GroupBy : public Operation {
   // skipping empty tables unless `singleIdTable` is set which causes the
   // function to yield a single id table with the complete result.
   template <size_t IN_WIDTH, size_t OUT_WIDTH>
-  cppcoro::generator<IdTable> computeResultLazily(
+  cppcoro::generator<Result::IdTableVocabPair> computeResultLazily(
       std::shared_ptr<const Result> subresult,
       std::vector<Aggregate> aggregates,
       std::vector<HashMapAliasInformation> aggregateAliases,
-      std::vector<size_t> groupByCols, std::shared_ptr<LocalVocab> localVocab,
-      bool singleIdTable) const;
+      std::vector<size_t> groupByCols, bool singleIdTable) const;
 
   template <size_t OUT_WIDTH>
   void processGroup(const Aggregate& expression,

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -140,7 +140,7 @@ class GroupBy : public Operation {
   // skipping empty tables unless `singleIdTable` is set which causes the
   // function to yield a single id table with the complete result.
   template <size_t IN_WIDTH, size_t OUT_WIDTH>
-  cppcoro::generator<Result::IdTableVocabPair> computeResultLazily(
+  Result::Generator computeResultLazily(
       std::shared_ptr<const Result> subresult,
       std::vector<Aggregate> aggregates,
       std::vector<HashMapAliasInformation> aggregateAliases,

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -135,7 +135,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
 }
 
 // _____________________________________________________________________________
-cppcoro::generator<IdTable> IndexScan::scanInChunks() const {
+cppcoro::generator<Result::IdTableVocabPair> IndexScan::scanInChunks() const {
   auto metadata = getMetadataForScan();
   if (!metadata.has_value()) {
     co_return;
@@ -145,7 +145,7 @@ cppcoro::generator<IdTable> IndexScan::scanInChunks() const {
   std::vector<CompressedBlockMetadata> blocks{blocksSpan.begin(),
                                               blocksSpan.end()};
   for (IdTable& idTable : getLazyScan(std::move(blocks))) {
-    co_yield std::move(idTable);
+    co_yield {std::move(idTable), LocalVocab{}};
   }
 }
 
@@ -153,7 +153,7 @@ cppcoro::generator<IdTable> IndexScan::scanInChunks() const {
 ProtoResult IndexScan::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "IndexScan result computation...\n";
   if (requestLaziness) {
-    return {scanInChunks(), resultSortedOn(), LocalVocab{}};
+    return {scanInChunks(), resultSortedOn()};
   }
   IdTable idTable{getExecutionContext()->getAllocator()};
 

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -135,7 +135,7 @@ VariableToColumnMap IndexScan::computeVariableToColumnMap() const {
 }
 
 // _____________________________________________________________________________
-cppcoro::generator<Result::IdTableVocabPair> IndexScan::scanInChunks() const {
+Result::Generator IndexScan::scanInChunks() const {
   auto metadata = getMetadataForScan();
   if (!metadata.has_value()) {
     co_return;

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -130,7 +130,7 @@ class IndexScan final : public Operation {
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
-  cppcoro::generator<IdTable> scanInChunks() const;
+  cppcoro::generator<Result::IdTableVocabPair> scanInChunks() const;
 
   //  Helper functions for the public `getLazyScanFor...` functions (see above).
   Permutation::IdTableGenerator getLazyScan(

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -130,7 +130,7 @@ class IndexScan final : public Operation {
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
-  cppcoro::generator<Result::IdTableVocabPair> scanInChunks() const;
+  Result::Generator scanInChunks() const;
 
   //  Helper functions for the public `getLazyScanFor...` functions (see above).
   Permutation::IdTableGenerator getLazyScan(

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -20,11 +20,11 @@ LocalVocab LocalVocab::clone() const {
 // _____________________________________________________________________________
 LocalVocab LocalVocab::merge(std::span<const LocalVocab*> vocabs) {
   LocalVocab res;
-  auto inserter = std::back_inserter(res.otherWordSets_);
-  for (const auto* vocab : vocabs) {
-    std::ranges::copy(vocab->otherWordSets_, inserter);
-    *inserter = vocab->primaryWordSet_;
-  }
+  res.mergeWith(vocabs |
+                std::views::transform(
+                    [](const LocalVocab* localVocab) -> const LocalVocab& {
+                      return *localVocab;
+                    }));
   return res;
 }
 

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -91,6 +91,17 @@ class LocalVocab {
   // of the `vocabs`. The primary word set of the newly created vocab is empty.
   static LocalVocab merge(std::span<const LocalVocab*> vocabs);
 
+  // Merge all passed local vocabs to keep alive all the words from each of the
+  // `vocabs`.
+  template <std::ranges::range R>
+  void mergeWith(R&& vocabs) {
+    auto inserter = std::back_inserter(otherWordSets_);
+    for (const auto& vocab : vocabs) {
+      std::ranges::copy(vocab.otherWordSets_, inserter);
+      *inserter = vocab.primaryWordSet_;
+    }
+  }
+
   // Return all the words from all the word sets as a vector.
   std::vector<LiteralOrIri> getAllWordsForTesting() const;
 

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -94,9 +94,9 @@ class LocalVocab {
   // Merge all passed local vocabs to keep alive all the words from each of the
   // `vocabs`.
   template <std::ranges::range R>
-  void mergeWith(R&& vocabs) {
+  void mergeWith(const R& vocabs) {
     auto inserter = std::back_inserter(otherWordSets_);
-    for (const auto& vocab : AD_FWD(vocabs)) {
+    for (const auto& vocab : vocabs) {
       std::ranges::copy(vocab.otherWordSets_, inserter);
       *inserter = vocab.primaryWordSet_;
     }

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -96,7 +96,7 @@ class LocalVocab {
   template <std::ranges::range R>
   void mergeWith(R&& vocabs) {
     auto inserter = std::back_inserter(otherWordSets_);
-    for (const auto& vocab : vocabs) {
+    for (const auto& vocab : AD_FWD(vocabs)) {
       std::ranges::copy(vocab.otherWordSets_, inserter);
       *inserter = vocab.primaryWordSet_;
     }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -180,12 +180,14 @@ CacheValue Operation::runComputationAndPrepareForCache(
     AD_CONTRACT_CHECK(!pinned);
     result.cacheDuringConsumption(
         [maxSize = cache.getMaxSizeSingleEntry()](
-            const std::optional<IdTable>& currentIdTable,
-            const IdTable& newIdTable) {
-          auto currentSize = currentIdTable.has_value()
-                                 ? CacheValue::getSize(currentIdTable.value())
-                                 : 0_B;
-          return maxSize >= currentSize + CacheValue::getSize(newIdTable);
+            const std::optional<Result::IdTableVocabPair>& currentIdTablePair,
+            const Result::IdTableVocabPair& newIdTable) {
+          auto currentSize =
+              currentIdTablePair.has_value()
+                  ? CacheValue::getSize(currentIdTablePair.value().idTable_)
+                  : 0_B;
+          return maxSize >=
+                 currentSize + CacheValue::getSize(newIdTable.idTable_);
         },
         [runtimeInfo = getRuntimeInfoPointer(), &cache,
          cacheKey](Result aggregatedResult) {

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -51,10 +51,11 @@ auto compareRowsBySortColumns(const std::vector<ColumnIndex>& sortedBy) {
 // _____________________________________________________________________________
 Result::Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
                SharedLocalVocabWrapper localVocab)
-    : data_{std::move(idTable)},
-      sortedBy_{std::move(sortedBy)},
-      localVocab_{std::move(localVocab.localVocab_)} {
-  AD_CONTRACT_CHECK(localVocab_ != nullptr);
+    : data_{IdTableSharedLocalVocabPair{std::move(idTable),
+                                        std::move(localVocab.localVocab_)}},
+      sortedBy_{std::move(sortedBy)} {
+  AD_CONTRACT_CHECK(std::get<IdTableSharedLocalVocabPair>(data_).localVocab_ !=
+                    nullptr);
   assertSortOrderIsRespected(this->idTable(), sortedBy_);
 }
 
@@ -65,40 +66,25 @@ Result::Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
              SharedLocalVocabWrapper{std::move(localVocab)}} {}
 
 // _____________________________________________________________________________
-Result::Result(cppcoro::generator<IdTable> idTables,
-               std::vector<ColumnIndex> sortedBy,
-               SharedLocalVocabWrapper localVocab)
-    : data_{GenContainer{
-          [](auto idTables, auto sortedBy) -> cppcoro::generator<IdTable> {
-            std::optional<IdTable::row_type> previousId = std::nullopt;
-            for (IdTable& idTable : idTables) {
-              if (!idTable.empty()) {
-                if (previousId.has_value()) {
-                  AD_EXPENSIVE_CHECK(!compareRowsBySortColumns(sortedBy)(
-                      idTable.at(0), previousId.value()));
-                }
-                previousId = idTable.at(idTable.size() - 1);
-              }
-              assertSortOrderIsRespected(idTable, sortedBy);
-              co_yield std::move(idTable);
+Result::Result(cppcoro::generator<IdTableVocabPair> idTables,
+               std::vector<ColumnIndex> sortedBy)
+    : data_{GenContainer{[](auto idTables, auto sortedBy)
+                             -> cppcoro::generator<IdTableVocabPair> {
+        std::optional<IdTable::row_type> previousId = std::nullopt;
+        for (IdTableVocabPair& pair : idTables) {
+          auto& idTable = pair.idTable_;
+          if (!idTable.empty()) {
+            if (previousId.has_value()) {
+              AD_EXPENSIVE_CHECK(!compareRowsBySortColumns(sortedBy)(
+                  idTable.at(0), previousId.value()));
             }
-          }(std::move(idTables), sortedBy)}},
-      sortedBy_{std::move(sortedBy)},
-      localVocab_{std::move(localVocab.localVocab_)} {
-  AD_CONTRACT_CHECK(localVocab_ != nullptr);
-}
-
-// _____________________________________________________________________________
-Result::Result(cppcoro::generator<IdTable> idTables,
-               std::vector<ColumnIndex> sortedBy, LocalVocab&& localVocab)
-    : Result{std::move(idTables), std::move(sortedBy),
-             SharedLocalVocabWrapper{std::move(localVocab)}} {}
-
-// _____________________________________________________________________________
-Result::Result(cppcoro::generator<IdTable> idTables,
-               std::vector<ColumnIndex> sortedBy, LocalVocabPtr localVocab)
-    : Result{std::move(idTables), std::move(sortedBy),
-             SharedLocalVocabWrapper{std::move(localVocab)}} {}
+            previousId = idTable.at(idTable.size() - 1);
+          }
+          assertSortOrderIsRespected(idTable, sortedBy);
+          co_yield pair;
+        }
+      }(std::move(idTables), sortedBy)}},
+      sortedBy_{std::move(sortedBy)} {}
 
 // _____________________________________________________________________________
 // Apply `LimitOffsetClause` to given `IdTable`.
@@ -131,16 +117,19 @@ void Result::applyLimitOffset(
   }
   if (isFullyMaterialized()) {
     ad_utility::timer::Timer limitTimer{ad_utility::timer::Timer::Started};
-    resizeIdTable(std::get<IdTable>(data_), limitOffset);
+    resizeIdTable(std::get<IdTableSharedLocalVocabPair>(data_).idTable_,
+                  limitOffset);
     limitTimeCallback(limitTimer.msecs(), idTable());
   } else {
-    auto generator = [](cppcoro::generator<IdTable> original,
-                        LimitOffsetClause limitOffset,
-                        auto limitTimeCallback) -> cppcoro::generator<IdTable> {
+    auto generator =
+        [](cppcoro::generator<IdTableVocabPair> original,
+           LimitOffsetClause limitOffset,
+           auto limitTimeCallback) -> cppcoro::generator<IdTableVocabPair> {
       if (limitOffset._limit.value_or(1) == 0) {
         co_return;
       }
-      for (IdTable& idTable : original) {
+      for (IdTableVocabPair& pair : original) {
+        auto& idTable = pair.idTable_;
         ad_utility::timer::Timer limitTimer{ad_utility::timer::Timer::Started};
         size_t originalSize = idTable.numRows();
         resizeIdTable(idTable, limitOffset);
@@ -152,7 +141,7 @@ void Result::applyLimitOffset(
         }
         limitTimeCallback(limitTimer.value(), idTable);
         if (limitOffset._offset == 0) {
-          co_yield idTable;
+          co_yield pair;
         }
         if (limitOffset._limit.value_or(1) == 0) {
           break;
@@ -170,15 +159,16 @@ void Result::assertThatLimitWasRespected(const LimitOffsetClause& limitOffset) {
     auto limit = limitOffset._limit;
     AD_CONTRACT_CHECK(!limit.has_value() || numRows <= limit.value());
   } else {
-    auto generator =
-        [](cppcoro::generator<IdTable> original,
-           LimitOffsetClause limitOffset) -> cppcoro::generator<IdTable> {
+    auto generator = [](cppcoro::generator<IdTableVocabPair> original,
+                        LimitOffsetClause limitOffset)
+        -> cppcoro::generator<IdTableVocabPair> {
       auto limit = limitOffset._limit;
       uint64_t elementCount = 0;
-      for (IdTable& idTable : original) {
+      for (IdTableVocabPair& pair : original) {
+        auto& idTable = pair.idTable_;
         elementCount += idTable.numRows();
         AD_CONTRACT_CHECK(!limit.has_value() || elementCount <= limit.value());
-        co_yield idTable;
+        co_yield pair;
       }
       AD_CONTRACT_CHECK(!limit.has_value() || elementCount <= limit.value());
     }(std::move(idTables()), limitOffset);
@@ -200,17 +190,18 @@ void Result::checkDefinedness(const VariableToColumnMap& varColMap) {
     });
   };
   if (isFullyMaterialized()) {
-    AD_EXPENSIVE_CHECK(performCheck(varColMap, std::get<IdTable>(data_)));
+    AD_EXPENSIVE_CHECK(performCheck(
+        varColMap, std::get<IdTableSharedLocalVocabPair>(data_).idTable_));
   } else {
-    auto generator =
-        [](cppcoro::generator<IdTable> original,
-           [[maybe_unused]] VariableToColumnMap varColMap,
-           [[maybe_unused]] auto performCheck) -> cppcoro::generator<IdTable> {
-      for (IdTable& idTable : original) {
+    auto generator = [](cppcoro::generator<IdTableVocabPair> original,
+                        [[maybe_unused]] VariableToColumnMap varColMap,
+                        [[maybe_unused]] auto performCheck)
+        -> cppcoro::generator<IdTableVocabPair> {
+      for (IdTableVocabPair& pair : original) {
         // No need to check subsequent idTables assuming the datatypes
         // don't change mid result.
-        AD_EXPENSIVE_CHECK(performCheck(varColMap, idTable));
-        co_yield idTable;
+        AD_EXPENSIVE_CHECK(performCheck(varColMap, pair.idTable_));
+        co_yield pair;
       }
     }(std::move(idTables()), varColMap, std::move(performCheck));
     data_.emplace<GenContainer>(std::move(generator));
@@ -222,17 +213,18 @@ void Result::runOnNewChunkComputed(
     std::function<void(const IdTable&, std::chrono::microseconds)> onNewChunk,
     std::function<void(bool)> onGeneratorFinished) {
   AD_CONTRACT_CHECK(!isFullyMaterialized());
-  auto generator = [](cppcoro::generator<IdTable> original, auto onNewChunk,
-                      auto onGeneratorFinished) -> cppcoro::generator<IdTable> {
+  auto generator =
+      [](cppcoro::generator<IdTableVocabPair> original, auto onNewChunk,
+         auto onGeneratorFinished) -> cppcoro::generator<IdTableVocabPair> {
     // Call this within destructor to make sure it is also called when an
     // operation stops iterating before reaching the end.
     absl::Cleanup cleanup{
         [&onGeneratorFinished]() { onGeneratorFinished(false); }};
     try {
       ad_utility::timer::Timer timer{ad_utility::timer::Timer::Started};
-      for (IdTable& idTable : original) {
-        onNewChunk(idTable, timer.value());
-        co_yield idTable;
+      for (IdTableVocabPair& pair : original) {
+        onNewChunk(pair.idTable_, timer.value());
+        co_yield pair;
         timer.start();
       }
     } catch (...) {
@@ -241,7 +233,7 @@ void Result::runOnNewChunkComputed(
       throw;
     }
   }(std::move(idTables()), std::move(onNewChunk),
-                                                std::move(onGeneratorFinished));
+                                   std::move(onGeneratorFinished));
   data_.emplace<GenContainer>(std::move(generator));
 }
 
@@ -260,11 +252,11 @@ void Result::assertSortOrderIsRespected(
 // _____________________________________________________________________________
 const IdTable& Result::idTable() const {
   AD_CONTRACT_CHECK(isFullyMaterialized());
-  return std::get<IdTable>(data_);
+  return std::get<IdTableSharedLocalVocabPair>(data_).idTable_;
 }
 
 // _____________________________________________________________________________
-cppcoro::generator<IdTable>& Result::idTables() const {
+cppcoro::generator<Result::IdTableVocabPair>& Result::idTables() const {
   AD_CONTRACT_CHECK(!isFullyMaterialized());
   const auto& container = std::get<GenContainer>(data_);
   AD_CONTRACT_CHECK(!container.consumed_->exchange(true));
@@ -273,33 +265,41 @@ cppcoro::generator<IdTable>& Result::idTables() const {
 
 // _____________________________________________________________________________
 bool Result::isFullyMaterialized() const noexcept {
-  return std::holds_alternative<IdTable>(data_);
+  return std::holds_alternative<IdTableSharedLocalVocabPair>(data_);
 }
 
 // _____________________________________________________________________________
 void Result::cacheDuringConsumption(
-    std::function<bool(const std::optional<IdTable>&, const IdTable&)>
+    std::function<bool(const std::optional<IdTableVocabPair>&,
+                       const IdTableVocabPair&)>
         fitInCache,
     std::function<void(Result)> storeInCache) {
   AD_CONTRACT_CHECK(!isFullyMaterialized());
   data_.emplace<GenContainer>(ad_utility::wrapGeneratorWithCache(
       std::move(idTables()),
-      [fitInCache = std::move(fitInCache)](std::optional<IdTable>& aggregate,
-                                           const IdTable& newTable) {
-        bool doBothFitInCache = fitInCache(aggregate, newTable);
+      [fitInCache = std::move(fitInCache)](
+          std::optional<IdTableVocabPair>& aggregate,
+          const IdTableVocabPair& newTablePair) {
+        bool doBothFitInCache = fitInCache(aggregate, newTablePair);
         if (doBothFitInCache) {
           if (aggregate.has_value()) {
-            aggregate.value().insertAtEnd(newTable);
+            auto& value = aggregate.value();
+            value.idTable_.insertAtEnd(newTablePair.idTable_);
+            std::array<const LocalVocab*, 2> vocabs{&value.localVocab_,
+                                                    &newTablePair.localVocab_};
+            value.localVocab_ = LocalVocab::merge(vocabs);
           } else {
-            aggregate.emplace(newTable.clone());
+            aggregate.emplace(newTablePair.idTable_.clone(),
+                              newTablePair.localVocab_.clone());
           }
         }
         return doBothFitInCache;
       },
-      [storeInCache = std::move(storeInCache), sortedBy = sortedBy_,
-       localVocab = localVocab_](IdTable idTable) mutable {
-        storeInCache(Result{std::move(idTable), std::move(sortedBy),
-                            SharedLocalVocabWrapper{std::move(localVocab)}});
+      [storeInCache = std::move(storeInCache),
+       sortedBy = sortedBy_](IdTableVocabPair pair) mutable {
+        storeInCache(
+            Result{std::move(pair.idTable_), std::move(sortedBy),
+                   SharedLocalVocabWrapper{std::move(pair.localVocab_)}});
       }));
 }
 

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -66,6 +66,11 @@ Result::Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
              SharedLocalVocabWrapper{std::move(localVocab)}} {}
 
 // _____________________________________________________________________________
+Result::Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy)
+    : Result{std::move(pair.idTable_), std::move(sortedBy),
+             std::move(pair.localVocab_)} {}
+
+// _____________________________________________________________________________
 Result::Result(cppcoro::generator<IdTableVocabPair> idTables,
                std::vector<ColumnIndex> sortedBy)
     : data_{GenContainer{[](auto idTables, auto sortedBy)

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -165,8 +165,7 @@ void Result::assertThatLimitWasRespected(const LimitOffsetClause& limitOffset) {
       auto limit = limitOffset._limit;
       uint64_t elementCount = 0;
       for (IdTableVocabPair& pair : original) {
-        auto& idTable = pair.idTable_;
-        elementCount += idTable.numRows();
+        elementCount += pair.idTable_.numRows();
         AD_CONTRACT_CHECK(!limit.has_value() || elementCount <= limit.value());
         co_yield pair;
       }

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -284,9 +284,8 @@ void Result::cacheDuringConsumption(
           if (aggregate.has_value()) {
             auto& value = aggregate.value();
             value.idTable_.insertAtEnd(newTablePair.idTable_);
-            std::array<const LocalVocab*, 2> vocabs{&value.localVocab_,
-                                                    &newTablePair.localVocab_};
-            value.localVocab_ = LocalVocab::merge(vocabs);
+            value.localVocab_.mergeWith(
+                std::span{&newTablePair.localVocab_, 1});
           } else {
             aggregate.emplace(newTablePair.idTable_.clone(),
                               newTablePair.localVocab_.clone());

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -33,13 +33,15 @@ class Result {
         : idTable_{std::move(idTable)}, localVocab_{std::move(localVocab)} {}
   };
 
+  using Generator = cppcoro::generator<IdTableVocabPair>;
+
  private:
   // Needs to be mutable in order to be consumable from a const result.
   struct GenContainer {
-    mutable cppcoro::generator<IdTableVocabPair> generator_;
+    mutable Generator generator_;
     mutable std::unique_ptr<std::atomic_bool> consumed_ =
         std::make_unique<std::atomic_bool>(false);
-    explicit GenContainer(cppcoro::generator<IdTableVocabPair> generator)
+    explicit GenContainer(Generator generator)
         : generator_{std::move(generator)} {}
   };
 
@@ -107,8 +109,7 @@ class Result {
   Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
          LocalVocab&& localVocab);
   Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy);
-  Result(cppcoro::generator<IdTableVocabPair> idTables,
-         std::vector<ColumnIndex> sortedBy);
+  Result(Generator idTables, std::vector<ColumnIndex> sortedBy);
   // Prevent accidental copying of a result table.
   Result(const Result& other) = delete;
   Result& operator=(const Result& other) = delete;
@@ -153,7 +154,7 @@ class Result {
 
   // Access to the underlying `IdTable`s. Throw an `ad_utility::Exception`
   // if the underlying `data_` member holds the wrong variant.
-  cppcoro::generator<IdTableVocabPair>& idTables() const;
+  Generator& idTables() const;
 
   // Const access to the columns by which the `idTable()` is sorted.
   const std::vector<ColumnIndex>& sortedBy() const { return sortedBy_; }

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -106,6 +106,7 @@ class Result {
          SharedLocalVocabWrapper localVocab);
   Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
          LocalVocab&& localVocab);
+  Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy);
   Result(cppcoro::generator<IdTableVocabPair> idTables,
          std::vector<ColumnIndex> sortedBy);
   // Prevent accidental copying of a result table.

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -22,27 +22,41 @@
 // through a generator via `idTables()` when it is supposed to be lazily
 // evaluated.
 class Result {
+ public:
+  struct IdTableVocabPair {
+    IdTable idTable_;
+    LocalVocab localVocab_;
+
+    // Explicit constructor to avoid problems with coroutines and temporaries.
+    // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103909 for details.
+    IdTableVocabPair(IdTable idTable, LocalVocab localVocab)
+        : idTable_{std::move(idTable)}, localVocab_{std::move(localVocab)} {}
+  };
+
  private:
   // Needs to be mutable in order to be consumable from a const result.
   struct GenContainer {
-    mutable cppcoro::generator<IdTable> generator_;
+    mutable cppcoro::generator<IdTableVocabPair> generator_;
     mutable std::unique_ptr<std::atomic_bool> consumed_ =
         std::make_unique<std::atomic_bool>(false);
-    explicit GenContainer(cppcoro::generator<IdTable> generator)
+    explicit GenContainer(cppcoro::generator<IdTableVocabPair> generator)
         : generator_{std::move(generator)} {}
   };
-  using Data = std::variant<IdTable, GenContainer>;
+
+  using LocalVocabPtr = std::shared_ptr<const LocalVocab>;
+
+  struct IdTableSharedLocalVocabPair {
+    IdTable idTable_;
+    // The local vocabulary of the result.
+    LocalVocabPtr localVocab_;
+  };
+  using Data = std::variant<IdTableSharedLocalVocabPair, GenContainer>;
   // The actual entries.
   Data data_;
 
   // The column indices by which the result is sorted (primary sort key first).
   // Empty if the result is not sorted on any column.
   std::vector<ColumnIndex> sortedBy_;
-
-  using LocalVocabPtr = std::shared_ptr<const LocalVocab>;
-
-  // The local vocabulary of the result.
-  LocalVocabPtr localVocab_ = std::make_shared<const LocalVocab>();
 
   // Note: If additional members and invariants are added to the class (for
   // example information about the datatypes in each column) make sure that
@@ -92,12 +106,8 @@ class Result {
          SharedLocalVocabWrapper localVocab);
   Result(IdTable idTable, std::vector<ColumnIndex> sortedBy,
          LocalVocab&& localVocab);
-  Result(cppcoro::generator<IdTable> idTables,
-         std::vector<ColumnIndex> sortedBy, SharedLocalVocabWrapper localVocab);
-  Result(cppcoro::generator<IdTable> idTables,
-         std::vector<ColumnIndex> sortedBy, LocalVocab&& localVocab);
-  Result(cppcoro::generator<IdTable> idTables,
-         std::vector<ColumnIndex> sortedBy, LocalVocabPtr localVocab);
+  Result(cppcoro::generator<IdTableVocabPair> idTables,
+         std::vector<ColumnIndex> sortedBy);
   // Prevent accidental copying of a result table.
   Result(const Result& other) = delete;
   Result& operator=(const Result& other) = delete;
@@ -131,7 +141,8 @@ class Result {
   // Throw an `ad_utility::Exception` if the underlying `data_` member holds the
   // wrong variant.
   void cacheDuringConsumption(
-      std::function<bool(const std::optional<IdTable>&, const IdTable&)>
+      std::function<bool(const std::optional<IdTableVocabPair>&,
+                         const IdTableVocabPair&)>
           fitInCache,
       std::function<void(Result)> storeInCache);
 
@@ -141,7 +152,7 @@ class Result {
 
   // Access to the underlying `IdTable`s. Throw an `ad_utility::Exception`
   // if the underlying `data_` member holds the wrong variant.
-  cppcoro::generator<IdTable>& idTables() const;
+  cppcoro::generator<IdTableVocabPair>& idTables() const;
 
   // Const access to the columns by which the `idTable()` is sorted.
   const std::vector<ColumnIndex>& sortedBy() const { return sortedBy_; }
@@ -157,12 +168,16 @@ class Result {
   // Filter::computeFilterImpl (evaluationContext)
   // Variable::evaluate (idToStringAndType)
   //
-  const LocalVocab& localVocab() const { return *localVocab_; }
+  const LocalVocab& localVocab() const {
+    AD_CONTRACT_CHECK(isFullyMaterialized());
+    return *std::get<IdTableSharedLocalVocabPair>(data_).localVocab_;
+  }
 
   // Get the local vocab as a shared pointer to const. This can be used if one
   // result has the same local vocab as one of its child results.
   SharedLocalVocabWrapper getSharedLocalVocab() const {
-    return SharedLocalVocabWrapper{localVocab_};
+    return SharedLocalVocabWrapper{
+        std::get<IdTableSharedLocalVocabPair>(data_).localVocab_};
   }
 
   // Like `getSharedLocalVocabFrom`, but takes more than one result and merges
@@ -176,7 +191,7 @@ class Result {
   static SharedLocalVocabWrapper getMergedLocalVocab(R&& subResults) {
     std::vector<const LocalVocab*> vocabs;
     for (const Result& table : subResults) {
-      vocabs.push_back(std::to_address(table.localVocab_));
+      vocabs.push_back(&table.localVocab());
     }
     return SharedLocalVocabWrapper{LocalVocab::merge(vocabs)};
   }

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -176,6 +176,7 @@ class Result {
   // Get the local vocab as a shared pointer to const. This can be used if one
   // result has the same local vocab as one of its child results.
   SharedLocalVocabWrapper getSharedLocalVocab() const {
+    AD_CONTRACT_CHECK(isFullyMaterialized());
     return SharedLocalVocabWrapper{
         std::get<IdTableSharedLocalVocabPair>(data_).localVocab_};
   }

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -188,12 +188,10 @@ ProtoResult Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   // details).
   auto generator =
       computeResultLazily(expVariableKeys, std::move(body), !requestLaziness);
-  if (requestLaziness) {
-    return ProtoResult{std::move(generator), resultSortedOn()};
-  }
-  auto pair = cppcoro::getSingleElement(std::move(generator));
-  return ProtoResult{std::move(pair.idTable_), resultSortedOn(),
-                     std::move(pair.localVocab_)};
+  return requestLaziness
+             ? ProtoResult{std::move(generator), resultSortedOn()}
+             : ProtoResult{cppcoro::getSingleElement(std::move(generator)),
+                           resultSortedOn()};
 }
 
 template <size_t I>

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -264,7 +264,7 @@ cppcoro::generator<Result::IdTableVocabPair> Service::computeResultLazily(
         Result::IdTableVocabPair pair{std::move(idTable),
                                       std::move(localVocab)};
         co_yield pair;
-        // Move back to re-use buffer if not moved out.
+        // Move back to reuse buffer if not moved out.
         idTable = std::move(pair.idTable_);
         idTable.clear();
         localVocab = LocalVocab{};

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -239,7 +239,7 @@ void Service::writeJsonResult(const std::vector<std::string>& vars,
 }
 
 // ____________________________________________________________________________
-cppcoro::generator<Result::IdTableVocabPair> Service::computeResultLazily(
+Result::Generator Service::computeResultLazily(
     const std::vector<std::string> vars,
     ad_utility::LazyJsonParser::Generator body, bool singleIdTable) {
   LocalVocab localVocab{};

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -148,8 +148,7 @@ class Service : public Operation {
 
   // Compute the result lazy as IdTable generator.
   // If the `singleIdTable` flag is set, the result is yielded as one idTable.
-  cppcoro::generator<IdTable> computeResultLazily(
+  cppcoro::generator<Result::IdTableVocabPair> computeResultLazily(
       const std::vector<std::string> vars,
-      ad_utility::LazyJsonParser::Generator body,
-      std::shared_ptr<LocalVocab> localVocab, bool singleIdTable);
+      ad_utility::LazyJsonParser::Generator body, bool singleIdTable);
 };

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -148,7 +148,7 @@ class Service : public Operation {
 
   // Compute the result lazy as IdTable generator.
   // If the `singleIdTable` flag is set, the result is yielded as one idTable.
-  cppcoro::generator<Result::IdTableVocabPair> computeResultLazily(
+  Result::Generator computeResultLazily(
       const std::vector<std::string> vars,
       ad_utility::LazyJsonParser::Generator body, bool singleIdTable);
 };

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -264,10 +264,9 @@ Result::Generator Union::computeResultLazily(
         transformToCorrectColumnFormat(result1->idTable().clone(), permutation),
         result1->getCopyOfLocalVocab()};
   } else {
-    for (Result::IdTableVocabPair& pair : result1->idTables()) {
-      co_yield {
-          transformToCorrectColumnFormat(std::move(pair.idTable_), permutation),
-          std::move(pair.localVocab_)};
+    for (auto& [idTable, localVocab] : result1->idTables()) {
+      co_yield {transformToCorrectColumnFormat(std::move(idTable), permutation),
+                std::move(localVocab)};
     }
   }
   permutation = computePermutation<false>();
@@ -276,10 +275,9 @@ Result::Generator Union::computeResultLazily(
         transformToCorrectColumnFormat(result2->idTable().clone(), permutation),
         result2->getCopyOfLocalVocab()};
   } else {
-    for (Result::IdTableVocabPair& pair : result2->idTables()) {
-      co_yield {
-          transformToCorrectColumnFormat(std::move(pair.idTable_), permutation),
-          std::move(pair.localVocab_)};
+    for (auto& [idTable, localVocab] : result2->idTables()) {
+      co_yield {transformToCorrectColumnFormat(std::move(idTable), permutation),
+                std::move(localVocab)};
     }
   }
 }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -255,7 +255,7 @@ IdTable Union::transformToCorrectColumnFormat(
 }
 
 // _____________________________________________________________________________
-cppcoro::generator<Result::IdTableVocabPair> Union::computeResultLazily(
+Result::Generator Union::computeResultLazily(
     std::shared_ptr<const Result> result1,
     std::shared_ptr<const Result> result2) const {
   std::vector<ColumnIndex> permutation = computePermutation<true>();

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -167,10 +167,8 @@ ProtoResult Union::computeResult(bool requestLaziness) {
       _subtrees[1]->getResult(requestLaziness);
 
   if (requestLaziness) {
-    auto localVocab = std::make_shared<LocalVocab>();
-    auto generator =
-        computeResultLazily(std::move(subRes1), std::move(subRes2), localVocab);
-    return {std::move(generator), resultSortedOn(), std::move(localVocab)};
+    return {computeResultLazily(std::move(subRes1), std::move(subRes2)),
+            resultSortedOn()};
   }
 
   LOG(DEBUG) << "Union subresult computation done." << std::endl;
@@ -257,29 +255,31 @@ IdTable Union::transformToCorrectColumnFormat(
 }
 
 // _____________________________________________________________________________
-cppcoro::generator<IdTable> Union::computeResultLazily(
+cppcoro::generator<Result::IdTableVocabPair> Union::computeResultLazily(
     std::shared_ptr<const Result> result1,
-    std::shared_ptr<const Result> result2,
-    std::shared_ptr<LocalVocab> localVocab) const {
+    std::shared_ptr<const Result> result2) const {
   std::vector<ColumnIndex> permutation = computePermutation<true>();
   if (result1->isFullyMaterialized()) {
-    co_yield transformToCorrectColumnFormat(result1->idTable().clone(),
-                                            permutation);
+    co_yield {
+        transformToCorrectColumnFormat(result1->idTable().clone(), permutation),
+        result1->getCopyOfLocalVocab()};
   } else {
-    for (IdTable& idTable : result1->idTables()) {
-      co_yield transformToCorrectColumnFormat(std::move(idTable), permutation);
+    for (Result::IdTableVocabPair& pair : result1->idTables()) {
+      co_yield {
+          transformToCorrectColumnFormat(std::move(pair.idTable_), permutation),
+          std::move(pair.localVocab_)};
     }
   }
   permutation = computePermutation<false>();
   if (result2->isFullyMaterialized()) {
-    co_yield transformToCorrectColumnFormat(result2->idTable().clone(),
-                                            permutation);
+    co_yield {
+        transformToCorrectColumnFormat(result2->idTable().clone(), permutation),
+        result2->getCopyOfLocalVocab()};
   } else {
-    for (IdTable& idTable : result2->idTables()) {
-      co_yield transformToCorrectColumnFormat(std::move(idTable), permutation);
+    for (Result::IdTableVocabPair& pair : result2->idTables()) {
+      co_yield {
+          transformToCorrectColumnFormat(std::move(pair.idTable_), permutation),
+          std::move(pair.localVocab_)};
     }
   }
-  std::array<const LocalVocab*, 2> vocabs{&result1->localVocab(),
-                                          &result2->localVocab()};
-  *localVocab = LocalVocab::merge(vocabs);
 }

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -81,8 +81,7 @@ class Union : public Operation {
   // Create a generator that yields the `IdTable` for the left or right child
   // one after another and apply a potential differing permutation to it. Write
   // the merged LocalVocab to the given `LocalVocab` object at the end.
-  cppcoro::generator<IdTable> computeResultLazily(
+  cppcoro::generator<Result::IdTableVocabPair> computeResultLazily(
       std::shared_ptr<const Result> result1,
-      std::shared_ptr<const Result> result2,
-      std::shared_ptr<LocalVocab> localVocab) const;
+      std::shared_ptr<const Result> result2) const;
 };

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -81,7 +81,7 @@ class Union : public Operation {
   // Create a generator that yields the `IdTable` for the left or right child
   // one after another and apply a potential differing permutation to it. Write
   // the merged LocalVocab to the given `LocalVocab` object at the end.
-  cppcoro::generator<Result::IdTableVocabPair> computeResultLazily(
+  Result::Generator computeResultLazily(
       std::shared_ptr<const Result> result1,
       std::shared_ptr<const Result> result2) const;
 };

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1228,9 +1228,8 @@ TEST(ExportQueryExecutionTrees, getIdTablesReturnsSingletonIterator) {
 TEST(ExportQueryExecutionTrees, getIdTablesMirrorsGenerator) {
   IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
   IdTable idTable2 = makeIdTableFromVector({{42}, {1337}});
-  auto tableGenerator =
-      [](IdTable idTableA,
-         IdTable idTableB) -> cppcoro::generator<Result::IdTableVocabPair> {
+  auto tableGenerator = [](IdTable idTableA,
+                           IdTable idTableB) -> Result::Generator {
     co_yield {std::move(idTableA), LocalVocab{}};
 
     co_yield {std::move(idTableB), LocalVocab{}};
@@ -1245,7 +1244,7 @@ TEST(ExportQueryExecutionTrees, getIdTablesMirrorsGenerator) {
 
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, ensureCorrectSlicingOfSingleIdTable) {
-  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+  auto tableGenerator = []() -> Result::Generator {
     Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
                                    LocalVocab{}};
     co_yield pair1;
@@ -1263,7 +1262,7 @@ TEST(ExportQueryExecutionTrees, ensureCorrectSlicingOfSingleIdTable) {
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenFirstIsSkipped) {
-  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+  auto tableGenerator = []() -> Result::Generator {
     Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
                                    LocalVocab{}};
     co_yield pair1;
@@ -1286,7 +1285,7 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenLastIsSkipped) {
-  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+  auto tableGenerator = []() -> Result::Generator {
     Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
                                    LocalVocab{}};
     co_yield pair1;
@@ -1309,7 +1308,7 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenFirstAndSecondArePartial) {
-  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+  auto tableGenerator = []() -> Result::Generator {
     Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
                                    LocalVocab{}};
     co_yield pair1;
@@ -1333,7 +1332,7 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenFirstAndLastArePartial) {
-  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+  auto tableGenerator = []() -> Result::Generator {
     Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
                                    LocalVocab{}};
     co_yield pair1;
@@ -1363,8 +1362,7 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, ensureGeneratorIsNotConsumedWhenNotRequired) {
   {
-    auto throwingGenerator =
-        []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    auto throwingGenerator = []() -> Result::Generator {
       ADD_FAILURE() << "Generator was started" << std::endl;
       throw std::runtime_error("Generator was started");
       co_return;
@@ -1377,8 +1375,7 @@ TEST(ExportQueryExecutionTrees, ensureGeneratorIsNotConsumedWhenNotRequired) {
   }
 
   {
-    auto throwAfterYieldGenerator =
-        []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    auto throwAfterYieldGenerator = []() -> Result::Generator {
       Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}}),
                                      LocalVocab{}};
       co_yield pair1;

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -226,10 +226,12 @@ static const std::string xmlTrailer = "\n</results>\n</sparql>";
 
 // Helper function for easier testing of the `IdTable` generator.
 std::vector<IdTable> convertToVector(
-    cppcoro::generator<const IdTable&> generator) {
+    cppcoro::generator<ExportQueryExecutionTrees::TableConstRefWithVocab>
+        generator) {
   std::vector<IdTable> result;
-  for (const IdTable& idTable : generator) {
-    result.push_back(idTable.clone());
+  for (const ExportQueryExecutionTrees::TableConstRefWithVocab& pair :
+       generator) {
+    result.push_back(pair.idTable_.clone());
   }
   return result;
 }
@@ -239,11 +241,11 @@ auto matchesIdTables(const auto&... tables) {
   return ElementsAre(matchesIdTable(tables)...);
 }
 
-// Template is only required because inner class is not visible
-template <typename T>
-std::vector<IdTable> convertToVector(cppcoro::generator<T> generator) {
+std::vector<IdTable> convertToVector(
+    cppcoro::generator<ExportQueryExecutionTrees::TableWithRange> generator) {
   std::vector<IdTable> result;
-  for (const auto& [idTable, range] : generator) {
+  for (const auto& [pair, range] : generator) {
+    const auto& idTable = pair.idTable_;
     result.emplace_back(idTable.numColumns(), idTable.getAllocator());
     result.back().insertAtEnd(idTable.begin() + *range.begin(),
                               idTable.begin() + *(range.end() - 1) + 1);
@@ -1226,14 +1228,15 @@ TEST(ExportQueryExecutionTrees, getIdTablesReturnsSingletonIterator) {
 TEST(ExportQueryExecutionTrees, getIdTablesMirrorsGenerator) {
   IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
   IdTable idTable2 = makeIdTableFromVector({{42}, {1337}});
-  auto tableGenerator = [](IdTable idTableA,
-                           IdTable idTableB) -> cppcoro::generator<IdTable> {
-    co_yield idTableA;
+  auto tableGenerator =
+      [](IdTable idTableA,
+         IdTable idTableB) -> cppcoro::generator<Result::IdTableVocabPair> {
+    co_yield {std::move(idTableA), LocalVocab{}};
 
-    co_yield idTableB;
+    co_yield {std::move(idTableB), LocalVocab{}};
   }(idTable1.clone(), idTable2.clone());
 
-  Result result{std::move(tableGenerator), {}, LocalVocab{}};
+  Result result{std::move(tableGenerator), {}};
   auto generator = ExportQueryExecutionTrees::getIdTables(result);
 
   EXPECT_THAT(convertToVector(std::move(generator)),
@@ -1242,12 +1245,13 @@ TEST(ExportQueryExecutionTrees, getIdTablesMirrorsGenerator) {
 
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, ensureCorrectSlicingOfSingleIdTable) {
-  auto tableGenerator = []() -> cppcoro::generator<IdTable> {
-    IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
-    co_yield idTable1;
+  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
+                                   LocalVocab{}};
+    co_yield pair1;
   }();
 
-  Result result{std::move(tableGenerator), {}, LocalVocab{}};
+  Result result{std::move(tableGenerator), {}};
   auto generator = ExportQueryExecutionTrees::getRowIndices(
       LimitOffsetClause{._limit = 1, ._offset = 1}, result);
 
@@ -1259,15 +1263,17 @@ TEST(ExportQueryExecutionTrees, ensureCorrectSlicingOfSingleIdTable) {
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenFirstIsSkipped) {
-  auto tableGenerator = []() -> cppcoro::generator<IdTable> {
-    IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
-    co_yield idTable1;
+  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
+                                   LocalVocab{}};
+    co_yield pair1;
 
-    IdTable idTable2 = makeIdTableFromVector({{4}, {5}});
-    co_yield idTable2;
+    Result::IdTableVocabPair pair2{makeIdTableFromVector({{4}, {5}}),
+                                   LocalVocab{}};
+    co_yield pair2;
   }();
 
-  Result result{std::move(tableGenerator), {}, LocalVocab{}};
+  Result result{std::move(tableGenerator), {}};
   auto generator = ExportQueryExecutionTrees::getRowIndices(
       LimitOffsetClause{._limit = std::nullopt, ._offset = 3}, result);
 
@@ -1280,15 +1286,17 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenLastIsSkipped) {
-  auto tableGenerator = []() -> cppcoro::generator<IdTable> {
-    IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
-    co_yield idTable1;
+  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
+                                   LocalVocab{}};
+    co_yield pair1;
 
-    IdTable idTable2 = makeIdTableFromVector({{4}, {5}});
-    co_yield idTable2;
+    Result::IdTableVocabPair pair2{makeIdTableFromVector({{4}, {5}}),
+                                   LocalVocab{}};
+    co_yield pair2;
   }();
 
-  Result result{std::move(tableGenerator), {}, LocalVocab{}};
+  Result result{std::move(tableGenerator), {}};
   auto generator = ExportQueryExecutionTrees::getRowIndices(
       LimitOffsetClause{._limit = 3}, result);
 
@@ -1301,15 +1309,17 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenFirstAndSecondArePartial) {
-  auto tableGenerator = []() -> cppcoro::generator<IdTable> {
-    IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
-    co_yield idTable1;
+  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
+                                   LocalVocab{}};
+    co_yield pair1;
 
-    IdTable idTable2 = makeIdTableFromVector({{4}, {5}});
-    co_yield idTable2;
+    Result::IdTableVocabPair pair2{makeIdTableFromVector({{4}, {5}}),
+                                   LocalVocab{}};
+    co_yield pair2;
   }();
 
-  Result result{std::move(tableGenerator), {}, LocalVocab{}};
+  Result result{std::move(tableGenerator), {}};
   auto generator = ExportQueryExecutionTrees::getRowIndices(
       LimitOffsetClause{._limit = 3, ._offset = 1}, result);
 
@@ -1323,18 +1333,21 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees,
      ensureCorrectSlicingOfIdTablesWhenFirstAndLastArePartial) {
-  auto tableGenerator = []() -> cppcoro::generator<IdTable> {
-    IdTable idTable1 = makeIdTableFromVector({{1}, {2}, {3}});
-    co_yield idTable1;
+  auto tableGenerator = []() -> cppcoro::generator<Result::IdTableVocabPair> {
+    Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}, {2}, {3}}),
+                                   LocalVocab{}};
+    co_yield pair1;
 
-    IdTable idTable2 = makeIdTableFromVector({{4}, {5}});
-    co_yield idTable2;
+    Result::IdTableVocabPair pair2{makeIdTableFromVector({{4}, {5}}),
+                                   LocalVocab{}};
+    co_yield pair2;
 
-    IdTable idTable3 = makeIdTableFromVector({{6}, {7}, {8}, {9}});
-    co_yield idTable3;
+    Result::IdTableVocabPair pair3{makeIdTableFromVector({{6}, {7}, {8}, {9}}),
+                                   LocalVocab{}};
+    co_yield pair3;
   }();
 
-  Result result{std::move(tableGenerator), {}, LocalVocab{}};
+  Result result{std::move(tableGenerator), {}};
   auto generator = ExportQueryExecutionTrees::getRowIndices(
       LimitOffsetClause{._limit = 5, ._offset = 2}, result);
 
@@ -1350,28 +1363,31 @@ TEST(ExportQueryExecutionTrees,
 // _____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, ensureGeneratorIsNotConsumedWhenNotRequired) {
   {
-    auto throwingGenerator = []() -> cppcoro::generator<IdTable> {
+    auto throwingGenerator =
+        []() -> cppcoro::generator<Result::IdTableVocabPair> {
       ADD_FAILURE() << "Generator was started" << std::endl;
       throw std::runtime_error("Generator was started");
       co_return;
     }();
 
-    Result result{std::move(throwingGenerator), {}, LocalVocab{}};
+    Result result{std::move(throwingGenerator), {}};
     auto generator = ExportQueryExecutionTrees::getRowIndices(
         LimitOffsetClause{._limit = 0, ._offset = 0}, result);
     EXPECT_NO_THROW(convertToVector(std::move(generator)));
   }
 
   {
-    auto throwAfterYieldGenerator = []() -> cppcoro::generator<IdTable> {
-      IdTable idTable1 = makeIdTableFromVector({{1}});
-      co_yield idTable1;
+    auto throwAfterYieldGenerator =
+        []() -> cppcoro::generator<Result::IdTableVocabPair> {
+      Result::IdTableVocabPair pair1{makeIdTableFromVector({{1}}),
+                                     LocalVocab{}};
+      co_yield pair1;
 
       ADD_FAILURE() << "Generator was resumed" << std::endl;
       throw std::runtime_error("Generator was resumed");
     }();
 
-    Result result{std::move(throwAfterYieldGenerator), {}, LocalVocab{}};
+    Result result{std::move(throwAfterYieldGenerator), {}};
     auto generator = ExportQueryExecutionTrees::getRowIndices(
         LimitOffsetClause{._limit = 1, ._offset = 0}, result);
     IdTable referenceTable1 = makeIdTableFromVector({{1}});

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -21,6 +21,10 @@ ValueId asBool(bool value) { return Id::makeFromBool(value); }
 std::vector<IdTable> toVector(Result::Generator generator) {
   std::vector<IdTable> result;
   for (auto& pair : generator) {
+    // IMPORTANT: The `LocalVocab` contained in the pair will be destroyed at
+    // the end of the iteration. The underlying assumption is that the
+    // `LocalVocab` will be empty and the `IdTable` won't contain any dangling
+    // references.
     result.push_back(std::move(pair.idTable_));
   }
   return result;

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -18,8 +18,7 @@ namespace {
 ValueId asBool(bool value) { return Id::makeFromBool(value); }
 
 // Convert a generator to a vector for easier comparison in assertions
-std::vector<IdTable> toVector(
-    cppcoro::generator<Result::IdTableVocabPair> generator) {
+std::vector<IdTable> toVector(Result::Generator generator) {
   std::vector<IdTable> result;
   for (auto& pair : generator) {
     result.push_back(std::move(pair.idTable_));

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -18,10 +18,11 @@ namespace {
 ValueId asBool(bool value) { return Id::makeFromBool(value); }
 
 // Convert a generator to a vector for easier comparison in assertions
-std::vector<IdTable> toVector(cppcoro::generator<IdTable> generator) {
+std::vector<IdTable> toVector(
+    cppcoro::generator<Result::IdTableVocabPair> generator) {
   std::vector<IdTable> result;
-  for (auto& table : generator) {
-    result.push_back(std::move(table));
+  for (auto& pair : generator) {
+    result.push_back(std::move(pair.idTable_));
   }
   return result;
 }

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -406,9 +406,7 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
       index, &cache, makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{}, [&](std::string) { ++updateCallCounter; }};
   CustomGeneratorOperation operation{
-      &context,
-      [](const IdTable& idTable)
-          -> cppcoro::generator<Result::IdTableVocabPair> {
+      &context, [](const IdTable& idTable) -> Result::Generator {
         std::this_thread::sleep_for(50ms);
         co_yield {idTable.clone(), LocalVocab{}};
         // This one should not trigger because it's below the 50ms threshold
@@ -451,9 +449,7 @@ TEST(Operation, ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption) {
       index, &cache, makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{}, [&](std::string) { ++updateCallCounter; }};
   CustomGeneratorOperation operation{
-      &context,
-      [](const IdTable& idTable)
-          -> cppcoro::generator<Result::IdTableVocabPair> {
+      &context, [](const IdTable& idTable) -> Result::Generator {
         co_yield {idTable.clone(), LocalVocab{}};
         co_yield {idTable.clone(), LocalVocab{}};
       }(idTable)};

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -406,18 +406,20 @@ TEST(Operation, ensureSignalUpdateIsOnlyCalledEvery50msAndAtTheEnd) {
       index, &cache, makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{}, [&](std::string) { ++updateCallCounter; }};
   CustomGeneratorOperation operation{
-      &context, [](const IdTable& idTable) -> cppcoro::generator<IdTable> {
+      &context,
+      [](const IdTable& idTable)
+          -> cppcoro::generator<Result::IdTableVocabPair> {
         std::this_thread::sleep_for(50ms);
-        co_yield idTable.clone();
+        co_yield {idTable.clone(), LocalVocab{}};
         // This one should not trigger because it's below the 50ms threshold
         std::this_thread::sleep_for(30ms);
-        co_yield idTable.clone();
+        co_yield {idTable.clone(), LocalVocab{}};
         std::this_thread::sleep_for(30ms);
-        co_yield idTable.clone();
+        co_yield {idTable.clone(), LocalVocab{}};
         // This one should not trigger directly, but trigger because it's the
         // last one
         std::this_thread::sleep_for(30ms);
-        co_yield idTable.clone();
+        co_yield {idTable.clone(), LocalVocab{}};
       }(idTable)};
 
   ad_utility::Timer timer{ad_utility::Timer::InitialStatus::Started};
@@ -449,9 +451,11 @@ TEST(Operation, ensureSignalUpdateIsCalledAtTheEndOfPartialConsumption) {
       index, &cache, makeAllocator(ad_utility::MemorySize::megabytes(100)),
       SortPerformanceEstimator{}, [&](std::string) { ++updateCallCounter; }};
   CustomGeneratorOperation operation{
-      &context, [](const IdTable& idTable) -> cppcoro::generator<IdTable> {
-        co_yield idTable.clone();
-        co_yield idTable.clone();
+      &context,
+      [](const IdTable& idTable)
+          -> cppcoro::generator<Result::IdTableVocabPair> {
+        co_yield {idTable.clone(), LocalVocab{}};
+        co_yield {idTable.clone(), LocalVocab{}};
       }(idTable)};
 
   {
@@ -523,7 +527,8 @@ TEST(Operation, ensureLazyOperationIsCachedIfSmallEnough) {
       timer, ComputationMode::LAZY_IF_SUPPORTED, "test", false);
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains("test"));
 
-  for ([[maybe_unused]] IdTable& _ : cacheValue.resultTable().idTables()) {
+  for ([[maybe_unused]] Result::IdTableVocabPair& _ :
+       cacheValue.resultTable().idTables()) {
   }
 
   auto aggregatedValue = qec->getQueryTreeCache().getIfContained("test");
@@ -575,7 +580,8 @@ TEST(Operation, checkLazyOperationIsNotCachedIfTooLarge) {
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains("test"));
   qec->getQueryTreeCache().setMaxSizeSingleEntry(originalSize);
 
-  for ([[maybe_unused]] IdTable& _ : cacheValue.resultTable().idTables()) {
+  for ([[maybe_unused]] Result::IdTableVocabPair& _ :
+       cacheValue.resultTable().idTables()) {
   }
 
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains("test"));
@@ -597,7 +603,8 @@ TEST(Operation, checkLazyOperationIsNotCachedIfUnlikelyToFitInCache) {
       timer, ComputationMode::LAZY_IF_SUPPORTED, "test", false);
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains("test"));
 
-  for ([[maybe_unused]] IdTable& _ : cacheValue.resultTable().idTables()) {
+  for ([[maybe_unused]] Result::IdTableVocabPair& _ :
+       cacheValue.resultTable().idTables()) {
   }
 
   EXPECT_FALSE(qec->getQueryTreeCache().cacheContains("test"));

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -17,9 +17,9 @@ using ::testing::Values;
 namespace {
 // Helper function to generate all possible splits of an IdTable in order to
 // exhaustively test generator variants.
-std::vector<cppcoro::generator<IdTable>> getAllSubSplits(
+std::vector<cppcoro::generator<Result::IdTableVocabPair>> getAllSubSplits(
     const IdTable& idTable) {
-  std::vector<cppcoro::generator<IdTable>> result;
+  std::vector<cppcoro::generator<Result::IdTableVocabPair>> result;
   for (size_t i = 0; i < std::pow(idTable.size() - 1, 2); ++i) {
     std::vector<size_t> reverseIndex{};
     size_t copy = i;
@@ -30,20 +30,24 @@ std::vector<cppcoro::generator<IdTable>> getAllSubSplits(
       copy /= 2;
     }
     result.push_back(
-        [](auto split, IdTable clone) -> cppcoro::generator<IdTable> {
+        [](auto split,
+           IdTable clone) -> cppcoro::generator<Result::IdTableVocabPair> {
           IdTable subSplit{clone.numColumns(),
                            ad_utility::makeUnlimitedAllocator<IdTable>()};
           size_t splitIndex = 0;
           for (size_t i = 0; i < clone.size(); ++i) {
             subSplit.push_back(clone[i]);
             if (splitIndex < split.size() && split[splitIndex] == i) {
-              co_yield subSplit;
+              Result::IdTableVocabPair pair{std::move(subSplit), LocalVocab{}};
+              co_yield pair;
+              // Move back if not moved out to re-use buffer.
+              subSplit = std::move(pair.idTable_);
               subSplit.clear();
               ++splitIndex;
             }
           }
           if (subSplit.size() > 0) {
-            co_yield subSplit;
+            co_yield {std::move(subSplit), LocalVocab{}};
           }
         }(std::move(reverseIndex), idTable.clone()));
   }
@@ -52,31 +56,27 @@ std::vector<cppcoro::generator<IdTable>> getAllSubSplits(
 }
 
 // _____________________________________________________________________________
-void consumeGenerator(cppcoro::generator<IdTable>& generator) {
-  for ([[maybe_unused]] IdTable& _ : generator) {
+void consumeGenerator(cppcoro::generator<Result::IdTableVocabPair>& generator) {
+  for ([[maybe_unused]] Result::IdTableVocabPair& _ : generator) {
   }
 }
 }  // namespace
 
 TEST(Result, verifyIdTableThrowsWhenActuallyLazy) {
-  Result result1{
-      []() -> cppcoro::generator<IdTable> { co_return; }(), {}, LocalVocab{}};
-  EXPECT_FALSE(result1.isFullyMaterialized());
-  EXPECT_THROW(result1.idTable(), ad_utility::Exception);
-
-  Result result2{[]() -> cppcoro::generator<IdTable> { co_return; }(),
-                 {},
-                 result1.getSharedLocalVocab()};
-  EXPECT_FALSE(result2.isFullyMaterialized());
-  EXPECT_THROW(result2.idTable(), ad_utility::Exception);
+  Result result{
+      []() -> cppcoro::generator<Result::IdTableVocabPair> { co_return; }(),
+      {}};
+  EXPECT_FALSE(result.isFullyMaterialized());
+  EXPECT_THROW(result.idTable(), ad_utility::Exception);
 }
 
 // _____________________________________________________________________________
 TEST(Result, verifyIdTableThrowsOnSecondAccess) {
   const Result result{
-      []() -> cppcoro::generator<IdTable> { co_return; }(), {}, LocalVocab{}};
+      []() -> cppcoro::generator<Result::IdTableVocabPair> { co_return; }(),
+      {}};
   // First access should work
-  for ([[maybe_unused]] IdTable& _ : result.idTables()) {
+  for ([[maybe_unused]] Result::IdTableVocabPair& _ : result.idTables()) {
     ADD_FAILURE() << "Generator is empty";
   }
   // Now it should throw
@@ -108,7 +108,7 @@ TEST_P(ResultSortTest, verifyAssertSortOrderIsRespectedSucceedsWhenSorted) {
   auto idTable = makeIdTableFromVector({{1, 6, 0}, {2, 5, 0}, {3, 4, 0}});
 
   for (auto& generator : getAllSubSplits(idTable)) {
-    Result result{std::move(generator), std::get<1>(GetParam()), LocalVocab{}};
+    Result result{std::move(generator), std::get<1>(GetParam())};
     if (std::get<0>(GetParam())) {
       EXPECT_NO_THROW(consumeGenerator(result.idTables()));
     } else {
@@ -147,7 +147,7 @@ TEST(Result,
       (Result{idTable.clone(), {3}, LocalVocab{}}), matcher, Exception);
 
   for (auto& generator : getAllSubSplits(idTable)) {
-    Result result{std::move(generator), {3}, LocalVocab{}};
+    Result result{std::move(generator), {3}};
     AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(consumeGenerator(result.idTables()),
                                           matcher, Exception);
   }
@@ -156,7 +156,7 @@ TEST(Result,
       (Result{idTable.clone(), {2, 1337}, LocalVocab{}}), matcher, Exception);
 
   for (auto& generator : getAllSubSplits(idTable)) {
-    Result result{std::move(generator), {2, 1337}, LocalVocab{}};
+    Result result{std::move(generator), {2, 1337}};
     AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(consumeGenerator(result.idTables()),
                                           matcher, Exception);
   }
@@ -178,17 +178,16 @@ TEST(Result, verifyRunOnNewChunkComputedFiresCorrectly) {
   auto idTable2 = makeIdTableFromVector({{3, 4, 0}});
   auto idTable3 = makeIdTableFromVector({{1, 6, 0}, {2, 5, 0}, {3, 4, 0}});
 
-  Result result{
-      [](auto& t1, auto& t2, auto& t3) -> cppcoro::generator<IdTable> {
-        std::this_thread::sleep_for(1ms);
-        co_yield t1;
-        std::this_thread::sleep_for(3ms);
-        co_yield t2;
-        std::this_thread::sleep_for(5ms);
-        co_yield t3;
-      }(idTable1, idTable2, idTable3),
-      {},
-      LocalVocab{}};
+  Result result{[](auto& t1, auto& t2,
+                   auto& t3) -> cppcoro::generator<Result::IdTableVocabPair> {
+                  std::this_thread::sleep_for(1ms);
+                  co_yield {t1.clone(), LocalVocab{}};
+                  std::this_thread::sleep_for(3ms);
+                  co_yield {t2.clone(), LocalVocab{}};
+                  std::this_thread::sleep_for(5ms);
+                  co_yield {t3.clone(), LocalVocab{}};
+                }(idTable1, idTable2, idTable3),
+                {}};
   uint32_t callCounter = 0;
   bool finishedConsuming = false;
 
@@ -196,13 +195,13 @@ TEST(Result, verifyRunOnNewChunkComputedFiresCorrectly) {
       [&](const IdTable& idTable, std::chrono::microseconds duration) {
         ++callCounter;
         if (callCounter == 1) {
-          EXPECT_EQ(&idTable1, &idTable);
+          EXPECT_EQ(idTable1, idTable);
           EXPECT_GE(duration, 1ms);
         } else if (callCounter == 2) {
-          EXPECT_EQ(&idTable2, &idTable);
+          EXPECT_EQ(idTable2, idTable);
           EXPECT_GE(duration, 3ms);
         } else if (callCounter == 3) {
-          EXPECT_EQ(&idTable3, &idTable);
+          EXPECT_EQ(idTable3, idTable);
           EXPECT_GE(duration, 5ms);
         }
       },
@@ -220,12 +219,11 @@ TEST(Result, verifyRunOnNewChunkComputedFiresCorrectly) {
 // _____________________________________________________________________________
 TEST(Result, verifyRunOnNewChunkCallsFinishOnError) {
   Result result{
-      []() -> cppcoro::generator<IdTable> {
+      []() -> cppcoro::generator<Result::IdTableVocabPair> {
         throw std::runtime_error{"verifyRunOnNewChunkCallsFinishOnError"};
         co_return;
       }(),
-      {},
-      LocalVocab{}};
+      {}};
   uint32_t callCounterGenerator = 0;
   uint32_t callCounterFinished = 0;
 
@@ -252,11 +250,11 @@ TEST(Result, verifyRunOnNewChunkCallsFinishOnPartialConsumption) {
   uint32_t callCounterFinished = 0;
 
   {
-    Result result{[](IdTable idTable) -> cppcoro::generator<IdTable> {
-                    co_yield idTable;
-                  }(makeIdTableFromVector({{}})),
-                  {},
-                  LocalVocab{}};
+    Result result{
+        [](IdTable idTable) -> cppcoro::generator<Result::IdTableVocabPair> {
+          co_yield {std::move(idTable), LocalVocab{}};
+        }(makeIdTableFromVector({{}})),
+        {}};
 
     result.runOnNewChunkComputed(
         [&](const IdTable&, std::chrono::microseconds) {
@@ -277,11 +275,11 @@ TEST(Result, verifyRunOnNewChunkCallsFinishOnPartialConsumption) {
 // _____________________________________________________________________________
 TEST(Result, verifyCacheDuringConsumptionThrowsWhenFullyMaterialized) {
   Result result{makeIdTableFromVector({{}}), {}, LocalVocab{}};
-  EXPECT_THROW(
-      result.cacheDuringConsumption(
-          [](const std::optional<IdTable>&, const IdTable&) { return true; },
-          [](Result) {}),
-      ad_utility::Exception);
+  EXPECT_THROW(result.cacheDuringConsumption(
+                   [](const std::optional<Result::IdTableVocabPair>&,
+                      const Result::IdTableVocabPair&) { return true; },
+                   [](Result) {}),
+               ad_utility::Exception);
 }
 
 // _____________________________________________________________________________
@@ -290,16 +288,17 @@ TEST(Result, verifyCacheDuringConsumptionRespectsPassedParameters) {
 
   // Test positive case
   for (auto& generator : getAllSubSplits(idTable)) {
-    Result result{std::move(generator), {0}, LocalVocab{}};
+    Result result{std::move(generator), {0}};
     result.cacheDuringConsumption(
-        [predictedSize = 0](const std::optional<IdTable>& aggregator,
-                            const IdTable& newTable) mutable {
+        [predictedSize = 0](
+            const std::optional<Result::IdTableVocabPair>& aggregator,
+            const Result::IdTableVocabPair& newTable) mutable {
           if (aggregator.has_value()) {
-            EXPECT_EQ(aggregator.value().numColumns(), predictedSize);
+            EXPECT_EQ(aggregator.value().idTable_.numColumns(), predictedSize);
           } else {
             EXPECT_EQ(predictedSize, 0);
           }
-          predictedSize += newTable.numColumns();
+          predictedSize += newTable.idTable_.numColumns();
           return true;
         },
         [&](Result aggregatedResult) {
@@ -312,9 +311,10 @@ TEST(Result, verifyCacheDuringConsumptionRespectsPassedParameters) {
   // Test negative case
   for (auto& generator : getAllSubSplits(idTable)) {
     uint32_t callCounter = 0;
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.cacheDuringConsumption(
-        [&](const std::optional<IdTable>& aggregator, const IdTable&) {
+        [&](const std::optional<Result::IdTableVocabPair>& aggregator,
+            const Result::IdTableVocabPair&) {
           EXPECT_FALSE(aggregator.has_value());
           ++callCounter;
           return false;
@@ -346,7 +346,7 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
   for (auto& generator : getAllSubSplits(idTable)) {
     std::vector<size_t> colSizes{};
     uint32_t totalRows = 0;
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.applyLimitOffset(
         limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
           // NOTE: duration can't be tested here, processors are too fast
@@ -365,7 +365,7 @@ TEST(Result, verifyApplyLimitOffsetDoesCorrectlyApplyLimitAndOffset) {
     EXPECT_TRUE(colSizes.empty());
 
     for (const auto& innerTable : result.idTables()) {
-      for (const auto& row : innerTable) {
+      for (const auto& row : innerTable.idTable_) {
         ASSERT_EQ(row.size(), 2);
         // Make sure we never get values that were supposed to be filtered
         // out.
@@ -396,7 +396,7 @@ TEST(Result, verifyApplyLimitOffsetHandlesZeroLimitCorrectly) {
 
   for (auto& generator : getAllSubSplits(idTable)) {
     uint32_t callCounter = 0;
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.applyLimitOffset(
         limitOffset,
         [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
@@ -424,7 +424,7 @@ TEST(Result, verifyApplyLimitOffsetHandlesNonZeroOffsetWithoutLimitCorrectly) {
 
   for (auto& generator : getAllSubSplits(idTable)) {
     uint32_t callCounter = 0;
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.applyLimitOffset(
         limitOffset, [&](std::chrono::microseconds, const IdTable& innerTable) {
           for (const auto& row : innerTable) {
@@ -457,7 +457,7 @@ TEST(Result, verifyApplyLimitOffsetIsNoOpWhenLimitClauseIsRedundant) {
   }
 
   for (auto& generator : getAllSubSplits(idTable)) {
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.applyLimitOffset(
         limitOffset,
         [&](std::chrono::microseconds, const IdTable&) { ++callCounter; });
@@ -487,7 +487,7 @@ TEST_P(ResultLimitTest,
   }
 
   for (auto& generator : getAllSubSplits(idTable)) {
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.assertThatLimitWasRespected(std::get<1>(GetParam()));
 
     if (std::get<0>(GetParam())) {
@@ -538,7 +538,7 @@ TEST_P(ResultDefinednessTest,
     }
   }
   for (auto& generator : getAllSubSplits(*std::get<1>(GetParam()))) {
-    Result result{std::move(generator), {}, LocalVocab{}};
+    Result result{std::move(generator), {}};
     result.checkDefinedness(map);
     if (std::get<0>(GetParam())) {
       EXPECT_NO_THROW(consumeGenerator(result.idTables()));

--- a/test/ResultTest.cpp
+++ b/test/ResultTest.cpp
@@ -40,7 +40,7 @@ std::vector<cppcoro::generator<Result::IdTableVocabPair>> getAllSubSplits(
             if (splitIndex < split.size() && split[splitIndex] == i) {
               Result::IdTableVocabPair pair{std::move(subSplit), LocalVocab{}};
               co_yield pair;
-              // Move back if not moved out to re-use buffer.
+              // Move back if not moved out to reuse buffer.
               subSplit = std::move(pair.idTable_);
               subSplit.clear();
               ++splitIndex;

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -103,11 +103,11 @@ TEST(Union, computeUnionLazy) {
 
     auto iterator = result.begin();
     ASSERT_NE(iterator, result.end());
-    ASSERT_EQ(*iterator, expected1);
+    ASSERT_EQ(iterator->idTable_, expected1);
 
     ++iterator;
     ASSERT_NE(iterator, result.end());
-    ASSERT_EQ(*iterator, expected2);
+    ASSERT_EQ(iterator->idTable_, expected2);
 
     ASSERT_EQ(++iterator, result.end());
   };
@@ -142,11 +142,11 @@ TEST(Union, ensurePermutationIsAppliedCorrectly) {
 
     auto iterator = result.begin();
     ASSERT_NE(iterator, result.end());
-    ASSERT_EQ(*iterator, expected1);
+    ASSERT_EQ(iterator->idTable_, expected1);
 
     ++iterator;
     ASSERT_NE(iterator, result.end());
-    ASSERT_EQ(*iterator, expected2);
+    ASSERT_EQ(iterator->idTable_, expected2);
 
     ASSERT_EQ(++iterator, result.end());
   }

--- a/test/engine/BindTest.cpp
+++ b/test/engine/BindTest.cpp
@@ -44,7 +44,7 @@ void expectBindYieldsIdTable(
     auto& idTables = result->idTables();
     auto iterator = idTables.begin();
     ASSERT_NE(iterator, idTables.end());
-    EXPECT_EQ(*iterator, expected);
+    EXPECT_EQ(iterator->idTable_, expected);
     EXPECT_EQ(++iterator, idTables.end());
   }
 }
@@ -125,9 +125,9 @@ TEST(
     auto& idTables = result->idTables();
     auto iterator = idTables.begin();
     ASSERT_NE(iterator, idTables.end());
-    EXPECT_EQ(*iterator, table);
+    EXPECT_EQ(iterator->idTable_, table);
     ASSERT_NE(++iterator, idTables.end());
-    EXPECT_EQ(*iterator, makeIdTableFromVector({{val, val}}));
+    EXPECT_EQ(iterator->idTable_, makeIdTableFromVector({{val, val}}));
     EXPECT_EQ(++iterator, idTables.end());
   }
 }

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -485,8 +485,8 @@ TEST(IndexScan, computeResultCanBeConsumedLazily) {
 
   IdTable resultTable{3, ad_utility::makeUnlimitedAllocator<Id>()};
 
-  for (IdTable& idTable : result.idTables()) {
-    resultTable.insertAtEnd(idTable);
+  for (Result::IdTableVocabPair& pair : result.idTables()) {
+    resultTable.insertAtEnd(pair.idTable_);
   }
 
   EXPECT_EQ(resultTable,
@@ -505,7 +505,7 @@ TEST(IndexScan, computeResultReturnsEmptyGeneratorIfScanIsEmpty) {
 
   ASSERT_FALSE(result.isFullyMaterialized());
 
-  for ([[maybe_unused]] IdTable& idTable : result.idTables()) {
+  for ([[maybe_unused]] Result::IdTableVocabPair& pair : result.idTables()) {
     ADD_FAILURE() << "Generator should be empty" << std::endl;
   }
 }

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -88,8 +88,8 @@ class ValuesForTesting : public Operation {
       for (const IdTable& idTable : tables_) {
         clones.push_back(idTable.clone());
       }
-      auto generator = [](auto idTables, LocalVocab localVocab)
-          -> cppcoro::generator<Result::IdTableVocabPair> {
+      auto generator = [](auto idTables,
+                          LocalVocab localVocab) -> Result::Generator {
         for (IdTable& idTable : idTables) {
           co_yield {std::move(idTable), localVocab.clone()};
         }

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -88,12 +88,13 @@ class ValuesForTesting : public Operation {
       for (const IdTable& idTable : tables_) {
         clones.push_back(idTable.clone());
       }
-      auto generator = [](auto idTables) -> cppcoro::generator<IdTable> {
+      auto generator = [](auto idTables, LocalVocab localVocab)
+          -> cppcoro::generator<Result::IdTableVocabPair> {
         for (IdTable& idTable : idTables) {
-          co_yield std::move(idTable);
+          co_yield {std::move(idTable), localVocab.clone()};
         }
-      }(std::move(clones));
-      return {std::move(generator), resultSortedOn(), localVocab_.clone()};
+      }(std::move(clones), localVocab_.clone());
+      return {std::move(generator), resultSortedOn()};
     }
     std::optional<IdTable> optionalTable;
     if (tables_.size() > 1) {

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -106,7 +106,7 @@ class AlwaysFailOperation : public Operation {
     if (!requestLaziness) {
       throw std::runtime_error{"AlwaysFailOperation"};
     }
-    return {[]() -> cppcoro::generator<Result::IdTableVocabPair> {
+    return {[]() -> Result::Generator {
               throw std::runtime_error{"AlwaysFailOperation"};
               // Required so that the exception only occurs within the generator
               co_return;
@@ -118,7 +118,7 @@ class AlwaysFailOperation : public Operation {
 // Lazy operation that will yield a result with a custom generator you can
 // provide via the constructor.
 class CustomGeneratorOperation : public Operation {
-  cppcoro::generator<Result::IdTableVocabPair> generator_;
+  Result::Generator generator_;
   std::vector<QueryExecutionTree*> getChildren() override { return {}; }
   string getCacheKeyImpl() const override { AD_FAIL(); }
   string getDescriptor() const override {
@@ -133,9 +133,8 @@ class CustomGeneratorOperation : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
 
  public:
-  CustomGeneratorOperation(
-      QueryExecutionContext* context,
-      cppcoro::generator<Result::IdTableVocabPair> generator)
+  CustomGeneratorOperation(QueryExecutionContext* context,
+                           Result::Generator generator)
       : Operation{context}, generator_{std::move(generator)} {}
   ProtoResult computeResult(bool requestLaziness) override {
     AD_CONTRACT_CHECK(requestLaziness);

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -106,19 +106,19 @@ class AlwaysFailOperation : public Operation {
     if (!requestLaziness) {
       throw std::runtime_error{"AlwaysFailOperation"};
     }
-    return {[]() -> cppcoro::generator<IdTable> {
+    return {[]() -> cppcoro::generator<Result::IdTableVocabPair> {
               throw std::runtime_error{"AlwaysFailOperation"};
               // Required so that the exception only occurs within the generator
               co_return;
             }(),
-            resultSortedOn(), LocalVocab{}};
+            resultSortedOn()};
   }
 };
 
 // Lazy operation that will yield a result with a custom generator you can
 // provide via the constructor.
 class CustomGeneratorOperation : public Operation {
-  cppcoro::generator<IdTable> generator_;
+  cppcoro::generator<Result::IdTableVocabPair> generator_;
   std::vector<QueryExecutionTree*> getChildren() override { return {}; }
   string getCacheKeyImpl() const override { AD_FAIL(); }
   string getDescriptor() const override {
@@ -133,12 +133,13 @@ class CustomGeneratorOperation : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override { return {}; }
 
  public:
-  CustomGeneratorOperation(QueryExecutionContext* context,
-                           cppcoro::generator<IdTable> generator)
+  CustomGeneratorOperation(
+      QueryExecutionContext* context,
+      cppcoro::generator<Result::IdTableVocabPair> generator)
       : Operation{context}, generator_{std::move(generator)} {}
   ProtoResult computeResult(bool requestLaziness) override {
     AD_CONTRACT_CHECK(requestLaziness);
-    return {std::move(generator_), resultSortedOn(), LocalVocab{}};
+    return {std::move(generator_), resultSortedOn()};
   }
 };
 


### PR DESCRIPTION
Lazy operations now yield pairs of `(IdTable, LocalVocab for that IdTable)`. Previously, there was one (potentially large) local vocab for the complete result, even if it was lazy. The new structure can reduce the RAM usage for lazy results that contain many local vocab entries dramatically. Consider for example queries like the following:
```
SELECT * WHERE {
  ?s ?p ?o 
  BIND( CONCAT(?o, "suffix") as ?bound)
}
```
Previously all the result strings of the `BIND` operation would be kept in RAM at the same time although the complete query (index scan + bind + export) could be computed lazily.