### PR TITLE
c++17 concepts with CPP_template for engine/*.{cpp,h} files

### DIFF
--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -17,14 +17,14 @@
 
 namespace ad_utility {
 
-namespace {
+namespace detail::concepts {
 template <typename T>
 CPP_requires(HasAsStaticView,
              requires(T& table)(table.template asStaticView<0>()));
 
 template <typename T>
 CPP_requires(HasGetLocalVocab, requires(T& table)(table.getLocalVocab()));
-}  // namespace
+}  // namespace detail::concepts
 
 // This class handles the efficient writing of the results of a JOIN operation
 // to a column-based `IdTable`. The underlying assumption is that in both inputs
@@ -141,7 +141,7 @@ class AddCombinedRowToIdTable {
   // `IdTableView<0>`. Identity for `IdTableView<0>`.
   template <typename T>
   static IdTableView<0> toView(const T& table) {
-    if constexpr (CPP_requires_ref(HasAsStaticView, T)) {
+    if constexpr (CPP_requires_ref(detail::concepts::HasAsStaticView, T)) {
       return table.template asStaticView<0>();
     } else {
       return table;
@@ -153,7 +153,7 @@ class AddCombinedRowToIdTable {
   template <typename T>
   void mergeVocab(const T& table, const LocalVocab*& currentVocab) {
     AD_CORRECTNESS_CHECK(currentVocab == nullptr);
-    if constexpr (CPP_requires_ref(HasGetLocalVocab, T)) {
+    if constexpr (CPP_requires_ref(detail::concepts::HasGetLocalVocab, T)) {
       currentVocab = &table.getLocalVocab();
       mergedVocab_.mergeWith(std::span{&table.getLocalVocab(), 1});
     }

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "backports/concepts.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "util/CancellationHandle.h"
@@ -15,6 +16,16 @@
 #include "util/TransparentFunctors.h"
 
 namespace ad_utility {
+
+namespace {
+template <typename T>
+CPP_requires(HasAsStaticView,
+             requires(T& table)(table.template asStaticView<0>()));
+
+template <typename T>
+CPP_requires(HasGetLocalVocab, requires(T& table)(table.getLocalVocab()));
+}  // namespace
+
 // This class handles the efficient writing of the results of a JOIN operation
 // to a column-based `IdTable`. The underlying assumption is that in both inputs
 // the join columns are the first columns. On each call to `addRow`, we only
@@ -130,7 +141,7 @@ class AddCombinedRowToIdTable {
   // `IdTableView<0>`. Identity for `IdTableView<0>`.
   template <typename T>
   static IdTableView<0> toView(const T& table) {
-    if constexpr (requires { table.template asStaticView<0>(); }) {
+    if constexpr (CPP_requires_ref(HasAsStaticView, T)) {
       return table.template asStaticView<0>();
     } else {
       return table;
@@ -142,7 +153,7 @@ class AddCombinedRowToIdTable {
   template <typename T>
   void mergeVocab(const T& table, const LocalVocab*& currentVocab) {
     AD_CORRECTNESS_CHECK(currentVocab == nullptr);
-    if constexpr (requires { table.getLocalVocab(); }) {
+    if constexpr (CPP_requires_ref(HasGetLocalVocab, T)) {
       currentVocab = &table.getLocalVocab();
       mergedVocab_.mergeWith(std::span{&table.getLocalVocab(), 1});
     }

--- a/test/FilterTest.cpp
+++ b/test/FilterTest.cpp
@@ -6,6 +6,7 @@
 
 #include "./PrefilterExpressionTestHelpers.h"
 #include "engine/Filter.h"
+#include "engine/IndexScan.h"
 #include "engine/ValuesForTesting.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpression.h"

--- a/test/HasPredicateScanTest.cpp
+++ b/test/HasPredicateScanTest.cpp
@@ -13,6 +13,7 @@
 #include "engine/CallFixedSize.h"
 #include "engine/CountAvailablePredicates.h"
 #include "engine/HasPredicateScan.h"
+#include "engine/IndexScan.h"
 #include "engine/ValuesForTesting.h"
 #include "util/IndexTestHelpers.h"
 

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 
+#include "engine/IndexScan.h"
 #include "engine/NeutralElementOperation.h"
 #include "engine/ValuesForTesting.h"
 #include "global/RuntimeParameters.h"

--- a/test/util/IdTableHelpers.h
+++ b/test/util/IdTableHelpers.h
@@ -19,8 +19,6 @@
 #include "./IdTestHelpers.h"
 #include "engine/CallFixedSize.h"
 #include "engine/Engine.h"
-#include "engine/Join.h"
-#include "engine/OptionalJoin.h"
 #include "engine/QueryExecutionTree.h"
 #include "engine/idTable/IdTable.h"
 #include "global/ValueId.h"


### PR DESCRIPTION
Backport the (few) occurences of C++20 concepts in the `src/engine` subdirecotory to C++17 using macros from `range-v3`.