### PR TITLE
Fixes for "Persist updates between server restarts (#1903)"

### DIFF
--- a/src/engine/ExecuteUpdate.cpp
+++ b/src/engine/ExecuteUpdate.cpp
@@ -24,8 +24,6 @@ UpdateMetadata ExecuteUpdate::executeUpdate(
   deltaTriples.insertTriples(cancellationHandle,
                              std::move(toInsert.idTriples_));
   metadata.insertionTime_ = timer.msecs();
-  // TODO add timing information to metadata
-  deltaTriples.writeToDisk();
   return metadata;
 }
 

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -238,6 +238,8 @@ ReturnType DeltaTriplesManager::modify(
         auto writeAndUpdateSnapshot = [&updateSnapshot, &deltaTriples,
                                        writeToDiskAfterRequest]() {
           if (writeToDiskAfterRequest) {
+            // TODO<RobinTF> Find a good way to track the time it takes to write
+            // this and store it into the corresponding metadata object.
             deltaTriples.writeToDisk();
           }
           updateSnapshot();

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -286,12 +286,12 @@ void DeltaTriples::writeToDisk() const {
     return;
   }
   auto toRange = [](const TriplesToHandlesMap& map) {
-    return ad_utility::SizedJoinView{
-        map | ql::views::keys |
-        ql::views::transform(
-            [](const IdTriple<0>& triple) -> const std::array<Id, 4>& {
-              return triple.ids_;
-            })};
+    return map | ql::views::keys |
+           ql::views::transform(
+               [](const IdTriple<0>& triple) -> const std::array<Id, 4>& {
+                 return triple.ids_;
+               }) |
+           ql::views::join;
   };
   std::filesystem::path tempPath = filenameForPersisting_.value();
   tempPath += ".tmp";

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -100,9 +100,8 @@ CPP_template(typename Serializer)(
 // Serialize a range of Ids to the output stream. If an Id is of type
 // LocalVocabIndex, apply the mapping to the Id before writing it.
 CPP_template(typename Range, typename Serializer)(
-    requires ql::ranges::sized_range<Range>) void serializeIds(Serializer&
-                                                                   serializer,
-                                                               Range&& range) {
+    requires ql::ranges::range<Range>) void serializeIds(Serializer& serializer,
+                                                         Range&& range) {
   ad_utility::serialization::VectorIncrementalSerializer<Id, Serializer>
       vectorSerializer{std::move(serializer)};
   for (const Id& value : range) {

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -70,10 +70,10 @@ CPP_template(typename Serializer)(
   AD_CONTRACT_CHECK(vocab.numSets() == 1);
   const auto& words = vocab.primaryWordSet();
   serializer << words.size();
-  for (const auto& localVocabEntry : words) {
+  ql::ranges::for_each(words, [&serializer](const auto& localVocabEntry) {
     serializer << Id::makeFromLocalVocabIndex(&localVocabEntry);
     serializer << localVocabEntry.toStringRepresentation();
-  }
+  });
 }
 
 // Deserialize the local vocabulary from the input stream.

--- a/src/util/Views.h
+++ b/src/util/Views.h
@@ -370,23 +370,6 @@ CPP_template(typename Range, typename ElementType)(
     co_yield std::span{buffer.data(), buffer.size()};
   }
 }
-
-// Helper struct to keep size information while joining a range.
-template <typename Range>
-requires requires { std::tuple_size_v<ql::ranges::range_value_t<Range>>; }
-class SizedJoinView : public ql::ranges::join_view<Range> {
-  using Base = ql::ranges::join_view<Range>;
-
- public:
-  using Base::Base;
-  constexpr std::size_t size() const {
-    return ql::ranges::size(this->base()) *
-           std::tuple_size_v<ql::ranges::range_value_t<Range>>;
-  }
-};
-
-CPP_template(typename R)(requires ql::ranges::viewable_range<R>)
-    SizedJoinView(R&&) -> SizedJoinView<R>;
 }  // namespace ad_utility
 
 // Enabling of "borrowed" ranges for `OwningView`.

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -153,7 +153,8 @@ TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   // Remove all permissions to make read fail
   std::filesystem::permissions(tmpFile, std::filesystem::perms::none);
 
-  if (fopen(tmpFile.c_str(), "r")) {
+  if (FILE* handle = fopen(tmpFile.c_str(), "r")) {
+    fclose(handle);
     // This can happen in docker environments.
     GTEST_SKIP_("File permissions are not set to none");
   }

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -142,4 +142,25 @@ TEST(TripleSerializer, onlySingleWordSetSupportedForLocalVocab) {
   EXPECT_THROW(ad_utility::detail::serializeLocalVocab(serializer, localVocab),
                ad_utility::Exception);
 }
+
+// _____________________________________________________________________________
+TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
+  using namespace ::testing;
+  auto tmpFile = std::filesystem::temp_directory_path() / "fileNoPermissions";
+  // Create empty file
+  std::ofstream{tmpFile}.close();
+  absl::Cleanup cleanup{[&tmpFile]() { std::filesystem::remove(tmpFile); }};
+  // Remove all permissions to make read fail
+  std::filesystem::permissions(tmpFile, std::filesystem::perms::none);
+
+  ad_utility::BlankNodeManager bm;
+  LocalVocab localVocab;
+
+  AD_EXPECT_THROW_WITH_MESSAGE_AND_TYPE(
+      ad_utility::deserializeIds(tmpFile, &bm),
+      AllOf(HasSubstr(tmpFile.generic_string()),
+            HasSubstr("cannot be opened for reading"),
+            HasSubstr("(Permission denied)")),
+      std::runtime_error);
+}
 }  // namespace

--- a/test/TripleSerializerTest.cpp
+++ b/test/TripleSerializerTest.cpp
@@ -153,6 +153,11 @@ TEST(TripleSerializer, rethrowsOnInvalidFileAccess) {
   // Remove all permissions to make read fail
   std::filesystem::permissions(tmpFile, std::filesystem::perms::none);
 
+  if (fopen(tmpFile.c_str(), "r")) {
+    // This can happen in docker environments.
+    GTEST_SKIP_("File permissions are not set to none");
+  }
+
   ad_utility::BlankNodeManager bm;
   LocalVocab localVocab;
 


### PR DESCRIPTION
This PR applies some follow-up fixes for #1903 that were omitted from the original PR due to time constraints.
In particular
1. Fix the duplicate writing of the delta triples.
2. Add some unit tests to improve the code coverage.