### PR TITLE
Use `DeltaTriplesManager` to process `update` request

### DIFF
--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -1007,7 +1007,7 @@ Awaitable<void> Server::processQueryOrUpdate(
         exceptionErrorMsg.value().append(absl::StrCat(
             " Highlighting an error for the command line log failed: ",
             e.what()));
-        LOG(ERROR) << "Failed to highlight error in query. " << e.what()
+        LOG(ERROR) << "Failed to highlight error in operation. " << e.what()
                    << std::endl;
         LOG(ERROR) << metadata.value().query_ << std::endl;
       }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -910,8 +910,8 @@ Awaitable<void> Server::processQueryOrUpdate(
       co_await processQuery(params, queryOrUpdate, requestTimer, request, send,
                             timeLimit);
     } else {
-      throw std::runtime_error(
-          "SPARQL 1.1 Update is  currently not supported by QLever.");
+      co_await processUpdate(params, queryOrUpdate, requestTimer, request, send,
+                             timeLimit);
     }
   } catch (const ParseException& e) {
     responseStatus = http::status::bad_request;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -868,10 +868,12 @@ Awaitable<void> Server::processUpdate(
     throw std::runtime_error("Expected Update but received Query.");
   }
 
-  DeltaTriples deltaTriples = qec.deltaTriples();
-  // TODO: activate once #1592 is merged
-  // ExecuteUpdate::executeUpdate(index_, plannedQuery.parsedQuery_, qet,
-  // deltaTriples, cancellationHandle);
+  // TODO: activate once #1603 is merged
+  // auto& deltaTriples = index_.deltaTriplesManager();
+  auto deltaTriples = DeltaTriples(index_);
+  // TODO: will work, once #1607 is merged
+  ExecuteUpdate::executeUpdate(index_, plannedQuery.parsedQuery_, qet,
+                               deltaTriples, cancellationHandle);
 
   LOG(INFO) << "Done processing update"
             << ", total time was " << requestTimer.msecs().count() << " ms"

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "engine/ExecuteUpdate.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "engine/QueryPlanner.h"
 #include "global/RuntimeParameters.h"

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -395,6 +395,12 @@ Awaitable<void> Server::process(
     logCommand(cmd, "clear cache completely (including unpinned elements)");
     cache_.clearAll();
     response = createJsonResponse(composeCacheStatsJson(), request);
+  } else if (auto cmd = checkParameter("cmd", "clear-delta-triples")) {
+    requireValidAccessToken("clear-delta-triples");
+    logCommand(cmd, "clear delta triples");
+    index_.deltaTriplesManager().clear();
+    response = createOkResponse("Delta triples have been cleared", request,
+                                MediaType::textPlain);
   } else if (auto cmd = checkParameter("cmd", "get-settings")) {
     logCommand(cmd, "get server settings");
     response = createJsonResponse(RuntimeParameters().toMap(), request);

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -811,6 +811,9 @@ Awaitable<void> Server::processQuery(
   // `computeInNewThread`. We also can't unwrap the optional directly in this
   // function, because then the conan build fails in a very strange way,
   // probably related to issues in GCC's coroutine implementation.
+  auto plannedQuery = setupPlannedQuery(params, query, qec, cancellationHandle,
+                                 timeLimit, requestTimer);
+  /*
   auto plannedQueryOpt = co_await computeInNewThread(
       queryThreadPool_,
       [this, &params, &query, &qec, cancellationHandle, &timeLimit,
@@ -821,6 +824,7 @@ Awaitable<void> Server::processQuery(
       cancellationHandle);
   AD_CORRECTNESS_CHECK(plannedQueryOpt.has_value());
   auto plannedQuery = std::move(plannedQueryOpt).value();
+  */
   auto qet = plannedQuery.queryExecutionTree_;
 
   if (plannedQuery.parsedQuery_.hasUpdateClause()) {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -811,10 +811,11 @@ Awaitable<void> Server::processQuery(
   // `computeInNewThread`. We also can't unwrap the optional directly in this
   // function, because then the conan build fails in a very strange way,
   // probably related to issues in GCC's coroutine implementation.
+  /*
   auto plannedQuery = setupPlannedQuery(params, query, qec, cancellationHandle,
                                  timeLimit, requestTimer);
-  /*
-  auto plannedQueryOpt = co_await computeInNewThread(
+                                 */
+  auto coroutine = computeInNewThread(
       queryThreadPool_,
       [this, &params, &query, &qec, cancellationHandle, &timeLimit,
        &requestTimer]() -> std::optional<PlannedQuery> {
@@ -822,9 +823,9 @@ Awaitable<void> Server::processQuery(
                                  timeLimit, requestTimer);
       },
       cancellationHandle);
+  auto plannedQueryOpt = co_await std::move(coroutine);
   AD_CORRECTNESS_CHECK(plannedQueryOpt.has_value());
   auto plannedQuery = std::move(plannedQueryOpt).value();
-  */
   auto qet = plannedQuery.queryExecutionTree_;
 
   if (plannedQuery.parsedQuery_.hasUpdateClause()) {

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -32,6 +32,8 @@ using std::vector;
 //! The HTTP Server used.
 class Server {
   FRIEND_TEST(ServerTest, parseHttpRequest);
+  FRIEND_TEST(ServerTest, getQueryId);
+  FRIEND_TEST(ServerTest, createMessageSender);
 
  public:
   explicit Server(unsigned short port, size_t numThreads,
@@ -172,10 +174,11 @@ class Server {
       SharedCancellationHandle handle, TimeLimit timeLimit,
       const ad_utility::Timer& requestTimer);
 
-  std::pair<std::shared_ptr<ad_utility::websocket::QueryHub>,
-            ad_utility::websocket::MessageSender>
-  createMessageSender(auto& queryHub_, const auto& request,
-                      const string& operation);
+  // Creates a `MessageSender` for the given operation.
+  ad_utility::websocket::MessageSender createMessageSender(
+      const std::weak_ptr<ad_utility::websocket::QueryHub>& queryHub,
+      const ad_utility::httpUtils::HttpRequest auto& request,
+      const string& operation);
 
   static json composeErrorResponseJson(
       const string& query, const std::string& errorMsg,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -174,8 +174,7 @@ class Server {
 
   std::pair<std::shared_ptr<ad_utility::websocket::QueryHub>,
             ad_utility::websocket::MessageSender>
-  createMessageSender(auto& queryHub_,
-                      const ad_utility::httpUtils::HttpRequest auto& request,
+  createMessageSender(auto& queryHub_, const auto& request,
                       const string& operation);
 
   static json composeErrorResponseJson(

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -147,6 +147,12 @@ class Server {
       ad_utility::Timer& requestTimer,
       const ad_utility::httpUtils::HttpRequest auto& request, auto&& send,
       TimeLimit timeLimit);
+  // Do the actual execution of an update.
+  Awaitable<void> processUpdate(
+      const ad_utility::url_parser::ParamValueMap& params, const string& update,
+      ad_utility::Timer& requestTimer,
+      const ad_utility::httpUtils::HttpRequest auto& request, auto&& send,
+      TimeLimit timeLimit);
 
   // Determine the media type to be used for the result. The media type is
   // determined (in this order) by the current action (e.g.,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -172,6 +172,12 @@ class Server {
       SharedCancellationHandle handle, TimeLimit timeLimit,
       const ad_utility::Timer& requestTimer);
 
+  std::pair<std::shared_ptr<ad_utility::websocket::QueryHub>,
+            ad_utility::websocket::MessageSender>
+  createMessageSender(auto& queryHub_,
+                      const ad_utility::httpUtils::HttpRequest auto& request,
+                      const string& operation);
+
   static json composeErrorResponseJson(
       const string& query, const std::string& errorMsg,
       ad_utility::Timer& requestTimer,

--- a/src/engine/Server.h
+++ b/src/engine/Server.h
@@ -169,11 +169,11 @@ class Server {
       const ad_utility::url_parser::ParamValueMap& params);
   FRIEND_TEST(ServerTest, determineResultPinning);
   // Sets up the PlannedQuery s.t. it is ready to be executed.
-  Awaitable<PlannedQuery> setupPlannedQuery(
+  PlannedQuery setupPlannedQuery(
       const ad_utility::url_parser::ParamValueMap& params,
       const std::string& operation, QueryExecutionContext& qec,
       SharedCancellationHandle handle, TimeLimit timeLimit,
-      const ad_utility::Timer& requestTimer);
+      const ad_utility::Timer& requestTimer) const;
   // Creates a `MessageSender` for the given operation.
   ad_utility::websocket::MessageSender createMessageSender(
       const std::weak_ptr<ad_utility::websocket::QueryHub>& queryHub,
@@ -181,7 +181,7 @@ class Server {
       const string& operation);
   // Execute an update operation. The function must have exclusive access to the
   // DeltaTriples object.
-  Awaitable<void> processUpdateImpl(
+  void processUpdateImpl(
       const ad_utility::url_parser::ParamValueMap& params, const string& update,
       ad_utility::Timer& requestTimer, TimeLimit timeLimit, auto& messageSender,
       ad_utility::SharedCancellationHandle cancellationHandle,
@@ -232,13 +232,11 @@ class Server {
 
   /// Run the SPARQL parser and then the query planner on the `query`. All
   /// computation is performed on the `threadPool_`.
-  /// Note: This function *never* returns `nullopt`. It either returns a value
-  /// or throws an exception. We still need to return an `optional` though for
-  /// technical reasons that are described in the definition of this function.
-  net::awaitable<std::optional<PlannedQuery>> parseAndPlan(
-      const std::string& query, const vector<DatasetClause>& queryDatasets,
-      QueryExecutionContext& qec, SharedCancellationHandle handle,
-      TimeLimit timeLimit);
+  PlannedQuery parseAndPlan(const std::string& query,
+                            const vector<DatasetClause>& queryDatasets,
+                            QueryExecutionContext& qec,
+                            SharedCancellationHandle handle,
+                            TimeLimit timeLimit) const;
 
   /// Acquire the `CancellationHandle` for the given `QueryId`, start the
   /// watchdog and call `cancelAfterDeadline` to set the timeout after

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -213,16 +213,7 @@ void DeltaTriplesManager::modify(
 }
 
 // _____________________________________________________________________________
-void DeltaTriplesManager::clear() {
-  deltaTriples_.withWriteLock([this](DeltaTriples& deltaTriples) {
-    deltaTriples.clear();
-    auto newSnapshot = deltaTriples.getSnapshot();
-    currentLocatedTriplesSnapshot_.withWriteLock(
-        [&newSnapshot](auto& currentSnapshot) {
-          currentSnapshot = std::move(newSnapshot);
-        });
-  });
-}
+void DeltaTriplesManager::clear() { modify(&DeltaTriples::clear); }
 
 // _____________________________________________________________________________
 SharedLocatedTriplesSnapshot DeltaTriplesManager::getCurrentSnapshot() const {

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -213,6 +213,18 @@ void DeltaTriplesManager::modify(
 }
 
 // _____________________________________________________________________________
+void DeltaTriplesManager::clear() {
+  deltaTriples_.withWriteLock([this](DeltaTriples& deltaTriples) {
+    deltaTriples.clear();
+    auto newSnapshot = deltaTriples.getSnapshot();
+    currentLocatedTriplesSnapshot_.withWriteLock(
+        [&newSnapshot](auto& currentSnapshot) {
+          currentSnapshot = std::move(newSnapshot);
+        });
+  });
+}
+
+// _____________________________________________________________________________
 SharedLocatedTriplesSnapshot DeltaTriplesManager::getCurrentSnapshot() const {
   return *currentLocatedTriplesSnapshot_.rlock();
 }

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -196,10 +196,15 @@ class DeltaTriplesManager {
   FRIEND_TEST(DeltaTriplesTest, DeltaTriplesManager);
 
   // Modify the underlying `DeltaTriples` by applying `function` and then update
-  // the current snapshot. Concurrent calls to `modify` will be serialized, and
-  // each call to `getCurrentSnapshot` will either return the snapshot before or
-  // after a modification, but never one of an ongoing modification.
+  // the current snapshot. Concurrent calls to `modify` and `clear` will be
+  // serialized, and each call to `getCurrentSnapshot` will either return the
+  // snapshot before or after a modification, but never one of an ongoing
+  // modification.
   void modify(const std::function<void(DeltaTriples&)>& function);
+
+  // Reset the updates represented by the underlying `DeltaTriples` and then
+  // update the current snapshot.
+  void clear();
 
   // Return a shared pointer to a deep copy of the current snapshot. This can
   // be safely used to execute a query without interfering with future updates.

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -79,7 +79,6 @@ class DeltaTriples {
  public:
   // Construct for given index.
   explicit DeltaTriples(const Index& index) : index_(index) {}
-  DeltaTriples(const DeltaTriples&) = default;
 
   // Get the common `LocalVocab` of the delta triples.
  private:

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -79,6 +79,7 @@ class DeltaTriples {
  public:
   // Construct for given index.
   explicit DeltaTriples(const Index& index) : index_(index) {}
+  DeltaTriples(const DeltaTriples&) = default;
 
   // Get the common `LocalVocab` of the delta triples.
  private:

--- a/src/util/CancellationHandle.h
+++ b/src/util/CancellationHandle.h
@@ -98,8 +98,8 @@ class CancellationException : public std::exception {
       : message_{std::move(message)} {}
   explicit CancellationException(CancellationState reason)
       : message_{reason == CancellationState::TIMEOUT
-                     ? "Query timed out."
-                     : "Query was manually cancelled."} {
+                     ? "Operation timed out."
+                     : "Operation was manually cancelled."} {
     AD_CONTRACT_CHECK(detail::isCancelled(reason));
   }
 

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -27,27 +27,27 @@ auto ParsedRequestIs = [](const std::string& path,
       AD_FIELD(ad_utility::url_parser::ParsedRequest, operation_,
                testing::Eq(operation)));
 };
+auto MakeBasicRequest = [](http::verb method, const std::string& target) {
+  // version 11 stands for HTTP/1.1
+  return http::request<http::string_body>{method, target, 11};
+};
+auto MakeGetRequest = [](const std::string& target) {
+  return MakeBasicRequest(http::verb::get, target);
+};
+auto MakePostRequest = [](const std::string& target,
+                          const std::string& contentType,
+                          const std::string& body) {
+  auto req = MakeBasicRequest(http::verb::post, target);
+  req.set(http::field::content_type, contentType);
+  req.body() = body;
+  req.prepare_payload();
+  return req;
+};
 }  // namespace
 
 TEST(ServerTest, parseHttpRequest) {
   namespace http = boost::beast::http;
 
-  auto MakeBasicRequest = [](http::verb method, const std::string& target) {
-    // version 11 stands for HTTP/1.1
-    return http::request<http::string_body>{method, target, 11};
-  };
-  auto MakeGetRequest = [&MakeBasicRequest](const std::string& target) {
-    return MakeBasicRequest(http::verb::get, target);
-  };
-  auto MakePostRequest = [&MakeBasicRequest](const std::string& target,
-                                             const std::string& contentType,
-                                             const std::string& body) {
-    auto req = MakeBasicRequest(http::verb::post, target);
-    req.set(http::field::content_type, contentType);
-    req.body() = body;
-    req.prepare_payload();
-    return req;
-  };
   auto parse = [](const ad_utility::httpUtils::HttpRequest auto& request) {
     return Server::parseHttpRequest(request);
   };
@@ -221,4 +221,66 @@ TEST(ServerTest, determineMediaType) {
   // No `Accept` header and an empty `Accept` header are not distinguished.
   EXPECT_THAT(Server::determineMediaType({}, MakeRequest("")),
               testing::Eq(ad_utility::MediaType::sparqlJson));
+}
+
+TEST(ServerTest, getQueryId) {
+  using namespace ad_utility::websocket;
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  auto reqWithExplicitQueryId = MakeGetRequest("/");
+  reqWithExplicitQueryId.set("Query-Id", "100");
+  const auto req = MakeGetRequest("/");
+  {
+    // A request with a custom query id.
+    auto queryId1 = server.getQueryId(reqWithExplicitQueryId,
+                                      "SELECT * WHERE { ?a ?b ?c }");
+    // Another request with the same custom query id. This throws an error,
+    // because query id cannot be used for multiple queries at the same time.
+    AD_EXPECT_THROW_WITH_MESSAGE(
+        server.getQueryId(reqWithExplicitQueryId,
+                          "SELECT * WHERE { ?a ?b ?c }"),
+        testing::HasSubstr("Query id '100' is already in use!"));
+  }
+  // The custom query id can be reused, once the query is finished.
+  auto queryId1 =
+      server.getQueryId(reqWithExplicitQueryId, "SELECT * WHERE { ?a ?b ?c }");
+  // Without custom query ids, unique ids are generated.
+  auto queryId2 = server.getQueryId(req, "SELECT * WHERE { ?a ?b ?c }");
+  auto queryId3 = server.getQueryId(req, "SELECT * WHERE { ?a ?b ?c }");
+}
+
+TEST(ServerTest, createMessageSender) {
+  Server server{9999, 1, ad_utility::MemorySize::megabytes(1), "accessToken"};
+  auto reqWithExplicitQueryId = MakeGetRequest("/");
+  std::string customQueryId = "100";
+  reqWithExplicitQueryId.set("Query-Id", customQueryId);
+  const auto req = MakeGetRequest("/");
+  // The query hub is only valid once, the server has been started.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      server.createMessageSender(server.queryHub_, req,
+                                 "SELECT * WHERE { ?a ?b ?c }"),
+      testing::HasSubstr("Assertion `queryHubLock` failed."));
+  {
+    // Set a dummy query hub.
+    boost::asio::io_context io_context;
+    auto queryHub =
+        std::make_shared<ad_utility::websocket::QueryHub>(io_context);
+    server.queryHub_ = queryHub;
+    // MessageSenders are created normally.
+    server.createMessageSender(server.queryHub_, req,
+                               "SELECT * WHERE { ?a ?b ?c }");
+    server.createMessageSender(server.queryHub_, req,
+                               "INSERT DATA { <foo> <bar> <baz> }");
+    EXPECT_THAT(
+        server.createMessageSender(server.queryHub_, reqWithExplicitQueryId,
+                                   "INSERT DATA { <foo> <bar> <baz> }"),
+        AD_PROPERTY(ad_utility::websocket::MessageSender, getQueryId,
+                    testing::Eq(ad_utility::websocket::QueryId::idFromString(
+                        customQueryId))));
+  }
+  // Once the query hub expires (e.g. because the io context dies), message
+  // senders can no longer be created.
+  AD_EXPECT_THROW_WITH_MESSAGE(
+      server.createMessageSender(server.queryHub_, req,
+                                 "SELECT * WHERE { ?a ?b ?c }"),
+      testing::HasSubstr("Assertion `queryHubLock` failed."));
 }


### PR DESCRIPTION
Add the missing code in `Server.cpp` and `Server.h` to process a parsed update request using the `DeltaTriplesManager` from #1603 .
As of this commit, QLever has an initial beta support for a subset of SPARQL UPDATE with the following limitations (all of which will be added in the future, and the list is far from being complete):
1. Updates are not yet persistent, so a restart or crash of the QLever server will delete all updates.
2. Only a single update request per query is allowed, not the syntax that atomically chains an arbitrary sequence of updates.
3. Only INSERT and DELETE queries are supported, the support for queries that drop or add a complete graph will be added in the future.