### PR TITLE
Don't use zero cost estimate for cached subtrees

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -77,10 +77,15 @@ QueryExecutionTree::selectedVariablesToColumnIndices(
 
 // _____________________________________________________________________________
 size_t QueryExecutionTree::getCostEstimate() {
-  if (cachedResult_) {
-    // result is pinned in cache. Nothing to compute
+  // If the result is cached and `zero-cost-for-cached-subtrees` is set to
+  // `true`, we set the cost estimate to zero.
+  if (cachedResult_ &&
+      RuntimeParameters().get<"zero-cost-for-cached-subtree">()) {
     return 0;
   }
+
+  // Otherwise, we return the cost estimate of the root operation. For index
+  // scans, we assume one unit of work per result row.
   if (getRootOperation()->isIndexScanWithNumVariables(1)) {
     return getSizeEstimate();
   } else {

--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -77,10 +77,10 @@ QueryExecutionTree::selectedVariablesToColumnIndices(
 
 // _____________________________________________________________________________
 size_t QueryExecutionTree::getCostEstimate() {
-  // If the result is cached and `zero-cost-for-cached-subtrees` is set to
-  // `true`, we set the cost estimate to zero.
+  // If the result is cached and `zero-cost-estimate-for-cached-subtrees` is set
+  // to `true`, we set the cost estimate to zero.
   if (cachedResult_ &&
-      RuntimeParameters().get<"zero-cost-for-cached-subtree">()) {
+      RuntimeParameters().get<"zero-cost-estimate-for-cached-subtree">()) {
     return 0;
   }
 

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -62,7 +62,7 @@ inline auto& RuntimeParameters() {
         SizeT<"small-index-scan-size-estimate-divisor">{5},
         // Determines whether the cost estimate for a cached subtree should be
         // set to zero in query planning.
-        Bool<"zero-cost-for-cached-subtree">{false},
+        Bool<"zero-cost-estimate-for-cached-subtree">{false},
     };
   }();
   return params;

--- a/src/global/RuntimeParameters.h
+++ b/src/global/RuntimeParameters.h
@@ -60,6 +60,9 @@ inline auto& RuntimeParameters() {
         // its size estimate will be the size of the block divided by this
         // value.
         SizeT<"small-index-scan-size-estimate-divisor">{5},
+        // Determines whether the cost estimate for a cached subtree should be
+        // set to zero in query planning.
+        Bool<"zero-cost-for-cached-subtree">{false},
     };
   }();
   return params;

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -242,14 +242,23 @@ TEST(OperationTest, estimatesForCachedResults) {
 
     [[maybe_unused]] auto res = qet->getResult();
   }
-  // The result is now cached inside the static execution context, if we create
-  // the same operation again, the cost estimate is 0. The size estimate doesn't
+  // The result is now cached inside the static execution context. If we create
+  // the same operation again and `zero-cost-for-cached-subtrees` is set to
+  // `true`, the cost estimate should be zero. The size estimate does not
   // change (see the `getCostEstimate` function for details on why).
   {
+    RuntimeParameters().set<"zero-cost-for-cached-subtree">(true);
     auto qet = makeQet();
     EXPECT_EQ(qet->getCacheKey(), qet->getRootOperation()->getCacheKey());
     EXPECT_EQ(qet->getSizeEstimate(), 24u);
     EXPECT_EQ(qet->getCostEstimate(), 0u);
+  }
+  {
+    RuntimeParameters().set<"zero-cost-for-cached-subtree">(false);
+    auto qet = makeQet();
+    EXPECT_EQ(qet->getCacheKey(), qet->getRootOperation()->getCacheKey());
+    EXPECT_EQ(qet->getSizeEstimate(), 24u);
+    EXPECT_EQ(qet->getCostEstimate(), 210u);
   }
 }
 

--- a/test/OperationTest.cpp
+++ b/test/OperationTest.cpp
@@ -243,18 +243,22 @@ TEST(OperationTest, estimatesForCachedResults) {
     [[maybe_unused]] auto res = qet->getResult();
   }
   // The result is now cached inside the static execution context. If we create
-  // the same operation again and `zero-cost-for-cached-subtrees` is set to
-  // `true`, the cost estimate should be zero. The size estimate does not
+  // the same operation again and `zero-cost-estimate-for-cached-subtrees` is
+  // set to `true`, the cost estimate should be zero. The size estimate does not
   // change (see the `getCostEstimate` function for details on why).
   {
-    RuntimeParameters().set<"zero-cost-for-cached-subtree">(true);
+    auto restoreWhenScopeEnds =
+        setRuntimeParameterForTest<"zero-cost-estimate-for-cached-subtree">(
+            true);
     auto qet = makeQet();
     EXPECT_EQ(qet->getCacheKey(), qet->getRootOperation()->getCacheKey());
     EXPECT_EQ(qet->getSizeEstimate(), 24u);
     EXPECT_EQ(qet->getCostEstimate(), 0u);
   }
   {
-    RuntimeParameters().set<"zero-cost-for-cached-subtree">(false);
+    auto restoreWhenScopeEnds =
+        setRuntimeParameterForTest<"zero-cost-estimate-for-cached-subtree">(
+            false);
     auto qet = makeQet();
     EXPECT_EQ(qet->getCacheKey(), qet->getRootOperation()->getCacheKey());
     EXPECT_EQ(qet->getSizeEstimate(), 24u);


### PR DESCRIPTION
This continues #1736, which changed the size estimate for cached subtrees from the exact size to the estimate size. Analogous to that, now also change the cost estimate for cached subtrees from zero to the normal cost estimate. That way, the cache no longer influences query planning (but can still improve query processing times because cached subtrees do not have to be computed again).

Introduce a runtime parameter `zero-cost-estimate-for-cached-subtree` to revert to the old behavior if desired (the default is `false`).