### PR TITLE
Don't use Abseil for `Hash(Set|Map)WithMemoryLimit`

### DIFF
--- a/src/util/HashMap.h
+++ b/src/util/HashMap.h
@@ -6,7 +6,10 @@
 #pragma once
 
 #include <absl/container/flat_hash_map.h>
-#include <util/AllocatorWithLimit.h>
+
+#include <unordered_map>
+
+#include "util/AllocatorWithLimit.h"
 
 namespace ad_utility {
 // Wrapper for HashMaps to be used everywhere throughout code for the semantic
@@ -15,10 +18,13 @@ namespace ad_utility {
 template <typename... Ts>
 using HashMap = absl::flat_hash_map<Ts...>;
 
-// A HashMap with a memory limit.
+// A HashMap with a memory limit. Note: We cannot use `absl::flat_hash_map`
+// here, because it is inherently not exception safe, and the
+// `AllocatorWithLimit` uses exceptions.
 template <class K, class V,
           class HashFct = absl::container_internal::hash_default_hash<K>,
           class EqualElem = absl::container_internal::hash_default_eq<K>,
           class Alloc = ad_utility::AllocatorWithLimit<std::pair<const K, V>>>
-using HashMapWithMemoryLimit = HashMap<K, V, HashFct, EqualElem, Alloc>;
+using HashMapWithMemoryLimit =
+    std::unordered_map<K, V, HashFct, EqualElem, Alloc>;
 }  // namespace ad_utility

--- a/src/util/HashSet.h
+++ b/src/util/HashSet.h
@@ -6,12 +6,10 @@
 
 #pragma once
 
-#include <string>
+#include <unordered_set>
 
 #include "absl/container/flat_hash_set.h"
 #include "util/AllocatorWithLimit.h"
-
-using std::string;
 
 namespace ad_utility {
 // Wrapper for HashSets (with elements of type T) to be used everywhere
@@ -25,11 +23,13 @@ template <class T,
 using HashSet = absl::flat_hash_set<T, HashFct, EqualElem, Alloc>;
 
 // A hash set (with elements of type T) with a memory Limit.
+// Note: We cannot use `absl::flat_hash_set`
+// here, because it is inherently not exception safe, and the
+// `AllocatorWithLimit` uses exceptions.
 template <class T,
           class HashFct = absl::container_internal::hash_default_hash<T>,
           class EqualElem = absl::container_internal::hash_default_eq<T>,
           class Alloc = ad_utility::AllocatorWithLimit<T>>
-using HashSetWithMemoryLimit =
-    absl::flat_hash_set<T, HashFct, EqualElem, Alloc>;
+using HashSetWithMemoryLimit = std::unordered_set<T, HashFct, EqualElem, Alloc>;
 
 }  // namespace ad_utility

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -160,7 +160,7 @@ addLinkAndDiscoverTest(TextLimitOperationTest engine)
 
 addLinkAndDiscoverTestSerial(QueryPlannerTest engine)
 
-addLinkAndDiscoverTest(HashMapTest)
+addLinkAndDiscoverTestNoLibs(HashMapTest)
 
 addLinkAndDiscoverTest(HashSetTest)
 

--- a/test/HashMapTest.cpp
+++ b/test/HashMapTest.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include "../src/util/HashMap.h"
+#include "util/HashMap.h"
 
 // Note: Since the HashMap class is a wrapper for a well tested hash map
 // implementation the following tests only check the API for functionality and


### PR DESCRIPTION
So far, `HashSetWithMemoryLimit` and `HashMapWithMemoryLimit` were implemented as `absl::flat_hash_set` and `absl::flat_hash_map`, respectively. However, the Abseil data structures are not exception safe, which potentially leads to unexpected or erroneous behavior in Qlever. The two data structures are now implemented using `std::unordered_set`.

These two classes are currently used in the following operations: `GroupBy`, `TransitivePath`, `Describe`. A quick performance comparison (of the current master and this PR on 20 example queries, and in a small standalone program), shows no significant performance difference.