### PR TITLE
Optimize FILTER(geof:distance) using SpatialJoin

### DIFF
--- a/src/engine/sparqlExpressions/NaryExpression.cpp
+++ b/src/engine/sparqlExpressions/NaryExpression.cpp
@@ -6,6 +6,7 @@
 
 #include "engine/sparqlExpressions/NaryExpression.h"
 
+#include "engine/sparqlExpressions/LiteralExpression.h"
 #include "engine/sparqlExpressions/NaryExpressionImpl.h"
 #include "engine/sparqlExpressions/SparqlExpressionValueGetters.h"
 #include "util/GeoSparqlHelpers.h"
@@ -28,6 +29,25 @@ using namespace detail;
 SparqlExpression::Ptr makeDistExpression(SparqlExpression::Ptr child1,
                                          SparqlExpression::Ptr child2) {
   return std::make_unique<DistExpression>(std::move(child1), std::move(child2));
+}
+
+std::optional<std::pair<Variable, Variable>> getDistExpressionVariables(
+    SparqlExpression* expr) {
+  auto distExpr = dynamic_cast<DistExpression*>(expr);
+  if (distExpr == nullptr) {
+    return std::nullopt;
+  }
+  auto p1 =
+      dynamic_cast<LiteralExpression<Variable>*>(distExpr->children()[0].get());
+  if (p1 == nullptr) {
+    return std::nullopt;
+  }
+  auto p2 =
+      dynamic_cast<LiteralExpression<Variable>*>(distExpr->children()[1].get());
+  if (p2 == nullptr) {
+    return std::nullopt;
+  }
+  return std::pair<Variable, Variable>{p1->value(), p2->value()};
 }
 
 SparqlExpression::Ptr makeLatitudeExpression(SparqlExpression::Ptr child) {

--- a/src/engine/sparqlExpressions/NaryExpression.h
+++ b/src/engine/sparqlExpressions/NaryExpression.h
@@ -168,6 +168,9 @@ SparqlExpression::Ptr makeConcatExpression(
 constexpr auto makeConcatExpressionVariadic =
     variadicExpressionFactory<&makeConcatExpression>;
 
+std::optional<std::pair<Variable, Variable>> getDistExpressionVariables(
+    SparqlExpression* expr);
+
 }  // namespace sparqlExpression
 
 #endif  // QLEVER_SRC_ENGINE_SPARQLEXPRESSIONS_NARYEXPRESSION_H

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1469,6 +1469,8 @@ SparqlFilter Visitor::visit(Parser::FilterRContext* ctx) {
   // might be bound after the filter appears in the query (which is perfectly
   // legal).
   return SparqlFilter{visitExpressionPimpl(ctx->constraint())};
+  // TODO<ullingerc> Alternative here: check visited expression and replace it
+  // by spatial already during parsing
 }
 
 // ____________________________________________________________________________________

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -1469,8 +1469,6 @@ SparqlFilter Visitor::visit(Parser::FilterRContext* ctx) {
   // might be bound after the filter appears in the query (which is perfectly
   // legal).
   return SparqlFilter{visitExpressionPimpl(ctx->constraint())};
-  // TODO<ullingerc> Alternative here: check visited expression and replace it
-  // by spatial already during parsing
 }
 
 // ____________________________________________________________________________________


### PR DESCRIPTION
[Early proof-of-concept draft]

This PR adds a query planning step, where a FILTER by "geographic distance less-or-equal numeric constant" is internally replaced by a spatial join operation. This means, you can use

```sparql
PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>
PREFIX geo: <http://www.opengis.net/ont/geosparql#>
PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
SELECT * WHERE {
  ?restaurant osmkey:amenity "restaurant" .
  ?restaurant geo:hasCentroid/geo:asWKT ?rest_centroid .
  ?stop osmkey:public_transport "platform" .
  ?stop geo:hasCentroid/geo:asWKT ?stop_centroid .
  FILTER (geof:distance(?rest_centroid,?stop_centroid) <= 0.5)
}
```

instead of

```sparql
PREFIX osmkey: <https://www.openstreetmap.org/wiki/Key:>
PREFIX geo: <http://www.opengis.net/ont/geosparql#>
PREFIX qlss: <https://qlever.cs.uni-freiburg.de/spatialSearch/>
SELECT * WHERE {
  ?restaurant osmkey:amenity "restaurant" .
  ?restaurant geo:hasCentroid/geo:asWKT ?rest_centroid .
  ?stop osmkey:public_transport "platform" .
  ?stop geo:hasCentroid/geo:asWKT ?stop_centroid .
  SERVICE qlss: {
    qlss:config qlss:left ?rest_centroid ;
                qlss:right ?stop_centroid ;
                qlss:maxDistance 500 .
  }
}
```