### PR TITLE
Let `CartesianProductJoinLazyTest` run a single ctest instance

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,6 +63,22 @@ function(addLinkAndDiscoverTest basename)
 
 endfunction()
 
+# Add a GTest/GMock test case that is called `basename` and compiled from a file called
+# `basename.cpp`. All tests are linked against `gmock_main` and the threading library.
+# In contrast to `addLinkAndDiscoverTest` this doesn't let ctest run all subtests individually,
+# but all at once to reduce overhead in the CI pipeline.
+function(addLinkAndRunAsSingleTest basename)
+    if (SINGLE_TEST_BINARY)
+        target_sources(QLeverAllUnitTestsMain PUBLIC ${basename}.cpp)
+        qlever_target_link_libraries(QLeverAllUnitTestsMain ${ARGN})
+    else ()
+        addTest(${basename})
+        linkTest(${basename} ${ARGN})
+        add_test(NAME ${basename} COMMAND ${basename})
+    endif ()
+
+endfunction()
+
 # Usage: `addAndLinkTestSerial(basename, [additionalLibraries...]`
 # Similar to `addAndLinkTest` but also requires that the test is run serially
 # (without any of the other test cases running in parallel). This can be

--- a/test/engine/CMakeLists.txt
+++ b/test/engine/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(idTable)
 addLinkAndDiscoverTest(IndexScanTest engine)
-addLinkAndDiscoverTest(CartesianProductJoinTest engine)
+addLinkAndRunAsSingleTest(CartesianProductJoinTest engine)
 addLinkAndDiscoverTest(TextIndexScanForWordTest engine)
 addLinkAndDiscoverTest(TextIndexScanForEntityTest engine)
 addLinkAndDiscoverTest(SpatialJoinTest engine)

--- a/test/engine/CartesianProductJoinTest.cpp
+++ b/test/engine/CartesianProductJoinTest.cpp
@@ -616,10 +616,10 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<
         std::tuple<bool, size_t, std::optional<size_t>>>& info) {
       std::ostringstream stream;
-      if (std::get<0>(info.param) == 0) {
-        stream << "FullyMaterialized";
-      } else {
+      if (std::get<0>(info.param)) {
         stream << "WithSplitTables";
+      } else {
+        stream << "FullyMaterialized";
       }
       stream << "_Offset_" << std::get<1>(info.param);
       stream << "_Limit_";


### PR DESCRIPTION
The `CartesianProductJoin` test contains a parametrized test suite which automatically creates more than 1000 test cases, each of which run very fast.  This PR merges these test cases s.t. ctest only runs them as a single test case `CartesianProductJoinTest`.
This increases the runtime of the GitHub actions by about 10%.