### PR TITLE
More correct behavior of `FILTER (NOT) EXISTS`

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -180,12 +180,8 @@ std::shared_ptr<QueryExecutionTree> ExistsJoin::addExistsJoinsToSubtree(
     const sparqlExpression::SparqlExpressionPimpl& expression,
     std::shared_ptr<QueryExecutionTree> subtree, QueryExecutionContext* qec,
     const ad_utility::SharedCancellationHandle& cancellationHandle) {
-  // Extract all `EXISTS` functions from the given `expression`.
-  std::vector<const sparqlExpression::SparqlExpression*> existsExpressions;
-  expression.getPimpl()->getExistsExpressions(existsExpressions);
-
   // For each `EXISTS` function, add the corresponding `ExistsJoin`.
-  for (auto* expr : existsExpressions) {
+  for (auto* expr : expression.getExistsExpressions()) {
     const auto& exists =
         dynamic_cast<const sparqlExpression::ExistsExpression&>(*expr);
     // If we have already considered this `EXIST` (which we can detect by its

--- a/src/engine/sparqlExpressions/ExistsExpression.h
+++ b/src/engine/sparqlExpressions/ExistsExpression.h
@@ -69,8 +69,8 @@ class ExistsExpression : public SparqlExpression {
     return argument_.selectClause().getSelectedVariables();
   }
 
-  // Select all visible variables of the `EXISTS` expression that are present in
-  // `variables`.
+  // Set the `SELECT` of the argument of this exists expression to all the
+  // variables that are visible in the argument AND contained in variables.
   void selectVariables(std::span<const Variable> variables) {
     std::vector<parsedQuery::SelectClause::VarOrAlias> intersection;
     const auto& visibleVariables = argument_.getVisibleVariables();

--- a/src/engine/sparqlExpressions/ExistsExpression.h
+++ b/src/engine/sparqlExpressions/ExistsExpression.h
@@ -66,10 +66,23 @@ class ExistsExpression : public SparqlExpression {
 
   // Return all the variables that are used in this expression.
   std::span<const Variable> getContainedVariablesNonRecursive() const override {
-    return argument_.getVisibleVariables();
+    return argument_.selectClause().getSelectedVariables();
+  }
+
+  // Select all visible variables of the `EXISTS` expression that are present in
+  // `variables`.
+  void selectVariables(std::span<const Variable> variables) {
+    std::vector<parsedQuery::SelectClause::VarOrAlias> intersection;
+    const auto& visibleVariables = argument_.getVisibleVariables();
+    for (const auto& var : variables) {
+      if (ad_utility::contains(visibleVariables, var)) {
+        intersection.emplace_back(var);
+      }
+    }
+    argument_.selectClause().setSelected(intersection);
   }
 
  private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override { return {}; }
+  std::span<Ptr> childrenImpl() override { return {}; }
 };
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/ExistsExpression.h
+++ b/src/engine/sparqlExpressions/ExistsExpression.h
@@ -27,11 +27,7 @@ class ExistsExpression : public SparqlExpression {
   Variable variable_{absl::StrCat("?ql_internal_exists_", index_)};
 
  public:
-  explicit ExistsExpression(ParsedQuery query) : argument_{std::move(query)} {
-    // If no visible variables exist within the `EXISTS` pattern, then it
-    // becomes pointless.
-    AD_CONTRACT_CHECK(!argument_.getVisibleVariables().empty());
-  }
+  explicit ExistsExpression(ParsedQuery query) : argument_{std::move(query)} {}
   const auto& argument() const { return argument_; }
   const auto& variable() const { return variable_; }
 

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -185,7 +185,6 @@ bool SparqlExpression::isInsideAggregate() const {
 bool SparqlExpression::isExistsExpression() const { return false; }
 
 //______________________________________________________________________________
-namespace {
 template <typename SparqlExpressionT>
 void getExistsExpressionsImpl(SparqlExpressionT& self,
                               std::vector<SparqlExpressionT*>& result) {
@@ -197,7 +196,7 @@ void getExistsExpressionsImpl(SparqlExpressionT& self,
     child->getExistsExpressions(result);
   }
 }
-}  // namespace
+
 //______________________________________________________________________________
 void SparqlExpression::getExistsExpressions(
     std::vector<const SparqlExpression*>& result) const {

--- a/src/engine/sparqlExpressions/SparqlExpression.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpression.cpp
@@ -184,14 +184,28 @@ bool SparqlExpression::isInsideAggregate() const {
 // ________________________________________________________________
 bool SparqlExpression::isExistsExpression() const { return false; }
 
-// ________________________________________________________________
-void SparqlExpression::getExistsExpressions(
-    std::vector<const SparqlExpression*>& result) const {
-  if (isExistsExpression()) {
-    result.push_back(this);
+//______________________________________________________________________________
+namespace {
+template <typename SparqlExpressionT>
+void getExistsExpressionsImpl(SparqlExpressionT& self,
+                              std::vector<SparqlExpressionT*>& result) {
+  static_assert(ad_utility::isSimilar<SparqlExpressionT, SparqlExpression>);
+  if (self.isExistsExpression()) {
+    result.push_back(&self);
   }
-  for (auto& child : children()) {
+  for (auto& child : self.children()) {
     child->getExistsExpressions(result);
   }
+}
+}  // namespace
+//______________________________________________________________________________
+void SparqlExpression::getExistsExpressions(
+    std::vector<const SparqlExpression*>& result) const {
+  getExistsExpressionsImpl(*this, result);
+}
+//______________________________________________________________________________
+void SparqlExpression::getExistsExpressions(
+    std::vector<SparqlExpression*>& result) {
+  getExistsExpressionsImpl(*this, result);
 }
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpression.h
+++ b/src/engine/sparqlExpressions/SparqlExpression.h
@@ -132,6 +132,8 @@ class SparqlExpression {
   // implementation.
   virtual void getExistsExpressions(
       std::vector<const SparqlExpression*>& result) const final;
+  virtual void getExistsExpressions(
+      std::vector<SparqlExpression*>& result) final;
 
   // __________________________________________________________________________
   virtual ~SparqlExpression() = default;

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.cpp
@@ -113,4 +113,19 @@ SparqlExpressionPimpl SparqlExpressionPimpl::makeVariableExpression(
     const Variable& variable) {
   return {std::make_unique<VariableExpression>(variable), variable.name()};
 }
+
+// _____________________________________________________________________________
+std::vector<const SparqlExpression*>
+SparqlExpressionPimpl::getExistsExpressions() const {
+  std::vector<const SparqlExpression*> result;
+  _pimpl->getExistsExpressions(result);
+  return result;
+}
+
+// _____________________________________________________________________________
+std::vector<SparqlExpression*> SparqlExpressionPimpl::getExistsExpressions() {
+  std::vector<SparqlExpression*> result;
+  _pimpl->getExistsExpressions(result);
+  return result;
+}
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionPimpl.h
@@ -130,6 +130,10 @@ class SparqlExpressionPimpl {
   // Create a `SparqlExpressionPimpl` from a single variable.
   static SparqlExpressionPimpl makeVariableExpression(const Variable& variable);
 
+  // Convenience functions, that delegate to the respective `SparqlExpression`.
+  std::vector<const SparqlExpression*> getExistsExpressions() const;
+  std::vector<SparqlExpression*> getExistsExpressions();
+
  private:
   // TODO<joka921> Why can't this be a unique_ptr.
   std::shared_ptr<SparqlExpression> _pimpl;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2589,11 +2589,12 @@ ExpressionPtr Visitor::visitExists(Parser::GroupGraphPatternContext* pattern,
   SelectClause& selectClause = argumentOfExists.selectClause();
   selectClause.setAsterisk();
   for (const Variable& variable : visibleVariables_) {
-    // If we're not negated, we can safely add all visible variables to the
+    // If we're not negated, we could safely add all visible variables to the
     // expression, resulting in this filter to be optimized away if no variables
-    // match in the main pattern. For the negative case a variable is a wildcard
-    // match, so we just ignore this variable.
-    if (!negate || ad_utility::contains(visibleVariablesBackup, variable)) {
+    // match in the main pattern. However, if the EXISTS expression is ever
+    // negated in a way before being applied to a filter variables are a
+    // wildcard match, so we just ignore them to prevent this optimization.
+    if (ad_utility::contains(visibleVariablesBackup, variable)) {
       selectClause.addVisibleVariable(variable);
     }
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2543,7 +2543,13 @@ ExpressionPtr Visitor::visitExists(Parser::GroupGraphPatternContext* pattern,
   SelectClause& selectClause = argumentOfExists.selectClause();
   selectClause.setAsterisk();
   for (Variable& variable : visibleVariables_) {
-    selectClause.addVisibleVariable(std::move(variable));
+    // If we're not negated, we can safely add all visible variables to the
+    // expression, resulting in this filter to be optimized away if no variables
+    // match in the main pattern. For the negative case a variable is a wildcard
+    // match, so we just ignore this variable.
+    if (!negate || ad_utility::contains(visibleVariablesBackup, variable)) {
+      selectClause.addVisibleVariable(std::move(variable));
+    }
   }
   argumentOfExists._rootGraphPattern = std::move(group);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2540,7 +2540,11 @@ ExpressionPtr Visitor::visitExists(Parser::GroupGraphPatternContext* pattern,
   auto group = visit(pattern);
   ParsedQuery argumentOfExists =
       std::exchange(parsedQuery_, std::move(queryBackup));
-  argumentOfExists.selectClause().setAsterisk();
+  SelectClause& selectClause = argumentOfExists.selectClause();
+  selectClause.setAsterisk();
+  for (Variable& variable : visibleVariables_) {
+    selectClause.addVisibleVariable(std::move(variable));
+  }
   argumentOfExists._rootGraphPattern = std::move(group);
 
   // The argument of `EXISTS` inherits the `FROM` and `FROM NAMED` clauses from

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2542,13 +2542,13 @@ ExpressionPtr Visitor::visitExists(Parser::GroupGraphPatternContext* pattern,
       std::exchange(parsedQuery_, std::move(queryBackup));
   SelectClause& selectClause = argumentOfExists.selectClause();
   selectClause.setAsterisk();
-  for (Variable& variable : visibleVariables_) {
+  for (const Variable& variable : visibleVariables_) {
     // If we're not negated, we can safely add all visible variables to the
     // expression, resulting in this filter to be optimized away if no variables
     // match in the main pattern. For the negative case a variable is a wildcard
     // match, so we just ignore this variable.
     if (!negate || ad_utility::contains(visibleVariablesBackup, variable)) {
-      selectClause.addVisibleVariable(std::move(variable));
+      selectClause.addVisibleVariable(variable);
     }
   }
   argumentOfExists._rootGraphPattern = std::move(group);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -843,9 +843,8 @@ vector<SparqlTripleSimpleWithGraph> Visitor::visit(
 
 // _____________________________________________________________________________
 void Visitor::selectExistsVariables(SparqlFilter& filter) const {
-  std::vector<SparqlExpression*> existsExpressions;
-  filter.expression_.getPimpl()->getExistsExpressions(existsExpressions);
-  for (SparqlExpression* sparqlExpression : existsExpressions) {
+  for (SparqlExpression* sparqlExpression :
+       filter.expression_.getExistsExpressions()) {
     auto* existsExpression = dynamic_cast<ExistsExpression*>(sparqlExpression);
     AD_CORRECTNESS_CHECK(existsExpression);
     existsExpression->selectVariables(visibleVariables_);
@@ -2603,6 +2602,10 @@ ExpressionPtr Visitor::visitExists(Parser::GroupGraphPatternContext* pattern,
   // variables to a potentially smaller subset when finishing the parsing of the
   // current group.
   selectClause.setAsterisk();
+  // `ExistsExpression`s are not parsed like regular `SparqlExpression`s, so
+  // they don't have a proper hierarchy of dependent variables. Because of that,
+  // we need to manually add all variables that are visible after parsing the
+  // body of `EXISTS`.
   for (const Variable& variable : visibleVariables_) {
     selectClause.addVisibleVariable(variable);
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -272,6 +272,11 @@ class SparqlQleverVisitor {
 
   Triples visit(Parser::TriplesTemplateContext* ctx);
 
+  // Limit the variables in the filter to the ones that are already known
+  // outside the EXISTS expression, so that the filter isn't optimized away
+  // because not all variables are covered.
+  void selectExistsVariables(SparqlFilter& filter) const;
+
   ParsedQuery::GraphPattern visit(Parser::GroupGraphPatternContext* ctx);
 
   OperationsAndFilters visit(Parser::GroupGraphPatternSubContext* ctx);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -143,10 +143,6 @@ class SparqlQleverVisitor {
     activeDatasetClauses_ = std::move(datasetClauses);
   }
 
-  void setVisibleVariablesForTesting(std::vector<Variable> visibleVariables) {
-    visibleVariables_ = std::move(visibleVariables);
-  }
-
   // ___________________________________________________________________________
   std::vector<ParsedQuery> visit(Parser::QueryOrUpdateContext* ctx);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -137,6 +137,10 @@ class SparqlQleverVisitor {
     activeDatasetClauses_ = std::move(datasetClauses);
   }
 
+  void setVisibleVariablesForTesting(std::vector<Variable> visibleVariables) {
+    visibleVariables_ = std::move(visibleVariables);
+  }
+
   // ___________________________________________________________________________
   std::vector<ParsedQuery> visit(Parser::QueryOrUpdateContext* ctx);
 

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -268,9 +268,9 @@ class SparqlQleverVisitor {
 
   Triples visit(Parser::TriplesTemplateContext* ctx);
 
-  // Limit the variables in the filter to the ones that are already known
-  // outside the EXISTS expression, so that the filter isn't optimized away
-  // because not all variables are covered.
+  // Limit the variables in EXISTS expressions of the filter to the ones that
+  // are already known outside the EXISTS expression, so that the filter isn't
+  // optimized away because not all variables are covered.
   void selectExistsVariables(SparqlFilter& filter) const;
 
   ParsedQuery::GraphPattern visit(Parser::GroupGraphPatternContext* ctx);

--- a/test/QueryPlannerTest.cpp
+++ b/test/QueryPlannerTest.cpp
@@ -2924,7 +2924,7 @@ TEST(QueryPlanner, Exists) {
 
   // Simple tests for EXISTS with FILTER, BIND, and GROUP BY.
   h::expect("SELECT * { ?x ?y ?z FILTER EXISTS {?a ?b ?c} }",
-            h::Filter("EXISTS {?a ?b ?c}", h::ExistsJoin(xyz, abc)));
+            h::IndexScanFromStrings("?x", "?y", "?z"));
   h::expect("SELECT * { ?x ?y ?z BIND(EXISTS {?a ?b ?c} as ?bound) }",
             h::Bind(h::ExistsJoin(xyz, abc), "EXISTS {?a ?b ?c}",
                     Variable("?bound")));
@@ -2937,8 +2937,7 @@ TEST(QueryPlanner, Exists) {
   auto existsAbcDef = h::ExistsJoin(h::ExistsJoin(xyz, abc), def);
   h::expect(
       "SELECT * { ?x ?y ?z FILTER (EXISTS {?a ?b ?c} || EXISTS {?d ?e ?f})}",
-      h::Filter("EXISTS {?a ?b ?c} || EXISTS {?d ?e ?f}", existsAbcDef));
-  ;
+      h::IndexScanFromStrings("?x", "?y", "?z"));
   h::expect(
       "SELECT * { ?x ?y ?z BIND(EXISTS {?a ?b ?c} || EXISTS {?d ?e ?f} as "
       "?bound)}",
@@ -2959,27 +2958,19 @@ TEST(QueryPlanner, Exists) {
   auto abcg = h::IndexScanFromStrings("?a", "?b", "?c", {}, H{"<g>"});
 
   // Various uses of FILTER EXISTS.
-  auto existsJoin = h::ExistsJoin(xyzg, abcg);
-  auto filter = h::Filter("EXISTS {?a ?b ?c}", existsJoin);
-  h::expect("SELECT * FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}", filter);
-  h::expect("ASK FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}", filter);
+  h::expect("SELECT * FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}", xyzg);
+  h::expect("ASK FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}", xyzg);
   h::expect(
       "CONSTRUCT {<a> <b> <c>} FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}",
-      filter);
+      xyzg);
   h::expect("Describe ?x FROM <g> { ?x ?y ?z FILTER EXISTS {?a ?b ?c}}",
-            h::Describe(::testing::_, filter));
+            h::Describe(::testing::_, xyzg));
 
   // Test the interaction of FROM NAMES with EXISTS
-  auto varG = std::vector{Variable{"?g"}};
-  std::vector<ColumnIndex> graphCol{ADDITIONAL_COLUMN_GRAPH_ID};
-  auto uvcg =
-      h::IndexScanFromStrings("?u", "?v", "?c", {}, H{"<g2>"}, varG, graphCol);
-  existsJoin = h::ExistsJoin(xyzg, h::UnorderedJoins(abcg, uvcg));
-  filter = h::Filter("EXISTS {?a ?b ?c. GRAPH ?g { ?u ?v ?c}}", existsJoin);
   h::expect(
       "SELECT * FROM <g> FROM NAMED <g2> { ?x ?y ?z FILTER EXISTS {?a ?b ?c. "
       "GRAPH ?g { ?u ?v ?c}}}",
-      filter);
+      xyzg);
 }
 
 // _____________________________________________________________________________

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2018,8 +2018,8 @@ TEST(SparqlParser, Exists) {
   using Graphs = ScanSpecificationAsTripleComponent::Graphs;
   auto selectABarFooMatcher = [](Graphs defaultGraphs = std::nullopt,
                                  Graphs namedGraphs = std::nullopt) {
-    return testing::AllOf(m::SelectQuery(
-        m::AsteriskSelect(),
+    return AllOf(m::SelectQuery(
+        AllOf(m::AsteriskSelect(), m::VariablesSelect({"?a", "?foo"})),
         m::GraphPattern(m::Triples({{Var{"?a"}, "<bar>", Var{"?foo"}}})),
         defaultGraphs, namedGraphs));
   };

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2081,8 +2081,9 @@ TEST(SparqlParser, Exists) {
   expectBuiltInCall("NOT EXISTS {?a <bar> ?foo}",
                     notExistsMatcher(selectABarFooMatcher()));
 
-  expectBuiltInCallNoVars("EXISTS {?a <bar> ?foo}",
-                          existsMatcher(selectABarFooMatcher()));
+  expectBuiltInCallNoVars(
+      "EXISTS {?a <bar> ?foo}",
+      existsMatcher(selectABarFooMatcher(std::nullopt, std::nullopt, {})));
   expectBuiltInCallNoVars(
       "NOT EXISTS {?a <bar> ?foo}",
       notExistsMatcher(selectABarFooMatcher(std::nullopt, std::nullopt, {})));

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -2137,8 +2137,8 @@ TEST(SparqlParser, Exists) {
                               std::nullopt, std::nullopt, {{"?a"}})));
 
   auto doesNotBindExists = [&]() {
-    auto innerMatcher = containsExistsClause(
-        selectABarFooMatcher(std::nullopt, std::nullopt, {{}}));
+    auto innerMatcher = containsExistsClause(selectABarFooMatcher(
+        std::nullopt, std::nullopt, std::vector<std::string>{}));
     using parsedQuery::GroupGraphPattern;
     return AD_FIELD(GraphPattern, _graphPatterns,
                     ::testing::ElementsAre(

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1572,7 +1572,10 @@ TEST(SingleUseExpression, simpleMembersForTestCoverage) {
 // `ExistsJoin` class, most of the testing happens in
 // `test/engine/ExistsJoinTest.cpp`.
 TEST(ExistsExpression, basicFunctionality) {
-  ExistsExpression exists{ParsedQuery{}};
+  using namespace ::testing;
+  ParsedQuery pq;
+  pq.selectClause().addVisibleVariable(Variable{"?testVar42"});
+  ExistsExpression exists{std::move(pq)};
   auto var = exists.variable();
   TestContext context;
   EXPECT_ANY_THROW(exists.evaluate(&context.context));
@@ -1583,4 +1586,6 @@ TEST(ExistsExpression, basicFunctionality) {
   EXPECT_THAT(exists.evaluate(&context.context), VariantWith<Variable>(var));
   EXPECT_THAT(exists.getCacheKey(context.varToColMap),
               HasSubstr("ExistsExpression col# 437"));
+  EXPECT_THAT(exists.containedVariables(),
+              ElementsAre(Pointee(Eq(Variable{"?testVar42"}))));
 }

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1575,6 +1575,7 @@ TEST(ExistsExpression, basicFunctionality) {
   using namespace ::testing;
   ParsedQuery pq;
   pq.selectClause().addVisibleVariable(Variable{"?testVar42"});
+  pq.selectClause().setAsterisk();
   ExistsExpression exists{std::move(pq)};
   auto var = exists.variable();
   TestContext context;


### PR DESCRIPTION
`FILTER EXISTS` and therefore also the query planner is now aware of which of its contained variables are also visible outside the filter and thus have to be connected with the previous partial query result in an EXISTS JOIN. 
This fixes (among others) queries where the FILTER EXISTS is the only connection between two variables. 
Note the following caveats:
* Such cases still first materializes the full Cartesian product of the inputs and THEN apply the FILTER EXISTS.
* There are false positives as to which variables are visible, because variables in outside group graph patterns are also seen as visible, although they are not. This however only leads to worse query plans in certain circumstances, not to wron gresults.

Fixes #1865 