### PR TITLE
Add flags support for `REPLACE` function

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -82,10 +82,12 @@ SparqlExpression::Ptr makeContainsExpression(SparqlExpression::Ptr child1,
                                              SparqlExpression::Ptr child2);
 SparqlExpression::Ptr makeStrAfterExpression(SparqlExpression::Ptr child1,
                                              SparqlExpression::Ptr child2);
-
+SparqlExpression::Ptr makeMergeRegexPatternAndFlagsExpression(
+    SparqlExpression::Ptr pattern, SparqlExpression::Ptr flags);
 SparqlExpression::Ptr makeReplaceExpression(SparqlExpression::Ptr input,
                                             SparqlExpression::Ptr pattern,
-                                            SparqlExpression::Ptr replacement);
+                                            SparqlExpression::Ptr replacement,
+                                            SparqlExpression::Ptr flags);
 SparqlExpression::Ptr makeStrBeforeExpression(SparqlExpression::Ptr child1,
                                               SparqlExpression::Ptr child2);
 SparqlExpression::Ptr makeLangMatchesExpression(SparqlExpression::Ptr child1,

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -369,12 +369,7 @@ using StrBeforeExpression =
   }
   auto firstInvalidFlag = flags.value().find_first_not_of("imsu");
   if (firstInvalidFlag != std::string::npos) {
-    throw std::runtime_error{absl::StrCat(
-        "Invalid regex flag '",
-        std::string_view{&flags.value()[firstInvalidFlag], 1}, "' found in \"",
-        flags.value(),
-        "\". The only supported flags are 'i', 'm', 's', 'u', and any "
-        "combination of them")};
+    return Id::makeUndefined();
   }
 
   // In Google RE2 the flags are directly part of the regex.

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -361,6 +361,33 @@ using StrBeforeExpression =
     StringExpressionImpl<2, LiftStringFunction<decltype(strBefore)>,
                          StringValueGetter>;
 
+[[maybe_unused]] auto mergeFlagsIntoRegex =
+    [](std::optional<std::string> regex,
+       const std::optional<std::string>& flags) -> IdOrLiteralOrIri {
+  if (!flags.has_value() || !regex.has_value()) {
+    return Id::makeUndefined();
+  }
+  auto firstInvalidFlag = flags.value().find_first_not_of("imsu");
+  if (firstInvalidFlag != std::string::npos) {
+    throw std::runtime_error{absl::StrCat(
+        "Invalid regex flag '",
+        std::string_view{&flags.value()[firstInvalidFlag], 1}, "' found in \"",
+        flags.value(),
+        "\". The only supported flags are 'i', 'm', 's', 'u', and any "
+        "combination of them")};
+  }
+
+  // In Google RE2 the flags are directly part of the regex.
+  std::string result =
+      flags.value().empty()
+          ? std::move(regex.value())
+          : absl::StrCat("(?", flags.value(), ":", regex.value() + ")");
+  return toLiteral(std::move(result));
+};
+
+using MergeRegexPatternAndFlagsExpression =
+    StringExpressionImpl<2, decltype(mergeFlagsIntoRegex), StringValueGetter>;
+
 [[maybe_unused]] auto replaceImpl =
     [](std::optional<std::string> input,
        const std::unique_ptr<re2::RE2>& pattern,
@@ -607,8 +634,14 @@ Expr makeStrAfterExpression(Expr child1, Expr child2) {
 Expr makeStrBeforeExpression(Expr child1, Expr child2) {
   return make<StrBeforeExpression>(child1, child2);
 }
-
-Expr makeReplaceExpression(Expr input, Expr pattern, Expr repl) {
+Expr makeMergeRegexPatternAndFlagsExpression(Expr pattern, Expr flags) {
+  return make<MergeRegexPatternAndFlagsExpression>(pattern, flags);
+}
+Expr makeReplaceExpression(Expr input, Expr pattern, Expr repl, Expr flags) {
+  if (flags) {
+    pattern = makeMergeRegexPatternAndFlagsExpression(std::move(pattern),
+                                                      std::move(flags));
+  }
   return make<ReplaceExpression>(input, pattern, repl);
 }
 Expr makeContainsExpression(Expr child1, Expr child2) {

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2490,20 +2490,10 @@ SparqlExpression::Ptr Visitor::visit(Parser::SubstringExpressionContext* ctx) {
 SparqlExpression::Ptr Visitor::visit(Parser::StrReplaceExpressionContext* ctx) {
   auto children = visitVector(ctx->expression());
   AD_CORRECTNESS_CHECK(children.size() == 3 || children.size() == 4);
-  if (children.size() == 4) {
-    reportError(
-        ctx,
-        "REPLACE expressions with four arguments (including regex flags) are "
-        "currently not supported by QLever. You can however incorporate "
-        "flags "
-        "directly into a regex by prepending `(?<flags>)` to your regex. For "
-        "example `(?i)[ei]` will match the regex `[ei]` in a "
-        "case-insensitive "
-        "way.");
-  }
-  return sparqlExpression::makeReplaceExpression(std::move(children.at(0)),
-                                                 std::move(children.at(1)),
-                                                 std::move(children.at(2)));
+  return makeReplaceExpression(
+      std::move(children.at(0)), std::move(children.at(1)),
+      std::move(children.at(2)),
+      children.size() == 4 ? std::move(children.at(3)) : nullptr);
 }
 
 // ____________________________________________________________________________

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1649,12 +1649,24 @@ TEST(SparqlParser, builtInCall) {
       "concat(?x, ?y, ?z)",
       matchNary(makeConcatExpressionVariadic, Var{"?x"}, Var{"?y"}, Var{"?z"}));
 
+  auto makeReplaceExpressionThreeArgs = [](auto&& arg0, auto&& arg1,
+                                           auto&& arg2) {
+    return makeReplaceExpression(AD_FWD(arg0), AD_FWD(arg1), AD_FWD(arg2),
+                                 nullptr);
+  };
+
+  expectBuiltInCall("replace(?x, ?y, ?z)",
+                    matchNary(makeReplaceExpressionThreeArgs, Var{"?x"},
+                              Var{"?y"}, Var{"?z"}));
   expectBuiltInCall(
-      "replace(?x, ?y, ?z)",
-      matchNary(&makeReplaceExpression, Var{"?x"}, Var{"?y"}, Var{"?z"}));
-  expectFails("replace(?x, ?y, ?z, \"i\")",
-              ::testing::AllOf(::testing::ContainsRegex("regex"),
-                               ::testing::ContainsRegex("flags")));
+      "replace(?x, ?y, ?z, \"imsu\")",
+      matchNaryWithChildrenMatchers(
+          makeReplaceExpressionThreeArgs, variableExpressionMatcher(Var{"?x"}),
+          matchNaryWithChildrenMatchers(
+              &makeMergeRegexPatternAndFlagsExpression,
+              variableExpressionMatcher(Var{"?y"}),
+              matchLiteralExpression(lit("imsu"))),
+          variableExpressionMatcher(Var{"?z"})));
   expectBuiltInCall("IF(?a, ?h, ?c)", matchNary(&makeIfExpression, Var{"?a"},
                                                 Var{"?h"}, Var{"?c"}));
   expectBuiltInCall("LANG(?x)", matchUnary(&makeLangExpression));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1419,14 +1419,10 @@ TEST(SparqlExpression, ReplaceExpression) {
 
   using ::testing::HasSubstr;
   // Invalid flags
-  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
-      checkReplaceWithFlags(
-          IdOrLiteralOrIriVec{U},
-          std::tuple{idOrLitOrStringVec({"null"}), IdOrLiteralOrIri{lit("[n]")},
-                     IdOrLiteralOrIri{lit("X")}, IdOrLiteralOrIri{lit("???")}}),
-      ::testing::AllOf(HasSubstr("'i'"), HasSubstr("'m'"), HasSubstr("'s'"),
-                       HasSubstr("'u'"), HasSubstr("?")),
-      std::runtime_error);
+  checkReplaceWithFlags(
+      IdOrLiteralOrIriVec{U},
+      std::tuple{idOrLitOrStringVec({"null"}), IdOrLiteralOrIri{lit("[n]")},
+                 IdOrLiteralOrIri{lit("X")}, IdOrLiteralOrIri{lit("???")}});
 
   // Illegal replacement.
   checkReplace(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1342,7 +1342,13 @@ TEST(SparqlExpression, concatExpression) {
 
 // ______________________________________________________________________________
 TEST(SparqlExpression, ReplaceExpression) {
-  auto checkReplace = testNaryExpressionVec<&makeReplaceExpression>;
+  auto makeReplaceExpressionThreeArgs = [](auto&& arg0, auto&& arg1,
+                                           auto&& arg2) {
+    return makeReplaceExpression(AD_FWD(arg0), AD_FWD(arg1), AD_FWD(arg2),
+                                 nullptr);
+  };
+  auto checkReplace = testNaryExpressionVec<makeReplaceExpressionThreeArgs>;
+  auto checkReplaceWithFlags = testNaryExpressionVec<&makeReplaceExpression>;
   // A simple replace( no regexes involved).
   checkReplace(
       idOrLitOrStringVec({"null", "Eins", "zwEi", "drEi", U, U}),
@@ -1370,6 +1376,19 @@ TEST(SparqlExpression, ReplaceExpression) {
                           IdOrLiteralOrIri{lit("(?i)[ei]")},
                           IdOrLiteralOrIri{lit("x")}});
 
+  // Case-insensitive matching using the flag
+  checkReplaceWithFlags(
+      idOrLitOrStringVec({"null", "xxns", "zwxx", "drxx"}),
+      std::tuple{idOrLitOrStringVec({"null", "eIns", "zwEi", "drei"}),
+                 IdOrLiteralOrIri{lit("[ei]")}, IdOrLiteralOrIri{lit("x")},
+                 IdOrLiteralOrIri{lit("i")}});
+  // Empty flag
+  checkReplaceWithFlags(
+      idOrLitOrStringVec({"null", "xIns", "zwEx", "drxx"}),
+      std::tuple{idOrLitOrStringVec({"null", "eIns", "zwEi", "drei"}),
+                 IdOrLiteralOrIri{lit("[ei]")}, IdOrLiteralOrIri{lit("x")},
+                 IdOrLiteralOrIri{lit("")}});
+
   // Multiple matches within the same string
   checkReplace(
       IdOrLiteralOrIri{lit("wEeDEflE")},
@@ -1386,6 +1405,29 @@ TEST(SparqlExpression, ReplaceExpression) {
       IdOrLiteralOrIriVec{U, U, U, U, U, U},
       std::tuple{idOrLitOrStringVec({"null", "Xs", "zwei", "drei", U, U}), U,
                  IdOrLiteralOrIri{lit("X")}});
+
+  checkReplaceWithFlags(
+      IdOrLiteralOrIriVec{U, U, U, U, U, U},
+      std::tuple{idOrLitOrStringVec({"null", "Xs", "zwei", "drei", U, U}), U,
+                 IdOrLiteralOrIri{lit("X")}, IdOrLiteralOrIri{lit("i")}});
+
+  // Undefined flags
+  checkReplaceWithFlags(
+      IdOrLiteralOrIriVec{U, U, U, U, U, U},
+      std::tuple{idOrLitOrStringVec({"null", "Xs", "zwei", "drei", U, U}),
+                 IdOrLiteralOrIri{lit("[ei]")}, IdOrLiteralOrIri{lit("X")}, U});
+
+  using ::testing::HasSubstr;
+  // Invalid flags
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      checkReplaceWithFlags(
+          IdOrLiteralOrIriVec{U},
+          std::tuple{idOrLitOrStringVec({"null"}), IdOrLiteralOrIri{lit("[n]")},
+                     IdOrLiteralOrIri{lit("X")}, IdOrLiteralOrIri{lit("???")}}),
+      ::testing::AllOf(HasSubstr("'i'"), HasSubstr("'m'"), HasSubstr("'s'"),
+                       HasSubstr("'u'"), HasSubstr("?")),
+      std::runtime_error);
+
   // Illegal replacement.
   checkReplace(
       IdOrLiteralOrIriVec{U, U, U, U, U, U},


### PR DESCRIPTION
 The builtin `REPLACE` expression is based on regular expressions, and so according to the standard it supports an optional fourth argument for flags that adapt the behavior of the regex engine (e.g. case-insensitive matching).
This PR adds the support for this argument with the exact same semantics as in the `REGEX`  expression.