### PR TITLE
Implement `Union` that can keep sort order

### DIFF
--- a/src/engine/QueryExecutionTree.cpp
+++ b/src/engine/QueryExecutionTree.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "engine/Sort.h"
+#include "engine/Union.h"
 #include "global/RuntimeParameters.h"
 
 using std::string;
@@ -164,7 +165,14 @@ std::shared_ptr<QueryExecutionTree> QueryExecutionTree::createSortedTree(
     return qet;
   }
 
+  // Push down sort into Union.
   QueryExecutionContext* qec = qet->getRootOperation()->getExecutionContext();
+  if (auto unionOperation =
+          std::dynamic_pointer_cast<Union>(qet->getRootOperation())) {
+    return std::make_shared<QueryExecutionTree>(
+        qec, unionOperation->createSortedVariant(sortColumns));
+  }
+
   auto sort = std::make_shared<Sort>(qec, std::move(qet), sortColumns);
   return std::make_shared<QueryExecutionTree>(qec, std::move(sort));
 }

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -1,0 +1,229 @@
+//   Copyright 2025, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#pragma once
+
+#include <optional>
+
+#include "engine/LocalVocab.h"
+#include "engine/Result.h"
+#include "engine/Union.h"
+#include "engine/idTable/IdTable.h"
+
+// Helper struct that has the same layout as Result::IdTableVocabPair but
+// doesn't own the data.
+struct Wrapper {
+  const IdTable& idTable_;
+  const LocalVocab& localVocab_;
+};
+
+// Move the data from a real `Result::IdTableVocabPair`.
+inline Result::IdTableVocabPair moveOrCopy(Result::IdTableVocabPair& element) {
+  return std::move(element);
+}
+
+// Copy the data from a `Wrapper`.
+inline Result::IdTableVocabPair moveOrCopy(const Wrapper& element) {
+  return {element.idTable_.clone(), element.localVocab_.clone()};
+}
+
+// Range that performs a zipper merge of two sorted ranges.
+template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
+struct SortedUnionImpl
+    : ad_utility::InputRangeFromGet<Result::IdTableVocabPair> {
+  std::shared_ptr<const Result> result1_;
+  std::shared_ptr<const Result> result2_;
+  Range1 range1_;
+  std::optional<typename Range1::iterator> it1_ = std::nullopt;
+  size_t index1_ = 0;
+  Range2 range2_;
+  std::optional<typename Range2::iterator> it2_ = std::nullopt;
+  size_t index2_ = 0;
+  IdTable resultTable_;
+  LocalVocab localVocab_{};
+  ad_utility::AllocatorWithLimit<Id> allocator_;
+  bool requestLaziness_;
+  std::vector<std::array<size_t, 2>> columnOrigins_;
+  std::vector<ColumnIndex> leftPermutation_;
+  std::vector<ColumnIndex> rightPermutation_;
+  std::vector<std::array<size_t, 2>> targetOrder_;
+  Func applyPermutation_;
+  bool aggregatedTableReturned_ = false;
+
+  SortedUnionImpl(std::shared_ptr<const Result> result1,
+                  std::shared_ptr<const Result> result2, Range1 range1,
+                  Range2 range2, bool requestLaziness,
+                  const std::vector<std::array<size_t, 2>>& columnOrigins,
+                  const ad_utility::AllocatorWithLimit<Id>& allocator,
+                  std::vector<ColumnIndex> leftPermutation,
+                  std::vector<ColumnIndex> rightPermutation,
+                  std::span<const ColumnIndex, SPAN_SIZE> comparatorView,
+                  Func applyPermutation)
+      : result1_{std::move(result1)},
+        result2_{std::move(result2)},
+        range1_{std::move(range1)},
+        range2_{std::move(range2)},
+        resultTable_{columnOrigins.size(), allocator},
+        allocator_{allocator},
+        requestLaziness_{requestLaziness},
+        columnOrigins_{columnOrigins},
+        leftPermutation_{std::move(leftPermutation)},
+        rightPermutation_{std::move(rightPermutation)},
+        applyPermutation_{std::move(applyPermutation)} {
+    if (requestLaziness) {
+      resultTable_.reserve(Union::chunkSize);
+    }
+    targetOrder_.reserve(comparatorView.size());
+    for (auto& col : comparatorView) {
+      targetOrder_.push_back(columnOrigins_.at(col));
+    }
+  }
+
+  // _____________________________________________________________________________
+  // Always inline makes makes a huge difference on large datasets.
+  AD_ALWAYS_INLINE bool isSmaller(const auto& row1, const auto& row2) const {
+    using StaticRange = std::span<const std::array<size_t, 2>, SPAN_SIZE>;
+    for (auto [index1, index2] : StaticRange{targetOrder_}) {
+      if (index1 == Union::NO_COLUMN) {
+        return true;
+      }
+      if (index2 == Union::NO_COLUMN) {
+        return false;
+      }
+      if (row1[index1] != row2[index2]) {
+        return row1[index1] < row2[index2];
+      }
+    }
+    return false;
+  }
+
+  // _____________________________________________________________________________
+  std::optional<Result::IdTableVocabPair> passNext(
+      const std::vector<ColumnIndex>& permutation, auto& it, auto end,
+      size_t& index) {
+    if (it != end) {
+      Result::IdTableVocabPair pair = moveOrCopy(*it);
+      pair.idTable_ = applyPermutation_(std::move(pair.idTable_), permutation);
+
+      index = 0;
+      ++it;
+      return pair;
+    }
+    return std::nullopt;
+  }
+
+  // ___________________________________________________________________________
+  void appendCurrent(const std::vector<ColumnIndex>& permutation, auto& it,
+                     size_t& index) {
+    resultTable_.insertAtEnd(it->idTable_, index, std::nullopt, permutation,
+                             Id::makeUndefined());
+    localVocab_.mergeWith(std::span{&it->localVocab_, 1});
+    index = 0;
+    ++it;
+  }
+
+  // ___________________________________________________________________________
+  void appendRemaining(const std::vector<ColumnIndex>& permutation, auto& it,
+                       auto end, size_t& index) {
+    while (it != end) {
+      appendCurrent(permutation, it, index);
+    }
+  }
+
+  // ___________________________________________________________________________
+  void pushRow(bool left, const auto& row) {
+    resultTable_.emplace_back();
+    for (size_t column = 0; column < resultTable_.numColumns(); column++) {
+      ColumnIndex origin = columnOrigins_.at(column).at(!left);
+      resultTable_.at(resultTable_.size() - 1, column) =
+          origin == Union::NO_COLUMN ? Id::makeUndefined() : row[origin];
+    }
+  }
+
+  // ___________________________________________________________________________
+  void advanceRangeIfConsumed() {
+    if (index1_ == it1_.value()->idTable_.size()) {
+      ++it1_.value();
+      index1_ = 0;
+    }
+    if (index2_ == it2_.value()->idTable_.size()) {
+      ++it2_.value();
+      index2_ = 0;
+    }
+  }
+
+  // ___________________________________________________________________________
+  Result::IdTableVocabPair popResult() {
+    auto result = Result::IdTableVocabPair{std::move(resultTable_),
+                                           std::move(localVocab_)};
+    resultTable_ = IdTable{resultTable_.numColumns(), allocator_};
+    resultTable_.reserve(Union::chunkSize);
+    localVocab_ = LocalVocab{};
+    return result;
+  }
+
+  // ___________________________________________________________________________
+  std::optional<Result::IdTableVocabPair> get() override {
+    if (aggregatedTableReturned_) {
+      return std::nullopt;
+    }
+    if (!it1_.has_value()) {
+      it1_ = range1_.begin();
+    }
+    if (!it2_.has_value()) {
+      it2_ = range2_.begin();
+    }
+    while (it1_ != range1_.end() && it2_ != range2_.end()) {
+      auto& idTable1 = it1_.value()->idTable_;
+      auto& idTable2 = it2_.value()->idTable_;
+      localVocab_.mergeWith(std::span{&it1_.value()->localVocab_, 1});
+      localVocab_.mergeWith(std::span{&it2_.value()->localVocab_, 1});
+      while (index1_ < idTable1.size() && index2_ < idTable2.size()) {
+        if (isSmaller(idTable1.at(index1_), idTable2.at(index2_))) {
+          pushRow(true, idTable1.at(index1_));
+          index1_++;
+        } else {
+          pushRow(false, idTable2.at(index2_));
+          index2_++;
+        }
+        if (requestLaziness_ && resultTable_.size() >= Union::chunkSize) {
+          auto result = popResult();
+          advanceRangeIfConsumed();
+          return result;
+        }
+      }
+      advanceRangeIfConsumed();
+    }
+    if (requestLaziness_) {
+      if (index1_ != 0) {
+        appendCurrent(leftPermutation_, it1_.value(), index1_);
+      }
+      if (index2_ != 0) {
+        appendCurrent(rightPermutation_, it2_.value(), index2_);
+      }
+      if (!resultTable_.empty()) {
+        return Result::IdTableVocabPair{std::move(resultTable_),
+                                        std::move(localVocab_)};
+      }
+      auto leftTable =
+          passNext(leftPermutation_, it1_.value(), range1_.end(), index1_);
+      return leftTable.has_value() ? std::move(leftTable)
+                                   : passNext(rightPermutation_, it2_.value(),
+                                              range2_.end(), index2_);
+    }
+    appendRemaining(leftPermutation_, it1_.value(), range1_.end(), index1_);
+    appendRemaining(rightPermutation_, it2_.value(), range2_.end(), index2_);
+    aggregatedTableReturned_ = true;
+    return Result::IdTableVocabPair{std::move(resultTable_),
+                                    std::move(localVocab_)};
+  }
+};
+
+template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
+SortedUnionImpl(std::shared_ptr<const Result>, std::shared_ptr<const Result>,
+                Range1, Range2, bool, const std::vector<std::array<size_t, 2>>&,
+                const ad_utility::AllocatorWithLimit<Id>&,
+                std::vector<ColumnIndex>, std::vector<ColumnIndex>,
+                std::span<const ColumnIndex, SPAN_SIZE>, Func)
+    -> SortedUnionImpl<SPAN_SIZE, Range1, Range2, Func>;

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -163,7 +163,7 @@ struct SortedUnionImpl
     }
   }
 
-  // Retreive the current result from `resultTable_` and `localVocab_` and reset
+  // Retrieve the current result from `resultTable_` and `localVocab_` and reset
   // those members back to their initial value so the next operation can
   // continue adding values.
   Result::IdTableVocabPair popResult() {

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -11,6 +11,7 @@
 #include "engine/Union.h"
 #include "engine/idTable/IdTable.h"
 
+namespace sortedUnion {
 // Helper struct that has the same layout as Result::IdTableVocabPair but
 // doesn't own the data.
 struct Wrapper {
@@ -28,19 +29,74 @@ inline Result::IdTableVocabPair moveOrCopy(const Wrapper& element) {
   return {element.idTable_.clone(), element.localVocab_.clone()};
 }
 
+// Represent one range of tables to be merged.
+template <typename Range>
+struct IterationData {
+  std::shared_ptr<const Result> result_;
+  Range range_;
+  std::vector<ColumnIndex> permutation_;
+  std::optional<typename Range::iterator> it_ = std::nullopt;
+  size_t index_ = 0;
+
+  // Call begin on the iterator if it hasn't been called yet.
+  void initIfNotStarted() {
+    if (!it_.has_value()) {
+      it_ = range_.begin();
+    }
+  }
+
+  // Fetch the next element from the range, make a copy if it's a `Wrapper`.
+  // Otherwise move it. If the range is exhausted, return `std::nullopt`.
+  std::optional<Result::IdTableVocabPair> passNext(auto applyPermutation) {
+    if (it_ == range_.end()) {
+      return std::nullopt;
+    }
+    Result::IdTableVocabPair pair = moveOrCopy(*it_.value());
+    pair.idTable_ = applyPermutation(std::move(pair.idTable_), permutation_);
+
+    index_ = 0;
+    ++it_.value();
+    return pair;
+  }
+
+  // Append the remainder of the last partially consumed table to the current
+  // result table and merge the local vocabs.
+  void appendCurrent(IdTable& resultTable, LocalVocab& localVocab) {
+    resultTable.insertAtEnd(it_.value()->idTable_, index_, std::nullopt,
+                            permutation_, Id::makeUndefined());
+    localVocab.mergeWith(std::span{&it_.value()->localVocab_, 1});
+    index_ = 0;
+    ++it_.value();
+  }
+
+  // For the non-lazy case just append the remaining tables to the aggregated
+  // result table until the range is exhausted.
+  void appendRemaining(IdTable& resultTable, LocalVocab& localVocab) {
+    while (it_ != range_.end()) {
+      appendCurrent(resultTable, localVocab);
+    }
+  }
+
+  // Increment the iterator if the last table has been fully consumed.
+  void advanceRangeIfConsumed() {
+    if (index_ == it_.value()->idTable_.size()) {
+      ++it_.value();
+      index_ = 0;
+    }
+  }
+};
+
+template <typename Range>
+IterationData(std::shared_ptr<const Result>, Range, std::vector<ColumnIndex>)
+    -> IterationData<Range>;
+
 // Range that performs a zipper merge of two sorted ranges.
 template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
 struct SortedUnionImpl
     : ad_utility::InputRangeFromGet<Result::IdTableVocabPair> {
   // Iterator and range storage.
-  std::shared_ptr<const Result> result1_;
-  std::shared_ptr<const Result> result2_;
-  Range1 range1_;
-  std::optional<typename Range1::iterator> it1_ = std::nullopt;
-  size_t index1_ = 0;
-  Range2 range2_;
-  std::optional<typename Range2::iterator> it2_ = std::nullopt;
-  size_t index2_ = 0;
+  IterationData<Range1> data1_;
+  IterationData<Range2> data2_;
 
   // Result storage.
   IdTable resultTable_;
@@ -50,32 +106,24 @@ struct SortedUnionImpl
   ad_utility::AllocatorWithLimit<Id> allocator_;
   bool requestLaziness_;
   std::vector<std::array<size_t, 2>> columnOrigins_;
-  std::vector<ColumnIndex> leftPermutation_;
-  std::vector<ColumnIndex> rightPermutation_;
   std::vector<std::array<size_t, 2>> targetOrder_;
-  bool aggregatedTableReturned_ = false;
+  // Only being used when `requestLaziness_` is false.
+  bool done_ = false;
   // Function forwarded from `Union`
   Func applyPermutation_;
 
-  SortedUnionImpl(std::shared_ptr<const Result> result1,
-                  std::shared_ptr<const Result> result2, Range1 range1,
-                  Range2 range2, bool requestLaziness,
+  SortedUnionImpl(IterationData<Range1> data1, IterationData<Range2> data2,
+                  bool requestLaziness,
                   const std::vector<std::array<size_t, 2>>& columnOrigins,
                   const ad_utility::AllocatorWithLimit<Id>& allocator,
-                  std::vector<ColumnIndex> leftPermutation,
-                  std::vector<ColumnIndex> rightPermutation,
                   std::span<const ColumnIndex, SPAN_SIZE> comparatorView,
                   Func applyPermutation)
-      : result1_{std::move(result1)},
-        result2_{std::move(result2)},
-        range1_{std::move(range1)},
-        range2_{std::move(range2)},
+      : data1_{std::move(data1)},
+        data2_{std::move(data2)},
         resultTable_{columnOrigins.size(), allocator},
         allocator_{allocator},
         requestLaziness_{requestLaziness},
         columnOrigins_{columnOrigins},
-        leftPermutation_{std::move(leftPermutation)},
-        rightPermutation_{std::move(rightPermutation)},
         applyPermutation_{std::move(applyPermutation)} {
     if (requestLaziness) {
       resultTable_.reserve(Union::chunkSize);
@@ -103,42 +151,6 @@ struct SortedUnionImpl
     return false;
   }
 
-  // Fetch the next element from the range, make a copy if it's a `Wrapper`.
-  // Otherwise move it. If the range is exhausted, return `std::nullopt`.
-  std::optional<Result::IdTableVocabPair> passNext(
-      const std::vector<ColumnIndex>& permutation, auto& it, auto end,
-      size_t& index) {
-    if (it != end) {
-      Result::IdTableVocabPair pair = moveOrCopy(*it);
-      pair.idTable_ = applyPermutation_(std::move(pair.idTable_), permutation);
-
-      index = 0;
-      ++it;
-      return pair;
-    }
-    return std::nullopt;
-  }
-
-  // Append the remainder of the last partially consumed table to the current
-  // result table and merge the local vocabs.
-  void appendCurrent(const std::vector<ColumnIndex>& permutation, auto& it,
-                     size_t& index) {
-    resultTable_.insertAtEnd(it->idTable_, index, std::nullopt, permutation,
-                             Id::makeUndefined());
-    localVocab_.mergeWith(std::span{&it->localVocab_, 1});
-    index = 0;
-    ++it;
-  }
-
-  // For the non-lazy case just append the remaining tables to the aggregated
-  // result table until the range is exhausted.
-  void appendRemaining(const std::vector<ColumnIndex>& permutation, auto& it,
-                       auto end, size_t& index) {
-    while (it != end) {
-      appendCurrent(permutation, it, index);
-    }
-  }
-
   // Write a new row to the result table. The parameter `left` controls which
   // permutation is used to write the row to the result table.
   void pushRow(bool left, const auto& row) {
@@ -153,14 +165,8 @@ struct SortedUnionImpl
   // Increment the iterators if the current id table is fully processed and
   // reset the index back to zero.
   void advanceRangeIfConsumed() {
-    if (index1_ == it1_.value()->idTable_.size()) {
-      ++it1_.value();
-      index1_ = 0;
-    }
-    if (index2_ == it2_.value()->idTable_.size()) {
-      ++it2_.value();
-      index2_ = 0;
-    }
+    data1_.advanceRangeIfConsumed();
+    data2_.advanceRangeIfConsumed();
   }
 
   // Retrieve the current result from `resultTable_` and `localVocab_` and reset
@@ -177,27 +183,26 @@ struct SortedUnionImpl
 
   // ___________________________________________________________________________
   std::optional<Result::IdTableVocabPair> get() override {
-    if (aggregatedTableReturned_) {
+    if (done_) {
       return std::nullopt;
     }
-    if (!it1_.has_value()) {
-      it1_ = range1_.begin();
-    }
-    if (!it2_.has_value()) {
-      it2_ = range2_.begin();
-    }
-    while (it1_ != range1_.end() && it2_ != range2_.end()) {
-      auto& idTable1 = it1_.value()->idTable_;
-      auto& idTable2 = it2_.value()->idTable_;
-      localVocab_.mergeWith(std::span{&it1_.value()->localVocab_, 1});
-      localVocab_.mergeWith(std::span{&it2_.value()->localVocab_, 1});
-      while (index1_ < idTable1.size() && index2_ < idTable2.size()) {
-        if (isSmaller(idTable1.at(index1_), idTable2.at(index2_))) {
-          pushRow(true, idTable1.at(index1_));
-          index1_++;
+    data1_.initIfNotStarted();
+    data2_.initIfNotStarted();
+    while (data1_.it_ != data1_.range_.end() &&
+           data2_.it_ != data2_.range_.end()) {
+      auto& idTable1 = data1_.it_.value()->idTable_;
+      auto& idTable2 = data2_.it_.value()->idTable_;
+      localVocab_.mergeWith(std::span{&data1_.it_.value()->localVocab_, 1});
+      localVocab_.mergeWith(std::span{&data2_.it_.value()->localVocab_, 1});
+      size_t& index1 = data1_.index_;
+      size_t& index2 = data2_.index_;
+      while (index1 < idTable1.size() && index2 < idTable2.size()) {
+        if (isSmaller(idTable1.at(index1), idTable2.at(index2))) {
+          pushRow(true, idTable1.at(index1));
+          index1++;
         } else {
-          pushRow(false, idTable2.at(index2_));
-          index2_++;
+          pushRow(false, idTable2.at(index2));
+          index2++;
         }
         if (requestLaziness_ && resultTable_.size() >= Union::chunkSize) {
           auto result = popResult();
@@ -208,34 +213,32 @@ struct SortedUnionImpl
       advanceRangeIfConsumed();
     }
     if (requestLaziness_) {
-      if (index1_ != 0) {
-        appendCurrent(leftPermutation_, it1_.value(), index1_);
+      if (data1_.index_ != 0) {
+        data1_.appendCurrent(resultTable_, localVocab_);
       }
-      if (index2_ != 0) {
-        appendCurrent(rightPermutation_, it2_.value(), index2_);
+      if (data2_.index_ != 0) {
+        data2_.appendCurrent(resultTable_, localVocab_);
       }
       if (!resultTable_.empty()) {
         return Result::IdTableVocabPair{std::move(resultTable_),
                                         std::move(localVocab_)};
       }
-      auto leftTable =
-          passNext(leftPermutation_, it1_.value(), range1_.end(), index1_);
+      auto leftTable = data1_.passNext(applyPermutation_);
       return leftTable.has_value() ? std::move(leftTable)
-                                   : passNext(rightPermutation_, it2_.value(),
-                                              range2_.end(), index2_);
+                                   : data2_.passNext(applyPermutation_);
     }
-    appendRemaining(leftPermutation_, it1_.value(), range1_.end(), index1_);
-    appendRemaining(rightPermutation_, it2_.value(), range2_.end(), index2_);
-    aggregatedTableReturned_ = true;
+    data1_.appendRemaining(resultTable_, localVocab_);
+    data2_.appendRemaining(resultTable_, localVocab_);
+    done_ = true;
     return Result::IdTableVocabPair{std::move(resultTable_),
                                     std::move(localVocab_)};
   }
 };
 
 template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
-SortedUnionImpl(std::shared_ptr<const Result>, std::shared_ptr<const Result>,
-                Range1, Range2, bool, const std::vector<std::array<size_t, 2>>&,
+SortedUnionImpl(IterationData<Range1>, IterationData<Range2>, bool,
+                const std::vector<std::array<size_t, 2>>&,
                 const ad_utility::AllocatorWithLimit<Id>&,
-                std::vector<ColumnIndex>, std::vector<ColumnIndex>,
                 std::span<const ColumnIndex, SPAN_SIZE>, Func)
     -> SortedUnionImpl<SPAN_SIZE, Range1, Range2, Func>;
+}  // namespace sortedUnion

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -7,7 +7,7 @@
 
 #include "engine/CallFixedSize.h"
 #include "util/ChunkedForLoop.h"
-#include "util/TransparentFunctors.h"
+#include "util/CompilerWarnings.h"
 
 const size_t Union::NO_COLUMN = std::numeric_limits<size_t>::max();
 
@@ -498,6 +498,9 @@ Result::Generator Union::computeResultKeepOrder(
                          ? Range{std::array{Wrapper{result2->idTable(),
                                                     result2->localVocab()}}}
                          : Range{std::move(result2->idTables())};
+
+  // Clang falsely reports that the this capture is unused here.
+  DISABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS
   return std::visit(
       [this, requestLaziness, &result1, &result2](auto leftRange,
                                                   auto rightRange) {
@@ -511,4 +514,5 @@ Result::Generator Union::computeResultKeepOrder(
             });
       },
       std::move(leftRange), std::move(rightRange));
+  ENABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS
 }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -356,8 +356,10 @@ Result::IdTableVocabPair moveOrCopy(const Wrapper& element) {
 }  // namespace
 
 // _____________________________________________________________________________
+// Always inline makes makes a huge difference on large datasets.
 template <size_t SPAN_SIZE>
-bool Union::isSmaller(const auto& row1, const auto& row2) const {
+AD_ALWAYS_INLINE bool Union::isSmaller(const auto& row1,
+                                       const auto& row2) const {
   using StaticRange = std::span<const ColumnIndex, SPAN_SIZE>;
   for (auto& col : StaticRange{targetOrder_}) {
     ColumnIndex index1 = _columnOrigins.at(col).at(0);

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -379,19 +379,19 @@ Result::LazyResult Union::computeResultKeepOrder(
 
   return std::visit(
       [this, requestLaziness, &result1, &result2, &trimmedTargetOrder,
-       &applyPermutation](auto leftRange, auto rightRange) {
+       &applyPermutation](auto left, auto right) {
         return ad_utility::callFixedSize(
             trimmedTargetOrder.size(),
-            [this, requestLaziness, &result1, &result2, &leftRange, &rightRange,
+            [this, requestLaziness, &result1, &result2, &left, &right,
              &trimmedTargetOrder, &applyPermutation]<int COMPARATOR_WIDTH>() {
               constexpr size_t extent = COMPARATOR_WIDTH == 0
                                             ? std::dynamic_extent
                                             : COMPARATOR_WIDTH;
               sortedUnion::IterationData leftData{std::move(result1),
-                                                  std::move(leftRange),
+                                                  std::move(left),
                                                   computePermutation<true>()};
               sortedUnion::IterationData rightData{std::move(result2),
-                                                   std::move(rightRange),
+                                                   std::move(right),
                                                    computePermutation<false>()};
               return Result::LazyResult{sortedUnion::SortedUnionImpl{
                   std::move(leftData), std::move(rightData), requestLaziness,

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -373,6 +373,7 @@ struct SortedUnionImpl
   std::vector<ColumnIndex> rightPermutation_;
   std::vector<std::array<size_t, 2>> targetOrder_;
   Func applyPermutation_;
+  bool aggregatedTableReturned_ = false;
 
   SortedUnionImpl(std::shared_ptr<const Result> result1,
                   std::shared_ptr<const Result> result2, Range1 range1,
@@ -489,6 +490,9 @@ struct SortedUnionImpl
 
   // ___________________________________________________________________________
   std::optional<Result::IdTableVocabPair> get() override {
+    if (aggregatedTableReturned_) {
+      return std::nullopt;
+    }
     if (!it1_.has_value()) {
       it1_ = range1_.begin();
     }
@@ -533,9 +537,7 @@ struct SortedUnionImpl
     }
     appendRemaining(leftPermutation_, it1_.value(), range1_.end(), index1_);
     appendRemaining(rightPermutation_, it2_.value(), range2_.end(), index2_);
-    if (resultTable_.empty()) {
-      return std::nullopt;
-    }
+    aggregatedTableReturned_ = true;
     return Result::IdTableVocabPair{std::move(resultTable_),
                                     std::move(localVocab_)};
   }

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -66,6 +66,8 @@ Union::Union(QueryExecutionContext* qec,
 
     // Swap children to get cheaper computation
     if (_columnOrigins.at(targetOrder_.at(0)).at(1) == NO_COLUMN) {
+      // Make sure variables are computed before swapping.
+      (void)getExternallyVisibleVariableColumns();
       std::swap(_subtrees[0], _subtrees[1]);
       ql::ranges::for_each(_columnOrigins,
                            [](auto& el) { std::swap(el[0], el[1]); });

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -375,7 +375,7 @@ bool Union::isSmaller(const auto& row1, const auto& row2) const {
 
 // _____________________________________________________________________________
 Result::Generator Union::processRemaining(std::vector<ColumnIndex> permutation,
-                                          auto& it, const auto& end,
+                                          auto& it, auto end,
                                           bool requestLaziness, size_t index,
                                           IdTable& resultTable,
                                           LocalVocab& localVocab) const {

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -6,8 +6,8 @@
 #include "Union.h"
 
 #include "engine/CallFixedSize.h"
+#include "engine/SortedUnionImpl.h"
 #include "util/ChunkedForLoop.h"
-#include "util/CompilerWarnings.h"
 
 const size_t Union::NO_COLUMN = std::numeric_limits<size_t>::max();
 
@@ -341,209 +341,6 @@ std::shared_ptr<Operation> Union::createSortedVariant(
                                  _subtrees.at(1), sortOrder);
 }
 
-namespace {
-struct Wrapper {
-  const IdTable& idTable_;
-  const LocalVocab& localVocab_;
-};
-Result::IdTableVocabPair moveOrCopy(Result::IdTableVocabPair& element) {
-  return std::move(element);
-}
-Result::IdTableVocabPair moveOrCopy(const Wrapper& element) {
-  return {element.idTable_.clone(), element.localVocab_.clone()};
-}
-
-template <size_t SPAN_SIZE, typename Range1, typename Range2, typename Func>
-struct SortedUnionImpl
-    : ad_utility::InputRangeFromGet<Result::IdTableVocabPair> {
-  std::shared_ptr<const Result> result1_;
-  std::shared_ptr<const Result> result2_;
-  Range1 range1_;
-  std::optional<typename Range1::iterator> it1_ = std::nullopt;
-  size_t index1_ = 0;
-  Range2 range2_;
-  std::optional<typename Range2::iterator> it2_ = std::nullopt;
-  size_t index2_ = 0;
-  IdTable resultTable_;
-  LocalVocab localVocab_{};
-  ad_utility::AllocatorWithLimit<Id> allocator_;
-  bool requestLaziness_;
-  std::vector<std::array<size_t, 2>> columnOrigins_;
-  std::vector<ColumnIndex> leftPermutation_;
-  std::vector<ColumnIndex> rightPermutation_;
-  std::vector<std::array<size_t, 2>> targetOrder_;
-  Func applyPermutation_;
-  bool aggregatedTableReturned_ = false;
-
-  SortedUnionImpl(std::shared_ptr<const Result> result1,
-                  std::shared_ptr<const Result> result2, Range1 range1,
-                  Range2 range2, bool requestLaziness,
-                  const std::vector<std::array<size_t, 2>>& columnOrigins,
-                  const ad_utility::AllocatorWithLimit<Id>& allocator,
-                  std::vector<ColumnIndex> leftPermutation,
-                  std::vector<ColumnIndex> rightPermutation,
-                  std::span<const ColumnIndex, SPAN_SIZE> comparatorView,
-                  Func applyPermutation)
-      : result1_{std::move(result1)},
-        result2_{std::move(result2)},
-        range1_{std::move(range1)},
-        range2_{std::move(range2)},
-        resultTable_{columnOrigins.size(), allocator},
-        allocator_{allocator},
-        requestLaziness_{requestLaziness},
-        columnOrigins_{columnOrigins},
-        leftPermutation_{std::move(leftPermutation)},
-        rightPermutation_{std::move(rightPermutation)},
-        applyPermutation_{std::move(applyPermutation)} {
-    if (requestLaziness) {
-      resultTable_.reserve(Union::chunkSize);
-    }
-    targetOrder_.reserve(comparatorView.size());
-    for (auto& col : comparatorView) {
-      targetOrder_.push_back(columnOrigins_.at(col));
-    }
-  }
-
-  // _____________________________________________________________________________
-  // Always inline makes makes a huge difference on large datasets.
-  AD_ALWAYS_INLINE bool isSmaller(const auto& row1, const auto& row2) const {
-    using StaticRange = std::span<const std::array<size_t, 2>, SPAN_SIZE>;
-    for (auto [index1, index2] : StaticRange{targetOrder_}) {
-      if (index1 == Union::NO_COLUMN) {
-        return true;
-      }
-      if (index2 == Union::NO_COLUMN) {
-        return false;
-      }
-      if (row1[index1] != row2[index2]) {
-        return row1[index1] < row2[index2];
-      }
-    }
-    return false;
-  }
-
-  // _____________________________________________________________________________
-  std::optional<Result::IdTableVocabPair> passNext(
-      const std::vector<ColumnIndex>& permutation, auto& it, auto end,
-      size_t& index) {
-    if (it != end) {
-      Result::IdTableVocabPair pair = moveOrCopy(*it);
-      pair.idTable_ = applyPermutation_(std::move(pair.idTable_), permutation);
-
-      index = 0;
-      ++it;
-      return pair;
-    }
-    return std::nullopt;
-  }
-
-  // ___________________________________________________________________________
-  void appendCurrent(const std::vector<ColumnIndex>& permutation, auto& it,
-                     size_t& index) {
-    resultTable_.insertAtEnd(it->idTable_, index, std::nullopt, permutation,
-                             Id::makeUndefined());
-    localVocab_.mergeWith(std::span{&it->localVocab_, 1});
-    index = 0;
-    ++it;
-  }
-
-  // ___________________________________________________________________________
-  void appendRemaining(const std::vector<ColumnIndex>& permutation, auto& it,
-                       auto end, size_t& index) {
-    while (it != end) {
-      appendCurrent(permutation, it, index);
-    }
-  }
-
-  // ___________________________________________________________________________
-  void pushRow(bool left, const auto& row) {
-    resultTable_.emplace_back();
-    for (size_t column = 0; column < resultTable_.numColumns(); column++) {
-      ColumnIndex origin = columnOrigins_.at(column).at(!left);
-      resultTable_.at(resultTable_.size() - 1, column) =
-          origin == Union::NO_COLUMN ? Id::makeUndefined() : row[origin];
-    }
-  }
-
-  // ___________________________________________________________________________
-  void advanceRangeIfConsumed() {
-    if (index1_ == it1_.value()->idTable_.size()) {
-      ++it1_.value();
-      index1_ = 0;
-    }
-    if (index2_ == it2_.value()->idTable_.size()) {
-      ++it2_.value();
-      index2_ = 0;
-    }
-  }
-
-  // ___________________________________________________________________________
-  Result::IdTableVocabPair popResult() {
-    auto result = Result::IdTableVocabPair{std::move(resultTable_),
-                                           std::move(localVocab_)};
-    resultTable_ = IdTable{resultTable_.numColumns(), allocator_};
-    resultTable_.reserve(Union::chunkSize);
-    localVocab_ = LocalVocab{};
-    advanceRangeIfConsumed();
-    return result;
-  }
-
-  // ___________________________________________________________________________
-  std::optional<Result::IdTableVocabPair> get() override {
-    if (aggregatedTableReturned_) {
-      return std::nullopt;
-    }
-    if (!it1_.has_value()) {
-      it1_ = range1_.begin();
-    }
-    if (!it2_.has_value()) {
-      it2_ = range2_.begin();
-    }
-    while (it1_ != range1_.end() && it2_ != range2_.end()) {
-      auto& idTable1 = it1_.value()->idTable_;
-      auto& idTable2 = it2_.value()->idTable_;
-      localVocab_.mergeWith(std::span{&it1_.value()->localVocab_, 1});
-      localVocab_.mergeWith(std::span{&it2_.value()->localVocab_, 1});
-      while (index1_ < idTable1.size() && index2_ < idTable2.size()) {
-        if (isSmaller(idTable1.at(index1_), idTable2.at(index2_))) {
-          pushRow(true, idTable1.at(index1_));
-          index1_++;
-        } else {
-          pushRow(false, idTable2.at(index2_));
-          index2_++;
-        }
-        if (requestLaziness_ && resultTable_.size() >= Union::chunkSize) {
-          return popResult();
-        }
-      }
-      advanceRangeIfConsumed();
-    }
-    if (requestLaziness_) {
-      if (index1_ != 0) {
-        appendCurrent(leftPermutation_, it1_.value(), index1_);
-      }
-      if (index2_ != 0) {
-        appendCurrent(rightPermutation_, it2_.value(), index2_);
-      }
-      if (!resultTable_.empty()) {
-        return Result::IdTableVocabPair{std::move(resultTable_),
-                                        std::move(localVocab_)};
-      }
-      auto leftTable =
-          passNext(leftPermutation_, it1_.value(), range1_.end(), index1_);
-      return leftTable.has_value() ? std::move(leftTable)
-                                   : passNext(rightPermutation_, it2_.value(),
-                                              range2_.end(), index2_);
-    }
-    appendRemaining(leftPermutation_, it1_.value(), range1_.end(), index1_);
-    appendRemaining(rightPermutation_, it2_.value(), range2_.end(), index2_);
-    aggregatedTableReturned_ = true;
-    return Result::IdTableVocabPair{std::move(resultTable_),
-                                    std::move(localVocab_)};
-  }
-};
-}  // namespace
-
 // _____________________________________________________________________________
 Result::LazyResult Union::computeResultKeepOrder(
     bool requestLaziness, std::shared_ptr<const Result> result1,
@@ -572,8 +369,8 @@ Result::LazyResult Union::computeResultKeepOrder(
 
   return std::visit(
       [this, requestLaziness, &result1, &result2, &trimmedTargetOrder,
-       &applyPermutation]<typename LR, typename RR>(
-          LR leftRange, RR rightRange) -> Result::LazyResult {
+       &applyPermutation]<typename LR, typename RR>(LR leftRange,
+                                                    RR rightRange) {
         return ad_utility::callFixedSize(
             trimmedTargetOrder.size(),
             [this, requestLaziness, &result1, &result2, &leftRange, &rightRange,
@@ -581,14 +378,13 @@ Result::LazyResult Union::computeResultKeepOrder(
               constexpr size_t extent = COMPARATOR_WIDTH == 0
                                             ? std::dynamic_extent
                                             : COMPARATOR_WIDTH;
-              return Result::LazyResult{
-                  SortedUnionImpl<extent, LR, RR, decltype(applyPermutation)>(
-                      std::move(result1), std::move(result2),
-                      std::move(leftRange), std::move(rightRange),
-                      requestLaziness, _columnOrigins, allocator(),
-                      computePermutation<true>(), computePermutation<false>(),
-                      std::span<const ColumnIndex, extent>{trimmedTargetOrder},
-                      std::move(applyPermutation))};
+              return Result::LazyResult{SortedUnionImpl{
+                  std::move(result1), std::move(result2), std::move(leftRange),
+                  std::move(rightRange), requestLaziness, _columnOrigins,
+                  allocator(), computePermutation<true>(),
+                  computePermutation<false>(),
+                  std::span<const ColumnIndex, extent>{trimmedTargetOrder},
+                  std::move(applyPermutation)}};
             });
       },
       std::move(leftRange), std::move(rightRange));

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -393,7 +393,7 @@ Result::Generator Union::processRemaining(std::vector<ColumnIndex> permutation,
         co_yield Result::IdTableVocabPair{std::move(resultTable),
                                           std::move(localVocab)};
       } else {
-        if (resultTable.size() != 0) {
+        if (!resultTable.empty()) {
           co_yield Result::IdTableVocabPair{std::move(resultTable),
                                             std::move(localVocab)};
         }

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -99,6 +99,14 @@ class Union : public Operation {
   // Compares two rows with respect to the columns that the result is sorted on.
   bool isSmaller(const auto& row1, const auto& row2) const;
 
+  // Helper function for `computeResultKeepOrderImpl` that processes any
+  // remaining elements once one side is exhausted.
+  Result::Generator processRemaining(std::vector<ColumnIndex> permutation,
+                                     auto& it, const auto& end,
+                                     bool requestLaziness, size_t index,
+                                     IdTable& resultTable,
+                                     LocalVocab& localVocab) const;
+
   // Actual implementation of `computeResultKeepOrder`.
   Result::Generator computeResultKeepOrderImpl(
       bool requestLaziness, auto range1, auto range2,

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -97,6 +97,7 @@ class Union : public Operation {
       std::shared_ptr<const Result> result2) const;
 
   // Compares two rows with respect to the columns that the result is sorted on.
+  template <size_t SPAN_SIZE>
   bool isSmaller(const auto& row1, const auto& row2) const;
 
   // Helper function for `computeResultKeepOrderImpl` that processes any
@@ -107,6 +108,7 @@ class Union : public Operation {
                                      LocalVocab& localVocab) const;
 
   // Actual implementation of `computeResultKeepOrder`.
+  template <int COMPARATOR_WIDTH>
   Result::Generator computeResultKeepOrderImpl(
       bool requestLaziness, auto range1, auto range2,
       std::pair<std::shared_ptr<const Result>, std::shared_ptr<const Result>>

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -102,9 +102,8 @@ class Union : public Operation {
   // Helper function for `computeResultKeepOrderImpl` that processes any
   // remaining elements once one side is exhausted.
   Result::Generator processRemaining(std::vector<ColumnIndex> permutation,
-                                     auto& it, const auto& end,
-                                     bool requestLaziness, size_t index,
-                                     IdTable& resultTable,
+                                     auto& it, auto end, bool requestLaziness,
+                                     size_t index, IdTable& resultTable,
                                      LocalVocab& localVocab) const;
 
   // Actual implementation of `computeResultKeepOrder`.

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -99,32 +99,11 @@ class Union : public Operation {
       std::shared_ptr<const Result> result1,
       std::shared_ptr<const Result> result2) const;
 
-  // Return is `row1` is smaller than `row2` based on the columns set in
-  // `targetOrder_`.
-  template <size_t SPAN_SIZE>
-  bool isSmaller(const auto& row1, const auto& row2) const;
-
-  // Helper function for `computeResultKeepOrderImpl` that processes any
-  // remaining elements once one side is exhausted.
-  Result::Generator processRemaining(std::vector<ColumnIndex> permutation,
-                                     auto& it, auto end, bool requestLaziness,
-                                     size_t index, IdTable& resultTable,
-                                     LocalVocab& localVocab) const;
-
-  // Actual implementation of `computeResultKeepOrder`. The parameter
-  // `lifetimeExtension` is just responsible for keeping the results alive for
-  // the lifetime of the generator.
-  template <int COMPARATOR_WIDTH>
-  Result::Generator computeResultKeepOrderImpl(
-      bool requestLaziness, auto range1, auto range2,
-      std::pair<std::shared_ptr<const Result>, std::shared_ptr<const Result>>
-          lifetimeExtension) const;
-
   // Similar to `computeResultLazily` but it keeps the order of the results.
   // This means that instead of just returning the results of the left and right
   // child one after another, the results are merged in a way that the order of
   // the results is preserved.
-  Result::Generator computeResultKeepOrder(
+  Result::LazyResult computeResultKeepOrder(
       bool requestLaziness, std::shared_ptr<const Result> result1,
       std::shared_ptr<const Result> result2) const;
 };

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -733,7 +733,12 @@ class IdTable {
   // Add all entries from the `table` at the end of this IdTable.
   // If `beginIdx` and/or `endIdx` are specified, then only the subrange
   // `[beginIdx, endIdx)` from the input is taken.
-  // The input must be some kind of `IdTable`.
+  // The input must be some kind of `IdTable`. The parameter `permutation`
+  // allows the caller to apply a permutation to the columns of the input table
+  // before inserting them into this table. If the permutation is not specified,
+  // the columns are inserted in the order they appear in the input table. If
+  // the permutation contains an index that is out of bounds for the input
+  // table, the corresponding column is filled with the `defaultValue`.
   // TODO<joka921> Can/should we constraint this functions by a concept?
   template <typename Table>
   void insertAtEnd(

--- a/src/util/CompilerWarnings.h
+++ b/src/util/CompilerWarnings.h
@@ -18,14 +18,4 @@
 #define ENABLE_UNINITIALIZED_WARNINGS
 #endif
 
-#if defined(__clang__) && (__clang_major__ >= 16 && __clang_major__ <= 18)
-#define DISABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS \
-  _Pragma("clang diagnostic push")             \
-      _Pragma("clang diagnostic ignored \"-Wunused-lambda-capture\"")
-#define ENABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS _Pragma("clang diagnostic pop")
-#else
-#define DISABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS
-#define ENABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS
-#endif
-
 #endif  // QLEVER_COMPILERWARNINGS_H

--- a/src/util/CompilerWarnings.h
+++ b/src/util/CompilerWarnings.h
@@ -18,4 +18,14 @@
 #define ENABLE_UNINITIALIZED_WARNINGS
 #endif
 
+#if defined(__clang__) && (__clang_major__ >= 16 && __clang_major__ <= 18)
+#define DISABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS \
+  _Pragma("clang diagnostic push")             \
+      _Pragma("clang diagnostic ignored \"-Wunused-lambda-capture\"")
+#define ENABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS _Pragma("clang diagnostic pop")
+#else
+#define DISABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS
+#define ENABLE_UNUSED_LAMBDA_CAPTURE_WARNINGS
+#endif
+
 #endif  // QLEVER_COMPILERWARNINGS_H

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -414,10 +414,10 @@ class InputRangeTypeErased {
 // it.
 template <typename Range>
 ql::ranges::range_value_t<Range> getSingleElement(Range&& range) {
-  auto it = range.begin();
-  AD_CORRECTNESS_CHECK(it != range.end());
+  auto it = ql::ranges::begin(range);
+  AD_CORRECTNESS_CHECK(it != ql::ranges::end(range));
   ql::ranges::range_value_t<Range> t = std::move(*it);
-  AD_CORRECTNESS_CHECK(++it == range.end());
+  AD_CORRECTNESS_CHECK(++it == ql::ranges::end(range));
   return t;
 }
 }  // namespace ad_utility

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -408,4 +408,13 @@ class InputRangeTypeErased {
   decltype(auto) end() { return impl_->end(); }
   using iterator = typename InputRangeFromGet<ValueType>::Iterator;
 };
+
+template <typename Range>
+auto getSingleElement(Range g) {
+  auto it = g.begin();
+  AD_CORRECTNESS_CHECK(it != g.end());
+  auto t = std::move(*it);
+  AD_CORRECTNESS_CHECK(++it == g.end());
+  return t;
+}
 }  // namespace ad_utility

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -409,12 +409,15 @@ class InputRangeTypeErased {
   using iterator = typename InputRangeFromGet<ValueType>::Iterator;
 };
 
+// Analogous to `cppcoro::getSingleElement`, but generalized for all ranges.
+// Ensure that the range only contains a single element, move it out and return
+// it.
 template <typename Range>
-auto getSingleElement(Range g) {
-  auto it = g.begin();
-  AD_CORRECTNESS_CHECK(it != g.end());
-  auto t = std::move(*it);
-  AD_CORRECTNESS_CHECK(++it == g.end());
+ql::ranges::range_value_t<Range> getSingleElement(Range&& range) {
+  auto it = range.begin();
+  AD_CORRECTNESS_CHECK(it != range.end());
+  ql::ranges::range_value_t<Range> t = std::move(*it);
+  AD_CORRECTNESS_CHECK(++it == range.end());
   return t;
 }
 }  // namespace ad_utility

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -369,6 +369,45 @@ TEST(IdTable, insertAtEnd) {
   runTestForDifferentTypes<3>(runTestForIdTable, "idTableTest.insertAtEnd");
 }
 
+// _____________________________________________________________________________
+TEST(IdTable, insertAtEndWithPermutationAndLimit) {
+  // A lambda that is used as the `testCase` argument to the
+  // `runTestForDifferentTypes` function (see above for details).
+  auto runTestForIdTable = []<typename Table>(auto make,
+                                              auto... additionalArgs) {
+    Table init{4, std::move(additionalArgs.at(0))...};
+    init.push_back({make(7), make(2), make(4), make(1)});
+    init.push_back({make(0), make(22), make(1), make(4)});
+
+    Table t1{3, std::move(additionalArgs.at(1))...};
+    t1.push_back({make(1), make(0), make(6)});
+    t1.push_back({make(3), make(1), make(8)});
+    t1.push_back({make(0), make(6), make(8)});
+    t1.push_back({make(9), make(2), make(6)});
+
+    Table t2 = clone(init, std::move(additionalArgs.at(2))...);
+    std::vector<ColumnIndex> permutation{2, 1, 0, 3};
+    // Test inserting at the end
+    t2.insertAtEnd(t1, 1, 3, permutation, make(1337));
+    for (size_t i = 0; i < init.size(); i++) {
+      ASSERT_EQ(init[i], t2[i]) << i;
+    }
+    ASSERT_EQ(t2.size(), init.size() + 2);
+
+    EXPECT_EQ(t2.at(2, 0), make(8));
+    EXPECT_EQ(t2.at(2, 1), make(1));
+    EXPECT_EQ(t2.at(2, 2), make(3));
+    EXPECT_EQ(t2.at(2, 3), make(1337));
+
+    EXPECT_EQ(t2.at(3, 0), make(8));
+    EXPECT_EQ(t2.at(3, 1), make(6));
+    EXPECT_EQ(t2.at(3, 2), make(0));
+    EXPECT_EQ(t2.at(3, 3), make(1337));
+  };
+  runTestForDifferentTypes<3>(runTestForIdTable,
+                              "IdTable.insertAtEndWithPermutationAndLimit");
+}
+
 TEST(IdTable, reserve_and_resize) {
   // A lambda that is used as the `testCase` argument to the
   // `runTestForDifferentTypes` function (see above for details).

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3203,20 +3203,20 @@ TEST(QueryPlanner, testDistributiveJoinInUnionRecursive) {
 
   h::expectWithGivenBudgets(
       std::move(query),
-      h::Union(h::TransitivePath(
-                   left1, right1, 0, std::numeric_limits<size_t>::max(),
-                   h::IndexScanFromStrings("<Q11629>", "<P279>",
-                                           "?_QLever_internal_variable_qp_0"),
-                   h::Sort(h::Union(
-                       h::TransitivePath(
+      h::Union(
+          h::TransitivePath(
+              left1, right1, 0, std::numeric_limits<size_t>::max(),
+              h::IndexScanFromStrings("<Q11629>", "<P279>",
+                                      "?_QLever_internal_variable_qp_0"),
+              h::Union(h::Sort(h::TransitivePath(
                            left2, right2, 0, std::numeric_limits<size_t>::max(),
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_2", "<P279>",
                                "?_QLever_internal_variable_qp_4"),
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_6", "<P279>",
-                               "?_QLever_internal_variable_qp_7")),
-                       h::TransitivePath(
+                               "?_QLever_internal_variable_qp_7"))),
+                       h::Sort(h::TransitivePath(
                            left2, right2, 0, std::numeric_limits<size_t>::max(),
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_2", "<P279>",
@@ -3224,20 +3224,19 @@ TEST(QueryPlanner, testDistributiveJoinInUnionRecursive) {
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_8", "<P31>",
                                "?_QLever_internal_variable_qp_9"))))),
-               h::TransitivePath(
-                   left1, right1, 0, std::numeric_limits<size_t>::max(),
-                   h::IndexScanFromStrings("<Q11629>", "<P279>",
-                                           "?_QLever_internal_variable_qp_0"),
-                   h::Sort(h::Union(
-                       h::TransitivePath(
+          h::TransitivePath(
+              left1, right1, 0, std::numeric_limits<size_t>::max(),
+              h::IndexScanFromStrings("<Q11629>", "<P279>",
+                                      "?_QLever_internal_variable_qp_0"),
+              h::Union(h::Sort(h::TransitivePath(
                            left3, right3, 0, std::numeric_limits<size_t>::max(),
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_11", "<P31>",
                                "?_QLever_internal_variable_qp_13"),
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_15", "<P279>",
-                               "?_QLever_internal_variable_qp_16")),
-                       h::TransitivePath(
+                               "?_QLever_internal_variable_qp_16"))),
+                       h::Sort(h::TransitivePath(
                            left3, right3, 0, std::numeric_limits<size_t>::max(),
                            h::IndexScanFromStrings(
                                "?_QLever_internal_variable_qp_11", "<P31>",

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -276,11 +276,11 @@ TEST(Union, sortedMergeWithOneSideNonLazy) {
   auto* qec = ad_utility::testing::getQec();
 
   auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
-      qec, makeIdTableFromVector({{1}}), Vars{Var{"?a"}}, false,
+      qec, makeIdTableFromVector({{2}}), Vars{Var{"?a"}}, false,
       std::vector<ColumnIndex>{0}, LocalVocab{}, std::nullopt, true);
 
   auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
-      qec, makeIdTableFromVector({{0}, {2}}), Vars{Var{"?a"}}, false,
+      qec, makeIdTableFromVector({{0}, {1}}), Vars{Var{"?a"}}, false,
       std::vector<ColumnIndex>{0});
   Union unionOperation{qec, std::move(leftT), std::move(rightT), {0}};
   auto expected = makeIdTableFromVector({{0}, {1}, {2}});
@@ -297,7 +297,11 @@ TEST(Union, sortedMergeWithOneSideNonLazy) {
     auto& idTables = result->idTables();
     auto it = idTables.begin();
     ASSERT_NE(it, idTables.end());
-    EXPECT_EQ(it->idTable_, expected);
+    EXPECT_EQ(it->idTable_, makeIdTableFromVector({{0}, {1}}));
+
+    ++it;
+    ASSERT_NE(it, idTables.end());
+    EXPECT_EQ(it->idTable_, makeIdTableFromVector({{2}}));
 
     ASSERT_EQ(++it, idTables.end());
   }

--- a/test/UnionTest.cpp
+++ b/test/UnionTest.cpp
@@ -196,3 +196,320 @@ TEST(Union, clone) {
   EXPECT_THAT(unionOperation, IsDeepCopy(*clone));
   EXPECT_EQ(clone->getDescriptor(), unionOperation.getDescriptor());
 }
+
+// _____________________________________________________________________________
+TEST(Union, cheapMergeIfOrderNotImportant) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 2}}), Vars{Var{"?a"}, Var{"?b"}}, false,
+      std::vector<ColumnIndex>{0, 1});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{0, 0}, {2, 4}}), Vars{Var{"?a"}, Var{"?b"}},
+      false, std::vector<ColumnIndex>{0, 1});
+  Union unionOperation{qec, std::move(leftT), std::move(rightT), {}};
+  EXPECT_TRUE(unionOperation.resultSortedOn().empty());
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto result =
+        unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
+    EXPECT_FALSE(result->isFullyMaterialized());
+    auto& idTables = result->idTables();
+    auto expected1 = makeIdTableFromVector({{1, 2}});
+    auto expected2 = makeIdTableFromVector({{0, 0}, {2, 4}});
+
+    auto iterator = idTables.begin();
+    ASSERT_NE(iterator, idTables.end());
+    ASSERT_EQ(iterator->idTable_, expected1);
+
+    ++iterator;
+    ASSERT_NE(iterator, idTables.end());
+    ASSERT_EQ(iterator->idTable_, expected2);
+
+    ASSERT_EQ(++iterator, idTables.end());
+  }
+}
+
+// _____________________________________________________________________________
+TEST(Union, sortedMerge) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+  auto U = Id::makeUndefined();
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 2, 4}}),
+      Vars{Var{"?a"}, Var{"?b"}, Var{"?c"}}, false,
+      std::vector<ColumnIndex>{0, 1, 2});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{4, 1}, {8, 2}}), Vars{Var{"?c"}, Var{"?a"}},
+      false, std::vector<ColumnIndex>{1, 0});
+  Union unionOperation{qec, std::move(leftT), std::move(rightT), {0, 1, 2}};
+  EXPECT_EQ(unionOperation.resultSortedOn(),
+            (std::vector<ColumnIndex>{0, 1, 2}));
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto result =
+        unionOperation.getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected = makeIdTableFromVector({{1, U, 4}, {1, 2, 4}, {2, U, 8}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto result =
+        unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
+    auto expected = makeIdTableFromVector({{1, U, 4}, {1, 2, 4}, {2, U, 8}});
+    auto& idTables = result->idTables();
+    auto it = idTables.begin();
+    ASSERT_NE(it, idTables.end());
+    EXPECT_EQ(it->idTable_, expected);
+
+    ASSERT_EQ(++it, idTables.end());
+  }
+}
+
+// _____________________________________________________________________________
+TEST(Union, sortedMergeWithLocalVocab) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+
+  LocalVocab vocab1;
+  vocab1.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"Test1\""));
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1}, {2}, {4}}), Vars{Var{"?a"}}, false,
+      std::vector<ColumnIndex>{0}, vocab1.clone());
+
+  LocalVocab vocab2;
+  vocab2.getIndexAndAddIfNotContained(
+      LocalVocabEntry::fromStringRepresentation("\"Test2\""));
+  std::vector<IdTable> tables;
+  tables.push_back(makeIdTableFromVector({{0}}));
+  tables.push_back(makeIdTableFromVector({{3}}));
+  tables.push_back(makeIdTableFromVector({{5}}));
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, std::move(tables), Vars{Var{"?a"}}, false,
+      std::vector<ColumnIndex>{0}, vocab2.clone());
+  {
+    qec->getQueryTreeCache().clearAll();
+    Union unionOperation{qec, leftT, rightT, {0}};
+    auto result =
+        unionOperation.getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected = makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}, {5}});
+    EXPECT_EQ(result->idTable(), expected);
+    EXPECT_THAT(result->localVocab().getAllWordsForTesting(),
+                ::testing::IsSupersetOf(vocab1.getAllWordsForTesting()));
+    EXPECT_THAT(result->localVocab().getAllWordsForTesting(),
+                ::testing::IsSupersetOf(vocab2.getAllWordsForTesting()));
+  }
+  {
+    qec->getQueryTreeCache().clearAll();
+    Union unionOperation{qec, std::move(leftT), std::move(rightT), {0}};
+    auto result =
+        unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
+    auto& idTables = result->idTables();
+
+    auto it = idTables.begin();
+    ASSERT_NE(it, idTables.end());
+    EXPECT_EQ(it->idTable_, makeIdTableFromVector({{0}, {1}, {2}, {3}, {4}}));
+    EXPECT_THAT(it->localVocab_.getAllWordsForTesting(),
+                ::testing::IsSupersetOf(vocab1.getAllWordsForTesting()));
+    EXPECT_THAT(it->localVocab_.getAllWordsForTesting(),
+                ::testing::IsSupersetOf(vocab2.getAllWordsForTesting()));
+
+    ++it;
+    ASSERT_NE(it, idTables.end());
+    EXPECT_EQ(it->idTable_, makeIdTableFromVector({{5}}));
+    EXPECT_EQ(it->localVocab_.getAllWordsForTesting(),
+              vocab2.getAllWordsForTesting());
+
+    ASSERT_EQ(++it, idTables.end());
+  }
+}
+
+// _____________________________________________________________________________
+TEST(Union, cacheKeyDiffersForDifferentOrdering) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+  auto U = Id::makeUndefined();
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 4}}), Vars{Var{"?a"}, Var{"?b"}}, false,
+      std::vector<ColumnIndex>{0, 1});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 8}}), Vars{Var{"?a"}, Var{"?c"}}, false,
+      std::vector<ColumnIndex>{0, 1});
+  Union unionOperation1{qec, leftT, rightT, {0, 1, 2}};
+  Union unionOperation2{qec, std::move(leftT), std::move(rightT), {0, 2, 1}};
+
+  EXPECT_NE(unionOperation1.getCacheKey(), unionOperation2.getCacheKey());
+  EXPECT_EQ(unionOperation1.getChildren().at(0)->getCacheKey(),
+            unionOperation2.getChildren().at(0)->getCacheKey());
+  EXPECT_EQ(unionOperation1.getChildren().at(1)->getCacheKey(),
+            unionOperation2.getChildren().at(1)->getCacheKey());
+
+  qec->getQueryTreeCache().clearAll();
+  {
+    auto result =
+        unionOperation1.getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected = makeIdTableFromVector({{1, U, 8}, {1, 4, U}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+  {
+    auto result =
+        unionOperation2.getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected = makeIdTableFromVector({{1, 4, U}, {1, U, 8}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+}
+
+// _____________________________________________________________________________
+// We use a trick to merge two children where the first sort column is not
+// present in both children. This test checks that the trick works correctly.
+TEST(Union, testEfficientMerge) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+  auto U = Id::makeUndefined();
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1}}), Vars{Var{"?a"}}, false,
+      std::vector<ColumnIndex>{0});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{2}}), Vars{Var{"?b"}}, false,
+      std::vector<ColumnIndex>{0});
+
+  {
+    qec->getQueryTreeCache().clearAll();
+    Union unionOperation{qec, leftT, rightT, {0, 1}};
+    // Check if children were swapped
+    EXPECT_EQ(unionOperation.getChildren().at(0)->getCacheKey(),
+              rightT->getCacheKey());
+    EXPECT_EQ(unionOperation.getChildren().at(1)->getCacheKey(),
+              leftT->getCacheKey());
+
+    auto result =
+        unionOperation.getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected = makeIdTableFromVector({{U, 2}, {1, U}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+  {
+    qec->getQueryTreeCache().clearAll();
+    Union unionOperation{qec, leftT, rightT, {1, 0}};
+    // Ensure children were not swapped
+    EXPECT_EQ(unionOperation.getChildren().at(0)->getCacheKey(),
+              leftT->getCacheKey());
+    EXPECT_EQ(unionOperation.getChildren().at(1)->getCacheKey(),
+              rightT->getCacheKey());
+
+    auto result =
+        unionOperation.getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected = makeIdTableFromVector({{1, U}, {U, 2}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(Union, createSortedVariantWorksProperly) {
+  using Var = Variable;
+  auto* qec = ad_utility::testing::getQec();
+  auto U = Id::makeUndefined();
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 2, 4}}),
+      Vars{Var{"?a"}, Var{"?b"}, Var{"?c"}});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, makeIdTableFromVector({{1, 4}, {2, 8}}), Vars{Var{"?a"}, Var{"?d"}});
+  Union unionOperation{qec, std::move(leftT), std::move(rightT), {}};
+  EXPECT_TRUE(unionOperation.resultSortedOn().empty());
+
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto variant = unionOperation.createSortedVariant({0, 1, 2, 3});
+    EXPECT_EQ(variant->getResultSortedOn(),
+              (std::vector<ColumnIndex>{0, 1, 2, 3}));
+    EXPECT_EQ(
+        variant->getChildren().at(0)->getRootOperation()->getResultSortedOn(),
+        (std::vector<ColumnIndex>{0, 1, 2}));
+    EXPECT_EQ(
+        variant->getChildren().at(1)->getRootOperation()->getResultSortedOn(),
+        (std::vector<ColumnIndex>{0, 1}));
+    auto result = variant->getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected =
+        makeIdTableFromVector({{1, U, U, 4}, {1, 2, 4, U}, {2, U, U, 8}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+  {
+    qec->getQueryTreeCache().clearAll();
+    auto variant = unionOperation.createSortedVariant({0, 3, 1, 2});
+    EXPECT_EQ(variant->getResultSortedOn(),
+              (std::vector<ColumnIndex>{0, 3, 1, 2}));
+    EXPECT_EQ(
+        variant->getChildren().at(0)->getRootOperation()->getResultSortedOn(),
+        (std::vector<ColumnIndex>{0, 1, 2}));
+    EXPECT_EQ(
+        variant->getChildren().at(1)->getRootOperation()->getResultSortedOn(),
+        (std::vector<ColumnIndex>{0, 1}));
+    auto result = variant->getResult(true, ComputationMode::FULLY_MATERIALIZED);
+    auto expected =
+        makeIdTableFromVector({{1, 2, 4, U}, {1, U, U, 4}, {2, U, U, 8}});
+    EXPECT_EQ(result->idTable(), expected);
+  }
+}
+
+// _____________________________________________________________________________
+TEST(Union, checkChunkSizeSplitsProperly) {
+  using Var = Variable;
+  using ::testing::Each;
+  auto* qec = ad_utility::testing::getQec();
+
+  IdTable reference{1, qec->getAllocator()};
+  reference.resize(Union::chunkSize + (Union::chunkSize / 2) + 1);
+  ql::ranges::fill(reference.getColumn(0), Id::makeFromInt(42));
+  // Make sure we compute the expensive way
+  reference.getColumn(0).back() = Id::makeFromInt(1337);
+
+  auto leftT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, reference.clone(), Vars{Var{"?a"}}, false,
+      std::vector<ColumnIndex>{0});
+
+  auto rightT = ad_utility::makeExecutionTree<ValuesForTesting>(
+      qec, std::move(reference), Vars{Var{"?a"}}, false,
+      std::vector<ColumnIndex>{0});
+
+  Union unionOperation{qec, std::move(leftT), std::move(rightT), {0}};
+
+  qec->getQueryTreeCache().clearAll();
+  auto result =
+      unionOperation.getResult(true, ComputationMode::LAZY_IF_SUPPORTED);
+  auto& idTables = result->idTables();
+
+  auto it = idTables.begin();
+  ASSERT_NE(it, idTables.end());
+  EXPECT_EQ(it->idTable_.size(), Union::chunkSize);
+  EXPECT_THAT(it->idTable_.getColumn(0), Each(Id::makeFromInt(42)));
+
+  ++it;
+  ASSERT_NE(it, idTables.end());
+  EXPECT_EQ(it->idTable_.size(), Union::chunkSize);
+  EXPECT_THAT(it->idTable_.getColumn(0), Each(Id::makeFromInt(42)));
+
+  ++it;
+  ASSERT_NE(it, idTables.end());
+  EXPECT_EQ(it->idTable_.size(), Union::chunkSize);
+  EXPECT_THAT(it->idTable_.getColumn(0), Each(Id::makeFromInt(42)));
+
+  ++it;
+  ASSERT_NE(it, idTables.end());
+  EXPECT_EQ(it->idTable_.size(), 2);
+  EXPECT_THAT(it->idTable_.getColumn(0), Each(Id::makeFromInt(1337)));
+
+  ++it;
+  EXPECT_EQ(it, idTables.end());
+}


### PR DESCRIPTION
If the result of a `UNION` has to be sorted, then the sort is propagated to the children of the UNION and the UNION is performed by a binary merge operation of the already sorted inputs.
This is especially beneficial when some of the inputs of the UNION are already implicitly sorted (e.g. because they are IndexScans).
Note: The query planner can currently not yet use the full potential of this feature, as the decision on the sorting of the subtrees of the UNION is made before we know that the result of the UNION has to be sorted, but at least for IndexScans this can be easily fixed.