### PR TITLE
Correct handling of Datasets

### DIFF
--- a/src/parser/SparqlParser.cpp
+++ b/src/parser/SparqlParser.cpp
@@ -9,12 +9,14 @@
 using AntlrParser = SparqlAutomaticParser;
 
 // _____________________________________________________________________________
-ParsedQuery SparqlParser::parseQuery(std::string query) {
+ParsedQuery SparqlParser::parseQuery(
+    std::string query, const std::vector<DatasetClause>& datasets) {
   // The second argument is the `PrefixMap` for QLever's internal IRIs.
   using S = std::string;
   sparqlParserHelpers::ParserAndVisitor p{
       std::move(query),
-      {{S{QLEVER_INTERNAL_PREFIX_NAME}, S{QLEVER_INTERNAL_PREFIX_IRI}}}};
+      {{S{QLEVER_INTERNAL_PREFIX_NAME}, S{QLEVER_INTERNAL_PREFIX_IRI}}},
+      parsedQuery::DatasetClauses::fromClauses(datasets)};
   // Note: `AntlrParser::query` is a method of `AntlrParser` (which is an alias
   // for `SparqlAutomaticParser`) that returns the `QueryContext*` for the whole
   // query.
@@ -25,17 +27,4 @@ ParsedQuery SparqlParser::parseQuery(std::string query) {
   // an earlier point.
   AD_CONTRACT_CHECK(resultOfParseAndRemainingText.remainingText_.empty());
   return std::move(resultOfParseAndRemainingText.resultOfParse_);
-}
-
-// _____________________________________________________________________________
-ParsedQuery SparqlParser::parseQuery(
-    std::string operation, const std::vector<DatasetClause>& datasets) {
-  auto parsedOperation = parseQuery(std::move(operation));
-  // SPARQL Protocol 2.1.4 specifies that the dataset from the query
-  // parameters overrides the dataset from the query itself.
-  if (!datasets.empty()) {
-    parsedOperation.datasetClauses_ =
-        parsedQuery::DatasetClauses::fromClauses(datasets);
-  }
-  return parsedOperation;
 }

--- a/src/parser/SparqlParser.h
+++ b/src/parser/SparqlParser.h
@@ -13,8 +13,7 @@
 // message is given.
 class SparqlParser {
  public:
-  static ParsedQuery parseQuery(std::string query);
-  // A convenience function for parsing the query and setting the datasets.
-  static ParsedQuery parseQuery(std::string operation,
-                                const std::vector<DatasetClause>& datasets);
+  // TODO: remove the default to make it explicit?
+  static ParsedQuery parseQuery(
+      std::string operation, const std::vector<DatasetClause>& datasets = {});
 };

--- a/src/parser/SparqlParserHelpers.cpp
+++ b/src/parser/SparqlParserHelpers.cpp
@@ -16,10 +16,10 @@ using std::string;
 
 // _____________________________________________________________________________
 ParserAndVisitor::ParserAndVisitor(
-    std::string input,
+    std::string input, ParsedQuery::DatasetClauses datasetClauses,
     SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
     : input_{unescapeUnicodeSequences(std::move(input))},
-      visitor_{{}, disableSomeChecks} {
+      visitor_{{}, std::move(datasetClauses), disableSomeChecks} {
   // The default in ANTLR is to log all errors to the console and to continue
   // the parsing. We need to turn parse errors into exceptions instead to
   // propagate them to the user.
@@ -32,8 +32,10 @@ ParserAndVisitor::ParserAndVisitor(
 // _____________________________________________________________________________
 ParserAndVisitor::ParserAndVisitor(
     std::string input, SparqlQleverVisitor::PrefixMap prefixes,
+    ParsedQuery::DatasetClauses datasetClauses,
     SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks)
-    : ParserAndVisitor{std::move(input), disableSomeChecks} {
+    : ParserAndVisitor{std::move(input), std::move(datasetClauses),
+                       disableSomeChecks} {
   visitor_.setPrefixMapManually(std::move(prefixes));
 }
 

--- a/src/parser/SparqlParserHelpers.h
+++ b/src/parser/SparqlParserHelpers.h
@@ -43,11 +43,14 @@ struct ParserAndVisitor {
   SparqlAutomaticParser parser_{&tokens_};
   SparqlQleverVisitor visitor_;
   explicit ParserAndVisitor(
-      string input,
+      // TODO: remove the default to make it explicit?
+      string input, ParsedQuery::DatasetClauses datasetClauses = {},
       SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
           SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False);
   ParserAndVisitor(
       string input, SparqlQleverVisitor::PrefixMap prefixes,
+      // TODO: remove the default to make it explicit?
+      ParsedQuery::DatasetClauses datasetClauses = {},
       SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
           SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -661,9 +661,10 @@ ParsedQuery Visitor::visit(Parser::ModifyContext* ctx) {
         }
       };
   AD_CORRECTNESS_CHECK(visibleVariables_.empty());
-  auto graphPattern = visit(ctx->groupGraphPattern());
   parsedQuery_.datasetClauses_ =
       parsedQuery::DatasetClauses::fromClauses(visitVector(ctx->usingClause()));
+  activeDatasetClauses_ = parsedQuery_.datasetClauses_;
+  auto graphPattern = visit(ctx->groupGraphPattern());
   parsedQuery_._rootGraphPattern = std::move(graphPattern);
   parsedQuery_.registerVariablesVisibleInQueryBody(visibleVariables_);
   visibleVariables_.clear();

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -110,10 +110,12 @@ class SparqlQleverVisitor {
  public:
   SparqlQleverVisitor() = default;
   explicit SparqlQleverVisitor(
-      PrefixMap prefixMap,
+      // TODO: remove the default to make it explicit?
+      PrefixMap prefixMap, ParsedQuery::DatasetClauses datasetClauses = {},
       DisableSomeChecksOnlyForTesting disableSomeChecksOnlyForTesting =
           DisableSomeChecksOnlyForTesting::False)
-      : prefixMap_{std::move(prefixMap)},
+      : activeDatasetClauses_{std::move(datasetClauses)},
+        prefixMap_{std::move(prefixMap)},
         disableSomeChecksOnlyForTesting_{disableSomeChecksOnlyForTesting} {}
 
   const PrefixMap& prefixMap() const { return prefixMap_; }
@@ -628,6 +630,9 @@ class SparqlQleverVisitor {
   // planner.
   static parsedQuery::BasicGraphPattern toGraphPattern(
       const ad_utility::sparql_types::Triples& triples);
+
+  parsedQuery::DatasetClauses setAndGetDatasetClauses(
+      const std::vector<DatasetClause>& clauses);
 
   FRIEND_TEST(SparqlParser, ensureExceptionOnInvalidGraphTerm);
 };

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2968,6 +2968,10 @@ TEST(QueryPlanner, Exists) {
       filter);
   h::expect("Describe ?x FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}",
             h::Describe(::testing::_, filter));
+  h::expect(
+      "DELETE { ?x <b> <c> } USING <g> WHERE { ?x ?y ?z FILTER EXISTS {?a ?b "
+      "?c}}",
+      filter);
 
   // Test the interaction of FROM NAMES with EXISTS
   auto varG = std::vector{Variable{"?g"}};

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -55,7 +55,7 @@ auto parse =
        ParsedQuery::DatasetClauses clauses = {},
        SparqlQleverVisitor::DisableSomeChecksOnlyForTesting disableSomeChecks =
            SparqlQleverVisitor::DisableSomeChecksOnlyForTesting::False) {
-      ParserAndVisitor p{input, std::move(prefixes), disableSomeChecks};
+      ParserAndVisitor p{input, std::move(prefixes), {}, disableSomeChecks};
       p.visitor_.setActiveDatasetClausesForTesting(std::move(clauses));
       if (testInsideConstructTemplate) {
         p.visitor_.setParseModeToInsideConstructTemplateForTesting();
@@ -2335,6 +2335,7 @@ TEST(SparqlParser, Datasets) {
       m::ConstructQuery(
           {std::array<GraphTerm, 3>{::Iri("<a>"), ::Iri("<b>"), ::Iri("<c>")}},
           filterGraphPattern, datasets));
+  // See comment in visit function for `DescribeQueryContext`.
   expectDescribe(
       "Describe ?x FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}",
       m::DescribeQuery(

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -10,8 +10,10 @@
 
 #include <iostream>
 #include <string>
+#include <typeindex>
 #include <vector>
 
+#include "engine/sparqlExpressions/ExistsExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionPimpl.h"
 #include "parser/Alias.h"
 #include "parser/DatasetClauses.h"
@@ -1039,6 +1041,133 @@ inline auto Quad = [](const TripleComponent& s, const TripleComponent& p,
       AD_FIELD(SparqlTripleSimpleWithGraph, p_, testing::Eq(p)),
       AD_FIELD(SparqlTripleSimpleWithGraph, o_, testing::Eq(o)),
       AD_FIELD(SparqlTripleSimpleWithGraph, g_, testing::Eq(g)));
+};
+
+// Some helper matchers for testing SparqlExpressions
+namespace builtInCall {
+using namespace sparqlExpression;
+
+// Return a matcher that checks whether a given `SparqlExpression::Ptr` actually
+// (via `dynamic_cast`) points to an object of type `Expression`, and that this
+// `Expression` matches the `matcher`.
+template <typename Expression, typename Matcher = decltype(testing::_)>
+auto matchPtr(Matcher matcher = Matcher{})
+    -> testing::Matcher<const SparqlExpression::Ptr&> {
+  return testing::Pointee(
+      testing::WhenDynamicCastTo<const Expression&>(matcher));
+}
+
+// Return a matcher that matches a `SparqlExpression::Ptr` that stores a
+// `VariableExpression` with the given  `variable`.
+inline auto variableExpressionMatcher = [](const ::Variable& variable) {
+  return matchPtr<VariableExpression>(
+      AD_PROPERTY(VariableExpression, value, testing::Eq(variable)));
+};
+
+// Return a matcher that matches a `SparqlExpression::Ptr`that stores an
+// `Expression` (template argument), the children of which match the
+// `childrenMatchers`.
+template <typename Expression>
+auto matchPtrWithChildren(auto&&... childrenMatchers)
+    -> Matcher<const SparqlExpression::Ptr&> {
+  return matchPtr<Expression>(
+      AD_PROPERTY(SparqlExpression, childrenForTesting,
+                  testing::ElementsAre(childrenMatchers...)));
+}
+
+// Same as `matchPtrWithChildren` above, but the children are all variables.
+template <typename Expression>
+auto matchPtrWithVariables(const std::same_as<::Variable> auto&... children)
+    -> Matcher<const SparqlExpression::Ptr&> {
+  return matchPtrWithChildren<Expression>(
+      variableExpressionMatcher(children)...);
+}
+
+// Return a matcher  that checks whether a given `SparqlExpression::Ptr` points
+// (via `dynamic_cast`) to an object of the same type that a call to the
+// `makeFunction` yields. The matcher also checks that the expression's children
+// match the `childrenMatchers`.
+auto matchNaryWithChildrenMatchers(auto makeFunction,
+                                   auto&&... childrenMatchers)
+    -> Matcher<const SparqlExpression::Ptr&> {
+  using namespace sparqlExpression;
+  auto typeIdLambda = [](const auto& ptr) {
+    return std::type_index{typeid(*ptr)};
+  };
+
+  [[maybe_unused]] auto makeDummyChild = [](auto&&) -> SparqlExpression::Ptr {
+    return std::make_unique<VariableExpression>(::Variable{"?x"});
+  };
+  auto expectedTypeIndex =
+      typeIdLambda(makeFunction(makeDummyChild(childrenMatchers)...));
+  Matcher<const SparqlExpression::Ptr&> typeIdMatcher =
+      ::testing::ResultOf(typeIdLambda, ::testing::Eq(expectedTypeIndex));
+  return ::testing::AllOf(typeIdMatcher,
+                          ::testing::Pointee(AD_PROPERTY(
+                              SparqlExpression, childrenForTesting,
+                              ::testing::ElementsAre(childrenMatchers...))));
+}
+
+inline auto idExpressionMatcher = [](Id id) {
+  return matchPtr<IdExpression>(
+      AD_PROPERTY(IdExpression, value, testing::Eq(id)));
+};
+
+// Return a matcher  that checks whether a given `SparqlExpression::Ptr` points
+// (via `dynamic_cast`) to an object of the same type that a call to the
+// `makeFunction` yields. The matcher also checks that the expression's children
+// are the `variables`.
+auto matchNary(auto makeFunction,
+               QL_CONCEPT_OR_NOTHING(
+                   ad_utility::SimilarTo<::Variable>) auto&&... variables)
+    -> Matcher<const sparqlExpression::SparqlExpression::Ptr&> {
+  using namespace sparqlExpression;
+  return matchNaryWithChildrenMatchers(makeFunction,
+                                       variableExpressionMatcher(variables)...);
+}
+auto matchUnary(auto makeFunction) -> Matcher<const SparqlExpression::Ptr&> {
+  return matchNary(makeFunction, ::Variable{"?x"});
+}
+
+template <typename T>
+auto matchLiteralExpression(const T& value)
+    -> Matcher<const SparqlExpression::Ptr&> {
+  using Expr = sparqlExpression::detail::LiteralExpression<T>;
+  return testing::Pointee(testing::WhenDynamicCastTo<const Expr&>(
+      AD_PROPERTY(Expr, value, testing::Eq(value))));
+}
+}  // namespace builtInCall
+
+// Match an EXISTS function
+inline auto Exists(Matcher<const ParsedQuery&> pattern) {
+  return testing::Pointee(
+      testing::WhenDynamicCastTo<const sparqlExpression::ExistsExpression&>(
+          AD_PROPERTY(sparqlExpression::ExistsExpression, argument, pattern)));
+}
+
+// Match a NOT EXISTS function
+inline auto NotExists(Matcher<const ParsedQuery&> pattern) {
+  return builtInCall::matchNaryWithChildrenMatchers(
+      &sparqlExpression::makeUnaryNegateExpression, Exists(pattern));
+}
+
+// Check that the given filters are set on the graph pattern.
+inline auto Filters = [](const auto&... filterMatchers)
+    -> Matcher<const ParsedQuery::GraphPattern&> {
+  return AD_FIELD(ParsedQuery::GraphPattern, _filters,
+                  testing::ElementsAre(filterMatchers...));
+};
+
+// Matcher for `FILTER EXISTS` filters.
+inline auto ExistsFilter =
+    [](const Matcher<const parsedQuery::GraphPattern&>& m,
+       ScanSpecificationAsTripleComponent::Graphs defaultGraphs = std::nullopt,
+       ScanSpecificationAsTripleComponent::Graphs namedGraphs =
+           std::nullopt) -> Matcher<const SparqlFilter&> {
+  return AD_FIELD(SparqlFilter, expression_,
+                  AD_PROPERTY(sparqlExpression::SparqlExpressionPimpl, getPimpl,
+                              Exists(SelectQuery(AsteriskSelect(), m,
+                                                 defaultGraphs, namedGraphs))));
 };
 
 }  // namespace matchers


### PR DESCRIPTION
- Add tests for dataset handling of visitor (is the current dataset propagated into contained `EXISTS) in `SparqlAntlrParserTest`. Previously this was only tested indirectly in the QueryPlanerTest.
  - Fixed that the active datasets were not propagated in Modify.
- Some refactoring of matchers. Of the code blocks that had to be moved only the `Describe` matcher was changed slightly (it now matcher `GraphPattern` for consistence with the other matchers).
- `SparqlQleverVisitor` takes the override dataset clause in its constructor and if these contain datasets then the datasets in the query are ignored.
  - Some accompanying tests in `SparqlParserTest`.

TODO:
- the Datasets are defaulted to empty in some layers of the call stack. Keep as few as possible, those at higher layers preferred.
- the new tests for `DESCRIBE` currently fail, because the datasets are not set in its contained select (code comments seem to indicate that this should be set)
- finalize the override implementation in the visitor (implicit by being empty vs explicit with an extra field)