### PR TITLE
Fix bug for UNION with SUBQUERY with invisible variables

### DIFF
--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -242,7 +242,10 @@ std::vector<ColumnIndex> Union::computePermutation() const {
 // _____________________________________________________________________________
 IdTable Union::transformToCorrectColumnFormat(
     IdTable idTable, const std::vector<ColumnIndex>& permutation) const {
-  while (idTable.numColumns() < getResultWidth()) {
+  // NOTE: previously the check was for `getResultWidth()`, but that is wrong if
+  // some variables in the subtree are invisible because of a subquery.
+  auto maxNumRequiredColumns = ql::ranges::max(permutation) + 1;
+  while (idTable.numColumns() < maxNumRequiredColumns) {
     idTable.addEmptyColumn();
     ad_utility::chunkedFill(idTable.getColumn(idTable.numColumns() - 1),
                             Id::makeUndefined(), chunkSize,


### PR DESCRIPTION
There was a bug in the following scenario: a UNION that is lazily computed and at least one of the inputs of the UNION contains a subquery that does not SELECT all possible variables. Then the UNION threw an assertion, because there was some confusion between the number of visible variables in the input (only the ones selected by the subquery) and the actual number of columns in the result (which includes the not-selected variables of the subquery).

Fixes #1681