### PR TITLE
Allow `;` after update request with a single operation

### DIFF
--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -438,7 +438,7 @@ std::optional<Values> Visitor::visit(Parser::ValuesClauseContext* ctx) {
   return visitOptional(ctx->dataBlock());
 }
 
-// ____________________________________________________________________________________
+// ____________________________________________________________________________
 ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
   // The prologue (BASE and PREFIX declarations)  only affects the internal
   // state of the visitor.
@@ -446,8 +446,8 @@ ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
 
   auto update = visit(ctx->update1());
 
-  // Relaxed rules for when multiple updates are present until we properly
-  // support them. A `;` is allowed but no update body.
+  // More than one operation in a single update request is not yet supported,
+  // but a semicolon after a single update is allowed.
   if (ctx->update() && !ctx->update()->getText().empty()) {
     parsedQuery_ = ParsedQuery{};
     reportNotSupported(ctx->update(), "Multiple updates in one query are");

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -447,8 +447,7 @@ ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
   auto update = visit(ctx->update1());
 
   // Relaxed rules for when multiple updates are present until we properly
-  // support them. A `;` and an additional prologue is allowed but no update
-  // body.
+  // support them. A `;` is allowed but no update body.
   if (ctx->update() && !ctx->update()->getText().empty()) {
     parsedQuery_ = ParsedQuery{};
     reportNotSupported(ctx->update(), "Multiple updates in one query are");

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -449,7 +449,7 @@ ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
   // Relaxed rules for when multiple updates are present until we properly
   // support them. A `;` and an additional prologue is allowed but no update
   // body.
-  if (ctx->update() && ctx->update()->update1()) {
+  if (ctx->update() && !ctx->update()->getText().empty()) {
     parsedQuery_ = ParsedQuery{};
     reportNotSupported(ctx->update(), "Multiple updates in one query are");
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -446,7 +446,10 @@ ParsedQuery Visitor::visit(Parser::UpdateContext* ctx) {
 
   auto update = visit(ctx->update1());
 
-  if (ctx->update()) {
+  // Relaxed rules for when multiple updates are present until we properly
+  // support them. A `;` and an additional prologue is allowed but no update
+  // body.
+  if (ctx->update() && ctx->update()->update1()) {
     parsedQuery_ = ParsedQuery{};
     reportNotSupported(ctx->update(), "Multiple updates in one query are");
   }

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2050,10 +2050,12 @@ TEST(SparqlParser, QuadData) {
 TEST(SparqlParser, Update) {
   auto expectUpdate_ = ExpectCompleteParse<&Parser::update>{defaultPrefixMap};
   // Automatically test all updates for their `_originalString`.
-  auto expectUpdate = [&expectUpdate_](const std::string& query,
-                                       auto&& expected) {
-    expectUpdate_(query,
-                  testing::AllOf(expected, m::pq::OriginalString(query)));
+  auto expectUpdate = [&expectUpdate_](
+                          const std::string& query, auto&& expected,
+                          ad_utility::source_location l =
+                              ad_utility::source_location::current()) {
+    expectUpdate_(query, testing::AllOf(expected, m::pq::OriginalString(query)),
+                  l);
   };
   auto expectUpdateFails = ExpectParseFails<&Parser::update>{};
   auto Iri = [](std::string_view stringWithBrackets) {
@@ -2185,23 +2187,21 @@ TEST(SparqlParser, Update) {
   expectUpdate("COPY DEFAULT TO GRAPH <foo>",
                m::UpdateClause(m::Copy(false, DEFAULT{}, Iri("<foo>")),
                                m::GraphPattern()));
-  auto expectParsesAsSingleUpdate = [&expectUpdate, &noGraph,
-                                     &Iri](const std::string& query) {
-    expectUpdate(
-        query,
-        m::UpdateClause(
-            m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}},
-                           std::nullopt),
-            m::GraphPattern()));
-  };
-  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> }");
-  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> };");
-  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> }; BASE <foo>");
-  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> }; PREFIX foo: <bar>");
-  expectUpdateFails(
-      "INSERT DATA { <a> <b> <c> }; INSERT DATA { <d> <e> <f> }",
-      testing::HasSubstr("Not supported: Multiple updates in one query are "
-                         "currently not supported by QLever"));
+  const auto simpleInsertMatcher = m::UpdateClause(
+      m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}},
+                     std::nullopt),
+      m::GraphPattern());
+  expectUpdate("INSERT DATA { <a> <b> <c> }", simpleInsertMatcher);
+  expectUpdate("INSERT DATA { <a> <b> <c> };", simpleInsertMatcher);
+  const auto multipleUpdatesError = testing::HasSubstr(
+      "Not supported: Multiple updates in one query are "
+      "currently not supported by QLever");
+  expectUpdateFails("INSERT DATA { <a> <b> <c> }; PREFIX foo: <foo>",
+                    multipleUpdatesError);
+  expectUpdateFails("INSERT DATA { <a> <b> <c> }; BASE <bar>",
+                    multipleUpdatesError);
+  expectUpdateFails("INSERT DATA { <a> <b> <c> }; INSERT DATA { <d> <e> <f> }",
+                    multipleUpdatesError);
 }
 
 TEST(SparqlParser, QueryOrUpdate) {

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2185,6 +2185,23 @@ TEST(SparqlParser, Update) {
   expectUpdate("COPY DEFAULT TO GRAPH <foo>",
                m::UpdateClause(m::Copy(false, DEFAULT{}, Iri("<foo>")),
                                m::GraphPattern()));
+  auto expectParsesAsSingleUpdate = [&expectUpdate, &noGraph,
+                                     &Iri](const std::string& query) {
+    expectUpdate(
+        query,
+        m::UpdateClause(
+            m::GraphUpdate({}, {{Iri("<a>"), Iri("<b>"), Iri("<c>"), noGraph}},
+                           std::nullopt),
+            m::GraphPattern()));
+  };
+  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> }");
+  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> };");
+  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> }; BASE <foo>");
+  expectParsesAsSingleUpdate("INSERT DATA { <a> <b> <c> }; PREFIX foo: <bar>");
+  expectUpdateFails(
+      "INSERT DATA { <a> <b> <c> }; INSERT DATA { <d> <e> <f> }",
+      testing::HasSubstr("Not supported: Multiple updates in one query are "
+                         "currently not supported by QLever"));
 }
 
 TEST(SparqlParser, QueryOrUpdate) {


### PR DESCRIPTION
QLever does not yet support update requests with more than one operation, e.g., `DELETE DATA { <pi> <value> 3.14 }; INSERT DATA { <pi> <value> 3.1459 }`. Due to an oversight, the current implementation also did not support single operations followed by a semicolon, e.g., `DELETE DATA { <pi> <value> 3.14 };`. These are now supported. Fixes #1747

NOTE: Support for multiple operations in a single update request will be added soon.