### PR TITLE
Use a memory limited hashset with `LocalVocab`

### DIFF
--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -71,7 +71,8 @@ const LocalVocab::LiteralOrIri& LocalVocab::getWord(
 std::vector<LocalVocab::LiteralOrIri> LocalVocab::getAllWordsForTesting()
     const {
   std::vector<LiteralOrIri> result;
-  std::ranges::copy(primaryWordSet(), std::back_inserter(result));
+  std::ranges::copy(primaryWordSet().begin(), primaryWordSet().end(),
+                    std::back_inserter(result));
   for (const auto& previous : otherWordSets_) {
     std::ranges::copy(*previous, std::back_inserter(result));
   }

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -49,8 +49,6 @@ class LocalVocab {
   ad_utility::detail::AllocationMemoryLeftThreadsafe limit_;
   std::shared_ptr<Set> primaryWordSet_;
 
-  IriSizeGetter sizeGetter;
-
   // Local vocabularies from child operations that were merged into this
   // vocabulary s.t. the pointers are kept alive. They have to be `const`
   // because they are possibly shared concurrently (for example via the cache).
@@ -66,9 +64,8 @@ class LocalVocab {
   // Create a new, empty local vocabulary.
   LocalVocab(ad_utility::detail::AllocationMemoryLeftThreadsafe memoryLimit =
                  ad_utility::makeAllocationMemoryLeftThreadsafeObject(
-                     ad_utility::MemorySize::megabytes(100)))
-      : limit_(memoryLimit),
-        primaryWordSet_(std::make_shared<Set>(limit_, sizeGetter)) {}
+                     ad_utility::MemorySize::max()))
+      : limit_(memoryLimit), primaryWordSet_(std::make_shared<Set>(limit_)) {}
 
   // Prevent accidental copying of a local vocabulary.
   LocalVocab(const LocalVocab&) = delete;

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -14,6 +14,7 @@
 #include "absl/container/node_hash_set.h"
 #include "global/Id.h"
 #include "parser/LiteralOrIri.h"
+#include "util/AllocatorWithLimit.h"
 #include "util/BlankNodeManager.h"
 #include "util/HashSet.h"
 #include "util/MemorySize/MemorySize.h"
@@ -42,7 +43,7 @@ class LocalVocab {
   // because we hand out pointers to them.
   using Set =
       ad_utility::CustomHashSetWithMemoryLimit<LiteralOrIri, IriSizeGetter>;
-  ad_utility::MemorySize limit_;
+  ad_utility::detail::AllocationMemoryLeftThreadsafe limit_;
   std::shared_ptr<Set> primaryWordSet_;
 
   IriSizeGetter sizeGetter;
@@ -60,8 +61,9 @@ class LocalVocab {
 
  public:
   // Create a new, empty local vocabulary.
-  LocalVocab(ad_utility::MemorySize memoryLimit =
-                 ad_utility::MemorySize::megabytes(100))
+  LocalVocab(ad_utility::detail::AllocationMemoryLeftThreadsafe memoryLimit =
+                 ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+                     ad_utility::MemorySize::megabytes(100)))
       : limit_(memoryLimit),
         primaryWordSet_(std::make_shared<Set>(limit_, sizeGetter)) {}
 

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -45,7 +45,7 @@ class LocalVocab {
   // `LiteralOrIri`) to remain stable over their lifetime in the hash map
   // because we hand out pointers to them.
   using Set =
-      ad_utility::CustomHashSetWithMemoryLimit<LiteralOrIri, IriSizeGetter>;
+      ad_utility::NodeHashSetWithMemoryLimit<LiteralOrIri, IriSizeGetter>;
   ad_utility::detail::AllocationMemoryLeftThreadsafe limit_;
   std::shared_ptr<Set> primaryWordSet_;
 

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -29,6 +29,9 @@ class LocalVocab {
   using Entry = LocalVocabEntry;
   using LiteralOrIri = LocalVocabEntry;
 
+  // A functor that calculates the memory size of an IRI or Literal.
+  // This struct defines an operator() that takes a `LiteralOrIri` object and
+  // returns its dynamic memory usage in bytes.
   struct IriSizeGetter {
     ad_utility::MemorySize operator()(
         const ad_utility::triple_component::LiteralOrIri& literalOrIri) {

--- a/src/parser/Iri.h
+++ b/src/parser/Iri.h
@@ -49,7 +49,12 @@ class Iri {
   // angled brackets.
   NormalizedStringView getContent() const;
 
-  size_t getDynamicMemoryUsage() const { return iri_.capacity(); }
+  // Calculate the memory usage of the `Iri` string. This might overestimate the
+  // memory usage as this does not currently take into account small string
+  // optimization of `std::string`
+  size_t getDynamicMemoryUsage() const {
+    return sizeof(std::string) + iri_.capacity();
+  }
 };
 
 }  // namespace ad_utility::triple_component

--- a/src/parser/Iri.h
+++ b/src/parser/Iri.h
@@ -52,9 +52,7 @@ class Iri {
   // Calculate the memory usage of the `Iri` string. This might overestimate the
   // memory usage as this does not currently take into account small string
   // optimization of `std::string`
-  size_t getDynamicMemoryUsage() const {
-    return sizeof(std::string) + iri_.capacity();
-  }
+  size_t getDynamicMemoryUsage() const { return iri_.capacity(); }
 };
 
 }  // namespace ad_utility::triple_component

--- a/src/parser/Iri.h
+++ b/src/parser/Iri.h
@@ -48,6 +48,8 @@ class Iri {
   // Return the string value of the iri object without any leading or trailing
   // angled brackets.
   NormalizedStringView getContent() const;
+
+  size_t getDynamicMemoryUsage() const { return iri_.capacity(); }
 };
 
 }  // namespace ad_utility::triple_component

--- a/src/parser/Literal.h
+++ b/src/parser/Literal.h
@@ -92,6 +92,11 @@ class Literal {
       std::string_view rdfContentWithoutQuotes,
       std::optional<std::variant<Iri, std::string>> descriptor = std::nullopt);
 
-  size_t getDynamicMemoryUsage() const { return content_.capacity(); }
+  // Calculate the memory usage of the `Literal` string. This might overestimate
+  // the memory usage as this does not currently take into account small string
+  // optimization of `std::string`
+  size_t getDynamicMemoryUsage() const {
+    return sizeof(std::string) + content_.capacity();
+  }
 };
 }  // namespace ad_utility::triple_component

--- a/src/parser/Literal.h
+++ b/src/parser/Literal.h
@@ -95,8 +95,6 @@ class Literal {
   // Calculate the memory usage of the `Literal` string. This might overestimate
   // the memory usage as this does not currently take into account small string
   // optimization of `std::string`
-  size_t getDynamicMemoryUsage() const {
-    return sizeof(std::string) + content_.capacity();
-  }
+  size_t getDynamicMemoryUsage() const { return content_.capacity(); }
 };
 }  // namespace ad_utility::triple_component

--- a/src/parser/Literal.h
+++ b/src/parser/Literal.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <optional>
 #include <variant>
 
@@ -90,5 +91,7 @@ class Literal {
   static Literal literalWithoutQuotes(
       std::string_view rdfContentWithoutQuotes,
       std::optional<std::variant<Iri, std::string>> descriptor = std::nullopt);
+
+  size_t getDynamicMemoryUsage() const { return content_.capacity(); }
 };
 }  // namespace ad_utility::triple_component

--- a/src/parser/LiteralOrIri.h
+++ b/src/parser/LiteralOrIri.h
@@ -129,6 +129,7 @@ class alignas(16) LiteralOrIri {
     s << literalOrIri.toStringRepresentation();
   }
 
+  // Return the memory usage of the `LitaralOrIri` variant
   size_t getDynamicMemoryUsage() const {
     return std::visit(
         [](const auto& val) { return val.getDynamicMemoryUsage(); }, data_);

--- a/src/parser/LiteralOrIri.h
+++ b/src/parser/LiteralOrIri.h
@@ -128,6 +128,11 @@ class alignas(16) LiteralOrIri {
     auto& s = *os;
     s << literalOrIri.toStringRepresentation();
   }
+
+  size_t getDynamicMemoryUsage() const {
+    return std::visit(
+        [](const auto& val) { return val.getDynamicMemoryUsage(); }, data_);
+  }
 };
 
 }  // namespace ad_utility::triple_component

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -60,6 +60,10 @@ class CustomHashSetWithMemoryLimit {
         memoryUsed_{MemorySize::bytes(0)},
         sizeGetter_{sizeGetter} {}
 
+  ~CustomHashSetWithMemoryLimit() {
+    memoryLeft_.ptr()->wlock()->increase(memoryUsed_);
+  }
+
   // Insert an element into the hash set. If the memory limit is exceeded, the
   // insert operation fails with a runtime error.
   std::pair<typename HashSet::iterator, bool> insert(const T& value) {

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -6,10 +6,15 @@
 
 #pragma once
 
+#include <absl/container/node_hash_set.h>
+
+#include <cstddef>
 #include <string>
+#include <utility>
 
 #include "absl/container/flat_hash_set.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/MemorySize/MemorySize.h"
 
 using std::string;
 
@@ -31,5 +36,89 @@ template <class T,
           class Alloc = ad_utility::AllocatorWithLimit<T>>
 using HashSetWithMemoryLimit =
     absl::flat_hash_set<T, HashFct, EqualElem, Alloc>;
+
+template <class T,
+          class HashFct = absl::container_internal::hash_default_hash<T>,
+          class EqualElem = absl::container_internal::hash_default_eq<T>,
+          class SizeGetter = std::function<size_t(const T&)>>
+class CustomHashSetWithMemoryLimit {
+ private:
+  absl::node_hash_set<T, HashFct, EqualElem> hashSet_;
+  detail::AllocationMemoryLeftThreadsafe memoryLeft_;
+  MemorySize memoryUsed_;
+  SizeGetter sizeGetter_;
+
+ public:
+  CustomHashSetWithMemoryLimit(MemorySize memory, SizeGetter sizeGetter)
+      : memoryLeft_(makeAllocationMemoryLeftThreadsafeObject(memory)),
+        memoryUsed_(MemorySize::bytes(0)),
+        sizeGetter_(sizeGetter) {}
+
+  // Insert an element into the hash set. If the memory limit is exceeded, the
+  // insert operation fails with a runtime error. Note: Other overloaded
+  // implementations are currently missing.
+  std::pair<typename absl::node_hash_set<T, HashFct, EqualElem>::iterator, bool>
+  insert(const T& value) {
+    MemorySize size = MemorySize::bytes(sizeGetter_(value));
+    if (!memoryLeft_.ptr()->wlock()->decrease_if_enough_left_or_return_false(
+            size)) {
+      throw std::runtime_error(
+          "The element to be inserted is too large for the hash set.");
+    }
+
+    auto result = hashSet_.insert(value);
+
+    if (result.second) {
+      memoryUsed_ += size;
+    } else {
+      memoryLeft_.ptr()->wlock()->increase(size);
+    }
+    return result;
+  }
+
+  void erase(const T& value) {
+    auto it = hashSet_.find(value);
+    if (it != hashSet_.end()) {
+      MemorySize size = sizeGetter_(*it);
+      hashSet_.erase(it);
+      memoryLeft_.ptr()->wlock()->increase(MemorySize::bytes(sizeGetter_(*it)));
+      memoryUsed_ -= size;
+    }
+  }
+
+  void clear() {
+    hashSet_.clear();
+    memoryLeft_.ptr()->wlock()->increase(memoryUsed_);
+    memoryUsed_ = MemorySize::bytes(0);
+  }
+
+  size_t size() const { return hashSet_.size(); }
+
+  bool empty() const { return hashSet_.empty(); }
+
+  size_t count(const T& value) const { return hashSet_.count(value); }
+
+  typename absl::node_hash_set<T, HashFct, EqualElem>::const_iterator find(
+      const T& value) const {
+    return hashSet_.find(value);
+  }
+
+  typename absl::node_hash_set<T, HashFct, EqualElem>::iterator find(
+      const T& value) {
+    return hashSet_.find(value);
+  }
+
+  typename absl::node_hash_set<T, HashFct, EqualElem>::const_iterator begin()
+      const {
+    return hashSet_.begin();
+  }
+
+  typename absl::node_hash_set<T, HashFct, EqualElem>::const_iterator end()
+      const {
+    return hashSet_.end();
+  }
+
+  MemorySize getCurrentMemoryUsage() const { return memoryUsed_; }
+};
 
 }  // namespace ad_utility

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -102,7 +102,7 @@ class CustomHashSetWithMemoryLimit {
     return hashSet_.find(value);
   }
 
-  HashSet::iterator find(const T& value) { return hashSet_.find(value); }
+  bool contains(const T& key) { return hashSet_.contains(key); }
 
   HashSet::const_iterator begin() const { return hashSet_.begin(); }
 

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -43,7 +43,8 @@ template <class T, class SizeGetter = SizeOfSizeGetter,
           class EqualElem = absl::container_internal::hash_default_eq<T>>
 class CustomHashSetWithMemoryLimit {
  private:
-  absl::node_hash_set<T, HashFct, EqualElem> hashSet_;
+  using HashSet = absl::node_hash_set<T, HashFct, EqualElem>;
+  HashSet hashSet_;
   detail::AllocationMemoryLeftThreadsafe memoryLeft_;
   MemorySize memoryUsed_;
   SizeGetter sizeGetter_;
@@ -57,8 +58,7 @@ class CustomHashSetWithMemoryLimit {
   // Insert an element into the hash set. If the memory limit is exceeded, the
   // insert operation fails with a runtime error. Note: Other overloaded
   // implementations are currently missing.
-  std::pair<typename absl::node_hash_set<T, HashFct, EqualElem>::iterator, bool>
-  insert(const T& value) {
+  std::pair<typename HashSet::iterator, bool> insert(const T& value) {
     MemorySize size = sizeGetter_(value);
     if (!memoryLeft_.ptr()->wlock()->decrease_if_enough_left_or_return_false(
             size)) {
@@ -98,25 +98,15 @@ class CustomHashSetWithMemoryLimit {
 
   size_t count(const T& value) const { return hashSet_.count(value); }
 
-  typename absl::node_hash_set<T, HashFct, EqualElem>::const_iterator find(
-      const T& value) const {
+  HashSet::const_iterator find(const T& value) const {
     return hashSet_.find(value);
   }
 
-  typename absl::node_hash_set<T, HashFct, EqualElem>::iterator find(
-      const T& value) {
-    return hashSet_.find(value);
-  }
+  HashSet::iterator find(const T& value) { return hashSet_.find(value); }
 
-  typename absl::node_hash_set<T, HashFct, EqualElem>::const_iterator begin()
-      const {
-    return hashSet_.begin();
-  }
+  HashSet::const_iterator begin() const { return hashSet_.begin(); }
 
-  typename absl::node_hash_set<T, HashFct, EqualElem>::const_iterator end()
-      const {
-    return hashSet_.end();
-  }
+  HashSet::const_iterator end() const { return hashSet_.end(); }
 
   MemorySize getCurrentMemoryUsage() const { return memoryUsed_; }
 };

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -22,20 +22,6 @@ using std::string;
 
 namespace ad_utility {
 
-// `slotMemoryCost` represents the per-slot memory cost of a node hash set.
-// It accounts for the memory used by a slot in the hash table, which typically
-// consists of a pointer (used for node storage) plus any additional control
-// bytes required for maintaining the hash set's structure and state.
-// This value helps estimate and manage memory consumption for operations that
-// involve slots, such as insertion and rehashing.
-//
-// The value is defined as `sizeof(void*) + 1` bytes, where:
-// - `sizeof(void*)` represents the size of a pointer on the platform (usually 4
-// bytes for 32-bit and 8 bytes for 64-bit systems).
-// - `+ 1` accounts for an extra control byte used for state management in the
-// hash set.
-constexpr size_t slotMemoryCost = sizeof(void*) + 1;
-
 // Wrapper for HashSets (with elements of type T) to be used everywhere
 // throughout code for the semantic search. This wrapper interface is not
 // designed to be complete from the beginning. Feel free to extend it at need.
@@ -68,6 +54,20 @@ class CustomHashSetWithMemoryLimit {
   MemorySize memoryUsed_;
   SizeGetter sizeGetter_;
   size_t currentSlotSize_;
+
+  // `slotMemoryCost` represents the per-slot memory cost of a node hash set.
+  // It accounts for the memory used by a slot in the hash table, which
+  // typically consists of a pointer (used for node storage) plus any additional
+  // control bytes required for maintaining the hash set's structure and state.
+  // This value helps estimate and manage memory consumption for operations that
+  // involve slots, such as insertion and rehashing.
+  //
+  // The value is defined as `sizeof(void*) + 1` bytes, where:
+  // - `sizeof(void*)` represents the size of a pointer on the platform (usually
+  // 4 bytes for 32-bit and 8 bytes for 64-bit systems).
+  // - `+ 1` accounts for an extra control byte used for state management in the
+  // hash set.
+  constexpr static size_t slotMemoryCost = sizeof(void*) + 1;
 
  public:
   CustomHashSetWithMemoryLimit(

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -52,7 +52,7 @@ class NodeHashSetWithMemoryLimit {
   HashSet hashSet_;
   detail::AllocationMemoryLeftThreadsafe memoryLeft_;
   MemorySize memoryUsed_{MemorySize::bytes(0)};
-  SizeGetter sizeGetter_;
+  SizeGetter sizeGetter_{};
   size_t currentNumSlots_{0};
 
   // `slotMemoryCost` represents the per-slot memory cost of a node hash set.
@@ -71,9 +71,8 @@ class NodeHashSetWithMemoryLimit {
       MemorySize::bytes(sizeof(void*) + 1);
 
  public:
-  NodeHashSetWithMemoryLimit(detail::AllocationMemoryLeftThreadsafe memoryLeft,
-                             SizeGetter sizeGetter = {})
-      : memoryLeft_{memoryLeft}, sizeGetter_{sizeGetter} {
+  NodeHashSetWithMemoryLimit(detail::AllocationMemoryLeftThreadsafe memoryLeft)
+      : memoryLeft_{memoryLeft} {
     // Once the hash set is initialized, calculate the initial memory
     // used by the slots of the hash set
     updateSlotArrayMemoryUsage();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,6 +132,8 @@ addLinkAndDiscoverTest(HashMapTest)
 
 addLinkAndDiscoverTest(HashSetTest)
 
+addLinkAndDiscoverTest(CustomHashSetWithMemoryLimitTest)
+
 addLinkAndDiscoverTestSerial(GroupByTest engine)
 
 addLinkAndDiscoverTest(VocabularyGeneratorTest index)

--- a/test/CustomHashSetWithMemoryLimitTest.cpp
+++ b/test/CustomHashSetWithMemoryLimitTest.cpp
@@ -1,0 +1,229 @@
+#include <gtest/gtest.h>
+
+#include "../src/util/HashSet.h"
+#include "util/AllocatorWithLimit.h"
+#include "util/MemorySize/MemorySize.h"
+
+using ad_utility::makeAllocationMemoryLeftThreadsafeObject;
+using namespace ad_utility::memory_literals;
+
+using Set = ad_utility::CustomHashSetWithMemoryLimit<int>;
+
+TEST(CustomHashSetWithMemoryLimitTest, sizeAndInsert) {
+  Set hashSet{makeAllocationMemoryLeftThreadsafeObject(100_B)};
+  ASSERT_EQ(hashSet.size(), 0);
+  hashSet.insert(1);
+  hashSet.insert(2);
+  hashSet.insert(3);
+  ASSERT_EQ(hashSet.size(), 3);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, memoryLimit) {
+  Set hashSet{makeAllocationMemoryLeftThreadsafeObject(10_B)};
+  std::initializer_list<int> testNums = {
+      1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+      18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+      35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
+      52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+      69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85,
+      86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100};
+  ASSERT_THROW(
+      {
+        for (auto num : testNums) {
+          hashSet.insert(num);
+        }
+      },
+      ad_utility::detail::AllocationExceedsLimitException);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, iteratorOperations) {
+  Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  hashSet.insert(1);
+  hashSet.insert(2);
+  hashSet.insert(3);
+
+  // Test iterator functionality
+  auto it = hashSet.find(2);
+  ASSERT_NE(it, hashSet.end());
+  ASSERT_EQ(*it, 2);
+
+  // Test non-existing element
+  ASSERT_EQ(hashSet.find(4), hashSet.end());
+
+  // Test iteration
+  std::vector<int> values;
+  for (const auto& val : hashSet) {
+    values.push_back(val);
+  }
+  std::sort(values.begin(), values.end());
+  ASSERT_EQ(values, std::vector<int>({1, 2, 3}));
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, eraseOperations) {
+  Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  hashSet.insert(1);
+  hashSet.insert(2);
+  hashSet.insert(3);
+
+  // Test erase of existing element
+  hashSet.erase(2);
+  ASSERT_EQ(hashSet.size(), 2);
+  ASSERT_FALSE(hashSet.contains(2));
+
+  // Test erase of non-existing element
+  size_t originalSize = hashSet.size();
+  hashSet.erase(4);
+  ASSERT_EQ(hashSet.size(), originalSize);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, clearOperation) {
+  Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  auto initialMemory = hashSet.getCurrentMemoryUsage();
+
+  // Add some elements
+  hashSet.insert(1);
+  hashSet.insert(2);
+  hashSet.insert(3);
+
+  auto usedMemory = hashSet.getCurrentMemoryUsage();
+  ASSERT_GT(usedMemory, initialMemory);
+
+  // Clear the set
+  hashSet.clear();
+  ASSERT_EQ(hashSet.size(), 0);
+  ASSERT_TRUE(hashSet.empty());
+
+  // Memory usage should be back to approximately initial state
+  // (might be slightly different due to bucket array size)
+  ASSERT_LE(hashSet.getCurrentMemoryUsage(), usedMemory);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, memoryTrackingAccuracy) {
+  Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  auto initialMemory = hashSet.getCurrentMemoryUsage();
+
+  // Insert and track memory changes
+  hashSet.insert(1);
+  auto afterOneInsert = hashSet.getCurrentMemoryUsage();
+  ASSERT_GT(afterOneInsert, initialMemory);
+
+  // Insert duplicate and verify memory doesn't change
+  auto beforeDuplicate = hashSet.getCurrentMemoryUsage();
+  hashSet.insert(1);
+  ASSERT_EQ(hashSet.getCurrentMemoryUsage(), beforeDuplicate);
+
+  // Remove element and verify memory decreases
+  hashSet.erase(1);
+  ASSERT_EQ(hashSet.getCurrentMemoryUsage(), initialMemory);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, edgeCases) {
+  // Test with zero memory limit
+  ASSERT_THROW(Set zeroHashSet{makeAllocationMemoryLeftThreadsafeObject(0_B)},
+               ad_utility::detail::AllocationExceedsLimitException);
+
+  // Test multiple insert/erase cycles
+  Set cycleHashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  for (int i = 0; i < 10; ++i) {
+    cycleHashSet.insert(i);
+    cycleHashSet.erase(i);
+  }
+  ASSERT_TRUE(cycleHashSet.empty());
+  ASSERT_EQ(cycleHashSet.getCurrentMemoryUsage(),
+            cycleHashSet.getCurrentMemoryUsage());
+}
+
+// Define a custom size getter for strings that includes the actual string
+// memory
+struct StringSizeGetter {
+  ad_utility::MemorySize operator()(const std::string& str) const {
+    return ad_utility::MemorySize::bytes(str.capacity());
+  }
+};
+
+using StringSet =
+    ad_utility::CustomHashSetWithMemoryLimit<std::string, StringSizeGetter>;
+
+TEST(CustomHashSetWithMemoryLimitTest, stringInsertAndMemoryTracking) {
+  StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  auto initialMemory = hashSet.getCurrentMemoryUsage();
+
+  // Insert string and verify memory increase
+  hashSet.insert("test");
+  auto afterFirstInsert = hashSet.getCurrentMemoryUsage();
+  ASSERT_GT(afterFirstInsert, initialMemory);
+
+  // Insert longer string and verify proportional memory increase
+  hashSet.insert("this is a much longer test string");
+  auto afterSecondInsert = hashSet.getCurrentMemoryUsage();
+  ASSERT_GT(afterSecondInsert, afterFirstInsert);
+
+  // The difference should be proportional to string lengths
+  ASSERT_GT(afterSecondInsert - afterFirstInsert,
+            afterFirstInsert - initialMemory);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, stringMemoryLimit) {
+  // Set a very small memory limit
+  StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(100_B)};
+
+  // This should work
+  ASSERT_NO_THROW(hashSet.insert("small"));
+
+  // This should fail due to memory limit
+  ASSERT_THROW(
+      hashSet.insert(
+          "this is a very long string that should exceed our memory limit"),
+      ad_utility::detail::AllocationExceedsLimitException);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, stringEraseAndClear) {
+  StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+
+  // Insert several strings
+  hashSet.insert("first");
+  hashSet.insert("second");
+  hashSet.insert("third");
+  auto memoryWithStrings = hashSet.getCurrentMemoryUsage();
+
+  // Erase one string and verify memory decrease
+  hashSet.erase("second");
+  auto memoryAfterErase = hashSet.getCurrentMemoryUsage();
+  ASSERT_LT(memoryAfterErase, memoryWithStrings);
+
+  // Clear all and verify memory is minimal
+  hashSet.clear();
+  auto memoryAfterClear = hashSet.getCurrentMemoryUsage();
+  ASSERT_LT(memoryAfterClear, memoryAfterErase);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, stringDuplicates) {
+  StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+
+  // Insert string and record memory
+  hashSet.insert("duplicate");
+  auto memoryAfterFirst = hashSet.getCurrentMemoryUsage();
+
+  // Insert same string again and verify no memory change
+  hashSet.insert("duplicate");
+  auto memoryAfterSecond = hashSet.getCurrentMemoryUsage();
+  ASSERT_EQ(memoryAfterFirst, memoryAfterSecond);
+  ASSERT_EQ(hashSet.size(), 1);
+}
+
+TEST(CustomHashSetWithMemoryLimitTest, stringCapacityVsSize) {
+  StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+
+  // Insert a string that will likely have different size and capacity
+  std::string str = "test";
+  str.reserve(100);  // Force larger capacity than needed
+
+  auto beforeInsert = hashSet.getCurrentMemoryUsage();
+  hashSet.insert(str);
+  auto afterInsert = hashSet.getCurrentMemoryUsage();
+
+  // The memory difference should account for the capacity, not just the size
+  auto memoryDifference = afterInsert - beforeInsert;
+  ASSERT_GT(memoryDifference, ad_utility::MemorySize::bytes(str.size()));
+  ASSERT_GE(memoryDifference, ad_utility::MemorySize::bytes(str.capacity()));
+}

--- a/test/CustomHashSetWithMemoryLimitTest.cpp
+++ b/test/CustomHashSetWithMemoryLimitTest.cpp
@@ -9,6 +9,7 @@ using namespace ad_utility::memory_literals;
 
 using Set = ad_utility::NodeHashSetWithMemoryLimit<int>;
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, sizeAndInsert) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(100_B)};
   ASSERT_EQ(hashSet.size(), 0);
@@ -18,6 +19,7 @@ TEST(CustomHashSetWithMemoryLimitTest, sizeAndInsert) {
   ASSERT_EQ(hashSet.size(), 3);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, memoryLimit) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(10_B)};
   std::initializer_list<int> testNums = {
@@ -36,6 +38,7 @@ TEST(CustomHashSetWithMemoryLimitTest, memoryLimit) {
       ad_utility::detail::AllocationExceedsLimitException);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, iteratorOperations) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
   hashSet.insert(1);
@@ -59,6 +62,7 @@ TEST(CustomHashSetWithMemoryLimitTest, iteratorOperations) {
   ASSERT_EQ(values, std::vector<int>({1, 2, 3}));
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, eraseOperations) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
   hashSet.insert(1);
@@ -76,6 +80,7 @@ TEST(CustomHashSetWithMemoryLimitTest, eraseOperations) {
   ASSERT_EQ(hashSet.size(), originalSize);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, clearOperation) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
   auto initialMemory = hashSet.getCurrentMemoryUsage();
@@ -98,6 +103,7 @@ TEST(CustomHashSetWithMemoryLimitTest, clearOperation) {
   ASSERT_LE(hashSet.getCurrentMemoryUsage(), usedMemory);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, memoryTrackingAccuracy) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
   auto initialMemory = hashSet.getCurrentMemoryUsage();
@@ -117,6 +123,7 @@ TEST(CustomHashSetWithMemoryLimitTest, memoryTrackingAccuracy) {
   ASSERT_EQ(hashSet.getCurrentMemoryUsage(), initialMemory);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, edgeCases) {
   // Test with zero memory limit
   ASSERT_THROW(Set zeroHashSet{makeAllocationMemoryLeftThreadsafeObject(0_B)},
@@ -124,13 +131,14 @@ TEST(CustomHashSetWithMemoryLimitTest, edgeCases) {
 
   // Test multiple insert/erase cycles
   Set cycleHashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
+  auto memoryBeforeCycle = cycleHashSet.getCurrentMemoryUsage();
   for (int i = 0; i < 10; ++i) {
     cycleHashSet.insert(i);
     cycleHashSet.erase(i);
   }
+  auto memoryAfterCycle = cycleHashSet.getCurrentMemoryUsage();
   ASSERT_TRUE(cycleHashSet.empty());
-  ASSERT_EQ(cycleHashSet.getCurrentMemoryUsage(),
-            cycleHashSet.getCurrentMemoryUsage());
+  ASSERT_EQ(memoryBeforeCycle, memoryAfterCycle);
 }
 
 // Define a custom size getter for strings that includes the actual string
@@ -144,6 +152,7 @@ struct StringSizeGetter {
 using StringSet =
     ad_utility::NodeHashSetWithMemoryLimit<std::string, StringSizeGetter>;
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, stringInsertAndMemoryTracking) {
   StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
   auto initialMemory = hashSet.getCurrentMemoryUsage();
@@ -163,6 +172,7 @@ TEST(CustomHashSetWithMemoryLimitTest, stringInsertAndMemoryTracking) {
             afterFirstInsert - initialMemory);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, stringMemoryLimit) {
   // Set a very small memory limit
   StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(100_B)};
@@ -177,6 +187,7 @@ TEST(CustomHashSetWithMemoryLimitTest, stringMemoryLimit) {
       ad_utility::detail::AllocationExceedsLimitException);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, stringEraseAndClear) {
   StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
 
@@ -197,6 +208,7 @@ TEST(CustomHashSetWithMemoryLimitTest, stringEraseAndClear) {
   ASSERT_LT(memoryAfterClear, memoryAfterErase);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, stringDuplicates) {
   StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
 
@@ -211,6 +223,7 @@ TEST(CustomHashSetWithMemoryLimitTest, stringDuplicates) {
   ASSERT_EQ(hashSet.size(), 1);
 }
 
+// _____________________________________________________________________________
 TEST(CustomHashSetWithMemoryLimitTest, stringCapacityVsSize) {
   StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};
 

--- a/test/CustomHashSetWithMemoryLimitTest.cpp
+++ b/test/CustomHashSetWithMemoryLimitTest.cpp
@@ -7,7 +7,7 @@
 using ad_utility::makeAllocationMemoryLeftThreadsafeObject;
 using namespace ad_utility::memory_literals;
 
-using Set = ad_utility::CustomHashSetWithMemoryLimit<int>;
+using Set = ad_utility::NodeHashSetWithMemoryLimit<int>;
 
 TEST(CustomHashSetWithMemoryLimitTest, sizeAndInsert) {
   Set hashSet{makeAllocationMemoryLeftThreadsafeObject(100_B)};
@@ -142,7 +142,7 @@ struct StringSizeGetter {
 };
 
 using StringSet =
-    ad_utility::CustomHashSetWithMemoryLimit<std::string, StringSizeGetter>;
+    ad_utility::NodeHashSetWithMemoryLimit<std::string, StringSizeGetter>;
 
 TEST(CustomHashSetWithMemoryLimitTest, stringInsertAndMemoryTracking) {
   StringSet hashSet{makeAllocationMemoryLeftThreadsafeObject(1000_B)};

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -5,7 +5,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <exception>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "./util/TripleComponentTestHelpers.h"
@@ -16,6 +18,7 @@
 #include "engine/GroupBy.h"
 #include "engine/HasPredicateScan.h"
 #include "engine/Join.h"
+#include "engine/LocalVocab.h"
 #include "engine/Minus.h"
 #include "engine/MultiColumnJoin.h"
 #include "engine/OptionalJoin.h"
@@ -29,7 +32,9 @@
 #include "engine/sparqlExpressions/GroupConcatExpression.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "global/Id.h"
+#include "gmock/gmock.h"
 #include "util/IndexTestHelpers.h"
+#include "util/MemorySize/MemorySize.h"
 
 namespace {
 // Get test collection of words of a given size. The words are all distinct.
@@ -377,4 +382,27 @@ TEST(LocalVocab, getBlankNodeIndex) {
   BlankNodeIndex a = v.getBlankNodeIndex(&bnm);
   BlankNodeIndex b = v.getBlankNodeIndex(&bnm);
   EXPECT_NE(a, b);
+}
+
+// _____________________________________________________________________________
+TEST(LocalVocab, memoryLimit) {
+  ad_utility::MemorySize smallLimit = ad_utility::MemorySize::kilobytes(1);
+  LocalVocab localVocab(smallLimit);
+  TestWords testWords = getTestCollectionOfWords(1000);
+
+  try {
+    for (const auto& word : testWords) {
+      localVocab.getIndexAndAddIfNotContained(word);
+    }
+  } catch (const std::exception& e) {
+    std::string errorMessage = e.what();
+    EXPECT_THAT(errorMessage, ::testing::StartsWith(
+                                  "The element to be inserted is too large"));
+  }
+
+  auto extraWord =
+      ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
+          "ExtraWord");
+  EXPECT_THROW(localVocab.getIndexAndAddIfNotContained(extraWord),
+               std::runtime_error);
 }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -33,6 +33,7 @@
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "global/Id.h"
 #include "gmock/gmock.h"
+#include "util/AllocatorWithLimit.h"
 #include "util/IndexTestHelpers.h"
 #include "util/MemorySize/MemorySize.h"
 
@@ -386,7 +387,9 @@ TEST(LocalVocab, getBlankNodeIndex) {
 
 // _____________________________________________________________________________
 TEST(LocalVocab, memoryLimit) {
-  ad_utility::MemorySize smallLimit = ad_utility::MemorySize::kilobytes(1);
+  ad_utility::detail::AllocationMemoryLeftThreadsafe smallLimit =
+      ad_utility::makeAllocationMemoryLeftThreadsafeObject(
+          ad_utility::MemorySize::kilobytes(1));
   LocalVocab localVocab(smallLimit);
   TestWords testWords = getTestCollectionOfWords(1000);
 

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -399,13 +399,12 @@ TEST(LocalVocab, memoryLimit) {
     }
   } catch (const std::exception& e) {
     std::string errorMessage = e.what();
-    EXPECT_THAT(errorMessage, ::testing::StartsWith(
-                                  "The element to be inserted is too large"));
+    EXPECT_THAT(errorMessage, ::testing::StartsWith("Tried to allocate"));
   }
 
   auto extraWord =
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(
           "ExtraWord");
   EXPECT_THROW(localVocab.getIndexAndAddIfNotContained(extraWord),
-               std::runtime_error);
+               ad_utility::detail::AllocationExceedsLimitException);
 }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -34,6 +34,7 @@
 #include "global/Id.h"
 #include "gmock/gmock.h"
 #include "util/AllocatorWithLimit.h"
+#include "util/GTestHelpers.h"
 #include "util/IndexTestHelpers.h"
 #include "util/MemorySize/MemorySize.h"
 
@@ -393,14 +394,13 @@ TEST(LocalVocab, memoryLimit) {
   LocalVocab localVocab(smallLimit);
   TestWords testWords = getTestCollectionOfWords(1000);
 
-  try {
-    for (const auto& word : testWords) {
-      localVocab.getIndexAndAddIfNotContained(word);
-    }
-  } catch (const std::exception& e) {
-    std::string errorMessage = e.what();
-    EXPECT_THAT(errorMessage, ::testing::StartsWith("Tried to allocate"));
-  }
+  EXPECT_THROW(
+      {
+        for (const auto& word : testWords) {
+          localVocab.getIndexAndAddIfNotContained(word);
+        }
+      },
+      ad_utility::detail::AllocationExceedsLimitException);
 
   auto extraWord =
       ad_utility::triple_component::LiteralOrIri::literalWithoutQuotes(


### PR DESCRIPTION
- Added `CustomHashSetWithMemoryLimit`:  a wrapper class around absl::node_hash_set which tracks the memory used by the elements of the hashset.
- Modified `LocalVocab` to use the wrapper hashset implementation.