### PR TITLE
Add concepts and concrete types for `BlockZipperJoinImpl`

### DIFF
--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -758,7 +758,10 @@ struct BlockZipperJoinImpl {
   using LeftBlocks = typename LeftSide::CurrentBlocks;
   using RightBlocks = typename RightSide::CurrentBlocks;
 
-  // We can't define aliases for these concepts, so we use macros instead.
+// We can't define aliases for these concepts, so we use macros instead.
+#if defined(Side) || defined(Blocks)
+#error Side or Blocks are already defined
+#endif
 #define Side SameAsAny<LeftSide, RightSide> auto
 #define Blocks SameAsAny<LeftBlocks, RightBlocks> auto
 

--- a/src/util/JoinAlgorithms/JoinAlgorithms.h
+++ b/src/util/JoinAlgorithms/JoinAlgorithms.h
@@ -1141,7 +1141,8 @@ struct BlockZipperJoinImpl {
                                   typename RightSide::CurrentBlocks> auto&
                 target,
             ad_utility::SameAsAny<LeftSide, RightSide> auto& side) {
-          removeEqualToCurrentEl(side.currentBlocks_, currentEl);
+          // Explicit this to avoid false positive warning in clang.
+          this->removeEqualToCurrentEl(side.currentBlocks_, currentEl);
           bool allBlocksWereFilled = fillEqualToCurrentEl(side, currentEl);
           if (side.currentBlocks_.empty()) {
             AD_CORRECTNESS_CHECK(allBlocksWereFilled);


### PR DESCRIPTION
This class (which is the central implementation of the lazy merge join) previously had a lot of `const auto&` etc. parameters, which made the (already rather complex) code harder to reason about. This PR adds concrete types wherever possible, and constrains the other parameters using concepts.
