### PR TITLE
Allow operations to not store their result in the cache

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -319,7 +319,7 @@ std::shared_ptr<const Result> Operation::getResult(
 
     auto result = [&]() {
       auto compute = [&](auto&&... args) {
-        if (!canResultBeCached_()) {
+        if (!canResultBeCached()) {
           return cache.computeButDontStore(AD_FWD(args)...);
         }
         return pinResult ? cache.computeOncePinned(AD_FWD(args)...)

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -232,7 +232,8 @@ CacheValue Operation::runComputationAndPrepareForCache(
   auto maxSize =
       std::min(RuntimeParameters().get<"lazy-result-max-cache-size">(),
                cache.getMaxSizeSingleEntry());
-  if (!result.isFullyMaterialized() && !unlikelyToFitInCache(maxSize)) {
+  if (canResultBeCached_() && !result.isFullyMaterialized() &&
+      !unlikelyToFitInCache(maxSize)) {
     AD_CONTRACT_CHECK(!pinned);
     result.cacheDuringConsumption(
         [maxSize](
@@ -316,11 +317,16 @@ std::shared_ptr<const Result> Operation::getResult(
 
     bool onlyReadFromCache = computationMode == ComputationMode::ONLY_IF_CACHED;
 
-    auto result =
-        pinResult ? cache.computeOncePinned(cacheKey, cacheSetup,
-                                            onlyReadFromCache, suitedForCache)
-                  : cache.computeOnce(cacheKey, cacheSetup, onlyReadFromCache,
-                                      suitedForCache);
+    auto result = [&]() {
+      auto compute = [&](auto&&... args) {
+        if (!canResultBeCached_()) {
+          return cache.computeButDontStore(AD_FWD(args)...);
+        }
+        return pinResult ? cache.computeOncePinned(AD_FWD(args)...)
+                         : cache.computeOnce(AD_FWD(args)...);
+      };
+      return compute(cacheKey, cacheSetup, onlyReadFromCache, suitedForCache);
+    }();
 
     if (result._resultPointer == nullptr) {
       AD_CORRECTNESS_CHECK(onlyReadFromCache);
@@ -594,5 +600,26 @@ const vector<ColumnIndex>& Operation::getResultSortedOn() const {
 void Operation::signalQueryUpdate() const {
   if (_executionContext) {
     _executionContext->signalQueryUpdate(*_rootRuntimeInfo);
+  }
+}
+
+// _____________________________________________________________________________
+std::string Operation::getCacheKey() const {
+  auto result = getCacheKeyImpl();
+  if (_limit._limit.has_value()) {
+    absl::StrAppend(&result, " LIMIT ", _limit._limit.value());
+  }
+  if (_limit._offset != 0) {
+    absl::StrAppend(&result, " OFFSET ", _limit._offset);
+  }
+  return result;
+}
+
+// _____________________________________________________________________________
+uint64_t Operation::getSizeEstimate() {
+  if (_limit._limit.has_value()) {
+    return std::min(_limit._limit.value(), getSizeEstimateBeforeLimit());
+  } else {
+    return getSizeEstimateBeforeLimit();
   }
 }

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -232,7 +232,7 @@ CacheValue Operation::runComputationAndPrepareForCache(
   auto maxSize =
       std::min(RuntimeParameters().get<"lazy-result-max-cache-size">(),
                cache.getMaxSizeSingleEntry());
-  if (canResultBeCached_() && !result.isFullyMaterialized() &&
+  if (canResultBeCached() && !result.isFullyMaterialized() &&
       !unlikelyToFitInCache(maxSize)) {
     AD_CONTRACT_CHECK(!pinned);
     result.cacheDuringConsumption(

--- a/test/ConcurrentCacheTest.cpp
+++ b/test/ConcurrentCacheTest.cpp
@@ -533,30 +533,36 @@ TEST(ConcurrentCache, testTryInsertIfNotPresentDoesWorkCorrectly) {
 
 TEST(ConcurrentCache, computeButDontStore) {
   SimpleConcurrentLruCache cache{};
+
+  // The last argument of `computeOnce...`: For the sake of this test, all
+  // results are suitable for the cache. Note: In the `computeButDontStore`
+  // function this argument is ignored, because the results are never stored in
+  // the cache.
+  auto alwaysSuitable = [](auto&&) { return true; };
   // Store the element in the cache.
   cache.computeOnce(
-      42, []() { return "42"; }, false, [](auto&&) { return true; });
+      42, []() { return "42"; }, false, alwaysSuitable);
 
   // The result is read from the cache, so we get "42", not "blubb".
   auto res = cache.computeButDontStore(
-      42, []() { return "blubb"; }, false, [](auto&&) { return true; });
+      42, []() { return "blubb"; }, false, alwaysSuitable);
   EXPECT_EQ(*res._resultPointer, "42");
 
   // The same with `onlyReadFromCache` == true;
   res = cache.computeButDontStore(
-      42, []() { return "blubb"; }, true, [](auto&&) { return true; });
+      42, []() { return "blubb"; }, true, alwaysSuitable);
   EXPECT_EQ(*res._resultPointer, "42");
 
   cache.clearAll();
 
   // Compute, but don't store.
   res = cache.computeButDontStore(
-      42, []() { return "blubb"; }, false, [](auto&&) { return true; });
+      42, []() { return "blubb"; }, false, alwaysSuitable);
   EXPECT_EQ(*res._resultPointer, "blubb");
 
   // Nothing is stored in the cache, so we cannot read it.
   EXPECT_FALSE(cache.getIfContained(42).has_value());
   res = cache.computeButDontStore(
-      42, []() { return "blubb"; }, true, [](auto&&) { return true; });
+      42, []() { return "blubb"; }, true, alwaysSuitable);
   EXPECT_EQ(res._resultPointer, nullptr);
 }


### PR DESCRIPTION
Each operation now has a `bool` that determines whether the results can be stored in the cache or not (whether it is actually stored depends on other circumstances, like the available cache size). That `bool` does not have to be fixed when the operation is created, but can be changed.

For example, this is useful for index scans that only return a subset of their full result (because of another constraining operation, like a join or a filter).