### PR TITLE
Allow computing the empty transitive path

### DIFF
--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -117,7 +117,7 @@ class TransitivePathBase : public Operation {
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
                      size_t minDist, size_t maxDist);
 
-  virtual ~TransitivePathBase() = 0;
+  ~TransitivePathBase() override = 0;
 
   /**
    * Returns a new TransitivePath operation that uses the fact that leftop

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -142,7 +142,7 @@ class TransitivePathImpl : public TransitivePathBase {
     for (auto& pair : result) {
       co_yield pair;
     }
-  };
+  }
 
  protected:
   /**
@@ -155,13 +155,6 @@ class TransitivePathImpl : public TransitivePathBase {
    * @return Result The result of the TransitivePath operation
    */
   ProtoResult computeResult(bool requestLaziness) override {
-    if (minDist_ == 0 && !isBoundOrId() && lhs_.isVariable() &&
-        rhs_.isVariable()) {
-      AD_THROW(
-          "This query might have to evaluate the empty path, which is "
-          "currently "
-          "not supported");
-    }
     auto [startSide, targetSide] = decideDirection();
     // In order to traverse the graph represented by this result, we need random
     // access across the whole table, so it doesn't make sense to lazily compute

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -627,28 +627,36 @@ TEST_P(TransitivePathTest, maxLength2ToId) {
 }
 
 // _____________________________________________________________________________
-TEST_P(TransitivePathTest, zeroLengthException) {
+TEST_P(TransitivePathTest, zeroLength) {
   auto sub = makeIdTableFromVector({
       {0, 2},
       {2, 4},
       {4, 7},
       {0, 7},
-      {3, 3},
-      {7, 0},
-      // Disconnected component.
       {10, 11},
   });
+
+  auto expected = makeIdTableFromVector({{0, 0},
+                                         {0, 2},
+                                         {0, 4},
+                                         {0, 7},
+                                         {2, 2},
+                                         {2, 4},
+                                         {2, 7},
+                                         {4, 4},
+                                         {4, 7},
+                                         {10, 10},
+                                         {10, 11},
+                                         {7, 7},
+                                         {11, 11}});
 
   TransitivePathSide left(std::nullopt, 0, Variable{"?start"}, 0);
   TransitivePathSide right(std::nullopt, 1, Variable{"?target"}, 1);
   auto T =
       makePathUnbound(std::move(sub), {Variable{"?start"}, Variable{"?target"}},
                       left, right, 0, std::numeric_limits<size_t>::max());
-  AD_EXPECT_THROW_WITH_MESSAGE(
-      T->computeResultOnlyForTesting(requestLaziness()),
-      ::testing::ContainsRegex("This query might have to evaluate the empty "
-                               "path, which is currently "
-                               "not supported"));
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, expected);
 }
 
 // _____________________________________________________________________________


### PR DESCRIPTION
It seems like the code was already there, so all this PR does is removing the check.