### PR TITLE
Update ubuntu version for docker runner from 20.04 to 24.04

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
20.04 images are deprecated and will experience scheduled "brownouts" (see [https://github.com/actions/runner-images/issues/11101](https://github.com/actions/runner-images/issues/11101)).
This bumps the version for the docker build runner.