### PR TITLE
Account for `FILTER`s when considering greedy query planning

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1346,9 +1346,14 @@ size_t QueryPlanner::countSubgraphs(
   graph.erase(std::ranges::unique(graph, ql::ranges::equal_to{}, getId).begin(),
               graph.end());
 
+  // We also have to consider the `filters`. To make life easy, we temporarily
+  // create simple `SubtreePlans` for them which just have the correct
+  // variables.
   std::vector<QueryPlanner::SubtreePlan> dummyPlansForFilter;
   for (const auto& filter : filters) {
     const auto& vars = filter.expression_.containedVariables();
+    // We use a `VALUES` clause as the dummy because this operation is the
+    // easiest to setup for a number of given variables.
     parsedQuery::SparqlValues values;
     for (auto* var : vars) {
       values._variables.push_back(*var);
@@ -1381,9 +1386,7 @@ size_t QueryPlanner::countSubgraphs(
     g.push_back(v);
   }
 
-  auto result = countConnectedSubgraphs::countSubgraphs(g, budget);
-  LOG(INFO) << "number of subgraphs inside a component " << result << std::endl;
-  return result;
+  return countConnectedSubgraphs::countSubgraphs(g, budget);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -485,6 +485,8 @@ class QueryPlanner {
   // if the number of subgraphs is `> budget`. This is used to analyze the
   // complexity of the query graph and to choose between the DP and the greedy
   // query planner see above.
+  // Note: We also need the added filters, because they behave like additional
+  // graph nodes wrt the performance of the DP based query planner.
   size_t countSubgraphs(std::vector<const SubtreePlan*> graph,
                         const std::vector<SparqlFilter>& filters,
                         size_t budget);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -485,8 +485,9 @@ class QueryPlanner {
   // if the number of subgraphs is `> budget`. This is used to analyze the
   // complexity of the query graph and to choose between the DP and the greedy
   // query planner see above.
-  static size_t countSubgraphs(std::vector<const SubtreePlan*> graph,
-                               size_t budget);
+  size_t countSubgraphs(std::vector<const SubtreePlan*> graph,
+                        const std::vector<SparqlFilter>& filters,
+                        size_t budget);
 
   // Creates a SubtreePlan for the given text leaf node in the triple graph.
   // While doing this the TextLimitMetaObjects are created and updated according


### PR DESCRIPTION
Since #1442, QLever switches to greedy query planning for large connected components. A connected component is considered large when the number of connected subgraphs is above the threshold determined by the runtime parameter `query-planning-budget`.

So far, `FILTER`s were simply ignored when counting the number of subgraphs. However, `FILTER`s can add significant complexity to the standard query planning because for each subplan, our query planner considers either adding all applicable `FILTER`s to it or none of them. As a result, for certain queries with a medium-sized component but a significant number of `FILTER`s, the query planning complexity was underestimated and the query was not planned greedily and the standard query planning took very long.

This is now fixed by replacing, for the purpose of query planning, each `FILTER` by a dummy `VALUES` clause which uses the set of distinct variables from the `FILTER`. A `FILTER` that has many variables in common with other triples will then increase the subgraph count substantially. If multiple `FILTER`s have the same set of distinct variables, the dummy `VALUES` clause is added only once (because our query planner either adds all applicable `FILTER`s at a certain point or none of them). Note that this trick overestimates the true query planning complexity. That is, the worst that can happen now is that with many `FILTER`s, we switch to greedy planning even though standard query planning would have still been feasible,