### PR TITLE
Optimize `ExistsJoin` for case with distinct join columns

### DIFF
--- a/src/engine/ExistsJoin.cpp
+++ b/src/engine/ExistsJoin.cpp
@@ -82,11 +82,38 @@ size_t ExistsJoin::getCostEstimate() {
 }
 
 // ____________________________________________________________________________
-Result ExistsJoin::computeResult([[maybe_unused]] bool requestLaziness) {
-  auto leftRes = left_->getResult();
+Result ExistsJoin::computeResult(bool requestLaziness) {
+  bool noJoinNecessary = joinColumns_.empty();
+  auto leftRes = left_->getResult(noJoinNecessary && requestLaziness);
+  if (noJoinNecessary) {
+    // For non-lazy results applying the limit introduces some overhead, but for
+    // lazy results it ensures that we don't have to compute the whole result,
+    // so we consider this a tradeoff worth to make.
+    right_->setLimit({1});
+  }
   auto rightRes = right_->getResult();
-  const auto& left = leftRes->idTable();
   const auto& right = rightRes->idTable();
+
+  if (!leftRes->isFullyMaterialized()) {
+    AD_CORRECTNESS_CHECK(noJoinNecessary);
+    // Forward lazy result, otherwise let the existing code handle the join with
+    // no column.
+    return {Result::LazyResult{
+                ad_utility::OwningView{std::move(leftRes->idTables())} |
+                ql::views::transform([exists = !right.empty(),
+                                      leftRes](Result::IdTableVocabPair& pair) {
+                  // Make sure we keep this shared ptr alive until the result is
+                  // completely consumed.
+                  (void)leftRes;
+                  auto& idTable = pair.idTable_;
+                  idTable.addEmptyColumn();
+                  ql::ranges::fill(idTable.getColumn(idTable.numColumns() - 1),
+                                   Id::makeFromBool(exists));
+                  return std::move(pair);
+                })},
+            leftRes->sortedBy()};
+  }
+  const auto& left = leftRes->idTable();
 
   // We reuse the generic `zipperJoinWithUndef` function, which has two two
   // callbacks: one for each matching pair of rows from `left` and `right`, and

--- a/src/engine/ExistsJoin.h
+++ b/src/engine/ExistsJoin.h
@@ -79,7 +79,7 @@ class ExistsJoin : public Operation {
  private:
   std::unique_ptr<Operation> cloneImpl() const override;
 
-  Result computeResult([[maybe_unused]] bool requestLaziness) override;
+  Result computeResult(bool requestLaziness) override;
 
   VariableToColumnMap computeVariableToColumnMap() const override;
 };


### PR DESCRIPTION
Just a small optimization that ensures that we don't have to unnecessarily perform an expensive Cartesian join computation when the result is the same for all columns, which happens for queries like:
```SPARQL
SELECT * {
  ?a ?b ?c .
  FILTER EXISTS { ?d ?e ?f }
}
```
where the left and right hand side of the filter have no variables in common.
In this case it suffices to evaluate the body of the `EXISTS {...}` function with a `LIMIT 1`