### PR TITLE
Implement casting functions `xsd:dateTime`  and `xsd:date`.

### DIFF
--- a/src/engine/sparqlExpressions/CMakeLists.txt
+++ b/src/engine/sparqlExpressions/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(sparqlExpressions
         ConditionalExpressions.cpp
         SparqlExpressionTypes.cpp
         SparqlExpression.cpp
-        ConvertToNumericExpression.cpp
+        ConvertToDtypeConstructor.cpp
         RdfTermExpressions.cpp
         LangExpression.cpp
         CountStarExpression.cpp

--- a/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
+++ b/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
@@ -8,21 +8,19 @@
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
 
 /*
-  The SparqlExpressions specified in the following namespace sections enable
-  xsd:datatype casting/mapping for XML-schema-datatype values.
+  The SparqlExpressions specified in the following namespace sections
+  enable datatype casting/mapping for XML-schema-datatype values.
 
   For more details regarding the casting/mapping definition see:
   https://www.w3.org/TR/sparql11-query/#FunctionMapping
 
   EXAMPLES
-  (1) BIND(xsd:dateTime(?var) as ?dateTimeValue) will try to convert the
-  date-time provided (bound to ?var) as an xsd:string value to an actual
-  xsd:dateTime value and bind it to ?dateTimeValue under the condition the
-  string was appropriately formatted.
+  (1) `xsd:dateTime(?var)` attempts to convert the date-time provided in form of
+  a xsd:string value, which is bound to ?var, into an actual xsd:dateTime
+  datatype value. If the conversion fails, the result is `undefined`.
 
-  (2) BIND(xsd:integer(?var) to ?integerValue) attempts to convert ?var to an
-  xsd:integer value and bind it to variable ?integerValue, given the datatype
-  casting can be successfully performed.
+  (2) `xsd:integer(?var)` attempts to convert the value bound to ?var into an
+  xsd:integer. If the conversion fails, the result is `undefined`.
 */
 
 namespace sparqlExpression {
@@ -139,9 +137,9 @@ inline auto convertStringToDateTimeValueId =
   }
   const auto& inputValue = input.value();
 
-  // Remark: If the parsing procedure for datetime / date string values with
-  // parseXsdDatetimeGetOptDate / parseXsdDateGetOptDate fails,
-  // Id::makeUndefined() is returned as well.
+  // Remark: If the parsing procedure for datetime/date string values with
+  // parseXsdDatetimeGetOptDate/parseXsdDateGetOptDate fails,
+  // return Id::makeUndefined().
   const auto retrieveValueId = [](std::optional<DateYearOrDuration> optValue) {
     if (optValue.has_value()) {
       return Id::makeFromDate(optValue.value());
@@ -150,7 +148,7 @@ inline auto convertStringToDateTimeValueId =
   };
 
   if (auto* valueId = std::get_if<ValueId>(&inputValue)) {
-    return valueId->getDate().isDate() ? *valueId : Id::makeUndefined();
+    return *valueId;
   }
 
   auto* str = std::get_if<std::string>(&inputValue);

--- a/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
+++ b/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
@@ -1,4 +1,4 @@
-//  Copyright 2024, University of Freiburg,
+//  Copyright 2024 - 2025, University of Freiburg,
 //                  Chair of Algorithms and Data Structures
 //  Author: Hannes Baumann <baumannh@informatik.uni-freiburg.de>
 
@@ -7,7 +7,28 @@
 
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
 
+/*
+  The SparqlExpressions specified in the following namespace sections enable
+  xsd:datatype casting/mapping for XML-schema-datatype values.
+
+  For more details regarding the casting/mapping definition see:
+  https://www.w3.org/TR/sparql11-query/#FunctionMapping
+
+  EXAMPLES
+  (1) BIND(xsd:dateTime(?var) as ?dateTimeValue) will try to convert the
+  date-time provided (bound to ?var) as an xsd:string value to an actual
+  xsd:dateTime value and bind it to ?dateTimeValue under the condition the
+  string was appropriately formatted.
+
+  (2) BIND(xsd:integer(?var) to ?integerValue) attempts to convert ?var to an
+  xsd:integer value and bind it to variable ?integerValue, given the datatype
+  casting can be successfully performed.
+*/
+
 namespace sparqlExpression {
+
+//______________________________________________________________________________
+// CONVERT TO NUMERIC
 namespace detail::to_numeric {
 
 // class that converts an input `int64_t`, `double` or `std::string`
@@ -16,7 +37,7 @@ CPP_template(typename T, bool AllowExponentialNotation = true)(
     requires(concepts::same_as<int64_t, T> ||
              concepts::same_as<double, T>)) class ToNumericImpl {
  private:
-  Id getFromString(const std::string& input) const {
+  ValueId getFromString(const std::string& input) const {
     auto str = absl::StripAsciiWhitespace(input);
     // Abseil and the standard library don't match leading + signs, so we skip
     // them.
@@ -57,7 +78,7 @@ CPP_template(typename T, bool AllowExponentialNotation = true)(
   };
 
  public:
-  Id operator()(IntDoubleStr value) const {
+  ValueId operator()(IntDoubleStr value) const {
     if (std::holds_alternative<std::string>(value)) {
       return getFromString(std::get<std::string>(value));
     } else if (std::holds_alternative<int64_t>(value)) {
@@ -77,6 +98,8 @@ using ToDecimal =
     NARY<1, FV<ToNumericImpl<double, false>, ToNumericValueGetter>>;
 }  // namespace detail::to_numeric
 
+//______________________________________________________________________________
+// CONVERT TO BOOLEAN
 namespace detail::to_boolean {
 class ToBooleanImpl {
  public:
@@ -103,8 +126,55 @@ class ToBooleanImpl {
 using ToBoolean = NARY<1, FV<ToBooleanImpl, ToNumericValueGetter>>;
 }  // namespace detail::to_boolean
 
+//______________________________________________________________________________
+// CONVERT TO DATE(TIME)
+namespace detail::to_datetime {
+
+// Cast to xsd:dateTime or xsd:date (ValueId)
+template <bool ToJustXsdDate>
+inline auto convertStringToDateTimeValueId =
+    [](OptIdOrString input) -> ValueId {
+  if (!input.has_value()) {
+    return Id::makeUndefined();
+  }
+  const auto& inputValue = input.value();
+
+  // Remark: If the parsing procedure for datetime / date string values with
+  // parseXsdDatetimeGetOptDate / parseXsdDateGetOptDate fails,
+  // Id::makeUndefined() is returned as well.
+  const auto retrieveValueId = [](std::optional<DateYearOrDuration> optValue) {
+    if (optValue.has_value()) {
+      return Id::makeFromDate(optValue.value());
+    }
+    return Id::makeUndefined();
+  };
+
+  if (auto* valueId = std::get_if<ValueId>(&inputValue)) {
+    return valueId->getDate().isDate() ? *valueId : Id::makeUndefined();
+  }
+
+  auto* str = std::get_if<std::string>(&inputValue);
+  AD_CORRECTNESS_CHECK(str != nullptr);
+  if constexpr (ToJustXsdDate) {
+    return retrieveValueId(DateYearOrDuration::parseXsdDateGetOptDate(*str));
+  } else {
+    return retrieveValueId(
+        DateYearOrDuration::parseXsdDatetimeGetOptDate(*str));
+  }
+};
+
+NARY_EXPRESSION(ToXsdDateTime, 1,
+                FV<decltype(convertStringToDateTimeValueId<false>),
+                   DateIdOrLiteralValueGetter>);
+NARY_EXPRESSION(ToXsdDate, 1,
+                FV<decltype(convertStringToDateTimeValueId<true>),
+                   DateIdOrLiteralValueGetter>);
+
+}  // namespace detail::to_datetime
+
 using namespace detail::to_numeric;
 using namespace detail::to_boolean;
+using namespace detail::to_datetime;
 using Expr = SparqlExpression::Ptr;
 
 Expr makeConvertToIntExpression(Expr child) {
@@ -122,4 +192,13 @@ Expr makeConvertToDecimalExpression(Expr child) {
 Expr makeConvertToBooleanExpression(Expr child) {
   return std::make_unique<ToBoolean>(std::move(child));
 }
+
+Expr makeConvertToDateTimeExpression(Expr child) {
+  return std::make_unique<ToXsdDateTime>(std::move(child));
+}
+
+Expr makeConvertToDateExpression(Expr child) {
+  return std::make_unique<ToXsdDate>(std::move(child));
+}
+
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
+++ b/src/engine/sparqlExpressions/ConvertToDtypeConstructor.cpp
@@ -130,18 +130,16 @@ namespace detail::to_datetime {
 
 // Cast to xsd:dateTime or xsd:date (ValueId)
 template <bool ToJustXsdDate>
-inline auto castStringToDateTimeValueId = [](OptIdOrString input) -> ValueId {
-  if (!input.has_value()) {
-    return Id::makeUndefined();
-  }
+inline const auto castStringToDateTimeValueId = [](OptIdOrString input) {
+  if (!input.has_value()) return Id::makeUndefined();
+
   using DYD = DateYearOrDuration;
   std::optional<DYD> optValueId = std::visit(
-      [&](const auto& value) {
-        using T = std::decay_t<decltype(value)>;
-        if constexpr (std::is_same_v<T, ValueId>) {
+      [&]<typename T>(const T& value) {
+        if constexpr (std::is_same_v<std::decay_t<T>, ValueId>) {
           return ToJustXsdDate ? DYD::convertToXsdDate(value.getDate())
                                : DYD::convertToXsdDatetime(value.getDate());
-        } else if constexpr (std::is_same_v<T, std::string>) {
+        } else if constexpr (std::is_same_v<std::decay_t<T>, std::string>) {
           return ToJustXsdDate ? DYD::parseXsdDateGetOptDate(value)
                                : DYD::parseXsdDatetimeGetOptDate(value);
         } else {

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -104,7 +104,7 @@ SparqlExpression::Ptr makeIfExpression(SparqlExpression::Ptr child1,
                                        SparqlExpression::Ptr child2,
                                        SparqlExpression::Ptr child3);
 
-// Implemented in ConvertToNumeric.cpp
+// Implemented in ConvertToDtypeConstructor.cpp
 SparqlExpression::Ptr makeConvertToIntExpression(SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeConvertToDoubleExpression(
     SparqlExpression::Ptr child);
@@ -112,6 +112,9 @@ SparqlExpression::Ptr makeConvertToDecimalExpression(
     SparqlExpression::Ptr child);
 SparqlExpression::Ptr makeConvertToBooleanExpression(
     SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeConvertToDateTimeExpression(
+    SparqlExpression::Ptr child);
+SparqlExpression::Ptr makeConvertToDateExpression(SparqlExpression::Ptr child);
 
 // Implemented in RdfTermExpressions.cpp
 SparqlExpression::Ptr makeDatatypeExpression(SparqlExpression::Ptr child);

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -353,20 +353,15 @@ struct IriOrUriValueGetter : Mixin<IriOrUriValueGetter> {
 // Defines the return type for value-getter `DateIdOrLiteralValueGetter`.
 using OptIdOrString = std::optional<std::variant<ValueId, std::string>>;
 
-// This value-getter returns a `Date` related `ValueId` or `std::string` (from
-// literal).
+// This value-getter returns a `DateYearOrDuration` related `ValueId` or
+// `std::string` (from literal).
 struct DateIdOrLiteralValueGetter : Mixin<DateIdOrLiteralValueGetter> {
   using Mixin<DateIdOrLiteralValueGetter>::operator();
   // Remark: We use only LiteralFromIdGetter because Iri values should never
   // contain date-related string values.
   OptIdOrString operator()(ValueId id, const EvaluationContext* context) const {
     if (id.getDatatype() == Datatype::Date) {
-      // Additionally check that `DateYearOrDuration` doesn't hold a
-      // `DayTimeDuration` value.
-      if (id.getDate().isDate()) {
-        return id;
-      }
-      return std::nullopt;
+      return id;
     }
     return LiteralFromIdGetter{}(id, context);
   }

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -350,23 +350,25 @@ struct IriOrUriValueGetter : Mixin<IriOrUriValueGetter> {
                               const EvaluationContext* context) const;
 };
 
-// Defines the return type for value-getter `DateIdOrLiteralValueGetter`.
-using OptIdOrString = std::optional<std::variant<ValueId, std::string>>;
+// Defines the return type for value-getter `StringOrDateGetter`.
+using OptStringOrDate =
+    std::optional<std::variant<DateYearOrDuration, std::string>>;
 
-// This value-getter returns a `DateYearOrDuration` related `ValueId` or
-// `std::string` (from literal).
-struct DateIdOrLiteralValueGetter : Mixin<DateIdOrLiteralValueGetter> {
-  using Mixin<DateIdOrLiteralValueGetter>::operator();
+// This value-getter retrieves `DateYearOrDuration` or `std::string`
+// (from literal) values.
+struct StringOrDateGetter : Mixin<StringOrDateGetter> {
+  using Mixin<StringOrDateGetter>::operator();
   // Remark: We use only LiteralFromIdGetter because Iri values should never
   // contain date-related string values.
-  OptIdOrString operator()(ValueId id, const EvaluationContext* context) const {
+  OptStringOrDate operator()(ValueId id,
+                             const EvaluationContext* context) const {
     if (id.getDatatype() == Datatype::Date) {
-      return id;
+      return id.getDate();
     }
     return LiteralFromIdGetter{}(id, context);
   }
-  OptIdOrString operator()(const LiteralOrIri& litOrIri,
-                           const EvaluationContext* context) const {
+  OptStringOrDate operator()(const LiteralOrIri& litOrIri,
+                             const EvaluationContext* context) const {
     return LiteralFromIdGetter{}(litOrIri, context);
   }
 };

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -350,4 +350,25 @@ struct IriOrUriValueGetter : Mixin<IriOrUriValueGetter> {
                               const EvaluationContext* context) const;
 };
 
+// Defines the return type for value-getter `DateIdOrLiteralValueGetter`.
+using OptIdOrString = std::optional<std::variant<ValueId, std::string>>;
+
+// This value-getter returns a `Date` related `ValueId` or `std::string` (from
+// literal).
+struct DateIdOrLiteralValueGetter : Mixin<DateIdOrLiteralValueGetter> {
+  using Mixin<DateIdOrLiteralValueGetter>::operator();
+  // Remark: We use only LiteralFromIdGetter because Iri values should never
+  // contain date-related string values.
+  OptIdOrString operator()(ValueId id, const EvaluationContext* context) const {
+    if (id.getDatatype() == Datatype::Date) {
+      return id;
+    }
+    return LiteralFromIdGetter{}(id, context);
+  }
+  OptIdOrString operator()(const LiteralOrIri& litOrIri,
+                           const EvaluationContext* context) const {
+    return LiteralFromIdGetter{}(litOrIri, context);
+  }
+};
+
 }  // namespace sparqlExpression::detail

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -361,7 +361,12 @@ struct DateIdOrLiteralValueGetter : Mixin<DateIdOrLiteralValueGetter> {
   // contain date-related string values.
   OptIdOrString operator()(ValueId id, const EvaluationContext* context) const {
     if (id.getDatatype() == Datatype::Date) {
-      return id;
+      // Additionally check that `DateYearOrDuration` doesn't hold a
+      // `DayTimeDuration` value.
+      if (id.getDate().isDate()) {
+        return id;
+      }
+      return std::nullopt;
     }
     return LiteralFromIdGetter{}(id, context);
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -109,85 +109,76 @@ ExpressionPtr Visitor::processIriFunctionCall(
     }
   };
 
+  using namespace sparqlExpression;
+  // Create `SparqlExpression` with one child.
+  auto createUnary =
+      CPP_template_lambda(&argList, &checkNumArgs)(typename F)(F function)(
+          requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr>) {
+    checkNumArgs(1);  // Check is unary.
+    return function(std::move(argList[0]));
+  };
+  // Create `SparqlExpression` with two children.
+  auto createBinary =
+      CPP_template_lambda(&argList, &checkNumArgs)(typename F)(F function)(
+          requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
+                                         ExpressionPtr>) {
+    checkNumArgs(2);  // Check is binary.
+    return function(std::move(argList[0]), std::move(argList[1]));
+  };
+
   // Geo functions.
   if (checkPrefix(GEOF_PREFIX)) {
     if (functionName == "distance") {
-      checkNumArgs(2);
-      return sparqlExpression::makeDistExpression(std::move(argList[0]),
-                                                  std::move(argList[1]));
+      return createBinary(&makeDistExpression);
     } else if (functionName == "longitude") {
-      checkNumArgs(1);
-      return sparqlExpression::makeLongitudeExpression(std::move(argList[0]));
+      return createUnary(&makeLongitudeExpression);
     } else if (functionName == "latitude") {
-      checkNumArgs(1);
-      return sparqlExpression::makeLatitudeExpression(std::move(argList[0]));
+      return createUnary(&makeLatitudeExpression);
     }
   }
 
   // Math functions.
   if (checkPrefix(MATH_PREFIX)) {
     if (functionName == "log") {
-      checkNumArgs(1);
-      return sparqlExpression::makeLogExpression(std::move(argList[0]));
+      return createUnary(&makeLogExpression);
     } else if (functionName == "exp") {
-      checkNumArgs(1);
-      return sparqlExpression::makeExpExpression(std::move(argList[0]));
+      return createUnary(&makeExpExpression);
     } else if (functionName == "sqrt") {
-      checkNumArgs(1);
-      return sparqlExpression::makeSqrtExpression(std::move(argList[0]));
+      return createUnary(&makeSqrtExpression);
     } else if (functionName == "sin") {
-      checkNumArgs(1);
-      return sparqlExpression::makeSinExpression(std::move(argList[0]));
+      return createUnary(&makeSinExpression);
     } else if (functionName == "cos") {
-      checkNumArgs(1);
-      return sparqlExpression::makeCosExpression(std::move(argList[0]));
+      return createUnary(&makeCosExpression);
     } else if (functionName == "tan") {
-      checkNumArgs(1);
-      return sparqlExpression::makeTanExpression(std::move(argList[0]));
+      return createUnary(&makeTanExpression);
     } else if (functionName == "pow") {
-      checkNumArgs(2);
-      return sparqlExpression::makePowExpression(std::move(argList[0]),
-                                                 std::move(argList[1]));
+      return createBinary(&makePowExpression);
     }
   }
 
   // XSD conversion functions.
   if (checkPrefix(XSD_PREFIX)) {
     if (functionName == "integer" || functionName == "int") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToIntExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToIntExpression);
     }
     if (functionName == "decimal") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToDecimalExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToDecimalExpression);
     }
     // We currently don't have a float type, so we just convert to double.
     if (functionName == "double" || functionName == "float") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToDoubleExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToDoubleExpression);
     }
     if (functionName == "boolean") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToBooleanExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToBooleanExpression);
     }
     if (functionName == "string") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToStringExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToStringExpression);
     }
     if (functionName == "dateTime") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToDateTimeExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToDateTimeExpression);
     }
     if (functionName == "date") {
-      checkNumArgs(1);
-      return sparqlExpression::makeConvertToDateExpression(
-          std::move(argList[0]));
+      return createUnary(&makeConvertToDateExpression);
     }
   }
 
@@ -196,8 +187,7 @@ ExpressionPtr Visitor::processIriFunctionCall(
   // NOTE: Predicates like `ql:has-predicate` etc. are handled elsewhere.
   if (checkPrefix(QL_PREFIX)) {
     if (functionName == "isGeoPoint") {
-      checkNumArgs(1);
-      return sparqlExpression::makeIsGeoPointExpression(std::move(argList[0]));
+      return createUnary(&makeIsGeoPointExpression);
     }
   }
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -179,6 +179,16 @@ ExpressionPtr Visitor::processIriFunctionCall(
       return sparqlExpression::makeConvertToStringExpression(
           std::move(argList[0]));
     }
+    if (functionName == "dateTime") {
+      checkNumArgs(1);
+      return sparqlExpression::makeConvertToDateTimeExpression(
+          std::move(argList[0]));
+    }
+    if (functionName == "date") {
+      checkNumArgs(1);
+      return sparqlExpression::makeConvertToDateExpression(
+          std::move(argList[0]));
+    }
   }
 
   // QLever-internal functions.

--- a/src/util/DateYearDuration.h
+++ b/src/util/DateYearDuration.h
@@ -185,6 +185,21 @@ class DateYearOrDuration {
   // Parse `xsd:dayTimeDuration` from a `DateYearOrDuration`.
   static std::optional<DateYearOrDuration> xsdDayTimeDurationFromDate(
       const DateYearOrDuration& dateOrLargeYear);
+
+  // If the provided `DateYearOrDuration` holds an actual `Date` value,
+  // transform it to `xsd:dateTime` by filling the missing date-components with
+  // `0`. If `DateYearOrDuration` holds a `xsd:dayTimeDuration` or `LargeYear`
+  // related value, return std::nullopt.
+  static std::optional<DateYearOrDuration> convertToXsdDatetime(
+      const DateYearOrDuration& dateValue);
+
+  // If the provided `DateYearOrDuration` holds an actual `Date` value,
+  // transform it to `xsd:dateTime` by filling the missing date-components with
+  // `0` or dropping the additional date-components. If `DateYearOrDuration`
+  // holds a `xsd:dayTimeDuration` or `LargeYear` related value, return
+  // std::nullopt.
+  static std::optional<DateYearOrDuration> convertToXsdDate(
+      const DateYearOrDuration& dateValue);
 };
 
 #endif  //  QLEVER_DATES_AND_DURATION_H

--- a/src/util/DateYearDuration.h
+++ b/src/util/DateYearDuration.h
@@ -154,19 +154,31 @@ class DateYearOrDuration {
   // 2. If the year is outside the range [-9999, 9999], then the date must be
   // January 1, 00:00 hours.
 
-  // Parse from xsd:dateTime (e.g. 1900-12-13T03:12:00.33Z)
+  // Parse from `xsd:dateTime` (e.g. `1900-12-13T03:12:00.33Z`)
   static DateYearOrDuration parseXsdDatetime(std::string_view dateString);
+  // Parse from `xsd:dateTime` (e.g. `1900-12-13T03:12:00.33Z`). Returns a
+  // `DateYearOrDuration` value under the condition that `dateString` adheres to
+  // the correct datetime string format (is parsable). If the parsing procedure
+  // fails `std::nullopt` is returned.
+  static std::optional<DateYearOrDuration> parseXsdDatetimeGetOptDate(
+      std::string_view dateString);
 
-  // Parse from xsd:date (e.g. 1900-12-13)
+  // Parse from `xsd:date` (e.g. `1900-12-13`)
   static DateYearOrDuration parseXsdDate(std::string_view dateString);
+  // Parse from `xsd:date` (e.g. `1900-12-13`). Returns a `DateYearOrDuration`
+  // value under the condition that `dateString` adheres to the correct date
+  // string format (is parsable). If the parsing procedure fails `std::nullopt`
+  // is returned.
+  static std::optional<DateYearOrDuration> parseXsdDateGetOptDate(
+      std::string_view dateString);
 
-  // Parse from xsd:gYearMonth (e.g. 1900-03)
+  // Parse from `xsd:gYearMonth` (e.g. `1900-03`)
   static DateYearOrDuration parseGYearMonth(std::string_view dateString);
 
-  // Parse from xsd:gYear (e.g. 1900)
+  // Parse from `xsd:gYear` (e.g. `1900`)
   static DateYearOrDuration parseGYear(std::string_view dateString);
 
-  // Parse from xsd:dayTimeDuration (e.g. P2DT3H59M59.99S)
+  // Parse from `xsd:dayTimeDuration` (e.g. `P2DT3H59M59.99S`)
   static DateYearOrDuration parseXsdDayTimeDuration(
       std::string_view dayTimeDurationString);
 

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1862,6 +1862,10 @@ TEST(SparqlParser, FunctionCall) {
                      matchUnary(&makeConvertToDecimalExpression));
   expectFunctionCall(absl::StrCat(xsd, "boolean>(?x)"),
                      matchUnary(&makeConvertToBooleanExpression));
+  expectFunctionCall(absl::StrCat(xsd, "date>(?x)"),
+                     matchUnary(&makeConvertToDateExpression));
+  expectFunctionCall(absl::StrCat(xsd, "dateTime>(?x)"),
+                     matchUnary(&makeConvertToDateTimeExpression));
 
   expectFunctionCall(absl::StrCat(xsd, "string>(?x)"),
                      matchUnary(&makeConvertToStringExpression));
@@ -1869,6 +1873,8 @@ TEST(SparqlParser, FunctionCall) {
   // Wrong number of arguments.
   expectFunctionCallFails(absl::StrCat(geof, "distance>(?a)"));
   expectFunctionCallFails(absl::StrCat(geof, "distance>(?a, ?b, ?c)"));
+  expectFunctionCallFails(absl::StrCat(xsd, "date>(?varYear, ?varMonth)"));
+  expectFunctionCallFails(absl::StrCat(xsd, "dateTime>(?varYear, ?varMonth)"));
 
   // Unknown function with `geof:`, `math:`, `xsd:`, or `ql` prefix.
   expectFunctionCallFails(absl::StrCat(geof, "nada>(?x)"));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1159,6 +1159,36 @@ TEST(SparqlExpression, testToNumericExpression) {
 }
 
 // ____________________________________________________________________________
+TEST(SparqlExpression, testToDateOrDateTimeExpression) {
+  using namespace ad_utility::testing;
+  Id T = Id::makeFromBool(true);
+  Id F = Id::makeFromBool(false);
+  Id G = Id::makeFromGeoPoint(GeoPoint(50.0, 50.0));
+  auto parserDate = DateYearOrDuration::parseXsdDate;
+  auto parserDateTime = DateYearOrDuration::parseXsdDatetime;
+  auto checkGetDate = testUnaryExpression<&makeConvertToDateExpression>;
+  auto checkGetDateTime = testUnaryExpression<&makeConvertToDateTimeExpression>;
+
+  checkGetDate(idOrLitOrStringVec({"---", T, F, G, "2025-02", I(10), D(0.01),
+                                   "-2025-02-20", "2025-02-20", "2025-1-1",
+                                   DateId(parserDate, "0000-01-01")}),
+               Ids{U, U, U, U, U, U, U, DateId(parserDate, "-2025-02-20"),
+                   DateId(parserDate, "2025-02-20"), U,
+                   DateId(parserDate, "0000-01-01")});
+  checkGetDateTime(
+      idOrLitOrStringVec({"---", T, F, G, "2025-02", I(10), D(0.01),
+                          "-2025-02-20", "2025-02-20", "2025-1-1",
+                          "1900-12-13T03:12:00.33Z", "-1900-12-13T03:12:00.33Z",
+                          "2025-02-20T17:12:00.01-05:00",
+                          DateId(parserDateTime, "2025-02-20T17:12:00.01Z")}),
+      Ids{U, U, U, U, U, U, U, U, U, U,
+          DateId(parserDateTime, "1900-12-13T03:12:00.33Z"),
+          DateId(parserDateTime, "-1900-12-13T03:12:00.33Z"),
+          DateId(parserDateTime, "2025-02-20T17:12:00.01-05:00"),
+          DateId(parserDateTime, "2025-02-20T17:12:00.01Z")});
+}
+
+// ____________________________________________________________________________
 TEST(SparqlExpression, testToBooleanExpression) {
   Id T = Id::makeFromBool(true);
   Id F = Id::makeFromBool(false);

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1166,26 +1166,34 @@ TEST(SparqlExpression, testToDateOrDateTimeExpression) {
   Id G = Id::makeFromGeoPoint(GeoPoint(50.0, 50.0));
   auto parserDate = DateYearOrDuration::parseXsdDate;
   auto parserDateTime = DateYearOrDuration::parseXsdDatetime;
+  auto parserDuration = DateYearOrDuration::parseXsdDayTimeDuration;
   auto checkGetDate = testUnaryExpression<&makeConvertToDateExpression>;
   auto checkGetDateTime = testUnaryExpression<&makeConvertToDateTimeExpression>;
 
-  checkGetDate(idOrLitOrStringVec({"---", T, F, G, "2025-02", I(10), D(0.01),
-                                   "-2025-02-20", "2025-02-20", "2025-1-1",
-                                   DateId(parserDate, "0000-01-01")}),
-               Ids{U, U, U, U, U, U, U, DateId(parserDate, "-2025-02-20"),
-                   DateId(parserDate, "2025-02-20"), U,
-                   DateId(parserDate, "0000-01-01")});
+  checkGetDate(
+      idOrLitOrStringVec(
+          {"---", T, F, G, "2025-02", I(10), D(0.01), "-2025-02-20",
+           "2025-02-20", "2025-1-1", DateId(parserDate, "0000-01-01"),
+           DateId(parserDuration, "-PT5H"),
+           DateId(parserDateTime, "1900-12-13T03:12:00.33Z"),
+           DateId(parserDateTime, "2025-02-20T17:12:00.01-05:00")}),
+      Ids{U, U, U, U, U, U, U, DateId(parserDate, "-2025-02-20"),
+          DateId(parserDate, "2025-02-20"), U, DateId(parserDate, "0000-01-01"),
+          U, DateId(parserDate, "1900-12-13"),
+          DateId(parserDate, "2025-02-20")});
   checkGetDateTime(
-      idOrLitOrStringVec({"---", T, F, G, "2025-02", I(10), D(0.01),
-                          "-2025-02-20", "2025-02-20", "2025-1-1",
-                          "1900-12-13T03:12:00.33Z", "-1900-12-13T03:12:00.33Z",
-                          "2025-02-20T17:12:00.01-05:00",
-                          DateId(parserDateTime, "2025-02-20T17:12:00.01Z")}),
+      idOrLitOrStringVec(
+          {"---", T, F, G, "2025-02", I(10), D(0.01), "-2025-02-20",
+           "2025-02-20", "2025-1-1", "1900-12-13T03:12:00.33Z",
+           "-1900-12-13T03:12:00.33Z", "2025-02-20T17:12:00.01-05:00",
+           DateId(parserDateTime, "2025-02-20T17:12:00.01Z"),
+           DateId(parserDuration, "PT1H4M"), DateId(parserDate, "0000-01-01")}),
       Ids{U, U, U, U, U, U, U, U, U, U,
           DateId(parserDateTime, "1900-12-13T03:12:00.33Z"),
           DateId(parserDateTime, "-1900-12-13T03:12:00.33Z"),
           DateId(parserDateTime, "2025-02-20T17:12:00.01-05:00"),
-          DateId(parserDateTime, "2025-02-20T17:12:00.01Z")});
+          DateId(parserDateTime, "2025-02-20T17:12:00.01Z"), U,
+          DateId(parserDateTime, "0000-01-01T00:00:00.00")});
 }
 
 // ____________________________________________________________________________


### PR DESCRIPTION
 xsd:date(?dateOrString)` and `xsd:dateTime(?dateOrString)` are now implemented as built-in function calls with the following semantics:
* for string arguments, the literal is parsed as a `date(Time)`
* `xsd:date(?someDateTime)` removes the time from a date.
* `xsd:dateTime(?someData)` adds the time `00:00:00` to a given date
* `xsd:date(?date)` and `xsd:dateTime(?dateTime)` are the identity function.
* All other cases (including parsing errors for the string case) lead to an undefined result.

Fixes #1819
