### PR TITLE
Better transitive path planning

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -164,6 +164,11 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     return qet;
   }
 
+  // Unwrap sort to avoid stacking sorts on top of each other.
+  if (auto sort = std::dynamic_pointer_cast<Sort>(qet->getRootOperation())) {
+    qet = sort->getSubtree();
+  }
+
   QueryExecutionContext* qec = qet->getRootOperation()->getExecutionContext();
   auto sort = std::make_shared<Sort>(qec, std::move(qet), sortColumns);
   return std::make_shared<QueryExecutionTree>(qec, std::move(sort));

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -2057,9 +2057,12 @@ auto QueryPlanner::createJoinWithUnitedTransitivePath(
                                                   bool unionIsLeft) {
     auto* qec = other._qet->getRootOperation()->getExecutionContext();
 
+    // Clone `other` once, to avoid using it twice in the same query plan.
+    SubtreePlan clonedOther = other;
+    clonedOther._qet = other._qet->clone();
     SubtreePlan tmpPlan = other;
     const auto& leftCandidate = unionIsLeft ? tmpPlan : other;
-    const auto& rightCandidate = unionIsLeft ? other : tmpPlan;
+    const auto& rightCandidate = unionIsLeft ? clonedOther : tmpPlan;
 
     tmpPlan._qet = unionOperation.leftChild();
     auto joinedLeft = createJoinCandidates(leftCandidate, rightCandidate, jcs);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -329,13 +329,21 @@ class QueryPlanner {
       const SubtreePlan& a, const SubtreePlan& b,
       boost::optional<const TripleGraph&> tg) const;
 
+  std::vector<QueryPlanner::SubtreePlan> createJoinCandidates(
+      const SubtreePlan& a, const SubtreePlan& b,
+      const std::vector<std::array<ColumnIndex, 2>>& jcs) const;
+
+  std::vector<SubtreePlan> createJoinWithUnitedTransitivePath(
+      SubtreePlan a, SubtreePlan b,
+      const std::vector<std::array<ColumnIndex, 2>>& jcs) const;
+
   // Used internally by `createJoinCandidates`. If `a` or `b` is a transitive
   // path operation and the other input can be bound to this transitive path
   // (see `TransitivePath.cpp` for details), then returns that bound transitive
-  // path. Else returns `std::nullopt`
-  static std::optional<SubtreePlan> createJoinWithTransitivePath(
+  // path. Else returns an empty vector.
+  std::vector<SubtreePlan> createJoinWithTransitivePath(
       SubtreePlan a, SubtreePlan b,
-      const std::vector<std::array<ColumnIndex, 2>>& jcs);
+      const std::vector<std::array<ColumnIndex, 2>>& jcs) const;
 
   // Used internally by `createJoinCandidates`. If  `a` or `b` is a
   // `HasPredicateScan` with a variable as a subject (`?x ql:has-predicate

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -26,7 +26,7 @@ struct TableColumnWithVocab {
   // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103909 for more info.
   TableColumnWithVocab(const IdTable* table, ColumnType column,
                        LocalVocab vocab)
-      : table_{table}, column_{std::move(column)}, vocab_{std::move(vocab)} {};
+      : table_{table}, column_{std::move(column)}, vocab_{std::move(vocab)} {}
 };
 };  // namespace detail
 
@@ -50,7 +50,7 @@ class TransitivePathImpl : public TransitivePathBase {
                      TransitivePathSide leftSide, TransitivePathSide rightSide,
                      size_t minDist, size_t maxDist)
       : TransitivePathBase(qec, std::move(child), std::move(leftSide),
-                           std::move(rightSide), minDist, maxDist){};
+                           std::move(rightSide), minDist, maxDist) {}
 
   /**
    * @brief Compute the transitive hull with a bound side.

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -61,6 +61,9 @@ class Union : public Operation {
     return {_subtrees[0].get(), _subtrees[1].get()};
   }
 
+  std::shared_ptr<QueryExecutionTree> leftChild() { return _subtrees[0]; }
+  std::shared_ptr<QueryExecutionTree> rightChild() { return _subtrees[1]; }
+
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 


### PR DESCRIPTION
Related to #1809 and #1780 
This changes the query planning so that joins are distributively pushed into unions if applicable if the cost is lower this way.