### PR TITLE
Fix bug in WKT point literal regex

### DIFF
--- a/src/util/GeoSparqlHelpers.cpp
+++ b/src/util/GeoSparqlHelpers.cpp
@@ -26,7 +26,7 @@ static constexpr auto wktPointRegex = ctll::fixed_string(
     "^\\s*[Pp][Oo][Ii][Nn][Tt]\\s*\\(\\s*"
     "(-?[0-9]+|-?[0-9]+\\.[0-9]+)"
     "\\s+"
-    "(-?[0-9+]|-?[0-9]+\\.[0-9]+)"
+    "(-?[0-9]+|-?[0-9]+\\.[0-9]+)"
     "\\s*\\)\\s*$");
 
 // Parse a single WKT point and returns a pair of longitude and latitude. If

--- a/test/GeoSparqlHelpersTest.cpp
+++ b/test/GeoSparqlHelpersTest.cpp
@@ -42,7 +42,12 @@ TEST(GeoSparqlHelpers, ParseWktPoint) {
   testParseWktPointCorrect("pOiNt(7 -0.0)", 7.0, 0.0);
   testParseWktPointCorrect(" pOiNt\t(  7 \r -0.0 \n ) ", 7.0, 0.0);
   testParseWktPointCorrect("POINT(2.2945 48.8585)", 2.2945, 48.8585);
+  testParseWktPointCorrect("POINT(2 48.8585)", 2.0, 48.8585);
+  testParseWktPointCorrect("POINT(20 48.8585)", 20.0, 48.8585);
   testParseWktPointCorrect("POINT(7.8529 47.9957)", 7.8529, 47.9957);
+  testParseWktPointCorrect("POINT(7.8529 47)", 7.8529, 47.0);
+  testParseWktPointCorrect("POINT(17 47)", 17.0, 47.0);
+  testParseWktPointCorrect("POINT(7 47)", 7.0, 47.0);
 
   // Invalid WKT points because of issues unrelated to the number format (one of
   // the quotes missing, one of the parentheses missing, it must be exactly two


### PR DESCRIPTION
This fixes a bug in the regular expression that is used for extracting points from WKT literals. The bug caused WKT literals with more than one digit but without a decimal point in the latitude coordinate to be falsely rejected as GeoPoints. Fixes #1579