### PR TITLE
Use the augmented metadata when performing `UPDATE`

### DIFF
--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -219,3 +219,12 @@ void DeltaTriplesManager::clear() { modify(&DeltaTriples::clear); }
 SharedLocatedTriplesSnapshot DeltaTriplesManager::getCurrentSnapshot() const {
   return *currentLocatedTriplesSnapshot_.rlock();
 }
+
+// _____________________________________________________________________________
+void DeltaTriples::setOriginalMetadata(
+    Permutation::Enum permutation,
+    std::vector<CompressedBlockMetadata> metadata) {
+  locatedTriples()
+      .at(static_cast<size_t>(permutation))
+      .setOriginalMetadata(std::move(metadata));
+}

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -142,6 +142,11 @@ class DeltaTriples {
   // `DeltaTriples` object.
   SharedLocatedTriplesSnapshot getSnapshot() const;
 
+  // Register the original `metadata` for the given `permutation`. This has to
+  // be called before any updates are processed.
+  void setOriginalMetadata(Permutation::Enum permutation,
+                           std::vector<CompressedBlockMetadata> metadata);
+
  private:
   // Find the position of the given triple in the given permutation and add it
   // to each of the six `LocatedTriplesPerBlock` maps (one per permutation).

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -882,14 +882,33 @@ void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
            range2.contain(id.getVocabIndex());
   };
 
-  pso_.loadFromDisk(onDiskBase_, isInternalId, true);
-  pos_.loadFromDisk(onDiskBase_, isInternalId, true);
+  // Load the permutations and register the original metadata for the delta
+  // triples.
+  // TODO<joka921> We could delegate the setting of the metadata to the
+  // `Permutation`class, but we first have to deal with The delta triples for
+  // the additional permutations.
+  auto setMetadata = [this](const Permutation& p) {
+    deltaTriplesManager().modify([&](DeltaTriples& deltaTriples) {
+      deltaTriples.setOriginalMetadata(p.permutation(),
+                                       p.metaData().blockData());
+    });
+  };
 
+  auto load = [this, &isInternalId, &setMetadata](
+                  Permutation& permutation,
+                  bool loadInternalPermutation = false) {
+    permutation.loadFromDisk(onDiskBase_, isInternalId,
+                             loadInternalPermutation);
+    setMetadata(permutation);
+  };
+
+  load(pso_, true);
+  load(pos_, true);
   if (loadAllPermutations_) {
-    ops_.loadFromDisk(onDiskBase_, isInternalId);
-    osp_.loadFromDisk(onDiskBase_, isInternalId);
-    spo_.loadFromDisk(onDiskBase_, isInternalId);
-    sop_.loadFromDisk(onDiskBase_, isInternalId);
+    load(ops_);
+    load(osp_);
+    load(spo_);
+    load(sop_);
   } else {
     AD_LOG_INFO
         << "Only the PSO and POS permutation were loaded, SPARQL queries "

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -888,7 +888,7 @@ void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
   // `Permutation`class, but we first have to deal with The delta triples for
   // the additional permutations.
   auto setMetadata = [this](const Permutation& p) {
-    deltaTriplesManager().modify([&](DeltaTriples& deltaTriples) {
+    deltaTriplesManager().modify([&p](DeltaTriples& deltaTriples) {
       deltaTriples.setOriginalMetadata(p.permutation(),
                                        p.metaData().blockData());
     });

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -233,7 +233,8 @@ const Permutation& Permutation::getActualPermutation(Id id) const {
 // TODO<joka921> The following two functions always assume that there were no
 // updates to the additional triples (which is technically true for now, because
 // we never modify the additional triples with the delta triples, because there
-// is some functionality missing for this. We have to fix this here and in the `DeltaTriples` class.
+// is some functionality missing for this. We have to fix this here and in the
+// `DeltaTriples` class.
 
 // ______________________________________________________________________
 const LocatedTriplesPerBlock& Permutation::getLocatedTriplesForPermutation(

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -161,6 +161,12 @@ class Permutation {
   const LocatedTriplesPerBlock& getLocatedTriplesForPermutation(
       const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
 
+  // From the given snapshot, get the augmented block metadata for this
+  // permutation.
+  const std::vector<CompressedBlockMetadata>&
+  getAugmentedMetadataForPermutation(
+      const LocatedTriplesSnapshot& locatedTriplesSnapshot) const;
+
   const CompressedRelationReader& reader() const { return reader_.value(); }
 
  private:

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -169,6 +169,8 @@ class Permutation {
 
   const CompressedRelationReader& reader() const { return reader_.value(); }
 
+  Enum permutation() const { return permutation_; }
+
  private:
   // Readable name for this permutation, e.g., `POS`.
   std::string readableName_;
@@ -191,4 +193,6 @@ class Permutation {
   std::unique_ptr<Permutation> internalPermutation_ = nullptr;
 
   std::function<bool(Id)> isInternalId_;
+
+  bool isInternalPermutation_ = false;
 };

--- a/test/util/IndexTestHelpers.cpp
+++ b/test/util/IndexTestHelpers.cpp
@@ -55,7 +55,7 @@ namespace {
 // folded into the permutations as additional columns.
 void checkConsistencyBetweenPatternPredicateAndAdditionalColumn(
     const Index& index) {
-  DeltaTriplesManager deltaTriplesManager(index.getImpl());
+  const DeltaTriplesManager& deltaTriplesManager{index.deltaTriplesManager()};
   auto sharedLocatedTriplesSnapshot = deltaTriplesManager.getCurrentSnapshot();
   const auto& locatedTriplesSnapshot = *sharedLocatedTriplesSnapshot;
   static constexpr size_t col0IdTag = 43;


### PR DESCRIPTION
Since #1379, the located triples for each permutation have their own "augmented" block metadata (an update can change the first or last triple of a block). But so far, all index scan operations still use the original block metadata. Now they use the augmented block metadata when appropriate. For the two internal permutations, we assume that they are not affected by updates and we always use their original block metadata.