### PR TITLE
Various smaller update improvements

### DIFF
--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -182,6 +182,8 @@ ExecuteUpdate::computeGraphUpdateQuads(
   };
   sortAndRemoveDuplicates(toInsert);
   sortAndRemoveDuplicates(toDelete);
+  metadata.inUpdate = DeltaTriplesCount{static_cast<int64_t>(toInsert.size()),
+                                        static_cast<int64_t>(toDelete.size())};
   std::vector<IdTriple<>> reducedToDelete;
   ql::ranges::set_difference(std::move(toDelete), toInsert,
                              std::back_inserter(reducedToDelete));

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -176,6 +176,12 @@ ExecuteUpdate::computeGraphUpdateQuads(
       cancellationHandle->throwIfCancelled();
     }
   }
+  auto sortAndRemoveDuplicates = [](auto& vec) {
+    ql::ranges::sort(vec);
+    vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
+  };
+  sortAndRemoveDuplicates(toInsert);
+  sortAndRemoveDuplicates(toDelete);
   metadata.triplePreparationTime_ = timer.msecs();
 
   return {

--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -182,6 +182,10 @@ ExecuteUpdate::computeGraphUpdateQuads(
   };
   sortAndRemoveDuplicates(toInsert);
   sortAndRemoveDuplicates(toDelete);
+  std::vector<IdTriple<>> reducedToDelete;
+  ql::ranges::set_difference(std::move(toDelete), toInsert,
+                             std::back_inserter(reducedToDelete));
+  toDelete.swap(reducedToDelete);
   metadata.triplePreparationTime_ = timer.msecs();
 
   return {

--- a/src/engine/ExecuteUpdate.h
+++ b/src/engine/ExecuteUpdate.h
@@ -17,6 +17,7 @@ struct UpdateMetadata {
   Milliseconds triplePreparationTime_ = Zero;
   Milliseconds insertionTime_ = Zero;
   Milliseconds deletionTime_ = Zero;
+  std::optional<DeltaTriplesCount> inUpdate;
 };
 
 class ExecuteUpdate {

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -961,6 +961,10 @@ json Server::createResponseMetadataForUpdate(
   response["delta-triples"]["after"] = nlohmann::json(countAfter);
   response["delta-triples"]["difference"] =
       nlohmann::json(countAfter - countBefore);
+  if (updateMetadata.inUpdate.has_value()) {
+    response["delta-triples"]["operation"] =
+        json(updateMetadata.inUpdate.value());
+  }
   response["time"]["planning"] =
       formatTime(runtimeInfoWholeOp.timeQueryPlanning);
   response["time"]["where"] =

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -245,6 +245,8 @@ template void DeltaTriplesManager::modify<void>(
     std::function<void(DeltaTriples&)> const&);
 template nlohmann::json DeltaTriplesManager::modify<nlohmann::json>(
     const std::function<nlohmann::json(DeltaTriples&)>&);
+template DeltaTriplesCount DeltaTriplesManager::modify<DeltaTriplesCount>(
+    const std::function<DeltaTriplesCount(DeltaTriples&)>&);
 
 // _____________________________________________________________________________
 void DeltaTriplesManager::clear() { modify<void>(&DeltaTriples::clear); }

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -150,9 +150,6 @@ void DeltaTriples::modifyTriplesImpl(CancellationHandle cancellationHandle,
                                      TriplesToHandlesMap& targetMap,
                                      TriplesToHandlesMap& inverseMap) {
   rewriteLocalVocabEntriesAndBlankNodes(triples);
-  ql::ranges::sort(triples);
-  auto first = std::unique(triples.begin(), triples.end());
-  triples.erase(first, triples.end());
   std::erase_if(triples, [&targetMap](const IdTriple<0>& triple) {
     return targetMap.contains(triple);
   });

--- a/src/index/DeltaTriples.h
+++ b/src/index/DeltaTriples.h
@@ -40,8 +40,8 @@ class SharedLocatedTriplesSnapshot
 
 // A class for keeping track of the number of triples of the `DeltaTriples`.
 struct DeltaTriplesCount {
-  size_t triplesInserted_;
-  size_t triplesDeleted_;
+  int64_t triplesInserted_;
+  int64_t triplesDeleted_;
 
   /// Output as json. The signature of this function is mandated by the json
   /// library to allow for implicit conversion.
@@ -146,8 +146,12 @@ class DeltaTriples {
   void clear();
 
   // The number of delta triples added and subtracted.
-  size_t numInserted() const { return triplesInserted_.size(); }
-  size_t numDeleted() const { return triplesDeleted_.size(); }
+  int64_t numInserted() const {
+    return static_cast<int64_t>(triplesInserted_.size());
+  }
+  int64_t numDeleted() const {
+    return static_cast<int64_t>(triplesDeleted_.size());
+  }
   DeltaTriplesCount getCounts() const;
 
   // Insert triples.

--- a/test/DeltaTriplesCountTest.cpp
+++ b/test/DeltaTriplesCountTest.cpp
@@ -21,7 +21,6 @@ TEST(DeltaTriplesCountTest, toJson) {
 TEST(DeltaTriplesCountTest, subtractOperator) {
   constexpr DeltaTriplesCount count1{10, 5};
   constexpr DeltaTriplesCount count2{3, 2};
-  constexpr DeltaTriplesCount expected{7, 3};
-  const DeltaTriplesCount actual = count1 - count2;
-  EXPECT_THAT(actual, testing::Eq(expected));
+  EXPECT_THAT(count1 - count2, testing::Eq(DeltaTriplesCount{7, 3}));
+  EXPECT_THAT(count2 - count1, testing::Eq(DeltaTriplesCount{-7, -3}));
 }

--- a/test/DeltaTriplesTestHelpers.h
+++ b/test/DeltaTriplesTestHelpers.h
@@ -41,7 +41,7 @@ inline auto NumTriplesInAllPermutations =
 // `getCounts()` of a `DeltaTriples` and `numTriples()` for all
 // `LocatedTriplesPerBlock` of the `DeltaTriples`.
 inline auto NumTriples =
-    [](size_t inserted, size_t deleted,
+    [](int64_t inserted, int64_t deleted,
        size_t inAllPermutations) -> testing::Matcher<const DeltaTriples&> {
   return testing::AllOf(
       AD_PROPERTY(DeltaTriples, numInserted, testing::Eq(inserted)),

--- a/test/ServerTest.cpp
+++ b/test/ServerTest.cpp
@@ -467,7 +467,8 @@ TEST(ServerTest, createResponseMetadata) {
   json deltaTriplesJson{
       {"before", {{"inserted", 0}, {"deleted", 0}, {"total", 0}}},
       {"after", {{"inserted", 1}, {"deleted", 0}, {"total", 1}}},
-      {"difference", {{"inserted", 1}, {"deleted", 0}, {"total", 1}}}};
+      {"difference", {{"inserted", 1}, {"deleted", 0}, {"total", 1}}},
+      {"operation", {{"inserted", 1}, {"deleted", 0}, {"total", 1}}}};
   json locatedTriplesJson{
       {"SPO", {{"blocks-affected", 1}, {"blocks-total", 1}}},
       {"POS", {{"blocks-affected", 1}, {"blocks-total", 1}}},


### PR DESCRIPTION
- Store DeltaTriplesCount as signed integer. The difference would otherwise underflow.
- Add the number of insertions and deletions by this operation to the update metadata. Previously only information on the change in delta triples was given. This only allowed limited conclusion on the effect of the update as insertions and deletions can cancel out in the number of delta triples over a operation.
- Return a JSON from the `clear-delta-triples`command with the number of delta triples after the clear. This is more consistent with the other operations.
- The triples to insert/delete are sorted and removed of duplicates earlier in the triple calculation (`ExecuteUpdate` vs. `DeltaTriples`). Triples that are inserted in an operation will not be deleted before that in the same operation.