### PR TITLE
Allow REGEX expressions with a dynamically computed regular expression

### DIFF
--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -28,7 +28,7 @@ class LRUCache {
   absl::flat_hash_map<K, std::pair<V, typename std::list<K>::iterator>> cache_;
 
  public:
-  explicit LRUCache(size_t cap) : capacity_{cap} {}
+  explicit LRUCache(size_t capacity) : capacity_{capacity} {}
 
   template <typename Func>
   const V& getOrCompute(const K& key, Func computeFunction) {
@@ -116,9 +116,9 @@ RegexExpression::RegexExpression(Ptr child, Ptr regex,
     : children_{std::move(child), nullptr} {
   // If we have a `STR()` expression, remove the `STR()` and remember that it
   // was there.
-  if (children_.at(0)->isStrExpression()) {
-    children_.at(0) =
-        std::move(std::move(*children_.at(0)).moveChildrenOut().at(0));
+  auto& firstChild = children_.at(0);
+  if (firstChild->isStrExpression()) {
+    firstChild = std::move(std::move(*firstChild).moveChildrenOut().at(0));
     childIsStrExpression_ = true;
   }
 

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -199,7 +199,7 @@ string RegexExpression::getCacheKey(
 
 // ___________________________________________________________________________
 std::span<SparqlExpression::Ptr> RegexExpression::childrenImpl() {
-  if (children_.at(1) != nullptr) {
+  if (children_.at(1) == nullptr) {
     return {&children_.at(0), 1};
   }
   return children_;

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -258,13 +258,11 @@ ExpressionResult PrefixRegexExpression::evaluate(
 auto PrefixRegexExpression::getEstimatesForFilterExpression(
     uint64_t inputSize,
     const std::optional<Variable>& firstSortedVariable) const -> Estimates {
-  // Assume that only 10^-k entries remain, where k is the length of the prefix.
+  // Assume that only 10^-k entries remain, where k is the length of the prefix
+  // and cap to reasonable maximal values to prevent numerical stability
+  // problems.
   double reductionFactor =
-      std::pow(10, std::max(0, static_cast<int>(prefixRegex_.size())));
-  // Cap to reasonable minimal and maximal values to prevent numerical
-  // stability problems.
-  reductionFactor = std::min(100000000.0, reductionFactor);
-  reductionFactor = std::max(1.0, reductionFactor);
+      std::pow(10, std::min<size_t>(8, prefixRegex_.size()));
   size_t sizeEstimate = inputSize / static_cast<size_t>(reductionFactor);
   size_t costEstimate = firstSortedVariable == variable_
                             ? sizeEstimate

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -54,12 +54,12 @@ void ensureIsValidFlagIfConstant(const SparqlExpression& expression) {
   if (stringLiteralExpression) {
     const auto& literal = stringLiteralExpression->value();
     const auto& string = asStringViewUnsafe(literal.getContent());
-    auto firstInvalidFlag = string.find_first_not_of("imsu");
+    auto firstInvalidFlag = string.find_first_not_of("imsU");
     if (firstInvalidFlag != std::string::npos) {
       throw std::runtime_error{absl::StrCat(
           "Invalid regex flag '", string.substr(firstInvalidFlag, 1),
           "' found in \"", string,
-          "\". The only supported flags are 'i', 'm', 's', 'u', and any "
+          "\". The only supported flags are 'i', 'm', 's', 'U', and any "
           "combination of them")};
     }
   }

--- a/src/engine/sparqlExpressions/RegexExpression.cpp
+++ b/src/engine/sparqlExpressions/RegexExpression.cpp
@@ -4,11 +4,11 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 
-#include "./RegexExpression.h"
+#include "engine/sparqlExpressions/RegexExpression.h"
 
-#include <absl/container/flat_hash_map.h>
 #include <re2/re2.h>
 
+#include "NaryExpressionImpl.h"
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpression.h"
 #include "engine/sparqlExpressions/SparqlExpressionGenerators.h"
@@ -19,44 +19,75 @@ using namespace std::literals;
 
 namespace sparqlExpression::detail {
 
-template <typename K, typename V>
-class LRUCache {
- private:
-  size_t capacity_;
-  // Stores keys in order of usage (MRU at front)
-  std::list<K> keys_;
-  absl::flat_hash_map<K, std::pair<V, typename std::list<K>::iterator>> cache_;
-
- public:
-  explicit LRUCache(size_t capacity) : capacity_{capacity} {}
-
-  template <typename Func>
-  const V& getOrCompute(const K& key, Func computeFunction) {
-    auto it = cache_.find(key);
-    if (it != cache_.end()) {
-      // Move accessed key to front (most recently used)
-      keys_.erase(it->second.second);
-      keys_.push_front(key);
-      it->second.second = keys_.begin();
-
-      return it->second.first;
-    }
-    // Evict LRU if cache is full
-    if (cache_.size() >= capacity_) {
-      K lruKey = keys_.back();
-      keys_.pop_back();
-      cache_.erase(lruKey);
-    }
-    // Insert new element
-    keys_.push_front(key);
-    auto result = cache_.try_emplace(key, computeFunction(key), keys_.begin());
-    AD_CORRECTNESS_CHECK(result.second);
-    return result.first->second.first;
+void ensureIsSimpleLiteral(
+    const ad_utility::triple_component::Literal& literal) {
+  if (literal.hasDatatype() || literal.hasLanguageTag()) {
+    throw std::runtime_error{
+        "The REGEX function only accepts simple literals (literals without a "
+        "language tag or a datatype)"};
   }
+}
+
+// _____________________________________________________________________________
+void ensureIsValidRegexIfConstant(const SparqlExpression::Ptr& expression) {
+  auto* stringLiteralExpression =
+      dynamic_cast<const StringLiteralExpression*>(expression.get());
+  if (stringLiteralExpression) {
+    const auto& literal = stringLiteralExpression->value();
+    const auto& string = asStringViewUnsafe(literal.getContent());
+    RE2 regex{string, RE2::Quiet};
+    if (!regex.ok()) {
+      throw std::runtime_error{absl::StrCat(
+          "The regex \"", string,
+          "\" is not supported by QLever (which uses Google's RE2 library); "
+          "the error from RE2 is: ",
+          regex.error())};
+    }
+  }
+}
+
+// _____________________________________________________________________________
+void ensureIsValidFlagIfConstant(const SparqlExpression::Ptr& expression) {
+  auto* stringLiteralExpression =
+      dynamic_cast<const StringLiteralExpression*>(expression.get());
+  if (stringLiteralExpression) {
+    const auto& literal = stringLiteralExpression->value();
+    const auto& string = asStringViewUnsafe(literal.getContent());
+    auto firstInvalidFlag = string.find_first_not_of("imsu");
+    if (firstInvalidFlag != std::string::npos) {
+      throw std::runtime_error{absl::StrCat(
+          "Invalid regex flag '", string.substr(firstInvalidFlag, 1),
+          "' found in \"", string,
+          "\". The only supported flags are 'i', 'm', 's', 'u', and any "
+          "combination of them")};
+    }
+  }
+}
+
+// _____________________________________________________________________________
+[[maybe_unused]] auto regexImpl =
+    [](const std::optional<std::string>& input,
+       const std::shared_ptr<RE2>& pattern) -> ValueId {
+  if (!input.has_value() || !pattern) {
+    return Id::makeUndefined();
+  }
+  // Check for invalid regexes.
+  if (!pattern->ok()) {
+    return Id::makeUndefined();
+  }
+  return Id::makeFromBool(RE2::PartialMatch(input.value(), *pattern));
 };
 
-// ____________________________________________________________________________
-std::optional<std::string> getPrefixRegex(std::string regex) {
+using RegexExpression =
+    NARY<2, FV<decltype(regexImpl), LiteralFromIdGetter, RegexValueGetter>>;
+
+}  // namespace sparqlExpression::detail
+
+namespace sparqlExpression {
+
+// _____________________________________________________________________________
+std::optional<std::string> PrefixRegexExpression::getPrefixRegex(
+    std::string regex) {
   if (!regex.starts_with('^')) {
     return std::nullopt;
   }
@@ -106,115 +137,37 @@ std::optional<std::string> getPrefixRegex(std::string regex) {
   return regex;
 }
 
-}  // namespace sparqlExpression::detail
-
-namespace sparqlExpression {
-
-// ___________________________________________________________________________
-RegexExpression::RegexExpression(Ptr child, Ptr regex,
-                                 std::optional<Ptr> optionalFlags)
-    : children_{std::move(child), nullptr} {
+// _____________________________________________________________________________
+PrefixRegexExpression::PrefixRegexExpression(Ptr child, std::string prefixRegex,
+                                             Variable variable)
+    : child_{std::move(child)},
+      prefixRegex_{std::move(prefixRegex)},
+      variable_{std::move(variable)} {
   // If we have a `STR()` expression, remove the `STR()` and remember that it
   // was there.
-  auto& firstChild = children_.at(0);
-  if (firstChild->isStrExpression()) {
-    firstChild = std::move(std::move(*firstChild).moveChildrenOut().at(0));
+  if (child_->isStrExpression()) {
+    child_ = std::move(std::move(*child_).moveChildrenOut().at(0));
     childIsStrExpression_ = true;
   }
-
-  bool precomputeRegex = false;
-  // Get the regex string, which must be a string literal without a datatype or
-  // language tag.
-  std::string regexString;
-  if (auto regexPtr =
-          dynamic_cast<const StringLiteralExpression*>(regex.get())) {
-    const auto& regexLiteral = regexPtr->value();
-    if (regexLiteral.hasDatatype() || regexLiteral.hasLanguageTag()) {
-      throw std::runtime_error(
-          "The second argument to the REGEX function (which contains the "
-          "regular expression) must not contain a language tag or a datatype");
-    }
-    regexString = asStringViewUnsafe(regexLiteral.getContent());
-    precomputeRegex = true;
-  }
-
-  // Parse the flags. The optional argument for that must, again, be a
-  // string literal without a datatype or language tag.
-  if (precomputeRegex && optionalFlags.has_value()) {
-    if (auto flagsPtr = dynamic_cast<const StringLiteralExpression*>(
-            optionalFlags.value().get())) {
-      const auto& flagsLiteral = flagsPtr->value();
-      if (flagsLiteral.hasDatatype() || flagsLiteral.hasLanguageTag()) {
-        throw std::runtime_error(
-            "The third argument to the REGEX function (which contains optional "
-            "flags to configure the evaluation) must not contain a language "
-            "tag or a datatype");
-      }
-      std::string_view flags = asStringViewUnsafe(flagsLiteral.getContent());
-      auto firstInvalidFlag = flags.find_first_not_of("imsu");
-      if (firstInvalidFlag != std::string::npos) {
-        throw std::runtime_error{absl::StrCat(
-            "Invalid regex flag '", std::string{flags[firstInvalidFlag]},
-            "' found in \"", flags,
-            "\". The only supported flags are 'i', 'm', 's', 'u', and any "
-            "combination of them")};
-      }
-
-      // In Google RE2 the flags are directly part of the regex.
-      if (!flags.empty()) {
-        regexString = absl::StrCat("(?", flags, ":", regexString + ")");
-      }
-    } else {
-      precomputeRegex = false;
-    }
-  }
-
-  // Create RE2 object from the regex string. If it is a simple prefix regex,
-  // store the prefix in `prefixRegex_` (otherwise that becomes `std::nullopt`).
-  prefixRegex_ = detail::getPrefixRegex(regexString);
-  if (precomputeRegex) {
-    const auto& compiledRegex = regex_.emplace(regexString, RE2::Quiet);
-    if (!compiledRegex.ok()) {
-      throw std::runtime_error{absl::StrCat(
-          "The regex \"", regexString,
-          "\" is not supported by QLever (which uses Google's RE2 library); "
-          "the error from RE2 is: ",
-          compiledRegex.error())};
-    }
-  } else {
-    if (optionalFlags.has_value()) {
-      children_.at(1) = makeMergeRegexPatternAndFlagsExpression(
-          std::move(regex), std::move(optionalFlags.value()));
-    } else {
-      children_.at(1) = std::move(regex);
-    }
-  }
 }
 
-// ___________________________________________________________________________
-string RegexExpression::getCacheKey(
+// _____________________________________________________________________________
+string PrefixRegexExpression::getCacheKey(
     const VariableToColumnMap& varColMap) const {
-  return absl::StrCat(
-      "REGEX expression ", children_.at(0)->getCacheKey(varColMap), " with ",
-      regex_.has_value() ? regex_.value().pattern()
-                         : children_.at(1)->getCacheKey(varColMap),
-      "str:", childIsStrExpression_);
+  return absl::StrCat("Prefix REGEX expression ",
+                      child_->getCacheKey(varColMap),
+                      " str:", childIsStrExpression_);
 }
 
-// ___________________________________________________________________________
-std::span<SparqlExpression::Ptr> RegexExpression::childrenImpl() {
-  if (children_.at(1) == nullptr) {
-    return {&children_.at(0), 1};
-  }
-  return children_;
+// _____________________________________________________________________________
+std::span<SparqlExpression::Ptr> PrefixRegexExpression::childrenImpl() {
+  return {&child_, 1};
 }
 
-// ___________________________________________________________________________
-ExpressionResult RegexExpression::evaluatePrefixRegex(
-    const Variable& variable, EvaluationContext* context) const {
+// _____________________________________________________________________________
+ExpressionResult PrefixRegexExpression::evaluate(
+    EvaluationContext* context) const {
   // This function must only be called if we have a simple prefix regex.
-  AD_CORRECTNESS_CHECK(prefixRegex_.has_value());
-  const std::string& prefixRegex = prefixRegex_.value();
 
   // If the expression is enclosed in `STR()`, we have two ranges: for the
   // prefix with and without leading "<".
@@ -227,9 +180,9 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   // TODO<joka921> prefix filters currently never find numbers or other
   // datatypes that are encoded directly inside the IDs.
   std::vector<std::string> actualPrefixes;
-  actualPrefixes.push_back("\"" + prefixRegex);
+  actualPrefixes.push_back("\"" + prefixRegex_);
   if (childIsStrExpression_) {
-    actualPrefixes.push_back("<" + prefixRegex);
+    actualPrefixes.push_back("<" + prefixRegex_);
   }
 
   // Compute the (one or two) ranges.
@@ -254,8 +207,8 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   // sorted by that variable, the result can be computed by a constant number
   // of binary searches and the result is a set of intervals.
   std::vector<ad_utility::SetOfIntervals> resultSetOfIntervals;
-  if (context->isResultSortedBy(variable)) {
-    auto optColumn = context->getColumnIndexForVariable(variable);
+  if (context->isResultSortedBy(variable_)) {
+    auto optColumn = context->getColumnIndexForVariable(variable_);
     AD_CORRECTNESS_CHECK(optColumn.has_value(),
                          "We have previously asserted that the input is sorted "
                          "by the variable, so we expect it to exist");
@@ -290,7 +243,7 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   auto resultSize = context->size();
   VectorWithMemoryLimit<Id> result{context->_allocator};
   result.reserve(resultSize);
-  for (auto id : detail::makeGenerator(variable, resultSize, context)) {
+  for (auto id : detail::makeGenerator(variable_, resultSize, context)) {
     result.push_back(Id::makeFromBool(
         ql::ranges::any_of(lowerAndUpperIds, [&](const auto& lowerUpper) {
           return !valueIdComparators::compareByBits(id, lowerUpper.first) &&
@@ -301,148 +254,78 @@ ExpressionResult RegexExpression::evaluatePrefixRegex(
   return result;
 }
 
-// ___________________________________________________________________________
-CPP_template_def(typename T, typename F)(requires SingleExpressionResult<T>)
-    ExpressionResult RegexExpression::evaluateGeneralCase(
-        T&& input, EvaluationContext* context, F getNextRegex) const {
-  // We have one result for each row of the input.
-  auto resultSize = context->size();
-  VectorWithMemoryLimit<Id> result{context->_allocator};
-  result.reserve(resultSize);
-
-  // Compute the result using the given value getter. If the getter returns
-  // `std::nullopt` for a row, the result is `UNDEF`. Otherwise, we have a
-  // string and evaluate the regex on it.
-  auto computeResult = [&]<typename ValueGetter>(const ValueGetter& getter) {
-    ql::ranges::for_each(
-        detail::makeGenerator(AD_FWD(input), resultSize, context),
-        [&getter, &context, &result, &getNextRegex](const auto& id) {
-          auto str = getter(id, context);
-          auto* nextRegex = getNextRegex();
-          if (!str.has_value() || !nextRegex) {
-            result.push_back(Id::makeUndefined());
-          } else {
-            result.push_back(
-                Id::makeFromBool(RE2::PartialMatch(str.value(), *nextRegex)));
-          }
-          checkCancellation(context);
-        });
-  };
-
-  // Compute the result with the correct value getter (depending on whether the
-  // expression is enclosed in `STR()` or not), and return it.
-  if (childIsStrExpression_) {
-    computeResult(detail::StringValueGetter{});
-  } else {
-    computeResult(detail::LiteralFromIdGetter{});
-  }
-  return result;
-}
-
-// ___________________________________________________________________________
-ExpressionResult RegexExpression::evaluate(EvaluationContext* context) const {
-  auto resultAsVariant = children_.at(0)->evaluate(context);
-  auto variablePtr = std::get_if<Variable>(&resultAsVariant);
-
-  if (prefixRegex_.has_value() && variablePtr != nullptr) {
-    return evaluatePrefixRegex(*variablePtr, context);
-  }
-  AD_CORRECTNESS_CHECK(regex_.has_value() || children_.at(1));
-
-  return std::visit(
-      [this, context](auto&& input) {
-        if (regex_.has_value()) {
-          return evaluateGeneralCase(AD_FWD(input), context,
-                                     [this]() { return &regex_.value(); });
-        }
-        return std::visit(
-            [this, context, &input](auto&& regexInput) {
-              auto generator = detail::makeGenerator(AD_FWD(regexInput),
-                                                     context->size(), context);
-
-              std::optional<ql::ranges::iterator_t<decltype(generator)>>
-                  resultIterator = std::nullopt;
-
-              detail::LRUCache<std::string, std::unique_ptr<RE2>> regexCache{
-                  100};
-
-              auto getNextRegex = [&generator, &resultIterator, context,
-                                   &regexCache]() -> const RE2* {
-                if (resultIterator.has_value()) {
-                  AD_CORRECTNESS_CHECK(resultIterator.value() !=
-                                       generator.end());
-                  ++resultIterator.value();
-                } else {
-                  resultIterator = generator.begin();
-                  AD_CORRECTNESS_CHECK(resultIterator.value() !=
-                                       generator.end());
-                }
-                auto regexString = detail::LiteralFromIdGetter{}(
-                    *resultIterator.value(), context);
-                if (regexString.has_value()) {
-                  const auto& regex = regexCache.getOrCompute(
-                      regexString.value(), [](const std::string& string) {
-                        return std::make_unique<RE2>(string, RE2::Quiet);
-                      });
-                  if (regex->ok()) {
-                    return regex.get();
-                  }
-                }
-                return nullptr;
-              };
-              return this->evaluateGeneralCase(AD_FWD(input), context,
-                                               std::move(getNextRegex));
-            },
-            children_.at(1)->evaluate(context));
-      },
-      std::move(resultAsVariant));
-}
-
-// ____________________________________________________________________________
-bool RegexExpression::isPrefixExpression() const {
-  return prefixRegex_.has_value();
-}
-
-// ____________________________________________________________________________
-auto RegexExpression::getEstimatesForFilterExpression(
+// _____________________________________________________________________________
+auto PrefixRegexExpression::getEstimatesForFilterExpression(
     uint64_t inputSize,
     const std::optional<Variable>& firstSortedVariable) const -> Estimates {
-  // If we have a simple prefix regex, assume that only 10^-k entries remain,
-  // where k is the length of the prefix.
-  if (isPrefixExpression()) {
-    double reductionFactor = std::pow(
-        10, std::max(0, static_cast<int>(prefixRegex_.value().size())));
-    // Cap to reasonable minimal and maximal values to prevent numerical
-    // stability problems.
-    reductionFactor = std::min(100000000.0, reductionFactor);
-    reductionFactor = std::max(1.0, reductionFactor);
-    size_t sizeEstimate = inputSize / static_cast<size_t>(reductionFactor);
-    auto varPtr = dynamic_cast<VariableExpression*>(children_.at(0).get());
-    size_t costEstimate = (varPtr && firstSortedVariable == varPtr->value())
-                              ? sizeEstimate
-                              : sizeEstimate + inputSize;
+  // Assume that only 10^-k entries remain, where k is the length of the prefix.
+  double reductionFactor =
+      std::pow(10, std::max(0, static_cast<int>(prefixRegex_.size())));
+  // Cap to reasonable minimal and maximal values to prevent numerical
+  // stability problems.
+  reductionFactor = std::min(100000000.0, reductionFactor);
+  reductionFactor = std::max(1.0, reductionFactor);
+  size_t sizeEstimate = inputSize / static_cast<size_t>(reductionFactor);
+  size_t costEstimate = firstSortedVariable == variable_
+                            ? sizeEstimate
+                            : sizeEstimate + inputSize;
 
-    return {sizeEstimate, costEstimate};
-  }
-
-  // For the general case, we make two assumptions.
-  //
-  // 1. Half of the entries remain after the filter. This is a very simple
-  // and arbitrary heuristic.
-  //
-  // 2. Checking a REGEX for an element is 10 times more expensive than a
-  // "simple" filter check. This is reasonable because regex evaluations are
-  // expensive, but the fixed factor disregard that it depends on the
-  // complexity of the regex how expensive it is.
-  size_t sizeEstimate = inputSize / 2;
-  size_t costEstimate = sizeEstimate + 10 * inputSize;
   return {sizeEstimate, costEstimate};
 }
 
-// ____________________________________________________________________________
-void RegexExpression::checkCancellation(const EvaluationContext* context,
-                                        ad_utility::source_location location) {
+// _____________________________________________________________________________
+void PrefixRegexExpression::checkCancellation(
+    const EvaluationContext* context, ad_utility::source_location location) {
   context->cancellationHandle_->throwIfCancelled(location);
+}
+
+// _____________________________________________________________________________
+std::optional<PrefixRegexExpression>
+PrefixRegexExpression::makePrefixRegexExpressionIfPossible(Ptr& string,
+                                                           const Ptr& regex) {
+  detail::ensureIsValidRegexIfConstant(regex);
+  auto* variableExpression = dynamic_cast<VariableExpression*>(
+      string->isStrExpression() ? string->children()[0].get() : string.get());
+  auto* stringLiteralExpression =
+      dynamic_cast<const StringLiteralExpression*>(regex.get());
+  if (stringLiteralExpression) {
+    const auto& stringLiteral = stringLiteralExpression->value();
+    detail::ensureIsSimpleLiteral(stringLiteral);
+    if (variableExpression) {
+      if (std::optional<std::string> prefixRegex = getPrefixRegex(
+              std::string{asStringViewUnsafe(stringLiteral.getContent())})) {
+        return PrefixRegexExpression{std::move(string),
+                                     std::move(prefixRegex.value()),
+                                     variableExpression->value()};
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+// _____________________________________________________________________________
+SparqlExpression::Ptr makeRegexExpression(SparqlExpression::Ptr string,
+                                          SparqlExpression::Ptr regex,
+                                          SparqlExpression::Ptr flags) {
+  if (flags) {
+    if (auto* stringLiteralExpression =
+            dynamic_cast<const StringLiteralExpression*>(flags.get())) {
+      detail::ensureIsSimpleLiteral(stringLiteralExpression->value());
+    }
+    detail::ensureIsValidRegexIfConstant(regex);
+    detail::ensureIsValidFlagIfConstant(flags);
+    regex = makeMergeRegexPatternAndFlagsExpression(std::move(regex),
+                                                    std::move(flags));
+  } else if (auto prefixExpression =
+                 PrefixRegexExpression::makePrefixRegexExpressionIfPossible(
+                     string, regex)) {
+    return std::make_unique<PrefixRegexExpression>(
+        std::move(prefixExpression.value()));
+  } else {
+    detail::ensureIsValidRegexIfConstant(regex);
+  }
+  return std::make_unique<detail::RegexExpression>(std::move(string),
+                                                   std::move(regex));
 }
 
 }  // namespace sparqlExpression

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -31,14 +31,16 @@ class PrefixRegexExpression : public SparqlExpression {
   PrefixRegexExpression(Ptr child, std::string prefixRegex, Variable variable);
 
  public:
-  PrefixRegexExpression(PrefixRegexExpression&&) = default;
-  PrefixRegexExpression& operator=(PrefixRegexExpression&&) = default;
-  PrefixRegexExpression(const PrefixRegexExpression&) = delete;
-  PrefixRegexExpression& operator=(const PrefixRegexExpression&) = delete;
+  PrefixRegexExpression(PrefixRegexExpression&&) noexcept = default;
+  PrefixRegexExpression& operator=(PrefixRegexExpression&&) noexcept = default;
+  PrefixRegexExpression(const PrefixRegexExpression&) noexcept = delete;
+  PrefixRegexExpression& operator=(const PrefixRegexExpression&) noexcept =
+      delete;
 
   // ___________________________________________________________________________
   static std::optional<PrefixRegexExpression>
-  makePrefixRegexExpressionIfPossible(Ptr& string, const Ptr& regex);
+  makePrefixRegexExpressionIfPossible(Ptr& string,
+                                      const SparqlExpression& regex);
 
   // ___________________________________________________________________________
   ExpressionResult evaluate(EvaluationContext* context) const override;

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -12,8 +12,8 @@
 #include "engine/sparqlExpressions/SparqlExpression.h"
 
 namespace sparqlExpression {
-// Class implementing the REGEX function, which takes two mandatory arguments
-// (an expression and a regex) and one optional argument (a string of flags).
+// Class implementing a specialization of the REGEX function. This optimization
+// is possible if the regex is known in advance and is a simple prefix regex.
 class PrefixRegexExpression : public SparqlExpression {
  private:
   Ptr child_;
@@ -37,7 +37,9 @@ class PrefixRegexExpression : public SparqlExpression {
   PrefixRegexExpression& operator=(const PrefixRegexExpression&) noexcept =
       delete;
 
-  // ___________________________________________________________________________
+  // Check if the children of this expression allow for the prefix regex
+  // optimization. If this is the case, a `PrefixRegexExpression` is returned,
+  // otherwise `std::nullopt`.
   static std::optional<PrefixRegexExpression>
   makePrefixRegexExpressionIfPossible(Ptr& string,
                                       const SparqlExpression& regex);

--- a/src/engine/sparqlExpressions/RegexExpression.h
+++ b/src/engine/sparqlExpressions/RegexExpression.h
@@ -16,9 +16,13 @@ namespace sparqlExpression {
 // (an expression and a regex) and one optional argument (a string of flags).
 class RegexExpression : public SparqlExpression {
  private:
-  Ptr child_;
-  // The reguar expression.
-  std::variant<Ptr, RE2> regex_;
+  // Array to both children of this expression. The first child represent the
+  // string to be matched. The second child represents the regex, it is null if
+  // the regex can be precomputed, in which case the regex is stored in the
+  // member variable `regex_`.
+  std::array<Ptr, 2> children_;
+  // The regular expression if precomputed.
+  std::optional<RE2> regex_;
   // If this `std::optional` holds a string, we have a simple prefix regex
   // (which translates to a range search) and this string holds the prefix.
   std::optional<std::string> prefixRegex_;

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -94,7 +94,7 @@ std::optional<std::string> StringValueGetter::operator()(
 std::optional<std::string> ReplacementStringGetter::operator()(
     Id id, const EvaluationContext* context) const {
   std::optional<std::string> originalString =
-      LiteralFromIdGetter::operator()(id, context);
+      LiteralFromIdGetter{}(id, context);
   if (!originalString.has_value()) {
     return originalString;
   }

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.cpp
@@ -94,7 +94,7 @@ std::optional<std::string> StringValueGetter::operator()(
 std::optional<std::string> ReplacementStringGetter::operator()(
     Id id, const EvaluationContext* context) const {
   std::optional<std::string> originalString =
-      StringValueGetter::operator()(id, context);
+      LiteralFromIdGetter::operator()(id, context);
   if (!originalString.has_value()) {
     return originalString;
   }

--- a/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
+++ b/src/engine/sparqlExpressions/SparqlExpressionValueGetters.h
@@ -255,8 +255,7 @@ struct LiteralFromIdGetter : Mixin<LiteralFromIdGetter> {
 // they can be used by re2 as replacement strings. So '$1 \abc \$' becomes
 // '\1 \\abc $', where the former variant is valid in the SPARQL standard and
 // the latter represents the format that re2 expects.
-struct ReplacementStringGetter : LiteralFromIdGetter,
-                                 Mixin<ReplacementStringGetter> {
+struct ReplacementStringGetter : Mixin<ReplacementStringGetter> {
   using Mixin<ReplacementStringGetter>::operator();
   std::optional<std::string> operator()(ValueId,
                                         const EvaluationContext*) const;

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -6,6 +6,7 @@
 
 #include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
+#include "engine/sparqlExpressions/StringExpressionsHelper.h"
 #include "engine/sparqlExpressions/VariadicExpression.h"
 
 namespace sparqlExpression {
@@ -36,55 +37,6 @@ NARY_EXPRESSION(StrExpressionImpl, 1, FV<decltype(strImpl), StringValueGetter>);
 class StrExpression : public StrExpressionImpl {
   using StrExpressionImpl::StrExpressionImpl;
   bool isStrExpression() const override { return true; }
-};
-
-// Template for an expression that works on string literals. The arguments are
-// the same as those to `NaryExpression` with the difference that the value
-// getter is deduced automatically. If the child of the expression is the
-// `STR()` expression, then the `StringValueGetter` will be used (which also
-// returns string values for IRIs, numeric literals, etc.), otherwise the
-// `LiteralFromIdGetter` is used (which returns `std::nullopt` for these cases).
-template <size_t N, typename Function,
-          typename... AdditionalNonStringValueGetters>
-class StringExpressionImpl : public SparqlExpression {
- private:
-  using ExpressionWithStr =
-      NARY<N,
-           FV<Function, StringValueGetter, AdditionalNonStringValueGetters...>>;
-  using ExpressionWithoutStr = NARY<
-      N, FV<Function, LiteralFromIdGetter, AdditionalNonStringValueGetters...>>;
-
-  SparqlExpression::Ptr impl_;
-
- public:
-  CPP_template(typename... C)(
-      requires(concepts::same_as<C, SparqlExpression::Ptr>&&...)
-          CPP_and(sizeof...(C) + 1 ==
-                  N)) explicit StringExpressionImpl(SparqlExpression::Ptr child,
-                                                    C... children) {
-    AD_CORRECTNESS_CHECK(child != nullptr);
-    if (child->isStrExpression()) {
-      auto childrenOfStr = std::move(*child).moveChildrenOut();
-      AD_CORRECTNESS_CHECK(childrenOfStr.size() == 1);
-      impl_ = std::make_unique<ExpressionWithStr>(
-          std::move(childrenOfStr.at(0)), std::move(children)...);
-    } else {
-      impl_ = std::make_unique<ExpressionWithoutStr>(std::move(child),
-                                                     std::move(children)...);
-    }
-  }
-
-  ExpressionResult evaluate(EvaluationContext* context) const override {
-    return impl_->evaluate(context);
-  }
-  std::string getCacheKey(const VariableToColumnMap& varColMap) const override {
-    return impl_->getCacheKey(varColMap);
-  }
-
- private:
-  std::span<SparqlExpression::Ptr> childrenImpl() override {
-    return impl_->children();
-  }
 };
 
 // Lift a `Function` that takes one or multiple `std::string`s (possibly via

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -381,11 +381,10 @@ using StrBeforeExpression =
 };
 
 using MergeRegexPatternAndFlagsExpression =
-    StringExpressionImpl<2, decltype(mergeFlagsIntoRegex), StringValueGetter>;
+    StringExpressionImpl<2, decltype(mergeFlagsIntoRegex), LiteralFromIdGetter>;
 
 [[maybe_unused]] auto replaceImpl =
-    [](std::optional<std::string> input,
-       const std::unique_ptr<re2::RE2>& pattern,
+    [](std::optional<std::string> input, const std::unique_ptr<RE2>& pattern,
        const std::optional<std::string>& replacement) -> IdOrLiteralOrIri {
   if (!input.has_value() || !pattern || !replacement.has_value()) {
     return Id::makeUndefined();
@@ -397,7 +396,7 @@ using MergeRegexPatternAndFlagsExpression =
     return Id::makeUndefined();
   }
   const auto& repl = replacement.value();
-  re2::RE2::GlobalReplace(&in, pat, repl);
+  RE2::GlobalReplace(&in, pat, repl);
   return toLiteral(in);
 };
 

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -319,7 +319,7 @@ using StrBeforeExpression =
   if (!flags.has_value() || !regex.has_value()) {
     return Id::makeUndefined();
   }
-  auto firstInvalidFlag = flags.value().find_first_not_of("imsu");
+  auto firstInvalidFlag = flags.value().find_first_not_of("imsU");
   if (firstInvalidFlag != std::string::npos) {
     return Id::makeUndefined();
   }

--- a/src/engine/sparqlExpressions/StringExpressions.cpp
+++ b/src/engine/sparqlExpressions/StringExpressions.cpp
@@ -384,7 +384,7 @@ using MergeRegexPatternAndFlagsExpression =
     StringExpressionImpl<2, decltype(mergeFlagsIntoRegex), LiteralFromIdGetter>;
 
 [[maybe_unused]] auto replaceImpl =
-    [](std::optional<std::string> input, const std::unique_ptr<RE2>& pattern,
+    [](std::optional<std::string> input, const std::shared_ptr<RE2>& pattern,
        const std::optional<std::string>& replacement) -> IdOrLiteralOrIri {
   if (!input.has_value() || !pattern || !replacement.has_value()) {
     return Id::makeUndefined();

--- a/src/engine/sparqlExpressions/StringExpressionsHelper.h
+++ b/src/engine/sparqlExpressions/StringExpressionsHelper.h
@@ -1,0 +1,56 @@
+//   Copyright 2025, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#pragma once
+
+#include "engine/sparqlExpressions/NaryExpressionImpl.h"
+
+namespace sparqlExpression::detail::string_expressions {
+
+// Template for an expression that works on string literals. The arguments are
+// the same as those to `NaryExpression` with the difference that the value
+// getter is deduced automatically. If the child of the expression is the
+// `STR()` expression, then the `StringValueGetter` will be used (which also
+// returns string values for IRIs, numeric literals, etc.), otherwise the
+// `LiteralFromIdGetter` is used (which returns `std::nullopt` for these cases).
+template <size_t N, typename Function,
+          typename... AdditionalNonStringValueGetters>
+class StringExpressionImpl : public SparqlExpression {
+ private:
+  using ExpressionWithStr =
+      NARY<N,
+           FV<Function, StringValueGetter, AdditionalNonStringValueGetters...>>;
+  using ExpressionWithoutStr = NARY<
+      N, FV<Function, LiteralFromIdGetter, AdditionalNonStringValueGetters...>>;
+
+  Ptr impl_;
+
+ public:
+  CPP_template(typename... C)(
+      requires(concepts::same_as<C, SparqlExpression::Ptr>&&...)
+          CPP_and(sizeof...(C) + 1 ==
+                  N)) explicit StringExpressionImpl(Ptr child, C... children) {
+    AD_CORRECTNESS_CHECK(child != nullptr);
+    if (child->isStrExpression()) {
+      auto childrenOfStr = std::move(*child).moveChildrenOut();
+      AD_CORRECTNESS_CHECK(childrenOfStr.size() == 1);
+      impl_ = std::make_unique<ExpressionWithStr>(
+          std::move(childrenOfStr.at(0)), std::move(children)...);
+    } else {
+      impl_ = std::make_unique<ExpressionWithoutStr>(std::move(child),
+                                                     std::move(children)...);
+    }
+  }
+
+  ExpressionResult evaluate(EvaluationContext* context) const override {
+    return impl_->evaluate(context);
+  }
+  std::string getCacheKey(const VariableToColumnMap& varColMap) const override {
+    return impl_->getCacheKey(varColMap);
+  }
+
+ private:
+  std::span<Ptr> childrenImpl() override { return impl_->children(); }
+};
+}  // namespace sparqlExpression::detail::string_expressions

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -2533,9 +2533,8 @@ ExpressionPtr Visitor::visit(Parser::RegexExpressionContext* ctx) {
   AD_CONTRACT_CHECK(numArgs >= 2 && numArgs <= 3);
   auto flags = numArgs == 3 ? visitOptional(exp[2]) : std::nullopt;
   try {
-    return makeRegexExpression(
-        visit(exp[0]), visit(exp[1]),
-        flags.has_value() ? std::move(flags.value()) : nullptr);
+    return makeRegexExpression(visit(exp[0]), visit(exp[1]),
+                               std::move(flags).value_or(nullptr));
   } catch (const std::exception& e) {
     reportError(ctx, e.what());
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -133,17 +133,16 @@ ExpressionPtr Visitor::processIriFunctionCall(
 
   using namespace sparqlExpression;
   // Create `SparqlExpression` with one child.
-  auto createUnary =
-      CPP_template_lambda(&argList, &checkNumArgs)(typename F)(F function)(
-          requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr>) {
+  auto createUnary = CPP_template_lambda(&argList, &checkNumArgs)(typename F)(
+      F function)(requires std::is_invocable_r_v<ExpressionPtr, F,
+                                                 ExpressionPtr>) {
     checkNumArgs(1);  // Check is unary.
     return function(std::move(argList[0]));
   };
   // Create `SparqlExpression` with two children.
-  auto createBinary =
-      CPP_template_lambda(&argList, &checkNumArgs)(typename F)(F function)(
-          requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
-                                         ExpressionPtr>) {
+  auto createBinary = CPP_template_lambda(&argList, &checkNumArgs)(typename F)(
+      F function)(requires std::is_invocable_r_v<
+                  ExpressionPtr, F, ExpressionPtr, ExpressionPtr>) {
     checkNumArgs(2);  // Check is binary.
     return function(std::move(argList[0]), std::move(argList[1]));
   };
@@ -2398,22 +2397,24 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
   using namespace sparqlExpression;
   // Create the expression using the matching factory function from
   // `NaryExpression.h`.
-  auto createUnary = CPP_template_lambda(&argList)(typename F)(F function)(
-      requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr>) {
+  auto createUnary = CPP_template_lambda(&argList)(typename F)(
+      F function)(requires std::is_invocable_r_v<ExpressionPtr, F,
+                                                 ExpressionPtr>) {
     AD_CORRECTNESS_CHECK(argList.size() == 1, argList.size());
     return function(std::move(argList[0]));
   };
 
-  auto createBinary = CPP_template_lambda(&argList)(typename F)(F function)(
-      requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
-                                     ExpressionPtr>) {
+  auto createBinary = CPP_template_lambda(&argList)(typename F)(
+      F function)(requires std::is_invocable_r_v<
+                  ExpressionPtr, F, ExpressionPtr, ExpressionPtr>) {
     AD_CORRECTNESS_CHECK(argList.size() == 2);
     return function(std::move(argList[0]), std::move(argList[1]));
   };
 
-  auto createTernary = CPP_template_lambda(&argList)(typename F)(F function)(
-      requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
-                                     ExpressionPtr, ExpressionPtr>) {
+  auto createTernary = CPP_template_lambda(&argList)(typename F)(
+      F function)(requires std::is_invocable_r_v<ExpressionPtr, F,
+                                                 ExpressionPtr, ExpressionPtr,
+                                                 ExpressionPtr>) {
     AD_CORRECTNESS_CHECK(argList.size() == 3);
     return function(std::move(argList[0]), std::move(argList[1]),
                     std::move(argList[2]));
@@ -2533,8 +2534,9 @@ ExpressionPtr Visitor::visit(Parser::RegexExpressionContext* ctx) {
   AD_CONTRACT_CHECK(numArgs >= 2 && numArgs <= 3);
   auto flags = numArgs == 3 ? visitOptional(exp[2]) : std::nullopt;
   try {
-    return std::make_unique<sparqlExpression::RegexExpression>(
-        visit(exp[0]), visit(exp[1]), std::move(flags));
+    return makeRegexExpression(
+        visit(exp[0]), visit(exp[1]),
+        flags.has_value() ? std::move(flags.value()) : nullptr);
   } catch (const std::exception& e) {
     reportError(ctx, e.what());
   }

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -133,16 +133,17 @@ ExpressionPtr Visitor::processIriFunctionCall(
 
   using namespace sparqlExpression;
   // Create `SparqlExpression` with one child.
-  auto createUnary = CPP_template_lambda(&argList, &checkNumArgs)(typename F)(
-      F function)(requires std::is_invocable_r_v<ExpressionPtr, F,
-                                                 ExpressionPtr>) {
+  auto createUnary =
+      CPP_template_lambda(&argList, &checkNumArgs)(typename F)(F function)(
+          requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr>) {
     checkNumArgs(1);  // Check is unary.
     return function(std::move(argList[0]));
   };
   // Create `SparqlExpression` with two children.
-  auto createBinary = CPP_template_lambda(&argList, &checkNumArgs)(typename F)(
-      F function)(requires std::is_invocable_r_v<
-                  ExpressionPtr, F, ExpressionPtr, ExpressionPtr>) {
+  auto createBinary =
+      CPP_template_lambda(&argList, &checkNumArgs)(typename F)(F function)(
+          requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
+                                         ExpressionPtr>) {
     checkNumArgs(2);  // Check is binary.
     return function(std::move(argList[0]), std::move(argList[1]));
   };
@@ -2397,24 +2398,22 @@ ExpressionPtr Visitor::visit([[maybe_unused]] Parser::BuiltInCallContext* ctx) {
   using namespace sparqlExpression;
   // Create the expression using the matching factory function from
   // `NaryExpression.h`.
-  auto createUnary = CPP_template_lambda(&argList)(typename F)(
-      F function)(requires std::is_invocable_r_v<ExpressionPtr, F,
-                                                 ExpressionPtr>) {
+  auto createUnary = CPP_template_lambda(&argList)(typename F)(F function)(
+      requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr>) {
     AD_CORRECTNESS_CHECK(argList.size() == 1, argList.size());
     return function(std::move(argList[0]));
   };
 
-  auto createBinary = CPP_template_lambda(&argList)(typename F)(
-      F function)(requires std::is_invocable_r_v<
-                  ExpressionPtr, F, ExpressionPtr, ExpressionPtr>) {
+  auto createBinary = CPP_template_lambda(&argList)(typename F)(F function)(
+      requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
+                                     ExpressionPtr>) {
     AD_CORRECTNESS_CHECK(argList.size() == 2);
     return function(std::move(argList[0]), std::move(argList[1]));
   };
 
-  auto createTernary = CPP_template_lambda(&argList)(typename F)(
-      F function)(requires std::is_invocable_r_v<ExpressionPtr, F,
-                                                 ExpressionPtr, ExpressionPtr,
-                                                 ExpressionPtr>) {
+  auto createTernary = CPP_template_lambda(&argList)(typename F)(F function)(
+      requires std::is_invocable_r_v<ExpressionPtr, F, ExpressionPtr,
+                                     ExpressionPtr, ExpressionPtr>) {
     AD_CORRECTNESS_CHECK(argList.size() == 3);
     return function(std::move(argList[0]), std::move(argList[1]),
                     std::move(argList[2]));

--- a/src/util/LruCache.h
+++ b/src/util/LruCache.h
@@ -1,0 +1,50 @@
+//   Copyright 2025, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#pragma once
+
+#include <absl/container/flat_hash_map.h>
+
+#include <cstdint>
+#include <list>
+
+namespace ad_utility::util {
+
+template <typename K, typename V>
+class LRUCache {
+ private:
+  size_t capacity_;
+  // Stores keys in order of usage (MRU at front)
+  std::list<K> keys_;
+  absl::flat_hash_map<K, std::pair<V, typename std::list<K>::iterator>> cache_;
+
+ public:
+  explicit LRUCache(size_t capacity) : capacity_{capacity} {}
+
+  template <typename Func>
+  const V& getOrCompute(const K& key, Func computeFunction) {
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+      // Move accessed key to front (most recently used)
+      keys_.erase(it->second.second);
+      keys_.push_front(key);
+      it->second.second = keys_.begin();
+
+      return it->second.first;
+    }
+    // Evict LRU if cache is full
+    if (cache_.size() >= capacity_) {
+      K lruKey = keys_.back();
+      keys_.pop_back();
+      cache_.erase(lruKey);
+    }
+    // Insert new element
+    keys_.push_front(key);
+    auto result = cache_.try_emplace(key, computeFunction(key), keys_.begin());
+    AD_CORRECTNESS_CHECK(result.second);
+    return result.first->second.first;
+  }
+};
+
+}  // namespace ad_utility::util

--- a/src/util/LruCache.h
+++ b/src/util/LruCache.h
@@ -9,6 +9,8 @@
 #include <cstdint>
 #include <list>
 
+#include "util/Exception.h"
+
 namespace ad_utility::util {
 
 template <typename K, typename V>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -458,3 +458,5 @@ addLinkAndDiscoverTest(GraphStoreProtocolTest engine)
 addLinkAndDiscoverTest(SPARQLProtocolTest engine)
 
 addLinkAndDiscoverTest(ParsedRequestBuilderTest engine)
+
+addLinkAndDiscoverTest(LruCacheTest)

--- a/test/LruCacheTest.cpp
+++ b/test/LruCacheTest.cpp
@@ -1,0 +1,37 @@
+//   Copyright 2025, University of Freiburg,
+//   Chair of Algorithms and Data Structures.
+//   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+
+#include <gtest/gtest.h>
+
+#include "util/LruCache.h"
+
+TEST(LRUCache, testLruCache) {
+  ad_utility::util::LRUCache<int, int> cache{2};
+
+  EXPECT_EQ(1, cache.getOrCompute(1, [](int i) {
+    EXPECT_EQ(i, 1);
+    return 1;
+  }));
+  EXPECT_EQ(2, cache.getOrCompute(2, [](int i) {
+    EXPECT_EQ(i, 2);
+    return 2;
+  }));
+
+  EXPECT_EQ(1, cache.getOrCompute(1, [](int) {
+    ADD_FAILURE();
+    return 0;
+  }));
+  EXPECT_EQ(3, cache.getOrCompute(3, [](int i) {
+    EXPECT_EQ(i, 3);
+    return 3;
+  }));
+  EXPECT_EQ(20, cache.getOrCompute(2, [](int i) {
+    EXPECT_EQ(i, 2);
+    return 20;
+  }));
+  EXPECT_EQ(10, cache.getOrCompute(1, [](int i) {
+    EXPECT_EQ(i, 1);
+    return 10;
+  }));
+}

--- a/test/LruCacheTest.cpp
+++ b/test/LruCacheTest.cpp
@@ -8,29 +8,31 @@
 
 TEST(LRUCache, testLruCache) {
   ad_utility::util::LRUCache<int, int> cache{2};
+  // Type-erase the lambdas to get a better coverage report.
+  using F = std::function<int(int)>;
 
-  EXPECT_EQ(1, cache.getOrCompute(1, [](int i) {
+  EXPECT_EQ(1, cache.getOrCompute<F>(1, [](int i) {
     EXPECT_EQ(i, 1);
     return 1;
   }));
-  EXPECT_EQ(2, cache.getOrCompute(2, [](int i) {
+  EXPECT_EQ(2, cache.getOrCompute<F>(2, [](int i) {
     EXPECT_EQ(i, 2);
     return 2;
   }));
 
-  EXPECT_EQ(1, cache.getOrCompute(1, [](int) {
+  EXPECT_EQ(1, cache.getOrCompute<F>(1, [](int) {
     ADD_FAILURE();
     return 0;
   }));
-  EXPECT_EQ(3, cache.getOrCompute(3, [](int i) {
+  EXPECT_EQ(3, cache.getOrCompute<F>(3, [](int i) {
     EXPECT_EQ(i, 3);
     return 3;
   }));
-  EXPECT_EQ(20, cache.getOrCompute(2, [](int i) {
+  EXPECT_EQ(20, cache.getOrCompute<F>(2, [](int i) {
     EXPECT_EQ(i, 2);
     return 20;
   }));
-  EXPECT_EQ(10, cache.getOrCompute(1, [](int i) {
+  EXPECT_EQ(10, cache.getOrCompute<F>(1, [](int i) {
     EXPECT_EQ(i, 1);
     return 10;
   }));

--- a/test/LruCacheTest.cpp
+++ b/test/LruCacheTest.cpp
@@ -37,3 +37,9 @@ TEST(LRUCache, testLruCache) {
     return 10;
   }));
 }
+
+// _____________________________________________________________________________
+TEST(LRUCache, testEmptyCapacityForbidden) {
+  EXPECT_THROW((ad_utility::util::LRUCache<int, int>{0}),
+               ad_utility::Exception);
+}

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -190,15 +190,6 @@ TEST(RegexExpression, nonPrefixRegex) {
                          {"abC", "[A-Z]", ""},
                          {"", "", ""}},
                         {T, F, T, T, T}, false);
-
-  std::vector<std::array<std::string, 3>> values;
-  std::vector<Id> expected;
-  // Make sure to exceed the cache limit
-  for (size_t i = 0; i < 101; i++) {
-    values.push_back({std::to_string(i), std::to_string(i), ""});
-    expected.push_back(T);
-  }
-  testValuesInVariables(values, expected, false);
 }
 
 // Test where the expression is not simply a variable.

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -375,6 +375,7 @@ TEST(RegexExpression, prefixRegexOrderedColumn) {
 
 // _____________________________________________________________________________
 TEST(RegexExpression, getCacheKey) {
+  using namespace ::testing;
   auto exp0 = makeRegexExpression("?first", "^alp");
   auto exp1 = makeRegexExpression("?first", "alp");
   auto exp2 = makeRegexExpression("?first", "alp");
@@ -383,9 +384,10 @@ TEST(RegexExpression, getCacheKey) {
   map[Variable{"?first"}] = makeAlwaysDefinedColumn(0);
   map[Variable{"?second"}] = makeAlwaysDefinedColumn(1);
   EXPECT_TRUE(isPrefixExpression(exp0));
-  EXPECT_THAT(exp0->getCacheKey(map),
-              ::testing::AllOf(::testing::StartsWith("Prefix REGEX"),
-                               ::testing::HasSubstr("str:0")));
+  EXPECT_THAT(
+      exp0->getCacheKey(map),
+      AllOf(StartsWith("Prefix REGEX"), HasSubstr("str:0"), HasSubstr("alp"),
+            HasSubstr(exp0->children()[0]->getCacheKey(map))));
   EXPECT_NE(exp0->getCacheKey(map), exp1->getCacheKey(map));
   ASSERT_EQ(exp1->getCacheKey(map), exp2->getCacheKey(map));
 
@@ -422,7 +424,9 @@ TEST(RegexExpression, getCacheKey) {
   EXPECT_NE(exp8->getCacheKey(map), exp9->getCacheKey(map));
 
   auto exp10 = makeRegexExpression("?first", "^alp", std::nullopt, true);
-  EXPECT_THAT(exp10->getCacheKey(map), ::testing::HasSubstr("str:1"));
+  EXPECT_THAT(exp10->getCacheKey(map),
+              AllOf(HasSubstr("str:1"), HasSubstr("alp"),
+                    HasSubstr(exp10->children()[0]->getCacheKey(map))));
   EXPECT_NE(exp0->getCacheKey(map), exp10->getCacheKey(map));
 }
 

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -203,15 +203,30 @@ TEST(RegexExpression, inputNotVariable) {
   VectorWithMemoryLimit<IdOrLiteralOrIri> input{
       ad_utility::testing::getQec()->getAllocator()};
   input.push_back(ad_utility::triple_component::LiteralOrIri(lit("\"hallo\"")));
-  auto child = std::make_unique<sparqlExpression::detail::SingleUseExpression>(
-      input.clone());
 
-  // "hallo" matches the regex "ha".
-  auto expr =
-      makeRegexExpression(std::move(child), literal("\"ha\""), literal("\"\""));
-  std::vector<Id> expected;
-  expected.push_back(Id::makeFromBool(true));
-  testWithExplicitResult(*expr, expected, input.size());
+  {
+    auto child =
+        std::make_unique<sparqlExpression::detail::SingleUseExpression>(
+            input.clone());
+
+    // "hallo" matches the regex "ha".
+    auto expr = makeRegexExpression(std::move(child), literal("\"ha\""),
+                                    literal("\"\""));
+    std::vector<Id> expected;
+    expected.push_back(Id::makeFromBool(true));
+    testWithExplicitResult(*expr, expected, input.size());
+  }
+
+  // Without variable it cannot be a prefix regex expression.
+  {
+    auto child =
+        std::make_unique<sparqlExpression::detail::SingleUseExpression>(
+            input.clone());
+
+    auto expr =
+        makeTestRegexExpression(std::move(child), literal("\"^ha\""), nullptr);
+    EXPECT_FALSE(isPrefixExpression(expr));
+  }
 }
 
 // _____________________________________________________________________________

--- a/test/RegexExpressionTest.cpp
+++ b/test/RegexExpressionTest.cpp
@@ -295,10 +295,11 @@ TEST(RegexExpression, nonPrefixRegexWithFlags) {
   testValuesInVariables({{"Abc", "[A-Z]", ""},
                          {"abc", "[A-Z]", ""},
                          {"abc", "[A-Z]", "i"},
+                         {"abc", "[A-Z]", "imsU"},
                          {"", "", ""},
                          {"", "(invalid", ""},
                          {"", "", "invalid"}},
-                        {T, F, T, T, U, U}, true);
+                        {T, F, T, T, T, U, U}, true);
 }
 
 namespace sparqlExpression {
@@ -453,7 +454,7 @@ TEST(RegexExpression, getChildren) {
   EXPECT_THAT(makeRegexExpression("?a", "^someRegex")->containedVariables(),
               ElementsAre(Pointee(Variable{"?a"})));
   EXPECT_THAT(
-      makeRegexExpression("?a", "someRegex", "ims")->containedVariables(),
+      makeRegexExpression("?a", "someRegex", "imsU")->containedVariables(),
       ElementsAre(Pointee(Variable{"?a"})));
   EXPECT_THAT(makeTestRegexExpression(variable("?a"), literal("someRegex"),
                                       variable("?c"))

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1752,13 +1752,13 @@ TEST(SparqlParser, builtInCall) {
                     matchNary(makeReplaceExpressionThreeArgs, Var{"?x"},
                               Var{"?y"}, Var{"?z"}));
   expectBuiltInCall(
-      "replace(?x, ?y, ?z, \"imsu\")",
+      "replace(?x, ?y, ?z, \"imsU\")",
       matchNaryWithChildrenMatchers(
           makeReplaceExpressionThreeArgs, variableExpressionMatcher(Var{"?x"}),
           matchNaryWithChildrenMatchers(
               &makeMergeRegexPatternAndFlagsExpression,
               variableExpressionMatcher(Var{"?y"}),
-              matchLiteralExpression(lit("imsu"))),
+              matchLiteralExpression(lit("imsU"))),
           variableExpressionMatcher(Var{"?z"})));
   expectBuiltInCall("IF(?a, ?h, ?c)", matchNary(&makeIfExpression, Var{"?a"},
                                                 Var{"?h"}, Var{"?c"}));
@@ -1800,13 +1800,13 @@ TEST(SparqlParser, builtInCall) {
                                     variableExpressionMatcher(Var{"?x"}),
                                     matchLiteralExpression(lit("ab"))));
   expectBuiltInCall(
-      "regex(?x, \"ab\", \"imsu\")",
+      "regex(?x, \"ab\", \"imsU\")",
       matchNaryWithChildrenMatchers(
           makeRegexExpressionTwoArgs, variableExpressionMatcher(Var{"?x"}),
           matchNaryWithChildrenMatchers(
               &makeMergeRegexPatternAndFlagsExpression,
               matchLiteralExpression(lit("ab")),
-              matchLiteralExpression(lit("imsu")))));
+              matchLiteralExpression(lit("imsU")))));
 
   expectBuiltInCall("MD5(?x)", matchUnary(&makeMD5Expression));
   expectBuiltInCall("SHA1(?x)", matchUnary(&makeSHA1Expression));

--- a/test/SparqlAntlrParserTest.cpp
+++ b/test/SparqlAntlrParserTest.cpp
@@ -1792,7 +1792,22 @@ TEST(SparqlParser, builtInCall) {
   // The following three cases delegate to a separate parsing function, so we
   // only perform rather simple checks.
   expectBuiltInCall("COUNT(?x)", matchPtr<CountExpression>());
-  expectBuiltInCall("regex(?x, \"ab\")", matchPtr<RegexExpression>());
+  auto makeRegexExpressionTwoArgs = [](auto&& arg0, auto&& arg1) {
+    return makeRegexExpression(AD_FWD(arg0), AD_FWD(arg1), nullptr);
+  };
+  expectBuiltInCall(
+      "regex(?x, \"ab\")",
+      matchNaryWithChildrenMatchers(makeRegexExpressionTwoArgs,
+                                    variableExpressionMatcher(Var{"?x"}),
+                                    matchLiteralExpression(lit("ab"))));
+  expectBuiltInCall(
+      "regex(?x, \"ab\", \"imsu\")",
+      matchNaryWithChildrenMatchers(
+          makeRegexExpressionTwoArgs, variableExpressionMatcher(Var{"?x"}),
+          matchNaryWithChildrenMatchers(
+              &makeMergeRegexPatternAndFlagsExpression,
+              matchLiteralExpression(lit("ab")),
+              matchLiteralExpression(lit("imsu")))));
 
   expectBuiltInCall("MD5(?x)", matchUnary(&makeMD5Expression));
   expectBuiltInCall("SHA1(?x)", matchUnary(&makeSHA1Expression));

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1383,6 +1383,13 @@ TEST(SparqlExpression, ReplaceExpression) {
       std::tuple{idOrLitOrStringVec({"null", "eIns", "zwEi", "drei"}),
                  IdOrLiteralOrIri{lit("[ei]")}, IdOrLiteralOrIri{lit("x")},
                  IdOrLiteralOrIri{lit("i")}});
+
+  // Matching using the all the flags
+  checkReplaceWithFlags(
+      idOrLitOrStringVec({"null", "xxns", "zwxx", "drxx"}),
+      std::tuple{idOrLitOrStringVec({"null", "eIns", "zwEi", "drei"}),
+                 IdOrLiteralOrIri{lit("[ei]")}, IdOrLiteralOrIri{lit("x")},
+                 IdOrLiteralOrIri{lit("imsU")}});
   // Empty flag
   checkReplaceWithFlags(
       idOrLitOrStringVec({"null", "xIns", "zwEx", "drxx"}),

--- a/test/SparqlExpressionTest.cpp
+++ b/test/SparqlExpressionTest.cpp
@@ -1365,7 +1365,8 @@ TEST(SparqlExpression, ReplaceExpression) {
                           IdOrLiteralOrIri{lit("([A-Z]+)")},
                           IdOrLiteralOrIri{lit(R"("\\$1 \\2 $1 \\")")}});
 
-  checkReplace(idOrLitOrStringVec({"truebc", "truef"}),
+  // Only simple literals should be replaced.
+  checkReplace(idOrLitOrStringVec({U, U}),
                std::tuple{idOrLitOrStringVec({"Abc", "DEf"}),
                           IdOrLiteralOrIri{lit("([A-Z]+)")},
                           IdOrLiteralOrIri{Id::makeFromBool(true)}});

--- a/test/SparqlExpressionTestHelpers.h
+++ b/test/SparqlExpressionTestHelpers.h
@@ -2,16 +2,12 @@
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 
+#pragma once
+
 #include "./util/IdTestHelpers.h"
-#include "./util/TripleComponentTestHelpers.h"
-#include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/SparqlExpression.h"
 #include "global/ValueIdComparators.h"
-#include "gtest/gtest.h"
-#include "index/ConstantsIndexBuilding.h"
 #include "util/IndexTestHelpers.h"
-
-#pragma once
 
 namespace sparqlExpression {
 


### PR DESCRIPTION
Add support for the `REGEX` function in the case where the regular expression is dynamically computed by the query, e.g.
`REGEX(?input, ?regex)` or `REGEX(?input, CONCAT("bla", "*"))`. Previously, QLever only supported hardcoded regular expressions like `REGEX(?input, "bla*")`.
The implementation optimizes for the case, that the regex is stored in a variable with a low multiplicity, so for example for the case `REGEX(?input, ?regex)`, where the `?regex` only binds to a few distinct values by using a simple LRU cache in the `RegexValueGetter`.
Also clean up the code for the `Regex`, `Replace` and `Prefix` expressions.
Fixes #1821
