### PR TITLE
Apply filter on neutral element

### DIFF
--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -262,7 +262,10 @@ std::vector<QueryPlanner::SubtreePlan> QueryPlanner::optimize(
     if (candidatePlans.at(0).empty()) {
       // This happens if either graph pattern is an empty group,
       // or it only consists of a MINUS clause (which then has no effect).
-      return {makeSubtreePlan<NeutralElementOperation>(_qec)};
+      std::vector neutralPlans{makeSubtreePlan<NeutralElementOperation>(_qec)};
+      // Neutral element can potentially still get filtered out
+      applyFiltersIfPossible<true>(neutralPlans, rootPattern->_filters);
+      return neutralPlans;
     }
     return candidatePlans[0];
   }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2981,3 +2981,15 @@ TEST(QueryPlanner, Exists) {
       "GRAPH ?g { ?u ?v ?c}}}",
       filter);
 }
+
+// _____________________________________________________________________________
+TEST(QueryPlanner, FilterOnNeutralElement) {
+  h::expect("SELECT * { FILTER(false) }",
+            h::Filter("false", h::NeutralElement()));
+  h::expect("SELECT * { FILTER(true) }",
+            h::Filter("true", h::NeutralElement()));
+
+  h::expect("SELECT * { { SELECT * WHERE { FILTER(false) } } VALUES ?x { 1 } }",
+            h::CartesianProductJoin(h::Filter("false", h::NeutralElement()),
+                                    h::ValuesClause("VALUES (?x) { (1) }")));
+}


### PR DESCRIPTION
The neutral element can still get filtered out if a constant-expression `FILTER` clause is present. This PR correctly applies this filter. This corrects the beahviors for queries such as 
```
ASK { FILTER (1 < 0) }
```
Which should return `false`, as the filter filters out all possible results, even if they have no bound variables.