### PR TITLE
Allow GROUP BY variables with parentheses or duplicates

### DIFF
--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2904,3 +2904,12 @@ TEST(QueryPlanner, Describe) {
                                     "?y", "<p>", "<o>", {},
                                     ad_utility::HashSet<std::string>{"<g>"})));
 }
+
+// ____________________________________________________________________________
+TEST(QueryPlanner, GroupByRedundanteParensAndVariables) {
+  auto matcher = h::GroupBy({Variable{"?x"}}, {},
+                            h::IndexScanFromStrings("?x", "?y", "?z"));
+  h::expect("SELECT ?x { ?x ?y ?z} GROUP BY (?x)", matcher);
+  h::expect("SELECT ?x { ?x ?y ?z} GROUP BY ?x ?x", matcher);
+  h::expect("SELECT ?x { ?x ?y ?z} GROUP BY ?x ?x (?x)", matcher);
+}


### PR DESCRIPTION
With this change, grouped variables can be put in parentheses and still be used in the SELECT clause. For example, `GROUP BY (?x)` is now handled exactly like `GROUP BY ?x`. Additionally, we now deduplicate the grouped variables. For example, `GROUP BY ?x ?x` is now equivalent to `GROUP BY ?x`.