### PR TITLE
Update graph info in the augmented block metadata

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1594,3 +1594,28 @@ void CompressedRelationReader::LazyScanMetadata::update(
     ++numBlocksSkippedBecauseOfGraph_;
   }
 }
+
+// _____________________________________________________________________________
+std::ostream& operator<<(
+    std::ostream& str,
+    const CompressedBlockMetadataNoBlockIndex& blockMetadata) {
+  str << "#BlockMetadata\n(first) " << blockMetadata.firstTriple_ << "(last) "
+      << blockMetadata.lastTriple_ << "num. rows: " << blockMetadata.numRows_
+      << ".\n";
+  if (blockMetadata.graphInfo_.has_value()) {
+    str << "Graphs: ";
+    ad_utility::lazyStrJoin(&str, blockMetadata.graphInfo_.value(), ", ");
+    str << '\n';
+  }
+  str << "[possibly] contains duplicates: "
+      << blockMetadata.containsDuplicatesWithDifferentGraphs_ << '\n';
+  return str;
+}
+
+// _____________________________________________________________________________
+std::ostream& operator<<(std::ostream& str,
+                         const CompressedBlockMetadata& blockMetadata) {
+  str << static_cast<const CompressedBlockMetadataNoBlockIndex&>(blockMetadata);
+  str << "block index: " << blockMetadata.blockIndex_ << "\n";
+  return str;
+}

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1594,28 +1594,3 @@ void CompressedRelationReader::LazyScanMetadata::update(
     ++numBlocksSkippedBecauseOfGraph_;
   }
 }
-
-// _____________________________________________________________________________
-std::ostream& operator<<(
-    std::ostream& str,
-    const CompressedBlockMetadataNoBlockIndex& blockMetadata) {
-  str << "#BlockMetadata\n(first) " << blockMetadata.firstTriple_ << "(last) "
-      << blockMetadata.lastTriple_ << "num. rows: " << blockMetadata.numRows_
-      << ".\n";
-  if (blockMetadata.graphInfo_.has_value()) {
-    str << "Graphs: ";
-    ad_utility::lazyStrJoin(&str, blockMetadata.graphInfo_.value(), ", ");
-    str << '\n';
-  }
-  str << "[possibly] contains duplicates: "
-      << blockMetadata.containsDuplicatesWithDifferentGraphs_ << '\n';
-  return str;
-}
-
-// _____________________________________________________________________________
-std::ostream& operator<<(std::ostream& str,
-                         const CompressedBlockMetadata& blockMetadata) {
-  str << static_cast<const CompressedBlockMetadataNoBlockIndex&>(blockMetadata);
-  str << "block index: " << blockMetadata.blockIndex_ << "\n";
-  return str;
-}

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -115,7 +115,19 @@ struct CompressedBlockMetadataNoBlockIndex {
   // Format BlockMetadata contents for debugging.
   friend std::ostream& operator<<(
       std::ostream& str,
-      const CompressedBlockMetadataNoBlockIndex& blockMetadata);
+      const CompressedBlockMetadataNoBlockIndex& blockMetadata) {
+    str << "#BlockMetadata\n(first) " << blockMetadata.firstTriple_ << "(last) "
+        << blockMetadata.lastTriple_ << "num. rows: " << blockMetadata.numRows_
+        << ".\n";
+    if (blockMetadata.graphInfo_.has_value()) {
+      str << "Graphs: ";
+      ad_utility::lazyStrJoin(&str, blockMetadata.graphInfo_.value(), ", ");
+      str << '\n';
+    }
+    str << "[possibly] contains duplicates: "
+        << blockMetadata.containsDuplicatesWithDifferentGraphs_ << '\n';
+    return str;
+  }
 };
 
 // The same as the above struct, but this block additionally knows its index.
@@ -129,8 +141,13 @@ struct CompressedBlockMetadata : CompressedBlockMetadataNoBlockIndex {
   bool operator==(const CompressedBlockMetadata&) const = default;
 
   // Format BlockMetadata contents for debugging.
-  friend std::ostream& operator<<(std::ostream& str,
-                                  const CompressedBlockMetadata& blockMetadata);
+  friend std::ostream& operator<<(
+      std::ostream& str, const CompressedBlockMetadata& blockMetadata) {
+    str << static_cast<const CompressedBlockMetadataNoBlockIndex&>(
+        blockMetadata);
+    str << "block index: " << blockMetadata.blockIndex_ << "\n";
+    return str;
+  }
 };
 
 // Serialization of the `OffsetAndcompressedSize` subclass.

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -59,6 +59,9 @@ struct CompressedBlockMetadataNoBlockIndex {
     size_t compressedSize_;
     bool operator==(const OffsetAndCompressedSize&) const = default;
   };
+
+  using GraphInfo = std::optional<std::vector<Id>>;
+
   std::vector<OffsetAndCompressedSize> offsetsAndCompressedSize_;
   size_t numRows_;
 
@@ -112,12 +115,7 @@ struct CompressedBlockMetadataNoBlockIndex {
   // Format BlockMetadata contents for debugging.
   friend std::ostream& operator<<(
       std::ostream& str,
-      const CompressedBlockMetadataNoBlockIndex& blockMetadata) {
-    str << "#BlockMetadata\n(first) " << blockMetadata.firstTriple_ << "(last) "
-        << blockMetadata.lastTriple_ << "num. rows: " << blockMetadata.numRows_
-        << "." << std::endl;
-    return str;
-  }
+      const CompressedBlockMetadataNoBlockIndex& blockMetadata);
 };
 
 // The same as the above struct, but this block additionally knows its index.
@@ -131,13 +129,8 @@ struct CompressedBlockMetadata : CompressedBlockMetadataNoBlockIndex {
   bool operator==(const CompressedBlockMetadata&) const = default;
 
   // Format BlockMetadata contents for debugging.
-  friend std::ostream& operator<<(
-      std::ostream& str, const CompressedBlockMetadata& blockMetadata) {
-    str << "#BlockMetadata\n(first) " << blockMetadata.firstTriple_ << "(last) "
-        << blockMetadata.lastTriple_ << "num. rows: " << blockMetadata.numRows_
-        << "." << std::endl;
-    return str;
-  }
+  friend std::ostream& operator<<(std::ostream& str,
+                                  const CompressedBlockMetadata& blockMetadata);
 };
 
 // Serialization of the `OffsetAndcompressedSize` subclass.

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -10,8 +10,8 @@
 
 #include "absl/strings/str_join.h"
 #include "index/CompressedRelation.h"
-#include "util/ChunkedForLoop.h"
 #include "index/ConstantsIndexBuilding.h"
+#include "util/ChunkedForLoop.h"
 
 // ____________________________________________________________________________
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
@@ -251,23 +251,45 @@ void LocatedTriplesPerBlock::setOriginalMetadata(
   updateAugmentedMetadata();
 }
 
-static auto updateGraphMetadata(CompressedBlockMetadata& blockMetadata, const LocatedTriples& locatedTriples) {
+// Update the `blockMetadata`, such that its metadata pertaining to the
+// contained graphs is consistent with the `locatedTriples` which are added to
+// that block. In particular, all graphs to which at least one triple is added
+// is added to the graph metadata, and if the number of total graphs is larger
+// than the configured threshold, then the graph metadata is set to `nullopt`,
+// which means that there is no metadata.
+static auto updateGraphMetadata(CompressedBlockMetadata& blockMetadata,
+                                const LocatedTriples& locatedTriples) {
+  // We do not know anything about the triples contained in the block, so we
+  // also Cannot know if the `locatedTriples` introduces duplicates. We thus
+  // have to be conservative and assume that there are duplicates.
+  blockMetadata.containsDuplicatesWithDifferentGraphs_ = true;
   auto& graphs = blockMetadata.graphInfo_;
   if (!graphs.has_value()) {
+    // The original block already contains too many graphs, don't store any
+    // metadata.
     return;
   }
-  ad_utility::HashSet<Id> newGraphs(graphs.value().begin(), graphs.value().end());
+
+  // Compute a hash set of all graphs that are originally contained in the block
+  // and all the graphs that are added via the `locatedTriples`.
+  ad_utility::HashSet<Id> newGraphs(graphs.value().begin(),
+                                    graphs.value().end());
   for (auto& lt : locatedTriples) {
     if (!lt.shouldTripleExist_) {
+      // Don't update the graph info for triples that are deleted.
       continue;
     }
     newGraphs.insert(lt.triple_.ids_.at(ADDITIONAL_COLUMN_GRAPH_ID));
+    // Handle the case that with the newly added triples we have too many
+    // distinct graphs to store them in the metadata.
     if (newGraphs.size() > MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA) {
       graphs.reset();
       return;
     }
   }
   graphs.emplace(newGraphs.begin(), newGraphs.end());
+  // Sort the stored graphs, to make the testing easier.
+  std::ranges::sort(graphs.value());
 }
 
 // ____________________________________________________________________________

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -291,7 +291,7 @@ addLinkAndDiscoverTest(AlgorithmTest)
 
 addLinkAndDiscoverTestSerial(CompressedRelationsTest index)
 
-addLinkAndDiscoverTestSerial(PrefilterExpressionIndexTest sparqlExpressions index)
+addLinkAndDiscoverTestSerial(PrefilterExpressionIndexTest sparqlExpressions sparqlExpressions parser index)
 
 addLinkAndDiscoverTestSerial(GetPrefilterExpressionFromSparqlExpressionTest sparqlExpressions index)
 

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -29,10 +29,12 @@ auto IT = [](const auto& c1, const auto& c2, const auto& c3, int graph = g) {
 auto PT = [](const auto& c1, const auto& c2, const auto& c3, int graph = g) {
   return CompressedBlockMetadata::PermutedTriple{V(c1), V(c2), V(c3), V(graph)};
 };
-auto CBM = [](const auto firstTriple, const auto lastTriple) {
+auto CBM = [](const auto firstTriple, const auto lastTriple,
+              CompressedBlockMetadata::GraphInfo graphs = std::nullopt) {
   size_t dummyBlockIndex = 0;
-  return CompressedBlockMetadata{{{}, 0, firstTriple, lastTriple, {}, false},
-                                 dummyBlockIndex};
+  return CompressedBlockMetadata{
+      {{}, 0, firstTriple, lastTriple, std::move(graphs), false},
+      dummyBlockIndex};
 };
 
 auto numBlocks =
@@ -750,10 +752,12 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
         Span{T1}, metadata, {0, 1, 2}, false, handle));
 
     expectedAugmentedMetadata[0] = CBM(T1.toPermutedTriple(), PT1);
+    expectedAugmentedMetadata[0].containsDuplicatesWithDifferentGraphs_ = true;
     EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
                 testing::ElementsAreArray(expectedAugmentedMetadata));
 
     // T2 is inside block 1. Borders don't change.
+    expectedAugmentedMetadata[1].containsDuplicatesWithDifferentGraphs_ = true;
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
         Span{T2}, metadata, {0, 1, 2}, true, handle));
 
@@ -762,6 +766,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
 
     // T3 is equal to PT4, the beginning of block 2. All update (update and
     // delete) add to the block borders. Borders don't change.
+    expectedAugmentedMetadata[2].containsDuplicatesWithDifferentGraphs_ = true;
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
         Span{T3}, metadata, {0, 1, 2}, false, handle));
 
@@ -774,6 +779,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
             Span{T4}, metadata, {0, 1, 2}, true, handle));
 
     expectedAugmentedMetadata[4] = CBM(T4.toPermutedTriple(), PT8);
+    expectedAugmentedMetadata[4].containsDuplicatesWithDifferentGraphs_ = true;
     EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
                 testing::ElementsAreArray(expectedAugmentedMetadata));
 
@@ -781,6 +787,9 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
     locatedTriplesPerBlock.erase(4, handles[0]);
 
     expectedAugmentedMetadata[4] = CBM(PT8, PT8);
+    // The block 4 has no more updates, so we restore the info about the block
+    // having no duplicates from the original metadata.
+    expectedAugmentedMetadata[4].containsDuplicatesWithDifferentGraphs_ = false;
     EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
                 testing::ElementsAreArray(expectedAugmentedMetadata));
 
@@ -794,6 +803,92 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
   {
     LocatedTriplesPerBlock ltpb;
     EXPECT_THROW(ltpb.getAugmentedMetadata(), ad_utility::Exception);
+  }
+}
+
+// _____________________________________________________________________________
+TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
+  // Create a vector that is automatically converted to a span.
+  using Span = std::vector<IdTriple<0>>;
+
+  auto PT1 = PT(1, 10, 10);
+  auto PT2 = PT(2, 10, 10);
+  auto PT3 = PT(2, 15, 20);
+  // Two blocks, one without graph info, and one with graph info.
+  const std::vector<CompressedBlockMetadata> metadata = {
+      CBM(PT1, PT1), CBM(PT2, PT3, std::vector<Id>{V(13)})};
+  std::vector<CompressedBlockMetadata> expectedAugmentedMetadata{metadata};
+
+  auto T1 = IT(
+      1, 10, 10,
+      12);  // Before block 0 (because `12` is smaller than the default graph)
+  auto T2 = IT(1, 10, 10,
+               99999999);  // Becomes the lower bound of block 1, although it
+                           // only differs in the graph info.
+  auto T3 = IT(2, 12, 10, 17);  // Inside block 1, add graph 17.
+  auto T4 = IT(2, 12, 10, 18);  // Inside block 1, add graph 18.
+
+  auto T5 = IT(20, 30, 40, 19);  // After the last block.
+
+  ad_utility::SharedCancellationHandle handle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+
+  {
+    LocatedTriplesPerBlock locatedTriplesPerBlock;
+    locatedTriplesPerBlock.setOriginalMetadata(metadata);
+
+    // Delete the located triples {T1 ... T4}
+    locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
+        Span{T1, T2, T3, T4}, metadata, {0, 1, 2}, false, handle));
+
+    // All the blocks have updates, so their value of `containsDuplicates..` is
+    // set to `true`.
+    expectedAugmentedMetadata[0] = CBM(T1.toPermutedTriple(), PT1);
+    expectedAugmentedMetadata[1].firstTriple_ = T2.toPermutedTriple();
+    expectedAugmentedMetadata[0].containsDuplicatesWithDifferentGraphs_ = true;
+    expectedAugmentedMetadata[1].containsDuplicatesWithDifferentGraphs_ = true;
+
+    // Note: the GraphInfo hasn't changed, because the new triples all were
+    // deleted.
+    EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
+                testing::ElementsAreArray(expectedAugmentedMetadata));
+  }
+  {
+    expectedAugmentedMetadata = metadata;
+    LocatedTriplesPerBlock locatedTriplesPerBlock;
+    locatedTriplesPerBlock.setOriginalMetadata(metadata);
+
+    // Add the located triples {T1 ... T5}
+    locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
+        Span{T1, T2, T3, T4, T5}, metadata, {0, 1, 2}, true, handle));
+
+    expectedAugmentedMetadata[0] = CBM(T1.toPermutedTriple(), PT1);
+    expectedAugmentedMetadata[1].firstTriple_ = T2.toPermutedTriple();
+    expectedAugmentedMetadata[1].graphInfo_.value() =
+        std::vector{V(13), V(17), V(18), V(99999999)};
+
+    // We have added a triple `T5` after the last block, so there now is an
+    // additional block, which also stores the correct graph info.
+    expectedAugmentedMetadata.push_back(
+        CBM(T5.toPermutedTriple(), T5.toPermutedTriple(), std::vector{V(19)}));
+
+    // The automatically added metadata for the last block also has the correct
+    // block index and number of columns, so we have to properly initialize it.
+    expectedAugmentedMetadata.back().blockIndex_ = 2;
+    expectedAugmentedMetadata.back().offsetsAndCompressedSize_.resize(4,
+                                                                      {0, 0});
+
+    // All the blocks have updates, so their value of `containsDuplicates..` is
+    // set to `true`.
+    expectedAugmentedMetadata[0].containsDuplicatesWithDifferentGraphs_ = true;
+    expectedAugmentedMetadata[1].containsDuplicatesWithDifferentGraphs_ = true;
+    expectedAugmentedMetadata[2].containsDuplicatesWithDifferentGraphs_ = true;
+
+    // Note: the GraphInfo hasn't changed, because the new triples all were
+    // deleted.
+    auto m = locatedTriplesPerBlock.getAugmentedMetadata();
+    EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
+                testing::ElementsAreArray(expectedAugmentedMetadata));
   }
 }
 

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -157,21 +157,32 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
 
 //______________________________________________________________________________
 TEST_F(PrefilterExpressionOnMetadataTest, testBlockFormatForDebugging) {
+  auto toString = [](const CompressedBlockMetadata& b) {
+    return (std::stringstream{} << b).str();
+  };
+
+  auto matcher = [&toString](const std::string& substring) {
+    return ::testing::ResultOf(toString, ::testing::HasSubstr(substring));
+  };
   EXPECT_THAT(
-      (std::stringstream() << b5).str(),
-      ::testing::HasSubstr(
+      b5,
+      matcher(
           "#BlockMetadata\n(first) Triple: I:0 V:10 D:33.000000 V:0\n(last) "
           "Triple: I:0 V:10 D:33.000000 V:0\nnum. rows: 0.\n"));
   EXPECT_THAT(
-      (std::stringstream() << b11).str(),
-      ::testing::HasSubstr(
+      b11,
+      matcher(
           "#BlockMetadata\n(first) Triple: I:-4 V:10 D:33.000000 V:0\n(last) "
           "Triple: D:2.000000 V:10 D:33.000000 V:0\nnum. rows: 0.\n"));
   EXPECT_THAT(
-      (std::stringstream() << b21).str(),
-      ::testing::HasSubstr(
+      b21,
+      matcher(
           "#BlockMetadata\n(first) Triple: V:14 V:10 D:33.000000 V:0\n(last) "
           "Triple: V:17 V:10 D:33.000000 V:0\nnum. rows: 0.\n"));
+
+  auto blockWithGraphInfo = b21;
+  blockWithGraphInfo.graphInfo_.emplace({IntId(12), IntId(13)});
+  EXPECT_THAT(blockWithGraphInfo, matcher("Graphs: I:12, I:13\n"));
 }
 
 // Test Relational Expressions

--- a/test/PrefilterExpressionIndexTest.cpp
+++ b/test/PrefilterExpressionIndexTest.cpp
@@ -2,7 +2,7 @@
 //                  Chair of Algorithms and Data Structures
 //  Author: Hannes Baumann <baumannh@informatik.uni-freiburg.de>
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <vector>
 
@@ -157,18 +157,21 @@ class PrefilterExpressionOnMetadataTest : public ::testing::Test {
 
 //______________________________________________________________________________
 TEST_F(PrefilterExpressionOnMetadataTest, testBlockFormatForDebugging) {
-  EXPECT_EQ(
-      "#BlockMetadata\n(first) Triple: I:0 V:10 D:33.000000 V:0\n(last) "
-      "Triple: I:0 V:10 D:33.000000 V:0\nnum. rows: 0.\n",
-      (std::stringstream() << b5).str());
-  EXPECT_EQ(
-      "#BlockMetadata\n(first) Triple: I:-4 V:10 D:33.000000 V:0\n(last) "
-      "Triple: D:2.000000 V:10 D:33.000000 V:0\nnum. rows: 0.\n",
-      (std::stringstream() << b11).str());
-  EXPECT_EQ(
-      "#BlockMetadata\n(first) Triple: V:14 V:10 D:33.000000 V:0\n(last) "
-      "Triple: V:17 V:10 D:33.000000 V:0\nnum. rows: 0.\n",
-      (std::stringstream() << b21).str());
+  EXPECT_THAT(
+      (std::stringstream() << b5).str(),
+      ::testing::HasSubstr(
+          "#BlockMetadata\n(first) Triple: I:0 V:10 D:33.000000 V:0\n(last) "
+          "Triple: I:0 V:10 D:33.000000 V:0\nnum. rows: 0.\n"));
+  EXPECT_THAT(
+      (std::stringstream() << b11).str(),
+      ::testing::HasSubstr(
+          "#BlockMetadata\n(first) Triple: I:-4 V:10 D:33.000000 V:0\n(last) "
+          "Triple: D:2.000000 V:10 D:33.000000 V:0\nnum. rows: 0.\n"));
+  EXPECT_THAT(
+      (std::stringstream() << b21).str(),
+      ::testing::HasSubstr(
+          "#BlockMetadata\n(first) Triple: V:14 V:10 D:33.000000 V:0\n(last) "
+          "Triple: V:17 V:10 D:33.000000 V:0\nnum. rows: 0.\n"));
 }
 
 // Test Relational Expressions


### PR DESCRIPTION
The graph info of the block meta data provides (a superset of) the set of distinct graphs of the triples in the block, if they are not too many. This enables skipping whole blocks for queries that restrict the set of graphs. An update operation many change that information, but this was ignored so far. Now the block meta data of the located triples for each permutation (called augmented block meta data) is updated accordingly.