### PR TITLE
Fix TurtleParser for `a` predicate

### DIFF
--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -151,16 +151,13 @@ bool TurtleParser<T>::objectList() {
 // ______________________________________________________
 template <class T>
 bool TurtleParser<T>::verb() {
-  return predicateSpecialA() || predicate();
+  return predicate() || predicateSpecialA();
 }
 
 // ___________________________________________________________________
 template <class T>
 bool TurtleParser<T>::predicateSpecialA() {
-  tok_.skipWhitespaceAndComments();
-  if (auto [success, word] = tok_.template getNextToken<TurtleTokenId::A>();
-      success) {
-    (void)word;
+  if (parseTerminal<TurtleTokenId::A>()) {
     activePredicate_ = TripleComponent::Iri::fromIriref(
         "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>");
     return true;

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -429,6 +429,7 @@ class TurtleParser : public RdfParserBase {
   FRIEND_TEST(RdfParserTest, booleanLiteralLongForm);
   FRIEND_TEST(RdfParserTest, collection);
   FRIEND_TEST(RdfParserTest, iriref);
+  FRIEND_TEST(RdfParserTest, specialPredicateA);
 };
 
 template <class Tokenizer_T>


### PR DESCRIPTION
Fixes #1763
Before this fix the Turtle parser was broken for prefixes that starts with `"a"`.