### PR TITLE
Unescape Unicode sequences in the SPARQL parser

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -3,6 +3,6 @@
 skip = .git*,.codespellrc,*.pdf,generated
 check-hidden = true
 # Ignore mixedCase variables, lines with latin, lines with codespell-ignore pragma, etc
-ignore-regex = \b([A-Z]*[a-z]+[A-Z][a-zA-Z]*)\b|.*(Lorem ipsum|eleifend|feugait|codespell-ignore).*
+ignore-regex = \b([A-Z]*[a-z]+[A-Z][a-zA-Z]*)\b|.*(Lorem ipsum|eleifend|feugait|codespell-ignore).*|https?://\S+
 # alph - is used frequently in tests, just ignore altogether
 ignore-words-list = ser,alph,inbetween,interm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,7 +231,7 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
 FetchContent_Declare(
         ctre
         GIT_REPOSITORY https://github.com/hanickadot/compile-time-regular-expressions.git
-        GIT_TAG b3d7788b559e34d985c8530c3e0e7260b67505a6 # v3.8.1
+        GIT_TAG eb9577aae3515d14e6c5564f9aeb046d2e7c1124 # v3.9.0
 )
 
 ################################

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -44,7 +44,7 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
                               input.size()};
   std::string output;
   size_t lastPos = 0;
-  UChar32 highSurrogate = '\0';
+  UChar32 highSurrogate = 0;
 
   auto throwError = [](bool condition, const std::string& message) {
     if (!condition) {
@@ -75,20 +75,20 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
       throwError(!isFullCodePoint,
                  "Surrogates should not be encoded as full code points.");
       throwError(
-          highSurrogate == '\0',
+          highSurrogate == 0,
           "A high surrogate cannot be followed by another high surrogate.");
       highSurrogate = codePoint;
       continue;
     } else if (U16_IS_TRAIL(codePoint)) {
       throwError(!isFullCodePoint,
                  "Surrogates should not be encoded as full code points.");
-      throwError(highSurrogate != '\0',
+      throwError(highSurrogate != 0,
                  "A low surrogate cannot be the first surrogate.");
       codePoint = U16_GET_SUPPLEMENTARY(highSurrogate, codePoint);
-      highSurrogate = '\0';
+      highSurrogate = 0;
     } else {
       throwError(
-          highSurrogate == '\0',
+          highSurrogate == 0,
           "A high surrogate cannot be followed by a regular code point.");
     }
 
@@ -96,7 +96,7 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
     helper.toUTF8String(output);
   }
 
-  throwError(highSurrogate == '\0',
+  throwError(highSurrogate == 0,
              "A high surrogate must be followed by a low surrogate.");
 
   output += input.substr(lastPos);

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -44,6 +44,7 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
                               input.size()};
   std::string output;
   size_t lastPos = 0;
+  UChar32 highSurrogate = '\0';
 
   for (auto match :
        ctre::search_all<R"(\\U[0-9A-Fa-f]{8}|\\u[0-9A-Fa-f]{4})">(utf8View)) {
@@ -58,13 +59,39 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
         startPointer + 2, startPointer + hexValue.size(), codePoint, 16);
     AD_CORRECTNESS_CHECK(result.ec == std::errc{});
 
-    AD_CORRECTNESS_CHECK(codePoint < 0xD800 || codePoint > 0xDFFF,
-                         "High or low surrogate escape sequence detected, "
-                         "please use a valid Unicode code point instead.");
+    bool isFullCodePoint = hexValue.size() == 10;
+
+    if (U16_IS_LEAD(codePoint)) {
+      AD_CORRECTNESS_CHECK(!isFullCodePoint,
+                           "Surrogates should not be encoded "
+                           "as full code points.");
+      AD_CORRECTNESS_CHECK(highSurrogate == '\0',
+                           "A high surrogate cannot be "
+                           "followed by another high "
+                           "surrogate.");
+      highSurrogate = codePoint;
+      continue;
+    } else if (U16_IS_TRAIL(codePoint)) {
+      AD_CORRECTNESS_CHECK(!isFullCodePoint,
+                           "Surrogates should not be encoded "
+                           "as full code points.");
+      AD_CORRECTNESS_CHECK(highSurrogate != '\0',
+                           "A low surrogate cannot "
+                           "be the first surrogate.");
+      codePoint = U16_GET_SUPPLEMENTARY(highSurrogate, codePoint);
+      highSurrogate = '\0';
+    } else {
+      AD_CORRECTNESS_CHECK(highSurrogate == '\0',
+                           "A high surrogate cannot be "
+                           "followed by a code point.");
+    }
 
     icu::UnicodeString helper{codePoint};
     helper.toUTF8String(output);
   }
+
+  AD_CORRECTNESS_CHECK(highSurrogate == '\0',
+                       "A high surrogate must be followed by a low surrogate.");
 
   output += input.substr(lastPos);
   return output;

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -58,6 +58,10 @@ std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
         startPointer + 2, startPointer + hexValue.size(), codePoint, 16);
     AD_CORRECTNESS_CHECK(result.ec == std::errc{});
 
+    AD_CORRECTNESS_CHECK(codePoint < 0xD800 || codePoint > 0xDFFF,
+                         "High or low surrogate escape sequence detected, "
+                         "please use a valid Unicode code point instead.");
+
     icu::UnicodeString helper{codePoint};
     helper.toUTF8String(output);
   }

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -4,6 +4,11 @@
 
 #include "SparqlParserHelpers.h"
 
+#include <unicode/unistr.h>
+
+#include <charconv>
+#include <ctre-unicode.hpp>
+
 #include "sparqlParser/generated/SparqlAutomaticLexer.h"
 
 namespace sparqlParserHelpers {
@@ -13,7 +18,8 @@ using std::string;
 ParserAndVisitor::ParserAndVisitor(
     std::string input,
     SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
-    : input_{std::move(input)}, visitor_{{}, disableSomeChecks} {
+    : input_{unescapeUnicodeSequences(std::move(input))},
+      visitor_{{}, disableSomeChecks} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
   // propagate them to the user.
@@ -27,7 +33,36 @@ ParserAndVisitor::ParserAndVisitor(
 ParserAndVisitor::ParserAndVisitor(
     std::string input, SparqlQleverVisitor::PrefixMap prefixes,
     SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
-    : ParserAndVisitor{std::move(input), disableSomeChecks} {
+    : ParserAndVisitor{unescapeUnicodeSequences(std::move(input)),
+                       disableSomeChecks} {
   visitor_.setPrefixMapManually(std::move(prefixes));
+}
+
+// _____________________________________________________________________________
+std::string ParserAndVisitor::unescapeUnicodeSequences(std::string input) {
+  std::u8string_view utf8View{reinterpret_cast<char8_t*>(input.data()),
+                              input.size()};
+  std::string output;
+  size_t lastPos = 0;
+
+  for (auto match :
+       ctre::search_all<R"(\\U[0-9A-Fa-f]{8}|\\u[0-9A-Fa-f]{4})">(utf8View)) {
+    output += input.substr(lastPos, match.data() - (utf8View.data() + lastPos));
+    lastPos = match.data() + match.size() - utf8View.data();
+
+    auto hexValue = match.to_view();
+
+    UChar32 codePoint;
+    const char* startPointer = reinterpret_cast<const char*>(hexValue.data());
+    auto result = std::from_chars(
+        startPointer + 2, startPointer + hexValue.size(), codePoint, 16);
+    AD_CORRECTNESS_CHECK(result.ec == std::errc{});
+
+    icu::UnicodeString helper{codePoint};
+    helper.toUTF8String(output);
+  }
+
+  output += input.substr(lastPos);
+  return output;
 }
 }  // namespace sparqlParserHelpers

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -33,8 +33,7 @@ ParserAndVisitor::ParserAndVisitor(
 ParserAndVisitor::ParserAndVisitor(
     std::string input, SparqlQleverVisitor::PrefixMap prefixes,
     SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
-    : ParserAndVisitor{unescapeUnicodeSequences(std::move(input)),
-                       disableSomeChecks} {
+    : ParserAndVisitor{std::move(input), disableSomeChecks} {
   visitor_.setPrefixMapManually(std::move(prefixes));
 }
 

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -35,6 +35,10 @@ struct ParserAndVisitor {
   ad_utility::antlr_utility::ThrowingErrorListener<InvalidSparqlQueryException>
       errorListener_{};
 
+  // Unescapes unicode sequences like \U01234567 and \u0123 in the input string
+  // before beginning with actual parsing as the SPARQL standard mandates.
+  static std::string unescapeUnicodeSequences(std::string input);
+
  public:
   SparqlAutomaticParser parser_{&tokens_};
   SparqlQleverVisitor visitor_;

--- a/src/util/StringUtilsImpl.h
+++ b/src/util/StringUtilsImpl.h
@@ -74,7 +74,7 @@ std::string insertThousandSeparator(const std::string_view str,
       "])(?<digit>\\d{4,})"};
   auto parseIterator = std::begin(str);
   ql::ranges::for_each(
-      ctre::range<regexPatDigitSequence>(str),
+      ctre::search_all<regexPatDigitSequence>(str),
       [&parseIterator, &ostream, &insertSeparator](const auto& match) {
         /*
         The digit sequence, that must be transformed. Note: The string view


### PR DESCRIPTION
This PR makes sure escape sequences are applied before passing the string to ANTLR for the real parsing step (see [the SPARQL 1.1 specification](https://www.w3.org/TR/sparql11-query/#codepointEscape) for details). UTF-16 surrogate pairs are correctly handled. Also the ctre version is incremented to use `search_all` (non-deprecated variant of `range`).