### PR TITLE
Backport the rest of the C++20 concepts to C++17 in the `index` module

### DIFF
--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 
+#include "backports/algorithm.h"
 #include "global/VocabIndex.h"
 #include "parser/LiteralOrIri.h"
 #include "util/CopyableSynchronization.h"
@@ -68,8 +69,9 @@ class alignas(16) LocalVocabEntry
 
   // It suffices to hash the base class `LiteralOrIri` as the position in the
   // vocab is redundant for those purposes.
-  template <typename H>
-  friend H AbslHashValue(H h, const std::same_as<LocalVocabEntry> auto& entry) {
+  template <typename H, typename V>
+  friend auto AbslHashValue(H h, const V& entry)
+      -> CPP_ret(H)(requires ranges::same_as<V, LocalVocabEntry>) {
     return AbslHashValue(std::move(h), static_cast<const Base&>(entry));
   }
 

--- a/src/index/StringSortComparator.h
+++ b/src/index/StringSortComparator.h
@@ -17,6 +17,7 @@
 #include <memory>
 #include <memory_resource>
 
+#include "backports/algorithm.h"
 #include "global/Constants.h"
 #include "util/Exception.h"
 #include "util/StringUtils.h"
@@ -177,9 +178,12 @@ class LocaleManager {
    * @return A weight string s.t. compare(s, t, level) ==
    * std::strcmp(getSortKey(s, level), getSortKey(t, level)
    */
-  void getSortKey(
-      std::string_view s, const Level level,
-      std::invocable<const uint8_t*, size_t> auto resultFunction) const {
+  // clang-format off
+  CPP_template(typename F)(
+    requires ranges::invocable<F, const uint8_t*, size_t>)
+      // clang-format on
+      void getSortKey(std::string_view s, const Level level,
+                      F resultFunction) const {
     // TODO<joka921> This function is one of the bottlenecks of the first pass
     // of the IndexBuilder One possible improvement is to reuse the memory
     // allocations for the `sortKeyBuffer`.

--- a/src/index/TextIndexReadWrite.h
+++ b/src/index/TextIndexReadWrite.h
@@ -277,7 +277,7 @@ class FrequencyEncode {
   // requires clause is kept only in the .h file and the constructor calls the
   // initialize function which has no direct requires clause.
   CPP_template(typename View)(requires(
-      !std::same_as<
+      !ranges::same_as<
           FrequencyEncode,
           std::remove_cvref_t<View>>)) explicit FrequencyEncode(View&& view) {
     initialize(std::forward<View>(view));
@@ -331,9 +331,8 @@ class GapEncode {
   // requires clause is kept only in the .h file and the constructor calls the
   // initialize function which has no direct requires clause.
   CPP_template(typename View)(requires(
-      !std::same_as<GapEncode,
-                    std::remove_cvref_t<View>>)) explicit GapEncode(View&&
-                                                                        view) {
+      !ranges::same_as<GapEncode, std::remove_cvref_t<
+                                      View>>)) explicit GapEncode(View&& view) {
     initialize(std::forward<View>(view));
   };
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -28,11 +28,11 @@ namespace ad_utility::vocabulary_merger {
 // If the `bool` is true, then the word is to be stored in the external
 // vocabulary else in the internal vocabulary.
 template <typename T>
-CPP_concept WordCallback = std::invocable<T, std::string_view, bool>;
+CPP_concept WordCallback = ranges::invocable<T, std::string_view, bool>;
 // Concept for a callable that compares to `string_view`s.
 template <typename T>
 CPP_concept WordComparator =
-    std::predicate<T, std::string_view, std::string_view>;
+    ranges::predicate<T, std::string_view, std::string_view>;
 
 // The result of a call to `mergeVocabulary` (see below).
 struct VocabularyMetaData {

--- a/src/index/vocabulary/CompressedVocabulary.h
+++ b/src/index/vocabulary/CompressedVocabulary.h
@@ -314,7 +314,7 @@ CPP_template(typename UnderlyingVocabulary,
   // _________________________________________________________________
   template <typename T>
   static std::string_view toStringView(const T& el) {
-    if constexpr (std::convertible_to<T, std::string_view>) {
+    if constexpr (ranges::convertible_to<T, std::string_view>) {
       return el;
     } else if constexpr (ad_utility::isInstantiation<T, std::optional>) {
       return toStringView(el.value());


### PR DESCRIPTION
This PR mainly replaces concepts such as `std::same_as` by their counterparts from `range-v3`.