### PR TITLE
Make output for results with zero columns standard-compliant

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -590,8 +590,11 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
             co_yield optionalStringAndType.value().first;
           }
         }
-        co_yield j + 1 < selectedColumnIndices.size() ? separator : '\n';
+        if (j + 1 < selectedColumnIndices.size()) {
+          co_yield separator;
+        }
       }
+      co_yield '\n';
       cancellationHandle->throwIfCancelled();
     }
   }

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -1045,6 +1045,31 @@ TEST(ExportQueryExecutionTrees, UndefinedValues) {
 }
 
 // ____________________________________________________________________________
+TEST(ExportQueryExecutionTrees, EmptyLines) {
+  std::string kg = "<s> <p> <o>";
+  std::string query = "SELECT * WHERE { <s> <p> <o> }";
+  std::string expectedXml = makeXMLHeader({}) +
+                            R"(
+  <result>
+  </result>)" + xmlTrailer;
+  TestCaseSelectQuery testCase{kg,
+                               query,
+                               1,
+                               "\n\n",
+                               "\n\n",
+                               nlohmann::json{std::vector{std::vector<int>{}}},
+                               []() {
+                                 nlohmann::json j;
+                                 j["head"]["vars"] = nlohmann::json::array();
+                                 j["results"]["bindings"] =
+                                     nlohmann::json::array();
+                                 return j;
+                               }(),
+                               expectedXml};
+  runSelectQueryTestCase(testCase);
+}
+
+// ____________________________________________________________________________
 TEST(ExportQueryExecutionTrees, BlankNode) {
   std::string kg = "<s> <p> _:blank";
   std::string objectQuery = "SELECT ?o WHERE {?s ?p ?o } ORDER BY ?o";


### PR DESCRIPTION
For queries with zero columns (e.g., `SELECT * WHERE { <s> <p> <o> }`), the results were not fully standard-compliant. In particular, only the empty header row was output for `text/tab-separated-values` and `text/csv`, but never any additional empty rows. This is now fixed. Fixes #1745