### PR TITLE
Truncate echo of SPARQL operation strings

### DIFF
--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -918,7 +918,8 @@ ExportQueryExecutionTrees::computeResultAsQLeverJSON(
 
   nlohmann::json jsonPrefix;
 
-  jsonPrefix["query"] = query._originalString;
+  jsonPrefix["query"] =
+      query._originalString.substr(0, MAX_LENGTH_OPERATION_ECHO);
   jsonPrefix["status"] = "OK";
   jsonPrefix["warnings"] = qet.collectWarnings();
   if (query.hasSelectClause()) {

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -918,8 +918,7 @@ ExportQueryExecutionTrees::computeResultAsQLeverJSON(
 
   nlohmann::json jsonPrefix;
 
-  jsonPrefix["query"] =
-      query._originalString.substr(0, MAX_LENGTH_OPERATION_ECHO);
+  jsonPrefix["query"] = ad_utility::truncateOperation(query._originalString);
   jsonPrefix["status"] = "OK";
   jsonPrefix["warnings"] = qet.collectWarnings();
   if (query.hasSelectClause()) {

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -918,7 +918,8 @@ ExportQueryExecutionTrees::computeResultAsQLeverJSON(
 
   nlohmann::json jsonPrefix;
 
-  jsonPrefix["query"] = ad_utility::truncateOperation(query._originalString);
+  jsonPrefix["query"] =
+      ad_utility::truncateOperationString(query._originalString);
   jsonPrefix["status"] = "OK";
   jsonPrefix["warnings"] = qet.collectWarnings();
   if (query.hasSelectClause()) {

--- a/src/engine/GraphStoreProtocol.h
+++ b/src/engine/GraphStoreProtocol.h
@@ -88,8 +88,7 @@ class GraphStoreProtocol {
     res._clause = parsedQuery::UpdateClause{std::move(up)};
     // Graph store protocol POST requests might have a very large body. Limit
     // the length used for the string representation.
-    string_view body =
-        string_view(rawRequest.body()).substr(0, MAX_LENGTH_OPERATION_ECHO);
+    string_view body = ad_utility::truncateOperation(rawRequest.body());
     res._originalString = absl::StrCat("Graph Store POST Operation\n", body);
     return res;
   }

--- a/src/engine/GraphStoreProtocol.h
+++ b/src/engine/GraphStoreProtocol.h
@@ -88,7 +88,7 @@ class GraphStoreProtocol {
     res._clause = parsedQuery::UpdateClause{std::move(up)};
     // Graph store protocol POST requests might have a very large body. Limit
     // the length used for the string representation.
-    string_view body = ad_utility::truncateOperation(rawRequest.body());
+    string_view body = ad_utility::truncateOperationString(rawRequest.body());
     res._originalString = absl::StrCat("Graph Store POST Operation\n", body);
     return res;
   }

--- a/src/engine/GraphStoreProtocol.h
+++ b/src/engine/GraphStoreProtocol.h
@@ -87,8 +87,9 @@ class GraphStoreProtocol {
     ParsedQuery res;
     res._clause = parsedQuery::UpdateClause{std::move(up)};
     // Graph store protocol POST requests might have a very large body. Limit
-    // the length used for the string representation (arbitrarily) to 5000.
-    string_view body = string_view(rawRequest.body()).substr(0, 5000);
+    // the length used for the string representation.
+    string_view body =
+        string_view(rawRequest.body()).substr(0, MAX_LENGTH_OPERATION_ECHO);
     res._originalString = absl::StrCat("Graph Store POST Operation\n", body);
     return res;
   }

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -823,7 +823,8 @@ json Server::createResponseMetadataForUpdate(
   };
 
   json response;
-  response["update"] = plannedQuery.parsedQuery_._originalString;
+  response["update"] = plannedQuery.parsedQuery_._originalString.substr(
+      0, MAX_LENGTH_OPERATION_ECHO);
   response["status"] = "OK";
   auto warnings = qet.collectWarnings();
   warnings.emplace(warnings.begin(),

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -587,15 +587,15 @@ json Server::composeErrorResponseJson(
   j["time"]["computeResult"] = requestTimer.msecs().count();
   j["exception"] = errorMsg;
 
-  if (metadata.has_value()) {
-    j["query"] = query;
+  j["query"] = ad_utility::truncateOperation(query);
+  // If the error location is truncated don't send it's location.
+  if (metadata.has_value() &&
+      metadata.value().stopIndex_ < MAX_LENGTH_OPERATION_ECHO) {
     auto& value = metadata.value();
     j["metadata"]["startIndex"] = value.startIndex_;
     j["metadata"]["stopIndex"] = value.stopIndex_;
     j["metadata"]["line"] = value.line_;
     j["metadata"]["positionInLine"] = value.charPositionInLine_;
-  } else {
-    j["query"] = ad_utility::truncateOperation(query);
   }
 
   return j;

--- a/src/engine/Server.cpp
+++ b/src/engine/Server.cpp
@@ -259,7 +259,8 @@ auto Server::prepareOperation(
   LOG(INFO) << "Processing the following " << operationName << ":"
             << (pinResult ? " [pin result]" : "")
             << (pinSubtrees ? " [pin subresults]" : "") << "\n"
-            << ad_utility::truncateOperation(operationSPARQL) << std::endl;
+            << ad_utility::truncateOperationString(operationSPARQL)
+            << std::endl;
   QueryExecutionContext qec(index_, &cache_, allocator_,
                             sortPerformanceEstimator_, std::ref(messageSender),
                             pinSubtrees, pinResult);
@@ -581,13 +582,13 @@ json Server::composeErrorResponseJson(
     const std::optional<ExceptionMetadata>& metadata) {
   json j;
   using ad_utility::Timer;
+  j["query"] = ad_utility::truncateOperationString(query);
   j["status"] = "ERROR";
   j["resultsize"] = 0;
   j["time"]["total"] = requestTimer.msecs().count();
   j["time"]["computeResult"] = requestTimer.msecs().count();
   j["exception"] = errorMsg;
 
-  j["query"] = ad_utility::truncateOperation(query);
   // If the error location is truncated don't send it's location.
   if (metadata.has_value() &&
       metadata.value().stopIndex_ < MAX_LENGTH_OPERATION_ECHO) {
@@ -825,8 +826,8 @@ json Server::createResponseMetadataForUpdate(
   };
 
   json response;
-  response["update"] =
-      ad_utility::truncateOperation(plannedQuery.parsedQuery_._originalString);
+  response["update"] = ad_utility::truncateOperationString(
+      plannedQuery.parsedQuery_._originalString);
   response["status"] = "OK";
   auto warnings = qet.collectWarnings();
   warnings.emplace(warnings.begin(),

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -255,3 +255,8 @@ constexpr inline std::string_view EMPH_OFF = "\033[22m";
 // Allowed range for geographical coordinates from WTK Text
 constexpr inline double COORDINATE_LAT_MAX = 90.0;
 constexpr inline double COORDINATE_LNG_MAX = 180.0;
+
+// When operation results are returned as `application/qlever-results+json` the
+// Operation string is echoed. This operation string is truncated to ensure
+// performance.
+constexpr inline size_t MAX_LENGTH_OPERATION_ECHO = 5000;

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -202,7 +202,7 @@ std::string addIndentation(std::string_view str,
 }
 
 // ___________________________________________________________________________
-std::string truncateOperation(std::string_view operation) {
+std::string truncateOperationString(std::string_view operation) {
   static_assert(MAX_LENGTH_OPERATION_ECHO >= 3);
   if (operation.length() <= MAX_LENGTH_OPERATION_ECHO) {
     return std::string{operation};

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -10,6 +10,7 @@
 #include <unicode/bytestream.h>
 #include <unicode/casemap.h>
 
+#include "global/Constants.h"
 #include "util/Algorithm.h"
 #include "util/Exception.h"
 #include "util/Forward.h"
@@ -198,5 +199,16 @@ std::string addIndentation(std::string_view str,
       indentationSymbol,
       absl::StrReplaceAll(str,
                           {{"\n", absl::StrCat("\n", indentationSymbol)}}));
+}
+
+// ___________________________________________________________________________
+std::string truncateOperation(std::string_view operation) {
+  static_assert(MAX_LENGTH_OPERATION_ECHO >= 3);
+  if (operation.length() <= MAX_LENGTH_OPERATION_ECHO) {
+    return std::string{operation};
+  } else {
+    return absl::StrCat(operation.substr(0, MAX_LENGTH_OPERATION_ECHO - 3),
+                        "...");
+  }
 }
 }  // namespace ad_utility

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -277,10 +277,9 @@ constexpr std::string_view constexprStrCat() {
   return {b.data(), b.size() - 1};
 }
 
-// TODO: make this a general truncate operation
 // Truncates the operation string to a maximum length of
 // `MAX_LENGTH_OPERATION_ECHO`.
-std::string truncateOperation(std::string_view operation);
+std::string truncateOperationString(std::string_view operation);
 }  // namespace ad_utility
 
 // A helper function for the `operator+` overloads below.

--- a/src/util/StringUtils.h
+++ b/src/util/StringUtils.h
@@ -276,6 +276,11 @@ constexpr std::string_view constexprStrCat() {
       detail::constexpr_str_cat_impl::constexprStrCatBufferVar<strings...>;
   return {b.data(), b.size() - 1};
 }
+
+// TODO: make this a general truncate operation
+// Truncates the operation string to a maximum length of
+// `MAX_LENGTH_OPERATION_ECHO`.
+std::string truncateOperation(std::string_view operation);
 }  // namespace ad_utility
 
 // A helper function for the `operator+` overloads below.


### PR DESCRIPTION
The raw operation strings are echoed in the response for `application/qlever-results+json` and the console during execution. These operation strings can become quite long. This PR truncates the operation strings to a fixed length.