### PR TITLE
Lazy `TransitivePath` operation

### DIFF
--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -92,10 +92,9 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
     bool yieldOnce, size_t skipCol) const {
   ad_utility::Timer timer{ad_utility::Timer::Stopped};
   size_t outputRow = 0;
-  size_t inputRow = 0;
   IdTableStatic<OUTPUT_WIDTH> table{getResultWidth(), allocator()};
   std::vector<LocalVocab> storedLocalVocabs;
-  for (auto& [node, linkedNodes, localVocab, idTable] : hull) {
+  for (auto& [node, linkedNodes, localVocab, idTable, inputRow] : hull) {
     timer.cont();
     if (!yieldOnce) {
       table.reserve(linkedNodes.size());
@@ -115,13 +114,6 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
       }
 
       outputRow++;
-    }
-    inputRow++;
-    // Reset row to zero so the next `IdTable` is accessed correctly. The
-    // implicit assumption here is that every row in all `IdTable`s corresponds
-    // to exactly one start node.
-    if (idTable != nullptr && inputRow == idTable->size()) {
-      inputRow = 0;
     }
 
     if (!table.empty()) {

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -117,6 +117,12 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
       outputRow++;
     }
     inputRow++;
+    // Reset row to zero so the next `IdTable` is accessed correctly. The
+    // implicit assumption here is that every row in all `IdTable`s corresponds
+    // to exactly one start node.
+    if (idTable != nullptr && inputRow == idTable->size()) {
+      inputRow = 0;
+    }
 
     if (!table.empty()) {
       if (yieldOnce) {
@@ -127,7 +133,6 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
         co_yield {std::move(table).toDynamic(), std::move(localVocab)};
         table = IdTableStatic<OUTPUT_WIDTH>{getResultWidth(), allocator()};
         outputRow = 0;
-        inputRow = 0;
       }
     }
     timer.stop();
@@ -411,7 +416,7 @@ void TransitivePathBase::copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
       continue;
     }
 
-    outputTable(outputRow, outCol) = inputTable(inputRow, inCol);
+    outputTable.at(outputRow, outCol) = inputTable.at(inputRow, inCol);
     inCol++;
     outCol++;
   }

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -102,7 +102,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
     }
     std::optional<IdTableView<INPUT_WIDTH>> inputView = std::nullopt;
     if (idTable != nullptr) {
-      inputView = idTable->asStaticView<INPUT_WIDTH>();
+      inputView = idTable->template asStaticView<INPUT_WIDTH>();
     }
     for (Id linkedNode : linkedNodes) {
       table.emplace_back();

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -52,9 +52,6 @@ TransitivePathBase::~TransitivePathBase() = default;
 std::pair<TransitivePathSide&, TransitivePathSide&>
 TransitivePathBase::decideDirection() {
   if (lhs_.isBoundVariable()) {
-    // TODO<RobinTF> In case both sides are bound variables, we could choose try
-    // to get a side that can do lazy evaluation to the left. This means we
-    // should somehow indicates that the sides are swappable
     LOG(DEBUG) << "Computing TransitivePath left to right" << std::endl;
     return {lhs_, rhs_};
   } else if (rhs_.isBoundVariable() || !rhs_.isVariable()) {

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -69,6 +69,22 @@ using Map = std::unordered_map<
     Id, Set, HashId, std::equal_to<Id>,
     ad_utility::AllocatorWithLimit<std::pair<const Id, Set>>>;
 
+struct NodeWithTargets {
+  Id node_;
+  Set targets_;
+  LocalVocab localVocab_;
+  const IdTable* idTable_;
+
+  NodeWithTargets(Id node, Set targets, LocalVocab localVocab,
+                  const IdTable* idTable)
+      : node_{node},
+        targets_{std::move(targets)},
+        localVocab_{std::move(localVocab)},
+        idTable_{idTable} {}
+};
+
+using NodeGenerator = cppcoro::generator<NodeWithTargets>;
+
 /**
  * @class TransitivePathBase
  * @brief A common base class for different implementations of the Transitive
@@ -147,10 +163,7 @@ class TransitivePathBase : public Operation {
    * startSideTable to fill in the rest of the columns.
    * This function is called if the start side is bound and a variable.
    *
-   * @param table The result table which will be filled.
    * @param hull The transitive hull.
-   * @param nodes The start nodes of the transitive hull. These need to be in
-   * the same order and amount as the starting side nodes in the startTable.
    * @param startSideCol The column of the result table for the startSide of the
    * hull
    * @param targetSideCol The column of the result table for the targetSide of
@@ -160,28 +173,27 @@ class TransitivePathBase : public Operation {
    * @param skipCol This column contains the Ids of the start side in the
    * startSideTable and will be skipped.
    */
-  void fillTableWithHull(IdTable& table, const Map& hull,
-                         std::vector<Id>& nodes, size_t startSideCol,
-                         size_t targetSideCol, const IdTable& startSideTable,
-                         size_t skipCol) const;
+  Result::Generator fillTableWithHull(NodeGenerator hull, size_t startSideCol,
+                                      size_t targetSideCol, size_t skipCol,
+                                      bool yieldOnce) const;
 
   /**
    * @brief Fill the given table with the transitive hull.
    * This function is called if the sides are unbound or ids.
    *
-   * @param table The result table which will be filled.
    * @param hull The transitive hull.
    * @param startSideCol The column of the result table for the startSide of the
    * hull
    * @param targetSideCol The column of the result table for the targetSide of
    * the hull
    */
-  void fillTableWithHull(IdTable& table, const Map& hull, size_t startSideCol,
-                         size_t targetSideCol) const;
+  Result::Generator fillTableWithHull(NodeGenerator hull, size_t startSideCol,
+                                      size_t targetSideCol,
+                                      bool yieldOnce) const;
 
   // Copy the columns from the input table to the output table
-  template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
-  void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
+  template <size_t OUTPUT_WIDTH>
+  void copyColumns(const IdTable& inputTable,
                    IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow,
                    size_t outputRow, size_t skipCol) const;
 
@@ -204,16 +216,12 @@ class TransitivePathBase : public Operation {
  private:
   uint64_t getSizeEstimateBeforeLimit() override;
 
-  template <size_t WIDTH, size_t START_WIDTH>
-  void fillTableWithHullImpl(IdTable& table, const Map& hull,
-                             std::vector<Id>& nodes, size_t startSideCol,
-                             size_t targetSideCol,
-                             const IdTable& startSideTable,
-                             size_t skipCol) const;
-
   template <size_t WIDTH>
-  void fillTableWithHullImpl(IdTable& table, const Map& hull,
-                             size_t startSideCol, size_t targetSideCol) const;
+  Result::Generator fillTableWithHullImpl(
+      NodeGenerator hull, size_t startSideCol, size_t targetSideCol,
+      std::invocable<IdTableStatic<WIDTH>&, const IdTable&, size_t, size_t> auto
+          onEntryAdded,
+      bool yieldOnce) const;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -69,8 +69,11 @@ using Map = std::unordered_map<
     Id, Set, HashId, std::equal_to<Id>,
     ad_utility::AllocatorWithLimit<std::pair<const Id, Set>>>;
 
-// Helper struct, that allows a generator to yield a combination of those to
-// store it within a new table.
+// Helper struct, that allows a generator to yield a a node and all its
+// connected nodes (the `targets`), along with a local vocabulary and the row
+// index of the node in the input table. The `IdTable` pointer might be null if
+// the `Id` is not associated with a table. In this case the `row` value does
+// not represent anything meaningful and should not be used.
 struct NodeWithTargets {
   Id node_;
   Set targets_;

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -175,7 +175,7 @@ class TransitivePathBase : public Operation {
    */
   Result::Generator fillTableWithHull(NodeGenerator hull, size_t startSideCol,
                                       size_t targetSideCol, size_t skipCol,
-                                      bool yieldOnce) const;
+                                      bool yieldOnce, size_t inputWidth) const;
 
   /**
    * @brief Fill the given table with the transitive hull.
@@ -192,8 +192,8 @@ class TransitivePathBase : public Operation {
                                       bool yieldOnce) const;
 
   // Copy the columns from the input table to the output table
-  template <size_t OUTPUT_WIDTH>
-  void copyColumns(const IdTable& inputTable,
+  template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
+  void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
                    IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow,
                    size_t outputRow, size_t skipCol) const;
 
@@ -216,12 +216,11 @@ class TransitivePathBase : public Operation {
  private:
   uint64_t getSizeEstimateBeforeLimit() override;
 
-  template <size_t WIDTH>
-  Result::Generator fillTableWithHullImpl(
-      NodeGenerator hull, size_t startSideCol, size_t targetSideCol,
-      std::invocable<IdTableStatic<WIDTH>&, const IdTable&, size_t, size_t> auto
-          onEntryAdded,
-      bool yieldOnce) const;
+  template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
+  Result::Generator fillTableWithHullImpl(NodeGenerator hull,
+                                          size_t startSideCol,
+                                          size_t targetSideCol, bool yieldOnce,
+                                          size_t skipCol = 0) const;
 
  public:
   size_t getCostEstimate() override;

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -74,13 +74,15 @@ struct NodeWithTargets {
   Set targets_;
   LocalVocab localVocab_;
   const IdTable* idTable_;
+  size_t row_;
 
   NodeWithTargets(Id node, Set targets, LocalVocab localVocab,
-                  const IdTable* idTable)
+                  const IdTable* idTable, size_t row)
       : node_{node},
         targets_{std::move(targets)},
         localVocab_{std::move(localVocab)},
-        idTable_{idTable} {}
+        idTable_{idTable},
+        row_{row} {}
 };
 
 using NodeGenerator = cppcoro::generator<NodeWithTargets>;

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -252,14 +252,14 @@ class TransitivePathImpl : public TransitivePathBase {
       mergedVocab.mergeWith(std::span{&edgesVocab, 1});
       size_t currentRow = 0;
       for (Id startNode : tableColumn.column_) {
-        timer.cont();
         Set connectedNodes = findConnectedNodes(edges, startNode, target);
         if (!connectedNodes.empty()) {
-          timer.stop();
           runtimeInfo().addDetail("Hull time", timer.msecs());
+          timer.stop();
           co_yield NodeWithTargets{startNode, std::move(connectedNodes),
                                    mergedVocab.clone(), tableColumn.table_,
                                    currentRow};
+          timer.cont();
         }
         currentRow++;
       }

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -50,7 +50,7 @@ class TransitivePathImpl : public TransitivePathBase {
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
                      size_t minDist, size_t maxDist)
       : TransitivePathBase(qec, std::move(child), std::move(leftSide),
-                           std::move(rightSide), minDist, maxDist) {};
+                           std::move(rightSide), minDist, maxDist){};
 
   /**
    * @brief Compute the transitive hull with a bound side.
@@ -195,7 +195,7 @@ class TransitivePathImpl : public TransitivePathBase {
    *
    * @param edges Adjacency lists, mapping Ids (nodes) to their connected
    * Ids.
-   * @param startNodes A range that yields an instanciation of
+   * @param startNodes A range that yields an instantiation of
    * `TableColumnWithVocab` that can be consumed to create a transitive hull.
    * @param target Optional target Id. If supplied, only paths which end
    * in this Id are added to the hull.

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -85,7 +85,8 @@ class TransitivePathImpl : public TransitivePathBase {
 
     auto result = fillTableWithHull(
         std::move(hull), startSide.outputCol_, targetSide.outputCol_,
-        startSide.treeAndCol_.value().second, yieldOnce);
+        startSide.treeAndCol_.value().second, yieldOnce,
+        startSide.treeAndCol_.value().first->getResultWidth());
 
     // Iterate over generator to prevent lifetime issues
     for (auto& pair : result) {

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -46,7 +46,7 @@ class TransitivePathImpl : public TransitivePathBase {
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
                      size_t minDist, size_t maxDist)
       : TransitivePathBase(qec, std::move(child), std::move(leftSide),
-                           std::move(rightSide), minDist, maxDist){};
+                           std::move(rightSide), minDist, maxDist) {};
 
   /**
    * @brief Compute the transitive hull with a bound side.
@@ -205,6 +205,7 @@ class TransitivePathImpl : public TransitivePathBase {
       timer.cont();
       LocalVocab mergedVocab = std::move(tableColumn.vocab_);
       mergedVocab.mergeWith(std::span{&edgesVocab, 1});
+      size_t currentRow = 0;
       for (Id startNode : tableColumn.column_) {
         Set connectedNodes{getExecutionContext()->getAllocator()};
         marks.clear();
@@ -239,8 +240,10 @@ class TransitivePathImpl : public TransitivePathBase {
         if (!marks.empty()) {
           runtimeInfo().addDetail("Hull time", timer.msecs());
           co_yield NodeWithTargets{startNode, std::move(connectedNodes),
-                                   mergedVocab.clone(), tableColumn.table_};
+                                   mergedVocab.clone(), tableColumn.table_,
+                                   currentRow};
         }
+        currentRow++;
       }
     }
   }

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -46,7 +46,7 @@ class TransitivePathImpl : public TransitivePathBase {
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
                      size_t minDist, size_t maxDist)
       : TransitivePathBase(qec, std::move(child), std::move(leftSide),
-                           std::move(rightSide), minDist, maxDist) {};
+                           std::move(rightSide), minDist, maxDist){};
 
   /**
    * @brief Compute the transitive hull with a bound side.

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -11,6 +11,21 @@
 #include "util/Exception.h"
 #include "util/Timer.h"
 
+namespace detail {
+template <typename ColumnType>
+struct TableColumnWithVocab {
+  const IdTable* table_;
+  ColumnType column_;
+  LocalVocab vocab_;
+
+  // Explicit to prevent issues with co_yield and lifetime.
+  // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103909 for more info.
+  TableColumnWithVocab(const IdTable* table, ColumnType column,
+                       LocalVocab vocab)
+      : table_{table}, column_{std::move(column)}, vocab_{std::move(vocab)} {};
+};
+};  // namespace detail
+
 /**
  * @class TransitivePathImpl
  * @brief This class implements common functions for the concrete TransitivePath
@@ -22,13 +37,16 @@
  */
 template <typename T>
 class TransitivePathImpl : public TransitivePathBase {
+  using TableColumnWithVocab =
+      detail::TableColumnWithVocab<std::span<const Id>>;
+
  public:
   TransitivePathImpl(QueryExecutionContext* qec,
                      std::shared_ptr<QueryExecutionTree> child,
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
                      size_t minDist, size_t maxDist)
       : TransitivePathBase(qec, std::move(child), std::move(leftSide),
-                           std::move(rightSide), minDist, maxDist){};
+                           std::move(rightSide), minDist, maxDist) {};
 
   /**
    * @brief Compute the transitive hull with a bound side.
@@ -36,44 +54,43 @@ class TransitivePathImpl : public TransitivePathBase {
    * it is a variable. The other IdTable contains the result
    * of the start side and will be used to get the start nodes.
    *
-   * @tparam RES_WIDTH Number of columns of the result table
-   * @tparam SUB_WIDTH Number of columns of the sub table
-   * @tparam SIDE_WIDTH Number of columns of the
-   * @param res The result table which will be filled in-place
-   * @param sub The IdTable for the sub result
+   * @param dynSub The IdTable for the sub result
    * @param startSide The start side for the transitive hull
    * @param targetSide The target side for the transitive hull
-   * @param startSideTable The IdTable of the startSide
+   * @param startSideResult The Result of the startSide
    */
-  template <size_t RES_WIDTH, size_t SUB_WIDTH, size_t SIDE_WIDTH>
-  void computeTransitivePathBound(IdTable* dynRes, const IdTable& dynSub,
-                                  const TransitivePathSide& startSide,
-                                  const TransitivePathSide& targetSide,
-                                  const IdTable& startSideTable) const {
+  Result::Generator computeTransitivePathBound(
+      std::shared_ptr<const Result> sub, const TransitivePathSide& startSide,
+      const TransitivePathSide& targetSide,
+      std::shared_ptr<const Result> startSideResult, bool yieldOnce) const {
     auto timer = ad_utility::Timer(ad_utility::Timer::Stopped);
     timer.start();
 
-    auto [edges, nodes] = setupMapAndNodes<SUB_WIDTH, SIDE_WIDTH>(
-        dynSub, startSide, targetSide, startSideTable);
+    auto edges = setupEdgesMap(sub->idTable(), startSide, targetSide);
+    auto nodes = setupNodes(startSide, std::move(startSideResult));
 
     timer.stop();
     auto initTime = timer.msecs();
     timer.start();
 
-    Map hull(allocator());
-    if (!targetSide.isVariable()) {
-      hull = transitiveHull(edges, nodes, std::get<Id>(targetSide.value_));
-    } else {
-      hull = transitiveHull(edges, nodes, std::nullopt);
-    }
+    NodeGenerator hull =
+        transitiveHull(edges, sub->getCopyOfLocalVocab(), std::move(nodes),
+                       targetSide.isVariable()
+                           ? std::nullopt
+                           : std::optional{std::get<Id>(targetSide.value_)});
 
     timer.stop();
     auto hullTime = timer.msecs();
     timer.start();
 
-    fillTableWithHull(*dynRes, hull, nodes, startSide.outputCol_,
-                      targetSide.outputCol_, startSideTable,
-                      startSide.treeAndCol_.value().second);
+    auto result = fillTableWithHull(
+        std::move(hull), startSide.outputCol_, targetSide.outputCol_,
+        startSide.treeAndCol_.value().second, yieldOnce);
+
+    // Iterate over generator to prevent lifetime issues
+    for (auto& pair : result) {
+      co_yield pair;
+    }
 
     timer.stop();
     auto fillTime = timer.msecs();
@@ -88,41 +105,53 @@ class TransitivePathImpl : public TransitivePathBase {
    * @brief Compute the transitive hull.
    * This function is called when no side is bound (or an id).
    *
-   * @tparam RES_WIDTH Number of columns of the result table
-   * @tparam SUB_WIDTH Number of columns of the sub table
-   * @param res The result table which will be filled in-place
-   * @param sub The IdTable for the sub result
+   * @param dynSub The IdTable for the sub result
    * @param startSide The start side for the transitive hull
    * @param targetSide The target side for the transitive hull
    */
 
-  template <size_t RES_WIDTH, size_t SUB_WIDTH>
-  void computeTransitivePath(IdTable* dynRes, const IdTable& dynSub,
-                             const TransitivePathSide& startSide,
-                             const TransitivePathSide& targetSide) const {
+  Result::Generator computeTransitivePath(std::shared_ptr<const Result> sub,
+                                          const TransitivePathSide& startSide,
+                                          const TransitivePathSide& targetSide,
+                                          bool yieldOnce) const {
     auto timer = ad_utility::Timer(ad_utility::Timer::Stopped);
     timer.start();
 
-    auto [edges, nodes] =
-        setupMapAndNodes<SUB_WIDTH>(dynSub, startSide, targetSide);
+    auto edges = setupEdgesMap(sub->idTable(), startSide, targetSide);
+    auto nodesWithDuplicates =
+        setupNodes(sub->idTable(), startSide, targetSide);
+    Set nodesWithoutDuplicates{allocator()};
+    for (const auto& span : nodesWithDuplicates) {
+      nodesWithoutDuplicates.insert(span.begin(), span.end());
+    }
 
     timer.stop();
     auto initTime = timer.msecs();
     timer.start();
 
-    Map hull{allocator()};
-    if (!targetSide.isVariable()) {
-      hull = transitiveHull(edges, nodes, std::get<Id>(targetSide.value_));
-    } else {
-      hull = transitiveHull(edges, nodes, std::nullopt);
-    }
+    // Technically we should pass the localVocab of `sub` here, but this will
+    // just lead to a merge with itself later on in the pipeline.
+    detail::TableColumnWithVocab<const Set&> tableInfo{
+        nullptr, nodesWithoutDuplicates, LocalVocab{}};
+
+    NodeGenerator hull = transitiveHull(
+        edges, sub->getCopyOfLocalVocab(), std::span{&tableInfo, 1},
+        targetSide.isVariable()
+            ? std::nullopt
+            : std::optional{std::get<Id>(targetSide.value_)});
 
     timer.stop();
     auto hullTime = timer.msecs();
     timer.start();
 
-    fillTableWithHull(*dynRes, hull, startSide.outputCol_,
-                      targetSide.outputCol_);
+    auto result = fillTableWithHull(std::move(hull), startSide.outputCol_,
+                                    targetSide.outputCol_, yieldOnce);
+
+    // Iterate over generator to prevent lifetime issues
+    for (auto& pair : result) {
+      co_yield pair;
+    }
+
     timer.stop();
     auto fillTime = timer.msecs();
 
@@ -142,7 +171,7 @@ class TransitivePathImpl : public TransitivePathBase {
    *
    * @return Result The result of the TransitivePath operation
    */
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
+  ProtoResult computeResult(bool requestLaziness) override {
     if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
         rhs_.isVariable()) {
       AD_THROW(
@@ -153,35 +182,30 @@ class TransitivePathImpl : public TransitivePathBase {
     auto [startSide, targetSide] = decideDirection();
     std::shared_ptr<const Result> subRes = subtree_->getResult();
 
-    IdTable idTable{allocator()};
-
-    idTable.setNumColumns(getResultWidth());
-
-    size_t subWidth = subRes->idTable().numColumns();
-
     if (startSide.isBoundVariable()) {
       std::shared_ptr<const Result> sideRes =
-          startSide.treeAndCol_.value().first->getResult();
-      size_t sideWidth = sideRes->idTable().numColumns();
+          startSide.treeAndCol_.value().first->getResult(true);
 
-      CALL_FIXED_SIZE((std::array{resultWidth_, subWidth, sideWidth}),
-                      &TransitivePathImpl<T>::computeTransitivePathBound, this,
-                      &idTable, subRes->idTable(), startSide, targetSide,
-                      sideRes->idTable());
+      auto gen =
+          computeTransitivePathBound(std::move(subRes), startSide, targetSide,
+                                     std::move(sideRes), !requestLaziness);
 
-      return {std::move(idTable), resultSortedOn(),
-              Result::getMergedLocalVocab(*sideRes, *subRes)};
+      return requestLaziness
+                 ? ProtoResult{std::move(gen), resultSortedOn()}
+                 : ProtoResult{cppcoro::getSingleElement(std::move(gen)),
+                               resultSortedOn()};
     }
-    CALL_FIXED_SIZE((std::array{resultWidth_, subWidth}),
-                    &TransitivePathImpl<T>::computeTransitivePath, this,
-                    &idTable, subRes->idTable(), startSide, targetSide);
+    auto gen = computeTransitivePath(std::move(subRes), startSide, targetSide,
+                                     !requestLaziness);
 
     // NOTE: The only place, where the input to a transitive path operation is
     // not an index scan (which has an empty local vocabulary by default) is the
     // `LocalVocabTest`. But it doesn't harm to propagate the local vocab here
     // either.
-    return {std::move(idTable), resultSortedOn(),
-            subRes->getSharedLocalVocab()};
+    return requestLaziness
+               ? ProtoResult{std::move(gen), resultSortedOn()}
+               : ProtoResult{cppcoro::getSingleElement(std::move(gen)),
+                             resultSortedOn()};
   };
 
   /**
@@ -197,115 +221,111 @@ class TransitivePathImpl : public TransitivePathBase {
    * in this Id are added to the hull.
    * @return Map Maps each Id to its connected Ids in the transitive hull
    */
-  Map transitiveHull(const T& edges, const std::vector<Id>& startNodes,
-                     std::optional<Id> target) const {
-    // For every node do a dfs on the graph
-    Map hull{allocator()};
-
+  NodeGenerator transitiveHull(const T& edges, LocalVocab edgesVocab,
+                               std::ranges::range auto startNodes,
+                               std::optional<Id> target) const {
     std::vector<std::pair<Id, size_t>> stack;
     ad_utility::HashSetWithMemoryLimit<Id> marks{
         getExecutionContext()->getAllocator()};
-    for (auto startNode : startNodes) {
-      if (hull.contains(startNode)) {
-        // We have already computed the hull for this node
-        continue;
-      }
+    for (auto&& tableColumn : startNodes) {
+      LocalVocab mergedVocab = std::move(tableColumn.vocab_);
+      mergedVocab.mergeWith(std::span{&edgesVocab, 1});
+      for (Id startNode : tableColumn.column_) {
+        Set connectedNodes{getExecutionContext()->getAllocator()};
+        marks.clear();
+        stack.clear();
+        stack.push_back({startNode, 0});
 
-      marks.clear();
-      stack.clear();
-      stack.push_back({startNode, 0});
+        if (minDist_ == 0 &&
+            (!target.has_value() || startNode == target.value())) {
+          connectedNodes.insert(startNode);
+        }
 
-      if (minDist_ == 0 &&
-          (!target.has_value() || startNode == target.value())) {
-        insertIntoMap(hull, startNode, startNode);
-      }
+        while (!stack.empty()) {
+          checkCancellation();
+          auto [node, steps] = stack.back();
+          stack.pop_back();
 
-      while (!stack.empty()) {
-        checkCancellation();
-        auto [node, steps] = stack.back();
-        stack.pop_back();
+          if (steps <= maxDist_ && marks.count(node) == 0) {
+            if (steps >= minDist_) {
+              marks.insert(node);
+              if (!target.has_value() || node == target.value()) {
+                connectedNodes.insert(node);
+              }
+            }
 
-        if (steps <= maxDist_ && marks.count(node) == 0) {
-          if (steps >= minDist_) {
-            marks.insert(node);
-            if (!target.has_value() || node == target.value()) {
-              insertIntoMap(hull, startNode, node);
+            const auto& successors = edges.successors(node);
+            for (auto successor : successors) {
+              stack.push_back({successor, steps + 1});
             }
           }
-
-          const auto& successors = edges.successors(node);
-          for (auto successor : successors) {
-            stack.push_back({successor, steps + 1});
-          }
+        }
+        if (!marks.empty()) {
+          co_yield NodeWithTargets{startNode, std::move(connectedNodes),
+                                   mergedVocab.clone(), tableColumn.table_};
         }
       }
     }
-    return hull;
   }
 
   /**
    * @brief Prepare a Map and a nodes vector for the transitive hull
    * computation.
    *
-   * @tparam SUB_WIDTH Number of columns of the sub table
    * @param sub The sub table result
    * @param startSide The TransitivePathSide where the edges start
    * @param targetSide The TransitivePathSide where the edges end
-   * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
+   * @return std::vector<std::span<const Id>> An Id vector (nodes) for the
    * transitive hull computation
    */
-  template <size_t SUB_WIDTH>
-  std::pair<T, std::vector<Id>> setupMapAndNodes(
+  std::vector<std::span<const Id>> setupNodes(
       const IdTable& sub, const TransitivePathSide& startSide,
       const TransitivePathSide& targetSide) const {
-    std::vector<Id> nodes;
-    auto edges = setupEdgesMap(sub, startSide, targetSide);
+    std::vector<std::span<const Id>> result;
 
     // id -> var|id
     if (!startSide.isVariable()) {
-      nodes.push_back(std::get<Id>(startSide.value_));
+      result.emplace_back(&std::get<Id>(startSide.value_), 1);
       // var -> var
     } else {
       std::span<const Id> startNodes = sub.getColumn(startSide.subCol_);
-      // TODO<C++23> Use ranges::to.
-      nodes.insert(nodes.end(), startNodes.begin(), startNodes.end());
+      result.emplace_back(startNodes);
       if (minDist_ == 0) {
         std::span<const Id> targetNodes = sub.getColumn(targetSide.subCol_);
-        nodes.insert(nodes.end(), targetNodes.begin(), targetNodes.end());
+        result.emplace_back(targetNodes);
       }
     }
 
-    return {std::move(edges), std::move(nodes)};
+    return result;
   };
 
   /**
    * @brief Prepare a Map and a nodes vector for the transitive hull
    * computation.
    *
-   * @tparam SUB_WIDTH Number of columns of the sub table
-   * @tparam SIDE_WIDTH Number of columns of the startSideTable
-   * @param sub The sub table result
    * @param startSide The TransitivePathSide where the edges start
-   * @param targetSide The TransitivePathSide where the edges end
    * @param startSideTable An IdTable containing the Ids for the startSide
-   * @return std::pair<Map, std::vector<Id>> A Map and Id vector (nodes) for the
-   * transitive hull computation
+   * @return cppcoro::generator<TableColumnWithVocab> An Id vector (nodes) for
+   * the transitive hull computation
    */
-  template <size_t SUB_WIDTH, size_t SIDE_WIDTH>
-  std::pair<T, std::vector<Id>> setupMapAndNodes(
-      const IdTable& sub, const TransitivePathSide& startSide,
-      const TransitivePathSide& targetSide,
-      const IdTable& startSideTable) const {
-    std::vector<Id> nodes;
-    auto edges = setupEdgesMap(sub, startSide, targetSide);
-
-    // Bound -> var|id
-    std::span<const Id> startNodes =
-        startSideTable.getColumn(startSide.treeAndCol_.value().second);
-    // TODO<C++23> Use ranges::to.
-    nodes.insert(nodes.end(), startNodes.begin(), startNodes.end());
-
-    return {std::move(edges), std::move(nodes)};
+  cppcoro::generator<TableColumnWithVocab> setupNodes(
+      const TransitivePathSide& startSide,
+      std::shared_ptr<const Result> startSideResult) const {
+    if (startSideResult->isFullyMaterialized()) {
+      // Bound -> var|id
+      std::span<const Id> startNodes = startSideResult->idTable().getColumn(
+          startSide.treeAndCol_.value().second);
+      co_yield TableColumnWithVocab{&startSideResult->idTable(), startNodes,
+                                    startSideResult->getCopyOfLocalVocab()};
+    } else {
+      for (auto& [idTable, localVocab] : startSideResult->idTables()) {
+        // Bound -> var|id
+        std::span<const Id> startNodes =
+            idTable.getColumn(startSide.treeAndCol_.value().second);
+        co_yield TableColumnWithVocab{&idTable, startNodes,
+                                      std::move(localVocab)};
+      }
+    }
   };
 
   virtual T setupEdgesMap(const IdTable& dynSub,

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -330,8 +330,15 @@ class IdTable {
   T& at(size_t row, size_t column) requires(!isView) {
     return data().at(column).at(row);
   }
-  const T& at(size_t row, size_t column) const {
+  // TODO<C++26> Remove overload for `isView` and drop requires clause.
+  const T& at(size_t row, size_t column) const requires(!isView) {
     return data().at(column).at(row);
+  }
+  // `std::span::at` is a C++26 feature, so we have to implement it ourselves.
+  const T& at(size_t row, size_t column) const requires(isView) {
+    const auto& col = data().at(column);
+    AD_CONTRACT_CHECK(row < col.size());
+    return col[row];
   }
 
   // Get a reference to the `i`-th row. The returned proxy objects can be

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -56,8 +56,9 @@ class TransitivePathTest
     auto [T, qec] = makePath(std::move(input), vars, std::move(left),
                              std::move(right), minDist, maxDist);
     auto leftOp = ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec, std::move(sideTable), sideVars, false, std::vector<ColumnIndex>{},
-        LocalVocab{}, std::nullopt, forceFullyMaterialized);
+        qec, std::move(sideTable), sideVars, false,
+        std::vector<ColumnIndex>{sideTableCol}, LocalVocab{}, std::nullopt,
+        forceFullyMaterialized);
     return T->bindLeftSide(leftOp, sideTableCol);
   }
 
@@ -68,7 +69,8 @@ class TransitivePathTest
     auto [T, qec] = makePath(std::move(input), vars, std::move(left),
                              std::move(right), minDist, maxDist);
     auto leftOp = ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec, std::move(sideTables), sideVars);
+        qec, std::move(sideTables), sideVars, false,
+        std::vector<ColumnIndex>{sideTableCol});
     return T->bindLeftSide(leftOp, sideTableCol);
   }
 
@@ -79,8 +81,9 @@ class TransitivePathTest
     auto [T, qec] = makePath(std::move(input), vars, std::move(left),
                              std::move(right), minDist, maxDist);
     auto rightOp = ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec, std::move(sideTable), sideVars, false, std::vector<ColumnIndex>{},
-        LocalVocab{}, std::nullopt, forceFullyMaterialized);
+        qec, std::move(sideTable), sideVars, false,
+        std::vector<ColumnIndex>{sideTableCol}, LocalVocab{}, std::nullopt,
+        forceFullyMaterialized);
     return T->bindRightSide(rightOp, sideTableCol);
   }
 
@@ -91,7 +94,8 @@ class TransitivePathTest
     auto [T, qec] = makePath(std::move(input), vars, std::move(left),
                              std::move(right), minDist, maxDist);
     auto rightOp = ad_utility::makeExecutionTree<ValuesForTesting>(
-        qec, std::move(sideTables), sideVars);
+        qec, std::move(sideTables), sideVars, false,
+        std::vector<ColumnIndex>{sideTableCol});
     return T->bindRightSide(rightOp, sideTableCol);
   }
 

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -4,7 +4,6 @@
 //         Johannes Herrmann (johannes.r.herrmann(at)gmail.com)
 
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 
 #include <limits>
 #include <memory>
@@ -14,7 +13,6 @@
 #include "engine/QueryExecutionTree.h"
 #include "engine/TransitivePathBase.h"
 #include "engine/ValuesForTesting.h"
-#include "gtest/gtest.h"
 #include "util/GTestHelpers.h"
 #include "util/IdTableHelpers.h"
 #include "util/IndexTestHelpers.h"
@@ -71,6 +69,15 @@ class TransitivePathTest : public testing::TestWithParam<bool> {
         qec, std::move(sideTable), sideVars);
     return T->bindRightSide(rightOp, sideTableCol);
   }
+
+  void assertResultMatchesIdTable(const Result& result, const IdTable& expected,
+                                  ad_utility::source_location loc =
+                                      ad_utility::source_location::current()) {
+    auto t = generateLocationTrace(loc);
+    ASSERT_TRUE(result.isFullyMaterialized());
+    ASSERT_THAT(result.idTable(),
+                ::testing::UnorderedElementsAreArray(expected));
+  }
 };
 
 TEST_P(TransitivePathTest, idToId) {
@@ -85,8 +92,7 @@ TEST_P(TransitivePathTest, idToId) {
                       left, right, 1, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, idToVar) {
@@ -101,8 +107,7 @@ TEST_P(TransitivePathTest, idToVar) {
                       left, right, 1, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, varToId) {
@@ -121,8 +126,7 @@ TEST_P(TransitivePathTest, varToId) {
                       left, right, 1, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, idToVarMinLengthZero) {
@@ -137,8 +141,7 @@ TEST_P(TransitivePathTest, idToVarMinLengthZero) {
                       left, right, 0, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, varToIdMinLengthZero) {
@@ -158,8 +161,7 @@ TEST_P(TransitivePathTest, varToIdMinLengthZero) {
                       left, right, 0, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, varTovar) {
@@ -186,8 +188,7 @@ TEST_P(TransitivePathTest, varTovar) {
                       left, right, 1, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, unlimitedMaxLength) {
@@ -226,8 +227,7 @@ TEST_P(TransitivePathTest, unlimitedMaxLength) {
                       left, right, 1, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, idToLeftBound) {
@@ -254,8 +254,7 @@ TEST_P(TransitivePathTest, idToLeftBound) {
         right, 0, std::numeric_limits<size_t>::max());
 
     auto resultTable = T->computeResultOnlyForTesting();
-    ASSERT_THAT(resultTable.idTable(),
-                ::testing::UnorderedElementsAreArray(expected));
+    assertResultMatchesIdTable(resultTable, expected);
   }
   {
     auto T = makePathLeftBound(
@@ -265,8 +264,7 @@ TEST_P(TransitivePathTest, idToLeftBound) {
         std::numeric_limits<size_t>::max());
 
     auto resultTable = T->computeResultOnlyForTesting();
-    ASSERT_THAT(resultTable.idTable(),
-                ::testing::UnorderedElementsAreArray(expected));
+    assertResultMatchesIdTable(resultTable, expected);
   }
 }
 
@@ -300,8 +298,7 @@ TEST_P(TransitivePathTest, idToRightBound) {
         right, 0, std::numeric_limits<size_t>::max());
 
     auto resultTable = T->computeResultOnlyForTesting();
-    ASSERT_THAT(resultTable.idTable(),
-                ::testing::UnorderedElementsAreArray(expected));
+    assertResultMatchesIdTable(resultTable, expected);
   }
   {
     auto T = makePathRightBound(
@@ -311,8 +308,7 @@ TEST_P(TransitivePathTest, idToRightBound) {
         std::numeric_limits<size_t>::max());
 
     auto resultTable = T->computeResultOnlyForTesting();
-    ASSERT_THAT(resultTable.idTable(),
-                ::testing::UnorderedElementsAreArray(expected));
+    assertResultMatchesIdTable(resultTable, expected);
   }
 }
 
@@ -352,8 +348,7 @@ TEST_P(TransitivePathTest, leftBoundToVar) {
         std::numeric_limits<size_t>::max());
 
     auto resultTable = T->computeResultOnlyForTesting();
-    ASSERT_THAT(resultTable.idTable(),
-                ::testing::UnorderedElementsAreArray(expected));
+    assertResultMatchesIdTable(resultTable, expected);
   }
 }
 
@@ -391,8 +386,7 @@ TEST_P(TransitivePathTest, rightBoundToVar) {
       std::move(left), std::move(right), 0, std::numeric_limits<size_t>::max());
 
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, maxLength2FromVariable) {
@@ -427,8 +421,7 @@ TEST_P(TransitivePathTest, maxLength2FromVariable) {
       makePathUnbound(std::move(sub), {Variable{"?start"}, Variable{"?target"}},
                       left, right, 1, 2);
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, maxLength2FromId) {
@@ -455,8 +448,7 @@ TEST_P(TransitivePathTest, maxLength2FromId) {
       makePathUnbound(std::move(sub), {Variable{"?start"}, Variable{"?target"}},
                       left, right, 1, 2);
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, maxLength2ToId) {
@@ -482,8 +474,7 @@ TEST_P(TransitivePathTest, maxLength2ToId) {
       makePathUnbound(std::move(sub), {Variable{"?start"}, Variable{"?target"}},
                       left, right, 1, 2);
   auto resultTable = T->computeResultOnlyForTesting();
-  ASSERT_THAT(resultTable.idTable(),
-              ::testing::UnorderedElementsAreArray(expected));
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 TEST_P(TransitivePathTest, zeroLengthException) {

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -550,6 +550,61 @@ TEST_P(TransitivePathTest, rightBoundToVar) {
   }
 }
 
+TEST_P(TransitivePathTest, startNodesWithNoMatchesRightBound) {
+  auto sub = makeIdTableFromVector({
+      {1, 2},
+      {3, 4},
+  });
+
+  auto rightOpTable = makeIdTableFromVector({
+      {2, 5},
+      {3, 6},
+      {4, 7},
+  });
+
+  auto expected = makeIdTableFromVector({
+      {1, 2, 5},
+      {3, 4, 7},
+  });
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  auto T = makePathRightBound(
+      sub.clone(), {Variable{"?start"}, Variable{"?target"}},
+      split(rightOpTable), 0, {Variable{"?target"}, Variable{"?x"}}, left,
+      right, 1, std::numeric_limits<size_t>::max());
+
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, expected);
+}
+
+TEST_P(TransitivePathTest, startNodesWithNoMatchesLeftBound) {
+  auto sub = makeIdTableFromVector({
+      {1, 2},
+      {3, 4},
+  });
+
+  auto leftOpTable = makeIdTableFromVector({
+      {2, 5},
+      {3, 6},
+      {4, 7},
+  });
+
+  auto expected = makeIdTableFromVector({
+      {3, 4, 6},
+  });
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  auto T = makePathLeftBound(
+      sub.clone(), {Variable{"?start"}, Variable{"?target"}},
+      split(leftOpTable), 0, {Variable{"?start"}, Variable{"?x"}}, left, right,
+      1, std::numeric_limits<size_t>::max());
+
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, expected);
+}
+
 TEST_P(TransitivePathTest, maxLength2FromVariable) {
   auto sub = makeIdTableFromVector({
       {0, 2},

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -41,6 +41,7 @@ class TransitivePathTest
             qec};
   }
 
+  // ___________________________________________________________________________
   [[nodiscard]] static std::shared_ptr<TransitivePathBase> makePathUnbound(
       IdTable input, Vars vars, TransitivePathSide left,
       TransitivePathSide right, size_t minDist, size_t maxDist) {
@@ -49,6 +50,7 @@ class TransitivePathTest
     return T;
   }
 
+  // ___________________________________________________________________________
   [[nodiscard]] static std::shared_ptr<TransitivePathBase> makePathLeftBound(
       IdTable input, Vars vars, IdTable sideTable, size_t sideTableCol,
       Vars sideVars, TransitivePathSide left, TransitivePathSide right,
@@ -62,6 +64,7 @@ class TransitivePathTest
     return T->bindLeftSide(leftOp, sideTableCol);
   }
 
+  // ___________________________________________________________________________
   [[nodiscard]] static std::shared_ptr<TransitivePathBase> makePathLeftBound(
       IdTable input, Vars vars, std::vector<IdTable> sideTables,
       size_t sideTableCol, Vars sideVars, TransitivePathSide left,
@@ -74,6 +77,7 @@ class TransitivePathTest
     return T->bindLeftSide(leftOp, sideTableCol);
   }
 
+  // ___________________________________________________________________________
   [[nodiscard]] static std::shared_ptr<TransitivePathBase> makePathRightBound(
       IdTable input, Vars vars, IdTable sideTable, size_t sideTableCol,
       Vars sideVars, TransitivePathSide left, TransitivePathSide right,
@@ -87,6 +91,7 @@ class TransitivePathTest
     return T->bindRightSide(rightOp, sideTableCol);
   }
 
+  // ___________________________________________________________________________
   [[nodiscard]] static std::shared_ptr<TransitivePathBase> makePathRightBound(
       IdTable input, Vars vars, std::vector<IdTable> sideTables,
       size_t sideTableCol, Vars sideVars, TransitivePathSide left,
@@ -99,6 +104,7 @@ class TransitivePathTest
     return T->bindRightSide(rightOp, sideTableCol);
   }
 
+  // ___________________________________________________________________________
   static std::vector<IdTable> split(const IdTable& idTable) {
     std::vector<IdTable> result;
     for (const auto& row : idTable) {
@@ -108,8 +114,10 @@ class TransitivePathTest
     return result;
   }
 
+  // ___________________________________________________________________________
   static bool requestLaziness() { return std::get<1>(GetParam()); }
 
+  // ___________________________________________________________________________
   void assertResultMatchesIdTable(const Result& result, const IdTable& expected,
                                   ad_utility::source_location loc =
                                       ad_utility::source_location::current()) {
@@ -130,6 +138,7 @@ class TransitivePathTest
   }
 };
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, idToId) {
   auto sub = makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 3}});
 
@@ -145,6 +154,7 @@ TEST_P(TransitivePathTest, idToId) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, idToVar) {
   auto sub = makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 3}});
 
@@ -160,6 +170,7 @@ TEST_P(TransitivePathTest, idToVar) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, varToId) {
   auto sub = makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 3}});
 
@@ -179,6 +190,7 @@ TEST_P(TransitivePathTest, varToId) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, idToVarMinLengthZero) {
   auto sub = makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 3}});
 
@@ -194,6 +206,7 @@ TEST_P(TransitivePathTest, idToVarMinLengthZero) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, varToIdMinLengthZero) {
   auto sub = makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 3}});
 
@@ -214,6 +227,7 @@ TEST_P(TransitivePathTest, varToIdMinLengthZero) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, varTovar) {
   auto sub = makeIdTableFromVector({
       {0, 1},
@@ -241,6 +255,7 @@ TEST_P(TransitivePathTest, varTovar) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, unlimitedMaxLength) {
   auto sub = makeIdTableFromVector({{0, 2},
                                     {2, 4},
@@ -280,6 +295,7 @@ TEST_P(TransitivePathTest, unlimitedMaxLength) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, idToLeftBound) {
   auto sub = makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 3}, {3, 4}});
 
@@ -354,6 +370,7 @@ TEST_P(TransitivePathTest, idToLeftBound) {
   }
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, idToRightBound) {
   auto sub = makeIdTableFromVector({
       {0, 1},
@@ -434,6 +451,7 @@ TEST_P(TransitivePathTest, idToRightBound) {
   }
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, leftBoundToVar) {
   auto sub = makeIdTableFromVector({
       {1, 2},
@@ -492,6 +510,7 @@ TEST_P(TransitivePathTest, leftBoundToVar) {
   }
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, rightBoundToVar) {
   auto sub = makeIdTableFromVector({
       {1, 2},
@@ -550,6 +569,7 @@ TEST_P(TransitivePathTest, rightBoundToVar) {
   }
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, startNodesWithNoMatchesRightBound) {
   auto sub = makeIdTableFromVector({
       {1, 2},
@@ -578,6 +598,27 @@ TEST_P(TransitivePathTest, startNodesWithNoMatchesRightBound) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
+TEST_P(TransitivePathTest, emptySideTable) {
+  auto sub = makeIdTableFromVector({
+      {1, 2},
+      {3, 4},
+  });
+
+  auto expected = makeIdTableFromVector({});
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
+  auto T =
+      makePathLeftBound(sub.clone(), {Variable{"?start"}, Variable{"?target"}},
+                        std::vector<IdTable>{}, 0, {Variable{"?start"}}, left,
+                        right, 0, std::numeric_limits<size_t>::max());
+
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, expected);
+}
+
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, startNodesWithNoMatchesLeftBound) {
   auto sub = makeIdTableFromVector({
       {1, 2},
@@ -605,6 +646,7 @@ TEST_P(TransitivePathTest, startNodesWithNoMatchesLeftBound) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, maxLength2FromVariable) {
   auto sub = makeIdTableFromVector({
       {0, 2},
@@ -640,6 +682,7 @@ TEST_P(TransitivePathTest, maxLength2FromVariable) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, maxLength2FromId) {
   auto sub = makeIdTableFromVector({
       {0, 2},
@@ -667,6 +710,7 @@ TEST_P(TransitivePathTest, maxLength2FromId) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, maxLength2ToId) {
   auto sub = makeIdTableFromVector({
       {0, 2},
@@ -693,6 +737,7 @@ TEST_P(TransitivePathTest, maxLength2ToId) {
   assertResultMatchesIdTable(resultTable, expected);
 }
 
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, zeroLengthException) {
   auto sub = makeIdTableFromVector({
       {0, 2},
@@ -717,6 +762,7 @@ TEST_P(TransitivePathTest, zeroLengthException) {
                                "not supported"));
 }
 
+// _____________________________________________________________________________
 INSTANTIATE_TEST_SUITE_P(
     TransitivePathTestSuite, TransitivePathTest,
     ::testing::Combine(::testing::Bool(), ::testing::Bool()),

--- a/test/util/IdTableHelpers.cpp
+++ b/test/util/IdTableHelpers.cpp
@@ -248,3 +248,15 @@ std::shared_ptr<QueryExecutionTree> idTableToExecutionTree(
   return ad_utility::makeExecutionTree<ValuesForTesting>(qec, input.clone(),
                                                          std::move(vars));
 }
+
+// _____________________________________________________________________________
+std::pair<IdTable, std::vector<LocalVocab>> aggregateTables(
+    Result::Generator generator, size_t numColumns) {
+  IdTable aggregateTable{numColumns, ad_utility::makeUnlimitedAllocator<Id>()};
+  std::vector<LocalVocab> localVocabs;
+  for (auto& [idTable, localVocab] : generator) {
+    localVocabs.emplace_back(std::move(localVocab));
+    aggregateTable.insertAtEnd(idTable);
+  }
+  return {std::move(aggregateTable), std::move(localVocabs)};
+}

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -256,3 +256,8 @@ IdTable createRandomlyFilledIdTable(
 /// and filling it with dummy variables.
 std::shared_ptr<QueryExecutionTree> idTableToExecutionTree(
     QueryExecutionContext*, const IdTable&);
+
+// Fully consume a given generator and store it in an `IdTable` and store the
+// local vocabs in a vector.
+std::pair<IdTable, std::vector<LocalVocab>> aggregateTables(
+    Result::Generator generator, size_t numColumns);


### PR DESCRIPTION
This PR enables the `TransitivePath` operation to yield its result lazily and to consume its left/right child lazily. Note that the graph which is transitively traversed needs to be fully materialized due to the underlying algorithm. E.G when computing the (large) result of `wdt:P31/wdt:P279*`, the large result and the `wdt:P31` can be dealt with lazily, but the full `wdt:P279` predicate needs to be materialized.