### PR TITLE
Store the index of each block in the block's metadata

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -874,13 +874,17 @@ void CompressedRelationWriter::compressAndWriteBlock(
     AD_CORRECTNESS_CHECK(lastCol0Id == last[0]);
 
     auto [hasDuplicates, graphInfo] = getGraphInfo(block);
+    // The block indices will be set later, write a recognizable dummy value for
+    // easier debugging.
+    static constexpr size_t blockIndexDummy = 4387;
     blockBuffer_.wlock()->push_back(
         CompressedBlockMetadata{std::move(offsets),
                                 numRows,
                                 {first[0], first[1], first[2]},
                                 {last[0], last[1], last[2]},
                                 std::move(graphInfo),
-                                hasDuplicates});
+                                hasDuplicates,
+                                blockIndexDummy});
     if (invokeCallback && smallBlocksCallback_) {
       std::invoke(smallBlocksCallback_, std::move(block));
     }

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -874,9 +874,10 @@ void CompressedRelationWriter::compressAndWriteBlock(
     AD_CORRECTNESS_CHECK(lastCol0Id == last[0]);
 
     auto [hasDuplicates, graphInfo] = getGraphInfo(block);
-    // The block indices will be set later, write a recognizable dummy value for
-    // easier debugging.
-    static constexpr size_t blockIndexDummy = 4387;
+    // The blocks are written in parallel and possibly out of order. We thus
+    // can't set the proper block indices here. The proper block indices are set
+    // in the `getFinishedBlocks` function.
+    static constexpr size_t blockIndexNotYetSet = 111333555;
     blockBuffer_.wlock()->push_back(
         CompressedBlockMetadata{std::move(offsets),
                                 numRows,
@@ -884,7 +885,7 @@ void CompressedRelationWriter::compressAndWriteBlock(
                                 {last[0], last[1], last[2]},
                                 std::move(graphInfo),
                                 hasDuplicates,
-                                blockIndexDummy});
+                                blockIndexNotYetSet});
     if (invokeCallback && smallBlocksCallback_) {
       std::invoke(smallBlocksCallback_, std::move(block));
     }

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -103,6 +103,11 @@ struct CompressedBlockMetadata {
   // blocks.
   bool containsDuplicatesWithDifferentGraphs_;
 
+  // The index of this block in the permutation. This is required to find
+  // the corresponding block from the `LocatedTriples` when only a subset of
+  // blocks is being used.
+  size_t blockIndex_;
+
   // Two of these are equal if all members are equal.
   bool operator==(const CompressedBlockMetadata&) const = default;
 };
@@ -121,6 +126,7 @@ AD_SERIALIZE_FUNCTION(CompressedBlockMetadata) {
   serializer | arg.lastTriple_;
   serializer | arg.graphInfo_;
   serializer | arg.containsDuplicatesWithDifferentGraphs_;
+  serializer | arg.blockIndex_;
 }
 
 // The metadata of a whole compressed "relation", where relation refers to a
@@ -257,6 +263,10 @@ class CompressedRelationWriter {
       return std::tie(bl.firstTriple_.col0Id_, bl.firstTriple_.col1Id_,
                       bl.firstTriple_.col2Id_);
     });
+    // Write the correct block indices
+    for (size_t i : ad_utility::integerRange(blocks.size())) {
+      blocks.at(i).blockIndex_ = i;
+    }
     return blocks;
   }
 

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -1,8 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-frei#pragma onceburg.de>
 
-#pragma once
+
 
 #include <cstdint>
 
@@ -36,5 +36,5 @@ struct IndexFormatVersion {
 // The actual index version. Change it once the binary format of the index
 // changes.
 inline const IndexFormatVersion& indexFormatVersion{
-    1504, DateYearOrDuration{Date{2024, 10, 18}}};
+    1571, DateYearOrDuration{Date{2024, 10, 21}}};
 }  // namespace qlever

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -2,8 +2,6 @@
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-frei#pragma onceburg.de>
 
-
-
 #include <cstdint>
 
 #include "util/DateYearDuration.h"

--- a/src/index/IndexFormatVersion.h
+++ b/src/index/IndexFormatVersion.h
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
-//  Author: Johannes Kalmbach <kalmbach@cs.uni-frei#pragma onceburg.de>
+//  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
+#pragma once
 
 #include <cstdint>
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -154,6 +154,11 @@ compressedRelationTestWriteCompressedRelations(
   r >> blocks;
 
   EXPECT_EQ(metaData.size(), inputs.size());
+
+  for (size_t i : ad_utility::integerRange(blocks.size())) {
+    EXPECT_EQ(blocks.at(i).blockIndex_, i);
+  }
+
   return {std::move(blocks), std::move(metaData)};
 }
 
@@ -481,11 +486,11 @@ TEST(CompressedRelationMetadata, GettersAndSetters) {
 
 TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
   CompressedBlockMetadata block1{
-      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false};
+      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false, 0};
   CompressedBlockMetadata block2{
-      {}, 0, {V(42), V(3), V(0)}, {V(42), V(4), V(12)}, {}, false};
+      {}, 0, {V(42), V(3), V(0)}, {V(42), V(4), V(12)}, {}, false, 1};
   CompressedBlockMetadata block3{
-      {}, 0, {V(42), V(4), V(13)}, {V(42), V(6), V(9)}, {}, false};
+      {}, 0, {V(42), V(4), V(13)}, {V(42), V(6), V(9)}, {}, false, 2};
 
   // We are only interested in blocks with a col0 of `42`.
   CompressedRelationMetadata relation;
@@ -529,15 +534,15 @@ TEST(CompressedRelationReader, getBlocksForJoinWithColumn) {
 }
 TEST(CompressedRelationReader, getBlocksForJoin) {
   CompressedBlockMetadata block1{
-      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false};
+      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false, 0};
   CompressedBlockMetadata block2{
-      {}, 0, {V(42), V(3), V(0)}, {V(42), V(4), V(12)}, {}, false};
+      {}, 0, {V(42), V(3), V(0)}, {V(42), V(4), V(12)}, {}, false, 1};
   CompressedBlockMetadata block3{
-      {}, 0, {V(42), V(5), V(13)}, {V(42), V(8), V(9)}, {}, false};
+      {}, 0, {V(42), V(5), V(13)}, {V(42), V(8), V(9)}, {}, false, 2};
   CompressedBlockMetadata block4{
-      {}, 0, {V(42), V(8), V(16)}, {V(42), V(20), V(9)}, {}, false};
+      {}, 0, {V(42), V(8), V(16)}, {V(42), V(20), V(9)}, {}, false, 3};
   CompressedBlockMetadata block5{
-      {}, 0, {V(42), V(20), V(16)}, {V(42), V(20), V(63)}, {}, false};
+      {}, 0, {V(42), V(20), V(16)}, {V(42), V(20), V(63)}, {}, false, 4};
 
   // We are only interested in blocks with a col0 of `42`.
   CompressedRelationMetadata relation;
@@ -551,17 +556,17 @@ TEST(CompressedRelationReader, getBlocksForJoin) {
       firstAndLastTriple};
 
   CompressedBlockMetadata blockB1{
-      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false};
+      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false, 0};
   CompressedBlockMetadata blockB2{
-      {}, 0, {V(47), V(3), V(0)}, {V(47), V(6), V(12)}, {}, false};
+      {}, 0, {V(47), V(3), V(0)}, {V(47), V(6), V(12)}, {}, false, 1};
   CompressedBlockMetadata blockB3{
-      {}, 0, {V(47), V(7), V(13)}, {V(47), V(9), V(9)}, {}, false};
+      {}, 0, {V(47), V(7), V(13)}, {V(47), V(9), V(9)}, {}, false, 2};
   CompressedBlockMetadata blockB4{
-      {}, 0, {V(47), V(38), V(7)}, {V(47), V(38), V(8)}, {}, false};
+      {}, 0, {V(47), V(38), V(7)}, {V(47), V(38), V(8)}, {}, false, 3};
   CompressedBlockMetadata blockB5{
-      {}, 0, {V(47), V(38), V(9)}, {V(47), V(38), V(12)}, {}, false};
+      {}, 0, {V(47), V(38), V(9)}, {V(47), V(38), V(12)}, {}, false, 4};
   CompressedBlockMetadata blockB6{
-      {}, 0, {V(47), V(38), V(13)}, {V(47), V(38), V(15)}, {}, false};
+      {}, 0, {V(47), V(38), V(13)}, {V(47), V(38), V(15)}, {}, false, 5};
 
   // We are only interested in blocks with a col0 of `42`.
   CompressedRelationMetadata relationB;
@@ -640,7 +645,7 @@ TEST(CompressedRelationReader, PermutedTripleToString) {
 TEST(CompressedRelationReader, filterDuplicatesAndGraphs) {
   auto table = makeIdTableFromVector({{3}, {4}, {5}});
   CompressedBlockMetadata metadata{
-      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false};
+      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false, 0};
   using Filter = CompressedRelationReader::FilterDuplicatesAndGraphs;
   ScanSpecification::Graphs graphs = std::nullopt;
   Filter f{graphs, 43, false};
@@ -677,7 +682,7 @@ TEST(CompressedRelationReader, filterDuplicatesAndGraphs) {
 
 TEST(CompressedRelationReader, makeCanBeSkippedForBlock) {
   CompressedBlockMetadata metadata{
-      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false};
+      {}, 0, {V(16), V(0), V(0)}, {V(38), V(4), V(12)}, {}, false, 0};
 
   using Graphs = ScanSpecification::Graphs;
   Graphs graphs = std::nullopt;

--- a/test/IndexMetaDataTest.cpp
+++ b/test/IndexMetaDataTest.cpp
@@ -16,9 +16,13 @@ auto V = ad_utility::testing::VocabId;
 }
 
 TEST(RelationMetaDataTest, writeReadTest) {
-  CompressedBlockMetadata rmdB{{{12, 34}, {46, 11}}, 5,
-                               {V(0), V(2), V(13)},  {V(3), V(24), V(62)},
-                               std::vector{V(85)},   true};
+  CompressedBlockMetadata rmdB{{{12, 34}, {46, 11}},
+                               5,
+                               {V(0), V(2), V(13)},
+                               {V(3), V(24), V(62)},
+                               std::vector{V(85)},
+                               true,
+                               13};
   CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
 
   ad_utility::serialization::FileWriteSerializer f("_testtmp.rmd");
@@ -41,18 +45,21 @@ TEST(IndexMetaDataTest, writeReadTest2Mmap) {
   std::string imdFilename = "_testtmp.imd";
   std::string mmapFilename = imdFilename + ".mmap";
   vector<CompressedBlockMetadata> bs;
+  // A value for the Graph Id.
   bs.push_back(CompressedBlockMetadata{{{12, 34}, {42, 17}},
                                        5,
                                        {V(0), V(2), V(13)},
                                        {V(2), V(24), V(62)},
                                        std::vector{V(512)},
-                                       true});
+                                       true,
+                                       17});
   bs.push_back(CompressedBlockMetadata{{{12, 34}, {16, 12}},
                                        5,
                                        {V(0), V(2), V(13)},
                                        {V(3), V(24), V(62)},
                                        {},
-                                       false});
+                                       false,
+                                       18});
   CompressedRelationMetadata rmdF{V(1), 3, 2.0, 42.0, 16};
   CompressedRelationMetadata rmdF2{V(2), 5, 3.0, 43.0, 10};
   // The index MetaData does not have an explicit clear, so we

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -24,7 +24,8 @@ auto PT = [](const auto& c1, const auto& c2, const auto& c3) {
 };
 auto CBM = [](const auto firstTriple, const auto lastTriple) {
   size_t dummyBlockIndex = 0;
-  return CompressedBlockMetadata{{}, 0, firstTriple, lastTriple, {}, false, 0};
+  return CompressedBlockMetadata{{}, 0,     firstTriple,    lastTriple,
+                                 {}, false, dummyBlockIndex};
 };
 
 auto numBlocks =

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -23,7 +23,8 @@ auto PT = [](const auto& c1, const auto& c2, const auto& c3) {
   return CompressedBlockMetadata::PermutedTriple{V(c1), V(c2), V(c3)};
 };
 auto CBM = [](const auto firstTriple, const auto lastTriple) {
-  return CompressedBlockMetadata{{}, 0, firstTriple, lastTriple, {}, false};
+  size_t dummyBlockIndex = 0;
+  return CompressedBlockMetadata{{}, 0, firstTriple, lastTriple, {}, false, 0};
 };
 
 auto numBlocks =


### PR DESCRIPTION
This is a preparation for SPARQL UPDATE: When working with a subset of all blocks (e.g. because some prefiltering was applied), then we still have to know the absolute index of that block to find the corresponding `LocatedTriples`. The easiest way to find that index is to explicitly store it in the `CompressedBlockMetadata`.