### PR TITLE
Preparations for migrating the lazy operations from Coroutines to C++17

### DIFF
--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -72,6 +72,10 @@ Result::Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy)
 
 // _____________________________________________________________________________
 Result::Result(Generator idTables, std::vector<ColumnIndex> sortedBy)
+    : Result{LazyResult{std::move(idTables)}, std::move(sortedBy)} {}
+
+// _____________________________________________________________________________
+Result::Result(LazyResult idTables, std::vector<ColumnIndex> sortedBy)
     : data_{GenContainer{[](auto idTables, auto sortedBy) -> Generator {
         std::optional<IdTable::row_type> previousId = std::nullopt;
         for (IdTableVocabPair& pair : idTables) {

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -117,6 +117,8 @@ class Result {
          LocalVocab&& localVocab);
   Result(IdTableVocabPair pair, std::vector<ColumnIndex> sortedBy);
   Result(Generator idTables, std::vector<ColumnIndex> sortedBy);
+  Result(LazyResult idTables, std::vector<ColumnIndex> sortedBy);
+
   // Prevent accidental copying of a result table.
   Result(const Result& other) = delete;
   Result& operator=(const Result& other) = delete;

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -276,6 +276,9 @@ class InputRangeFromGet {
 
  public:
   virtual ~InputRangeFromGet() = default;
+  InputRangeFromGet() = default;
+  InputRangeFromGet(InputRangeFromGet&&) = default;
+  InputRangeFromGet& operator=(InputRangeFromGet&&) = default;
 
   // Get the next value and store it.
   void getNextAndStore() { storage_ = get(); }

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -279,6 +279,8 @@ class InputRangeFromGet {
   InputRangeFromGet() = default;
   InputRangeFromGet(InputRangeFromGet&&) = default;
   InputRangeFromGet& operator=(InputRangeFromGet&&) = default;
+  InputRangeFromGet(const InputRangeFromGet&) = default;
+  InputRangeFromGet& operator=(const InputRangeFromGet&) = default;
 
   // Get the next value and store it.
   void getNextAndStore() { storage_ = get(); }


### PR DESCRIPTION
* `Result` can now be constructed from a `LazyResult` (which is a type-erased input range).
* `InputRangeFromGet` now works with move-only types.