### PR TITLE
In the greedy query planner, compute only `O(n²)` trees instead of `O(n³)`

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -1401,9 +1401,9 @@ QueryPlanner::runGreedyPlanningOnConnectedComponent(
   // above pre-/postconditions. Exception: if `isFirstStep` then `cache` and
   // `nextResult` must be empty, and the first step of greedy planning is
   // performed, which also establishes the pre-/postconditions.
-  auto greedyStep = [this, tg, filters, textLimits](Plans* input, Plans* cache,
-                                                    Plans* nextResult,
-                                                    bool isFirstStep) {
+  auto greedyStep = [this, &tg, &filters, &textLimits](
+                        Plans* input, Plans* cache, Plans* nextResult,
+                        bool isFirstStep) {
     checkCancellation();
     // We already have all combinations of two nodes in `input` in the cache, so
     // we only have to add the combinations between `input` and `nextResult`. In

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -17,6 +17,8 @@
 class QueryPlanner {
   using TextLimitMap =
       ad_utility::HashMap<Variable, parsedQuery::TextLimitMetaObject>;
+  using TextLimitVec =
+      std::vector<std::pair<Variable, parsedQuery::TextLimitMetaObject>>;
   using CancellationHandle = ad_utility::SharedCancellationHandle;
   template <typename T>
   using vector = std::vector<T>;
@@ -400,7 +402,7 @@ class QueryPlanner {
   // 1) There is no text operation for the text record column left.
   // 2) The text limit has not already been applied to the plan.
   void applyTextLimitsIfPossible(std::vector<SubtreePlan>& row,
-                                 const TextLimitMap& textLimits,
+                                 const TextLimitVec& textLimits,
                                  bool replaceInsteadOfAddPlans) const;
 
   /**
@@ -470,7 +472,7 @@ class QueryPlanner {
   std::vector<QueryPlanner::SubtreePlan>
   runDynamicProgrammingOnConnectedComponent(
       std::vector<SubtreePlan> connectedComponent,
-      const vector<SparqlFilter>& filters, const TextLimitMap& textLimits,
+      const vector<SparqlFilter>& filters, const TextLimitVec& textLimits,
       const TripleGraph& tg) const;
 
   // Same as `runDynamicProgrammingOnConnectedComponent`, but uses a greedy
@@ -478,7 +480,7 @@ class QueryPlanner {
   // join operations using the "Greedy Operator Ordering (GOO)" algorithm.
   std::vector<QueryPlanner::SubtreePlan> runGreedyPlanningOnConnectedComponent(
       std::vector<SubtreePlan> connectedComponent,
-      const vector<SparqlFilter>& filters, const TextLimitMap& textLimits,
+      const vector<SparqlFilter>& filters, const TextLimitVec& textLimits,
       const TripleGraph& tg) const;
 
   // Return the number of connected subgraphs is the `graph`, or `budget + 1`,


### PR DESCRIPTION
First, a quick recap: For a connected component of `n` triples, the greedy query planner maintains a set of disjoint query execution trees. The initial set are `n` simple query execution trees, each consisting of one index scan. In each step, the cheapest possible join of two trees that are not yet connected, is computed. The worst case is when each pair of triples is connected, so that the induced triple graph is a clique.

In the implementation so far, a possible join is computed and its cost estimated (which involved constructing the respective tree) potentially many times, namely in each step until it is picked or no longer possible. Now, each possible join (and the respective query execution tree) is computed and evaluated exactly once and then discarded when it has been picked or is no longer possible.  Since each step except the first adds exactly one tree (and throws out two trees, namely those that were joined), only a linear number of new trees have to be constructed in each step. In the code so far, this was a quadratic number in the worst case. This cost significant time for large connected components.

NOTE: The cheapest possible join in each step is still computed by a linear scan over all candidates, which in the worst case is a quadratic number in the first half of the steps. This could be improved by using a priority queues and other tricks. However, we would need to evaluate first whether these minimum computations actually cost significant time. In the code so far, the expensive part was the construction of the trees.