### PR TITLE
Make zero-column results standard-compliant also for `application/sparql-results+json`

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -749,13 +749,10 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
   co_yield absl::StrCat(R"({"head":{"vars":)", jsonVars.dump(),
                         R"(},"results":{"bindings":[)");
 
+  // Get all columns with defined variables.
   QueryExecutionTree::ColumnIndicesAndTypes columns =
       qet.selectedVariablesToColumnIndices(selectClause, false);
   std::erase(columns, std::nullopt);
-  if (columns.empty()) {
-    co_yield "]}}";
-    co_return;
-  }
 
   auto getBinding = [&](const IdTable& idTable, const uint64_t& i,
                         const LocalVocab& localVocab) {
@@ -773,6 +770,8 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
     return binding.dump();
   };
 
+  // Iterate over the result and yield the bindings. Note that when `columns`
+  // is empty, we have to output an empty set of bindings per row.
   bool isFirstRow = true;
   uint64_t resultSize = 0;
   for (const auto& [pair, range] :
@@ -781,7 +780,11 @@ ad_utility::streams::stream_generator ExportQueryExecutionTrees::
       if (!isFirstRow) [[likely]] {
         co_yield ",";
       }
-      co_yield getBinding(pair.idTable_, i, pair.localVocab_);
+      if (columns.empty()) {
+        co_yield "{}";
+      } else {
+        co_yield getBinding(pair.idTable_, i, pair.localVocab_);
+      }
       cancellationHandle->throwIfCancelled();
       isFirstRow = false;
     }


### PR DESCRIPTION
Pull request #1749 fixed this for `application/csv` and `application/tab-separated-values`, now it is also fixed for `application/sparql-results+json`. Fixes the remaining part of #1745