### PR TITLE
Make parallel parsing the default again for a single input stream

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -289,7 +289,7 @@ std::pair<size_t, size_t> IndexImpl::createInternalPSOandPOS(
 // _____________________________________________________________________________
 void IndexImpl::updateInputFileSpecificationsAndLog(
     std::vector<Index::InputFileSpecification>& spec,
-    bool parallelParsingSpecifiedViaJson) {
+    std::optional<bool> parallelParsingSpecifiedViaJson) {
   if (spec.size() == 1) {
     LOG(INFO) << "Processing triples from " << spec.at(0).filename_ << " ..."
               << std::endl;
@@ -297,7 +297,7 @@ void IndexImpl::updateInputFileSpecificationsAndLog(
     LOG(INFO) << "Processing triples from " << spec.size()
               << " input streams ..." << std::endl;
   }
-  if (parallelParsingSpecifiedViaJson) {
+  if (parallelParsingSpecifiedViaJson.value_or(false) == true) {
     if (spec.size() == 1) {
       LOG(WARN) << "Parallel parsing set to `true` in the `.settings.json` "
                    "file; this is deprecated, please use the command-line "
@@ -310,6 +310,15 @@ void IndexImpl::updateInputFileSpecificationsAndLog(
           "specified via the `.settings.json` file, but has to be specified "
           " via the command-line option --parse-parallel or -p"};
     }
+  }
+
+  if (spec.size() == 1 && !parallelParsingSpecifiedViaJson.has_value()) {
+    LOG(WARN) << "Implicitly using the parallel parser for a single input file "
+                 "to be consistent with previous behavior. Please set the "
+                 "settings for parallel parsing explicitly via the command "
+                 "line to suppress this warning"
+              << std::endl;
+    spec.at(0).parseInParallel_ = true;
   }
 }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -314,9 +314,9 @@ void IndexImpl::updateInputFileSpecificationsAndLog(
 
   if (spec.size() == 1 && !parallelParsingSpecifiedViaJson.has_value()) {
     LOG(WARN) << "Implicitly using the parallel parser for a single input file "
-                 "to be consistent with previous behavior. Please set the "
-                 "settings for parallel parsing explicitly via the command "
-                 "line to suppress this warning"
+                 "for reasons of backward compatibility; this is deprecated, "
+                 "please use the command-line option --parse-parallel or -p "
+                 "instead"
               << std::endl;
     spec.at(0).parseInParallel_ = true;
   }

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -119,7 +119,8 @@ class IndexImpl {
   string onDiskBase_;
   string settingsFileName_;
   bool onlyAsciiTurtlePrefixes_ = false;
-  bool useParallelParser_ = false;
+  // Note: `std::nullopt` means `not specified by the user`.
+  std::optional<bool> useParallelParser_ = std::nullopt;
   TurtleParserIntegerOverflowBehavior turtleParserIntegerOverflowBehavior_ =
       TurtleParserIntegerOverflowBehavior::Error;
   bool turtleParserSkipIllegalLiterals_ = false;
@@ -771,5 +772,5 @@ class IndexImpl {
   // and write a summary to the log.
   static void updateInputFileSpecificationsAndLog(
       std::vector<Index::InputFileSpecification>& spec,
-      bool parallelParsingSpecifiedViaJson);
+      std::optional<bool> parallelParsingSpecifiedViaJson);
 };

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -487,13 +487,13 @@ TEST(IndexTest, trivialGettersAndSetters) {
   EXPECT_EQ(std::as_const(index).memoryLimitIndexBuilding(), 7_kB);
 }
 
-TEST(IndexTest, loggingAndSettingOfParallelParsing) {
+TEST(IndexTest, updateInputFileSpecificationsAndLog) {
   using enum qlever::Filetype;
   std::vector<qlever::InputFileSpecification> files{
       {"singleFile.ttl", Turtle, std::nullopt, false}};
-  testing::internal::CaptureStdout();
   using namespace ::testing;
   {
+    testing::internal::CaptureStdout();
     IndexImpl::updateInputFileSpecificationsAndLog(files, false);
     EXPECT_THAT(
         testing::internal::GetCapturedStdout(),
@@ -507,6 +507,14 @@ TEST(IndexTest, loggingAndSettingOfParallelParsing) {
     EXPECT_THAT(testing::internal::GetCapturedStdout(),
                 AllOf(HasSubstr("from singleFile.ttl"), HasSubstr("deprecated"),
                       HasSubstr("--parse-parallel")));
+    EXPECT_TRUE(files.at(0).parseInParallel_);
+  }
+  {
+    testing::internal::CaptureStdout();
+    IndexImpl::updateInputFileSpecificationsAndLog(files, std::nullopt);
+    EXPECT_THAT(testing::internal::GetCapturedStdout(),
+                AllOf(HasSubstr("from singleFile.ttl"), HasSubstr("parallel"),
+                      HasSubstr("consistent with previous behavior")));
     EXPECT_TRUE(files.at(0).parseInParallel_);
   }
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -505,16 +505,16 @@ TEST(IndexTest, updateInputFileSpecificationsAndLog) {
     testing::internal::CaptureStdout();
     IndexImpl::updateInputFileSpecificationsAndLog(files, true);
     EXPECT_THAT(testing::internal::GetCapturedStdout(),
-                AllOf(HasSubstr("from singleFile.ttl"), HasSubstr("deprecated"),
-                      HasSubstr("--parse-parallel")));
+                AllOf(HasSubstr("from singleFile.ttl"),
+                      HasSubstr("settings.json"), HasSubstr("deprecated")));
     EXPECT_TRUE(files.at(0).parseInParallel_);
   }
   {
     testing::internal::CaptureStdout();
     IndexImpl::updateInputFileSpecificationsAndLog(files, std::nullopt);
     EXPECT_THAT(testing::internal::GetCapturedStdout(),
-                AllOf(HasSubstr("from singleFile.ttl"), HasSubstr("parallel"),
-                      HasSubstr("consistent with previous behavior")));
+                AllOf(HasSubstr("from singleFile.ttl"),
+                      HasSubstr("single input"), HasSubstr("deprecated")));
     EXPECT_TRUE(files.at(0).parseInParallel_);
   }
 


### PR DESCRIPTION
With the introduction of mutiple input streams (through #1537), the default regarding "parallel-parsing" became "false". That was unfortunate because most existing configurations (in particular, all the Qleverfiles from https://github.com/ad-freiburg/qlever-control) do not set the "parallel-parsing" option explicitly. Without parallel parsing, indexing is much slower. This felt like a regression for many users, for example, see #1563.

This is now fixed as follows: When there is a single input stream, and "parallel-parsing" is neither specified in the `settings.json` file (which is deprecated) nor on the command line for `IndexBuilderMain` (new since #1537), then the default is "true". A warning is shown that this is deprecated. The QLever CLI and Qleverfiles from https://github.com/ad-freiburg/qlever-control will be adapted to avoid this deprecated behavior.