### PR TITLE
Simplify the `CartesianProductJoin` class

### DIFF
--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -124,10 +124,6 @@ void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
 // ____________________________________________________________________________
 ProtoResult CartesianProductJoin::computeResult(
     [[maybe_unused]] bool requestLaziness) {
-  if (knownEmptyResult()) {
-    return {IdTable{getResultWidth(), getExecutionContext()->getAllocator()},
-            resultSortedOn(), LocalVocab{}};
-  }
   std::vector<std::shared_ptr<const Result>> subResults = calculateSubResults();
 
   IdTable result = writeAllColumns(subResults);

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -86,4 +86,11 @@ class CartesianProductJoin : public Operation {
   void writeResultColumn(std::span<Id> targetColumn,
                          std::span<const Id> inputColumn, size_t groupSize,
                          size_t offset) const;
+
+  // Write all columns of the subresults into an `IdTable` and return it.
+  IdTable writeAllColumns(
+      const std::vector<std::shared_ptr<const Result>>& subResults) const;
+
+  // Calculate the subresults of the children and store them into a vector.
+  std::vector<std::shared_ptr<const Result>> calculateSubResults();
 };

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -82,11 +82,8 @@ class CartesianProductJoin : public Operation {
   // Copy each element from the `inputColumn` `groupSize` times to the
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip
   // the first `offset` write operations to the `targetColumn`. Call
-  // `checkCancellation` after each write. If `StaticGroupSize != 0`, then the
-  // group size is known at compile time which allows for more efficient loop
-  // processing for very small group sizes.
-  template <size_t StaticGroupSize = 0>
+  // `checkCancellation` after each write.
   void writeResultColumn(std::span<Id> targetColumn,
                          std::span<const Id> inputColumn, size_t groupSize,
-                         size_t offset);
+                         size_t offset) const;
 };


### PR DESCRIPTION
Refactor some rather large functions into smaller ones. This will make the lazy implementation of this class much simpler to implement and to review.