### PR TITLE
Support post query values in top-level query

### DIFF
--- a/e2e/scientists_queries.yaml
+++ b/e2e/scientists_queries.yaml
@@ -1171,6 +1171,23 @@ queries:
       - selected: ["?a", "?b"]
       - contains_row: ["<Charles,_Prince_of_Wales>", "<Lord_of_the_Isles>"]
 
+  - query: trailing-values-limit
+    type: no-text
+    sparql: |
+      SELECT * {
+        VALUES (?x) { ("A") }
+      }
+      LIMIT 1
+      VALUES (?x) {
+        ("A")
+        ("A")
+      }
+    checks:
+      - num_cols: 1
+      - num_rows: 1
+      - selected: [ "?x" ]
+      - contains_row: [ "A" ]
+
 
   - query : filter-depending-on-last-optional
     type: no-text

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -195,6 +195,16 @@ std::vector<SubtreePlan> QueryPlanner::createExecutionTrees(ParsedQuery& pq,
     }
   }
 
+  if (pq.postQueryValuesClause_.has_value()) {
+    auto values = makeSubtreePlan<::Values>(
+        _qec, std::move(pq.postQueryValuesClause_.value()._inlineValues));
+    std::vector<SubtreePlan> originalLastRow = std::move(lastRow);
+    for (auto& plan : originalLastRow) {
+      ql::ranges::move(createJoinCandidates(plan, values, boost::none),
+                       std::back_inserter(lastRow));
+    }
+  }
+
   checkCancellation();
 
   for (const auto& warning : pq.warnings()) {

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -344,6 +344,11 @@ class QueryPlanner {
                                                 const SubtreePlan& b,
                                                 const JoinColumns& jcs) const;
 
+  // Same as `createJoinCandidates(SubtreePlan, SubtreePlan, JoinColumns)`, but
+  // creates a cartesian product when `jcs` is empty.
+  std::vector<SubtreePlan> createJoinCandidatesAllowEmpty(
+      const SubtreePlan& a, const SubtreePlan& b, const JoinColumns& jcs) const;
+
   // Whenever a join is applied to a `Union`, add candidates that try applying
   // join to the children of the union directly, which can be more efficient if
   // one of the children has an optimized join, which can happen for
@@ -401,6 +406,11 @@ class QueryPlanner {
 
   vector<SubtreePlan> getHavingRow(
       const ParsedQuery& pq, const vector<vector<SubtreePlan>>& dpTab) const;
+
+  // Apply the passed `VALUES` clause to the current plans.
+  std::vector<SubtreePlan> applyPostQueryValues(
+      const parsedQuery::Values& values,
+      const std::vector<SubtreePlan>& currentPlans) const;
 
   bool connected(const SubtreePlan& a, const SubtreePlan& b,
                  const TripleGraph& graph) const;

--- a/src/parser/ParsedQuery.h
+++ b/src/parser/ParsedQuery.h
@@ -90,6 +90,7 @@ class ParsedQuery {
   vector<Variable> _groupByVariables;
   LimitOffsetClause _limitOffset{};
   string _originalString;
+  std::optional<parsedQuery::Values> postQueryValuesClause_ = std::nullopt;
 
   // Contains warnings about queries that are valid according to the SPARQL
   // standard, but are probably semantically wrong.

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -225,6 +225,8 @@ ParsedQuery Visitor::visit(Parser::QueryContext* ctx) {
       visitAlternative<ParsedQuery>(ctx->selectQuery(), ctx->constructQuery(),
                                     ctx->describeQuery(), ctx->askQuery());
 
+  query.postQueryValuesClause_ = visit(ctx->valuesClause());
+
   query._originalString = ctx->getStart()->getInputStream()->toString();
 
   return query;

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3253,4 +3253,9 @@ TEST(QueryPlanner, postQueryValuesClause) {
   h::expect("SELECT ?s ?p1 ?o1 { ?s ?p1 ?o1 } VALUES ?p1 { <pred> }",
             h::Join(h::IndexScanFromStrings("?s", "?p1", "?o1"),
                     h::Sort(h::ValuesClause("VALUES (?p1) { (<pred>) }"))));
+  h::expect("SELECT * { } VALUES () { () }", h::NeutralElement());
+  h::expect(
+      "SELECT * { } VALUES (?x ?y) { (1 2) }",
+      h::CartesianProductJoin(h::NeutralElement(),
+                              h::ValuesClause("VALUES (?x\t?y) { (1 2) }")));
 }

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -3247,3 +3247,10 @@ TEST(QueryPlanner, testDistributiveJoinInUnionRecursive) {
                                "?_QLever_internal_variable_qp_18")))))),
       qec, {4, 16, 64'000'000});
 }
+
+// _____________________________________________________________________________
+TEST(QueryPlanner, postQueryValuesClause) {
+  h::expect("SELECT ?s ?p1 ?o1 { ?s ?p1 ?o1 } VALUES ?p1 { <pred> }",
+            h::Join(h::IndexScanFromStrings("?s", "?p1", "?o1"),
+                    h::Sort(h::ValuesClause("VALUES (?p1) { (<pred>) }"))));
+}


### PR DESCRIPTION
Implement a `VALUES` clause that appears after the query body.
The `VALUES` clause is currently joined at the very end. In the future, we can create more optimized query plans that incorporate the clause into the query plan earlier, but there we have to be careful with the semantics of `FILTER`s with columns that contain unbound values.