### PR TITLE
Docker build no tests for ARM

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,6 +38,7 @@ jobs:
         run: echo "pr_num=$(git log --format=%s -n 1 | sed -nr 's/.*\(\#([0-9]+)\)/\1/p')" >> $GITHUB_OUTPUT
       - name: Build X-86-64
         uses: docker/build-push-action@v6
+        if: false
         with:
           context: .
           # Docker multiplatform images require an entry in their manifests. If this
@@ -56,6 +57,7 @@ jobs:
           tags: adfreiburg/qlever:test
 
       - name: E2E in Docker
+        if: false
         run: | 
           sudo mkdir ${{github.workspace}}/e2e_data
           sudo chmod a+rwx ${{github.workspace}}/e2e_data

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,7 +38,6 @@ jobs:
         run: echo "pr_num=$(git log --format=%s -n 1 | sed -nr 's/.*\(\#([0-9]+)\)/\1/p')" >> $GITHUB_OUTPUT
       - name: Build X-86-64
         uses: docker/build-push-action@v6
-        if: false
         with:
           context: .
           # Docker multiplatform images require an entry in their manifests. If this
@@ -57,7 +56,6 @@ jobs:
           tags: adfreiburg/qlever:test
 
       - name: E2E in Docker
-        if: false
         run: | 
           sudo mkdir ${{github.workspace}}/e2e_data
           sudo chmod a+rwx ${{github.workspace}}/e2e_data
@@ -70,8 +68,7 @@ jobs:
         # future, then we can set this to `true`. Then the ARM64 image will also
         # be built on pull requests which allows for debugging without changing
         # the master branch.
-        #if: false
-        #if: true
+        if: false
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,7 +68,8 @@ jobs:
         # future, then we can set this to `true`. Then the ARM64 image will also
         # be built on pull requests which allows for debugging without changing
         # the master branch.
-        if: false
+        #if: false
+        #if: true
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:22.04 as base
+ARG TARGETPLATFORM
 LABEL maintainer="Johannes Kalmbach <kalmbacj@informatik.uni-freiburg.de>"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "Building for platform ->$TARGETPLATFORM<-"
+RUN if [[ $TARGETPLATFORM -eq "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y software-properties-common wget && add-apt-repository -y ppa:mhier/libboost-latest
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh &&./kitware-archive.sh
 
@@ -19,7 +22,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if ["$TARGETPLATFORM" = "linux/arm64"] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
+RUN if [[ $TARGETPLATFORM -eq "linux/arm64"] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
 RUN ctest --rerun-failed --output-on-failure
 
 FROM base as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,15 @@ ENV LC_ALL C.UTF-8
 ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if [[ $TARGETPLATFORM -eq "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y software-properties-common wget && add-apt-repository -y ppa:mhier/libboost-latest
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh &&./kitware-archive.sh
 
 FROM base as builder
 ARG TARGETPLATFORM
+RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev
-
+RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 COPY . /app/
 
 WORKDIR /app/
@@ -22,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if [[ $TARGETPLATFORM -eq "linux/arm64"] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
+RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
 RUN ctest --rerun-failed --output-on-failure
 
 FROM base as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
 # When cross-compiling the container for ARM64, then compiling and running all tests runs into a timeout on GitHub actions,
 # so we disable tests for this platform.
-# TODO(joka921) reenable these tests as soon as we can use a native ARM64 platform to compile the docker container.
+# TODO(joka921) re-enable these tests as soon as we can use a native ARM64 platform to compile the docker container.
 RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM64, don't build tests to avoid timeout"; fi
 RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
-RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then ctest --rerun-failed --output-on-failure ; fi
+RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "Skipping tests for ARM64" ; else ctest --rerun-failed --output-on-failure ; fi
 
 FROM base as runtime
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y software-properties-common wget && add-
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh &&./kitware-archive.sh
 
 FROM base as builder
+ARG TARGETPLATFORM
 RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev
 
 COPY . /app/
@@ -16,7 +17,9 @@ WORKDIR /app/
 ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja .. && ninja
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
+RUN echo "Building for platform ->$TARGETPLATFORM<-"
+RUN if ["$TARGETPLATFORM" = "linux/arm64"] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
 RUN ctest --rerun-failed --output-on-failure
 
 FROM base as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,15 @@ ENV LC_ALL C.UTF-8
 ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if  [ $TARGETPLATFORM = "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y software-properties-common wget && add-apt-repository -y ppa:mhier/libboost-latest
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh &&./kitware-archive.sh
 
 FROM base as builder
 ARG TARGETPLATFORM
-RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if  [ $TARGETPLATFORM = "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev
-RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if  [ $TARGETPLATFORM = "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 COPY . /app/
 
 WORKDIR /app/
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if [[ $TARGETPLATFORM -eq "linux/arm64"]] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
+RUN if [ $TARGETPLATFORM = "linux/arm64"] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
 RUN ctest --rerun-failed --output-on-failure
 
 FROM base as runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,15 @@
 FROM ubuntu:22.04 as base
-ARG TARGETPLATFORM
 LABEL maintainer="Johannes Kalmbach <kalmbacj@informatik.uni-freiburg.de>"
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
-RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y software-properties-common wget && add-apt-repository -y ppa:mhier/libboost-latest
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh &&./kitware-archive.sh
 
 FROM base as builder
 ARG TARGETPLATFORM
-RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev
-RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 COPY . /app/
 
 WORKDIR /app/
@@ -22,9 +17,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
-RUN echo "Building for platform ->$TARGETPLATFORM<-"
+# When cross-compiling the container for ARM64, then compiling and running all tests runs into a timeout on GitHub actions,
+# so we disable tests for this platform.
+# TODO(joka921) reenable these tests as soon as we can use a native ARM64 platform to compile the docker container.
+RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM64, don't build tests to avoid timeout"; fi
 RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
-RUN ctest --rerun-failed --output-on-failure
+RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then ctest --rerun-failed --output-on-failure ; fi
 
 FROM base as runtime
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,15 @@ ENV LC_ALL C.UTF-8
 ENV LC_CTYPE C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if  [ $TARGETPLATFORM = "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y software-properties-common wget && add-apt-repository -y ppa:mhier/libboost-latest
 RUN wget https://apt.kitware.com/kitware-archive.sh && chmod +x kitware-archive.sh &&./kitware-archive.sh
 
 FROM base as builder
 ARG TARGETPLATFORM
-RUN if  [ $TARGETPLATFORM = "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 RUN apt-get update && apt-get install -y build-essential cmake libicu-dev tzdata pkg-config uuid-runtime uuid-dev git libjemalloc-dev ninja-build libzstd-dev libssl-dev libboost1.81-dev libboost-program-options1.81-dev libboost-iostreams1.81-dev libboost-url1.81-dev
-RUN if  [ $TARGETPLATFORM = "linux/arm64"] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
+RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM"; else echo "target is not ARM, probably AMD64"; fi
 COPY . /app/
 
 WORKDIR /app/
@@ -23,7 +23,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app/build/
 RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
 RUN echo "Building for platform ->$TARGETPLATFORM<-"
-RUN if [ $TARGETPLATFORM = "linux/arm64"] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
+RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
 RUN ctest --rerun-failed --output-on-failure
 
 FROM base as runtime


### PR DESCRIPTION
The cross-compilatiion currently takes more than 6 hours and is then cancelled by GitHub actions.
We thus disable the building and execution of unit tests for the ARM64 build.