### PR TITLE
Implement negated property path

### DIFF
--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -312,6 +312,11 @@ class QueryPlanner {
   ParsedQuery::GraphPattern seedFromInverse(const TripleComponent& left,
                                             const PropertyPath& path,
                                             const TripleComponent& right);
+  // Create `GraphPattern` for property paths of the form `!(<a> | ^<b>)` or
+  // `!<a>` and similar.
+  ParsedQuery::GraphPattern seedFromNegated(const TripleComponent& left,
+                                            const PropertyPath& path,
+                                            const TripleComponent& right);
   static ParsedQuery::GraphPattern seedFromIri(const TripleComponent& left,
                                                const PropertyPath& path,
                                                const TripleComponent& right);

--- a/src/parser/PropertyPath.cpp
+++ b/src/parser/PropertyPath.cpp
@@ -48,6 +48,19 @@ void PropertyPath::writeToStream(std::ostream& out) const {
       }
       out << ")";
       break;
+    case Operation::NEGATED: {
+      out << "!(";
+      bool firstRun = true;
+      for (const auto& child : children_) {
+        if (!firstRun) {
+          out << '|';
+        }
+        firstRun = false;
+        child.writeToStream(out);
+      }
+      out << ")";
+      break;
+    }
     case Operation::IRI:
       out << iri_;
       break;

--- a/src/parser/PropertyPath.h
+++ b/src/parser/PropertyPath.h
@@ -19,7 +19,8 @@ class PropertyPath {
     IRI,
     ZERO_OR_MORE,
     ONE_OR_MORE,
-    ZERO_OR_ONE
+    ZERO_OR_ONE,
+    NEGATED
   };
 
   PropertyPath() : operation_(Operation::IRI) {}
@@ -91,6 +92,10 @@ class PropertyPath {
 
   static PropertyPath makeZeroOrOne(PropertyPath child) {
     return makeWithChildren({std::move(child)}, Operation::ZERO_OR_ONE);
+  }
+
+  static PropertyPath makeNegated(std::vector<PropertyPath> children) {
+    return makeWithChildren(std::move(children), Operation::NEGATED);
   }
 
   bool operator==(const PropertyPath& other) const = default;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -54,6 +54,11 @@ using SparqlValues = parsedQuery::SparqlValues;
 using Visitor = SparqlQleverVisitor;
 using Parser = SparqlAutomaticParser;
 
+namespace {
+constexpr std::string_view a =
+    "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>";
+}
+
 // _____________________________________________________________________________
 std::string Visitor::getOriginalInputForContext(
     const antlr4::ParserRuleContext* context) {
@@ -1571,7 +1576,7 @@ GraphTerm Visitor::visit(Parser::VerbContext* ctx) {
   } else {
     // Special keyword 'a'
     AD_CORRECTNESS_CHECK(ctx->getText() == "a");
-    return GraphTerm{Iri{"<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"}};
+    return GraphTerm{Iri{std::string{a}}};
   }
 }
 
@@ -1864,21 +1869,27 @@ PropertyPath Visitor::visit(Parser::PathPrimaryContext* ctx) {
   } else {
     AD_CORRECTNESS_CHECK(ctx->getText() == "a");
     // Special keyword 'a'
-    return PropertyPath::fromIri(
-        "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>");
+    return PropertyPath::fromIri(std::string{a});
   }
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visit(const Parser::PathNegatedPropertySetContext* ctx) {
-  reportNotSupported(ctx, "\"!\" inside a property path is ");
+PropertyPath Visitor::visit(Parser::PathNegatedPropertySetContext* ctx) {
+  return PropertyPath::makeNegated(visitVector(ctx->pathOneInPropertySet()));
 }
 
 // ____________________________________________________________________________________
-PropertyPath Visitor::visit(Parser::PathOneInPropertySetContext*) {
-  // This rule is only used by the `PathNegatedPropertySet` rule which also is
-  // not supported and should already have thrown an exception.
-  AD_FAIL();
+PropertyPath Visitor::visit(Parser::PathOneInPropertySetContext* ctx) {
+  std::string iri = ctx->iri()
+                        ? std::move(visit(ctx->iri()).toStringRepresentation())
+                        : std::string{a};
+  const std::string& text = ctx->getText();
+  AD_CORRECTNESS_CHECK((iri == a) == (text == "a" || text == "^a"));
+  auto propertyPath = PropertyPath::fromIri(std::move(iri));
+  if (text.starts_with("^")) {
+    return PropertyPath::makeInverse(propertyPath);
+  }
+  return propertyPath;
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -368,11 +368,9 @@ class SparqlQleverVisitor {
 
   PropertyPath visit(Parser::PathPrimaryContext* ctx);
 
-  [[noreturn]] static PropertyPath visit(
-      const Parser::PathNegatedPropertySetContext*);
+  PropertyPath visit(Parser::PathNegatedPropertySetContext*);
 
-  [[noreturn]] static PropertyPath visit(
-      Parser::PathOneInPropertySetContext* ctx);
+  PropertyPath visit(Parser::PathOneInPropertySetContext* ctx);
 
   /// Note that in the SPARQL grammar the INTEGER rule refers to positive
   /// integers without an explicit sign.


### PR DESCRIPTION
This allows to specify queries of the form
```sparql
SELECT * {
  ?a !a ?b
}
```
```sparql
SELECT * {
  ?a !(^a|a) ?b
}
```
```sparql
SELECT * {
  ?a !(<some>|<predicate>|^<here>) ?b
}
```