### PR TITLE
Correct cache key of `UNION` operation to be distinct for different variable inputs

### DIFF
--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -77,10 +77,15 @@ Union::Union(QueryExecutionContext* qec,
 
 string Union::getCacheKeyImpl() const {
   std::ostringstream os;
+  os << "{\n";
   os << _subtrees[0]->getCacheKey() << "\n";
-  os << "UNION\n";
+  os << "} UNION {\n";
   os << _subtrees[1]->getCacheKey() << "\n";
-  os << "sort order: ";
+  os << "} column origins: ";
+  for (auto [left, right] : _columnOrigins) {
+    os << '(' << left << ", " << right << ") ";
+  }
+  os << " sort order: ";
   for (size_t i : targetOrder_) {
     os << i << " ";
   }


### PR DESCRIPTION
This corrects the behaviour for `UNION` cache keys so that it doesn't retrieve a wrong result from the cache. Fixes #1900 and potentially also #1898 but we have to check.