### PR TITLE
Support joins between full index scans

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1185,13 +1185,6 @@ void QueryPlanner::applyFiltersIfPossible(
   // in one go. Changing `row` inside the loop would invalidate the iterators.
   std::vector<SubtreePlan> addedPlans;
   for (auto& plan : row) {
-    if constexpr (!replace) {
-      if (plan._qet->getRootOperation()->isIndexScanWithNumVariables(3)) {
-        // Do not apply filters to dummies, except at the very end of query
-        // planning.
-        continue;
-      }
-    }
     for (size_t i = 0; i < filters.size(); ++i) {
       if (((plan._idsOfIncludedFilters >> i) & 1) != 0) {
         continue;
@@ -1856,12 +1849,6 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::createJoinCandidates(
   }
 
   // CASE: JOIN ON ONE COLUMN ONLY.
-
-  // Skip if we have two operations, where all three positions are variables.
-  if (a._qet->getRootOperation()->isIndexScanWithNumVariables(3) &&
-      b._qet->getRootOperation()->isIndexScanWithNumVariables(3)) {
-    return candidates;
-  }
 
   // Check if one of the two operations is a HAS_PREDICATE_SCAN.
   // If the join column corresponds to the has-predicate scan's

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -274,6 +274,25 @@ TEST(QueryPlanner, joinOfTwoScans) {
       h::Join(scan("?y", "<pre/r>", "?x"), scan("?z", "<pre/r>", "?x")));
 }
 
+// _____________________________________________________________________________
+TEST(QueryPlanner, joinOfFullScans) {
+  auto scan = h::IndexScanFromStrings;
+  // Join between two full index scans on a single column
+  h::expect("SELECT * {?s ?p ?x. ?x ?p2 ?o2 .}",
+            h::Join(scan("?s", "?p", "?x"), scan("?x", "?p2", "?o2")));
+
+  // Join between two full index scans on two columns.
+  h::expect(
+      "SELECT * {?s ?p ?x. ?x ?p2 ?s .}",
+      h::MultiColumnJoin(scan("?s", "?p", "?x"), scan("?x", "?p2", "?s")));
+
+  // Join between two full index scans, one of which has a FILTER which can be
+  // applied before the JOIN.
+  h::expect("SELECT * {?s ?p ?x. ?x ?p2 ?o2 . FILTER (?s = ?p)}",
+            h::Join(h::Filter("?s = ?p", scan("?s", "?p", "?x")),
+                    scan("?x", "?p2", "?o2")));
+}
+
 TEST(QueryPlanner, testActorsBornInEurope) {
   auto scan = h::IndexScanFromStrings;
   using enum ::OrderBy::AscOrDesc;


### PR DESCRIPTION
So far, joins between full index scans were explicitly disallowed because their results are bound to be huge. Now that most operations are lazy, they make more send, for example, when counting or grouping the result. They are hence allowed now. In that context, allow `FILTER` to be applied as soon as possible also when a full index scan is involved.