### PR TITLE
Better error message on parallel turtle parsing of scattered base and prefix declarations

### DIFF
--- a/src/engine/GraphStoreProtocol.cpp
+++ b/src/engine/GraphStoreProtocol.cpp
@@ -4,6 +4,7 @@
 
 #include "engine/GraphStoreProtocol.h"
 
+#include "parser/Tokenizer.h"
 #include "util/http/beast.h"
 
 // ____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -21,6 +21,8 @@
 #include "index/IndexFormatVersion.h"
 #include "index/VocabularyMerger.h"
 #include "parser/ParallelParseBuffer.h"
+#include "parser/Tokenizer.h"
+#include "parser/TokenizerCtre.h"
 #include "util/BatchedPipeline.h"
 #include "util/CachingMemoryResource.h"
 #include "util/HashMap.h"

--- a/src/parser/RdfEscaping.h
+++ b/src/parser/RdfEscaping.h
@@ -5,15 +5,12 @@
 #ifndef QLEVER_RDFESCAPING_H
 #define QLEVER_RDFESCAPING_H
 
-#include <unicode/ustream.h>
-
 #include <sstream>
 #include <string>
 
 #include "global/TypedIndex.h"
 #include "parser/NormalizedString.h"
 #include "util/Exception.h"
-#include "util/HashSet.h"
 #include "util/StringUtils.h"
 
 namespace RdfEscaping {

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -15,8 +15,8 @@
 #include "global/Constants.h"
 #include "parser/GeoPoint.h"
 #include "parser/NormalizedString.h"
-#include "parser/RdfEscaping.h"
-#include "util/Conversions.h"
+#include "parser/Tokenizer.h"
+#include "parser/TokenizerCtre.h"
 #include "util/DateYearDuration.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
 
@@ -630,7 +630,7 @@ bool TurtleParser<T>::iri() {
 // _____________________________________________________________________
 template <class T>
 bool TurtleParser<T>::prefixedName() {
-  if constexpr (UseRelaxedParsing) {
+  if constexpr (T::UseRelaxedParsing) {
     if (!(pnameLnRelaxed() || pnameNS())) {
       return false;
     }
@@ -745,7 +745,7 @@ bool TurtleParser<T>::iriref() {
   // In relaxed mode, that is all we check. Otherwise, we check if the IRI is
   // standard-compliant. If not, we output a warning and try to parse it in a
   // more relaxed way.
-  if constexpr (UseRelaxedParsing) {
+  if constexpr (T::UseRelaxedParsing) {
     tok_.remove_prefix(endPos + 1);
     lastParseResult_ = TripleComponent::Iri::fromIrirefConsiderBase(
         view.substr(0, endPos + 1), baseForRelativeIri(), baseForAbsoluteIri());

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -31,13 +31,14 @@ bool TurtleParser<T>::statement() {
 // ______________________________________________________________
 template <class T>
 bool TurtleParser<T>::directive() {
-  if (prefixAndBaseDisabled_) {
+  bool successfulParse = prefixID() || base() || sparqlPrefix() || sparqlBase();
+  if (successfulParse && prefixAndBaseDisabled_) {
     raise(
         "@prefix or @base directives need to be at the beginning of the file "
         "when using the parallel parser. Use '--parse-parallel false' if you "
         "can't guarantee this.");
   }
-  return prefixID() || base() || sparqlPrefix() || sparqlBase();
+  return successfulParse;
 }
 
 // ________________________________________________________________

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -6,7 +6,6 @@
 #include "parser/RdfParser.h"
 
 #include <absl/strings/charconv.h>
-#include <util/TransparentFunctors.h>
 
 #include <cstring>
 #include <exception>
@@ -20,6 +19,7 @@
 #include "parser/TokenizerCtre.h"
 #include "util/DateYearDuration.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
+#include "util/TransparentFunctors.h"
 
 using namespace std::chrono_literals;
 // _______________________________________________________________

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -716,6 +716,12 @@ class RdfParallelParser : public Parser {
       QUEUE_SIZE_BEFORE_PARALLEL_PARSING, NUM_PARALLEL_PARSER_THREADS,
       "parallel parser"};
   std::future<void> parseFuture_;
+
+  // Collect error messages in case of multiple failures. The `size_t` is the
+  // start position of the corresponding batch, used to order the errors in case
+  // the batches are finished out of order.
+  ad_utility::Synchronized<std::vector<std::pair<size_t, std::string>>>
+      errorMessages_;
   // The parallel parsers need to know when the last batch has been parsed, s.t.
   // the parser threads can be destroyed. The following two members are needed
   // for keeping track of this condition.

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -216,6 +216,8 @@ class TurtleParser : public RdfParserBase {
   static inline std::atomic<size_t> numParsers_ = 0;
   size_t blankNodePrefix_ = numParsers_.fetch_add(1);
 
+  bool prefixAndBaseDisabled_ = false;
+
  public:
   TurtleParser() = default;
   explicit TurtleParser(TripleComponent defaultGraphIri)
@@ -542,6 +544,9 @@ CPP_template(typename Parser)(
   // can be used to test if the advancing of the tokenizer works
   // as expected
   size_t getPosition() const { return this->tok_.begin() - tmpToParse_.data(); }
+
+  // Disable prefix parsing for turtle parsers during parallel parsing.
+  void disablePrefixParsing() { this->prefixAndBaseDisabled_ = true; }
 
   FRIEND_TEST(RdfParserTest, prefixedName);
   FRIEND_TEST(RdfParserTest, prefixID);

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -781,7 +781,8 @@ class RdfMultifileParser : public RdfParserBase {
   // `parsingQueue_` is declared *after* the `finishedBatchQueue_`, s.t. when
   // destroying the parser, the threads from the `parsingQueue_` are all joined
   // before the `finishedBatchQueue_` (which they are using!) is destroyed.
-  ad_utility::TaskQueue<false> parsingQueue_{10, NUM_PARALLEL_PARSER_THREADS};
+  ad_utility::TaskQueue<false> parsingQueue_{QUEUE_SIZE_BEFORE_PARALLEL_PARSING,
+                                             NUM_PARALLEL_PARSER_THREADS};
 
   // The number of parsers that have started, but not yet finished. This is
   // needed to detect the complete parsing.

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -237,7 +237,7 @@ struct SkipWhitespaceAndCommentsMixin {
     auto v = self().view();
     if (v.starts_with('#')) {
       auto pos = v.find('\n');
-      if (pos == string::npos) {
+      if (pos == std::string::npos) {
         // TODO<joka921>: This should rather yield an error.
         LOG(INFO) << "Warning, unfinished comment found while parsing"
                   << std::endl;

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -7,10 +7,7 @@
 #include <gtest/gtest_prod.h>
 #include <re2/re2.h>
 
-#include <regex>
-
 #include "parser/TurtleTokenId.h"
-#include "util/Exception.h"
 #include "util/Log.h"
 
 using re2::RE2;
@@ -272,6 +269,8 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
   // Construct from a std::string_view;
   Tokenizer(std::string_view input)
       : _tokens(), _data(input.data(), input.size()) {}
+
+  static constexpr bool UseRelaxedParsing = false;
 
   // if a prefix of the input stream matches the regex argument,
   // return true and that prefix and move the input stream forward

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -154,6 +154,8 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
    */
   explicit TokenizerCtre(std::string_view data) : _data(data) {}
 
+  static constexpr bool UseRelaxedParsing = true;
+
   /// iterator to the next character that we have not yet consumed
   [[nodiscard]] auto begin() const { return _data.begin(); }
 

--- a/src/util/TaskQueue.h
+++ b/src/util/TaskQueue.h
@@ -120,6 +120,11 @@ class TaskQueue {
            std::to_string(popTime_) + "ms (pop)";
   }
 
+  // Block the current thread until `finish()` on the queue has been called and
+  // successfully completed. This function may NOT be called from inside a queue
+  // thread, otherwise there will be a deadlock.
+  void waitUntilFinished() const { finishedFinishing_.wait(false); }
+
   ~TaskQueue() {
     if (startedFinishing_.test_and_set()) {
       // Someone has already called `finish`, we have to wait for the finishing

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -4,17 +4,18 @@
 //    2023 Hannah Bast <bast@cs.uni-freiburg.de>
 //    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 
+#include <absl/strings/str_split.h>
 #include <gtest/gtest.h>
 
 #include "./DeltaTriplesTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/IndexTestHelpers.h"
-#include "absl/strings/str_split.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "index/DeltaTriples.h"
 #include "index/IndexImpl.h"
 #include "index/Permutation.h"
 #include "parser/RdfParser.h"
+#include "parser/Tokenizer.h"
 
 using namespace deltaTriplesTestHelpers;
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -14,12 +14,12 @@
 #include "./util/IdTableHelpers.h"
 #include "./util/IdTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
-#include "global/Pattern.h"
 #include "index/Index.h"
 #include "index/IndexImpl.h"
 #include "util/IndexTestHelpers.h"
 
 using namespace ad_utility::testing;
+using namespace std::string_literals;
 
 using ::testing::UnorderedElementsAre;
 

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -1025,11 +1025,23 @@ TEST(RdfParserTest, exceptionOnScatteredPrefixOrBaseInParallelParser) {
       "<subject2> <predicate2> <object2> . \n"
       "@prefix ex: <http://example.org/> . \n";
   forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
+  std::string inputWithScatteredSparqlPrefix =
+      "PREFIX ex: <http://example.org/> . \n"
+      "<subject1> <predicate1> <object1> . \n "
+      "<subject2> <predicate2> <object2> . \n"
+      "PREFIX ex: <http://example.org/> . \n";
+  forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
   std::string inputWithScatteredBase =
-      "@base: <http://example.org/> . \n"
+      "@base <http://example.org/> . \n"
       "<subject1> <predicate1> <object1> . \n "
       "<subject2> <predicate2> <object2> . \n"
       "@base <http://example.org/> . \n";
+  forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
+  std::string inputWithScatteredSparqlBase =
+      "BASE <http://example.org/> . \n"
+      "<subject1> <predicate1> <object1> . \n "
+      "<subject2> <predicate2> <object2> . \n"
+      "BASE <http://example.org/> . \n";
   forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
 }
 

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -13,8 +13,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "parser/RdfParser.h"
+#include "parser/Tokenizer.h"
+#include "parser/TokenizerCtre.h"
 #include "parser/TripleComponent.h"
-#include "util/Conversions.h"
 #include "util/MemorySize/MemorySize.h"
 
 using std::string;


### PR DESCRIPTION
The parallel Turtle parser requires that all `PREFIX` and `BASE` declarations stand in a single block at the beginning of the file. 
Until now, prefix declarations after this initial block led to an exception about the prefix being undeclared, which was highly misleading. With this PR, this case triggers a proper exception about PREFIX declarations being illegal in the middle of a Turtle file with the parallel parser, together with some guidance to mitigate this issue by either refactoring the input, or deactivating the parallel parser.

Fixes #1794 by providing a better message for the described error.