### PR TITLE
Fix `getResultSizeImpl` for small scans with updates

### DIFF
--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -709,10 +709,6 @@ std::pair<size_t, size_t> CompressedRelationReader::getResultSizeImpl(
     --endBlock;
   }
 
-  if (beginBlock == endBlock) {
-    return {numResults, numResults};
-  }
-
   ql::ranges::for_each(
       ql::ranges::subrange{beginBlock, endBlock}, [&](const auto& block) {
         const auto [ins, del] =

--- a/src/index/Index.h
+++ b/src/index/Index.h
@@ -116,7 +116,7 @@ class Index {
   // Get a (non-owning) pointer to the BlankNodeManager of this Index.
   ad_utility::BlankNodeManager* getBlankNodeManager() const;
 
-  // Get a (non-owning) pointer to the BlankNodeManager of this Index.
+  // Get a reference to the DeltaTriplesManager of this Index.
   DeltaTriplesManager& deltaTriplesManager();
   const DeltaTriplesManager& deltaTriplesManager() const;
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -832,11 +832,12 @@ TEST(CompressedRelationReader, getResultSizeImpl) {
   auto sharedLocatedTriplesSnapshot = deltaTriplesManager.getCurrentSnapshot();
   const auto& locatedTriplesSnapshot = *sharedLocatedTriplesSnapshot;
   auto& impl = index.getImpl();
-  auto expect = [&impl, &locatedTriplesSnapshot](
-                    Permutation::Enum p, const ScanSpecification& scanSpec,
-                    size_t lower, size_t upper, size_t exact,
-                    ad_utility::source_location sourceLocation =
-                        ad_utility::source_location::current()) {
+  auto expectResultSizes = [&impl, &locatedTriplesSnapshot](
+                               Permutation::Enum p,
+                               const ScanSpecification& scanSpec, size_t lower,
+                               size_t upper, size_t exact,
+                               ad_utility::source_location sourceLocation =
+                                   ad_utility::source_location::current()) {
     auto loc = generateLocationTrace(sourceLocation);
     auto& perm = impl.getPermutation(p);
     auto& reader = perm.reader();
@@ -854,13 +855,16 @@ TEST(CompressedRelationReader, getResultSizeImpl) {
   };
   // The Scans request all triples of the one and only block.
   for (auto perm : Permutation::ALL) {
-    expect(perm, {std::nullopt, std::nullopt, std::nullopt}, 0, 2, 2);
+    expectResultSizes(perm, {std::nullopt, std::nullopt, std::nullopt}, 0, 2,
+                      2);
   }
-  expect(Permutation::SPO, {V(0), std::nullopt, std::nullopt}, 0, 2, 2);
+  expectResultSizes(Permutation::SPO, {V(0), std::nullopt, std::nullopt}, 0, 2,
+                    2);
   // Not all triples of the block are requested. The size estimate is truncated
   // by a factor which is a RuntimeParameter.
-  expect(Permutation::PSO, {V(1), std::nullopt, std::nullopt}, 0, 1, 1);
-  expect(Permutation::PSO, {V(1), V(5), std::nullopt}, 0, 1, 0);
+  expectResultSizes(Permutation::PSO, {V(1), std::nullopt, std::nullopt}, 0, 1,
+                    1);
+  expectResultSizes(Permutation::PSO, {V(1), V(5), std::nullopt}, 0, 1, 0);
 }
 
 // Test the correct setting of the metadata for the contained graphs.


### PR DESCRIPTION
There was a bug in `CompressedRelationReader::getResultSizeImpl` that ignored updates for index scans with only one or two blocks. This was especially dramatic for the exact result size which could lead to whole queries being optimized out because the exact size of an index scan was falsely reported as zero (because a block contained no triples in the initial index, but contained updates).

Fixes #1861