### PR TITLE
Optimize several includes

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -7,6 +7,7 @@
 #include "ExportQueryExecutionTrees.h"
 
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_replace.h>
 
 #include <ranges>
 

--- a/src/engine/sparqlExpressions/ConvertToNumericExpression.cpp
+++ b/src/engine/sparqlExpressions/ConvertToNumericExpression.cpp
@@ -2,6 +2,9 @@
 //                  Chair of Algorithms and Data Structures
 //  Author: Hannes Baumann <baumannh@informatik.uni-freiburg.de>
 
+#include <absl/strings/ascii.h>
+#include <absl/strings/charconv.h>
+
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
 
 namespace sparqlExpression {

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -6,9 +6,6 @@
 
 #include <ranges>
 
-#include "absl/strings/ascii.h"
-#include "absl/strings/charconv.h"
-#include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "util/CryptographicHashUtils.h"

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -11,7 +11,6 @@
 #include "engine/VariableToColumnMap.h"
 #include "engine/sparqlExpressions/PrefilterExpressionIndex.h"
 #include "parser/data/Variable.h"
-#include "util/HashMap.h"
 #include "util/HashSet.h"
 
 namespace sparqlExpression {

--- a/src/engine/sparqlExpressions/SparqlExpressionTypes.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionTypes.h
@@ -10,8 +10,6 @@
 #include "engine/QueryExecutionContext.h"
 #include "engine/sparqlExpressions/SetOfIntervals.h"
 #include "global/Id.h"
-#include "parser/LiteralOrIri.h"
-#include "parser/TripleComponent.h"
 #include "parser/data/Variable.h"
 #include "util/AllocatorWithLimit.h"
 #include "util/HashSet.h"

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <chrono>
-#include <ctre.hpp>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/src/util/ConfigManager/ConfigManager.cpp
+++ b/src/util/ConfigManager/ConfigManager.cpp
@@ -7,6 +7,7 @@
 #include <ANTLRInputStream.h>
 #include <CommonTokenStream.h>
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_replace.h>
 #include <antlr4-runtime.h>
 
 #include <functional>

--- a/src/util/GeoSparqlHelpers.h
+++ b/src/util/GeoSparqlHelpers.h
@@ -5,10 +5,9 @@
 #ifndef QLEVER_GEOSPARQLHELPERS_H
 #define QLEVER_GEOSPARQLHELPERS_H
 
-#include <ctre-unicode.hpp>
 #include <limits>
 #include <optional>
-#include <string>
+#include <string_view>
 
 #include "parser/GeoPoint.h"
 

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -6,6 +6,7 @@
 #include "util/StringUtils.h"
 
 #include <absl/strings/str_cat.h>
+#include <absl/strings/str_replace.h>
 #include <unicode/bytestream.h>
 #include <unicode/casemap.h>
 

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -4,15 +4,11 @@
 
 #pragma once
 
-#include <absl/strings/str_replace.h>
-#include <gmock/gmock-spec-builders.h>
-
 #include <string_view>
 
 #include "backports/algorithm.h"
 #include "util/Concepts.h"
 #include "util/ConstexprSmallString.h"
-#include "util/CtreHelpers.h"
 
 using std::string;
 using std::string_view;

--- a/src/util/StringUtilsImpl.h
+++ b/src/util/StringUtilsImpl.h
@@ -5,7 +5,10 @@
 
 #pragma once
 
+#include <ctre-unicode.hpp>
+
 #include "util/Algorithm.h"
+#include "util/CtreHelpers.h"
 #include "util/Exception.h"
 #include "util/StringUtils.h"
 

--- a/test/HttpTest.cpp
+++ b/test/HttpTest.cpp
@@ -3,7 +3,7 @@
 // Author: Hannah Bast (bast@cs.uni-freiburg.de)
 
 #include <absl/strings/str_cat.h>
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include <thread>
 
@@ -16,6 +16,7 @@
 
 using namespace ad_utility::httpUtils;
 using namespace boost::beast::http;
+using ::testing::HasSubstr;
 
 namespace {
 


### PR DESCRIPTION
Remove unused `#include` directives, or move them from header files to the `.cpp` files. This should reduce QLever's compile time by a significant amount, especially as the expensive `CTRE` headers are included in less places.