### PR TITLE
Fix assertion error in `LocalVocab` implementation and add convenience `mergeWith` function.

### DIFF
--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -155,7 +155,7 @@ class AddCombinedRowToIdTable {
     AD_CORRECTNESS_CHECK(currentVocab == nullptr);
     if constexpr (CPP_requires_ref(detail::concepts::HasGetLocalVocab, T)) {
       currentVocab = &table.getLocalVocab();
-      mergedVocab_.mergeWith(std::span{&table.getLocalVocab(), 1});
+      mergedVocab_.mergeWith(table.getLocalVocab());
     }
   }
 

--- a/src/engine/CartesianProductJoin.cpp
+++ b/src/engine/CartesianProductJoin.cpp
@@ -347,7 +347,7 @@ Result::Generator CartesianProductJoin::createLazyConsumer(
       continue;
     }
     idTables.emplace_back(idTable);
-    localVocab.mergeWith(std::span{&staticMergedVocab, 1});
+    localVocab.mergeWith(staticMergedVocab);
     size_t producedTableSize = 0;
     for (auto& idTableAndVocab : produceTablesLazily(
              std::move(localVocab),

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -183,7 +183,7 @@ IdTable Describe::makeAndExecuteJoinWithFullIndex(
 
   // The `indexScan` might have added some delta triples with local vocab IDs,
   // so make sure to merge them into the `localVocab`.
-  localVocab.mergeWith(std::span{&result->localVocab(), 1});
+  localVocab.mergeWith(result->localVocab());
 
   return resultTable;
 }

--- a/src/engine/Filter.cpp
+++ b/src/engine/Filter.cpp
@@ -98,7 +98,7 @@ Result Filter::computeResult(bool requestLaziness) {
         for (Result::IdTableVocabPair& pair : subRes->idTables()) {
           computeFilterImpl<WIDTH>(result, std::move(pair.idTable_),
                                    pair.localVocab_, subRes->sortedBy());
-          resultLocalVocab.mergeWith(std::span{&pair.localVocab_, 1});
+          resultLocalVocab.mergeWith(pair.localVocab_);
         }
       });
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1535,7 +1535,7 @@ Result GroupBy::computeGroupByForHashMapOptimization(
     //
     // NOTE: If the input blocks have very similar or even identical non-empty
     // local vocabs, no deduplication is performed.
-    localVocab.mergeWith(std::span{&inputLocalVocab, 1});
+    localVocab.mergeWith(inputLocalVocab);
     // Setup the `EvaluationContext` for this input block.
     sparqlExpression::EvaluationContext evaluationContext(
         *getExecutionContext(), _subtree->getVariableColumns(), inputTable,

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -25,7 +25,7 @@ LocalVocab LocalVocab::merge(std::span<const LocalVocab*> vocabs) {
 
 // _____________________________________________________________________________
 void LocalVocab::mergeWith(const LocalVocab& other) {
-  mergeWith(std::span{&other, 1});
+  mergeWith(std::span<const LocalVocab, 1>{&other, 1});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.cpp
+++ b/src/engine/LocalVocab.cpp
@@ -11,7 +11,7 @@
 // _____________________________________________________________________________
 LocalVocab LocalVocab::clone() const {
   LocalVocab result;
-  result.mergeWith(std::span{this, 1});
+  result.mergeWith(*this);
   AD_CORRECTNESS_CHECK(result.size_ == size_);
   return result;
 }
@@ -21,6 +21,11 @@ LocalVocab LocalVocab::merge(std::span<const LocalVocab*> vocabs) {
   LocalVocab result;
   result.mergeWith(vocabs | ql::views::transform(ad_utility::dereference));
   return result;
+}
+
+// _____________________________________________________________________________
+void LocalVocab::mergeWith(const LocalVocab& other) {
+  mergeWith(std::span{&other, 1});
 }
 
 // _____________________________________________________________________________

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -153,6 +153,9 @@ class LocalVocab {
     localBlankNodeManager_->mergeWith(localManagersView);
   }
 
+  // Convenience function for a single `LocalVocab`.
+  void mergeWith(const LocalVocab& other);
+
   // Create a new local vocab with empty set and other sets that are the union
   // of all sets (primary and other) of the given local vocabs.
   static LocalVocab merge(std::span<const LocalVocab*> vocabs);

--- a/src/engine/LocalVocab.h
+++ b/src/engine/LocalVocab.h
@@ -117,6 +117,9 @@ class LocalVocab {
       const R& vocabs) {
     using ql::views::filter;
     auto addWordSet = [this](const std::shared_ptr<const Set>& set) {
+      if (set == primaryWordSet_) {
+        return;
+      }
       bool added = otherWordSets_.insert(set).second;
       size_ += static_cast<size_t>(added) * set->size();
     };

--- a/src/engine/Result.cpp
+++ b/src/engine/Result.cpp
@@ -288,8 +288,7 @@ void Result::cacheDuringConsumption(
             if (aggregate.has_value()) {
               auto& value = aggregate.value();
               value.idTable_.insertAtEnd(newTablePair.idTable_);
-              value.localVocab_.mergeWith(
-                  std::span{&newTablePair.localVocab_, 1});
+              value.localVocab_.mergeWith(newTablePair.localVocab_);
             } else {
               aggregate.emplace(newTablePair.idTable_.clone(),
                                 newTablePair.localVocab_.clone());

--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -612,7 +612,7 @@ void Service::precomputeSiblingResult(std::shared_ptr<Operation> left,
 
   for (auto& pair : resultPairs) {
     siblingPair.idTable_.insertAtEnd(pair.idTable_);
-    siblingPair.localVocab_.mergeWith(std::span{&pair.localVocab_, 1});
+    siblingPair.localVocab_.mergeWith(pair.localVocab_);
   }
 
   service->siblingInfo_.emplace(

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -64,7 +64,7 @@ struct IterationData {
   void appendCurrent(IdTable& resultTable, LocalVocab& localVocab) {
     resultTable.insertAtEnd(it_.value()->idTable_, index_, std::nullopt,
                             permutation_, Id::makeUndefined());
-    localVocab.mergeWith(std::span{&it_.value()->localVocab_, 1});
+    localVocab.mergeWith(it_.value()->localVocab_);
     index_ = 0;
     ++it_.value();
   }
@@ -192,8 +192,8 @@ struct SortedUnionImpl
            data2_.it_ != data2_.range_.end()) {
       auto& idTable1 = data1_.it_.value()->idTable_;
       auto& idTable2 = data2_.it_.value()->idTable_;
-      localVocab_.mergeWith(std::span{&data1_.it_.value()->localVocab_, 1});
-      localVocab_.mergeWith(std::span{&data2_.it_.value()->localVocab_, 1});
+      localVocab_.mergeWith(data1_.it_.value()->localVocab_);
+      localVocab_.mergeWith(data2_.it_.value()->localVocab_);
       size_t& index1 = data1_.index_;
       size_t& index2 = data2_.index_;
       while (index1 < idTable1.size() && index2 < idTable2.size()) {

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -150,7 +150,7 @@ Result::Generator TransitivePathBase::fillTableWithHullImpl(
     }
 
     if (yieldOnce) {
-      mergedVocab.mergeWith(std::span{&localVocab, 1});
+      mergedVocab.mergeWith(localVocab);
     } else {
       timer.stop();
       runtimeInfo().addDetail("IdTable fill time", timer.msecs());

--- a/src/engine/TransitivePathImpl.h
+++ b/src/engine/TransitivePathImpl.h
@@ -236,7 +236,7 @@ class TransitivePathImpl : public TransitivePathBase {
     for (auto&& tableColumn : startNodes) {
       timer.cont();
       LocalVocab mergedVocab = std::move(tableColumn.vocab_);
-      mergedVocab.mergeWith(std::span{&edgesVocab, 1});
+      mergedVocab.mergeWith(edgesVocab);
       size_t currentRow = 0;
       for (Id startNode : tableColumn.column_) {
         Set connectedNodes = findConnectedNodes(edges, startNode, target);

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -441,14 +441,17 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
   clone2.mergeWith(std::span{&original, 1});
   original.mergeWith(std::span{&clone1, 1});
 
-  // Implementation detail, merging does add to the "other word set" but does
-  // not deduplicate with the primary word set.
-  EXPECT_EQ(original.size(), 2);
+  // Make sure we deduplicate `otherWordSets_` with the primary word set.
+  EXPECT_EQ(original.size(), 1);
   EXPECT_THAT(original.getAllWordsForTesting(),
-              UnorderedElementsAre(LiteralOrIri::literalWithoutQuotes("test"),
-                                   LiteralOrIri::literalWithoutQuotes("test")));
+              UnorderedElementsAre(LiteralOrIri::literalWithoutQuotes("test")));
 
   EXPECT_EQ(clone2.size(), 1);
   EXPECT_THAT(clone2.getAllWordsForTesting(),
+              UnorderedElementsAre(LiteralOrIri::literalWithoutQuotes("test")));
+
+  LocalVocab clone3 = original.clone();
+  EXPECT_EQ(clone3.size(), 1);
+  EXPECT_THAT(clone3.getAllWordsForTesting(),
               UnorderedElementsAre(LiteralOrIri::literalWithoutQuotes("test")));
 }

--- a/test/LocalVocabTest.cpp
+++ b/test/LocalVocabTest.cpp
@@ -420,7 +420,7 @@ TEST(LocalVocab, otherWordSetIsTransitivelyPropagated) {
 
   LocalVocab clone = original.clone();
   LocalVocab mergeCandidate;
-  mergeCandidate.mergeWith(std::span{&clone, 1});
+  mergeCandidate.mergeWith(clone);
 
   EXPECT_EQ(mergeCandidate.size(), 1);
   EXPECT_THAT(mergeCandidate.getAllWordsForTesting(),
@@ -438,8 +438,8 @@ TEST(LocalVocab, sizeIsProperlyUpdatedOnMerge) {
 
   LocalVocab clone1 = original.clone();
   LocalVocab clone2 = original.clone();
-  clone2.mergeWith(std::span{&original, 1});
-  original.mergeWith(std::span{&clone1, 1});
+  clone2.mergeWith(original);
+  original.mergeWith(clone1);
 
   // Make sure we deduplicate `otherWordSets_` with the primary word set.
   EXPECT_EQ(original.size(), 1);


### PR DESCRIPTION
Fixes #1890 by deduplicating `otherWordSets_` with the primary word set.