### PR TITLE
Revert "Better error message on parallel turtle parsing ... (#1807)"

### DIFF
--- a/src/engine/GraphStoreProtocol.cpp
+++ b/src/engine/GraphStoreProtocol.cpp
@@ -4,7 +4,6 @@
 
 #include "engine/GraphStoreProtocol.h"
 
-#include "parser/Tokenizer.h"
 #include "util/http/beast.h"
 
 // ____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -21,8 +21,6 @@
 #include "index/IndexFormatVersion.h"
 #include "index/VocabularyMerger.h"
 #include "parser/ParallelParseBuffer.h"
-#include "parser/Tokenizer.h"
-#include "parser/TokenizerCtre.h"
 #include "util/BatchedPipeline.h"
 #include "util/CachingMemoryResource.h"
 #include "util/HashMap.h"

--- a/src/parser/RdfEscaping.h
+++ b/src/parser/RdfEscaping.h
@@ -5,12 +5,15 @@
 #ifndef QLEVER_RDFESCAPING_H
 #define QLEVER_RDFESCAPING_H
 
+#include <unicode/ustream.h>
+
 #include <sstream>
 #include <string>
 
 #include "global/TypedIndex.h"
 #include "parser/NormalizedString.h"
 #include "util/Exception.h"
+#include "util/HashSet.h"
 #include "util/StringUtils.h"
 
 namespace RdfEscaping {

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -15,11 +15,10 @@
 #include "global/Constants.h"
 #include "parser/GeoPoint.h"
 #include "parser/NormalizedString.h"
-#include "parser/Tokenizer.h"
-#include "parser/TokenizerCtre.h"
+#include "parser/RdfEscaping.h"
+#include "util/Conversions.h"
 #include "util/DateYearDuration.h"
 #include "util/OnDestructionDontThrowDuringStackUnwinding.h"
-#include "util/TransparentFunctors.h"
 
 using namespace std::chrono_literals;
 // _______________________________________________________________
@@ -32,17 +31,7 @@ bool TurtleParser<T>::statement() {
 // ______________________________________________________________
 template <class T>
 bool TurtleParser<T>::directive() {
-  bool successfulParse = prefixID() || base() || sparqlPrefix() || sparqlBase();
-  if (successfulParse && prefixAndBaseDisabled_) {
-    raise(
-        "@prefix or @base directives need to be at the beginning of the file "
-        "when using the parallel parser. Use '--parse-parallel false' if you "
-        "can't guarantee this. If the reason for this error is that the input "
-        "is a concatenation of Turtle files, each of which has the prefixes at "
-        "the beginning, you should feed the files to QLever separately instead "
-        "of concatenated");
-  }
-  return successfulParse;
+  return prefixID() || base() || sparqlPrefix() || sparqlBase();
 }
 
 // ________________________________________________________________
@@ -641,7 +630,7 @@ bool TurtleParser<T>::iri() {
 // _____________________________________________________________________
 template <class T>
 bool TurtleParser<T>::prefixedName() {
-  if constexpr (T::UseRelaxedParsing) {
+  if constexpr (UseRelaxedParsing) {
     if (!(pnameLnRelaxed() || pnameNS())) {
       return false;
     }
@@ -756,7 +745,7 @@ bool TurtleParser<T>::iriref() {
   // In relaxed mode, that is all we check. Otherwise, we check if the IRI is
   // standard-compliant. If not, we output a warning and try to parse it in a
   // more relaxed way.
-  if constexpr (T::UseRelaxedParsing) {
+  if constexpr (UseRelaxedParsing) {
     tok_.remove_prefix(endPos + 1);
     lastParseResult_ = TripleComponent::Iri::fromIrirefConsiderBase(
         view.substr(0, endPos + 1), baseForRelativeIri(), baseForAbsoluteIri());
@@ -959,20 +948,20 @@ bool RdfStreamParser<T>::getLineImpl(TurtleTriple* triple) {
 // `parallelParser_` have been fully processed. After the last batch we will
 // push another call to this lambda to the `parallelParser_` which will then
 // finish the `tripleCollector_` as soon as all batches have been computed.
-template <typename T>
-void RdfParallelParser<T>::finishTripleCollectorIfLastBatch() {
+template <typename Tokenizer_T>
+void RdfParallelParser<Tokenizer_T>::finishTripleCollectorIfLastBatch() {
   if (batchIdx_.fetch_add(1) == numBatchesTotal_) {
     tripleCollector_.finish();
   }
 }
 
 // __________________________________________________________________________________
-template <typename T>
-void RdfParallelParser<T>::parseBatch(size_t parsePosition, auto batch) {
+template <typename Tokenizer_T>
+void RdfParallelParser<Tokenizer_T>::parseBatch(size_t parsePosition,
+                                                auto batch) {
   try {
-    RdfStringParser<T> parser{defaultGraphIri_};
+    RdfStringParser<Tokenizer_T> parser{defaultGraphIri_};
     parser.prefixMap_ = this->prefixMap_;
-    parser.disablePrefixParsing();
     parser.setPositionOffset(parsePosition);
     parser.setInputStream(std::move(batch));
     // TODO: raise error message if a prefix parsing fails;
@@ -983,15 +972,14 @@ void RdfParallelParser<T>::parseBatch(size_t parsePosition, auto batch) {
     });
     finishTripleCollectorIfLastBatch();
   } catch (std::exception& e) {
-    errorMessages_.wlock()->emplace_back(parsePosition, e.what());
     tripleCollector_.pushException(std::current_exception());
     parallelParser_.finish();
   }
 };
 
 // _______________________________________________________________________
-template <typename T>
-void RdfParallelParser<T>::feedBatchesToParser(
+template <typename Tokenizer_T>
+void RdfParallelParser<Tokenizer_T>::feedBatchesToParser(
     auto remainingBatchFromInitialization) {
   bool first = true;
   size_t parsePosition = 0;
@@ -1031,15 +1019,14 @@ void RdfParallelParser<T>::feedBatchesToParser(
       }
     }
   } catch (std::exception& e) {
-    errorMessages_.wlock()->emplace_back(parsePosition, e.what());
     tripleCollector_.pushException(std::current_exception());
   }
 };
 
 // _______________________________________________________________________
-template <typename T>
-void RdfParallelParser<T>::initialize(const string& filename,
-                                      ad_utility::MemorySize bufferSize) {
+template <typename Tokenizer_T>
+void RdfParallelParser<Tokenizer_T>::initialize(
+    const string& filename, ad_utility::MemorySize bufferSize) {
   fileBuffer_ = std::make_unique<ParallelBufferWithEndRegex>(
       bufferSize.getBytes(), "\\.[\\t ]*([\\r\\n]+)");
   ParallelBuffer::BufferType remainingBatchFromInitialization;
@@ -1048,7 +1035,7 @@ void RdfParallelParser<T>::initialize(const string& filename,
     LOG(WARN) << "Empty input to the TURTLE parser, is this what you intended?"
               << std::endl;
   } else {
-    RdfStringParser<T> declarationParser{};
+    RdfStringParser<Tokenizer_T> declarationParser{};
     declarationParser.setInputStream(std::move(batch.value()));
     while (declarationParser.parseDirectiveManually()) {
     }
@@ -1075,20 +1062,7 @@ bool RdfParallelParser<T>::getLineImpl(TurtleTriple* triple) {
   // contains no triples. (Theoretically this might happen, and it is safer this
   // way)
   while (triples_.empty()) {
-    auto optionalTripleTask = [&]() {
-      try {
-        return tripleCollector_.pop();
-      } catch (const std::exception&) {
-        // In case of multiple errors in parallel batches, we always report the
-        // first error.
-        parallelParser_.waitUntilFinished();
-        auto errors = std::move(*errorMessages_.wlock());
-        const auto& firstError =
-            ql::ranges::min_element(errors, {}, ad_utility::first);
-        AD_CORRECTNESS_CHECK(firstError != errors.end());
-        throw std::runtime_error{firstError->second};
-      }
-    }();
+    auto optionalTripleTask = tripleCollector_.pop();
     if (!optionalTripleTask) {
       // Everything has been parsed
       return false;

--- a/src/parser/Tokenizer.h
+++ b/src/parser/Tokenizer.h
@@ -7,7 +7,10 @@
 #include <gtest/gtest_prod.h>
 #include <re2/re2.h>
 
+#include <regex>
+
 #include "parser/TurtleTokenId.h"
+#include "util/Exception.h"
 #include "util/Log.h"
 
 using re2::RE2;
@@ -237,7 +240,7 @@ struct SkipWhitespaceAndCommentsMixin {
     auto v = self().view();
     if (v.starts_with('#')) {
       auto pos = v.find('\n');
-      if (pos == std::string::npos) {
+      if (pos == string::npos) {
         // TODO<joka921>: This should rather yield an error.
         LOG(INFO) << "Warning, unfinished comment found while parsing"
                   << std::endl;
@@ -269,8 +272,6 @@ class Tokenizer : public SkipWhitespaceAndCommentsMixin<Tokenizer> {
   // Construct from a std::string_view;
   Tokenizer(std::string_view input)
       : _tokens(), _data(input.data(), input.size()) {}
-
-  static constexpr bool UseRelaxedParsing = false;
 
   // if a prefix of the input stream matches the regex argument,
   // return true and that prefix and move the input stream forward

--- a/src/parser/TokenizerCtre.h
+++ b/src/parser/TokenizerCtre.h
@@ -154,8 +154,6 @@ class TokenizerCtre : public SkipWhitespaceAndCommentsMixin<TokenizerCtre> {
    */
   explicit TokenizerCtre(std::string_view data) : _data(data) {}
 
-  static constexpr bool UseRelaxedParsing = true;
-
   /// iterator to the next character that we have not yet consumed
   [[nodiscard]] auto begin() const { return _data.begin(); }
 

--- a/src/util/TaskQueue.h
+++ b/src/util/TaskQueue.h
@@ -120,11 +120,6 @@ class TaskQueue {
            std::to_string(popTime_) + "ms (pop)";
   }
 
-  // Block the current thread until `finish()` on the queue has been called and
-  // successfully completed. This function may NOT be called from inside a queue
-  // thread, otherwise there will be a deadlock.
-  void waitUntilFinished() const { finishedFinishing_.wait(false); }
-
   ~TaskQueue() {
     if (startedFinishing_.test_and_set()) {
       // Someone has already called `finish`, we have to wait for the finishing

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -4,18 +4,17 @@
 //    2023 Hannah Bast <bast@cs.uni-freiburg.de>
 //    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 
-#include <absl/strings/str_split.h>
 #include <gtest/gtest.h>
 
 #include "./DeltaTriplesTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/IndexTestHelpers.h"
+#include "absl/strings/str_split.h"
 #include "engine/ExportQueryExecutionTrees.h"
 #include "index/DeltaTriples.h"
 #include "index/IndexImpl.h"
 #include "index/Permutation.h"
 #include "parser/RdfParser.h"
-#include "parser/Tokenizer.h"
 
 using namespace deltaTriplesTestHelpers;
 

--- a/test/IndexTest.cpp
+++ b/test/IndexTest.cpp
@@ -14,12 +14,12 @@
 #include "./util/IdTableHelpers.h"
 #include "./util/IdTestHelpers.h"
 #include "./util/TripleComponentTestHelpers.h"
+#include "global/Pattern.h"
 #include "index/Index.h"
 #include "index/IndexImpl.h"
 #include "util/IndexTestHelpers.h"
 
 using namespace ad_utility::testing;
-using namespace std::string_literals;
 
 using ::testing::UnorderedElementsAre;
 

--- a/test/RdfParserTest.cpp
+++ b/test/RdfParserTest.cpp
@@ -13,9 +13,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "parser/RdfParser.h"
-#include "parser/Tokenizer.h"
-#include "parser/TokenizerCtre.h"
 #include "parser/TripleComponent.h"
+#include "util/Conversions.h"
 #include "util/MemorySize/MemorySize.h"
 
 using std::string;
@@ -1001,48 +1000,6 @@ TEST(RdfParserTest, exceptionPropagationFileBufferReading) {
       "<veryLongSubject> <veryLongPredicate> "
       "<veryLongObject> .";
   forAllParallelParsers(testWithParser, 40_B, inputWithLongTriple);
-}
-
-// Test that in parallel parsing scattered prefixes or base declarations lead to
-// an exception
-TEST(RdfParserTest, exceptionOnScatteredPrefixOrBaseInParallelParser) {
-  std::string filename{"turtleParserExceptionPropagationFileBufferReading.dat"};
-  auto testWithParser = [&]<typename Parser>(bool useBatchInterface,
-                                             ad_utility::MemorySize bufferSize,
-                                             std::string_view input) {
-    {
-      auto of = ad_utility::makeOfstream(filename);
-      of << input;
-    }
-    AD_EXPECT_THROW_WITH_MESSAGE(
-        (parseFromFile<Parser>(filename, useBatchInterface, bufferSize)),
-        ::testing::HasSubstr("'--parse-parallel false'"));
-    ad_utility::deleteFile(filename);
-  };
-  std::string inputWithScatteredPrefix =
-      "@prefix ex: <http://example.org/> . \n"
-      "<subject1> <predicate1> <object1> . \n "
-      "<subject2> <predicate2> <object2> . \n"
-      "@prefix ex: <http://example.org/> . \n";
-  forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
-  std::string inputWithScatteredSparqlPrefix =
-      "PREFIX ex: <http://example.org/> . \n"
-      "<subject1> <predicate1> <object1> . \n "
-      "<subject2> <predicate2> <object2> . \n"
-      "PREFIX ex: <http://example.org/> . \n";
-  forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
-  std::string inputWithScatteredBase =
-      "@base <http://example.org/> . \n"
-      "<subject1> <predicate1> <object1> . \n "
-      "<subject2> <predicate2> <object2> . \n"
-      "@base <http://example.org/> . \n";
-  forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
-  std::string inputWithScatteredSparqlBase =
-      "BASE <http://example.org/> . \n"
-      "<subject1> <predicate1> <object1> . \n "
-      "<subject2> <predicate2> <object2> . \n"
-      "BASE <http://example.org/> . \n";
-  forAllParallelParsers(testWithParser, 40_B, inputWithScatteredPrefix);
 }
 
 // Test that the parallel parser's destructor can be run quickly and without


### PR DESCRIPTION
This reverts commit 8678731edf09615c066f682b53d9660784388529, which breaks the index build, see https://github.com/ad-freiburg/qlever-control/issues/139