### PR TITLE
Parse `POINT(...)` as `GeoPoint` in a SPARQL query

### DIFF
--- a/src/parser/TripleComponent.cpp
+++ b/src/parser/TripleComponent.cpp
@@ -28,7 +28,11 @@ std::ostream& operator<<(std::ostream& stream, const TripleComponent& obj) {
           stream << "DATE: " << value.toStringAndType().first;
         } else if constexpr (std::is_same_v<T, bool>) {
           stream << (value ? "true" : "false");
+        } else if constexpr (std::is_same_v<T, GeoPoint>) {
+          stream << Id::makeFromGeoPoint(value);
         } else {
+          static_assert(
+              ad_utility::SameAsAny<T, Id, double, int64_t, std::string>);
           stream << value;
         }
       },

--- a/test/TripleComponentTest.cpp
+++ b/test/TripleComponentTest.cpp
@@ -226,15 +226,27 @@ TEST(TripleComponent, invalidDatatypeForLiteral) {
   ASSERT_ANY_THROW(lit("\"alpha\"", "fr-ca"));
 }
 
-/*
+// _____________________________________________________________________________1
 TEST(TripleComponent, toString) {
+  using namespace ::testing;
+  auto match = [](const auto& matcher) {
+    auto makeTcAndToString = [](auto&& val) {
+      return TripleComponent{AD_FWD(val)}.toString();
+    };
+    return ResultOf(makeTcAndToString, matcher);
+  };
+
+  EXPECT_THAT(GeoPoint(13, 14), match(StartsWith("G:POINT(14.")));
+  EXPECT_THAT("hello", match("hello"));
+  EXPECT_THAT(12, match("12"));
+  EXPECT_THAT(12.3, match("12.3"));
   using Tc = TripleComponent;
-  auto match = [](const std::string& s) {
-    .. Todo...
-
-  }
-  EXPECT_EQ({GeoPoint{13, 14}};
-  EXPECT_EQ()
-
+  EXPECT_THAT(Tc::UNDEF{}, match("UNDEF"));
+  EXPECT_THAT(Variable("?x"), match("?x"));
+  EXPECT_THAT(Tc::Literal::literalWithoutQuotes("hallo"), match("\"hallo\""));
+  EXPECT_THAT(Tc::Iri::fromIrirefWithoutBrackets("blim"), match("<blim>"));
+  EXPECT_THAT(DateYearOrDuration(Date(2000, 1, 1)), match("DATE: 2000-01-01"));
+  EXPECT_THAT(true, match("true"));
+  EXPECT_THAT(false, match("false"));
+  EXPECT_THAT(Id::makeFromInt(42), match("I:42"));
 }
-*/

--- a/test/TripleComponentTest.cpp
+++ b/test/TripleComponentTest.cpp
@@ -3,7 +3,7 @@
 // Author: Johannes Kalmbach(joka921) <johannes.kalmbach@gmail.com>
 //
 
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "./util/IdTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
@@ -225,3 +225,16 @@ TEST(TripleComponent, invalidDatatypeForLiteral) {
   // Something that is invalid because it is none of the above
   ASSERT_ANY_THROW(lit("\"alpha\"", "fr-ca"));
 }
+
+/*
+TEST(TripleComponent, toString) {
+  using Tc = TripleComponent;
+  auto match = [](const std::string& s) {
+    .. Todo...
+
+  }
+  EXPECT_EQ({GeoPoint{13, 14}};
+  EXPECT_EQ()
+
+}
+*/


### PR DESCRIPTION
Specifying an explicit `POINT(...)` in a SPARQL query could lead to a segmentation fault because it wasn't actually parsed as a `GeoPoint`. This is now fixed.