### PR TITLE
Fix the lazy block prefilter

### DIFF
--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -594,14 +594,14 @@ Result::Generator IndexScan::createPrefilteredJoinSide(
   }
   auto& prefetchedValues = innerState->prefetchedValues_;
   while (true) {
-    while (prefetchedValues.empty()) {
+    if (prefetchedValues.empty()) {
       if (innerState->doneFetching_) {
         co_return;
       }
       innerState->fetch();
+      AD_CORRECTNESS_CHECK(!prefetchedValues.empty() ||
+                           innerState->doneFetching_);
     }
-    AD_CORRECTNESS_CHECK(!prefetchedValues.empty() ||
-                         innerState->doneFetching_);
     // Make a defensive copy of the values to avoid modification during
     // iteration when yielding.
     auto copy = std::move(prefetchedValues);

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -590,14 +590,14 @@ Result::Generator IndexScan::createPrefilteredJoinSide(
   }
   auto& prefetchedValues = innerState->prefetchedValues_;
   while (true) {
-    if (prefetchedValues.empty()) {
+    while (prefetchedValues.empty()) {
       if (innerState->doneFetching_) {
         co_return;
       }
       innerState->fetch();
-      AD_CORRECTNESS_CHECK(!prefetchedValues.empty() ||
-                           innerState->doneFetching_);
     }
+    AD_CORRECTNESS_CHECK(!prefetchedValues.empty() ||
+                         innerState->doneFetching_);
     // Make a defensive copy of the values to avoid modification during
     // iteration when yielding.
     auto copy = std::move(prefetchedValues);

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -939,6 +939,8 @@ TEST_P(IndexScanWithLazyJoin,
     using P = Result::IdTableVocabPair;
     P p1{makeIdTableFromVector({{Id::makeFromBool(true)}}), LocalVocab{}};
     co_yield p1;
+    P p2{makeIdTableFromVector({{Id::makeFromBool(true)}}), LocalVocab{}};
+    co_yield p2;
   };
 
   auto [joinSideResults, scanResults] =


### PR DESCRIPTION
This fixes a bug introduced in #1647, which led to a failure of ` AD_CORRECTNESS_CHECK(!prefetchedValues.empty() || innerState->doneFetching_);` in `IndexScan::createPrefilteredJoinSide`.