### PR TITLE
Remove `ProtoResult` alias

### DIFF
--- a/src/engine/Bind.cpp
+++ b/src/engine/Bind.cpp
@@ -105,7 +105,7 @@ IdTable Bind::cloneSubView(const IdTable& idTable,
 }
 
 // _____________________________________________________________________________
-ProtoResult Bind::computeResult(bool requestLaziness) {
+Result Bind::computeResult(bool requestLaziness) {
   _subtree->setLimit(getLimit());
   LOG(DEBUG) << "Get input to BIND operation..." << std::endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult(requestLaziness);

--- a/src/engine/Bind.h
+++ b/src/engine/Bind.h
@@ -44,7 +44,7 @@ class Bind : public Operation {
   [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
 
  private:
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   static IdTable cloneSubView(const IdTable& idTable,
                               const std::pair<size_t, size_t>& subrange);

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -131,7 +131,7 @@ void CartesianProductJoin::writeResultColumn(std::span<Id> targetColumn,
 }
 
 // ____________________________________________________________________________
-ProtoResult CartesianProductJoin::computeResult(bool requestLaziness) {
+Result CartesianProductJoin::computeResult(bool requestLaziness) {
   if (knownEmptyResult()) {
     return {IdTable{getResultWidth(), getExecutionContext()->getAllocator()},
             resultSortedOn(), LocalVocab{}};
@@ -192,7 +192,7 @@ CPP_template_def(typename R)(requires ql::ranges::random_access_range<R>)
   IdTable result{getResultWidth(), getExecutionContext()->getAllocator()};
   // TODO<joka921> Find a solution to cheaply handle the case, that only a
   // single result is left. This can probably be done by using the
-  // `ProtoResult`.
+  // `Result`.
 
   auto sizesView = ql::views::transform(idTables, &IdTable::size);
   auto totalResultSize =

--- a/src/engine/CartesianProductJoin.h
+++ b/src/engine/CartesianProductJoin.h
@@ -81,7 +81,7 @@ class CartesianProductJoin : public Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   // Copy each element from the `inputColumn` `groupSize` times to the
   // `targetColumn`. Repeat until the `targetColumn` is completely filled. Skip

--- a/src/engine/CountAvailablePredicates.cpp
+++ b/src/engine/CountAvailablePredicates.cpp
@@ -100,7 +100,7 @@ size_t CountAvailablePredicates::getCostEstimate() {
 }
 
 // _____________________________________________________________________________
-ProtoResult CountAvailablePredicates::computeResult(
+Result CountAvailablePredicates::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "CountAvailablePredicates result computation..." << std::endl;
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/CountAvailablePredicates.h
+++ b/src/engine/CountAvailablePredicates.h
@@ -100,6 +100,6 @@ class CountAvailablePredicates : public Operation {
   void computePatternTrickAllEntities(
       IdTable* result, const CompactVectorOfStrings<Id>& patterns) const;
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -222,7 +222,7 @@ IdTable Describe::getIdsToDescribe(const Result& result,
 }
 
 // _____________________________________________________________________________
-ProtoResult Describe::computeResult([[maybe_unused]] bool requestLaziness) {
+Result Describe::computeResult([[maybe_unused]] bool requestLaziness) {
   LocalVocab localVocab;
   // Compute the results of the WHERE clause and extract the `Id`s to describe.
   //

--- a/src/engine/Describe.h
+++ b/src/engine/Describe.h
@@ -49,7 +49,7 @@ class Describe : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
   [[nodiscard]] vector<ColumnIndex> resultSortedOn() const override;
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
   VariableToColumnMap computeVariableToColumnMap() const override;
 
   // Add all triples where the subject is one of the `blankNodes` (an `IdTable`

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -59,7 +59,7 @@ Result::Generator Distinct::lazyDistinct(Result::LazyResult input,
 }
 
 // _____________________________________________________________________________
-ProtoResult Distinct::computeResult(bool requestLaziness) {
+Result Distinct::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-result for distinct result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult(true);
 
@@ -77,9 +77,9 @@ ProtoResult Distinct::computeResult(bool requestLaziness) {
       CALL_FIXED_SIZE(width, &Distinct::lazyDistinct, this,
                       std::move(subRes->idTables()), !requestLaziness);
   return requestLaziness
-             ? ProtoResult{std::move(generator), resultSortedOn()}
-             : ProtoResult{cppcoro::getSingleElement(std::move(generator)),
-                           resultSortedOn()};
+             ? Result{std::move(generator), resultSortedOn()}
+             : Result{cppcoro::getSingleElement(std::move(generator)),
+                      resultSortedOn()};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -58,7 +58,7 @@ class Distinct : public Operation {
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -82,7 +82,7 @@ size_t ExistsJoin::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-ProtoResult ExistsJoin::computeResult([[maybe_unused]] bool requestLaziness) {
+Result ExistsJoin::computeResult([[maybe_unused]] bool requestLaziness) {
   auto leftRes = left_->getResult();
   auto rightRes = right_->getResult();
   const auto& left = leftRes->idTable();

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -78,7 +78,7 @@ class ExistsJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -60,7 +60,7 @@ void Filter::setPrefilterExpressionForChildren() {
 }
 
 // _____________________________________________________________________________
-ProtoResult Filter::computeResult(bool requestLaziness) {
+Result Filter::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-result for Filter result computation..." << endl;
   std::shared_ptr<const Result> subRes = _subtree->getResult(true);
   LOG(DEBUG) << "Filter result computation..." << endl;

--- a/src/engine/Filter.h
+++ b/src/engine/Filter.h
@@ -68,7 +68,7 @@ class Filter : public Operation {
   // entity will be updated.
   void setPrefilterExpressionForChildren();
 
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   // Perform the actual filter operation of the data provided.
   CPP_template(int WIDTH, typename Table)(

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -309,7 +309,7 @@ sparqlExpression::EvaluationContext GroupBy::createEvaluationContext(
 }
 
 // _____________________________________________________________________________
-ProtoResult GroupBy::computeResult(bool requestLaziness) {
+Result GroupBy::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "GroupBy result computation..." << std::endl;
 
   if (auto idTable = computeOptimizedGroupByIfPossible()) {
@@ -411,9 +411,9 @@ ProtoResult GroupBy::computeResult(bool requestLaziness) {
         std::move(groupByCols), !requestLaziness);
 
     return requestLaziness
-               ? ProtoResult{std::move(generator), resultSortedOn()}
-               : ProtoResult{cppcoro::getSingleElement(std::move(generator)),
-                             resultSortedOn()};
+               ? Result{std::move(generator), resultSortedOn()}
+               : Result{cppcoro::getSingleElement(std::move(generator)),
+                        resultSortedOn()};
   }
 
   AD_CORRECTNESS_CHECK(subresult->idTable().numColumns() == inWidth);

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -100,7 +100,7 @@ class GroupBy : public Operation {
   sparqlExpression::EvaluationContext createEvaluationContext(
       const LocalVocab& localVocab, const IdTable& idTable) const;
 
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   // Find the boundaries of blocks in a sorted `IdTable`. If these represent a
   // whole group they can be aggregated into ids afterwards. This can happen by

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -255,8 +255,7 @@ size_t HasPredicateScan::getCostEstimate() {
 }
 
 // ___________________________________________________________________________
-ProtoResult HasPredicateScan::computeResult(
-    [[maybe_unused]] bool requestLaziness) {
+Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());
 
@@ -372,7 +371,7 @@ void HasPredicateScan::computeFullScan(
 
 // ___________________________________________________________________________
 template <int WIDTH>
-ProtoResult HasPredicateScan::computeSubqueryS(
+Result HasPredicateScan::computeSubqueryS(
     IdTable* dynResult, const CompactVectorOfStrings<Id>& patterns) {
   auto subresult = subtree().getResult();
   auto patternCol = subtreeColIdx();

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -105,13 +105,13 @@ class HasPredicateScan : public Operation {
                               size_t resultSize);
 
   template <int WIDTH>
-  ProtoResult computeSubqueryS(IdTable* result,
-                               const CompactVectorOfStrings<Id>& patterns);
+  Result computeSubqueryS(IdTable* result,
+                          const CompactVectorOfStrings<Id>& patterns);
 
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -231,7 +231,7 @@ IdTable IndexScan::materializedIndexScan() const {
 }
 
 // _____________________________________________________________________________
-ProtoResult IndexScan::computeResult(bool requestLaziness) {
+Result IndexScan::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "IndexScan result computation...\n";
   if (requestLaziness) {
     return {chunkedIndexScan(), resultSortedOn()};

--- a/src/engine/IndexScan.h
+++ b/src/engine/IndexScan.h
@@ -178,7 +178,7 @@ class IndexScan final : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 

--- a/src/engine/Join.cpp
+++ b/src/engine/Join.cpp
@@ -153,7 +153,7 @@ string Join::getCacheKeyImpl() const {
 string Join::getDescriptor() const { return "Join on " + _joinVar.name(); }
 
 // _____________________________________________________________________________
-ProtoResult Join::computeResult(bool requestLaziness) {
+Result Join::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "Getting sub-results for join result computation..." << endl;
   if (_left->knownEmptyResult() || _right->knownEmptyResult()) {
     _left->getRootOperation()->updateRuntimeInformationWhenOptimizedOut();
@@ -477,7 +477,7 @@ CPP_template_2(typename ActionT)(
     requires ad_utility::InvocableWithExactReturnType<
         ActionT, Result::IdTableVocabPair,
         std::function<void(IdTable&, LocalVocab&)>>)
-    ProtoResult Join::createResult(
+    Result Join::createResult(
         bool requestedLaziness, ActionT action,
         std::optional<std::vector<ColumnIndex>> permutation) const {
   if (requestedLaziness) {
@@ -492,9 +492,9 @@ CPP_template_2(typename ActionT)(
 }
 
 // ______________________________________________________________________________
-ProtoResult Join::lazyJoin(std::shared_ptr<const Result> a,
-                           std::shared_ptr<const Result> b,
-                           bool requestLaziness) const {
+Result Join::lazyJoin(std::shared_ptr<const Result> a,
+                      std::shared_ptr<const Result> b,
+                      bool requestLaziness) const {
   // If both inputs are fully materialized, we can join them more
   // efficiently.
   AD_CONTRACT_CHECK(!a->isFullyMaterialized() || !b->isFullyMaterialized());
@@ -653,7 +653,7 @@ void Join::addCombinedRowToIdTable(const ROW_A& rowA, const ROW_B& rowB,
 }
 
 // ______________________________________________________________________________________________________
-ProtoResult Join::computeResultForTwoIndexScans(bool requestLaziness) const {
+Result Join::computeResultForTwoIndexScans(bool requestLaziness) const {
   return createResult(
       requestLaziness,
       [this](std::function<void(IdTable&, LocalVocab&)> yieldTable) {
@@ -695,7 +695,7 @@ ProtoResult Join::computeResultForTwoIndexScans(bool requestLaziness) const {
 
 // ______________________________________________________________________________________________________
 template <bool idTableIsRightInput>
-ProtoResult Join::computeResultForIndexScanAndIdTable(
+Result Join::computeResultForIndexScanAndIdTable(
     bool requestLaziness, std::shared_ptr<const Result> resultWithIdTable,
     std::shared_ptr<IndexScan> scan) const {
   AD_CORRECTNESS_CHECK((idTableIsRightInput ? _leftJoinCol : _rightJoinCol) ==
@@ -774,7 +774,7 @@ ProtoResult Join::computeResultForIndexScanAndIdTable(
 }
 
 // ______________________________________________________________________________________________________
-ProtoResult Join::computeResultForIndexScanAndLazyOperation(
+Result Join::computeResultForIndexScanAndLazyOperation(
     bool requestLaziness, std::shared_ptr<const Result> resultWithIdTable,
     std::shared_ptr<IndexScan> scan) const {
   AD_CORRECTNESS_CHECK(_rightJoinCol == 0);
@@ -808,7 +808,7 @@ ProtoResult Join::computeResultForIndexScanAndLazyOperation(
       std::move(resultPermutation));
 }
 // _____________________________________________________________________________
-ProtoResult Join::computeResultForTwoMaterializedInputs(
+Result Join::computeResultForTwoMaterializedInputs(
     std::shared_ptr<const Result> leftRes,
     std::shared_ptr<const Result> rightRes) const {
   IdTable idTable{getResultWidth(), allocator()};
@@ -820,7 +820,7 @@ ProtoResult Join::computeResultForTwoMaterializedInputs(
 }
 
 // _____________________________________________________________________________
-ProtoResult Join::createEmptyResult() const {
+Result Join::createEmptyResult() const {
   return {IdTable{getResultWidth(), allocator()}, resultSortedOn(),
           LocalVocab{}};
 }

--- a/src/engine/Join.h
+++ b/src/engine/Join.h
@@ -115,16 +115,15 @@ class Join : public Operation {
   CPP_template_2(typename ActionT)(
       requires ad_utility::InvocableWithExactReturnType<
           ActionT, Result::IdTableVocabPair,
-          std::function<void(IdTable&, LocalVocab&)>>) ProtoResult
+          std::function<void(IdTable&, LocalVocab&)>>) Result
       createResult(bool requestedLaziness, ActionT action,
                    OptionalPermutation permutation = {}) const;
 
   // Fallback implementation of a join that is used when at least one of the two
   // inputs is not fully materialized. This represents the general case where we
   // don't have any optimization left to try.
-  ProtoResult lazyJoin(std::shared_ptr<const Result> a,
-                       std::shared_ptr<const Result> b,
-                       bool requestLaziness) const;
+  Result lazyJoin(std::shared_ptr<const Result> a,
+                  std::shared_ptr<const Result> b, bool requestLaziness) const;
 
   /**
    * @brief Joins IdTables dynA and dynB on join column jc2, returning
@@ -148,14 +147,14 @@ class Join : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 
   // A special implementation that is called when both children are
   // `IndexScan`s. Uses the lazy scans to only retrieve the subset of the
   // `IndexScan`s that is actually needed without fully materializing them.
-  ProtoResult computeResultForTwoIndexScans(bool requestLaziness) const;
+  Result computeResultForTwoIndexScans(bool requestLaziness) const;
 
   // A special implementation that is called when exactly one of the children is
   // an `IndexScan` and the other one is a fully materialized result. The
@@ -163,7 +162,7 @@ class Join : public Operation {
   // left or the right child of this `Join`. This needs to be known to determine
   // the correct order of the columns in the result.
   template <bool idTableIsRightInput>
-  ProtoResult computeResultForIndexScanAndIdTable(
+  Result computeResultForIndexScanAndIdTable(
       bool requestLaziness, std::shared_ptr<const Result> resultWithIdTable,
       std::shared_ptr<IndexScan> scan) const;
 
@@ -171,12 +170,12 @@ class Join : public Operation {
   // `IndexScan` and the left child is a lazy result. (The constructor will
   // ensure the correct order if they are initially swapped). This allows the
   // `IndexScan` to skip rows that won't match in the join operation.
-  ProtoResult computeResultForIndexScanAndLazyOperation(
+  Result computeResultForIndexScanAndLazyOperation(
       bool requestLaziness, std::shared_ptr<const Result> resultWithIdTable,
       std::shared_ptr<IndexScan> scan) const;
 
   // Default case where both inputs are fully materialized.
-  ProtoResult computeResultForTwoMaterializedInputs(
+  Result computeResultForTwoMaterializedInputs(
       std::shared_ptr<const Result> leftRes,
       std::shared_ptr<const Result> rightRes) const;
 
@@ -206,7 +205,7 @@ class Join : public Operation {
                            IdTable* dynRes);
 
   // Commonly used code for the various known-to-be-empty cases.
-  ProtoResult createEmptyResult() const;
+  Result createEmptyResult() const;
 
   // Get permutation of input and output columns to apply before and after
   // joining. This is required because the join algorithms expect the join

--- a/src/engine/Minus.cpp
+++ b/src/engine/Minus.cpp
@@ -33,7 +33,7 @@ string Minus::getCacheKeyImpl() const {
 string Minus::getDescriptor() const { return "Minus"; }
 
 // _____________________________________________________________________________
-ProtoResult Minus::computeResult([[maybe_unused]] bool requestLaziness) {
+Result Minus::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "Minus result computation..." << endl;
 
   // If the right of the RootOperations is a Service, precompute the result of

--- a/src/engine/Minus.h
+++ b/src/engine/Minus.h
@@ -74,7 +74,7 @@ class Minus : public Operation {
       const IdTableView<A_WIDTH>& a, const IdTableView<B_WIDTH>& b, size_t ia,
       size_t ib, const vector<std::array<ColumnIndex, 2>>& matchedColumns);
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };

--- a/src/engine/MultiColumnJoin.cpp
+++ b/src/engine/MultiColumnJoin.cpp
@@ -61,8 +61,7 @@ string MultiColumnJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ProtoResult MultiColumnJoin::computeResult(
-    [[maybe_unused]] bool requestLaziness) {
+Result MultiColumnJoin::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "MultiColumnJoin result computation..." << endl;
 
   IdTable idTable{getExecutionContext()->getAllocator()};

--- a/src/engine/MultiColumnJoin.h
+++ b/src/engine/MultiColumnJoin.h
@@ -65,7 +65,7 @@ class MultiColumnJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/NeutralElementOperation.h
+++ b/src/engine/NeutralElementOperation.h
@@ -44,7 +44,7 @@ class NeutralElementOperation : public Operation {
   };
 
  private:
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     IdTable idTable{getExecutionContext()->getAllocator()};
     idTable.setNumColumns(0);
     idTable.resize(1);

--- a/src/engine/NeutralOptional.cpp
+++ b/src/engine/NeutralOptional.cpp
@@ -105,7 +105,7 @@ bool NeutralOptional::singleRowCroppedByLimit() const {
 }
 
 // _____________________________________________________________________________
-ProtoResult NeutralOptional::computeResult(bool requestLaziness) {
+Result NeutralOptional::computeResult(bool requestLaziness) {
   const auto& limit = getLimit();
   tree_->setLimit(limit);
 

--- a/src/engine/NeutralOptional.h
+++ b/src/engine/NeutralOptional.h
@@ -20,7 +20,7 @@ class NeutralOptional : public Operation {
   std::string getCacheKeyImpl() const override;
   uint64_t getSizeEstimateBeforeLimit() override;
   std::unique_ptr<Operation> cloneImpl() const override;
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
   VariableToColumnMap computeVariableToColumnMap() const override;
 
   // Return true, if `_limit` is configured in a way that will prevent the

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -133,13 +133,13 @@ void Operation::updateRuntimeStats(bool applyToLimit, uint64_t numRows,
 }
 
 // _____________________________________________________________________________
-ProtoResult Operation::runComputation(const ad_utility::Timer& timer,
-                                      ComputationMode computationMode) {
+Result Operation::runComputation(const ad_utility::Timer& timer,
+                                 ComputationMode computationMode) {
   AD_CONTRACT_CHECK(computationMode != ComputationMode::ONLY_IF_CACHED);
   checkCancellation();
   runtimeInfo().status_ = RuntimeInformation::Status::inProgress;
   signalQueryUpdate();
-  ProtoResult result =
+  Result result =
       computeResult(computationMode == ComputationMode::LAZY_IF_SUPPORTED);
   AD_CONTRACT_CHECK(computationMode == ComputationMode::LAZY_IF_SUPPORTED ||
                     result.isFullyMaterialized());

--- a/src/engine/Operation.h
+++ b/src/engine/Operation.h
@@ -309,7 +309,7 @@ class Operation {
   // Direct access to the `computeResult()` method. This should be only used for
   // testing, otherwise the `getResult()` function should be used which also
   // sets the runtime info and uses the cache.
-  virtual ProtoResult computeResultOnlyForTesting(
+  virtual Result computeResultOnlyForTesting(
       bool requestLaziness = false) final {
     return computeResult(requestLaziness);
   }
@@ -366,7 +366,7 @@ class Operation {
 
  private:
   //! Compute the result of the query-subtree rooted at this element..
-  virtual ProtoResult computeResult(bool requestLaziness) = 0;
+  virtual Result computeResult(bool requestLaziness) = 0;
 
   // Update the runtime information of this operation according to the given
   // arguments, considering the possibility that the initial runtime information
@@ -384,8 +384,8 @@ class Operation {
   // `Operation`. The value provided by `computationMode` decides if lazy
   // results are preferred. It must not be `ONLY_IF_CACHED`, this will lead to
   // an `ad_utility::Exception`.
-  ProtoResult runComputation(const ad_utility::Timer& timer,
-                             ComputationMode computationMode);
+  Result runComputation(const ad_utility::Timer& timer,
+                        ComputationMode computationMode);
 
   // Call `runComputation` and transform it into a value that could be inserted
   // into the cache.

--- a/src/engine/OptionalJoin.cpp
+++ b/src/engine/OptionalJoin.cpp
@@ -90,7 +90,7 @@ string OptionalJoin::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ProtoResult OptionalJoin::computeResult([[maybe_unused]] bool requestLaziness) {
+Result OptionalJoin::computeResult([[maybe_unused]] bool requestLaziness) {
   LOG(DEBUG) << "OptionalJoin result computation..." << endl;
 
   // If the right of the RootOperations is a Service, precompute the result of

--- a/src/engine/OptionalJoin.h
+++ b/src/engine/OptionalJoin.h
@@ -71,7 +71,7 @@ class OptionalJoin : public Operation {
 
   void computeSizeEstimateAndMultiplicities();
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/OrderBy.cpp
+++ b/src/engine/OrderBy.cpp
@@ -63,7 +63,7 @@ std::string OrderBy::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ProtoResult OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
+Result OrderBy::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for OrderBy result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/OrderBy.h
+++ b/src/engine/OrderBy.h
@@ -80,7 +80,7 @@ class OrderBy : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override {
     return subtree_->getVariableColumns();

--- a/src/engine/Result.h
+++ b/src/engine/Result.h
@@ -258,7 +258,3 @@ class Result {
   // generator.
   void checkDefinedness(const VariableToColumnMap& varColMap);
 };
-
-// Class alias to conceptually differentiate between Results that produce
-// values and Results meant to be consumed.
-using ProtoResult = Result;

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -94,7 +94,7 @@ size_t Service::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
+Result Service::computeResult([[maybe_unused]] bool requestLaziness) {
   // Try to simplify the Service Query using it's sibling Operation.
   if (auto valuesClause = getSiblingValuesClause(); valuesClause.has_value()) {
     auto openBracketPos = parsedServiceClause_.graphPatternAsString_.find('{');
@@ -120,7 +120,7 @@ ProtoResult Service::computeResult([[maybe_unused]] bool requestLaziness) {
 }
 
 // ____________________________________________________________________________
-ProtoResult Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
+Result Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   // Get the URL of the SPARQL endpoint.
   ad_utility::httpUtils::Url serviceUrl{
       asStringViewUnsafe(parsedServiceClause_.serviceIri_.getContent())};
@@ -188,9 +188,9 @@ ProtoResult Service::computeResultImpl([[maybe_unused]] bool requestLaziness) {
   auto generator =
       computeResultLazily(expVariableKeys, std::move(body), !requestLaziness);
   return requestLaziness
-             ? ProtoResult{std::move(generator), resultSortedOn()}
-             : ProtoResult{cppcoro::getSingleElement(std::move(generator)),
-                           resultSortedOn()};
+             ? Result{std::move(generator), resultSortedOn()}
+             : Result{cppcoro::getSingleElement(std::move(generator)),
+                      resultSortedOn()};
 }
 
 template <size_t I>
@@ -405,7 +405,7 @@ TripleComponent Service::bindingToTripleComponent(
 }
 
 // ____________________________________________________________________________
-ProtoResult Service::makeNeutralElementResultForSilentFail() const {
+Result Service::makeNeutralElementResultForSilentFail() const {
   IdTable idTable{getResultWidth(), getExecutionContext()->getAllocator()};
   idTable.emplace_back();
   for (size_t colIdx = 0; colIdx < getResultWidth(); ++colIdx) {

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -109,16 +109,16 @@ class Service : public Operation {
   std::string getCacheKeyImpl() const override;
 
   // Compute the result using `getResultFunction_` and `siblingInfo_`.
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   // Actually compute the result for the function above.
-  ProtoResult computeResultImpl([[maybe_unused]] bool requestLaziness);
+  Result computeResultImpl([[maybe_unused]] bool requestLaziness);
 
   // Get a VALUES clause that contains the values of the siblingTree's result.
   std::optional<std::string> getSiblingValuesClause() const;
 
   // Create result for silent fail.
-  ProtoResult makeNeutralElementResultForSilentFail() const;
+  Result makeNeutralElementResultForSilentFail() const;
 
   // Check that all visible variables of the SERVICE clause exist in the json
   // object, otherwise throw an error.

--- a/src/engine/Sort.cpp
+++ b/src/engine/Sort.cpp
@@ -51,7 +51,7 @@ std::string Sort::getDescriptor() const {
 }
 
 // _____________________________________________________________________________
-ProtoResult Sort::computeResult([[maybe_unused]] bool requestLaziness) {
+Result Sort::computeResult([[maybe_unused]] bool requestLaziness) {
   using std::endl;
   LOG(DEBUG) << "Getting sub-result for Sort result computation..." << endl;
   std::shared_ptr<const Result> subRes = subtree_->getResult();

--- a/src/engine/Sort.h
+++ b/src/engine/Sort.h
@@ -69,8 +69,7 @@ class Sort : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  virtual ProtoResult computeResult(
-      [[maybe_unused]] bool requestLaziness) override;
+  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   [[nodiscard]] VariableToColumnMap computeVariableToColumnMap()
       const override {

--- a/src/engine/TextIndexScanForEntity.cpp
+++ b/src/engine/TextIndexScanForEntity.cpp
@@ -14,7 +14,7 @@ TextIndexScanForEntity::TextIndexScanForEntity(
       word_(std::move(word)) {}
 
 // _____________________________________________________________________________
-ProtoResult TextIndexScanForEntity::computeResult(
+Result TextIndexScanForEntity::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   IdTable idTable = getExecutionContext()->getIndex().getEntityMentionsForWord(
       word_, getExecutionContext()->getAllocator());

--- a/src/engine/TextIndexScanForEntity.h
+++ b/src/engine/TextIndexScanForEntity.h
@@ -100,7 +100,7 @@ class TextIndexScanForEntity : public Operation {
     return std::get<FixedEntity>(varOrFixed_.entity_).second;
   }
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextIndexScanForWord.cpp
+++ b/src/engine/TextIndexScanForWord.cpp
@@ -13,7 +13,7 @@ TextIndexScanForWord::TextIndexScanForWord(QueryExecutionContext* qec,
       isPrefix_(word_.ends_with('*')) {}
 
 // _____________________________________________________________________________
-ProtoResult TextIndexScanForWord::computeResult(
+Result TextIndexScanForWord::computeResult(
     [[maybe_unused]] bool requestLaziness) {
   IdTable idTable = getExecutionContext()->getIndex().getWordPostingsForTerm(
       word_, getExecutionContext()->getAllocator());

--- a/src/engine/TextIndexScanForWord.h
+++ b/src/engine/TextIndexScanForWord.h
@@ -49,7 +49,7 @@ class TextIndexScanForWord : public Operation {
 
   // Returns a Result containing an IdTable with the columns being
   // the text variable and the completed word (if it was prefixed)
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {}; }
 };

--- a/src/engine/TextLimit.cpp
+++ b/src/engine/TextLimit.cpp
@@ -20,7 +20,7 @@ TextLimit::TextLimit(QueryExecutionContext* qec, const size_t limit,
 }
 
 // _____________________________________________________________________________
-ProtoResult TextLimit::computeResult([[maybe_unused]] bool requestLaziness) {
+Result TextLimit::computeResult([[maybe_unused]] bool requestLaziness) {
   std::shared_ptr<const Result> childRes = child_->getResult();
 
   if (limit_ == 0) {

--- a/src/engine/TextLimit.h
+++ b/src/engine/TextLimit.h
@@ -64,7 +64,7 @@ class TextLimit : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   vector<QueryExecutionTree*> getChildren() override { return {child_.get()}; }
 };

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -147,7 +147,7 @@ class TransitivePathImpl : public TransitivePathBase {
    *
    * @return Result The result of the TransitivePath operation
    */
-  ProtoResult computeResult(bool requestLaziness) override {
+  Result computeResult(bool requestLaziness) override {
     auto [startSide, targetSide] = decideDirection();
     // In order to traverse the graph represented by this result, we need random
     // access across the whole table, so it doesn't make sense to lazily compute
@@ -162,17 +162,15 @@ class TransitivePathImpl : public TransitivePathBase {
           computeTransitivePathBound(std::move(subRes), startSide, targetSide,
                                      std::move(sideRes), !requestLaziness);
 
-      return requestLaziness
-                 ? ProtoResult{std::move(gen), resultSortedOn()}
-                 : ProtoResult{cppcoro::getSingleElement(std::move(gen)),
-                               resultSortedOn()};
+      return requestLaziness ? Result{std::move(gen), resultSortedOn()}
+                             : Result{cppcoro::getSingleElement(std::move(gen)),
+                                      resultSortedOn()};
     }
     auto gen = computeTransitivePath(std::move(subRes), startSide, targetSide,
                                      !requestLaziness);
-    return requestLaziness
-               ? ProtoResult{std::move(gen), resultSortedOn()}
-               : ProtoResult{cppcoro::getSingleElement(std::move(gen)),
-                             resultSortedOn()};
+    return requestLaziness ? Result{std::move(gen), resultSortedOn()}
+                           : Result{cppcoro::getSingleElement(std::move(gen)),
+                                    resultSortedOn()};
   }
 
   /**

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -190,7 +190,7 @@ size_t Union::getCostEstimate() {
          getSizeEstimateBeforeLimit();
 }
 
-ProtoResult Union::computeResult(bool requestLaziness) {
+Result Union::computeResult(bool requestLaziness) {
   LOG(DEBUG) << "Union result computation..." << std::endl;
   std::shared_ptr<const Result> subRes1 =
       _subtrees[0]->getResult(requestLaziness);
@@ -203,9 +203,9 @@ ProtoResult Union::computeResult(bool requestLaziness) {
       _columnOrigins.at(targetOrder_.at(0)).at(0) != NO_COLUMN) {
     auto generator = computeResultKeepOrder(requestLaziness, std::move(subRes1),
                                             std::move(subRes2));
-    return requestLaziness ? ProtoResult{std::move(generator), resultSortedOn()}
-                           : ProtoResult{getSingleElement(std::move(generator)),
-                                         resultSortedOn()};
+    return requestLaziness ? Result{std::move(generator), resultSortedOn()}
+                           : Result{getSingleElement(std::move(generator)),
+                                    resultSortedOn()};
   }
 
   if (requestLaziness) {

--- a/src/engine/Union.h
+++ b/src/engine/Union.h
@@ -93,7 +93,7 @@ class Union : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  ProtoResult computeResult(bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/src/engine/Values.cpp
+++ b/src/engine/Values.cpp
@@ -108,7 +108,7 @@ void Values::computeMultiplicities() {
 }
 
 // ____________________________________________________________________________
-ProtoResult Values::computeResult([[maybe_unused]] bool requestLaziness) {
+Result Values::computeResult([[maybe_unused]] bool requestLaziness) {
   // Set basic properties of the result table.
   IdTable idTable{getExecutionContext()->getAllocator()};
   idTable.setNumColumns(getResultWidth());

--- a/src/engine/Values.h
+++ b/src/engine/Values.h
@@ -48,8 +48,7 @@ class Values : public Operation {
 
  public:
   // These two are also used by class `Service`, hence public.
-  virtual ProtoResult computeResult(
-      [[maybe_unused]] bool requestLaziness) override;
+  virtual Result computeResult([[maybe_unused]] bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 

--- a/test/ServiceTest.cpp
+++ b/test/ServiceTest.cpp
@@ -672,13 +672,13 @@ TEST_F(ServiceTest, precomputeSiblingResult) {
                parsedQuery::SparqlValues parsedValues)
         : Values(qec, parsedValues) {}
 
-    ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
-      ProtoResult res = Values::computeResult(false);
+    Result computeResult([[maybe_unused]] bool requestLaziness) override {
+      Result res = Values::computeResult(false);
 
       if (!requestLaziness) {
-        return ProtoResult(Result::IdTableVocabPair(res.idTable().clone(),
-                                                    res.localVocab().clone()),
-                           res.sortedBy());
+        return Result(Result::IdTableVocabPair(res.idTable().clone(),
+                                               res.localVocab().clone()),
+                      res.sortedBy());
       }
 
       // yield each row individually

--- a/test/engine/IndexScanTest.cpp
+++ b/test/engine/IndexScanTest.cpp
@@ -526,7 +526,7 @@ TEST(IndexScan, computeResultCanBeConsumedLazily) {
   SparqlTripleSimple scanTriple{V{"?x"}, V{"?y"}, V{"?z"}};
   IndexScan scan{qec, Permutation::Enum::POS, scanTriple};
 
-  ProtoResult result = scan.computeResultOnlyForTesting(true);
+  Result result = scan.computeResultOnlyForTesting(true);
 
   ASSERT_FALSE(result.isFullyMaterialized());
 
@@ -548,7 +548,7 @@ TEST(IndexScan, computeResultReturnsEmptyGeneratorIfScanIsEmpty) {
   SparqlTripleSimple scanTriple{V{"?x"}, I::fromIriref("<abcdef>"), V{"?z"}};
   IndexScan scan{qec, Permutation::Enum::POS, scanTriple};
 
-  ProtoResult result = scan.computeResultOnlyForTesting(true);
+  Result result = scan.computeResultOnlyForTesting(true);
 
   ASSERT_FALSE(result.isFullyMaterialized());
 

--- a/test/engine/TextIndexScanTestHelpers.h
+++ b/test/engine/TextIndexScanTestHelpers.h
@@ -15,7 +15,7 @@ namespace textIndexScanTestHelpers {
 // The only problem is the increased size of the docsDB and the double saving
 // of the literals.
 inline string getTextRecordFromResultTable(const QueryExecutionContext* qec,
-                                           const ProtoResult& result,
+                                           const Result& result,
                                            const size_t& rowIndex) {
   size_t nofNonLiterals = qec->getIndex().getNofNonLiteralsInTextIndex();
   uint64_t textRecordIdFromTable =
@@ -32,14 +32,14 @@ inline string getTextRecordFromResultTable(const QueryExecutionContext* qec,
 }
 
 inline const TextRecordIndex getTextRecordIdFromResultTable(
-    [[maybe_unused]] const QueryExecutionContext* qec,
-    const ProtoResult& result, const size_t& rowIndex) {
+    [[maybe_unused]] const QueryExecutionContext* qec, const Result& result,
+    const size_t& rowIndex) {
   return result.idTable().getColumn(0)[rowIndex].getTextRecordIndex();
 }
 
 // Only use on prefix search results
 inline string getEntityFromResultTable(const QueryExecutionContext* qec,
-                                       const ProtoResult& result,
+                                       const Result& result,
                                        const size_t& rowIndex) {
   return qec->getIndex().indexToString(
       result.idTable().getColumn(1)[rowIndex].getVocabIndex());
@@ -47,15 +47,15 @@ inline string getEntityFromResultTable(const QueryExecutionContext* qec,
 
 // Only use on prefix search results
 inline string getWordFromResultTable(const QueryExecutionContext* qec,
-                                     const ProtoResult& result,
+                                     const Result& result,
                                      const size_t& rowIndex) {
   return std::string{qec->getIndex().indexToString(
       result.idTable().getColumn(1)[rowIndex].getWordVocabIndex())};
 }
 
 inline size_t getScoreFromResultTable(
-    [[maybe_unused]] const QueryExecutionContext* qec,
-    const ProtoResult& result, const size_t& rowIndex, bool wasPrefixSearch) {
+    [[maybe_unused]] const QueryExecutionContext* qec, const Result& result,
+    const size_t& rowIndex, bool wasPrefixSearch) {
   size_t colToRetrieve = wasPrefixSearch ? 2 : 1;
   return static_cast<size_t>(
       result.idTable().getColumn(colToRetrieve)[rowIndex].getInt());

--- a/test/engine/ValuesForTesting.h
+++ b/test/engine/ValuesForTesting.h
@@ -83,7 +83,7 @@ class ValuesForTesting : public Operation {
   size_t& costEstimate() { return costEstimate_; }
 
   // ___________________________________________________________________________
-  ProtoResult computeResult(bool requestLaziness) override {
+  Result computeResult(bool requestLaziness) override {
     if (requestLaziness && !forceFullyMaterialized_) {
       // Not implemented yet
       AD_CORRECTNESS_CHECK(!supportsLimit_);

--- a/test/util/OperationTestHelpers.h
+++ b/test/util/OperationTestHelpers.h
@@ -32,7 +32,7 @@ class StallForeverOperation : public Operation {
   using Operation::Operation;
   // Do-nothing operation that runs for 100ms without computing anything, but
   // which can be cancelled.
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     auto end = std::chrono::steady_clock::now() + 100ms;
     while (std::chrono::steady_clock::now() < end) {
       checkCancellation();
@@ -79,7 +79,7 @@ class ShallowParentOperation : public Operation {
     return {child_.get()};
   }
 
-  ProtoResult computeResult([[maybe_unused]] bool requestLaziness) override {
+  Result computeResult([[maybe_unused]] bool requestLaziness) override {
     auto childResult = child_->getResult();
     return {childResult->idTable().clone(), resultSortedOn(),
             childResult->getSharedLocalVocab()};
@@ -127,7 +127,7 @@ class AlwaysFailOperation : public Operation {
   using Operation::Operation;
   AlwaysFailOperation(QueryExecutionContext* qec, Variable variable)
       : Operation{qec}, variable_{std::move(variable)} {}
-  ProtoResult computeResult(bool requestLaziness) override {
+  Result computeResult(bool requestLaziness) override {
     if (!requestLaziness) {
       throw std::runtime_error{"AlwaysFailOperation"};
     }
@@ -166,7 +166,7 @@ class CustomGeneratorOperation : public Operation {
   CustomGeneratorOperation(QueryExecutionContext* context,
                            Result::Generator generator)
       : Operation{context}, generator_{std::move(generator)} {}
-  ProtoResult computeResult(bool requestLaziness) override {
+  Result computeResult(bool requestLaziness) override {
     AD_CONTRACT_CHECK(requestLaziness);
     return {std::move(generator_), resultSortedOn()};
   }


### PR DESCRIPTION
This removes the more verbose alias of `Result`. It was originally meant to act as a placeholder for a future class, but we ended up implementing lazy results differently.