### PR TITLE
Backport C++20 concepts to C++17 in the `index` module

### DIFF
--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1622,11 +1622,12 @@ constexpr auto makeNumDistinctIdsCounter = [](size_t& numDistinctIds) {
 }  // namespace
 
 // _____________________________________________________________________________
-CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-void IndexImpl::createPSOAndPOSImpl(size_t numColumns,
-                                    BlocksOfTriples sortedTriples,
-                                    bool doWriteConfiguration,
-                                    NextSorter&&... nextSorter)
+CPP_template_def(typename... NextSorter)(requires(
+    sizeof...(NextSorter) <=
+    1)) void IndexImpl::createPSOAndPOSImpl(size_t numColumns,
+                                            BlocksOfTriples sortedTriples,
+                                            bool doWriteConfiguration,
+                                            NextSorter&&... nextSorter)
 
 {
   size_t numTriplesNormal = 0;
@@ -1653,19 +1654,20 @@ void IndexImpl::createPSOAndPOSImpl(size_t numColumns,
 };
 
 // _____________________________________________________________________________
-CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-void IndexImpl::createPSOAndPOS(size_t numColumns,
-                                BlocksOfTriples sortedTriples,
-                                NextSorter&&... nextSorter) {
+CPP_template_def(typename... NextSorter)(
+    requires(sizeof...(NextSorter) <=
+             1)) void IndexImpl::createPSOAndPOS(size_t numColumns,
+                                                 BlocksOfTriples sortedTriples,
+                                                 NextSorter&&... nextSorter) {
   createPSOAndPOSImpl(numColumns, std::move(sortedTriples), true,
                       AD_FWD(nextSorter)...);
 }
 
 // _____________________________________________________________________________
 CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
-    size_t numColumns, BlocksOfTriples sortedTriples,
-    NextSorter&&... nextSorter) {
+    std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
+        size_t numColumns, BlocksOfTriples sortedTriples,
+        NextSorter&&... nextSorter) {
   size_t numSubjectsNormal = 0;
   size_t numSubjectsTotal = 0;
   auto numSubjectCounter = makeNumDistinctIdsCounter<0>(numSubjectsNormal);
@@ -1713,10 +1715,11 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
 };
 
 // _____________________________________________________________________________
-CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-void IndexImpl::createOSPAndOPS(size_t numColumns,
-                                BlocksOfTriples sortedTriples,
-                                NextSorter&&... nextSorter) {
+CPP_template_def(typename... NextSorter)(
+    requires(sizeof...(NextSorter) <=
+             1)) void IndexImpl::createOSPAndOPS(size_t numColumns,
+                                                 BlocksOfTriples sortedTriples,
+                                                 NextSorter&&... nextSorter) {
   // For the last pair of permutations we don't need a next sorter, so we
   // have no fourth argument.
   size_t numObjectsNormal = 0;

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1622,8 +1622,7 @@ constexpr auto makeNumDistinctIdsCounter = [](size_t& numDistinctIds) {
 }  // namespace
 
 // _____________________________________________________________________________
-template <typename... NextSorter>
-requires(sizeof...(NextSorter) <= 1)
+CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
 void IndexImpl::createPSOAndPOSImpl(size_t numColumns,
                                     BlocksOfTriples sortedTriples,
                                     bool doWriteConfiguration,
@@ -1654,8 +1653,7 @@ void IndexImpl::createPSOAndPOSImpl(size_t numColumns,
 };
 
 // _____________________________________________________________________________
-template <typename... NextSorter>
-requires(sizeof...(NextSorter) <= 1)
+CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
 void IndexImpl::createPSOAndPOS(size_t numColumns,
                                 BlocksOfTriples sortedTriples,
                                 NextSorter&&... nextSorter) {
@@ -1664,8 +1662,7 @@ void IndexImpl::createPSOAndPOS(size_t numColumns,
 }
 
 // _____________________________________________________________________________
-template <typename... NextSorter>
-requires(sizeof...(NextSorter) <= 1)
+CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
 std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
     size_t numColumns, BlocksOfTriples sortedTriples,
     NextSorter&&... nextSorter) {
@@ -1716,8 +1713,7 @@ std::optional<PatternCreator::TripleSorter> IndexImpl::createSPOAndSOP(
 };
 
 // _____________________________________________________________________________
-template <typename... NextSorter>
-requires(sizeof...(NextSorter) <= 1)
+CPP_template_def(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
 void IndexImpl::createOSPAndOPS(size_t numColumns,
                                 BlocksOfTriples sortedTriples,
                                 NextSorter&&... nextSorter) {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -12,6 +12,7 @@
 #include <stxxl/vector>
 #include <vector>
 
+#include "backports/algorithm.h"
 #include "engine/Result.h"
 #include "engine/idTable/CompressedExternalIdTable.h"
 #include "global/Pattern.h"
@@ -678,15 +679,13 @@ class IndexImpl {
   // Create the SPO and SOP permutations. Additionally, count the number of
   // distinct actual (not internal) subjects in the input and write it to the
   // metadata. Also builds the patterns if specified.
-  template <typename... NextSorter>
-  requires(sizeof...(NextSorter) <= 1)
+  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
   std::optional<PatternCreator::TripleSorter> createSPOAndSOP(
       size_t numColumns, BlocksOfTriples sortedTriples,
       NextSorter&&... nextSorter);
   // Create the OSP and OPS permutations. Additionally, count the number of
   // distinct objects and write it to the metadata.
-  template <typename... NextSorter>
-  requires(sizeof...(NextSorter) <= 1)
+  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
   void createOSPAndOPS(size_t numColumns, BlocksOfTriples sortedTriples,
                        NextSorter&&... nextSorter);
 
@@ -695,15 +694,13 @@ class IndexImpl {
   // metadata. The meta-data JSON file for the index statistics will only be
   // written iff `doWriteConfiguration` is true. That parameter is set to
   // `false` when building the additional permutations for the internal triples.
-  template <typename... NextSorter>
-  requires(sizeof...(NextSorter) <= 1)
+  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
   void createPSOAndPOSImpl(size_t numColumns, BlocksOfTriples sortedTriples,
                            bool doWriteConfiguration,
                            NextSorter&&... nextSorter);
   // Call `createPSOAndPOSImpl` with the given arguments and with
   // `doWriteConfiguration` set to `true` (see above).
-  template <typename... NextSorter>
-  requires(sizeof...(NextSorter) <= 1)
+  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
   void createPSOAndPOS(size_t numColumns, BlocksOfTriples sortedTriples,
                        NextSorter&&... nextSorter);
 

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -680,29 +680,33 @@ class IndexImpl {
   // distinct actual (not internal) subjects in the input and write it to the
   // metadata. Also builds the patterns if specified.
   CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-  std::optional<PatternCreator::TripleSorter> createSPOAndSOP(
-      size_t numColumns, BlocksOfTriples sortedTriples,
-      NextSorter&&... nextSorter);
+      std::optional<PatternCreator::TripleSorter> createSPOAndSOP(
+          size_t numColumns, BlocksOfTriples sortedTriples,
+          NextSorter&&... nextSorter);
   // Create the OSP and OPS permutations. Additionally, count the number of
   // distinct objects and write it to the metadata.
-  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-  void createOSPAndOPS(size_t numColumns, BlocksOfTriples sortedTriples,
-                       NextSorter&&... nextSorter);
+  CPP_template(typename... NextSorter)(requires(
+      sizeof...(NextSorter) <=
+      1)) void createOSPAndOPS(size_t numColumns, BlocksOfTriples sortedTriples,
+                               NextSorter&&... nextSorter);
 
   // Create the PSO and POS permutations. Additionally, count the number of
   // distinct predicates and the number of actual triples and write them to the
   // metadata. The meta-data JSON file for the index statistics will only be
   // written iff `doWriteConfiguration` is true. That parameter is set to
   // `false` when building the additional permutations for the internal triples.
-  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-  void createPSOAndPOSImpl(size_t numColumns, BlocksOfTriples sortedTriples,
-                           bool doWriteConfiguration,
-                           NextSorter&&... nextSorter);
+  CPP_template(typename... NextSorter)(
+      requires(sizeof...(NextSorter) <=
+               1)) void createPSOAndPOSImpl(size_t numColumns,
+                                            BlocksOfTriples sortedTriples,
+                                            bool doWriteConfiguration,
+                                            NextSorter&&... nextSorter);
   // Call `createPSOAndPOSImpl` with the given arguments and with
   // `doWriteConfiguration` set to `true` (see above).
-  CPP_template(typename... NextSorter)(requires(sizeof...(NextSorter) <= 1))
-  void createPSOAndPOS(size_t numColumns, BlocksOfTriples sortedTriples,
-                       NextSorter&&... nextSorter);
+  CPP_template(typename... NextSorter)(requires(
+      sizeof...(NextSorter) <=
+      1)) void createPSOAndPOS(size_t numColumns, BlocksOfTriples sortedTriples,
+                               NextSorter&&... nextSorter);
 
   // Create the internal PSO and POS permutations from the sorted internal
   // triples. Return `(numInternalTriples, numInternalPredicates)`.

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -61,9 +61,9 @@ NumAddedAndDeleted LocatedTriplesPerBlock::numTriples(size_t blockIndex) const {
 // `numIndexColumns` and `includeGraphColumn`. For example, if `numIndexColumns`
 // is `2` and `includeGraphColumn` is `true`, the function returns
 // `std::tie(row[0], row[1], row[2])`.
-template <size_t numIndexColumns, bool includeGraphColumn>
-requires(numIndexColumns >= 1 && numIndexColumns <= 3)
-auto tieIdTableRow(auto& row) {
+CPP_template(size_t numIndexColumns, bool includeGraphColumn)(
+    requires(numIndexColumns >= 1 &&
+             numIndexColumns <= 3)) auto tieIdTableRow(auto& row) {
   return [&row]<size_t... I>(std::index_sequence<I...>) {
     return std::tie(row[I]...);
   }(std::make_index_sequence<numIndexColumns +
@@ -75,9 +75,9 @@ auto tieIdTableRow(auto& row) {
 // `numIndexColumns` is `2` and `includeGraphColumn` is `true`, the function
 // returns `std::tie(ids_[1], ids_[2], ids_[3])`, where `ids_` is from
 // `lt->triple_`.
-template <size_t numIndexColumns, bool includeGraphColumn>
-requires(numIndexColumns >= 1 && numIndexColumns <= 3)
-auto tieLocatedTriple(auto& lt) {
+CPP_template(size_t numIndexColumns, bool includeGraphColumn)(
+    requires(numIndexColumns >= 1 &&
+             numIndexColumns <= 3)) auto tieLocatedTriple(auto& lt) {
   constexpr auto indices = []() {
     std::array<size_t,
                numIndexColumns + static_cast<size_t>(includeGraphColumn)>

--- a/src/index/TextIndexReadWrite.cpp
+++ b/src/index/TextIndexReadWrite.cpp
@@ -129,23 +129,3 @@ void FrequencyEncode<T>::writeToFile(ad_utility::File& out,
   textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<size_t>(
       encodedVector_, out, currentOffset);
 }
-
-// ____________________________________________________________________________
-template <typename T>
-requires std::is_arithmetic_v<T> template <typename View>
-void GapEncode<T>::initialize(View&& view) {
-  if (ql::ranges::empty(view)) {
-    return;
-  }
-  encodedVector_.reserve(ql::ranges::size(view));
-  std::adjacent_difference(ql::ranges::begin(view), ql::ranges::end(view),
-                           std::back_inserter(encodedVector_));
-}
-
-// ____________________________________________________________________________
-template <typename T>
-requires std::is_arithmetic_v<T>
-void GapEncode<T>::writeToFile(ad_utility::File& out, off_t& currentOffset) {
-  textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<T>(encodedVector_, out,
-                                                         currentOffset);
-}

--- a/src/index/TextIndexReadWrite.cpp
+++ b/src/index/TextIndexReadWrite.cpp
@@ -129,3 +129,22 @@ void FrequencyEncode<T>::writeToFile(ad_utility::File& out,
   textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<size_t>(
       encodedVector_, out, currentOffset);
 }
+
+// ____________________________________________________________________________
+template <typename T>
+template <typename View>
+void GapEncode<T>::initialize(View&& view) {
+  if (ql::ranges::empty(view)) {
+    return;
+  }
+  encodedVector_.reserve(ql::ranges::size(view));
+  std::adjacent_difference(ql::ranges::begin(view), ql::ranges::end(view),
+                           std::back_inserter(encodedVector_));
+}
+
+// ____________________________________________________________________________
+template <typename T>
+void GapEncode<T>::writeToFile(ad_utility::File& out, off_t& currentOffset) {
+  textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<T>(encodedVector_, out,
+                                                         currentOffset);
+}

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -316,8 +316,10 @@ FrequencyEncode(View&& view)
  *        encoded vector. It also has a method to write the encoded vector to
  *        a file.
  */
-CPP_template(typename T)(requires std::is_arithmetic_v<T>)
+template <typename T>
 class GapEncode {
+  static_assert(std::is_arithmetic_v<T>);
+
  public:
   using TypedVector = std::vector<T>;
 
@@ -343,7 +345,7 @@ class GapEncode {
 
   void writeToFile(ad_utility::File& out, off_t& currentOffset) {
     textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<T>(encodedVector_, out,
-                                                         currentOffset);
+                                                           currentOffset);
   }
 
   const TypedVector& getEncodedVector() const { return encodedVector_; }
@@ -354,11 +356,11 @@ class GapEncode {
   template <typename View>
   void initialize(View&& view) {
     if (ql::ranges::empty(view)) {
-    return;
-  }
-  encodedVector_.reserve(ql::ranges::size(view));
-  std::adjacent_difference(ql::ranges::begin(view), ql::ranges::end(view),
-                           std::back_inserter(encodedVector_));
+      return;
+    }
+    encodedVector_.reserve(ql::ranges::size(view));
+    std::adjacent_difference(ql::ranges::begin(view), ql::ranges::end(view),
+                             std::back_inserter(encodedVector_));
   }
 
   TypedVector encodedVector_;

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -343,10 +343,7 @@ class GapEncode {
   GapEncode(GapEncode&&) = delete;
   GapEncode& operator=(GapEncode&&) = delete;
 
-  void writeToFile(ad_utility::File& out, off_t& currentOffset) {
-    textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<T>(encodedVector_, out,
-                                                           currentOffset);
-  }
+  void writeToFile(ad_utility::File& out, off_t& currentOffset);
 
   const TypedVector& getEncodedVector() const { return encodedVector_; }
 
@@ -354,14 +351,7 @@ class GapEncode {
   // This method implements the constructor. The reason is explained in the
   // comment above the constructor.
   template <typename View>
-  void initialize(View&& view) {
-    if (ql::ranges::empty(view)) {
-      return;
-    }
-    encodedVector_.reserve(ql::ranges::size(view));
-    std::adjacent_difference(ql::ranges::begin(view), ql::ranges::end(view),
-                             std::back_inserter(encodedVector_));
-  }
+  void initialize(View&& view);
 
   TypedVector encodedVector_;
 };

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -316,8 +316,8 @@ FrequencyEncode(View&& view)
  *        encoded vector. It also has a method to write the encoded vector to
  *        a file.
  */
-template <typename T>
-requires std::is_arithmetic_v<T> class GapEncode {
+CPP_template(typename T)(requires std::is_arithmetic_v<T>)
+class GapEncode {
  public:
   using TypedVector = std::vector<T>;
 
@@ -341,7 +341,10 @@ requires std::is_arithmetic_v<T> class GapEncode {
   GapEncode(GapEncode&&) = delete;
   GapEncode& operator=(GapEncode&&) = delete;
 
-  void writeToFile(ad_utility::File& out, off_t& currentOffset);
+  void writeToFile(ad_utility::File& out, off_t& currentOffset) {
+    textIndexReadWrite::encodeAndWriteSpanAndMoveOffset<T>(encodedVector_, out,
+                                                         currentOffset);
+  }
 
   const TypedVector& getEncodedVector() const { return encodedVector_; }
 
@@ -349,7 +352,14 @@ requires std::is_arithmetic_v<T> class GapEncode {
   // This method implements the constructor. The reason is explained in the
   // comment above the constructor.
   template <typename View>
-  void initialize(View&& view);
+  void initialize(View&& view) {
+    if (ql::ranges::empty(view)) {
+    return;
+  }
+  encodedVector_.reserve(ql::ranges::size(view));
+  std::adjacent_difference(ql::ranges::begin(view), ql::ranges::end(view),
+                           std::back_inserter(encodedVector_));
+  }
 
   TypedVector encodedVector_;
 };

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -143,11 +143,11 @@ struct VocabularyMetaData {
 // strings (case-sensitive or not). Argument `wordCallback`
 // is called for each merged word in the vocabulary in the order of their
 // appearance.
-template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
-          QL_CONCEPT_OR_TYPENAME(WordCallback) C>
-VocabularyMetaData mergeVocabulary(const std::string& basename, size_t numFiles,
-                                   W comparator, C& wordCallback,
-                                   ad_utility::MemorySize memoryToUse);
+template <typename W, typename C>
+auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
+                     C& wordCallback, ad_utility::MemorySize memoryToUse)
+    -> CPP_ret(VocabularyMetaData)(
+        requires WordComparator<W>&& WordCallback<C>);
 
 // A helper class that implements the `mergeVocabulary` function (see
 // above). Everything in this class is private and only the
@@ -165,23 +165,23 @@ class VocabularyMerger {
   const size_t bufferSize_ = BATCH_SIZE_VOCABULARY_MERGE;
 
   // Friend declaration for the publicly available function.
-  template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
-            QL_CONCEPT_OR_TYPENAME(WordCallback) C>
-  friend VocabularyMetaData mergeVocabulary(const std::string& basename,
-                                            size_t numFiles, W comparator,
-                                            C& wordCallback,
-                                            ad_utility::MemorySize memoryToUse);
+  template <typename W, typename C>
+  friend auto mergeVocabulary(const std::string& basename, size_t numFiles,
+                              W comparator, C& wordCallback,
+                              ad_utility::MemorySize memoryToUse)
+      -> CPP_ret(VocabularyMetaData)(
+          requires WordComparator<W>&& WordCallback<C>);
   VocabularyMerger() = default;
 
   // _______________________________________________________________
   // The function that performs the actual merge. See the static global
   // `mergeVocabulary` function for details.
-  template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
-            QL_CONCEPT_OR_TYPENAME(WordCallback) C>
-  VocabularyMetaData mergeVocabulary(const std::string& basename,
-                                     size_t numFiles, W comparator,
-                                     C& wordCallback,
-                                     ad_utility::MemorySize memoryToUse);
+  template <typename W, typename C>
+  auto mergeVocabulary(const std::string& basename, size_t numFiles,
+                       W comparator, C& wordCallback,
+                       ad_utility::MemorySize memoryToUse)
+      -> CPP_ret(VocabularyMetaData)(
+          requires WordComparator<W>&& WordCallback<C>);
 
   // Helper `struct` for a word from a partial vocabulary.
   struct QueueWord {
@@ -210,19 +210,15 @@ class VocabularyMerger {
   // Write the queue words in the buffer to their corresponding `idPairVecs`.
   // The `QueueWord`s must be passed in alphabetical order wrt `lessThan` (also
   // across multiple calls).
+  // clang-format off
   CPP_template(typename C, typename L)(
       requires WordCallback<C> CPP_and ranges::predicate<
           L, TripleComponentWithIndex,
-          TripleComponentWithIndex>) void writeQueueWordsToIdVec(const std::
-                                                                     vector<
-                                                                         QueueWord>&
-                                                                         buffer,
-                                                                 C& wordCallback,
-                                                                 const L&
-                                                                     lessThan,
-                                                                 ad_utility::
-                                                                     ProgressBar&
-                                                                         progressBar);
+          TripleComponentWithIndex>)
+      // clang-format on
+      void writeQueueWordsToIdVec(const std::vector<QueueWord>& buffer,
+                                  C& wordCallback, const L& lessThan,
+                                  ad_utility::ProgressBar& progressBar);
 
   // Close all associated files and MmapVectors and reset all internal
   // variables.

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -210,11 +210,19 @@ class VocabularyMerger {
   // Write the queue words in the buffer to their corresponding `idPairVecs`.
   // The `QueueWord`s must be passed in alphabetical order wrt `lessThan` (also
   // across multiple calls).
-  CPP_template(typename C)(requires WordCallback<C>) void writeQueueWordsToIdVec(
-      const std::vector<QueueWord>& buffer, C& wordCallback,
-      std::predicate<TripleComponentWithIndex,
-                     TripleComponentWithIndex> auto const& lessThan,
-      ad_utility::ProgressBar& progressBar);
+  CPP_template(typename C, typename L)(
+      requires WordCallback<C> CPP_and ranges::predicate<
+          L, TripleComponentWithIndex,
+          TripleComponentWithIndex>) void writeQueueWordsToIdVec(const std::
+                                                                     vector<
+                                                                         QueueWord>&
+                                                                         buffer,
+                                                                 C& wordCallback,
+                                                                 const L&
+                                                                     lessThan,
+                                                                 ad_utility::
+                                                                     ProgressBar&
+                                                                         progressBar);
 
   // Close all associated files and MmapVectors and reset all internal
   // variables.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -31,24 +31,25 @@
 
 namespace ad_utility::vocabulary_merger {
 // _________________________________________________________________
-template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
-          QL_CONCEPT_OR_TYPENAME(WordCallback) C>
-VocabularyMetaData mergeVocabulary(const std::string& basename, size_t numFiles,
-                                   W comparator, C& internalWordCallback,
-                                   ad_utility::MemorySize memoryToUse) {
+template <typename W, typename C>
+auto mergeVocabulary(const std::string& basename, size_t numFiles, W comparator,
+                     C& internalWordCallback,
+                     ad_utility::MemorySize memoryToUse)
+    -> CPP_ret(VocabularyMetaData)(
+        requires WordComparator<W>&& WordCallback<C>) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
                                 internalWordCallback, memoryToUse);
 }
 
 // _________________________________________________________________
-template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
-          QL_CONCEPT_OR_TYPENAME(WordCallback) C>
+template <typename W, typename C>
 auto VocabularyMerger::mergeVocabulary(const std::string& basename,
                                        size_t numFiles, W comparator,
                                        C& wordCallback,
                                        ad_utility::MemorySize memoryToUse)
-    -> VocabularyMetaData {
+    -> CPP_ret(VocabularyMetaData)(
+        requires WordComparator<W>&& WordCallback<C>) {
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
   // or literal.
   auto lessThan = [&comparator](const TripleComponentWithIndex& t1,
@@ -87,8 +88,8 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
 
   std::future<void> writeFuture;
 
-  // Some memory (that is hard to measure exactly) is used for the writing of a
-  // batch of merged words, so we only give 80% of the total memory to the
+  // Some memory (that is hard to measure exactly) is used for the writing of
+  // a batch of merged words, so we only give 80% of the total memory to the
   // merging. This is very approximate and should be investigated in more
   // detail.
   auto mergedWords =
@@ -114,8 +115,8 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
       // wait for the last batch
 
       LOG(TIMING) << "A new batch of words is ready" << std::endl;
-      // First wait for the last batch to finish, that way there will be no race
-      // conditions.
+      // First wait for the last batch to finish, that way there will be no
+      // race conditions.
       if (writeFuture.valid()) {
         writeFuture.get();
       }

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -13,6 +13,7 @@
 #include <utility>
 #include <vector>
 
+#include "backports/algorithm.h"
 #include "index/ConstantsIndexBuilding.h"
 #include "index/Vocabulary.h"
 #include "index/VocabularyMerger.h"
@@ -30,9 +31,10 @@
 
 namespace ad_utility::vocabulary_merger {
 // _________________________________________________________________
+template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
+          QL_CONCEPT_OR_TYPENAME(WordCallback) C>
 VocabularyMetaData mergeVocabulary(const std::string& basename, size_t numFiles,
-                                   WordComparator auto comparator,
-                                   WordCallback auto& internalWordCallback,
+                                   W comparator, C& internalWordCallback,
                                    ad_utility::MemorySize memoryToUse) {
   VocabularyMerger merger;
   return merger.mergeVocabulary(basename, numFiles, std::move(comparator),
@@ -40,10 +42,11 @@ VocabularyMetaData mergeVocabulary(const std::string& basename, size_t numFiles,
 }
 
 // _________________________________________________________________
+template <QL_CONCEPT_OR_TYPENAME(WordComparator) W,
+          QL_CONCEPT_OR_TYPENAME(WordCallback) C>
 auto VocabularyMerger::mergeVocabulary(const std::string& basename,
-                                       size_t numFiles,
-                                       WordComparator auto comparator,
-                                       WordCallback auto& wordCallback,
+                                       size_t numFiles, W comparator,
+                                       C& wordCallback,
                                        ad_utility::MemorySize memoryToUse)
     -> VocabularyMetaData {
   // Return true iff p1 >= p2 according to the lexicographic order of the IRI
@@ -139,11 +142,12 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
 }
 
 // ________________________________________________________________________________
-void VocabularyMerger::writeQueueWordsToIdVec(
-    const std::vector<QueueWord>& buffer, WordCallback auto& wordCallback,
-    std::predicate<TripleComponentWithIndex,
-                   TripleComponentWithIndex> auto const& lessThan,
-    ad_utility::ProgressBar& progressBar) {
+CPP_template_def(typename C)(requires WordCallback<C>) void VocabularyMerger::
+    writeQueueWordsToIdVec(
+        const std::vector<QueueWord>& buffer, C& wordCallback,
+        std::predicate<TripleComponentWithIndex,
+                       TripleComponentWithIndex> auto const& lessThan,
+        ad_utility::ProgressBar& progressBar) {
   LOG(TIMING) << "Start writing a batch of merged words\n";
 
   // Smaller grained buffer for the actual inner write.

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -142,12 +142,13 @@ auto VocabularyMerger::mergeVocabulary(const std::string& basename,
 }
 
 // ________________________________________________________________________________
-CPP_template_def(typename C)(requires WordCallback<C>) void VocabularyMerger::
-    writeQueueWordsToIdVec(
-        const std::vector<QueueWord>& buffer, C& wordCallback,
-        std::predicate<TripleComponentWithIndex,
-                       TripleComponentWithIndex> auto const& lessThan,
-        ad_utility::ProgressBar& progressBar) {
+CPP_template_def(typename C, typename L)(
+    requires WordCallback<C> CPP_and
+        ranges::predicate<L, TripleComponentWithIndex,
+                          TripleComponentWithIndex>) void VocabularyMerger::
+    writeQueueWordsToIdVec(const std::vector<QueueWord>& buffer,
+                           C& wordCallback, const L& lessThan,
+                           ad_utility::ProgressBar& progressBar) {
   LOG(TIMING) << "Start writing a batch of merged words\n";
 
   // Smaller grained buffer for the actual inner write.

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -293,10 +293,10 @@ CPP_template(typename UnderlyingVocabulary,
 
   // Decompress the word that `it` points to. `it` is an iterator into the
   // underlying vocabulary.
-  auto decompressFromIterator(auto it) const {
+  template <typename It>
+  auto decompressFromIterator(It it) const {
     auto idx = [&]() {
-      if constexpr (detail::IterableVocabulary<UnderlyingVocabulary,
-                                               decltype(it)>) {
+      if constexpr (detail::IterableVocabulary<UnderlyingVocabulary, It>) {
         return it - underlyingVocabulary_.begin();
       } else {
         return underlyingVocabulary_.iteratorToIndex(it);

--- a/src/index/vocabulary/CompressionWrappers.h
+++ b/src/index/vocabulary/CompressionWrappers.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include "backports/algorithm.h"
-
 #include "index/PrefixHeuristic.h"
 #include "index/vocabulary/PrefixCompressor.h"
 #include "util/FsstCompressor.h"
@@ -13,11 +12,13 @@
 namespace ad_utility::vocabulary {
 
 template <typename T, typename Decoder>
-CPP_requires(BulkResultForDecoder_, requires(T t) (
-  std::tuple_size_v<T> == 3,
-  ad_utility::SimilarToAny<decltype(std::get<1>(t)), std::vector<std::string_view>,std::vector<std::string>>,
-  ad_utility::SimilarTo<decltype(std::get<2>(t)), Decoder>
-));
+CPP_requires(
+    BulkResultForDecoder_,
+    requires(T t)(std::tuple_size_v<T> == 3,
+                  ad_utility::SimilarToAny<decltype(std::get<1>(t)),
+                                           std::vector<std::string_view>,
+                                           std::vector<std::string>>,
+                  ad_utility::SimilarTo<decltype(std::get<2>(t)), Decoder>));
 
 // A helper concept for the compression wrappers below.
 // A `BulkResultForDecoder` is a tuple of 3 elements, the first of which is an
@@ -26,20 +27,25 @@ CPP_requires(BulkResultForDecoder_, requires(T t) (
 // `vector<string>` that stores compressed strings and the third of which is a
 // `Decoder`.
 template <typename T, typename Decoder>
-CPP_concept BulkResultForDecoder = CPP_requires_ref(BulkResultForDecoder_, T, Decoder);
+CPP_concept BulkResultForDecoder =
+    CPP_requires_ref(BulkResultForDecoder_, T, Decoder);
 
 template <typename T>
-CPP_requires(CompressionWrapper_, requires(const T&t) (
-  // Return the number of decoders that are stored.
-  concepts::same_as<decltype(t.numDecoders()), size_t>,
-  // Decompress the given string, use the Decoder specified by the second
-  // argument.
-  concepts::same_as<decltype(t.decompress(std::string_view{}, size_t{0})), std::string>,
-  // Compress all the strings and return the strings together with a `Decoder`
-  // that can be used to decompress the strings again.
-  BulkResultForDecoder<decltype(T::compressAll(std::vector<std::string>{})), typename T::Decoder>,
-  concepts::constructible_from<T, std::vector<typename T::Decoder>>
-));
+CPP_requires(
+    CompressionWrapper_,
+    requires(const T& t)(
+        // Return the number of decoders that are stored.
+        concepts::same_as<decltype(t.numDecoders()), size_t>,
+        // Decompress the given string, use the Decoder specified by the second
+        // argument.
+        concepts::same_as<decltype(t.decompress(std::string_view{}, size_t{0})),
+                          std::string>,
+        // Compress all the strings and return the strings together with a
+        // `Decoder` that can be used to decompress the strings again.
+        BulkResultForDecoder<
+            decltype(T::compressAll(std::vector<std::string>{})),
+            typename T::Decoder>,
+        concepts::constructible_from<T, std::vector<typename T::Decoder>>));
 
 // A concept for the `CompressionWrappers` that can be passed as template
 // arguments to the compressed vocabulary to specify the compression algorithm.

--- a/src/index/vocabulary/CompressionWrappers.h
+++ b/src/index/vocabulary/CompressionWrappers.h
@@ -4,13 +4,20 @@
 
 #pragma once
 
-#include <concepts>
+#include "backports/algorithm.h"
 
 #include "index/PrefixHeuristic.h"
 #include "index/vocabulary/PrefixCompressor.h"
 #include "util/FsstCompressor.h"
 
 namespace ad_utility::vocabulary {
+
+template <typename T, typename Decoder>
+CPP_requires(BulkResultForDecoder_, requires(T t) (
+  std::tuple_size_v<T> == 3,
+  ad_utility::SimilarToAny<decltype(std::get<1>(t)), std::vector<std::string_view>,std::vector<std::string>>,
+  ad_utility::SimilarTo<decltype(std::get<2>(t)), Decoder>
+));
 
 // A helper concept for the compression wrappers below.
 // A `BulkResultForDecoder` is a tuple of 3 elements, the first of which is an
@@ -19,32 +26,25 @@ namespace ad_utility::vocabulary {
 // `vector<string>` that stores compressed strings and the third of which is a
 // `Decoder`.
 template <typename T, typename Decoder>
-concept BulkResultForDecoder = requires(T t) {
-  requires(std::tuple_size_v<T> == 3);
-  {
-    std::get<1>(t)
-  } -> ad_utility::SimilarToAny<std::vector<std::string_view>,
-                                std::vector<std::string>>;
-  { std::get<2>(t) } -> ad_utility::SimilarTo<Decoder>;
-};
+CPP_concept BulkResultForDecoder = CPP_requires_ref(BulkResultForDecoder_, T, Decoder);
+
+template <typename T>
+CPP_requires(CompressionWrapper_, requires(const T&t) (
+  // Return the number of decoders that are stored.
+  concepts::same_as<decltype(t.numDecoders()), size_t>,
+  // Decompress the given string, use the Decoder specified by the second
+  // argument.
+  concepts::same_as<decltype(t.decompress(std::string_view{}, size_t{0})), std::string>,
+  // Compress all the strings and return the strings together with a `Decoder`
+  // that can be used to decompress the strings again.
+  BulkResultForDecoder<decltype(T::compressAll(std::vector<std::string>{})), typename T::Decoder>,
+  concepts::constructible_from<T, std::vector<typename T::Decoder>>
+));
 
 // A concept for the `CompressionWrappers` that can be passed as template
 // arguments to the compressed vocabulary to specify the compression algorithm.
 template <typename T>
-concept CompressionWrapper = requires(const T& t) {
-  typename T::Decoder;
-  // Return the number of decoders that are stored.
-  { t.numDecoders() } -> std::same_as<size_t>;
-  // Decompress the given string, use the Decoder specified by the second
-  // argument.
-  { t.decompress(std::string_view{}, size_t{0}) } -> std::same_as<std::string>;
-  // Compress all the strings and return the strings together with a `Decoder`
-  // that can be used to decompress the strings again.
-  {
-    T::compressAll(std::vector<std::string>{})
-  } -> BulkResultForDecoder<typename T::Decoder>;
-  requires(std::constructible_from<T, std::vector<typename T::Decoder>>);
-};
+CPP_concept CompressionWrapper = CPP_requires_ref(CompressionWrapper_, T);
 
 namespace detail {
 // A class that holds a `vector<DecoderT>` and implements the

--- a/src/index/vocabulary/CompressionWrappers.h
+++ b/src/index/vocabulary/CompressionWrappers.h
@@ -11,6 +11,12 @@
 
 namespace ad_utility::vocabulary {
 
+// A helper concept for the compression wrappers below.
+// A `BulkResultForDecoder` is a tuple of 3 elements, the first of which is an
+// implementation detail (e.g. a buffer that stores the data for the second
+// argument ), the second of which is a `vector<string_view>` or
+// `vector<string>` that stores compressed strings and the third of which is a
+// `Decoder`.
 template <typename T, typename Decoder>
 CPP_requires(
     BulkResultForDecoder_,
@@ -19,13 +25,6 @@ CPP_requires(
                                            std::vector<std::string_view>,
                                            std::vector<std::string>>,
                   ad_utility::SimilarTo<decltype(std::get<2>(t)), Decoder>));
-
-// A helper concept for the compression wrappers below.
-// A `BulkResultForDecoder` is a tuple of 3 elements, the first of which is an
-// implementation detail (e.g. a buffer that stores the data for the second
-// argument ), the second of which is a `vector<string_view>` or
-// `vector<string>` that stores compressed strings and the third of which is a
-// `Decoder`.
 template <typename T, typename Decoder>
 CPP_concept BulkResultForDecoder =
     CPP_requires_ref(BulkResultForDecoder_, T, Decoder);

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include "VocabularyTestHelpers.h"
+#include "backports/algorithm.h"
 #include "index/VocabularyOnDisk.h"
 #include "index/vocabulary/CompressedVocabulary.h"
 #include "index/vocabulary/PrefixCompressor.h"
@@ -84,8 +85,9 @@ using Compressors =
                      PrefixCompressionWrapper, DummyCompressionWrapper>;
 
 // _________________________________________________________________________
-template <ad_utility::vocabulary::CompressionWrapper Compressor>
-struct CompressedVocabularyF : public testing::Test {
+CPP_template(typename Compressor)(
+    requires ad_utility::vocabulary::CompressionWrapper<
+        Compressor>) struct CompressedVocabularyF : public testing::Test {
   // Tests for the FSST-compressed vocabulary. These use the generic testing
   // framework that was set up for all the other vocabularies.
   static constexpr auto createCompressedVocabulary(


### PR DESCRIPTION
The backport is (as usual) implemented using the `CPP_template` etc. macros from Eric Niebler's `range-v3` library.