### PR TITLE
Add `DeltaTriplesManager`

### DIFF
--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -165,9 +165,10 @@ void CountAvailablePredicates::computePatternTrickAllEntities(
           TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE), std::nullopt,
           std::nullopt}
           .toScanSpecification(index);
-  auto fullHasPattern = index.getPermutation(Permutation::Enum::PSO)
-                            .lazyScan(scanSpec, std::nullopt, {},
-                                      cancellationHandle_, deltaTriples());
+  auto fullHasPattern =
+      index.getPermutation(Permutation::Enum::PSO)
+          .lazyScan(scanSpec, std::nullopt, {}, cancellationHandle_,
+                    locatedTriplesSnapshot());
   for (const auto& idTable : fullHasPattern) {
     for (const auto& patternId : idTable.getColumn(1)) {
       AD_CORRECTNESS_CHECK(patternId.getDatatype() == Datatype::Int);

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -665,7 +665,7 @@ std::optional<IdTable> GroupBy::computeGroupByObjectWithCount() const {
       getExecutionContext()->getIndex().getPimpl().getPermutation(
           indexScan->permutation());
   auto result = permutation.getDistinctCol1IdsAndCounts(
-      col0Id.value(), cancellationHandle_, deltaTriples());
+      col0Id.value(), cancellationHandle_, locatedTriplesSnapshot());
   indexScan->updateRuntimeInformationWhenOptimizedOut(
       {}, RuntimeInformation::Status::optimizedOut);
 
@@ -717,8 +717,8 @@ std::optional<IdTable> GroupBy::computeGroupByForFullIndexScan() const {
   const auto& permutation =
       getExecutionContext()->getIndex().getPimpl().getPermutation(
           permutationEnum.value());
-  auto table = permutation.getDistinctCol0IdsAndCounts(cancellationHandle_,
-                                                       deltaTriples());
+  auto table = permutation.getDistinctCol0IdsAndCounts(
+      cancellationHandle_, locatedTriplesSnapshot());
   if (numCounts == 0) {
     table.setColumnSubset({{0}});
   }
@@ -840,7 +840,7 @@ std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() const {
   Id currentId = subresult->idTable()(0, columnIndex);
   size_t currentCount = 0;
   size_t currentCardinality =
-      index.getCardinality(currentId, permutation, deltaTriples());
+      index.getCardinality(currentId, permutation, locatedTriplesSnapshot());
 
   auto pushRow = [&]() {
     // If the count is 0 this means that the element with the `currentId`
@@ -863,7 +863,7 @@ std::optional<IdTable> GroupBy::computeGroupByForJoinWithFullScan() const {
       // without the internally added triples, but that is not easy to
       // retrieve right now.
       currentCardinality =
-          index.getCardinality(id, permutation, deltaTriples());
+          index.getCardinality(id, permutation, locatedTriplesSnapshot());
     }
     currentCount += currentCardinality;
   }

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -267,9 +267,10 @@ ProtoResult HasPredicateScan::computeResult(
           TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE), std::nullopt,
           std::nullopt}
           .toScanSpecification(index);
-  auto hasPattern = index.getPermutation(Permutation::Enum::PSO)
-                        .lazyScan(scanSpec, std::nullopt, {},
-                                  cancellationHandle_, deltaTriples());
+  auto hasPattern =
+      index.getPermutation(Permutation::Enum::PSO)
+          .lazyScan(scanSpec, std::nullopt, {}, cancellationHandle_,
+                    locatedTriplesSnapshot());
 
   auto getId = [this](const TripleComponent tc) {
     std::optional<Id> id = tc.toValueId(getIndex().getVocab());
@@ -339,9 +340,9 @@ void HasPredicateScan::computeFreeO(
           TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE), subjectAsId,
           std::nullopt}
           .toScanSpecification(index);
-  auto hasPattern =
-      index.getPermutation(Permutation::Enum::PSO)
-          .scan(std::move(scanSpec), {}, cancellationHandle_, deltaTriples());
+  auto hasPattern = index.getPermutation(Permutation::Enum::PSO)
+                        .scan(std::move(scanSpec), {}, cancellationHandle_,
+                              locatedTriplesSnapshot());
   AD_CORRECTNESS_CHECK(hasPattern.numRows() <= 1);
   for (Id patternId : hasPattern.getColumn(0)) {
     const auto& pattern = patterns[patternId.getInt()];

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -162,7 +162,7 @@ ProtoResult IndexScan::computeResult(bool requestLaziness) {
   const auto& index = _executionContext->getIndex();
   idTable =
       index.scan(getScanSpecification(), permutation_, additionalColumns(),
-                 cancellationHandle_, deltaTriples(), getLimit());
+                 cancellationHandle_, locatedTriplesSnapshot(), getLimit());
   AD_CORRECTNESS_CHECK(idTable.numColumns() == getResultWidth());
   LOG(DEBUG) << "IndexScan result computation done.\n";
   checkCancellation();
@@ -174,7 +174,7 @@ ProtoResult IndexScan::computeResult(bool requestLaziness) {
 size_t IndexScan::computeSizeEstimate() const {
   AD_CORRECTNESS_CHECK(_executionContext);
   return getIndex().getResultSizeOfScan(getScanSpecification(), permutation_,
-                                        deltaTriples());
+                                        locatedTriplesSnapshot());
 }
 
 // _____________________________________________________________________________
@@ -195,7 +195,7 @@ void IndexScan::determineMultiplicities() {
       return {1.0f};
     } else if (numVariables_ == 2) {
       return idx.getMultiplicities(*getPermutedTriple()[0], permutation_,
-                                   deltaTriples());
+                                   locatedTriplesSnapshot());
     } else {
       AD_CORRECTNESS_CHECK(numVariables_ == 3);
       return idx.getMultiplicities(permutation_);
@@ -245,8 +245,8 @@ Permutation::IdTableGenerator IndexScan::getLazyScan(
       .getImpl()
       .getPermutation(permutation())
       .lazyScan(getScanSpecification(), std::move(actualBlocks),
-                additionalColumns(), cancellationHandle_, deltaTriples(),
-                getLimit());
+                additionalColumns(), cancellationHandle_,
+                locatedTriplesSnapshot(), getLimit());
 };
 
 // ________________________________________________________________
@@ -254,7 +254,7 @@ std::optional<Permutation::MetadataAndBlocks> IndexScan::getMetadataForScan()
     const {
   const auto& index = getExecutionContext()->getIndex().getImpl();
   return index.getPermutation(permutation())
-      .getMetadataAndBlocks(getScanSpecification(), deltaTriples());
+      .getMetadataAndBlocks(getScanSpecification(), locatedTriplesSnapshot());
 };
 
 // ________________________________________________________________

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -69,7 +69,9 @@ class Operation {
 
   const Index& getIndex() const { return _executionContext->getIndex(); }
 
-  const auto& deltaTriples() const { return _executionContext->deltaTriples(); }
+  const auto& locatedTriplesSnapshot() const {
+    return _executionContext->locatedTriplesSnapshot();
+  }
 
   // Get a unique, not ambiguous string representation for a subtree.
   // This should act like an ID for each subtree.

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -69,9 +69,7 @@ class Operation {
 
   const Index& getIndex() const { return _executionContext->getIndex(); }
 
-  const DeltaTriples& deltaTriples() const {
-    return _executionContext->deltaTriples();
-  }
+  const auto& deltaTriples() const { return _executionContext->deltaTriples(); }
 
   // Get a unique, not ambiguous string representation for a subtree.
   // This should act like an ID for each subtree.

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -92,10 +92,9 @@ class QueryExecutionContext {
 
   [[nodiscard]] const Index& getIndex() const { return _index; }
 
-  // TODO<joka921> Don't return the pointer, but simply a reference.
-  const LocatedTriplesPerBlockPtr& deltaTriples() const {
-    AD_CORRECTNESS_CHECK(deltaTriples_ != nullptr);
-    return deltaTriples_;
+  const LocatedTriplesSnapshot& locatedTriplesSnapshot() const {
+    AD_CORRECTNESS_CHECK(sharedLocatedTriplesSnapshot != nullptr);
+    return *sharedLocatedTriplesSnapshot;
   }
 
   void clearCacheUnpinnedOnly() { getQueryTreeCache().clearUnpinnedOnly(); }
@@ -129,8 +128,8 @@ class QueryExecutionContext {
   const Index& _index;
   // TODO<joka921> This has to be stored externally once we properly support
   // SPARQL UPDATE, currently it is just a stub to make the interface work.
-  LocatedTriplesPerBlockPtr deltaTriples_{
-      _index.deltaTriplesManager().getLocatedTriples()};
+  SharedLocatedTriplesSnapshot sharedLocatedTriplesSnapshot{
+      _index.deltaTriplesManager().getSnapshot()};
   QueryResultCache* const _subtreeCache;
   // allocators are copied but hold shared state
   ad_utility::AllocatorWithLimit<Id> _allocator;

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -92,8 +92,8 @@ class QueryExecutionContext {
   [[nodiscard]] const Index& getIndex() const { return _index; }
 
   const LocatedTriplesSnapshot& locatedTriplesSnapshot() const {
-    AD_CORRECTNESS_CHECK(sharedLocatedTriplesSnapshot != nullptr);
-    return *sharedLocatedTriplesSnapshot;
+    AD_CORRECTNESS_CHECK(sharedLocatedTriplesSnapshot_ != nullptr);
+    return *sharedLocatedTriplesSnapshot_;
   }
 
   void clearCacheUnpinnedOnly() { getQueryTreeCache().clearUnpinnedOnly(); }
@@ -130,7 +130,7 @@ class QueryExecutionContext {
   // snapshot of the current (located) delta triples. These can then be used
   // by the respective query without interfering with further incoming
   // update operations.
-  SharedLocatedTriplesSnapshot sharedLocatedTriplesSnapshot{
+  SharedLocatedTriplesSnapshot sharedLocatedTriplesSnapshot_{
       _index.deltaTriplesManager().getCurrentSnapshot()};
   QueryResultCache* const _subtreeCache;
   // allocators are copied but hold shared state

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -126,10 +126,12 @@ class QueryExecutionContext {
 
  private:
   const Index& _index;
-  // TODO<joka921> This has to be stored externally once we properly support
-  // SPARQL UPDATE, currently it is just a stub to make the interface work.
+
+  // When the `QueryExecutionContext` is constructed, get a stable snapshot of
+  // the current UPDATE status from the `DeltaTriplesManager`, which can then by
+  // used by the query without interfering with concurrent UPDATEs.
   SharedLocatedTriplesSnapshot sharedLocatedTriplesSnapshot{
-      _index.deltaTriplesManager().getSnapshot()};
+      _index.deltaTriplesManager().getCurrentSnapshot()};
   QueryResultCache* const _subtreeCache;
   // allocators are copied but hold shared state
   ad_utility::AllocatorWithLimit<Id> _allocator;

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -1,8 +1,7 @@
-// Copyright 2011, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author:
-//   2011-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+// Copyright 2011 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de> [2011 - 2017]
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de> [2017 - 2024]
 
 #pragma once
 
@@ -127,9 +126,10 @@ class QueryExecutionContext {
  private:
   const Index& _index;
 
-  // When the `QueryExecutionContext` is constructed, get a stable snapshot of
-  // the current UPDATE status from the `DeltaTriplesManager`, which can then by
-  // used by the query without interfering with concurrent UPDATEs.
+  // When the `QueryExecutionContext` is constructed, get a stable read-only
+  // snapshot of the current (located) delta triples. These can then be used
+  // by the respective query without interfering with further incoming
+  // update operations.
   SharedLocatedTriplesSnapshot sharedLocatedTriplesSnapshot{
       _index.deltaTriplesManager().getCurrentSnapshot()};
   QueryResultCache* const _subtreeCache;

--- a/src/engine/QueryExecutionContext.h
+++ b/src/engine/QueryExecutionContext.h
@@ -92,7 +92,11 @@ class QueryExecutionContext {
 
   [[nodiscard]] const Index& getIndex() const { return _index; }
 
-  const DeltaTriples& deltaTriples() const { return *deltaTriples_; }
+  // TODO<joka921> Don't return the pointer, but simply a reference.
+  const LocatedTriplesPerBlockPtr& deltaTriples() const {
+    AD_CORRECTNESS_CHECK(deltaTriples_ != nullptr);
+    return deltaTriples_;
+  }
 
   void clearCacheUnpinnedOnly() { getQueryTreeCache().clearUnpinnedOnly(); }
 
@@ -125,8 +129,8 @@ class QueryExecutionContext {
   const Index& _index;
   // TODO<joka921> This has to be stored externally once we properly support
   // SPARQL UPDATE, currently it is just a stub to make the interface work.
-  std::shared_ptr<DeltaTriples> deltaTriples_{
-      std::make_shared<DeltaTriples>(_index)};
+  LocatedTriplesPerBlockPtr deltaTriples_{
+      _index.deltaTriplesManager().getLocatedTriples()};
   QueryResultCache* const _subtreeCache;
   // allocators are copied but hold shared state
   ad_utility::AllocatorWithLimit<Id> _allocator;

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -1,8 +1,7 @@
-// Copyright 2015, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author:
-//   2015-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+// Copyright 2015 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de> [2015 - 2017]
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de> [2017 - 2024]
 
 #include "./QueryExecutionTree.h"
 

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -1,6 +1,8 @@
-// Copyright 2015, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+// Copyright 2015 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
 #pragma once
 
 #include <memory>

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -1,8 +1,8 @@
 // Copyright 2023 - 2024, University of Freiburg
-//  Chair of Algorithms and Data Structures.
-//  Authors:
-//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
-//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Chair of Algorithms and Data Structures
+// Authors: Hannah Bast <bast@cs.uni-freiburg.de>
+//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #include "index/DeltaTriples.h"
 
@@ -179,8 +179,9 @@ LocatedTriplesSnapshot::getLocatedTriplesForPermutation(
 
 // ____________________________________________________________________________
 SharedLocatedTriplesSnapshot DeltaTriples::getSnapshot() const {
-  // Note: Semantically, both the members are copied, but the `localVocab_` has
-  // no explicit copy constructor, hence the explicit `clone`.
+  // NOTE: Both members of the `LocatedTriplesSnapshot` are copied, but the
+  // `localVocab_` has no copy constructor (in order to avoid accidental
+  // copies), hence the explicit `clone`.
   return SharedLocatedTriplesSnapshot{std::make_shared<LocatedTriplesSnapshot>(
       locatedTriples(), localVocab_.clone())};
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -196,7 +196,8 @@ DeltaTriplesManager::DeltaTriplesManager(const IndexImpl& index)
       currentLocatedTriplesSnapshot_{deltaTriples_.rlock()->getSnapshot()} {}
 
 // _____________________________________________________________________________
-void DeltaTriplesManager::modify(std::function<void(DeltaTriples&)> function) {
+void DeltaTriplesManager::modify(
+    const std::function<void(DeltaTriples&)>& function) {
   // While holding the lock for the underlying `DeltaTriples`, perform the
   // actual `function` (typically some combination of insert and delete
   // operations) and (while still holding the lock) update the

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -178,7 +178,7 @@ const LocatedTriplesPerBlock& LocatedTriplesSnapshot::getLocatedTriplesPerBlock(
 }
 
 // ____________________________________________________________________________
-std::shared_ptr<LocatedTriplesSnapshot> DeltaTriples::copySnapshot() const {
+SharedLocatedTriplesSnapshot DeltaTriples::copySnapshot() const {
   return std::make_shared<LocatedTriplesSnapshot>(locatedTriplesPerBlock(),
                                                   localVocab_.clone());
 }
@@ -200,7 +200,7 @@ void DeltaTriplesManager::modify(std::function<void(DeltaTriples&)> function) {
   deltaTriples_.withWriteLock([this, &function](DeltaTriples& deltaTriples) {
     function(deltaTriples);
     currentLocatedTriplesSnapshot_.withWriteLock([&deltaTriples](auto& ptr) {
-      ptr = SharedLocatedTriplesSnapshot{deltaTriples.copySnapshot()};
+      ptr = deltaTriples.copySnapshot();
     });
   });
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -40,7 +40,8 @@ DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
         cancellationHandle);
     cancellationHandle->throwIfCancelled();
     intermediateHandles[static_cast<size_t>(permutation)] =
-        locatedTriples()[static_cast<size_t>(permutation)].add(locatedTriples);
+        this->locatedTriples()[static_cast<size_t>(permutation)].add(
+            locatedTriples);
     cancellationHandle->throwIfCancelled();
   }
   std::vector<DeltaTriples::LocatedTripleHandles> handles{idTriples.size()};

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -21,7 +21,7 @@ LocatedTriples::iterator& DeltaTriples::LocatedTripleHandles::forPermutation(
 void DeltaTriples::clear() {
   triplesInserted_.clear();
   triplesDeleted_.clear();
-  std::ranges::for_each(locatedTriplesPerBlock_,
+  std::ranges::for_each(locatedTriplesPerBlock(),
                         &LocatedTriplesPerBlock::clear);
 }
 
@@ -41,7 +41,7 @@ DeltaTriples::locateAndAddTriples(CancellationHandle cancellationHandle,
         cancellationHandle);
     cancellationHandle->throwIfCancelled();
     intermediateHandles[static_cast<size_t>(permutation)] =
-        locatedTriplesPerBlock_[static_cast<size_t>(permutation)].add(
+        locatedTriplesPerBlock()[static_cast<size_t>(permutation)].add(
             locatedTriples);
     cancellationHandle->throwIfCancelled();
   }
@@ -60,7 +60,7 @@ void DeltaTriples::eraseTripleInAllPermutations(LocatedTripleHandles& handles) {
   // Erase for all permutations.
   for (auto permutation : Permutation::ALL) {
     auto ltIter = handles.forPermutation(permutation);
-    locatedTriplesPerBlock_[static_cast<int>(permutation)].erase(
+    locatedTriplesPerBlock()[static_cast<int>(permutation)].erase(
         ltIter->blockIndex_, ltIter);
   }
 }
@@ -174,5 +174,10 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
 // ____________________________________________________________________________
 const LocatedTriplesPerBlock& DeltaTriples::getLocatedTriplesPerBlock(
     Permutation::Enum permutation) const {
-  return locatedTriplesPerBlock_[static_cast<int>(permutation)];
+  return locatedTriplesPerBlock()[static_cast<int>(permutation)];
+}
+
+// ____________________________________________________________________________
+std::shared_ptr<DeltaTriples::LocatedTriplesAndLocalVocab> DeltaTriples::copyContent() const {
+  return std::make_shared<LocatedTriplesAndLocalVocab>(locatedTriplesPerBlock(), localVocab_.clone());
 }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -214,9 +214,9 @@ void DeltaTriplesManager::deleteTriples(
 template <typename Function>
 void DeltaTriplesManager::insertOrDeleteImpl(
     CancellationHandle cancellationHandle, Triples triples, Function function) {
-  // While holding the lock for the underlying `DeltaTriples`, perform the actual
-  // update (insert or delete) and (while still holding the lock) update the
-  // `currentLocatedTriplesPerBlock`.
+  // While holding the lock for the underlying `DeltaTriples`, perform the
+  // actual update (insert or delete) and (while still holding the lock) update
+  // the `currentLocatedTriplesPerBlock`.
   deltaTriples_.withWriteLock([this, &cancellationHandle, &triples,
                                &function](DeltaTriples& deltaTriples) {
     std::invoke(function, deltaTriples, std::move(cancellationHandle),

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -198,7 +198,7 @@ class DeltaTriplesManager {
   // the current snapshot. Concurrent calls to `modify` will be serialized, and
   // each call to `getCurrentSnapshot` will either return the snapshot before or
   // after a modification, but never one of an ongoing modification.
-  void modify(std::function<void(DeltaTriples&)> function);
+  void modify(const std::function<void(DeltaTriples&)>& function);
 
   // Return a shared pointer to a deep copy of the current snapshot. This can
   // be safely used to execute a query without interfering with future updates.

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -14,10 +14,10 @@
 #include "index/Permutation.h"
 #include "util/Synchronized.h"
 
-// The positions of the delta triples (triples that were inserted or deleted
-// since the index was built) in each of the six permutations, and the local
-// vocab. This is all the information that is required to perform a query that
-// correctly respects the delta triples, hence the name.
+// The locations of a set of delta triples (triples that were inserted or
+// deleted since the index was built) in each of the six permutations, and a
+// local vocab. This is all the information that is required to perform a query
+// that correctly respects these delta triples, hence the name.
 class LocatedTriplesSnapshot {
  private:
   std::array<LocatedTriplesPerBlock, Permutation::ALL.size()>
@@ -60,7 +60,6 @@ class DeltaTriples {
 
  public:
   using LocatedTriplesPerBlockPtr = std::shared_ptr<LocatedTriplesSnapshot>;
-
   using Triples = std::vector<IdTriple<0>>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
 

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -1,8 +1,8 @@
 // Copyright 2023 - 2024, University of Freiburg
-//  Chair of Algorithms and Data Structures.
-//  Authors:
-//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
-//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Chair of Algorithms and Data Structures
+// Authors: Hannah Bast <bast@cs.uni-freiburg.de>
+//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #pragma once
 
@@ -31,8 +31,8 @@ struct LocatedTriplesSnapshot {
       Permutation::Enum permutation) const;
 };
 
-// A `shared_ptr` to a const `LocatedTriplesSnapshot`, but as an explicit class,
-// s.t. it can be forward-declared.
+// A shared pointer to a constant `LocatedTriplesSnapshot`, but as an explicit
+// class, such that it can be forward-declared.
 class SharedLocatedTriplesSnapshot
     : public std::shared_ptr<const LocatedTriplesSnapshot> {};
 
@@ -194,21 +194,13 @@ class DeltaTriplesManager {
   explicit DeltaTriplesManager(const IndexImpl& index);
   FRIEND_TEST(DeltaTriplesTest, DeltaTriplesManager);
 
-  // Modify the underlying `DeltaTriples` by applying the `function` to them.
-  // Then update the current snapshot, s.t. subsequent calls to
-  // `getCurrentSnapshot` will observe the modifications. All this is done in a
-  // thread-safe way, meaning that there can be only one call to `modify` at the
-  // same time.
+  // Modify the underlying `DeltaTriples` by applying `function` and then update
+  // the current snapshot. Concurrent calls to `modify` will be serialized, and
+  // each call to `getCurrentSnapshot` will either return the snapshot before or
+  // after a modification, but never one of an ongoing modification.
   void modify(std::function<void(DeltaTriples&)> function);
 
-  // Return a `SharedLocatedTriplesSnapshot` that contains a deep copy of the
-  // state of the underlying `DeltaTriples` after the last completed UPDATE, and
-  // thus is not affected by future UPDATE requests. It can therefore be used to
-  // execute a query in a consistent way.
+  // Return a shared pointer to a deep copy of the current snapshot. This can
+  // be safely used to execute a query without interfering with future updates.
   SharedLocatedTriplesSnapshot getCurrentSnapshot() const;
 };
-
-// DELTA TRIPLES AND THE CACHE
-//
-// Changes to the DeltaTriples invalidate all cache results that have an index
-// scan in their subtree, which is almost all entries in practice.

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -59,15 +59,15 @@ ad_utility::BlankNodeManager* Index::getBlankNodeManager() const {
 // ____________________________________________________________________________
 size_t Index::getCardinality(
     const TripleComponent& comp, Permutation::Enum p,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
-  return pimpl_->getCardinality(comp, p, deltaTriples);
+    const LocatedTriplesSnapshot& locatedTriples) const {
+  return pimpl_->getCardinality(comp, p, locatedTriples);
 }
 
 // ____________________________________________________________________________
 size_t Index::getCardinality(
     Id id, Permutation::Enum p,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
-  return pimpl_->getCardinality(id, p, deltaTriples);
+    const LocatedTriplesSnapshot& locatedTriples) const {
+  return pimpl_->getCardinality(id, p, locatedTriples);
 }
 
 // ____________________________________________________________________________
@@ -258,8 +258,8 @@ vector<float> Index::getMultiplicities(Permutation::Enum p) const {
 // ____________________________________________________________________________
 vector<float> Index::getMultiplicities(
     const TripleComponent& key, Permutation::Enum p,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
-  return pimpl_->getMultiplicities(key, p, deltaTriples);
+    const LocatedTriplesSnapshot& locatedTriples) const {
+  return pimpl_->getMultiplicities(key, p, locatedTriples);
 }
 
 // ____________________________________________________________________________
@@ -267,10 +267,10 @@ IdTable Index::scan(
     const ScanSpecificationAsTripleComponent& scanSpecification,
     Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesPerBlockPtr& deltaTriples,
+    const LocatedTriplesSnapshot& locatedTriples,
     const LimitOffsetClause& limitOffset) const {
   return pimpl_->scan(scanSpecification, p, additionalColumns,
-                      cancellationHandle, deltaTriples, limitOffset);
+                      cancellationHandle, locatedTriples, limitOffset);
 }
 
 // ____________________________________________________________________________
@@ -278,19 +278,19 @@ IdTable Index::scan(
     const ScanSpecification& scanSpecification, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesPerBlockPtr& deltaTriples,
+    const LocatedTriplesSnapshot& locatedTriples,
     const LimitOffsetClause& limitOffset) const {
   return pimpl_->scan(scanSpecification, p, additionalColumns,
-                      cancellationHandle, deltaTriples, limitOffset);
+                      cancellationHandle, locatedTriples, limitOffset);
 }
 
 // ____________________________________________________________________________
 size_t Index::getResultSizeOfScan(
     const ScanSpecification& scanSpecification,
     const Permutation::Enum& permutation,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
+    const LocatedTriplesSnapshot& locatedTriples) const {
   return pimpl_->getResultSizeOfScan(scanSpecification, permutation,
-                                     deltaTriples);
+                                     locatedTriples);
 }
 
 // ____________________________________________________________________________

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -57,14 +57,16 @@ ad_utility::BlankNodeManager* Index::getBlankNodeManager() const {
 }
 
 // ____________________________________________________________________________
-size_t Index::getCardinality(const TripleComponent& comp, Permutation::Enum p,
-                             const DeltaTriples& deltaTriples) const {
+size_t Index::getCardinality(
+    const TripleComponent& comp, Permutation::Enum p,
+    const LocatedTriplesPerBlockPtr& deltaTriples) const {
   return pimpl_->getCardinality(comp, p, deltaTriples);
 }
 
 // ____________________________________________________________________________
-size_t Index::getCardinality(Id id, Permutation::Enum p,
-                             const DeltaTriples& deltaTriples) const {
+size_t Index::getCardinality(
+    Id id, Permutation::Enum p,
+    const LocatedTriplesPerBlockPtr& deltaTriples) const {
   return pimpl_->getCardinality(id, p, deltaTriples);
 }
 
@@ -254,9 +256,9 @@ vector<float> Index::getMultiplicities(Permutation::Enum p) const {
 }
 
 // ____________________________________________________________________________
-vector<float> Index::getMultiplicities(const TripleComponent& key,
-                                       Permutation::Enum p,
-                                       const DeltaTriples& deltaTriples) const {
+vector<float> Index::getMultiplicities(
+    const TripleComponent& key, Permutation::Enum p,
+    const LocatedTriplesPerBlockPtr& deltaTriples) const {
   return pimpl_->getMultiplicities(key, p, deltaTriples);
 }
 
@@ -265,7 +267,7 @@ IdTable Index::scan(
     const ScanSpecificationAsTripleComponent& scanSpecification,
     Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const DeltaTriples& deltaTriples,
+    const LocatedTriplesPerBlockPtr& deltaTriples,
     const LimitOffsetClause& limitOffset) const {
   return pimpl_->scan(scanSpecification, p, additionalColumns,
                       cancellationHandle, deltaTriples, limitOffset);
@@ -276,16 +278,17 @@ IdTable Index::scan(
     const ScanSpecification& scanSpecification, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const DeltaTriples& deltaTriples,
+    const LocatedTriplesPerBlockPtr& deltaTriples,
     const LimitOffsetClause& limitOffset) const {
   return pimpl_->scan(scanSpecification, p, additionalColumns,
                       cancellationHandle, deltaTriples, limitOffset);
 }
 
 // ____________________________________________________________________________
-size_t Index::getResultSizeOfScan(const ScanSpecification& scanSpecification,
-                                  const Permutation::Enum& permutation,
-                                  const DeltaTriples& deltaTriples) const {
+size_t Index::getResultSizeOfScan(
+    const ScanSpecification& scanSpecification,
+    const Permutation::Enum& permutation,
+    const LocatedTriplesPerBlockPtr& deltaTriples) const {
   return pimpl_->getResultSizeOfScan(scanSpecification, permutation,
                                      deltaTriples);
 }
@@ -293,4 +296,14 @@ size_t Index::getResultSizeOfScan(const ScanSpecification& scanSpecification,
 // ____________________________________________________________________________
 void Index::createFromFiles(const std::vector<InputFileSpecification>& files) {
   return pimpl_->createFromFiles(files);
+}
+
+// ____________________________________________________________________________
+const DeltaTriplesManager& Index::deltaTriplesManager() const {
+  return pimpl_->deltaTriplesManager();
+}
+
+// ____________________________________________________________________________
+DeltaTriplesManager& Index::deltaTriplesManager() {
+  return pimpl_->deltaTriplesManager();
 }

--- a/src/index/Index.cpp
+++ b/src/index/Index.cpp
@@ -59,15 +59,15 @@ ad_utility::BlankNodeManager* Index::getBlankNodeManager() const {
 // ____________________________________________________________________________
 size_t Index::getCardinality(
     const TripleComponent& comp, Permutation::Enum p,
-    const LocatedTriplesSnapshot& locatedTriples) const {
-  return pimpl_->getCardinality(comp, p, locatedTriples);
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
+  return pimpl_->getCardinality(comp, p, locatedTriplesSnapshot);
 }
 
 // ____________________________________________________________________________
 size_t Index::getCardinality(
     Id id, Permutation::Enum p,
-    const LocatedTriplesSnapshot& locatedTriples) const {
-  return pimpl_->getCardinality(id, p, locatedTriples);
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
+  return pimpl_->getCardinality(id, p, locatedTriplesSnapshot);
 }
 
 // ____________________________________________________________________________
@@ -258,8 +258,8 @@ vector<float> Index::getMultiplicities(Permutation::Enum p) const {
 // ____________________________________________________________________________
 vector<float> Index::getMultiplicities(
     const TripleComponent& key, Permutation::Enum p,
-    const LocatedTriplesSnapshot& locatedTriples) const {
-  return pimpl_->getMultiplicities(key, p, locatedTriples);
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
+  return pimpl_->getMultiplicities(key, p, locatedTriplesSnapshot);
 }
 
 // ____________________________________________________________________________
@@ -267,10 +267,10 @@ IdTable Index::scan(
     const ScanSpecificationAsTripleComponent& scanSpecification,
     Permutation::Enum p, Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesSnapshot& locatedTriples,
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot,
     const LimitOffsetClause& limitOffset) const {
   return pimpl_->scan(scanSpecification, p, additionalColumns,
-                      cancellationHandle, locatedTriples, limitOffset);
+                      cancellationHandle, locatedTriplesSnapshot, limitOffset);
 }
 
 // ____________________________________________________________________________
@@ -278,19 +278,19 @@ IdTable Index::scan(
     const ScanSpecification& scanSpecification, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesSnapshot& locatedTriples,
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot,
     const LimitOffsetClause& limitOffset) const {
   return pimpl_->scan(scanSpecification, p, additionalColumns,
-                      cancellationHandle, locatedTriples, limitOffset);
+                      cancellationHandle, locatedTriplesSnapshot, limitOffset);
 }
 
 // ____________________________________________________________________________
 size_t Index::getResultSizeOfScan(
     const ScanSpecification& scanSpecification,
     const Permutation::Enum& permutation,
-    const LocatedTriplesSnapshot& locatedTriples) const {
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   return pimpl_->getResultSizeOfScan(scanSpecification, permutation,
-                                     locatedTriples);
+                                     locatedTriplesSnapshot);
 }
 
 // ____________________________________________________________________________

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -1,4 +1,3 @@
-// Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author:
 //   2014-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
@@ -23,7 +22,7 @@
 class IdTable;
 class TextBlockMetaData;
 class IndexImpl;
-class LocatedTriplesSnapshot;
+struct LocatedTriplesSnapshot;
 class DeltaTriplesManager;
 
 class Index {
@@ -126,10 +125,10 @@ class Index {
   // --------------------------------------------------------------------------
   [[nodiscard]] size_t getCardinality(
       const TripleComponent& comp, Permutation::Enum permutation,
-      const LocatedTriplesSnapshot& locatedTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
   [[nodiscard]] size_t getCardinality(
       Id id, Permutation::Enum permutation,
-      const LocatedTriplesSnapshot& locatedTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // TODO<joka921> Once we have an overview over the folding this logic should
   // probably not be in the index class.
@@ -225,7 +224,7 @@ class Index {
   // _____________________________________________________________________________
   vector<float> getMultiplicities(
       const TripleComponent& key, Permutation::Enum permutation,
-      const LocatedTriplesSnapshot& locatedTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // ___________________________________________________________________
   vector<float> getMultiplicities(Permutation::Enum p) const;
@@ -249,14 +248,14 @@ class Index {
                Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesSnapshot& locatedTriples,
+               const LocatedTriplesSnapshot& locatedTriplesSnapshot,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
   IdTable scan(const ScanSpecification& scanSpecification, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesSnapshot& locatedTriples,
+               const LocatedTriplesSnapshot& locatedTriplesSnapshot,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
@@ -264,7 +263,7 @@ class Index {
   size_t getResultSizeOfScan(
       const ScanSpecification& scanSpecification,
       const Permutation::Enum& permutation,
-      const LocatedTriplesSnapshot& locatedTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // Get access to the implementation. This should be used rarely as it
   // requires including the rather expensive `IndexImpl.h` header

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -23,7 +23,8 @@
 class IdTable;
 class TextBlockMetaData;
 class IndexImpl;
-class DeltaTriples;
+class LocatedTriplesPerBlockPtr;
+class DeltaTriplesManager;
 
 class Index {
  private:
@@ -116,14 +117,19 @@ class Index {
   // Get a (non-owning) pointer to the BlankNodeManager of this Index.
   ad_utility::BlankNodeManager* getBlankNodeManager() const;
 
+  // Get a (non-owning) pointer to the BlankNodeManager of this Index.
+  DeltaTriplesManager& deltaTriplesManager();
+  const DeltaTriplesManager& deltaTriplesManager() const;
+
   // --------------------------------------------------------------------------
   // RDF RETRIEVAL
   // --------------------------------------------------------------------------
-  [[nodiscard]] size_t getCardinality(const TripleComponent& comp,
-                                      Permutation::Enum permutation,
-                                      const DeltaTriples& deltaTriples) const;
-  [[nodiscard]] size_t getCardinality(Id id, Permutation::Enum permutation,
-                                      const DeltaTriples& deltaTriples) const;
+  [[nodiscard]] size_t getCardinality(
+      const TripleComponent& comp, Permutation::Enum permutation,
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+  [[nodiscard]] size_t getCardinality(
+      Id id, Permutation::Enum permutation,
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // TODO<joka921> Once we have an overview over the folding this logic should
   // probably not be in the index class.
@@ -217,9 +223,9 @@ class Index {
   bool hasAllPermutations() const;
 
   // _____________________________________________________________________________
-  vector<float> getMultiplicities(const TripleComponent& key,
-                                  Permutation::Enum permutation,
-                                  const DeltaTriples& deltaTriples) const;
+  vector<float> getMultiplicities(
+      const TripleComponent& key, Permutation::Enum permutation,
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // ___________________________________________________________________
   vector<float> getMultiplicities(Permutation::Enum p) const;
@@ -243,21 +249,22 @@ class Index {
                Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const DeltaTriples& deltaTriples,
+               const LocatedTriplesPerBlockPtr& deltaTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
   IdTable scan(const ScanSpecification& scanSpecification, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const DeltaTriples& deltaTriples,
+               const LocatedTriplesPerBlockPtr& deltaTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
   // the scan result.
-  size_t getResultSizeOfScan(const ScanSpecification& scanSpecification,
-                             const Permutation::Enum& permutation,
-                             const DeltaTriples& deltaTriples) const;
+  size_t getResultSizeOfScan(
+      const ScanSpecification& scanSpecification,
+      const Permutation::Enum& permutation,
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // Get access to the implementation. This should be used rarely as it
   // requires including the rather expensive `IndexImpl.h` header

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -23,7 +23,7 @@
 class IdTable;
 class TextBlockMetaData;
 class IndexImpl;
-class LocatedTriplesPerBlockPtr;
+class LocatedTriplesSnapshot;
 class DeltaTriplesManager;
 
 class Index {
@@ -126,10 +126,10 @@ class Index {
   // --------------------------------------------------------------------------
   [[nodiscard]] size_t getCardinality(
       const TripleComponent& comp, Permutation::Enum permutation,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriples) const;
   [[nodiscard]] size_t getCardinality(
       Id id, Permutation::Enum permutation,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriples) const;
 
   // TODO<joka921> Once we have an overview over the folding this logic should
   // probably not be in the index class.
@@ -225,7 +225,7 @@ class Index {
   // _____________________________________________________________________________
   vector<float> getMultiplicities(
       const TripleComponent& key, Permutation::Enum permutation,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriples) const;
 
   // ___________________________________________________________________
   vector<float> getMultiplicities(Permutation::Enum p) const;
@@ -249,14 +249,14 @@ class Index {
                Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesPerBlockPtr& deltaTriples,
+               const LocatedTriplesSnapshot& locatedTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // Similar to the overload of `scan` above, but the keys are specified as IDs.
   IdTable scan(const ScanSpecification& scanSpecification, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesPerBlockPtr& deltaTriples,
+               const LocatedTriplesSnapshot& locatedTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // Similar to the previous overload of `scan`, but only get the exact size of
@@ -264,7 +264,7 @@ class Index {
   size_t getResultSizeOfScan(
       const ScanSpecification& scanSpecification,
       const Permutation::Enum& permutation,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriples) const;
 
   // Get access to the implementation. This should be used rarely as it
   // requires including the rather expensive `IndexImpl.h` header

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1448,9 +1448,9 @@ Index::NumNormalAndInternal IndexImpl::numDistinctCol0(
 // ___________________________________________________________________________
 size_t IndexImpl::getCardinality(
     Id id, Permutation::Enum permutation,
-    const LocatedTriplesSnapshot& locatedTriples) const {
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   if (const auto& meta =
-          getPermutation(permutation).getMetadata(id, locatedTriples);
+          getPermutation(permutation).getMetadata(id, locatedTriplesSnapshot);
       meta.has_value()) {
     return meta.value().numRows_;
   }
@@ -1460,7 +1460,7 @@ size_t IndexImpl::getCardinality(
 // ___________________________________________________________________________
 size_t IndexImpl::getCardinality(
     const TripleComponent& comp, Permutation::Enum permutation,
-    const LocatedTriplesSnapshot& locatedTriples) const {
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   // TODO<joka921> This special case is only relevant for the `PSO` and `POS`
   // permutations, but this internal predicate should never appear in subjects
   // or objects anyway.
@@ -1470,7 +1470,7 @@ size_t IndexImpl::getCardinality(
     return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
   }
   if (std::optional<Id> relId = comp.toValueId(getVocab()); relId.has_value()) {
-    return getCardinality(relId.value(), permutation, locatedTriples);
+    return getCardinality(relId.value(), permutation, locatedTriplesSnapshot);
   }
   return 0;
 }
@@ -1493,10 +1493,10 @@ Index::Vocab::PrefixRanges IndexImpl::prefixRanges(
 // _____________________________________________________________________________
 vector<float> IndexImpl::getMultiplicities(
     const TripleComponent& key, Permutation::Enum permutation,
-    const LocatedTriplesSnapshot& locatedTriples) const {
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   if (auto keyId = key.toValueId(getVocab()); keyId.has_value()) {
-    auto meta =
-        getPermutation(permutation).getMetadata(keyId.value(), locatedTriples);
+    auto meta = getPermutation(permutation)
+                    .getMetadata(keyId.value(), locatedTriplesSnapshot);
     if (meta.has_value()) {
       return {meta.value().getCol1Multiplicity(),
               meta.value().getCol2Multiplicity()};
@@ -1522,21 +1522,21 @@ IdTable IndexImpl::scan(
     const Permutation::Enum& permutation,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesSnapshot& locatedTriples,
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot,
     const LimitOffsetClause& limitOffset) const {
   auto scanSpecification = scanSpecificationAsTc.toScanSpecification(*this);
   return scan(scanSpecification, permutation, additionalColumns,
-              cancellationHandle, locatedTriples, limitOffset);
+              cancellationHandle, locatedTriplesSnapshot, limitOffset);
 }
 // _____________________________________________________________________________
 IdTable IndexImpl::scan(
     const ScanSpecification& scanSpecification, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesSnapshot& locatedTriples,
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot,
     const LimitOffsetClause& limitOffset) const {
   return getPermutation(p).scan(scanSpecification, additionalColumns,
-                                cancellationHandle, locatedTriples,
+                                cancellationHandle, locatedTriplesSnapshot,
                                 limitOffset);
 }
 
@@ -1544,9 +1544,9 @@ IdTable IndexImpl::scan(
 size_t IndexImpl::getResultSizeOfScan(
     const ScanSpecification& scanSpecification,
     const Permutation::Enum& permutation,
-    const LocatedTriplesSnapshot& locatedTriples) const {
+    const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   return getPermutation(permutation)
-      .getResultSizeOfScan(scanSpecification, locatedTriples);
+      .getResultSizeOfScan(scanSpecification, locatedTriplesSnapshot);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1448,9 +1448,9 @@ Index::NumNormalAndInternal IndexImpl::numDistinctCol0(
 // ___________________________________________________________________________
 size_t IndexImpl::getCardinality(
     Id id, Permutation::Enum permutation,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
+    const LocatedTriplesSnapshot& locatedTriples) const {
   if (const auto& meta =
-          getPermutation(permutation).getMetadata(id, deltaTriples);
+          getPermutation(permutation).getMetadata(id, locatedTriples);
       meta.has_value()) {
     return meta.value().numRows_;
   }
@@ -1460,7 +1460,7 @@ size_t IndexImpl::getCardinality(
 // ___________________________________________________________________________
 size_t IndexImpl::getCardinality(
     const TripleComponent& comp, Permutation::Enum permutation,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
+    const LocatedTriplesSnapshot& locatedTriples) const {
   // TODO<joka921> This special case is only relevant for the `PSO` and `POS`
   // permutations, but this internal predicate should never appear in subjects
   // or objects anyway.
@@ -1470,7 +1470,7 @@ size_t IndexImpl::getCardinality(
     return TEXT_PREDICATE_CARDINALITY_ESTIMATE;
   }
   if (std::optional<Id> relId = comp.toValueId(getVocab()); relId.has_value()) {
-    return getCardinality(relId.value(), permutation, deltaTriples);
+    return getCardinality(relId.value(), permutation, locatedTriples);
   }
   return 0;
 }
@@ -1493,10 +1493,10 @@ Index::Vocab::PrefixRanges IndexImpl::prefixRanges(
 // _____________________________________________________________________________
 vector<float> IndexImpl::getMultiplicities(
     const TripleComponent& key, Permutation::Enum permutation,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
+    const LocatedTriplesSnapshot& locatedTriples) const {
   if (auto keyId = key.toValueId(getVocab()); keyId.has_value()) {
     auto meta =
-        getPermutation(permutation).getMetadata(keyId.value(), deltaTriples);
+        getPermutation(permutation).getMetadata(keyId.value(), locatedTriples);
     if (meta.has_value()) {
       return {meta.value().getCol1Multiplicity(),
               meta.value().getCol2Multiplicity()};
@@ -1522,30 +1522,31 @@ IdTable IndexImpl::scan(
     const Permutation::Enum& permutation,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesPerBlockPtr& deltaTriples,
+    const LocatedTriplesSnapshot& locatedTriples,
     const LimitOffsetClause& limitOffset) const {
   auto scanSpecification = scanSpecificationAsTc.toScanSpecification(*this);
   return scan(scanSpecification, permutation, additionalColumns,
-              cancellationHandle, deltaTriples, limitOffset);
+              cancellationHandle, locatedTriples, limitOffset);
 }
 // _____________________________________________________________________________
 IdTable IndexImpl::scan(
     const ScanSpecification& scanSpecification, Permutation::Enum p,
     Permutation::ColumnIndicesRef additionalColumns,
     const ad_utility::SharedCancellationHandle& cancellationHandle,
-    const LocatedTriplesPerBlockPtr& deltaTriples,
+    const LocatedTriplesSnapshot& locatedTriples,
     const LimitOffsetClause& limitOffset) const {
   return getPermutation(p).scan(scanSpecification, additionalColumns,
-                                cancellationHandle, deltaTriples, limitOffset);
+                                cancellationHandle, locatedTriples,
+                                limitOffset);
 }
 
 // _____________________________________________________________________________
 size_t IndexImpl::getResultSizeOfScan(
     const ScanSpecification& scanSpecification,
     const Permutation::Enum& permutation,
-    const LocatedTriplesPerBlockPtr& deltaTriples) const {
+    const LocatedTriplesSnapshot& locatedTriples) const {
   return getPermutation(permutation)
-      .getResultSizeOfScan(scanSpecification, deltaTriples);
+      .getResultSizeOfScan(scanSpecification, locatedTriples);
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -18,6 +18,7 @@
 #include "global/SpecialIds.h"
 #include "index/CompressedRelation.h"
 #include "index/ConstantsIndexBuilding.h"
+#include "index/DeltaTriples.h"
 #include "index/DocsDB.h"
 #include "index/Index.h"
 #include "index/IndexBuilderTypes.h"
@@ -188,6 +189,8 @@ class IndexImpl {
   // BlankNodeManager, initialized during `readConfiguration`
   std::unique_ptr<ad_utility::BlankNodeManager> blankNodeManager_{nullptr};
 
+  std::optional<DeltaTriplesManager> deltaTriples_;
+
  public:
   explicit IndexImpl(ad_utility::AllocatorWithLimit<Id> allocator);
 
@@ -261,6 +264,11 @@ class IndexImpl {
 
   ad_utility::BlankNodeManager* getBlankNodeManager() const;
 
+  DeltaTriplesManager& deltaTriplesManager() { return deltaTriples_.value(); }
+  const DeltaTriplesManager& deltaTriplesManager() const {
+    return deltaTriples_.value();
+  }
+
   // --------------------------------------------------------------------------
   //  -- RETRIEVAL ---
   // --------------------------------------------------------------------------
@@ -283,12 +291,12 @@ class IndexImpl {
 
   // ___________________________________________________________________________
   size_t getCardinality(Id id, Permutation::Enum permutation,
-                        const DeltaTriples&) const;
+                        const LocatedTriplesPerBlockPtr&) const;
 
   // ___________________________________________________________________________
   size_t getCardinality(const TripleComponent& comp,
                         Permutation::Enum permutation,
-                        const DeltaTriples& deltaTriples) const;
+                        const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // ___________________________________________________________________________
   std::string indexToString(VocabIndex id) const;
@@ -422,7 +430,7 @@ class IndexImpl {
   // _____________________________________________________________________________
   vector<float> getMultiplicities(const TripleComponent& key,
                                   Permutation::Enum permutation,
-                                  const DeltaTriples&) const;
+                                  const LocatedTriplesPerBlockPtr&) const;
 
   // ___________________________________________________________________
   vector<float> getMultiplicities(Permutation::Enum permutation) const;
@@ -432,20 +440,21 @@ class IndexImpl {
                const Permutation::Enum& permutation,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const DeltaTriples& deltaTriples,
+               const LocatedTriplesPerBlockPtr& deltaTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
   IdTable scan(const ScanSpecification& scanSpecification, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const DeltaTriples& deltaTriples,
+               const LocatedTriplesPerBlockPtr& deltaTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
-  size_t getResultSizeOfScan(const ScanSpecification& scanSpecification,
-                             const Permutation::Enum& permutation,
-                             const DeltaTriples& deltaTriples) const;
+  size_t getResultSizeOfScan(
+      const ScanSpecification& scanSpecification,
+      const Permutation::Enum& permutation,
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
  private:
   // Private member functions

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -291,12 +291,12 @@ class IndexImpl {
 
   // ___________________________________________________________________________
   size_t getCardinality(Id id, Permutation::Enum permutation,
-                        const LocatedTriplesPerBlockPtr&) const;
+                        const LocatedTriplesSnapshot&) const;
 
   // ___________________________________________________________________________
   size_t getCardinality(const TripleComponent& comp,
                         Permutation::Enum permutation,
-                        const LocatedTriplesPerBlockPtr& deltaTriples) const;
+                        const LocatedTriplesSnapshot& locatedTriples) const;
 
   // ___________________________________________________________________________
   std::string indexToString(VocabIndex id) const;
@@ -428,9 +428,9 @@ class IndexImpl {
   bool hasAllPermutations() const { return SPO().isLoaded(); }
 
   // _____________________________________________________________________________
-  vector<float> getMultiplicities(const TripleComponent& key,
-                                  Permutation::Enum permutation,
-                                  const LocatedTriplesPerBlockPtr&) const;
+  vector<float> getMultiplicities(
+      const TripleComponent& key, Permutation::Enum permutation,
+      const LocatedTriplesSnapshot& locatedTriples) const;
 
   // ___________________________________________________________________
   vector<float> getMultiplicities(Permutation::Enum permutation) const;
@@ -440,21 +440,21 @@ class IndexImpl {
                const Permutation::Enum& permutation,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesPerBlockPtr& deltaTriples,
+               const LocatedTriplesSnapshot& locatedTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
   IdTable scan(const ScanSpecification& scanSpecification, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesPerBlockPtr& deltaTriples,
+               const LocatedTriplesSnapshot& locatedTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
   size_t getResultSizeOfScan(
       const ScanSpecification& scanSpecification,
       const Permutation::Enum& permutation,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriples) const;
 
  private:
   // Private member functions

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -294,9 +294,9 @@ class IndexImpl {
                         const LocatedTriplesSnapshot&) const;
 
   // ___________________________________________________________________________
-  size_t getCardinality(const TripleComponent& comp,
-                        Permutation::Enum permutation,
-                        const LocatedTriplesSnapshot& locatedTriples) const;
+  size_t getCardinality(
+      const TripleComponent& comp, Permutation::Enum permutation,
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // ___________________________________________________________________________
   std::string indexToString(VocabIndex id) const;
@@ -430,7 +430,7 @@ class IndexImpl {
   // _____________________________________________________________________________
   vector<float> getMultiplicities(
       const TripleComponent& key, Permutation::Enum permutation,
-      const LocatedTriplesSnapshot& locatedTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // ___________________________________________________________________
   vector<float> getMultiplicities(Permutation::Enum permutation) const;
@@ -440,21 +440,21 @@ class IndexImpl {
                const Permutation::Enum& permutation,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesSnapshot& locatedTriples,
+               const LocatedTriplesSnapshot& locatedTriplesSnapshot,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
   IdTable scan(const ScanSpecification& scanSpecification, Permutation::Enum p,
                Permutation::ColumnIndicesRef additionalColumns,
                const ad_utility::SharedCancellationHandle& cancellationHandle,
-               const LocatedTriplesSnapshot& locatedTriples,
+               const LocatedTriplesSnapshot& locatedTriplesSnapshot,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // _____________________________________________________________________________
   size_t getResultSizeOfScan(
       const ScanSpecification& scanSpecification,
       const Permutation::Enum& permutation,
-      const LocatedTriplesSnapshot& locatedTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
  private:
   // Private member functions

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -285,7 +285,7 @@ std::ostream& operator<<(std::ostream& os, const std::vector<IdTriple<0>>& v) {
 }
 
 // ____________________________________________________________________________
-bool LocatedTriplesPerBlock::containsTriple(const IdTriple<0> triple,
+bool LocatedTriplesPerBlock::containsTriple(const IdTriple<0>& triple,
                                             bool shouldExist) const {
   auto blockContains = [&triple, shouldExist](const LocatedTriples& lt,
                                               size_t blockIndex) {

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -283,3 +283,19 @@ std::ostream& operator<<(std::ostream& os, const std::vector<IdTriple<0>>& v) {
   std::ranges::copy(v, std::ostream_iterator<IdTriple<0>>(os, ", "));
   return os;
 }
+
+// ____________________________________________________________________________
+bool LocatedTriplesPerBlock::containsTriple(const IdTriple<0> triple,
+                                            bool shouldExist) const {
+  auto blockContains = [&triple, shouldExist](const LocatedTriples& lt,
+                                              size_t blockIndex) {
+    LocatedTriple locatedTriple{blockIndex, triple, shouldExist};
+    locatedTriple.blockIndex_ = blockIndex;
+    return ad_utility::contains(lt, locatedTriple);
+  };
+
+  return std::ranges::any_of(map_, [&blockContains](auto& indexAndBlock) {
+    const auto& [index, block] = indexAndBlock;
+    return blockContains(block, index);
+  });
+}

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -93,8 +93,6 @@ class LocatedTriplesPerBlock {
   void updateAugmentedMetadata();
 
  public:
-
-
   // Get upper limits for the number of located triples for the given block. The
   // return value is a pair of numbers: first, the number of existing triples
   // ("to be deleted") and second, the number of new triples ("to be inserted").

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -169,7 +169,7 @@ class LocatedTriplesPerBlock {
 
   // Only used for testing. Return `true` iff a `LocatedTriple` with the given
   // value for `shouldExist` is contained in any block.
-  bool containsTriple(const IdTriple<0> triple, bool shouldExist) const;
+  bool containsTriple(const IdTriple<0>& triple, bool shouldExist) const;
 
   // This operator is only for debugging and testing. It returns a
   // human-readable representation.

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -127,14 +127,14 @@ class LocatedTriplesPerBlock {
   IdTable mergeTriples(size_t blockIndex, const IdTable& block,
                        size_t numIndexColumns, bool includeGraphColumn) const;
 
-  // Add `locatedTriples` to the `LocatedTriplesPerBlock`.
+  // Add `getLocatedTriplesForPermutation` to the `LocatedTriplesPerBlock`.
   // Return handles to where they were added (`LocatedTriples` is a sorted set,
   // see above). We need the handles so that we can easily remove the
-  // `locatedTriples` from the set again in case we need to.
+  // `getLocatedTriplesForPermutation` from the set again in case we need to.
   //
   // PRECONDITIONS:
   //
-  // 1. The `locatedTriples` must not already exist in
+  // 1. The `getLocatedTriplesForPermutation` must not already exist in
   // `LocatedTriplesPerBlock`.
   std::vector<LocatedTriples::iterator> add(
       std::span<const LocatedTriple> locatedTriples);

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -93,6 +93,8 @@ class LocatedTriplesPerBlock {
   void updateAugmentedMetadata();
 
  public:
+
+
   // Get upper limits for the number of located triples for the given block. The
   // return value is a pair of numbers: first, the number of existing triples
   // ("to be deleted") and second, the number of new triples ("to be inserted").

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -167,6 +167,10 @@ class LocatedTriplesPerBlock {
     augmentedMetadata_ = originalMetadata_;
   }
 
+  // Only used for testing. Return `true` iff a `LocatedTriple` with the given
+  // value for `shouldExist` is contained in any block.
+  bool containsTriple(const IdTriple<0> triple, bool shouldExist) const;
+
   // This operator is only for debugging and testing. It returns a
   // human-readable representation.
   friend std::ostream& operator<<(std::ostream& os,

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -64,9 +64,9 @@ IdTable Permutation::scan(const ScanSpecification& scanSpec,
 
   const auto& p = getActualPermutation(scanSpec);
 
-  return p.reader().scan(scanSpec, p.meta_.blockData(), additionalColumns,
-                         cancellationHandle,
-                         locatedTriples(locatedTriplesSnapshot), limitOffset);
+  return p.reader().scan(
+      scanSpec, p.meta_.blockData(), additionalColumns, cancellationHandle,
+      getLocatedTriplesForPermutation(locatedTriplesSnapshot), limitOffset);
 }
 
 // _____________________________________________________________________
@@ -74,8 +74,9 @@ size_t Permutation::getResultSizeOfScan(
     const ScanSpecification& scanSpec,
     const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   const auto& p = getActualPermutation(scanSpec);
-  return p.reader().getResultSizeOfScan(scanSpec, p.meta_.blockData(),
-                                        locatedTriples(locatedTriplesSnapshot));
+  return p.reader().getResultSizeOfScan(
+      scanSpec, p.meta_.blockData(),
+      getLocatedTriplesForPermutation(locatedTriplesSnapshot));
 }
 
 // ____________________________________________________________________________
@@ -85,7 +86,7 @@ IdTable Permutation::getDistinctCol1IdsAndCounts(
   const auto& p = getActualPermutation(col0Id);
   return p.reader().getDistinctCol1IdsAndCounts(
       col0Id, p.meta_.blockData(), cancellationHandle,
-      locatedTriples(locatedTriplesSnapshot));
+      getLocatedTriplesForPermutation(locatedTriplesSnapshot));
 }
 
 // ____________________________________________________________________________
@@ -94,7 +95,7 @@ IdTable Permutation::getDistinctCol0IdsAndCounts(
     const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
   return reader().getDistinctCol0IdsAndCounts(
       meta_.blockData(), cancellationHandle,
-      locatedTriples(locatedTriplesSnapshot));
+      getLocatedTriplesForPermutation(locatedTriplesSnapshot));
 }
 
 // _____________________________________________________________________
@@ -145,7 +146,8 @@ std::optional<CompressedRelationMetadata> Permutation::getMetadata(
     return p.meta_.getMetaData(col0Id);
   }
   return p.reader().getMetadataForSmallRelation(
-      p.meta_.blockData(), col0Id, locatedTriples(locatedTriplesSnapshot));
+      p.meta_.blockData(), col0Id,
+      getLocatedTriplesForPermutation(locatedTriplesSnapshot));
 }
 
 // _____________________________________________________________________
@@ -158,7 +160,7 @@ std::optional<Permutation::MetadataAndBlocks> Permutation::getMetadataAndBlocks(
                     scanSpec, p.meta_.blockData())};
 
   auto firstAndLastTriple = p.reader().getFirstAndLastTriple(
-      mb, locatedTriples(locatedTriplesSnapshot));
+      mb, getLocatedTriplesForPermutation(locatedTriplesSnapshot));
   if (!firstAndLastTriple.has_value()) {
     return std::nullopt;
   }
@@ -181,10 +183,10 @@ Permutation::IdTableGenerator Permutation::lazyScan(
     blocks = std::vector(blockSpan.begin(), blockSpan.end());
   }
   ColumnIndices columns{additionalColumns.begin(), additionalColumns.end()};
-  return p.reader().lazyScan(scanSpec, std::move(blocks.value()),
-                             std::move(columns), std::move(cancellationHandle),
-                             locatedTriples(locatedTriplesSnapshot),
-                             limitOffset);
+  return p.reader().lazyScan(
+      scanSpec, std::move(blocks.value()), std::move(columns),
+      std::move(cancellationHandle),
+      getLocatedTriplesForPermutation(locatedTriplesSnapshot), limitOffset);
 }
 
 // ______________________________________________________________________
@@ -214,7 +216,7 @@ const Permutation& Permutation::getActualPermutation(Id id) const {
 }
 
 // ______________________________________________________________________
-const LocatedTriplesPerBlock& Permutation::locatedTriples(
+const LocatedTriplesPerBlock& Permutation::getLocatedTriplesForPermutation(
     const LocatedTriplesSnapshot& locatedTriplesSnapshot) const {
-  return locatedTriplesSnapshot.getLocatedTriplesPerBlock(permutation_);
+  return locatedTriplesSnapshot.getLocatedTriplesForPermutation(permutation_);
 }

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -214,6 +214,5 @@ const Permutation& Permutation::getActualPermutation(Id id) const {
 // ______________________________________________________________________
 const LocatedTriplesPerBlock& Permutation::locatedTriples(
     const LocatedTriplesPerBlockPtr& deltaTriples) const {
-  return deltaTriples->locatedTriplesPerBlock_.at(
-      static_cast<size_t>(permutation_));
+  return deltaTriples->getLocatedTriplesPerBlock(permutation_);
 }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -18,7 +18,8 @@
 class IdTable;
 // Forward declaration of `LocatedTriplesPerBlock`
 class LocatedTriplesPerBlock;
-class LocatedTriplesPerBlockPtr;
+class SharedLocatedTriplesSnapshot;
+class LocatedTriplesSnapshot;
 
 // Helper class to store static properties of the different permutations to
 // avoid code duplication. The first template parameter is a search functor for
@@ -66,7 +67,7 @@ class Permutation {
   IdTable scan(const ScanSpecification& scanSpec,
                ColumnIndicesRef additionalColumns,
                const CancellationHandle& cancellationHandle,
-               const LocatedTriplesPerBlockPtr& deltaTriples,
+               const LocatedTriplesSnapshot& locatedTriplesSnapshot,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // For a given relation, determine the `col1Id`s and their counts. This is
@@ -74,11 +75,11 @@ class Permutation {
   // in `meta_`.
   IdTable getDistinctCol1IdsAndCounts(
       Id col0Id, const CancellationHandle& cancellationHandle,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   IdTable getDistinctCol0IdsAndCounts(
       const CancellationHandle& cancellationHandle,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks =
@@ -102,11 +103,11 @@ class Permutation {
       const ScanSpecification& scanSpec,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns, CancellationHandle cancellationHandle,
-      const LocatedTriplesPerBlockPtr& deltaTriples,
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot,
       const LimitOffsetClause& limitOffset = {}) const;
 
   std::optional<CompressedRelationMetadata> getMetadata(
-      Id col0Id, const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      Id col0Id, const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // Return the metadata for the scan specified by the `scanSpecification`
   // along with the metadata for all the blocks that are relevant for this scan.
@@ -114,13 +115,13 @@ class Permutation {
   // empty) return `nullopt`.
   std::optional<MetadataAndBlocks> getMetadataAndBlocks(
       const ScanSpecification& scanSpec,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   /// Similar to the previous `scan` function, but only get the size of the
   /// result
   size_t getResultSizeOfScan(
       const ScanSpecification& scanSpec,
-      const LocatedTriplesPerBlockPtr& deltaTriples) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   // _______________________________________________________
   void setKbName(const string& name) { meta_.setName(name); }
@@ -148,7 +149,7 @@ class Permutation {
   const Permutation& getActualPermutation(Id id) const;
 
   const LocatedTriplesPerBlock& locatedTriples(
-      const LocatedTriplesPerBlockPtr&) const;
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   const CompressedRelationReader& reader() const { return reader_.value(); }
 

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -19,7 +19,7 @@ class IdTable;
 // Forward declaration of `LocatedTriplesPerBlock`
 class LocatedTriplesPerBlock;
 class SharedLocatedTriplesSnapshot;
-class LocatedTriplesSnapshot;
+struct LocatedTriplesSnapshot;
 
 // Helper class to store static properties of the different permutations to
 // avoid code duplication. The first template parameter is a search functor for
@@ -148,7 +148,7 @@ class Permutation {
   const Permutation& getActualPermutation(const ScanSpecification& spec) const;
   const Permutation& getActualPermutation(Id id) const;
 
-  const LocatedTriplesPerBlock& locatedTriples(
+  const LocatedTriplesPerBlock& getLocatedTriplesForPermutation(
       const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   const CompressedRelationReader& reader() const { return reader_.value(); }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -18,7 +18,7 @@
 class IdTable;
 // Forward declaration of `LocatedTriplesPerBlock`
 class LocatedTriplesPerBlock;
-class DeltaTriples;
+class LocatedTriplesPerBlockPtr;
 
 // Helper class to store static properties of the different permutations to
 // avoid code duplication. The first template parameter is a search functor for
@@ -66,7 +66,7 @@ class Permutation {
   IdTable scan(const ScanSpecification& scanSpec,
                ColumnIndicesRef additionalColumns,
                const CancellationHandle& cancellationHandle,
-               const DeltaTriples& deltaTriples,
+               const LocatedTriplesPerBlockPtr& deltaTriples,
                const LimitOffsetClause& limitOffset = {}) const;
 
   // For a given relation, determine the `col1Id`s and their counts. This is
@@ -74,11 +74,11 @@ class Permutation {
   // in `meta_`.
   IdTable getDistinctCol1IdsAndCounts(
       Id col0Id, const CancellationHandle& cancellationHandle,
-      const DeltaTriples& deltaTriples) const;
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   IdTable getDistinctCol0IdsAndCounts(
       const CancellationHandle& cancellationHandle,
-      const DeltaTriples& deltaTriples) const;
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // Typedef to propagate the `MetadataAndblocks` and `IdTableGenerator` type.
   using MetadataAndBlocks =
@@ -102,11 +102,11 @@ class Permutation {
       const ScanSpecification& scanSpec,
       std::optional<std::vector<CompressedBlockMetadata>> blocks,
       ColumnIndicesRef additionalColumns, CancellationHandle cancellationHandle,
-      const DeltaTriples& deltaTriples,
+      const LocatedTriplesPerBlockPtr& deltaTriples,
       const LimitOffsetClause& limitOffset = {}) const;
 
   std::optional<CompressedRelationMetadata> getMetadata(
-      Id col0Id, const DeltaTriples& deltaTriples) const;
+      Id col0Id, const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // Return the metadata for the scan specified by the `scanSpecification`
   // along with the metadata for all the blocks that are relevant for this scan.
@@ -114,12 +114,13 @@ class Permutation {
   // empty) return `nullopt`.
   std::optional<MetadataAndBlocks> getMetadataAndBlocks(
       const ScanSpecification& scanSpec,
-      const DeltaTriples& deltaTriples) const;
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   /// Similar to the previous `scan` function, but only get the size of the
   /// result
-  size_t getResultSizeOfScan(const ScanSpecification& scanSpec,
-                             const DeltaTriples& deltaTriples) const;
+  size_t getResultSizeOfScan(
+      const ScanSpecification& scanSpec,
+      const LocatedTriplesPerBlockPtr& deltaTriples) const;
 
   // _______________________________________________________
   void setKbName(const string& name) { meta_.setName(name); }
@@ -146,7 +147,8 @@ class Permutation {
   const Permutation& getActualPermutation(const ScanSpecification& spec) const;
   const Permutation& getActualPermutation(Id id) const;
 
-  const LocatedTriplesPerBlock& locatedTriples(const DeltaTriples&) const;
+  const LocatedTriplesPerBlock& locatedTriples(
+      const LocatedTriplesPerBlockPtr&) const;
 
   const CompressedRelationReader& reader() const { return reader_.value(); }
 

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -1,6 +1,7 @@
-// Copyright 2018, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Author: Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
+// Copyright 2018 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+
 #pragma once
 
 #include <array>
@@ -148,20 +149,21 @@ class Permutation {
   const Permutation& getActualPermutation(const ScanSpecification& spec) const;
   const Permutation& getActualPermutation(Id id) const;
 
+  // From the given snapshot, get the located triples for this permutation.
   const LocatedTriplesPerBlock& getLocatedTriplesForPermutation(
       const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
   const CompressedRelationReader& reader() const { return reader_.value(); }
 
  private:
-  // for Log output, e.g. "POS"
+  // Readable name for this permutation, e.g., `POS`.
   std::string readableName_;
-  // e.g. ".pos"
+  // File name suffix for this permutation, e.g., `.pos`.
   std::string fileSuffix_;
-  // order of the 3 keys S(0), P(1), and O(2) for which this permutation is
-  // sorted, for example {1, 0, 2} for PSO.
+  // The order of the three components (S=0, P=1, O=2) in this permutation,
+  // e.g., `{1, 0, 2}` for `PSO`.
   array<size_t, 3> keyOrder_;
-
+  // The metadata for this permutation.
   MetaData meta_;
 
   // This member is `optional` because we initialize it in a deferred way in the

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -412,7 +412,7 @@ TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
   // deleted right after. Additionally, there is one common triple inserted by
   // all the threads and one common triple that is deleted by all the threads.
   //
-  // TODO(Hannah): I don't understand why the number of thread-exclusive delted
+  // TODO(Hannah): I don't understand why the number of thread-exclusive deleted
   // triples is twice that of the thread-exclusive inserted triples.
   auto deltaImpl = deltaTriplesManager.deltaTriples_.rlock();
   EXPECT_THAT(*deltaImpl, NumTriples(numThreads + 1, 2 * numThreads + 1,

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -382,12 +382,14 @@ TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
           // Check for several of the thread-exclusive triples that they are
           // properly contained in the current snapshot.
           //
-          // TODO(Hannah): I don't understand the `false` for the second
-          // `containsTriple`.
           auto p = deltaTriplesManager.getCurrentSnapshot();
           const auto& locatedSPO =
               p->getLocatedTriplesForPermutation(Permutation::SPO);
           EXPECT_TRUE(locatedSPO.containsTriple(triplesToInsert.at(1), true));
+          // This triple is exclusive to the thread and is inserted and then
+          // immediately deleted again. The `DeltaTriples` thus only store it as
+          // deleted. It might be contained in the original input, hence we
+          // cannot simply drop it.
           EXPECT_TRUE(locatedSPO.containsTriple(triplesToInsert.at(2), false));
           EXPECT_TRUE(locatedSPO.containsTriple(triplesToDelete.at(2), false));
         }
@@ -409,11 +411,12 @@ TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
 
   // Each of the threads above inserts on thread-exclusive triple, deletes one
   // thread-exclusive triple and inserts one thread-exclusive triple that is
-  // deleted right after. Additionally, there is one common triple inserted by
-  // all the threads and one common triple that is deleted by all the threads.
+  // deleted right after (This triple is stored as deleted in the `DeltaTriples`
+  // because it might be contained in the original input). Additionally, there
+  // is one common triple inserted by// all the threads and one common triple
+  // that is deleted by all the threads.
   //
-  // TODO(Hannah): I don't understand why the number of thread-exclusive deleted
-  // triples is twice that of the thread-exclusive inserted triples.
+
   auto deltaImpl = deltaTriplesManager.deltaTriples_.rlock();
   EXPECT_THAT(*deltaImpl, NumTriples(numThreads + 1, 2 * numThreads + 1,
                                      3 * numThreads + 2));

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -397,7 +397,7 @@ TEST_F(DeltaTriplesTest, DeltaTriplesManager) {
         {
           // Before the first iteration, none of the thread-exclusive triples
           // are contained in the snapshot returned by the
-          // `locatedTriplesSnapshot`. As the snapshot is persistent over time,
+          // `locatedTriplesSnapshot_`. As the snapshot is persistent over time,
           // this doesn't change in further iterations.
           const auto& locatedSPO =
               beforeUpdate->getLocatedTriplesPerBlock(Permutation::SPO);

--- a/test/DeltaTriplesTestHelpers.h
+++ b/test/DeltaTriplesTestHelpers.h
@@ -25,7 +25,7 @@ inline auto InAllPermutations =
             absl::StrCat(".getLocatedTriplesPerBlock(",
                          Permutation::toString(perm), ")"),
             [perm](const DeltaTriples& deltaTriples) {
-              return deltaTriples.getLocatedTriplesPerBlock(perm);
+              return deltaTriples.getLocatedTriplesForPermutation(perm);
             },
             InnerMatcher);
       }));

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -92,7 +92,7 @@ TEST(IndexTest, createFromTurtleTest) {
         return;
       }
       const auto& [index, qec] = getIndex();
-      const auto& deltaTriples = qec.locatedTriplesSnapshot();
+      const auto& deltaTriples = qec.locatedTriplesSnapshot_();
 
       auto getId = makeGetId(getQec(kb)->getIndex());
       Id a = getId("<a>");

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -92,7 +92,7 @@ TEST(IndexTest, createFromTurtleTest) {
         return;
       }
       const auto& [index, qec] = getIndex();
-      const auto& deltaTriples = qec.locatedTriplesSnapshot_();
+      const auto& locatedTriplesSnapshot = qec.locatedTriplesSnapshot();
 
       auto getId = makeGetId(getQec(kb)->getIndex());
       Id a = getId("<a>");
@@ -103,33 +103,49 @@ TEST(IndexTest, createFromTurtleTest) {
       Id c2 = getId("<c2>");
 
       // TODO<joka921> We could also test the multiplicities here.
-      ASSERT_TRUE(index.PSO().getMetadata(b, deltaTriples).has_value());
-      ASSERT_TRUE(index.PSO().getMetadata(b2, deltaTriples).has_value());
-      ASSERT_FALSE(index.PSO().getMetadata(a2, deltaTriples).has_value());
-      ASSERT_FALSE(index.PSO().getMetadata(c, deltaTriples).has_value());
+      ASSERT_TRUE(
+          index.PSO().getMetadata(b, locatedTriplesSnapshot).has_value());
+      ASSERT_TRUE(
+          index.PSO().getMetadata(b2, locatedTriplesSnapshot).has_value());
+      ASSERT_FALSE(
+          index.PSO().getMetadata(a2, locatedTriplesSnapshot).has_value());
+      ASSERT_FALSE(
+          index.PSO().getMetadata(c, locatedTriplesSnapshot).has_value());
       ASSERT_FALSE(
           index.PSO()
               .getMetadata(Id::makeFromVocabIndex(VocabIndex::make(735)),
-                           deltaTriples)
+                           locatedTriplesSnapshot)
               .has_value());
-      ASSERT_FALSE(
-          index.PSO().getMetadata(b, deltaTriples).value().isFunctional());
-      ASSERT_TRUE(
-          index.PSO().getMetadata(b2, deltaTriples).value().isFunctional());
+      ASSERT_FALSE(index.PSO()
+                       .getMetadata(b, locatedTriplesSnapshot)
+                       .value()
+                       .isFunctional());
+      ASSERT_TRUE(index.PSO()
+                      .getMetadata(b2, locatedTriplesSnapshot)
+                      .value()
+                      .isFunctional());
 
-      ASSERT_TRUE(index.POS().getMetadata(b, deltaTriples).has_value());
-      ASSERT_TRUE(index.POS().getMetadata(b2, deltaTriples).has_value());
-      ASSERT_FALSE(index.POS().getMetadata(a2, deltaTriples).has_value());
-      ASSERT_FALSE(index.POS().getMetadata(c, deltaTriples).has_value());
+      ASSERT_TRUE(
+          index.POS().getMetadata(b, locatedTriplesSnapshot).has_value());
+      ASSERT_TRUE(
+          index.POS().getMetadata(b2, locatedTriplesSnapshot).has_value());
+      ASSERT_FALSE(
+          index.POS().getMetadata(a2, locatedTriplesSnapshot).has_value());
+      ASSERT_FALSE(
+          index.POS().getMetadata(c, locatedTriplesSnapshot).has_value());
       ASSERT_FALSE(
           index.POS()
               .getMetadata(Id::makeFromVocabIndex(VocabIndex::make(735)),
-                           deltaTriples)
+                           locatedTriplesSnapshot)
               .has_value());
-      ASSERT_TRUE(
-          index.POS().getMetadata(b, deltaTriples).value().isFunctional());
-      ASSERT_TRUE(
-          index.POS().getMetadata(b2, deltaTriples).value().isFunctional());
+      ASSERT_TRUE(index.POS()
+                      .getMetadata(b, locatedTriplesSnapshot)
+                      .value()
+                      .isFunctional());
+      ASSERT_TRUE(index.POS()
+                      .getMetadata(b2, locatedTriplesSnapshot)
+                      .value()
+                      .isFunctional());
 
       // Relation b
       // Pair index

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -41,7 +41,7 @@ auto makeTestScanWidthOne = [](const IndexImpl& index,
         IdTable result =
             index.scan({c0, c1, std::nullopt}, permutation, additionalColumns,
                        std::make_shared<ad_utility::CancellationHandle<>>(),
-                       qec.deltaTriples());
+                       qec.locatedTriplesSnapshot());
         ASSERT_EQ(result.numColumns(), 1 + additionalColumns.size());
         ASSERT_EQ(result, makeIdTableFromVector(expected));
       };
@@ -62,7 +62,7 @@ auto makeTestScanWidthTwo = [](const IndexImpl& index,
             index.scan({c0, std::nullopt, std::nullopt}, permutation,
                        Permutation::ColumnIndicesRef{},
                        std::make_shared<ad_utility::CancellationHandle<>>(),
-                       qec.deltaTriples());
+                       qec.locatedTriplesSnapshot());
         ASSERT_EQ(wol, makeIdTableFromVector(expected));
       };
 };
@@ -92,7 +92,7 @@ TEST(IndexTest, createFromTurtleTest) {
         return;
       }
       const auto& [index, qec] = getIndex();
-      const auto& deltaTriples = qec.deltaTriples();
+      const auto& deltaTriples = qec.locatedTriplesSnapshot();
 
       auto getId = makeGetId(getQec(kb)->getIndex());
       Id a = getId("<a>");
@@ -167,7 +167,7 @@ TEST(IndexTest, createFromTurtleTest) {
 
       const auto& qec = *getQec(kb);
       const IndexImpl& index = qec.getIndex().getImpl();
-      const auto& deltaTriples = qec.deltaTriples();
+      const auto& deltaTriples = qec.locatedTriplesSnapshot();
 
       auto getId = makeGetId(getQec(kb)->getIndex());
       Id zero = getId("<0>");
@@ -224,7 +224,7 @@ TEST(IndexTest, createFromOnDiskIndexTest) {
       "<a2> <b2> <c2> .";
   const auto& qec = *getQec(kb);
   const IndexImpl& index = qec.getIndex().getImpl();
-  const auto& deltaTriples = qec.deltaTriples();
+  const auto& deltaTriples = qec.locatedTriplesSnapshot();
 
   auto getId = makeGetId(getQec(kb)->getIndex());
   Id b = getId("<b>");
@@ -465,8 +465,8 @@ TEST(IndexTest, NumDistinctEntities) {
   EXPECT_FLOAT_EQ(multiplicities[1], 7.0 / 2.0);
   EXPECT_FLOAT_EQ(multiplicities[2], 7.0 / 7.0);
 
-  multiplicities =
-      index.getMultiplicities(iri("<x>"), Permutation::SPO, qec.deltaTriples());
+  multiplicities = index.getMultiplicities(iri("<x>"), Permutation::SPO,
+                                           qec.locatedTriplesSnapshot());
   EXPECT_FLOAT_EQ(multiplicities[0], 2.5);
   EXPECT_FLOAT_EQ(multiplicities[1], 1);
 }

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -56,17 +56,18 @@ namespace {
 void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     const Index& index) {
   DeltaTriplesManager deltaTriplesManager(index.getImpl());
-  auto deltaTriples = deltaTriplesManager.getLocatedTriples();
+  auto sharedLocatedTriplesSnapshot = deltaTriplesManager.getSnapshot();
+  const auto& locatedTriplesSnapshot = *sharedLocatedTriplesSnapshot;
   static constexpr size_t col0IdTag = 43;
   auto cancellationDummy = std::make_shared<ad_utility::CancellationHandle<>>();
   auto iriOfHasPattern =
       TripleComponent::Iri::fromIriref(HAS_PATTERN_PREDICATE);
   auto checkSingleElement = [&cancellationDummy, &iriOfHasPattern,
-                             &deltaTriples](const Index& index,
-                                            size_t patternIdx, Id id) {
+                             &locatedTriplesSnapshot](
+                                const Index& index, size_t patternIdx, Id id) {
     auto scanResultHasPattern = index.scan(
         ScanSpecificationAsTripleComponent{iriOfHasPattern, id, std::nullopt},
-        Permutation::Enum::PSO, {}, cancellationDummy, deltaTriples);
+        Permutation::Enum::PSO, {}, cancellationDummy, locatedTriplesSnapshot);
     // Each ID has at most one pattern, it can have none if it doesn't
     // appear as a subject in the knowledge graph.
     AD_CORRECTNESS_CHECK(scanResultHasPattern.numRows() <= 1);
@@ -87,7 +88,7 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
             ScanSpecification{col0Id, std::nullopt, std::nullopt}, permutation,
             std::array{ColumnIndex{ADDITIONAL_COLUMN_INDEX_SUBJECT_PATTERN},
                        ColumnIndex{ADDITIONAL_COLUMN_INDEX_OBJECT_PATTERN}},
-            cancellationDummy, deltaTriples);
+            cancellationDummy, locatedTriplesSnapshot);
         ASSERT_EQ(scanResult.numColumns(), 4u);
         for (const auto& row : scanResult) {
           auto patternIdx = row[2].getInt();
@@ -113,12 +114,12 @@ void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
   auto cancellationHandle =
       std::make_shared<ad_utility::CancellationHandle<>>();
   auto predicates = index.getImpl().PSO().getDistinctCol0IdsAndCounts(
-      cancellationHandle, deltaTriples);
+      cancellationHandle, locatedTriplesSnapshot);
   for (const auto& predicate : predicates.getColumn(0)) {
     checkConsistencyForPredicate(predicate);
   }
   auto objects = index.getImpl().OSP().getDistinctCol0IdsAndCounts(
-      cancellationHandle, deltaTriples);
+      cancellationHandle, locatedTriplesSnapshot);
   for (const auto& object : objects.getColumn(0)) {
     checkConsistencyForObject(object);
   }

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -55,7 +55,8 @@ namespace {
 // folded into the permutations as additional columns.
 void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     const Index& index) {
-  DeltaTriples deltaTriples(index);
+  DeltaTriplesManager deltaTriplesManager(index.getImpl());
+  auto deltaTriples = deltaTriplesManager.getLocatedTriples();
   static constexpr size_t col0IdTag = 43;
   auto cancellationDummy = std::make_shared<ad_utility::CancellationHandle<>>();
   auto iriOfHasPattern =

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -56,7 +56,7 @@ namespace {
 void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     const Index& index) {
   DeltaTriplesManager deltaTriplesManager(index.getImpl());
-  auto sharedLocatedTriplesSnapshot = deltaTriplesManager.getSnapshot();
+  auto sharedLocatedTriplesSnapshot = deltaTriplesManager.getCurrentSnapshot();
   const auto& locatedTriplesSnapshot = *sharedLocatedTriplesSnapshot;
   static constexpr size_t col0IdTag = 43;
   auto cancellationDummy = std::make_shared<ad_utility::CancellationHandle<>>();


### PR DESCRIPTION
The already existing `DeltaTriples` class maintains a dynamically changing set of insertions and deletions relative to the original input data, together with a (single) local vocab. The class is not threadsafe and has to be used with care. In particular, concurrent update queries have to be serialized, and while a query makes use of the "delta triples", it has to be made sure that they are not changed over the course of the processing of that query.

Both of these problems are solved by the new `DeltaTriplesManager` class. The index has a single object of this class. It maintains a single `DeltaTriples` object, write access to which is strictly serialized. Each new query gets a so-called *snapshot* of the current delta triples. This is a full copy (of the delta triples located in each of the permutations and of the local vocab). These snapshots are read-only and multiple queries can share the same snapshot. A snapshot lives as long as one query using it is still being processed.