### PR TITLE
Reduce the memory overhead of the `augmentedMetadata`

### DIFF
--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -260,7 +260,7 @@ SharedLocatedTriplesSnapshot DeltaTriplesManager::getCurrentSnapshot() const {
 // _____________________________________________________________________________
 void DeltaTriples::setOriginalMetadata(
     Permutation::Enum permutation,
-    std::vector<CompressedBlockMetadata> metadata) {
+    std::shared_ptr<const std::vector<CompressedBlockMetadata>> metadata) {
   locatedTriples()
       .at(static_cast<size_t>(permutation))
       .setOriginalMetadata(std::move(metadata));

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -163,8 +163,9 @@ class DeltaTriples {
 
   // Register the original `metadata` for the given `permutation`. This has to
   // be called before any updates are processed.
-  void setOriginalMetadata(Permutation::Enum permutation,
-                           std::vector<CompressedBlockMetadata> metadata);
+  void setOriginalMetadata(
+      Permutation::Enum permutation,
+      std::shared_ptr<const std::vector<CompressedBlockMetadata>> metadata);
 
  private:
   // Find the position of the given triple in the given permutation and add it

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -894,7 +894,7 @@ void IndexImpl::createFromOnDiskIndex(const string& onDiskBase) {
   auto setMetadata = [this](const Permutation& p) {
     deltaTriplesManager().modify<void>([&p](DeltaTriples& deltaTriples) {
       deltaTriples.setOriginalMetadata(p.permutation(),
-                                       p.metaData().blockData());
+                                       p.metaData().blockDataShared());
     });
   };
 

--- a/src/index/IndexMetaData.h
+++ b/src/index/IndexMetaData.h
@@ -89,7 +89,7 @@ class IndexMetaData {
   // For each relation, its meta data.
   MapType data_;
   // For each compressed block, its meta data.
-  BlocksType blockData_;
+  std::shared_ptr<BlocksType> blockData_ = std::make_shared<BlocksType>();
 
   size_t totalElements_ = 0;
   size_t numDistinctCol0_ = 0;
@@ -175,8 +175,11 @@ class IndexMetaData {
 
   const MapType& data() const { return data_; }
 
-  BlocksType& blockData() { return blockData_; }
-  const BlocksType& blockData() const { return blockData_; }
+  BlocksType& blockData() { return *blockData_; }
+  const BlocksType& blockData() const { return *blockData_; }
+  std::shared_ptr<const BlocksType> blockDataShared() const {
+    return blockData_;
+  }
 
   // Symmetric serialization function for the ad_utility::serialization module.
   AD_SERIALIZE_FRIEND_FUNCTION(IndexMetaData) {
@@ -207,7 +210,7 @@ class IndexMetaData {
     // Serialize the rest of the data members
     serializer | arg.name_;
     serializer | arg.data_;
-    serializer | arg.blockData_;
+    serializer | arg.blockData();
     serializer | arg.offsetAfter_;
     serializer | arg.totalElements_;
     serializer | arg.numDistinctCol0_;

--- a/src/index/IndexMetaDataImpl.h
+++ b/src/index/IndexMetaDataImpl.h
@@ -96,7 +96,7 @@ string IndexMetaData<MapType>::statistics() const {
   std::locale locWithNumberGrouping(loc, &facet);
   os.imbue(locWithNumberGrouping);
   os << "#relations = " << numDistinctCol0_
-     << ", #blocks = " << blockData_.size()
+     << ", #blocks = " << blockData().size()
      << ", #triples = " << totalElements_;
   return std::move(os).str();
 }
@@ -106,7 +106,7 @@ template <class MapType>
 void IndexMetaData<MapType>::calculateStatistics(size_t numDistinctCol0) {
   totalElements_ = 0;
   numDistinctCol0_ = numDistinctCol0;
-  for (const auto& block : blockData_) {
+  for (const auto& block : blockData()) {
     totalElements_ += block.numRows_;
   }
 }


### PR DESCRIPTION
The current version of the code makes two copies of the complete block metadata, even when no updates are ever performed. For datasets like OpenStreetMap or UniProt this caused a base RAM consumption of 40 GB+ versus the usual 13 GB. The copies also noticeably slowed down the time needed for starting the server.

This is now fixed by storing the block metadata (for each permutation) as a shared pointer and adapting all the functions and interfaces depending on this. As long as there are no updates, the base RAM consumption of the server is now as it used to be (before update was implement). Once there is an update, the block meta data is copied and stored twice (original and augmented) from then on.