### PR TITLE
Fix out of memory issue with transitive paths

### DIFF
--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -10,11 +10,9 @@
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
-  LocalVocab localVocabClone;
-  localVocabClone.otherWordSets_ = otherWordSets_;
-  localVocabClone.otherWordSets_.push_back(primaryWordSet_);
-  // Return the clone.
-  return localVocabClone;
+  LocalVocab clone;
+  clone.mergeWith(std::span{this, 1});
+  return clone;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -10,9 +10,7 @@
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
-  LocalVocab clone;
-  clone.mergeWith(std::span{this, 1});
-  return clone;
+ return merge(std::span{this, 1});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -10,7 +10,9 @@
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
-  return merge(std::array<const LocalVocab*, 1>{this});
+  LocalVocab clone;
+  clone.mergeWith(std::span{this, 1});
+  return clone;
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -9,9 +9,7 @@
 #include "global/ValueId.h"
 
 // _____________________________________________________________________________
-LocalVocab LocalVocab::clone() const {
- return merge(std::span{this, 1});
-}
+LocalVocab LocalVocab::clone() const { return merge(std::span{this, 1}); }
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::merge(std::span<const LocalVocab*> vocabs) {

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -9,7 +9,9 @@
 #include "global/ValueId.h"
 
 // _____________________________________________________________________________
-LocalVocab LocalVocab::clone() const { return merge(std::span{this, 1}); }
+LocalVocab LocalVocab::clone() const {
+  return merge(std::array<const LocalVocab*, 1>{this});
+}
 
 // _____________________________________________________________________________
 LocalVocab LocalVocab::merge(std::span<const LocalVocab*> vocabs) {

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -96,10 +96,8 @@ class LocalVocab {
   template <std::ranges::range R>
   void mergeWith(const R& vocabs) {
     auto inserter = std::back_inserter(otherWordSets_);
-    for (const auto& vocab : vocabs) {
-      if (vocab.empty()) {
-        continue;
-      }
+    using std::views::filter;
+    for (const auto& vocab : vocabs | filter(std::not_fn(&LocalVocab::empty))) {
       std::ranges::copy(vocab.otherWordSets_, inserter);
       *inserter = vocab.primaryWordSet_;
     }

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -97,6 +97,9 @@ class LocalVocab {
   void mergeWith(const R& vocabs) {
     auto inserter = std::back_inserter(otherWordSets_);
     for (const auto& vocab : vocabs) {
+      if (vocab.empty()) {
+        continue;
+      }
       std::ranges::copy(vocab.otherWordSets_, inserter);
       *inserter = vocab.primaryWordSet_;
     }

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -93,8 +93,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
   ad_utility::Timer timer{ad_utility::Timer::Stopped};
   size_t outputRow = 0;
   IdTableStatic<OUTPUT_WIDTH> table{getResultWidth(), allocator()};
-  std::vector<LocalVocab, ad_utility::AllocatorWithLimit<LocalVocab>>
-      storedLocalVocabs{allocator()};
+  LocalVocab mergedVocab{};
   for (auto& [node, linkedNodes, localVocab, idTable, inputRow] : hull) {
     timer.cont();
     // As an optimization nodes without any linked nodes should not get yielded
@@ -121,7 +120,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
     }
 
     if (yieldOnce) {
-      storedLocalVocabs.emplace_back(std::move(localVocab));
+      mergedVocab.mergeWith(std::span{&localVocab, 1});
     } else {
       timer.stop();
       runtimeInfo().addDetail("IdTable fill time", timer.msecs());
@@ -133,8 +132,6 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
   }
   if (yieldOnce) {
     timer.start();
-    LocalVocab mergedVocab{};
-    mergedVocab.mergeWith(storedLocalVocabs);
     runtimeInfo().addDetail("IdTable fill time", timer.msecs());
     co_yield {std::move(table).toDynamic(), std::move(mergedVocab)};
   }

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -93,7 +93,8 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
   ad_utility::Timer timer{ad_utility::Timer::Stopped};
   size_t outputRow = 0;
   IdTableStatic<OUTPUT_WIDTH> table{getResultWidth(), allocator()};
-  std::vector<LocalVocab> storedLocalVocabs;
+  std::vector<LocalVocab, ad_utility::AllocatorWithLimit<LocalVocab>>
+      storedLocalVocabs{allocator()};
   for (auto& [node, linkedNodes, localVocab, idTable, inputRow] : hull) {
     timer.cont();
     // As an optimization nodes without any linked nodes should not get yielded

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -242,6 +242,10 @@ class TransitivePathImpl : public TransitivePathBase {
    * `TableColumnWithVocab` that can be consumed to create a transitive hull.
    * @param target Optional target Id. If supplied, only paths which end
    * in this Id are added to the hull.
+   * @param yieldOnce This has to be set to the same value as the consuming
+   * code. When set to true, this will prevent yielding the same LocalVocab over
+   * and over again to make merging faster (because merging with an empty
+   * LocalVocab is a no-op).
    * @return Map Maps each Id to its connected Ids in the transitive hull
    */
   NodeGenerator transitiveHull(const T& edges, LocalVocab edgesVocab,


### PR DESCRIPTION
The introduction of lazy transitive paths via #1595 caused transitive path operations with lazy inputs and a fully materialized result to store the same local vocab once per input row. This lead to OOM errors even if that local vocab was empty. This commit fixes that behavior by 
1. Not merging empty local vocabs at all
2. Only storing the local vocab for each input block, without repeating them for each row.

Note that this still might lead to redundant stores in the local vocab, but deduplicating those will be done in a separate PR.