### PR TITLE
Fix Docker build for `CMake` version `4.0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY CompilationInfo.cmake /qlever/
 # Don't build and run tests on ARM64, as it takes too long on GitHub actions.
 # TODO: re-enable these tests as soon as we can use a native ARM64 platform to compile the Docker container.
 WORKDIR /qlever/build/
-RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -GNinja ..
+RUN cmake -DCMAKE_BUILD_TYPE=Release -DLOGLEVEL=INFO -DUSE_PARALLEL=true -D_NO_TIMING_TESTS=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -GNinja ..
 RUN if  [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "target is ARM64, don't build tests to avoid timeout"; fi
 RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then cmake --build . --target IndexBuilderMain ServerMain; else cmake --build . ; fi
 RUN if [ $TARGETPLATFORM = "linux/arm64" ] ; then echo "Skipping tests for ARM64" ; else ctest --rerun-failed --output-on-failure ; fi


### PR DESCRIPTION
Since the GitHub workers switched to `CMake` version `4.0`, the docker build no longer succeeds. This is a temporary fix to override the configuration for `stxxl `and `foxxl`. Fixes #1914

NOTE: We will soon completely remove `stxxl` and `foxxl` from the codebase (most uses have already been replaced).