### PR TITLE
Merge local vocabs in the `Filter` operation

### DIFF
--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -71,18 +71,16 @@ ProtoResult Filter::computeResult(bool requestLaziness) {
   // single IdTable.
   size_t width = getSubtree().get()->getResultWidth();
   IdTable result{width, getExecutionContext()->getAllocator()};
-  std::vector<LocalVocab> localVocabs;
+
+  LocalVocab resultLocalVocab{};
   ad_utility::callFixedSize(
-      width, [this, &subRes, &result, &localVocabs]<int WIDTH>() {
+      width, [this, &subRes, &result, &resultLocalVocab]<int WIDTH>() {
         for (Result::IdTableVocabPair& pair : subRes->idTables()) {
           computeFilterImpl<WIDTH>(result, pair.idTable_, pair.localVocab_,
                                    subRes->sortedBy());
-          localVocabs.emplace_back(std::move(pair.localVocab_));
+          resultLocalVocab.mergeWith(std::span{&pair.localVocab_, 1});
         }
       });
-
-  LocalVocab resultLocalVocab{};
-  resultLocalVocab.mergeWith(localVocabs);
 
   LOG(DEBUG) << "Filter result computation done." << endl;
 


### PR DESCRIPTION
This commit affects the case when the input to a FILTER is lazy, but the result is fully materialized. Now the local vocabs of the lazy input blocks are directly merged into the local vocab of the result. Previously they were first stored in a vector, which had a higher RAM footprint for the case of many redundant and typically empty local vocabs in the input.