### PR TITLE
Add `AD_CORRECTNESS_CHECK`s to prevent memory access issues

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -164,6 +164,7 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
     if (vocabSize > 1) {
       runtimeInfo().addDetail("local-vocab-size", vocabSize);
     }
+    AD_CORRECTNESS_CHECK(result.idTable().numColumns() == getResultWidth());
     updateRuntimeInformationOnSuccess(result.idTable().size(),
                                       ad_utility::CacheStatus::computed,
                                       timer.msecs(), std::nullopt);
@@ -176,6 +177,7 @@ Result Operation::runComputation(const ad_utility::Timer& timer,
           const IdTable& idTable = pair.idTable_;
           updateRuntimeStats(false, idTable.numRows(), idTable.numColumns(),
                              duration);
+          AD_CORRECTNESS_CHECK(idTable.numColumns() == getResultWidth());
           LOG(DEBUG) << "Computed partial chunk of size " << idTable.numRows()
                      << " x " << idTable.numColumns() << std::endl;
           mergeStats(vocabStats, pair.localVocab_);
@@ -336,6 +338,15 @@ std::shared_ptr<const Result> Operation::getResult(
     }
 
     if (result._resultPointer->resultTable().isFullyMaterialized()) {
+      AD_CORRECTNESS_CHECK(
+          result._resultPointer->resultTable().idTable().numColumns() ==
+              getResultWidth(),
+          result._cacheStatus == ad_utility::CacheStatus::computed
+              ? "This should never happen, non-matching result widths should "
+                "have been caught earlier"
+              : "Retrieved result from cache whose amount of column does not "
+                "match the expected amount. There's something wrong with the "
+                "cache key.");
       updateRuntimeInformationOnSuccess(result, timer.msecs());
     }
 

--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -344,9 +344,9 @@ std::shared_ptr<const Result> Operation::getResult(
           result._cacheStatus == ad_utility::CacheStatus::computed
               ? "This should never happen, non-matching result widths should "
                 "have been caught earlier"
-              : "Retrieved result from cache whose amount of column does not "
-                "match the expected amount. There's something wrong with the "
-                "cache key.");
+              : "Retrieved result from cache with a different number of "
+                "columns than expected. There's something wrong with the cache "
+                "key.");
       updateRuntimeInformationOnSuccess(result, timer.msecs());
     }
 

--- a/src/engine/Union.cpp
+++ b/src/engine/Union.cpp
@@ -45,13 +45,17 @@ Union::Union(QueryExecutionContext* qec,
   }
   // Make sure that the column origins are valid. Because later down the line we
   // might perform unchecked access using these indices.
-  AD_CORRECTNESS_CHECK(
-      ql::ranges::all_of(_columnOrigins, [this](const auto& el) {
-        return (el[0] != NO_COLUMN || el[1] != NO_COLUMN) &&
-               (el[0] == Union::NO_COLUMN ||
-                el[0] < _subtrees[0]->getResultWidth()) &&
-               (el[1] == Union::NO_COLUMN ||
-                el[1] < _subtrees[1]->getResultWidth());
+  auto atLeastOneDefined = [](const std::array<size_t, 2>& element) {
+    return element[0] != NO_COLUMN || element[1] != NO_COLUMN;
+  };
+  auto isValid = [](size_t column,
+                    const std::shared_ptr<QueryExecutionTree>& subtree) {
+    return column == NO_COLUMN || column < subtree->getResultWidth();
+  };
+  AD_CORRECTNESS_CHECK(ql::ranges::all_of(
+      _columnOrigins, [this, &atLeastOneDefined, &isValid](const auto& el) {
+        return atLeastOneDefined(el) && isValid(el[0], _subtrees[0]) &&
+               isValid(el[1], _subtrees[1]);
       }));
 
   if (!targetOrder_.empty()) {


### PR DESCRIPTION
Add several `AD_CORRECTNESS_CHECK`s that are supposed to fire before worse things happen, like invalid memory accesses. In particular, this would have been useful to debug #1920 and probably also the segmentation fault from #1898   