### PR TITLE
Add a numPathsPerTarget parameter to PathSearch

### DIFF
--- a/docs/path_search.md
+++ b/docs/path_search.md
@@ -48,6 +48,10 @@ SELECT ?start ?end ?path ?edge WHERE {
   **one target**. Sources and targets are paired based on their index (i.e. the paths
   from the first source to the first target are searched, then the second source and
   target, and so on).
+- **pathSearch:numPathsPerTarget** (optional): The path search will only search and store paths,
+  if the number of found paths is lower or equal to the value of the parameter. Expects an integer.
+  Example: if the value is 5, then the search will enumerate all paths until 5 paths have been found.
+  Other paths will be ignored.
 
 
 ### Example 1: Single Source and Target
@@ -170,7 +174,7 @@ SELECT ?start ?end ?path ?edge WHERE {
 }
 ```
 
-This is esecially useful for [N-ary relations](https://www.w3.org/TR/swbp-n-aryRelations/). 
+This is especially useful for [N-ary relations](https://www.w3.org/TR/swbp-n-aryRelations/). 
 Considering the example above, it is possible to query additional relations of `?middle`:
 
 ```sparql
@@ -249,6 +253,39 @@ SELECT ?start ?end ?path ?edge WHERE {
     {
       SELECT * WHERE {
         ?start <p> ?end.
+      }
+    }
+  }
+}
+```
+
+### Example 5: Limit Number of Paths per Target
+
+It is possible to limit how many paths per target are returned. This is especially useful if
+the query uses a lot of memory. In that case, it is possible to query a limited number of
+paths to debug where the problem is.
+
+The following query for example will only return one path per source and target pair.
+I.e. one path for `(<source1>, <target1>)`, one path for `(<source1>, <target2>)` and so on.
+
+```sparql
+PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>
+
+SELECT ?start ?end ?path ?edge WHERE {
+  SERVICE pathSearch: {
+    _:path pathSearch:algorithm pathSearch:allPaths ;
+           pathSearch:source <source1> ;
+           pathSearch:source <source2> ;
+           pathSearch:target <target1> ;
+           pathSearch:target <target2> ;
+           pathSearch:pathColumn ?path ;
+           pathSearch:edgeColumn ?edge ;
+           pathSearch:start ?start ;
+           pathSearch:end ?end ;
+           pathSearch:numPathsPerTarget 1;
+    {
+      SELECT * WHERE {
+        ?start <predicate> ?end.
       }
     }
   }

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -362,13 +362,10 @@ PathsLimited PathSearch::findPaths(
 
     auto edgeEnd = edge.end_.getBits();
     if (numPathsPerTarget) {
-      numPathsPerNode.try_emplace(edgeEnd, 0);
-      auto numPaths = numPathsPerNode[edgeEnd];
+      auto numPaths = ++numPathsPerNode[edgeEnd];
 
-      if (numPaths >= numPathsPerTarget) {
+      if (numPaths > numPathsPerTarget) {
         continue;
-      } else {
-        numPathsPerNode[edgeEnd] = numPaths + 1;
       }
     }
 

--- a/src/engine/PathSearch.cpp
+++ b/src/engine/PathSearch.cpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <optional>
 #include <ranges>
+#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -262,7 +263,8 @@ Result PathSearch::computeResult([[maybe_unused]] bool requestLaziness) {
       allSources = binSearch.getSources();
       sources = allSources;
     }
-    paths = allPaths(sources, targets, binSearch, config_.cartesian_);
+    paths = allPaths(sources, targets, binSearch, config_.cartesian_,
+                     config_.numPathsPerTarget_);
 
     timer.stop();
     auto searchTime = timer.msecs();
@@ -326,15 +328,16 @@ PathSearch::handleSearchSides() const {
 }
 
 // _____________________________________________________________________________
-PathsLimited PathSearch::findPaths(const Id& source,
-                                   const std::unordered_set<uint64_t>& targets,
-                                   const BinSearchWrapper& binSearch) const {
+PathsLimited PathSearch::findPaths(
+    const Id& source, const std::unordered_set<uint64_t>& targets,
+    const BinSearchWrapper& binSearch,
+    std::optional<uint64_t> numPathsPerTarget) const {
   std::vector<Edge> edgeStack;
   Path currentPath{EdgesLimited(allocator())};
   std::unordered_map<
-      uint64_t, PathsLimited, std::hash<uint64_t>, std::equal_to<uint64_t>,
-      ad_utility::AllocatorWithLimit<std::pair<const uint64_t, PathsLimited>>>
-      pathCache{allocator()};
+      uint64_t, uint64_t, std::hash<uint64_t>, std::equal_to<uint64_t>,
+      ad_utility::AllocatorWithLimit<std::pair<const uint64_t, uint64_t>>>
+      numPathsPerNode{allocator()};
   PathsLimited result{allocator()};
   std::unordered_set<uint64_t, std::hash<uint64_t>, std::equal_to<uint64_t>,
                      ad_utility::AllocatorWithLimit<uint64_t>>
@@ -357,9 +360,21 @@ PathsLimited PathSearch::findPaths(const Id& source,
       currentPath.pop_back();
     }
 
+    auto edgeEnd = edge.end_.getBits();
+    if (numPathsPerTarget) {
+      numPathsPerNode.try_emplace(edgeEnd, 0);
+      auto numPaths = numPathsPerNode[edgeEnd];
+
+      if (numPaths >= numPathsPerTarget) {
+        continue;
+      } else {
+        numPathsPerNode[edgeEnd] = numPaths + 1;
+      }
+    }
+
     currentPath.push_back(edge);
 
-    if (targets.empty() || targets.contains(edge.end_.getBits())) {
+    if (targets.empty() || targets.contains(edgeEnd)) {
       result.push_back(currentPath);
     }
 
@@ -374,10 +389,10 @@ PathsLimited PathSearch::findPaths(const Id& source,
 }
 
 // _____________________________________________________________________________
-PathsLimited PathSearch::allPaths(std::span<const Id> sources,
-                                  std::span<const Id> targets,
-                                  const BinSearchWrapper& binSearch,
-                                  bool cartesian) const {
+PathsLimited PathSearch::allPaths(
+    std::span<const Id> sources, std::span<const Id> targets,
+    const BinSearchWrapper& binSearch, bool cartesian,
+    std::optional<uint64_t> numPathsPerTarget) const {
   PathsLimited paths{allocator()};
   Path path{EdgesLimited(allocator())};
 
@@ -387,14 +402,15 @@ PathsLimited PathSearch::allPaths(std::span<const Id> sources,
       targetSet.insert(target.getBits());
     }
     for (auto source : sources) {
-      for (const auto& path : findPaths(source, targetSet, binSearch)) {
+      for (const auto& path :
+           findPaths(source, targetSet, binSearch, numPathsPerTarget)) {
         paths.push_back(path);
       }
     }
   } else {
     for (size_t i = 0; i < sources.size(); i++) {
-      for (const auto& path :
-           findPaths(sources[i], {targets[i].getBits()}, binSearch)) {
+      for (const auto& path : findPaths(sources[i], {targets[i].getBits()},
+                                        binSearch, numPathsPerTarget)) {
         paths.push_back(path);
       }
     }

--- a/src/engine/PathSearch.h
+++ b/src/engine/PathSearch.h
@@ -98,6 +98,7 @@ struct PathSearchConfiguration {
   Variable edgeColumn_;
   std::vector<Variable> edgeProperties_;
   bool cartesian_ = true;
+  std::optional<uint64_t> numPathsPerTarget_ = std::nullopt;
 
   bool sourceIsVariable() const {
     return std::holds_alternative<Variable>(sources_);
@@ -260,7 +261,8 @@ class PathSearch : public Operation {
    */
   pathSearch::PathsLimited findPaths(
       const Id& source, const std::unordered_set<uint64_t>& targets,
-      const pathSearch::BinSearchWrapper& binSearch) const;
+      const pathSearch::BinSearchWrapper& binSearch,
+      std::optional<uint64_t> numPathsPerTarget) const;
 
   /**
    * @brief Finds all paths in the graph.
@@ -268,7 +270,8 @@ class PathSearch : public Operation {
    */
   pathSearch::PathsLimited allPaths(
       std::span<const Id> sources, std::span<const Id> targets,
-      const pathSearch::BinSearchWrapper& binSearch, bool cartesian) const;
+      const pathSearch::BinSearchWrapper& binSearch, bool cartesian,
+      std::optional<uint64_t> numPathsPerTarget) const;
 
   /**
    * @brief Converts paths to a result table with a specified width.

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -128,6 +128,12 @@ void PathQuery::addParameter(const SparqlTriple& triple) {
       throw PathSearchException("The parameter 'cartesian' expects a boolean");
     }
     cartesian_ = object.getBool();
+  } else if (predString.ends_with("numPathsPerTarget>")) {
+    if (!object.isInt()) {
+      throw PathSearchException(
+          "The parameter 'numPathsPerTarget' expects an integer");
+    }
+    numPathsPerTarget_ = object.getInt();
   } else if (predString.ends_with("algorithm>")) {
     if (!object.isIri()) {
       throw PathSearchException("The 'algorithm' value has to be an Iri");
@@ -209,7 +215,8 @@ PathSearchConfiguration PathQuery::toPathSearchConfiguration(
   return PathSearchConfiguration{
       algorithm_,          sources,         targets,
       start_.value(),      end_.value(),    pathColumn_.value(),
-      edgeColumn_.value(), edgeProperties_, cartesian_};
+      edgeColumn_.value(), edgeProperties_, cartesian_,
+      numPathsPerTarget_};
 }
 
 // ____________________________________________________________________________

--- a/src/parser/GraphPatternOperation.h
+++ b/src/parser/GraphPatternOperation.h
@@ -174,6 +174,7 @@ struct PathQuery {
 
   GraphPattern childGraphPattern_;
   bool cartesian_ = true;
+  std::optional<uint64_t> numPathsPerTarget_ = std::nullopt;
 
   /**
    * @brief Add a parameter to the PathQuery from the given triple.

--- a/test/PathSearchTest.cpp
+++ b/test/PathSearchTest.cpp
@@ -543,6 +543,38 @@ TEST(PathSearchTest, elongatedDiamond) {
               ::testing::UnorderedElementsAreArray(expected));
 }
 
+TEST(PathSearchTest, numPathsPerTarget) {
+  auto sub =
+      makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 4}, {3, 4}, {4, 5}});
+  auto expected = makeIdTableFromVector({
+      {V(0), V(1), I(0), I(0)},
+      {V(1), V(3), I(0), I(1)},
+      {V(3), V(4), I(0), I(2)},
+      {V(0), V(1), I(1), I(0)},
+      {V(1), V(3), I(1), I(1)},
+      {V(3), V(4), I(1), I(2)},
+      {V(4), V(5), I(1), I(3)},
+  });
+
+  std::vector<Id> sources{V(0)};
+  std::vector<Id> targets{V(4), V(5)};
+  Vars vars = {Variable{"?start"}, Variable{"?end"}};
+  PathSearchConfiguration config{PathSearchAlgorithm::ALL_PATHS,
+                                 sources,
+                                 targets,
+                                 Var{"?start"},
+                                 Var{"?end"},
+                                 Var{"?edgeIndex"},
+                                 Var{"?pathIndex"},
+                                 {},
+                                 true,
+                                 1};
+
+  auto resultTable = performPathSearch(config, std::move(sub), vars);
+  ASSERT_THAT(resultTable.idTable(),
+              ::testing::UnorderedElementsAreArray(expected));
+}
+
 /**
  * Graph:
  *  0       4

--- a/test/PathSearchTest.cpp
+++ b/test/PathSearchTest.cpp
@@ -543,6 +543,7 @@ TEST(PathSearchTest, elongatedDiamond) {
               ::testing::UnorderedElementsAreArray(expected));
 }
 
+// _____________________________________________________________________________
 TEST(PathSearchTest, numPathsPerTarget) {
   auto sub =
       makeIdTableFromVector({{0, 1}, {1, 2}, {1, 3}, {2, 4}, {3, 4}, {4, 5}});

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -1522,6 +1522,86 @@ TEST(QueryPlanner, PathSearchUnsupportedAlgorithm) {
       parsedQuery::PathSearchException);
 }
 
+// __________________________________________________________________________
+TEST(QueryPlanner, PathSearchWrongArgumentCartesian) {
+  auto qec = ad_utility::testing::getQec("<x> <p> <y>. <y> <p> <z>");
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+
+  auto query =
+      "PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>"
+      "SELECT ?start ?end ?path ?edge WHERE {"
+      "SERVICE pathSearch: {"
+      "_:path pathSearch:algorithm pathSearch:allPaths ;"
+      "pathSearch:source ?source1 ;"
+      "pathSearch:source ?source2 ;"
+      "pathSearch:target <z> ;"
+      "pathSearch:pathColumn ?path ;"
+      "pathSearch:edgeColumn ?edge ;"
+      "pathSearch:start ?start;"
+      "pathSearch:end ?end;"
+      "pathSearch:cartesian <false>;"
+      "{SELECT * WHERE {"
+      "?start <p> ?end."
+      "}}}}";
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      h::parseAndPlan(std::move(query), qec),
+      HasSubstr("The parameter 'cartesian' expects a boolean"),
+      parsedQuery::PathSearchException);
+}
+
+// __________________________________________________________________________
+TEST(QueryPlanner, PathSearchWrongArgumentNumPathsPerTarget) {
+  auto qec = ad_utility::testing::getQec("<x> <p> <y>. <y> <p> <z>");
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+
+  auto query =
+      "PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>"
+      "SELECT ?start ?end ?path ?edge WHERE {"
+      "SERVICE pathSearch: {"
+      "_:path pathSearch:algorithm pathSearch:allPaths ;"
+      "pathSearch:source ?source1 ;"
+      "pathSearch:source ?source2 ;"
+      "pathSearch:target <z> ;"
+      "pathSearch:pathColumn ?path ;"
+      "pathSearch:edgeColumn ?edge ;"
+      "pathSearch:start ?start;"
+      "pathSearch:end ?end;"
+      "pathSearch:numPathsPerTarget <five>;"
+      "{SELECT * WHERE {"
+      "?start <p> ?end."
+      "}}}}";
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      h::parseAndPlan(std::move(query), qec),
+      HasSubstr("The parameter 'numPathsPerTarget' expects an integer"),
+      parsedQuery::PathSearchException);
+}
+
+// __________________________________________________________________________
+TEST(QueryPlanner, PathSearchWrongArgumentAlgorithm) {
+  auto qec = ad_utility::testing::getQec("<x> <p> <y>. <y> <p> <z>");
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+
+  auto query =
+      "PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>"
+      "SELECT ?start ?end ?path ?edge WHERE {"
+      "SERVICE pathSearch: {"
+      "_:path pathSearch:algorithm 1 ;"
+      "pathSearch:source ?source1 ;"
+      "pathSearch:source ?source2 ;"
+      "pathSearch:target <z> ;"
+      "pathSearch:pathColumn ?path ;"
+      "pathSearch:edgeColumn ?edge ;"
+      "pathSearch:start ?start;"
+      "pathSearch:end ?end;"
+      "{SELECT * WHERE {"
+      "?start <p> ?end."
+      "}}}}";
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      h::parseAndPlan(std::move(query), qec),
+      HasSubstr("The 'algorithm' value has to be an Iri"),
+      parsedQuery::PathSearchException);
+}
+
 TEST(QueryPlanner, SpatialJoinViaMaxDistPredicate) {
   auto scan = h::IndexScanFromStrings;
   h::expect(

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -920,6 +920,7 @@ TEST(QueryPlanner, PathSearchMultipleSourcesAndTargetsCartesian) {
       "}}}}",
       h::PathSearch(config, true, true, scan("?start", "<p>", "?end")), qec);
 }
+
 TEST(QueryPlanner, PathSearchMultipleSourcesAndTargetsNonCartesian) {
   auto scan = h::IndexScanFromStrings;
   auto qec =
@@ -951,6 +952,44 @@ TEST(QueryPlanner, PathSearchMultipleSourcesAndTargetsNonCartesian) {
       "pathSearch:start ?start;"
       "pathSearch:end ?end;"
       "pathSearch:cartesian false;"
+      "{SELECT * WHERE {"
+      "?start <p> ?end."
+      "}}}}",
+      h::PathSearch(config, true, true, scan("?start", "<p>", "?end")), qec);
+}
+
+TEST(QueryPlanner, numPathsPerTarget) {
+  auto scan = h::IndexScanFromStrings;
+  auto qec =
+      ad_utility::testing::getQec("<x1> <p> <y>. <x2> <p> <y>. <y> <p> <z>");
+  auto getId = ad_utility::testing::makeGetId(qec->getIndex());
+
+  std::vector<Id> sources{getId("<x1>"), getId("<x2>")};
+  std::vector<Id> targets{getId("<y>"), getId("<z>")};
+  PathSearchConfiguration config{PathSearchAlgorithm::ALL_PATHS,
+                                 sources,
+                                 targets,
+                                 Variable("?start"),
+                                 Variable("?end"),
+                                 Variable("?path"),
+                                 Variable("?edge"),
+                                 {},
+                                 true,
+                                 1};
+  h::expect(
+      "PREFIX pathSearch: <https://qlever.cs.uni-freiburg.de/pathSearch/>"
+      "SELECT ?start ?end ?path ?edge WHERE {"
+      "SERVICE pathSearch: {"
+      "_:path pathSearch:algorithm pathSearch:allPaths ;"
+      "pathSearch:source <x1> ;"
+      "pathSearch:source <x2> ;"
+      "pathSearch:target <y> ;"
+      "pathSearch:target <z> ;"
+      "pathSearch:pathColumn ?path ;"
+      "pathSearch:edgeColumn ?edge ;"
+      "pathSearch:start ?start;"
+      "pathSearch:end ?end;"
+      "pathSearch:numPathsPerTarget 1;"
       "{SELECT * WHERE {"
       "?start <p> ?end."
       "}}}}",

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -958,6 +958,7 @@ TEST(QueryPlanner, PathSearchMultipleSourcesAndTargetsNonCartesian) {
       h::PathSearch(config, true, true, scan("?start", "<p>", "?end")), qec);
 }
 
+// _____________________________________________________________________________
 TEST(QueryPlanner, numPathsPerTarget) {
   auto scan = h::IndexScanFromStrings;
   auto qec =


### PR DESCRIPTION
When this parameter is set, the `PathSearch` service limits the number of paths per `[source, target]` pair. This makes it possible to use the path search for cases where enumerating all paths would exhaust the available time and memory constraints.