### PR TITLE
Fix the cost estimate of the `Spatial Join` operation

### DIFF
--- a/src/engine/SpatialJoin.cpp
+++ b/src/engine/SpatialJoin.cpp
@@ -213,10 +213,13 @@ size_t SpatialJoin::getResultWidth() const {
 // ____________________________________________________________________________
 size_t SpatialJoin::getCostEstimate() {
   if (childLeft_ && childRight_) {
-    size_t inputEstimate =
-        childLeft_->getSizeEstimate() * childRight_->getSizeEstimate();
+    auto n = childLeft_->getSizeEstimate();
+    auto m = childRight_->getSizeEstimate();
+
+    size_t spatialJoinCostEst = 1;
+
     if (config_.algo_ == SpatialJoinAlgorithm::BASELINE) {
-      return inputEstimate * inputEstimate;
+      spatialJoinCostEst = n * m;
     } else {
       AD_CORRECTNESS_CHECK(
           config_.algo_ == SpatialJoinAlgorithm::S2_GEOMETRY ||
@@ -229,12 +232,13 @@ size_t SpatialJoin::getCostEstimate() {
       // for each item do a lookup on the index for the right table in O(log m).
       // Together we have O(n log(m) + m log(m)), because in general we can't
       // draw conclusions about the relation between the sizes of n and m.
-      auto n = childLeft_->getSizeEstimate();
-      auto m = childRight_->getSizeEstimate();
-      auto logm = static_cast<size_t>(
-          log(static_cast<double>(childRight_->getSizeEstimate())));
-      return (n * logm) + (m * logm);
+      auto logm = static_cast<size_t>(std::log(static_cast<double>(m)));
+      spatialJoinCostEst = (n * logm) + (m * logm);
     }
+
+    // The cost to compute the children needs to be taken into account.
+    return spatialJoinCostEst + childLeft_->getCostEstimate() +
+           childRight_->getCostEstimate();
   }
   return 1;  // dummy return, as the class does not have its children yet
 }

--- a/test/engine/SpatialJoinAlgorithmsTest.cpp
+++ b/test/engine/SpatialJoinAlgorithmsTest.cpp
@@ -106,10 +106,16 @@ class SpatialJoinParamTest
     spatialJoin->selectAlgorithm(std::get<0>(GetParam()));
 
     // At worst quadratic time
-    ASSERT_LE(
-        spatialJoin->getCostEstimate(),
-        std::pow(firstChild->getSizeEstimate() * secondChild->getSizeEstimate(),
-                 2));
+    ASSERT_LE(spatialJoin->getCostEstimate(),
+              (firstChild->getSizeEstimate() * secondChild->getSizeEstimate()) +
+                  firstChild->getCostEstimate() +
+                  secondChild->getCostEstimate() + 1);
+
+    // The cost of the child operations needs to be included in the cost
+    // estimate of the spatial join (which is based on the childrens' size not
+    // cost estimate)
+    ASSERT_GE(spatialJoin->getCostEstimate(),
+              firstChild->getCostEstimate() + secondChild->getCostEstimate());
 
     auto res = spatialJoin->computeResult(false);
     auto vec = printTable(qec, &res);


### PR DESCRIPTION
Previously, the cost estimate of the `SpatialJoin` class didn't account for the cost of computing the children. This is now fixed.