### PR TITLE
Make empty path return empty set when the graph is empty

### DIFF
--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -354,13 +354,15 @@ std::shared_ptr<TransitivePathBase> TransitivePathBase::bindLeftOrRightSide(
   // subtrees. This has the effect that the `TransitivePathBinSearch` will
   // never re-sort an index scan (which should not happen because we can just
   // take the appropriate index scan in the first place).
+  bool useBinSearch = dynamic_cast<const TransitivePathBinSearch*>(this);
   std::vector<std::shared_ptr<TransitivePathBase>> candidates;
-  candidates.push_back(TransitivePathBase::makeTransitivePath(
-      getExecutionContext(), subtree_, lhs, rhs, minDist_, maxDist_));
+  candidates.push_back(makeTransitivePath(getExecutionContext(), subtree_, lhs,
+                                          rhs, minDist_, maxDist_,
+                                          useBinSearch));
   for (const auto& alternativeSubtree : alternativeSubtrees()) {
-    candidates.push_back(TransitivePathBase::makeTransitivePath(
-        getExecutionContext(), alternativeSubtree, lhs, rhs, minDist_,
-        maxDist_));
+    candidates.push_back(makeTransitivePath(getExecutionContext(),
+                                            alternativeSubtree, lhs, rhs,
+                                            minDist_, maxDist_, useBinSearch));
   }
 
   auto& p = *ql::ranges::min_element(

--- a/src/engine/TransitivePathBinSearch.h
+++ b/src/engine/TransitivePathBinSearch.h
@@ -53,6 +53,12 @@ struct BinSearchMap {
 
     return targetIds_.subspan(startIndex, range.size());
   }
+
+  // Linear lookup if the node is in the map, either as a key or as a value.
+  bool containsNode(const Id node) const {
+    return ql::ranges::binary_search(startIds_, node) ||
+           ad_utility::contains(targetIds_, node);
+  }
 };
 
 /**

--- a/src/engine/TransitivePathHashMap.h
+++ b/src/engine/TransitivePathHashMap.h
@@ -40,6 +40,14 @@ struct HashMapWrapper {
     }
     return iterator->second;
   }
+
+  // Linear lookup if the node is in the map, either as a key or as a value.
+  bool containsNode(const Id node) const {
+    return map_.contains(node) ||
+           ql::ranges::any_of(map_ | ql::views::values, [node](const Set& set) {
+             return ad_utility::contains(set, node);
+           });
+  }
 };
 
 /**

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -234,8 +234,9 @@ class TransitivePathImpl : public TransitivePathBase {
       }
     }
 
-    // If we need to check the first node separately, we try the cheaper lookup
-    // in connected nodes first, and then fallback to the expensive computation.
+    // If we need to check the first node separately, we check `startNodeFound`
+    // first because its cheaper and then fallback to the expensive computation
+    // that gives the definitive answer.
     if (minDist_ == 0 && checkFirstNode && !startNodeFound &&
         !edges.containsNode(startNode)) {
       connectedNodes.erase(startNode);

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -234,7 +234,7 @@ class TransitivePathImpl : public TransitivePathBase {
     // in connected nodes first, and then fallback to the expensive computation.
     if (minDist_ == 0 && checkFirstNode &&
         (!target.has_value() || startNode == target.value()) &&
-        (connectedNodes.contains(startNode) || edges.containsNode(startNode))) {
+        !connectedNodes.contains(startNode) && edges.containsNode(startNode)) {
       connectedNodes.insert(startNode);
     }
 

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -206,16 +206,12 @@ class TransitivePathImpl : public TransitivePathBase {
     Set connectedNodes{getExecutionContext()->getAllocator()};
     stack.emplace_back(startNode, 0);
 
-    if (minDist_ == 0 && (!target.has_value() || startNode == target.value())) {
-      connectedNodes.insert(startNode);
-    }
-
     while (!stack.empty()) {
       checkCancellation();
       auto [node, steps] = stack.back();
       stack.pop_back();
 
-      if (steps <= maxDist_ && marks.count(node) == 0) {
+      if (steps <= maxDist_ && !marks.contains(node)) {
         if (steps >= minDist_) {
           marks.insert(node);
           if (!target.has_value() || node == target.value()) {
@@ -313,7 +309,8 @@ class TransitivePathImpl : public TransitivePathBase {
    * computation.
    *
    * @param startSide The TransitivePathSide where the edges start
-   * @param startSideTable An IdTable containing the Ids for the startSide
+   * @param startSideResult A `Result` wrapping an `IdTable` containing the Ids
+   * for the startSide
    * @return cppcoro::generator<TableColumnWithVocab> An generator for
    * the transitive hull computation
    */
@@ -335,7 +332,7 @@ class TransitivePathImpl : public TransitivePathBase {
                                       std::move(localVocab)};
       }
     }
-  };
+  }
 
   virtual T setupEdgesMap(const IdTable& dynSub,
                           const TransitivePathSide& startSide,

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -15,7 +15,6 @@
 #include "engine/ValuesForTesting.h"
 #include "util/GTestHelpers.h"
 #include "util/IdTableHelpers.h"
-#include "util/IndexTestHelpers.h"
 
 using ad_utility::testing::getQec;
 namespace {
@@ -530,6 +529,56 @@ TEST_P(TransitivePathTest, startNodesWithNoMatchesLeftBound) {
       true, sub.clone(), {Variable{"?start"}, Variable{"?target"}},
       split(leftOpTable), 0, {Variable{"?start"}, Variable{"?x"}}, left, right,
       1, std::numeric_limits<size_t>::max());
+
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, expected);
+}
+
+// _____________________________________________________________________________
+TEST_P(TransitivePathTest, boundReverseConnectedValuesOnZeroPath) {
+  auto sub = makeIdTableFromVector({
+      {1, 2},
+      {3, 4},
+  });
+
+  auto leftOpTable = makeIdTableFromVector({
+      {2},
+  });
+
+  auto expected = makeIdTableFromVector({
+      {2, 2},
+  });
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?x"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?y"}, 1);
+  auto T =
+      makePathBound(true, sub.clone(), {Variable{"?x"}, Variable{"?y"}},
+                    split(leftOpTable), 0, {Variable{"?x"}}, left, right, 0, 0);
+
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, expected);
+}
+
+// _____________________________________________________________________________
+TEST_P(TransitivePathTest, boundForwardValuesOnZeroPath) {
+  auto sub = makeIdTableFromVector({
+      {1, 2},
+      {3, 4},
+  });
+
+  auto leftOpTable = makeIdTableFromVector({
+      {3},
+  });
+
+  auto expected = makeIdTableFromVector({
+      {3, 3},
+  });
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?x"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?y"}, 1);
+  auto T =
+      makePathBound(true, sub.clone(), {Variable{"?x"}, Variable{"?y"}},
+                    split(leftOpTable), 0, {Variable{"?x"}}, left, right, 0, 0);
 
   auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
   assertResultMatchesIdTable(resultTable, expected);

--- a/test/TransitivePathTest.cpp
+++ b/test/TransitivePathTest.cpp
@@ -585,6 +585,27 @@ TEST_P(TransitivePathTest, boundForwardValuesOnZeroPath) {
 }
 
 // _____________________________________________________________________________
+TEST_P(TransitivePathTest, unboundValuesOnZeroPath) {
+  auto sub = makeIdTableFromVector({
+      {1, 2},
+      {3, 4},
+  });
+
+  auto leftOpTable = makeIdTableFromVector({
+      {5},
+  });
+
+  TransitivePathSide left(std::nullopt, 0, Variable{"?x"}, 0);
+  TransitivePathSide right(std::nullopt, 1, Variable{"?y"}, 1);
+  auto T =
+      makePathBound(true, sub.clone(), {Variable{"?x"}, Variable{"?y"}},
+                    split(leftOpTable), 0, {Variable{"?x"}}, left, right, 0, 0);
+
+  auto resultTable = T->computeResultOnlyForTesting(requestLaziness());
+  assertResultMatchesIdTable(resultTable, IdTable{2, T->allocator()});
+}
+
+// _____________________________________________________________________________
 TEST_P(TransitivePathTest, maxLength2FromVariable) {
   auto sub = makeIdTableFromVector({
       {0, 2},


### PR DESCRIPTION
When the graph is empty, the empty path should return an empty set, even when one of the two sides has a binding. For example, consider the following query on an empty graph. So far, QLever would return the binding `{ "?a": 1, "?b": 1 }` because the left size has the binding `{ "?a": 1 }`. But the correct result is to return an empty solution set because the graph is empty. This is now fixed.
```
SELECT * WHERE {
  VALUES ?a { 1 }
  ?a a? ?b
}
```