### PR TITLE
Correct `STRLEN` function for UTF-8 multibyte characters

### DIFF
--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -125,9 +125,11 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 
 // STRLEN
 [[maybe_unused]] auto strlen = [](std::string_view s) {
-  // Count UTF-8 characters by skipping continuation bytes (those starting with "10").
-  auto utf8Len = std::count_if(s.begin(), s.end(),
-    [](char c) { return (static_cast<unsigned char>(c) & 0xC0) != 0x80; } );
+  // Count UTF-8 characters by skipping continuation bytes (those starting with
+  // "10").
+  auto utf8Len = std::count_if(s.begin(), s.end(), [](char c) {
+    return (static_cast<unsigned char>(c) & 0xC0) != 0x80;
+  });
   return Id::makeFromInt(static_cast<int64_t>(utf8Len));
 };
 using StrlenExpression =

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -125,7 +125,7 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 
 // STRLEN
 [[maybe_unused]] auto strlen = [](std::string_view s) {
-  // Counts UTF-8 characters by skipping continuation bytes (those starting with "10").
+  // Count UTF-8 characters by skipping continuation bytes (those starting with "10").
   auto utf8Len = std::count_if(s.begin(), s.end(),
     [](char c) { return (static_cast<unsigned char>(c) & 0xC0) != 0x80; } );
   return Id::makeFromInt(static_cast<int64_t>(utf8Len));

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -125,7 +125,7 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 
 // STRLEN
 [[maybe_unused]] auto strlen = [](std::string_view s) {
-  // Counts UTF-8 characters by skipping continuation bytes (those starting with "10").test
+  // Counts UTF-8 characters by skipping continuation bytes (those starting with "10").
   auto utf8Len = std::count_if(s.begin(), s.end(),
     [](char c) { return (static_cast<unsigned char>(c) & 0xC0) != 0x80; } );
   return Id::makeFromInt(static_cast<int64_t>(utf8Len));

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -125,9 +125,11 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 
 // STRLEN
 [[maybe_unused]] auto strlen = [](std::string_view s) {
-  return Id::makeFromInt(static_cast<int64_t>(s.size()));
+  // Counts UTF-8 characters by skipping continuation bytes (those starting with "10").
+  auto utf8Len = std::count_if(s.begin(), s.end(),
+    [](char c) { return (static_cast<unsigned char>(c) & 0xC0) != 0x80; } );
+  return Id::makeFromInt(static_cast<int64_t>(utf8Len));
 };
-
 using StrlenExpression =
     StringExpressionImpl<1, LiftStringFunction<decltype(strlen)>>;
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -125,7 +125,7 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 
 // STRLEN
 [[maybe_unused]] auto strlen = [](std::string_view s) {
-  // Counts UTF-8 characters by skipping continuation bytes (those starting with "10").
+  // Counts UTF-8 characters by skipping continuation bytes (those starting with "10").test
   auto utf8Len = std::count_if(s.begin(), s.end(),
     [](char c) { return (static_cast<unsigned char>(c) & 0xC0) != 0x80; } );
   return Id::makeFromInt(static_cast<int64_t>(utf8Len));

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -130,7 +130,7 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
   auto utf8Len = std::ranges::count_if(s, [](char c) {
     return (static_cast<unsigned char>(c) & 0xC0) != 0x80;
   });
-  return Id::makeFromInt(static_cast<int64_t>(utf8Len));
+  return Id::makeFromInt(utf8Len);
 };
 using StrlenExpression =
     StringExpressionImpl<1, LiftStringFunction<decltype(strlen)>>;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -127,7 +127,7 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 [[maybe_unused]] auto strlen = [](std::string_view s) {
   // Count UTF-8 characters by skipping continuation bytes (those starting with
   // "10").
-  auto utf8Len = std::count_if(s.begin(), s.end(), [](char c) {
+  auto utf8Len = std::ranges::count_if(s, [](char c) {
     return (static_cast<unsigned char>(c) & 0xC0) != 0x80;
   });
   return Id::makeFromInt(static_cast<int64_t>(utf8Len));

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -127,9 +127,8 @@ using IriOrUriExpression = NARY<1, FV<std::identity, IriOrUriValueGetter>>;
 [[maybe_unused]] auto strlen = [](std::string_view s) {
   // Count UTF-8 characters by skipping continuation bytes (those starting with
   // "10").
-  auto utf8Len = std::ranges::count_if(s, [](char c) {
-    return (static_cast<unsigned char>(c) & 0xC0) != 0x80;
-  });
+  auto utf8Len = std::ranges::count_if(
+      s, [](char c) { return (static_cast<unsigned char>(c) & 0xC0) != 0x80; });
   return Id::makeFromInt(utf8Len);
 };
 using StrlenExpression =

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -587,8 +587,8 @@ TEST(SparqlExpression, stringOperators) {
 
   // Test the different (optimized) behavior depending on whether the STR()
   // function was applied to the argument.
-  checkStrlen(IdOrLiteralOrIriVec{lit("one"), I(1), D(3.6), lit("")},
-              Ids{I(3), U, U, I(0)});
+  checkStrlen(IdOrLiteralOrIriVec{lit("one"), lit("tschüss"), I(1), D(3.6), lit("")},
+              Ids{I(3),I(6), U, U, I(0)});
   checkStrlenWithStrChild(
       IdOrLiteralOrIriVec{lit("one"), I(1), D(3.6), lit("")},
       Ids{I(3), I(1), I(3), I(0)});

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -586,7 +586,7 @@ TEST(SparqlExpression, stringOperators) {
       Ids{I(3), I(3), I(5), I(0)});
 
   // Test the different (optimized) behavior depending on whether the STR()
-  // function was applied to the argument. test
+  // function was applied to the argument.
   checkStrlen(IdOrLiteralOrIriVec{lit("one"), lit("tschüss"), I(1), D(3.6), lit("")},
               Ids{I(3),I(6), U, U, I(0)});
   checkStrlenWithStrChild(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -586,7 +586,7 @@ TEST(SparqlExpression, stringOperators) {
       Ids{I(3), I(3), I(5), I(0)});
 
   // Test the different (optimized) behavior depending on whether the STR()
-  // function was applied to the argument.
+  // function was applied to the argument. test
   checkStrlen(IdOrLiteralOrIriVec{lit("one"), lit("tschüss"), I(1), D(3.6), lit("")},
               Ids{I(3),I(6), U, U, I(0)});
   checkStrlenWithStrChild(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -587,8 +587,9 @@ TEST(SparqlExpression, stringOperators) {
 
   // Test the different (optimized) behavior depending on whether the STR()
   // function was applied to the argument.
-  checkStrlen(IdOrLiteralOrIriVec{lit("one"), lit("tschüss"), I(1), D(3.6), lit("")},
-              Ids{I(3),I(6), U, U, I(0)});
+  checkStrlen(
+      IdOrLiteralOrIriVec{lit("one"), lit("tschüss"), I(1), D(3.6), lit("")},
+      Ids{I(3), I(7), U, U, I(0)});
   checkStrlenWithStrChild(
       IdOrLiteralOrIriVec{lit("one"), I(1), D(3.6), lit("")},
       Ids{I(3), I(1), I(3), I(0)});


### PR DESCRIPTION
The `STRLEN` function now correctly counts the number of UTF codepoints in the Input (previously: The number of bytes in the UTF-8 serialization). So for example `STRLEN("Bäh") now correctly returns `3`.