### PR TITLE
Fix inconsistency in hash and `operator==` for IDs with LocalVocabIndex

### DIFF
--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -345,9 +345,11 @@ class ValueId {
   /// and `ad_utility::HashMap`
   template <typename H>
   friend H AbslHashValue(H h, const ValueId& id) {
-    // Depending on the case a number is added to the hashing. This ensures that
-    // for two unequal elements the hash expansion (~list of simpler values
-    // being hashed with `combine`) of neither is a suffix of the other.
+    // Adding 0/1 to the hash is required to ensure that for two unequal
+    // elements the hash expansions of neither is a suffix of the other.This is
+    // a property that absl requires for hashes. The hash expansion is the list
+    // of simpler values actually being hashed (here: bits or hash expansion of
+    // the LocalVocabEntry).
     if (id.getDatatype() != Datatype::LocalVocabIndex) {
       return H::combine(std::move(h), id._bits, 0);
     }

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -351,8 +351,7 @@ class ValueId {
     if (id.getDatatype() != Datatype::LocalVocabIndex) {
       return H::combine(std::move(h), id._bits, 0);
     }
-    auto lvi = id.getLocalVocabIndex();
-    auto [lower, upper] = lvi->positionInVocab();
+    auto [lower, upper] = id.getLocalVocabIndex()->positionInVocab();
     if (upper != lower) {
       return H::combine(std::move(h), makeFromVocabIndex(lower)._bits, 1);
     }

--- a/src/global/ValueId.h
+++ b/src/global/ValueId.h
@@ -353,9 +353,9 @@ class ValueId {
     }
     auto [lower, upper] = id.getLocalVocabIndex()->positionInVocab();
     if (upper != lower) {
-      return H::combine(std::move(h), makeFromVocabIndex(lower)._bits, 1);
+      return H::combine(std::move(h), makeFromVocabIndex(lower)._bits, 0);
     }
-    return H::combine(std::move(h), *id.getLocalVocabIndex(), 2);
+    return H::combine(std::move(h), *id.getLocalVocabIndex(), 1);
   }
 
   /// Enable the serialization of `ValueId` in the `ad_utility::serialization`

--- a/src/index/LocalVocabEntry.cpp
+++ b/src/index/LocalVocabEntry.cpp
@@ -13,8 +13,14 @@ auto LocalVocabEntry::positionInVocabExpensiveCase() const -> PositionInVocab {
   const IndexImpl& index = IndexImpl::staticGlobalSingletonIndex();
   PositionInVocab positionInVocab;
   const auto& vocab = index.getVocab();
-  positionInVocab.lowerBound_ = vocab.lower_bound(toStringRepresentation());
-  positionInVocab.upperBound_ = vocab.upper_bound(toStringRepresentation());
+  using SortLevel = Index::Vocab::SortLevel;
+  positionInVocab.lowerBound_ =
+      vocab.lower_bound(toStringRepresentation(), SortLevel::TOTAL);
+  positionInVocab.upperBound_ =
+      vocab.upper_bound(toStringRepresentation(), SortLevel::TOTAL);
+  AD_CORRECTNESS_CHECK(positionInVocab.upperBound_.get() -
+                           positionInVocab.lowerBound_.get() <=
+                       1);
   lowerBoundInVocab_.store(positionInVocab.lowerBound_,
                            std::memory_order_relaxed);
   upperBoundInVocab_.store(positionInVocab.upperBound_,

--- a/src/index/LocalVocabEntry.h
+++ b/src/index/LocalVocabEntry.h
@@ -72,7 +72,7 @@ class alignas(16) LocalVocabEntry
   template <typename H, typename V>
   friend auto AbslHashValue(H h, const V& entry)
       -> CPP_ret(H)(requires ranges::same_as<V, LocalVocabEntry>) {
-    return AbslHashValue(std::move(h), static_cast<const Base&>(entry));
+    return H::combine(std::move(h), static_cast<const Base&>(entry));
   }
 
   // Comparison between two entries could in theory also be sped up using the

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -9,6 +9,7 @@
 #include "./ValueIdTestHelpers.h"
 #include "./util/GTestHelpers.h"
 #include "./util/IndexTestHelpers.h"
+#include "absl/hash/hash_testing.h"
 #include "global/ValueId.h"
 #include "util/HashSet.h"
 #include "util/Random.h"
@@ -280,22 +281,47 @@ TEST_F(ValueIdTest, Serialization) {
 }
 
 TEST_F(ValueIdTest, Hashing) {
-  auto ids = makeRandomIds();
-  ad_utility::HashSet<ValueId> idsWithoutDuplicates;
-  for (size_t i = 0; i < 2; ++i) {
-    for (auto id : ids) {
-      idsWithoutDuplicates.insert(id);
+  {
+    auto ids = makeRandomIds();
+    ad_utility::HashSet<ValueId> idsWithoutDuplicates;
+    for (size_t i = 0; i < 2; ++i) {
+      for (auto id : ids) {
+        idsWithoutDuplicates.insert(id);
+      }
     }
+    std::vector<ValueId> idsWithoutDuplicatesAsVector(
+        idsWithoutDuplicates.begin(), idsWithoutDuplicates.end());
+
+    std::sort(idsWithoutDuplicatesAsVector.begin(),
+              idsWithoutDuplicatesAsVector.end());
+    std::sort(ids.begin(), ids.end());
+    ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+
+    ASSERT_EQ(ids, idsWithoutDuplicatesAsVector);
   }
-  std::vector<ValueId> idsWithoutDuplicatesAsVector(
-      idsWithoutDuplicates.begin(), idsWithoutDuplicates.end());
-
-  std::sort(idsWithoutDuplicatesAsVector.begin(),
-            idsWithoutDuplicatesAsVector.end());
-  std::sort(ids.begin(), ids.end());
-  ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
-
-  ASSERT_EQ(ids, idsWithoutDuplicatesAsVector);
+  {
+    using namespace ad_utility::triple_component;
+    LocalVocab lv1;
+    LocalVocab lv2;
+    Iri iri = Iri::fromIriref("<foo>");
+    LocalVocabEntry lve1(iri);
+    LocalVocabEntry lve2(iri);
+    LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""));
+    auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
+      return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
+    };
+    // Checks that hashing is implemented correctly using `==` for equality. The
+    // hash expansion is the values added with `combine`.
+    // - If two elements are equal, then their hash expansions must be equal.
+    // - If two elements are not equal, then hash expansions must differ and
+    // neither can be a suffix of the other.
+    EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
+        {LVID(lve1, lv1), LVID(lve2, lv2), LVID(lve3, lv1), Id::makeFromInt(0),
+         Id::makeFromInt(42), Id::makeFromDouble(0), Id::makeFromDouble(1.56),
+         Id::makeFromDouble(1e-10), Id::makeFromDouble(1e+100),
+         Id::makeFromBool(true), Id::makeFromBool(false),
+         Id::makeUndefined()}));
+  }
 }
 
 TEST_F(ValueIdTest, toDebugString) {

--- a/test/ValueIdTest.cpp
+++ b/test/ValueIdTest.cpp
@@ -301,12 +301,16 @@ TEST_F(ValueIdTest, Hashing) {
   }
   {
     using namespace ad_utility::triple_component;
+    using namespace ad_utility::testing;
+    Index index = makeTestIndex("ValueIdTest_Hashing");
+    auto mkId = makeGetId(index);
     LocalVocab lv1;
     LocalVocab lv2;
     Iri iri = Iri::fromIriref("<foo>");
     LocalVocabEntry lve1(iri);
     LocalVocabEntry lve2(iri);
     LocalVocabEntry lve3(Literal::fromStringRepresentation("\"foo\""));
+    LocalVocabEntry lve4(Iri::fromIriref("<x>"));
     auto LVID = [](LocalVocabEntry& lve, LocalVocab& lv) {
       return Id::makeFromLocalVocabIndex(lv.getIndexAndAddIfNotContained(lve));
     };
@@ -316,8 +320,9 @@ TEST_F(ValueIdTest, Hashing) {
     // - If two elements are not equal, then hash expansions must differ and
     // neither can be a suffix of the other.
     EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly(
-        {LVID(lve1, lv1), LVID(lve2, lv2), LVID(lve3, lv1), Id::makeFromInt(0),
-         Id::makeFromInt(42), Id::makeFromDouble(0), Id::makeFromDouble(1.56),
+        {LVID(lve1, lv1), LVID(lve2, lv2), LVID(lve3, lv1), LVID(lve4, lv1),
+         mkId("<x>"), Id::makeFromInt(0), Id::makeFromInt(42),
+         Id::makeFromDouble(0), Id::makeFromDouble(1.56),
          Id::makeFromDouble(1e-10), Id::makeFromDouble(1e+100),
          Id::makeFromBool(true), Id::makeFromBool(false),
          Id::makeUndefined()}));


### PR DESCRIPTION
For two Ids where one is a LocalVocabIndex and the other one is either a LocalVocabIndex or a VocabIndex,  `operator==` (and `operator<=>`) have a complex comparison logic that doesn't only look at the bits.
Before this PR, the hashing function only considered the bits, which lead to the case that there were IDs that had different hash values, but compared equal, which is a serious bug that breaks hash sets and hash maps for these IDs.
This PR fixes that bug by incorporating all the data of an ID into the hash that is also relevant for the equality comparison.
Fixes #1863