### PR TITLE
Fix `REPLACE` function with replace patterns

### DIFF
--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -91,6 +91,55 @@ std::optional<std::string> StringValueGetter::operator()(
 }
 
 // ____________________________________________________________________________
+std::optional<std::string> ReplacementStringGetter::operator()(
+    Id id, const EvaluationContext* context) const {
+  std::optional<std::string> originalString =
+      StringValueGetter::operator()(id, context);
+  if (!originalString.has_value()) {
+    return originalString;
+  }
+  return convertToReplacementString(originalString.value());
+}
+
+// ____________________________________________________________________________
+std::optional<std::string> ReplacementStringGetter::operator()(
+    const LiteralOrIri& s, const EvaluationContext*) const {
+  return convertToReplacementString(asStringViewUnsafe(s.getContent()));
+}
+
+// ____________________________________________________________________________
+std::string ReplacementStringGetter::convertToReplacementString(
+    std::string_view view) {
+  std::string result;
+  // Rough estimate of the size of the result string.
+  result.reserve(view.size());
+  for (size_t i = 0; i < view.size(); i++) {
+    char c = view.at(i);
+    switch (c) {
+      case '$':
+        // "$$" is unescaped to "$"
+        if (i + 1 < view.size() && view.at(i + 1) == '$') {
+          result.push_back(c);
+          i++;
+        } else {
+          // Re2 used \1, \2, ... for backreferences, so we change $ to \.
+          result.push_back('\\');
+        }
+        break;
+      case '\\':
+        // Escape existing backslashes.
+        result.push_back(c);
+        result.push_back(c);
+        break;
+      default:
+        result.push_back(c);
+        break;
+    }
+  }
+  return result;
+}
+
+// ____________________________________________________________________________
 template <auto isSomethingFunction, auto prefix>
 Id IsSomethingValueGetter<isSomethingFunction, prefix>::operator()(
     ValueId id, const EvaluationContext* context) const {

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -117,19 +117,19 @@ std::string ReplacementStringGetter::convertToReplacementString(
     char c = view.at(i);
     switch (c) {
       case '$':
-        // "$$" is unescaped to "$"
-        if (i + 1 < view.size() && view.at(i + 1) == '$') {
-          result.push_back(c);
-          i++;
-        } else {
-          // Re2 used \1, \2, ... for backreferences, so we change $ to \.
-          result.push_back('\\');
-        }
+        // Re2 used \1, \2, ... for backreferences, so we change $ to \.
+        result.push_back('\\');
         break;
       case '\\':
-        // Escape existing backslashes.
-        result.push_back(c);
-        result.push_back(c);
+        // "\$" is unescaped to "$"
+        if (i + 1 < view.size() && view.at(i + 1) == '$') {
+          result.push_back('$');
+          i++;
+        } else {
+          // Escape existing backslashes.
+          result.push_back(c);
+          result.push_back(c);
+        }
         break;
       default:
         result.push_back(c);

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -140,6 +140,20 @@ struct StringValueGetter : Mixin<StringValueGetter> {
     return std::string(asStringViewUnsafe(s.getContent()));
   }
 };
+// Similar to `StringValueGetter`, but correctly escapes and unescapes string
+// sequences.
+struct ReplacementStringGetter : StringValueGetter,
+                                 Mixin<ReplacementStringGetter> {
+  using Mixin<ReplacementStringGetter>::operator();
+  std::optional<std::string> operator()(ValueId,
+                                        const EvaluationContext*) const;
+
+  std::optional<std::string> operator()(const LiteralOrIri& s,
+                                        const EvaluationContext*) const;
+
+ private:
+  static std::string convertToReplacementString(std::string_view view);
+};
 
 // Boolean value getter that checks whether the given `Id` is a `ValueId` of the
 // given `datatype`.

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -140,8 +140,10 @@ struct StringValueGetter : Mixin<StringValueGetter> {
     return std::string(asStringViewUnsafe(s.getContent()));
   }
 };
-// Similar to `StringValueGetter`, but correctly escapes and unescapes string
-// sequences.
+// Similar to `StringValueGetter`, but correctly preprocesses strings so that
+// they can be used by re2 as replacement strings. So '$1 \abc \$' becomes
+// '\1 \\abc $', where the former variant is valid in the SPARQL standard and
+// the latter represents the format that re2 expects.
 struct ReplacementStringGetter : StringValueGetter,
                                  Mixin<ReplacementStringGetter> {
   using Mixin<ReplacementStringGetter>::operator();

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -357,7 +357,7 @@ using StrBeforeExpression =
 
 using ReplaceExpression =
     StringExpressionImpl<3, decltype(replaceImpl), RegexValueGetter,
-                         StringValueGetter>;
+                         ReplacementStringGetter>;
 
 // CONCAT
 class ConcatExpression : public detail::VariadicExpression {

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1242,6 +1242,12 @@ TEST(SparqlExpression, ReplaceExpression) {
       idOrLitOrStringVec({"null", "Xs", "zwei", "drei", U, U}),
       std::tuple{idOrLitOrStringVec({"null", "eins", "zwei", "drei", U, U}),
                  IdOrLiteralOrIri{lit("e.[a-z]")}, IdOrLiteralOrIri{lit("X")}});
+  // A regex with replacement with substitutions
+  checkReplace(
+      idOrLitOrStringVec({"\"$1 \\\\2 A \\\\bc\"", "\"$1 \\\\2 DE \\\\f\""}),
+      std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),
+                 IdOrLiteralOrIri{lit("([A-Z]+)")},
+                 IdOrLiteralOrIri{lit("\"$$1 \\\\2 $1 \\\\\"")}});
 
   // Case-insensitive matching using the hack for google regex:
   checkReplace(idOrLitOrStringVec({"null", "xxns", "zwxx", "drxx"}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1249,6 +1249,11 @@ TEST(SparqlExpression, ReplaceExpression) {
                  IdOrLiteralOrIri{lit("([A-Z]+)")},
                  IdOrLiteralOrIri{lit("\"$$1 \\\\2 $1 \\\\\"")}});
 
+  checkReplace(idOrLitOrStringVec({"truebc", "truef"}),
+               std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),
+                          IdOrLiteralOrIri{lit("([A-Z]+)")},
+                          IdOrLiteralOrIri{Id::makeFromBool(true)}});
+
   // Case-insensitive matching using the hack for google regex:
   checkReplace(idOrLitOrStringVec({"null", "xxns", "zwxx", "drxx"}),
                std::tuple{idOrLitOrStringVec({"null", "eIns", "zwEi", "drei"}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1243,11 +1243,10 @@ TEST(SparqlExpression, ReplaceExpression) {
       std::tuple{idOrLitOrStringVec({"null", "eins", "zwei", "drei", U, U}),
                  IdOrLiteralOrIri{lit("e.[a-z]")}, IdOrLiteralOrIri{lit("X")}});
   // A regex with replacement with substitutions
-  checkReplace(
-      idOrLitOrStringVec({"\"$1 \\\\2 A \\\\bc\"", "\"$1 \\\\2 DE \\\\f\""}),
-      std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),
-                 IdOrLiteralOrIri{lit("([A-Z]+)")},
-                 IdOrLiteralOrIri{lit("\"\\\\$1 \\\\2 $1 \\\\\"")}});
+  checkReplace(idOrLitOrStringVec({R"("$1 \\2 A \\bc")", R"("$1 \\2 DE \\f")"}),
+               std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),
+                          IdOrLiteralOrIri{lit("([A-Z]+)")},
+                          IdOrLiteralOrIri{lit(R"("\\$1 \\2 $1 \\")")}});
 
   checkReplace(idOrLitOrStringVec({"truebc", "truef"}),
                std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1247,7 +1247,7 @@ TEST(SparqlExpression, ReplaceExpression) {
       idOrLitOrStringVec({"\"$1 \\\\2 A \\\\bc\"", "\"$1 \\\\2 DE \\\\f\""}),
       std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),
                  IdOrLiteralOrIri{lit("([A-Z]+)")},
-                 IdOrLiteralOrIri{lit("\"$$1 \\\\2 $1 \\\\\"")}});
+                 IdOrLiteralOrIri{lit("\"\\\\$1 \\\\2 $1 \\\\\"")}});
 
   checkReplace(idOrLitOrStringVec({"truebc", "truef"}),
                std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),


### PR DESCRIPTION
In the replace string of the `REPLACE` function, QLever now uses a dollar sign `$` to dynamically fetch the replacement from the input. For example `REPLACE("aabc", "(a+)b", "$1def$1")` will now correctly result in "aadefaac".
This fix is implemented by manually converting the replacement string to the format the Google RE2 expects where the replacement format is not `$n` but `\n`.
Fixes #1664