### PR TITLE
Backport C++20 functions with auto arguments to C++17

### DIFF
--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (November of 2022,
 // schlegea@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #pragma once
 

--- a/benchmark/infrastructure/Benchmark.h
+++ b/benchmark/infrastructure/Benchmark.h
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (November of 2022,
 // schlegea@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #pragma once
 
@@ -69,9 +71,11 @@ class BenchmarkResults {
   that the new `CopyableUniquePtr` will own.
   */
   template <QL_CONCEPT_OR_TYPENAME(
-      ad_utility::SameAsAny<ResultTable, ResultEntry, ResultGroup>) EntryType>
+                ad_utility::SameAsAny<ResultTable, ResultEntry, ResultGroup>)
+                EntryType,
+            typename... Args>
   static EntryType& addEntryToContainerVector(
-      PointerVector<EntryType>& targetVector, auto&&... constructorArgs) {
+      PointerVector<EntryType>& targetVector, Args&&... constructorArgs) {
     targetVector.push_back(ad_utility::make_copyable_unique<EntryType>(
         AD_FWD(constructorArgs)...));
     return (*targetVector.back());

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.cpp
@@ -351,8 +351,9 @@ void to_json(nlohmann::ordered_json& j, const ResultTable& resultTable) {
 
 // The code for the string insertion operator of a class, that can be casted to
 // string.
+template <typename T>
 static std::ostream& streamInserterOperatorImplementation(std::ostream& os,
-                                                          const auto& obj) {
+                                                          const T& obj) {
   os << static_cast<std::string>(obj);
   return os;
 }

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -1,8 +1,6 @@
 // Copyright 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #pragma once
 

--- a/benchmark/infrastructure/BenchmarkMeasurementContainer.h
+++ b/benchmark/infrastructure/BenchmarkMeasurementContainer.h
@@ -1,6 +1,8 @@
 // Copyright 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (March of 2023, schlegea@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #pragma once
 
@@ -94,8 +96,8 @@ class ResultEntry : public BenchmarkMetadataGetter {
   @param functionToMeasure The function, who's execution time will be
   measured and saved.
   */
-  ResultEntry(const std::string& descriptor,
-              const std::invocable auto& functionToMeasure)
+  template <std::invocable F>
+  ResultEntry(const std::string& descriptor, const F& functionToMeasure)
       : descriptor_{descriptor},
         measuredTime_{measureTimeOfFunction(functionToMeasure, descriptor)} {}
 
@@ -110,8 +112,9 @@ class ResultEntry : public BenchmarkMetadataGetter {
   @param functionToMeasure The function, who's execution time will be
   measured and saved.
   */
+  template <std::invocable F>
   ResultEntry(const std::string& descriptor, std::string_view descriptorForLog,
-              const std::invocable auto& functionToMeasure)
+              const F& functionToMeasure)
       : descriptor_{descriptor},
         measuredTime_{
             measureTimeOfFunction(functionToMeasure, descriptorForLog)} {}

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
 #define QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
@@ -12,7 +10,6 @@
 #include <vector>
 
 #include "backports/concepts.h"
-#include "engine/LocalVocab.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "util/CancellationHandle.h"

--- a/src/engine/AddCombinedRowToTable.h
+++ b/src/engine/AddCombinedRowToTable.h
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
 #define QLEVER_SRC_ENGINE_ADDCOMBINEDROWTOTABLE_H
@@ -10,6 +12,7 @@
 #include <vector>
 
 #include "backports/concepts.h"
+#include "engine/LocalVocab.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
 #include "util/CancellationHandle.h"
@@ -184,7 +187,8 @@ class AddCombinedRowToIdTable {
   // inputs. The arguments to `inputLeft` and `inputRight` can either be
   // `IdTable` or `IdTableView<0>`, or any other type that has a
   // `asStaticView<0>` method that returns an `IdTableView<0>`.
-  void setInput(const auto& inputLeft, const auto& inputRight) {
+  template <typename L, typename R>
+  void setInput(const L& inputLeft, const R& inputRight) {
     flushBeforeInputChange();
     mergeVocab(inputLeft, currentVocabs_.at(0));
     mergeVocab(inputRight, currentVocabs_.at(1));
@@ -194,7 +198,8 @@ class AddCombinedRowToIdTable {
 
   // Only set the left input. After this it is only allowed to call
   // `addOptionalRow` and not `addRow` until `setInput` has been called again.
-  void setOnlyLeftInputForOptionalJoin(const auto& inputLeft) {
+  template <typename L>
+  void setOnlyLeftInputForOptionalJoin(const L& inputLeft) {
     flushBeforeInputChange();
     mergeVocab(inputLeft, currentVocabs_.at(0));
     // The right input will be empty, but with the correct number of columns.

--- a/src/engine/CallFixedSize.h
+++ b/src/engine/CallFixedSize.h
@@ -1,8 +1,6 @@
 // Copyright 2019, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_CALLFIXEDSIZE_H
 #define QLEVER_SRC_ENGINE_CALLFIXEDSIZE_H

--- a/src/engine/CallFixedSize.h
+++ b/src/engine/CallFixedSize.h
@@ -1,6 +1,8 @@
 // Copyright 2019, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_CALLFIXEDSIZE_H
 #define QLEVER_SRC_ENGINE_CALLFIXEDSIZE_H
@@ -53,9 +55,10 @@ namespace detail {
 // Internal helper functions that calls `lambda.template operator()<I,
 // J,...)(args)` where `I, J, ...` are the elements in the `array`. Requires
 // that each element in the `array` is `<= maxValue`.
-template <int maxValue, size_t NumValues, std::integral Int>
-auto callLambdaForIntArray(std::array<Int, NumValues> array, auto&& lambda,
-                           auto&&... args) {
+template <int maxValue, size_t NumValues, std::integral Int, typename F,
+          typename... Args>
+auto callLambdaForIntArray(std::array<Int, NumValues> array, F&& lambda,
+                           Args&&... args) {
   AD_CONTRACT_CHECK(
       ql::ranges::all_of(array, [](auto el) { return el <= maxValue; }));
   using ArrayType = std::array<Int, NumValues>;
@@ -109,8 +112,8 @@ auto callLambdaForIntArray(std::array<Int, NumValues> array, auto&& lambda,
 }
 
 // Overload for a single int.
-template <int maxValue, std::integral Int>
-auto callLambdaForIntArray(Int i, auto&& lambda, auto&&... args) {
+template <int maxValue, std::integral Int, typename F, typename... Args>
+auto callLambdaForIntArray(Int i, F&& lambda, Args&&... args) {
   return callLambdaForIntArray<maxValue>(std::array{i}, AD_FWD(lambda),
                                          AD_FWD(args)...);
 }
@@ -126,9 +129,9 @@ constexpr int mapToZeroIfTooLarge(int x, int maxValue) {
 // where `INT<N>` is `std::integral_constant<int, N>` and `f` is
 // `mapToZeroIfTooLarge`.
 template <int MaxValue = DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE,
-          size_t NumIntegers, std::integral Int>
-decltype(auto) callFixedSize(std::array<Int, NumIntegers> ints, auto&& functor,
-                             auto&&... args) {
+          size_t NumIntegers, std::integral Int, typename F, typename... Args>
+decltype(auto) callFixedSize(std::array<Int, NumIntegers> ints, F&& functor,
+                             Args&&... args) {
   static_assert(NumIntegers > 0);
   // TODO<joka921, C++23> Use `std::bind_back`
   auto p = [](int i) { return detail::mapToZeroIfTooLarge(i, MaxValue); };
@@ -144,8 +147,8 @@ decltype(auto) callFixedSize(std::array<Int, NumIntegers> ints, auto&& functor,
 
 // Overload for a single integer.
 template <int MaxValue = DEFAULT_MAX_NUM_COLUMNS_STATIC_ID_TABLE,
-          std::integral Int>
-decltype(auto) callFixedSize(Int i, auto&& functor, auto&&... args) {
+          std::integral Int, typename F, typename... Args>
+decltype(auto) callFixedSize(Int i, F&& functor, Args&&... args) {
   return callFixedSize<MaxValue>(std::array{i}, AD_FWD(functor),
                                  AD_FWD(args)...);
 }

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -1,8 +1,6 @@
 // Copyright 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/Describe.h"
 

--- a/src/engine/Describe.cpp
+++ b/src/engine/Describe.cpp
@@ -1,6 +1,8 @@
 // Copyright 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/Describe.h"
 
@@ -96,9 +98,10 @@ VariableToColumnMap Describe::computeVariableToColumnMap() const {
 // A helper function for the recursive BFS. Return those `Id`s from `input` (an
 // `IdTable` with one column) that are blank nodes and not in `alreadySeen`,
 // with duplicates removed. The returned `Id`s are added to `alreadySeen`.
+template <typename Allocator>
 static IdTable getNewBlankNodes(
-    const auto& allocator, ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen,
-    std::span<Id> input) {
+    const Allocator& allocator,
+    ad_utility::HashSetWithMemoryLimit<Id>& alreadySeen, std::span<Id> input) {
   IdTable result{1, allocator};
   result.resize(input.size());
   decltype(auto) resultColumn = result.getColumn(0);

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -1,8 +1,6 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "./Distinct.h"
 

--- a/src/engine/Distinct.cpp
+++ b/src/engine/Distinct.cpp
@@ -1,6 +1,8 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "./Distinct.h"
 
@@ -87,7 +89,8 @@ Result Distinct::computeResult(bool requestLaziness) {
 }
 
 // _____________________________________________________________________________
-bool Distinct::matchesRow(const auto& a, const auto& b) const {
+template <typename T1, typename T2>
+bool Distinct::matchesRow(const T1& a, const T2& b) const {
   return ql::ranges::all_of(keepIndices_,
                             [&a, &b](ColumnIndex i) { return a[i] == b[i]; });
 }

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -1,8 +1,6 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_DISTINCT_H
 #define QLEVER_SRC_ENGINE_DISTINCT_H

--- a/src/engine/Distinct.h
+++ b/src/engine/Distinct.h
@@ -1,6 +1,8 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_DISTINCT_H
 #define QLEVER_SRC_ENGINE_DISTINCT_H
@@ -65,7 +67,8 @@ class Distinct : public Operation {
   VariableToColumnMap computeVariableToColumnMap() const override;
 
   // Helper function that only compares rows on the columns in `keepIndices_`.
-  bool matchesRow(const auto& a, const auto& b) const;
+  template <typename T1, typename T2>
+  bool matchesRow(const T1& a, const T2& b) const;
 
   // Return a generator that applies an in-place unique algorithm to the
   // `IdTables`s yielded by the input generator. The `yieldOnce` flag controls

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -3,6 +3,8 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Robin Textor-Falconi <textorr@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "ExportQueryExecutionTrees.h"
 
@@ -771,8 +773,10 @@ ExportQueryExecutionTrees::selectQueryResultToStream(
 }
 
 // Convert a single ID to an XML binding of the given `variable`.
+template <typename IndexType, typename LocalVocabType>
 static std::string idToXMLBinding(std::string_view variable, Id id,
-                                  const auto& index, const auto& localVocab) {
+                                  const IndexType& index,
+                                  const LocalVocabType& localVocab) {
   using namespace std::string_view_literals;
   using namespace std::string_literals;
   const auto& optionalValue =

--- a/src/engine/ExportQueryExecutionTrees.cpp
+++ b/src/engine/ExportQueryExecutionTrees.cpp
@@ -3,8 +3,6 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Robin Textor-Falconi <textorr@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "ExportQueryExecutionTrees.h"
 

--- a/src/engine/GroupBy.cpp
+++ b/src/engine/GroupBy.cpp
@@ -1511,10 +1511,10 @@ static constexpr auto makeProcessGroupsVisitor =
     };
 
 // _____________________________________________________________________________
-template <size_t NUM_GROUP_COLUMNS>
+template <size_t NUM_GROUP_COLUMNS, typename SubResults>
 Result GroupBy::computeGroupByForHashMapOptimization(
-    std::vector<HashMapAliasInformation>& aggregateAliases, auto subresults,
-    const std::vector<size_t>& columnIndices) const {
+    std::vector<HashMapAliasInformation>& aggregateAliases,
+    SubResults subresults, const std::vector<size_t>& columnIndices) const {
   AD_CORRECTNESS_CHECK(columnIndices.size() == NUM_GROUP_COLUMNS ||
                        NUM_GROUP_COLUMNS == 0);
   LocalVocab localVocab;

--- a/src/engine/GroupBy.h
+++ b/src/engine/GroupBy.h
@@ -319,10 +319,10 @@ class GroupBy : public Operation {
 
   // Create result IdTable by using a HashMap mapping groups to aggregation data
   // and subsequently calling `createResultFromHashMap`.
-  template <size_t NUM_GROUP_COLUMNS>
+  template <size_t NUM_GROUP_COLUMNS, typename SubResults>
   Result computeGroupByForHashMapOptimization(
-      std::vector<HashMapAliasInformation>& aggregateAliases, auto subresults,
-      const std::vector<size_t>& columnIndices) const;
+      std::vector<HashMapAliasInformation>& aggregateAliases,
+      SubResults subresults, const std::vector<size_t>& columnIndices) const;
 
   using AggregationData =
       std::variant<AvgAggregationData, CountAggregationData, MinAggregationData,

--- a/src/engine/GroupByHashMapOptimization.h
+++ b/src/engine/GroupByHashMapOptimization.h
@@ -36,7 +36,8 @@ struct AvgAggregationData {
   int64_t count_ = 0;
 
   // _____________________________________________________________________________
-  void addValue(auto&& value, const sparqlExpression::EvaluationContext* ctx) {
+  template <typename T>
+  void addValue(T&& value, const sparqlExpression::EvaluationContext* ctx) {
     auto val = ValueGetter{}(AD_FWD(value), ctx);
     std::visit([this](auto val) { valueAdder(val, sum_, error_); }, val);
     count_++;
@@ -55,7 +56,8 @@ struct CountAggregationData {
   int64_t count_ = 0;
 
   // _____________________________________________________________________________
-  void addValue(auto&& value, const sparqlExpression::EvaluationContext* ctx) {
+  template <typename T>
+  void addValue(T&& value, const sparqlExpression::EvaluationContext* ctx) {
     if (ValueGetter{}(AD_FWD(value), ctx)) count_++;
   }
 
@@ -105,7 +107,8 @@ struct SumAggregationData {
   int64_t intSum_ = 0;
 
   // _____________________________________________________________________________
-  void addValue(auto&& value, const sparqlExpression::EvaluationContext* ctx) {
+  template <typename T>
+  void addValue(T&& value, const sparqlExpression::EvaluationContext* ctx) {
     auto val = ValueGetter{}(AD_FWD(value), ctx);
 
     auto doubleValueAdder = [this](double value) {
@@ -139,7 +142,8 @@ struct GroupConcatAggregationData {
   std::string_view separator_;
 
   // _____________________________________________________________________________
-  void addValue(auto&& value, const sparqlExpression::EvaluationContext* ctx) {
+  template <typename T>
+  void addValue(T&& value, const sparqlExpression::EvaluationContext* ctx) {
     auto val = ValueGetter{}(AD_FWD(value), ctx);
     if (val.has_value()) {
       if (!currentValue_.empty()) currentValue_.append(separator_);

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -2,8 +2,6 @@
 //                 Chair of Algorithms and Data Structures.
 // Authors: (2018 - 2019) Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 //          (2024 -     ) Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/HasPredicateScan.h"
 

--- a/src/engine/HasPredicateScan.cpp
+++ b/src/engine/HasPredicateScan.cpp
@@ -2,6 +2,8 @@
 //                 Chair of Algorithms and Data Structures.
 // Authors: (2018 - 2019) Florian Kramer (florian.kramer@mail.uni-freiburg.de)
 //          (2024 -     ) Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "engine/HasPredicateScan.h"
 
@@ -306,8 +308,9 @@ Result HasPredicateScan::computeResult([[maybe_unused]] bool requestLaziness) {
 }
 
 // ___________________________________________________________________________
+template <typename HasPattern>
 void HasPredicateScan::computeFreeS(
-    IdTable* resultTable, Id objectId, auto& hasPattern,
+    IdTable* resultTable, Id objectId, HasPattern& hasPattern,
     const CompactVectorOfStrings<Id>& patterns) {
   IdTableStatic<1> result = std::move(*resultTable).toStatic<1>();
   // TODO<joka921> This can be a much simpler and cheaper implementation that
@@ -351,8 +354,9 @@ void HasPredicateScan::computeFreeO(
 }
 
 // ___________________________________________________________________________
+template <typename HasPattern>
 void HasPredicateScan::computeFullScan(
-    IdTable* resultTable, auto& hasPattern,
+    IdTable* resultTable, HasPattern& hasPattern,
     const CompactVectorOfStrings<Id>& patterns, size_t resultSize) {
   IdTableStatic<2> result = std::move(*resultTable).toStatic<2>();
   result.reserve(resultSize);

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -1,8 +1,6 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_HASPREDICATESCAN_H
 #define QLEVER_SRC_ENGINE_HASPREDICATESCAN_H

--- a/src/engine/HasPredicateScan.h
+++ b/src/engine/HasPredicateScan.h
@@ -1,6 +1,8 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Florian Kramer (florian.kramer@mail.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_HASPREDICATESCAN_H
 #define QLEVER_SRC_ENGINE_HASPREDICATESCAN_H
@@ -96,15 +98,17 @@ class HasPredicateScan : public Operation {
   }
 
   // These are made static and public mainly for easier testing
-  static void computeFreeS(IdTable* resultTable, Id objectId, auto& hasPattern,
-                           const CompactVectorOfStrings<Id>& patterns);
+  template <typename HasPattern>
+  void computeFreeS(IdTable* resultTable, Id objectId, HasPattern& hasPattern,
+                    const CompactVectorOfStrings<Id>& patterns);
 
   void computeFreeO(IdTable* resultTable, Id subjectAsId,
                     const CompactVectorOfStrings<Id>& patterns) const;
 
-  static void computeFullScan(IdTable* resultTable, auto& hasPattern,
-                              const CompactVectorOfStrings<Id>& patterns,
-                              size_t resultSize);
+  template <typename HasPattern>
+  void computeFullScan(IdTable* resultTable, HasPattern& hasPattern,
+                       const CompactVectorOfStrings<Id>& patterns,
+                       size_t resultSize);
 
   template <int WIDTH>
   Result computeSubqueryS(IdTable* result,

--- a/src/engine/LazyGroupBy.cpp
+++ b/src/engine/LazyGroupBy.cpp
@@ -1,8 +1,6 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "LazyGroupBy.h"
 

--- a/src/engine/LazyGroupBy.cpp
+++ b/src/engine/LazyGroupBy.cpp
@@ -1,6 +1,8 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "LazyGroupBy.h"
 
@@ -89,10 +91,11 @@ void LazyGroupBy::processBlock(
 }
 
 // _____________________________________________________________________________
+template <typename Visitor, typename... Args>
 void LazyGroupBy::visitAggregate(
-    const auto& visitor,
+    const Visitor& visitor,
     const GroupBy::HashMapAggregateInformation& aggregateInfo,
-    auto&&... additionalVariants) {
+    Args&&... additionalVariants) {
   std::visit(visitor,
              aggregationData_.getAggregationDataVariant(
                  aggregateInfo.aggregateDataIndex_),

--- a/src/engine/LazyGroupBy.h
+++ b/src/engine/LazyGroupBy.h
@@ -1,6 +1,8 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_LAZYGROUPBY_H
 #define QLEVER_SRC_ENGINE_LAZYGROUPBY_H
@@ -46,9 +48,10 @@ class LazyGroupBy {
   void resetAggregationData();
 
   // Helper function to visit the correct variant of the aggregation data.
-  void visitAggregate(const auto& visitor,
+  template <typename Visitor, typename... Args>
+  void visitAggregate(const Visitor& visitor,
                       const GroupBy::HashMapAggregateInformation& aggregateInfo,
-                      auto&&... additionalVariants);
+                      Args&&... additionalVariants);
 
   auto allAggregateInfoView() const {
     return aggregateAliases_ |

--- a/src/engine/LazyGroupBy.h
+++ b/src/engine/LazyGroupBy.h
@@ -1,8 +1,6 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_LAZYGROUPBY_H
 #define QLEVER_SRC_ENGINE_LAZYGROUPBY_H

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de>
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_QUERYEXECUTIONTREE_H
 #define QLEVER_SRC_ENGINE_QUERYEXECUTIONTREE_H

--- a/src/engine/QueryExecutionTree.h
+++ b/src/engine/QueryExecutionTree.h
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures
 // Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de>
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_QUERYEXECUTIONTREE_H
 #define QLEVER_SRC_ENGINE_QUERYEXECUTIONTREE_H
@@ -264,9 +266,9 @@ namespace ad_utility {
 // Create a `QueryExecutionTree` with `Operation` at the root.
 // The `Operation` is created using `qec` and `args...` as constructor
 // arguments.
-template <typename Operation>
+template <typename Operation, typename... Args>
 std::shared_ptr<QueryExecutionTree> makeExecutionTree(
-    QueryExecutionContext* qec, auto&&... args) {
+    QueryExecutionContext* qec, Args&&... args) {
   return std::make_shared<QueryExecutionTree>(
       qec, std::make_shared<Operation>(qec, AD_FWD(args)...));
 }

--- a/src/engine/QueryPlanner.cpp
+++ b/src/engine/QueryPlanner.cpp
@@ -61,8 +61,8 @@ namespace {
 using ad_utility::makeExecutionTree;
 using SubtreePlan = QueryPlanner::SubtreePlan;
 
-template <typename Operation>
-SubtreePlan makeSubtreePlan(QueryExecutionContext* qec, auto&&... args) {
+template <typename Operation, typename... Args>
+SubtreePlan makeSubtreePlan(QueryExecutionContext* qec, Args&&... args) {
   return {qec, std::make_shared<Operation>(qec, AD_FWD(args)...)};
 }
 
@@ -619,10 +619,10 @@ void QueryPlanner::indexScanSingleVarCase(
 }
 
 // _____________________________________________________________________________
-template <typename AddedIndexScanFunction>
+template <typename AddedIndexScanFunction, typename AddedFilter>
 void QueryPlanner::indexScanTwoVarsCase(
     const SparqlTripleSimple& triple,
-    const AddedIndexScanFunction& addIndexScan, const auto& addFilter) {
+    const AddedIndexScanFunction& addIndexScan, const AddedFilter& addFilter) {
   using enum Permutation::Enum;
 
   // Replace the position of the `triple` that is specified by the
@@ -670,10 +670,10 @@ void QueryPlanner::indexScanTwoVarsCase(
 }
 
 // _____________________________________________________________________________
-template <typename AddedIndexScanFunction>
+template <typename AddedIndexScanFunction, typename AddedFilter>
 void QueryPlanner::indexScanThreeVarsCase(
     const SparqlTripleSimple& triple,
-    const AddedIndexScanFunction& addIndexScan, const auto& addFilter) {
+    const AddedIndexScanFunction& addIndexScan, const AddedFilter& addFilter) {
   using enum Permutation::Enum;
   AD_CONTRACT_CHECK(!_qec || _qec->getIndex().hasAllPermutations(),
                     "With only 2 permutations registered (no -a option), "
@@ -2537,8 +2537,9 @@ void QueryPlanner::checkCancellation(
 }
 
 // _____________________________________________________________________________
+template <typename Variables>
 bool QueryPlanner::GraphPatternPlanner::handleUnconnectedMinusOrOptional(
-    std::vector<SubtreePlan>& candidates, const auto& variables) {
+    std::vector<SubtreePlan>& candidates, const Variables& variables) {
   using enum SubtreePlan::Type;
   bool areVariablesUnconnected = ql::ranges::all_of(
       variables,

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -3,6 +3,8 @@
 // Author:
 //   2015-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 //   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_QUERYPLANNER_H
 #define QLEVER_SRC_ENGINE_QUERYPLANNER_H
@@ -269,16 +271,16 @@ class QueryPlanner {
                               const AddedIndexScanFunction& addIndexScan) const;
 
   // Helper function used by the seedFromOrdinaryTriple function
-  template <typename AddedIndexScanFunction>
+  template <typename AddedIndexScanFunction, typename AddedFilter>
   void indexScanTwoVarsCase(const SparqlTripleSimple& triple,
                             const AddedIndexScanFunction& addIndexScan,
-                            const auto& addFilter);
+                            const AddedFilter& addFilter);
 
   // Helper function used by the seedFromOrdinaryTriple function
-  template <typename AddedIndexScanFunction>
+  template <typename AddedIndexScanFunction, typename AddedFilter>
   void indexScanThreeVarsCase(const SparqlTripleSimple& triple,
                               const AddedIndexScanFunction& addIndexScan,
-                              const auto& addFilter);
+                              const AddedFilter& addFilter);
 
   /**
    * @brief Fills children with all operations that are associated with a single
@@ -586,8 +588,9 @@ class QueryPlanner {
     // Helper function for `visitGroupOptionalOrMinus`. SPARQL queries like
     // `SELECT * { OPTIONAL { ?a ?b ?c }}`, `SELECT * { MINUS { ?a ?b ?c }}` or
     // `SELECT * { ?x ?y ?z . OPTIONAL { ?a ?b ?c }}` need special handling.
+    template <typename Variables>
     bool handleUnconnectedMinusOrOptional(std::vector<SubtreePlan>& candidates,
-                                          const auto& variables);
+                                          const Variables& variables);
 
     // This function is called for groups, optional, or minus clauses.
     // The `candidates` are the result of planning the pattern inside the
@@ -606,7 +609,8 @@ class QueryPlanner {
     void optimizeCommutatively();
 
     // Find a single best candidate for a given graph pattern.
-    SubtreePlan optimizeSingle(const auto& pattern) {
+    template <typename Pattern>
+    SubtreePlan optimizeSingle(const Pattern& pattern) {
       auto v = planner_.optimize(pattern);
       auto idx = planner_.findCheapestExecutionTree(v);
       return std::move(v[idx]);

--- a/src/engine/QueryPlanner.h
+++ b/src/engine/QueryPlanner.h
@@ -3,8 +3,6 @@
 // Author:
 //   2015-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 //   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_QUERYPLANNER_H
 #define QLEVER_SRC_ENGINE_QUERYPLANNER_H

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -1,6 +1,8 @@
 //   Copyright 2025, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_SORTEDUNIONIMPL_H
 #define QLEVER_SRC_ENGINE_SORTEDUNIONIMPL_H
@@ -48,7 +50,8 @@ struct IterationData {
 
   // Fetch the next element from the range, make a copy if it's a `Wrapper`.
   // Otherwise move it. If the range is exhausted, return `std::nullopt`.
-  std::optional<Result::IdTableVocabPair> passNext(auto applyPermutation) {
+  template <typename T>
+  std::optional<Result::IdTableVocabPair> passNext(T applyPermutation) {
     if (it_ == range_.end()) {
       return std::nullopt;
     }
@@ -136,7 +139,8 @@ struct SortedUnionImpl
   }
 
   // Always inline makes makes a huge difference on large datasets.
-  AD_ALWAYS_INLINE bool isSmaller(const auto& row1, const auto& row2) const {
+  template <typename T1, typename T2>
+  AD_ALWAYS_INLINE bool isSmaller(const T1& row1, const T2& row2) const {
     using StaticRange = std::span<const std::array<size_t, 2>, SPAN_SIZE>;
     for (auto [index1, index2] : StaticRange{targetOrder_}) {
       if (index1 == Union::NO_COLUMN) {
@@ -154,7 +158,8 @@ struct SortedUnionImpl
 
   // Write a new row to the result table. The parameter `left` controls which
   // permutation is used to write the row to the result table.
-  void pushRow(bool left, const auto& row) {
+  template <typename T>
+  void pushRow(bool left, const T& row) {
     resultTable_.emplace_back();
     for (size_t column = 0; column < resultTable_.numColumns(); column++) {
       ColumnIndex origin = columnOrigins_.at(column).at(!left);

--- a/src/engine/SortedUnionImpl.h
+++ b/src/engine/SortedUnionImpl.h
@@ -1,8 +1,6 @@
 //   Copyright 2025, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_SORTEDUNIONIMPL_H
 #define QLEVER_SRC_ENGINE_SORTEDUNIONIMPL_H

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_COMPRESSEDEXTERNALIDTABLE_H
 #define QLEVER_COMPRESSEDEXTERNALIDTABLE_H
@@ -222,9 +224,9 @@ class CompressedExternalIdTableWriter {
   }
 
   // The actual implementation of `makeGeneratorForIdTable` above.
-  template <size_t NumCols = 0>
+  template <size_t NumCols = 0, typename Cleanup>
   cppcoro::generator<const IdTableStatic<NumCols>> makeGeneratorForIdTableImpl(
-      size_t index, auto cleanup) {
+      size_t index, Cleanup cleanup) {
     using Table = IdTableStatic<NumCols>;
     auto firstBlock = startOfSingleIdTables_.at(index);
     auto lastBlock = index + 1 < startOfSingleIdTables_.size()
@@ -540,7 +542,8 @@ inline std::atomic<bool>
 template <typename Comparator>
 struct BlockSorter {
   [[no_unique_address]] Comparator comparator_{};
-  void operator()(auto& block) {
+  template <typename T>
+  void operator()(T& block) {
 #ifdef _PARALLEL_SORT
     ad_utility::parallel_sort(std::begin(block), std::end(block), comparator_);
 #else

--- a/src/engine/idTable/CompressedExternalIdTable.h
+++ b/src/engine/idTable/CompressedExternalIdTable.h
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_COMPRESSEDEXTERNALIDTABLE_H
 #define QLEVER_COMPRESSEDEXTERNALIDTABLE_H

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -1,6 +1,8 @@
 // Copyright 2021 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H
 #define QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H
@@ -818,7 +820,8 @@ class IdTable {
 
   // Common implementation for const and mutable overloads of `getColumns`
   // (see below).
-  static auto getColumnsImpl(auto&& self) {
+  template <typename Self>
+  static auto getColumnsImpl(Self&& self) {
     using Column = decltype(self.getColumn(0));
     if constexpr (isDynamic) {
       // TODO<joka921, for the dynamic case we could maybe use a vector with

--- a/src/engine/idTable/IdTable.h
+++ b/src/engine/idTable/IdTable.h
@@ -1,8 +1,6 @@
 // Copyright 2021 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H
 #define QLEVER_SRC_ENGINE_IDTABLE_IDTABLE_H

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -1,6 +1,8 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_IDTABLE_IDTABLEROW_H
 #define QLEVER_SRC_ENGINE_IDTABLE_IDTABLEROW_H
@@ -180,7 +182,8 @@ class RowReferenceImpl {
                                                         size_t i) {
       return (*self.table_)(self.row_, i);
     }
-    static const T& operatorBracketImpl(const auto& self, size_t i) {
+    template <typename Self>
+    static const T& operatorBracketImpl(const Self& self, size_t i) {
       return (*self.table_)(self.row_, i);
     }
 
@@ -200,7 +203,8 @@ class RowReferenceImpl {
     // Define iterators.
     template <typename RowT>
     struct IteratorHelper {
-      decltype(auto) operator()(auto&& row, size_t colIdx) const {
+      template <typename T>
+      decltype(auto) operator()(T&& row, size_t colIdx) const {
         return std::decay_t<decltype(row)>::operatorBracketImpl(AD_FWD(row),
                                                                 colIdx);
       }
@@ -294,7 +298,8 @@ class RowReferenceImpl {
    protected:
     // Internal implementation of the assignment from a `Row` as well as a
     // `RowReference`. This assignment actually writes to the underlying table.
-    static This& assignmentImpl(auto&& self, const auto& other) {
+    template <typename T1, typename T2>
+    static This& assignmentImpl(T1&& self, const T2& other) {
       if constexpr (numStaticColumns == 0) {
         AD_CONTRACT_CHECK(self.numColumns() == other.numColumns());
       }

--- a/src/engine/idTable/IdTableRow.h
+++ b/src/engine/idTable/IdTableRow.h
@@ -1,8 +1,6 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_IDTABLE_IDTABLEROW_H
 #define QLEVER_SRC_ENGINE_IDTABLE_IDTABLEROW_H

--- a/src/engine/sparqlExpressions/NaryExpressionImpl.h
+++ b/src/engine/sparqlExpressions/NaryExpressionImpl.h
@@ -104,7 +104,8 @@ struct NumericIdWrapper {
   // Note: Sonarcloud suggests `[[no_unique_address]]` for the following member,
   // but adding it causes an internal compiler error in Clang 16.
   Function function_{};
-  Id operator()(auto&&... args) const {
+  template <typename... Args>
+  Id operator()(Args&&... args) const {
     return makeNumericId<nanToUndef>(function_(AD_FWD(args)...));
   }
 };

--- a/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
+++ b/src/engine/sparqlExpressions/RelationalExpressionHelpers.h
@@ -71,8 +71,8 @@ CPP_concept AreComparable =
 // is `LT`, returns `a < b`. Note that the second template argument `Dummy` is
 // only needed to make the static check for the exhaustiveness of the if-else
 // cascade possible.
-template <Comparison Comp, typename Dummy = int>
-bool applyComparison(const auto& a, const auto& b) {
+template <Comparison Comp, typename Dummy = int, typename A, typename B>
+bool applyComparison(const A& a, const B& b) {
   using enum Comparison;
   if constexpr (Comp == LT) {
     return a < b;

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -3,8 +3,6 @@
 // Authors: Björn Buchhold <buchhold@gmail.com> [2014 - 2017]
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_GLOBAL_CONSTANTS_H
 #define QLEVER_SRC_GLOBAL_CONSTANTS_H

--- a/src/global/Constants.h
+++ b/src/global/Constants.h
@@ -3,6 +3,8 @@
 // Authors: Björn Buchhold <buchhold@gmail.com> [2014 - 2017]
 //          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_GLOBAL_CONSTANTS_H
 #define QLEVER_SRC_GLOBAL_CONSTANTS_H
@@ -47,7 +49,8 @@ constexpr std::string_view makeQleverInternalIriConst() {
   return ad_utility::constexprStrCat<"<", QLEVER_INTERNAL_PREFIX_URL,
                                      suffixes..., ">">();
 }
-inline std::string makeQleverInternalIri(const auto&... suffixes) {
+template <typename... T>
+inline std::string makeQleverInternalIri(const T&... suffixes) {
   return absl::StrCat("<", std::string_view{QLEVER_INTERNAL_PREFIX_URL},
                       suffixes..., ">");
 }

--- a/src/global/ValueIdComparators.h
+++ b/src/global/ValueIdComparators.h
@@ -145,17 +145,20 @@ class RangeFilter {
   // Let X be the set of numbers x for which x _comparison _value is true. The
   // given range for `addEqualRange` are numbers that are equal to `_value` (not
   // necessarily all of them). The function adds them if they are a subset of X.
-  void addEqual(auto begin, auto end) {
+  template <typename T>
+  void addEqual(T begin, T end) {
     addImpl<Comparison::LE, Comparison::EQ, Comparison::GE>(begin, end);
   };
 
   // Analogous to `addEqual`.
-  void addSmaller(auto begin, auto end) {
+  template <typename T>
+  void addSmaller(T begin, T end) {
     addImpl<Comparison::LT, Comparison::LE, Comparison::NE>(begin, end);
   }
 
   // Analogous to `addEqual`.
-  void addGreater(auto begin, auto end) {
+  template <typename T>
+  void addGreater(T begin, T end) {
     addImpl<Comparison::GE, Comparison::GT, Comparison::NE>(begin, end);
   }
 
@@ -485,8 +488,9 @@ inline bool areTypesCompatible(Datatype typeA, Datatype typeB) {
 
 // This function is part of the implementation of `compareIds` (see below).
 template <ComparisonForIncompatibleTypes comparisonForIncompatibleTypes =
-              ComparisonForIncompatibleTypes::AlwaysUndef>
-ComparisonResult compareIdsImpl(ValueId a, ValueId b, auto comparator) {
+              ComparisonForIncompatibleTypes::AlwaysUndef,
+          typename Comparator>
+ComparisonResult compareIdsImpl(ValueId a, ValueId b, Comparator comparator) {
   Datatype typeA = a.getDatatype();
   Datatype typeB = b.getDatatype();
   using enum ComparisonResult;

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -27,7 +27,8 @@
 using namespace std::chrono_literals;
 
 // A small helper function to obtain the begin and end iterator of a range
-static auto getBeginAndEnd(auto& range) {
+template <typename T>
+static auto getBeginAndEnd(T& range) {
   return std::pair{ql::ranges::begin(range), ql::ranges::end(range)};
 }
 
@@ -63,7 +64,8 @@ static auto isTripleInSpecification =
 // modify the `block` according to the `limitOffset`. Also modify the
 // `limitOffset` to reflect the parts of the LIMIT and OFFSET that have been
 // performed by pruning this `block`.
-static void pruneBlock(auto& block, LimitOffsetClause& limitOffset) {
+template <typename T>
+static void pruneBlock(T& block, LimitOffsetClause& limitOffset) {
   auto& offset = limitOffset._offset;
   auto offsetInBlock = std::min(static_cast<size_t>(offset), block.size());
   if (offsetInBlock == block.size()) {
@@ -82,9 +84,10 @@ static void pruneBlock(auto& block, LimitOffsetClause& limitOffset) {
 }
 
 // ____________________________________________________________________________
+template <typename T>
 CompressedRelationReader::IdTableGenerator
 CompressedRelationReader::asyncParallelBlockGenerator(
-    auto beginBlock, auto endBlock, const ScanImplConfig& scanConfig,
+    T beginBlock, T endBlock, const ScanImplConfig& scanConfig,
     CancellationHandle cancellationHandle,
     LimitOffsetClause& limitOffset) const {
   // Empty range.
@@ -1327,8 +1330,9 @@ class DistinctIdCounter {
 }  // namespace
 
 // __________________________________________________________________________
+template <typename T>
 CompressedRelationMetadata CompressedRelationWriter::addCompleteLargeRelation(
-    Id col0Id, auto&& sortedBlocks) {
+    Id col0Id, T&& sortedBlocks) {
   DistinctIdCounter distinctCol1Counter;
   for (auto& block : sortedBlocks) {
     ql::ranges::for_each(block.getColumn(1), std::ref(distinctCol1Counter));

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -1,8 +1,6 @@
 // Copyright 2021 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_COMPRESSEDRELATION_H
 #define QLEVER_SRC_INDEX_COMPRESSEDRELATION_H

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -1,6 +1,8 @@
 // Copyright 2021 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_COMPRESSEDRELATION_H
 #define QLEVER_SRC_INDEX_COMPRESSEDRELATION_H
@@ -97,7 +99,8 @@ struct CompressedBlockMetadataNoBlockIndex {
       return str;
     }
 
-    friend std::true_type allowTrivialSerialization(PermutedTriple, auto);
+    template <typename T>
+    friend std::true_type allowTrivialSerialization(PermutedTriple, T);
   };
   PermutedTriple firstTriple_;
   PermutedTriple lastTriple_;
@@ -394,15 +397,17 @@ class CompressedRelationWriter {
   // each block in the `sortedBlocks` and then calling `finishLargeRelation`.
   // The number of distinct col1 entries will be computed from the blocks
   // directly.
+  template <typename T>
   CompressedRelationMetadata addCompleteLargeRelation(Id col0Id,
-                                                      auto&& sortedBlocks);
+                                                      T&& sortedBlocks);
 
   // This is a function in `CompressedRelationsTest.cpp` that tests the
   // internals of this class and therefore needs private access.
+  template <typename T>
   friend std::pair<std::vector<CompressedBlockMetadata>,
                    std::vector<CompressedRelationMetadata>>
   compressedRelationTestWriteCompressedRelations(
-      auto inputs, std::string filename, ad_utility::MemorySize blocksize);
+      T inputs, std::string filename, ad_utility::MemorySize blocksize);
 };
 
 using namespace std::string_view_literals;
@@ -718,8 +723,9 @@ class CompressedRelationReader {
   // are yielded, else all columns are yielded. The blocks are yielded
   // in the correct order, but asynchronously read and decompressed using
   // multiple worker threads.
+  template <typename T>
   IdTableGenerator asyncParallelBlockGenerator(
-      auto beginBlock, auto endBlock, const ScanImplConfig& scanConfig,
+      T beginBlock, T endBlock, const ScanImplConfig& scanConfig,
       CancellationHandle cancellationHandle,
       LimitOffsetClause& limitOffset) const;
 

--- a/src/index/ExternalSortFunctors.h
+++ b/src/index/ExternalSortFunctors.h
@@ -1,8 +1,6 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_EXTERNALSORTFUNCTORS_H
 #define QLEVER_SRC_INDEX_EXTERNALSORTFUNCTORS_H

--- a/src/index/ExternalSortFunctors.h
+++ b/src/index/ExternalSortFunctors.h
@@ -1,6 +1,8 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_EXTERNALSORTFUNCTORS_H
 #define QLEVER_SRC_INDEX_EXTERNALSORTFUNCTORS_H
@@ -14,7 +16,8 @@ template <int i0, int i1, int i2, bool hasGraphColumn = true>
 struct SortTriple {
   using T = std::array<Id, 3>;
   // comparison function
-  bool operator()(const auto& a, const auto& b) const {
+  template <typename T1, typename T2>
+  bool operator()(const T1& a, const T2& b) const {
     if constexpr (!hasGraphColumn) {
       AD_EXPENSIVE_CHECK(a.size() >= 3 && b.size() >= 3);
     } else {

--- a/src/index/IndexBuilderMain.cpp
+++ b/src/index/IndexBuilderMain.cpp
@@ -31,7 +31,8 @@ namespace po = boost::program_options;
 // vector will also be accepted. If this condition is violated, throw an
 // exception. This is used to validate the parameters for file types and default
 // graphs.
-static void checkNumParameterValues(const auto& values, size_t numFiles,
+template <typename T>
+static void checkNumParameterValues(const T& values, size_t numFiles,
                                     std::string_view parameterName) {
   if (values.empty()) {
     return;
@@ -100,8 +101,8 @@ qlever::Filetype getFiletype(std::optional<std::string_view> filetype,
 // Get the parameter value at the given index. If the vector is empty, return
 // the given `defaultValue`. If the vector has exactly one element, return that
 // element, no matter what the index is.
-template <typename T>
-T getParameterValue(size_t idx, const auto& values, const T& defaultValue) {
+template <typename T, typename TsList>
+T getParameterValue(size_t idx, const TsList& values, const T& defaultValue) {
   if (values.empty()) {
     return defaultValue;
   }

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -1,8 +1,6 @@
 //  Copyright 2020, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 // Common classes / Typedefs that are used during Index Creation
 

--- a/src/index/IndexBuilderTypes.h
+++ b/src/index/IndexBuilderTypes.h
@@ -1,6 +1,8 @@
 //  Copyright 2020, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 // Common classes / Typedefs that are used during Index Creation
 
@@ -229,11 +231,11 @@ struct LangtagAndTriple {
  * ranges for the individual HashMaps
  * @return A Tuple of lambda functions (see above)
  */
-template <size_t NumThreads>
+template <size_t NumThreads, typename IndexPtr>
 auto getIdMapLambdas(
     std::array<std::optional<ItemMapManager>, NumThreads>* itemArrayPtr,
     size_t maxNumberOfTriples, const TripleComponentComparator* comp,
-    auto* indexPtr, ItemAlloc alloc) {
+    IndexPtr* indexPtr, ItemAlloc alloc) {
   // that way the different ids won't interfere
   auto& itemArray = *itemArrayPtr;
   for (size_t j = 0; j < NumThreads; ++j) {

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -3,8 +3,6 @@
 // Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de>
 //          Johannes Kalmbach <johannes.kalmbach@gmail.com>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "index/IndexImpl.h"
 

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -3,6 +3,8 @@
 // Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de>
 //          Johannes Kalmbach <johannes.kalmbach@gmail.com>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "index/IndexImpl.h"
 
@@ -446,7 +448,8 @@ static cppcoro::generator<std::string> fourLetterPrefixes() {
 }
 
 /// Check if the `fourLetterPrefixes` are sorted wrt to the `comparator`
-static bool areFourLetterPrefixesSorted(auto comparator) {
+template <typename T>
+static bool areFourLetterPrefixesSorted(T comparator) {
   std::string first;
   for (auto second : fourLetterPrefixes()) {
     if (!comparator(first, second)) {

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -3,8 +3,6 @@
 // Author:
 //   2014-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 //   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_INDEXIMPL_H
 #define QLEVER_SRC_INDEX_INDEXIMPL_H

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -3,6 +3,8 @@
 // Author:
 //   2014-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
 //   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_INDEXIMPL_H
 #define QLEVER_SRC_INDEX_INDEXIMPL_H
@@ -527,9 +529,10 @@ class IndexImpl {
   std::unique_ptr<RdfParserBase> makeRdfParser(
       const std::vector<Index::InputFileSpecification>& files) const;
 
+  template <typename Func>
   FirstPermutationSorterAndInternalTriplesAsPso convertPartialToGlobalIds(
       TripleVec& data, const vector<size_t>& actualLinesPerPartial,
-      size_t linesPerPartial, auto isQLeverInternalTriple);
+      size_t linesPerPartial, Func isQLeverInternalTriple);
 
   // Generator that returns all words in the given context file (if not empty)
   // and then all words in all literals (if second argument is true).
@@ -561,12 +564,13 @@ class IndexImpl {
 
   // TODO<joka921> Get rid of the `numColumns` by including them into the
   // `sortedTriples` argument.
+  template <typename T, typename... Callbacks>
   std::tuple<size_t, IndexMetaDataMmapDispatcher::WriteType,
              IndexMetaDataMmapDispatcher::WriteType>
   createPermutationPairImpl(size_t numColumns, const string& fileName1,
-                            const string& fileName2, auto&& sortedTriples,
+                            const string& fileName2, T&& sortedTriples,
                             Permutation::KeyOrder permutation,
-                            auto&&... perTripleCallbacks);
+                            Callbacks&&... perTripleCallbacks);
 
   // _______________________________________________________________________
   // Create a pair of permutations. Only works for valid pairs (PSO-POS,
@@ -597,11 +601,12 @@ class IndexImpl {
   // Careful: only multiplicities for first column is valid after call, need to
   // call exchangeMultiplicities as done by createPermutationPair
   // the optional is std::nullopt if vec and thus the index is empty
+  template <typename T, typename... Callbacks>
   std::tuple<size_t, IndexMetaDataMmapDispatcher::WriteType,
              IndexMetaDataMmapDispatcher::WriteType>
-  createPermutations(size_t numColumns, auto&& sortedTriples,
+  createPermutations(size_t numColumns, T&& sortedTriples,
                      const Permutation& p1, const Permutation& p2,
-                     auto&&... perTripleCallbacks);
+                     Callbacks&&... perTripleCallbacks);
 
   void createTextIndex(const string& filename, TextVec& vec);
 
@@ -725,8 +730,9 @@ class IndexImpl {
 
   // Create the internal PSO and POS permutations from the sorted internal
   // triples. Return `(numInternalTriples, numInternalPredicates)`.
+  template <typename InternalTriplePsoSorter>
   std::pair<size_t, size_t> createInternalPSOandPOS(
-      auto&& internalTriplesPsoSorter);
+      InternalTriplePsoSorter&& internalTriplesPsoSorter);
 
   // Set up one of the permutation sorters with the appropriate memory limit.
   // The `permutationName` is used to determine the filename and must be unique
@@ -763,12 +769,14 @@ class IndexImpl {
     }
   }
 
-  void createSecondPermutationPair(auto&&... args) {
+  template <typename... Args>
+  void createSecondPermutationPair(Args&&... args) {
     static_assert(std::is_same_v<SecondPermutation, SortByOSP>);
     return createOSPAndOPS(AD_FWD(args)...);
   }
 
-  void createThirdPermutationPair(auto&&... args) {
+  template <typename... Args>
+  void createThirdPermutationPair(Args&&... args) {
     static_assert(std::is_same_v<ThirdPermutation, SortByPSO>);
     return createPSOAndPOS(AD_FWD(args)...);
   }
@@ -779,9 +787,10 @@ class IndexImpl {
   // subject pattern of the object (which is created by this function). Return
   // these five columns sorted by PSO, to be used as an input for building the
   // PSO and POS permutations.
+  template <typename InternalTripleSorter>
   std::unique_ptr<ExternalSorter<SortByPSO, NumColumnsIndexBuilding + 2>>
   buildOspWithPatterns(PatternCreator::TripleSorter sortersFromPatternCreator,
-                       auto& internalTripleSorter);
+                       InternalTripleSorter& internalTripleSorter);
 
   // During the index, building add the number of internal triples and internal
   // predicates to the configuration. Note: the number of internal objects and

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -3,8 +3,6 @@
 // Authors:
 //    2023 Hannah Bast <bast@cs.uni-freiburg.de>
 //    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "index/LocatedTriples.h"
 

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -3,6 +3,8 @@
 // Authors:
 //    2023 Hannah Bast <bast@cs.uni-freiburg.de>
 //    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "index/LocatedTriples.h"
 
@@ -61,9 +63,10 @@ NumAddedAndDeleted LocatedTriplesPerBlock::numTriples(size_t blockIndex) const {
 // `numIndexColumns` and `includeGraphColumn`. For example, if `numIndexColumns`
 // is `2` and `includeGraphColumn` is `true`, the function returns
 // `std::tie(row[0], row[1], row[2])`.
-CPP_template(size_t numIndexColumns, bool includeGraphColumn)(
-    requires(numIndexColumns >= 1 &&
-             numIndexColumns <= 3)) auto tieIdTableRow(auto& row) {
+CPP_template(size_t numIndexColumns, bool includeGraphColumn,
+             typename T)(requires(numIndexColumns >= 1 &&
+                                  numIndexColumns <=
+                                      3)) auto tieIdTableRow(T& row) {
   return [&row]<size_t... I>(std::index_sequence<I...>) {
     return std::tie(row[I]...);
   }(std::make_index_sequence<numIndexColumns +
@@ -75,9 +78,10 @@ CPP_template(size_t numIndexColumns, bool includeGraphColumn)(
 // `numIndexColumns` is `2` and `includeGraphColumn` is `true`, the function
 // returns `std::tie(ids_[1], ids_[2], ids_[3])`, where `ids_` is from
 // `lt->triple_`.
-CPP_template(size_t numIndexColumns, bool includeGraphColumn)(
-    requires(numIndexColumns >= 1 &&
-             numIndexColumns <= 3)) auto tieLocatedTriple(auto& lt) {
+CPP_template(size_t numIndexColumns, bool includeGraphColumn,
+             typename T)(requires(numIndexColumns >= 1 &&
+                                  numIndexColumns <=
+                                      3)) auto tieLocatedTriple(T& lt) {
   constexpr auto indices = []() {
     std::array<size_t,
                numIndexColumns + static_cast<size_t>(includeGraphColumn)>

--- a/src/index/TextMetaData.h
+++ b/src/index/TextMetaData.h
@@ -1,8 +1,6 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_TEXTMETADATA_H
 #define QLEVER_SRC_INDEX_TEXTMETADATA_H

--- a/src/index/TextMetaData.h
+++ b/src/index/TextMetaData.h
@@ -1,6 +1,8 @@
 // Copyright 2015, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Björn Buchhold (buchhold@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_TEXTMETADATA_H
 #define QLEVER_SRC_INDEX_TEXTMETADATA_H
@@ -78,7 +80,9 @@ class TextBlockMetaData {
   static constexpr size_t sizeOnDisk() {
     return 2 * sizeof(Id) + 2 * ContextListMetaData::sizeOnDisk();
   }
-  friend std::true_type allowTrivialSerialization(TextBlockMetaData, auto);
+
+  template <typename T>
+  friend std::true_type allowTrivialSerialization(TextBlockMetaData, T);
 };
 
 ad_utility::File& operator<<(ad_utility::File& f, const TextBlockMetaData& md);

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -1,6 +1,8 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H
@@ -260,7 +262,8 @@ ad_utility::HashMap<uint64_t, uint64_t> createInternalMapping(ItemVec* els);
  * @brief for each of the IdTriples in <input>: map the three Ids using the
  * <map> and write the resulting Id triple to <*writePtr>
  */
-void writeMappedIdsToExtVec(const auto& input,
+template <typename T>
+void writeMappedIdsToExtVec(const T& input,
                             const ad_utility::HashMap<Id, Id>& map,
                             std::unique_ptr<TripleVec>* writePtr);
 

--- a/src/index/VocabularyMerger.h
+++ b/src/index/VocabularyMerger.h
@@ -1,8 +1,6 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGER_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGER_H

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -1,6 +1,8 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
@@ -258,8 +260,9 @@ inline ad_utility::HashMap<uint64_t, uint64_t> createInternalMapping(
 }
 
 // ________________________________________________________________________________________________________
+template <typename T>
 inline void writeMappedIdsToExtVec(
-    const auto& input, const ad_utility::HashMap<uint64_t, uint64_t>& map,
+    const T& input, const ad_utility::HashMap<uint64_t, uint64_t>& map,
     std::unique_ptr<TripleVec>* writePtr) {
   auto& vec = *(*writePtr);
   for (const auto& curTriple : input) {

--- a/src/index/VocabularyMergerImpl.h
+++ b/src/index/VocabularyMergerImpl.h
@@ -1,8 +1,6 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H
 #define QLEVER_SRC_INDEX_VOCABULARYMERGERIMPL_H

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -1,6 +1,8 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINMEMORY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINMEMORY_H
@@ -55,7 +57,8 @@ class VocabularyInMemory
   auto operator[](uint64_t i) const { return _words[i]; }
 
   // Conversion function that is used by the Mixin base class.
-  WordAndIndex iteratorToWordAndIndex(auto it) const {
+  template <typename It>
+  WordAndIndex iteratorToWordAndIndex(It it) const {
     if (it == _words.end()) {
       return WordAndIndex::end();
     }

--- a/src/index/vocabulary/VocabularyInMemory.h
+++ b/src/index/vocabulary/VocabularyInMemory.h
@@ -1,8 +1,6 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach<joka921> (johannes.kalmbach@gmail.com)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINMEMORY_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINMEMORY_H

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -1,6 +1,8 @@
 // Copyright 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach<joka921> (kalmbach@cs.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
@@ -142,9 +144,10 @@ class VocabularyInternalExternal {
   // `lower_bound_iterator`, and `upper_bound_iterator`. The `boundFunction`
   // must be a lambda, that calls the corresponding function (e.g.
   // `lower_bound`) on its first argument (see above for usages).
-  template <typename InternalStringType, typename Comparator>
+  template <typename InternalStringType, typename Comparator,
+            typename BoundFunction>
   WordAndIndex boundImpl(const InternalStringType& word, Comparator comparator,
-                         auto boundFunction) const {
+                         BoundFunction boundFunction) const {
     // First do a binary search in the internal vocab.
     WordAndIndex boundFromInternalVocab =
         boundFunction(internalVocab_, word, comparator);

--- a/src/index/vocabulary/VocabularyInternalExternal.h
+++ b/src/index/vocabulary/VocabularyInternalExternal.h
@@ -1,8 +1,6 @@
 // Copyright 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach<joka921> (kalmbach@cs.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H
 #define QLEVER_SRC_INDEX_VOCABULARY_VOCABULARYINTERNALEXTERNAL_H

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -3,6 +3,8 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 // Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "parser/GraphPatternOperation.h"
 
@@ -47,7 +49,8 @@ std::string SparqlValues::valuesToString() const {
 // Small anonymous helper function that is used in the definition of the member
 // functions of the `Subquery` class.
 namespace {
-auto m(auto&&... args) {
+template <typename... Args>
+auto m(Args&&... args) {
   return std::make_unique<ParsedQuery>(AD_FWD(args)...);
 }
 }  // namespace

--- a/src/parser/GraphPatternOperation.cpp
+++ b/src/parser/GraphPatternOperation.cpp
@@ -3,8 +3,6 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
 // Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "parser/GraphPatternOperation.h"
 

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "parser/RdfParser.h"
 
@@ -1077,7 +1079,8 @@ void RdfParallelParser<T>::finishTripleCollectorIfLastBatch() {
 
 // __________________________________________________________________________________
 template <typename T>
-void RdfParallelParser<T>::parseBatch(size_t parsePosition, auto batch) {
+template <typename Batch>
+void RdfParallelParser<T>::parseBatch(size_t parsePosition, Batch batch) {
   try {
     RdfStringParser<T> parser{defaultGraphIri_};
     parser.prefixMap_ = this->prefixMap_;
@@ -1100,8 +1103,9 @@ void RdfParallelParser<T>::parseBatch(size_t parsePosition, auto batch) {
 
 // _______________________________________________________________________
 template <typename T>
+template <typename Batch>
 void RdfParallelParser<T>::feedBatchesToParser(
-    auto remainingBatchFromInitialization) {
+    Batch remainingBatchFromInitialization) {
   bool first = true;
   size_t parsePosition = 0;
   auto cleanup =

--- a/src/parser/RdfParser.cpp
+++ b/src/parser/RdfParser.cpp
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "parser/RdfParser.h"
 

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -1,8 +1,6 @@
 // Copyright 2018 - 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_PARSER_RDFPARSER_H
 #define QLEVER_SRC_PARSER_RDFPARSER_H

--- a/src/parser/RdfParser.h
+++ b/src/parser/RdfParser.h
@@ -1,6 +1,8 @@
 // Copyright 2018 - 2024, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_PARSER_RDFPARSER_H
 #define QLEVER_SRC_PARSER_RDFPARSER_H
@@ -632,11 +634,14 @@ class RdfParallelParser : public Parser {
   // interacts with the functions next to it.
   void finishTripleCollectorIfLastBatch();
   // Parse the single `batch` and push the result to the `triplesCollector_`.
-  void parseBatch(size_t parsePosition, auto batch);
+  template <typename Batch>
+  void parseBatch(size_t parsePosition, Batch batch);
+
   // Read all the batches from the file and feed them to the parallel parser
   // threads. The argument is the first batch which might have been leftover
   // from the initialization phase where the prefixes are parsed.
-  void feedBatchesToParser(auto remainingBatchFromInitialization);
+  template <typename Batch>
+  void feedBatchesToParser(Batch remainingBatchFromInitialization);
 
   using Parser::isParserExhausted_;
   using Parser::tok_;

--- a/src/parser/sparqlParser/SparqlQleverVisitor.cpp
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.cpp
@@ -249,8 +249,9 @@ void Visitor::addVisibleVariable(Variable var) {
 }
 
 // ___________________________________________________________________________
+template <typename List>
 PathObjectPairs joinPredicateAndObject(const VarOrPath& predicate,
-                                       auto objectList) {
+                                       List objectList) {
   PathObjectPairs tuples;
   tuples.reserve(objectList.first.size());
   for (auto& object : objectList.first) {
@@ -260,7 +261,8 @@ PathObjectPairs joinPredicateAndObject(const VarOrPath& predicate,
 }
 
 // ___________________________________________________________________________
-SparqlExpressionPimpl Visitor::visitExpressionPimpl(auto* ctx) {
+template <typename Context>
+SparqlExpressionPimpl Visitor::visitExpressionPimpl(Context* ctx) {
   return {visit(ctx), getOriginalInputForContext(ctx)};
 }
 
@@ -1471,8 +1473,9 @@ GraphPatternOperation Visitor::visit(
 }
 
 // ____________________________________________________________________________________
+template <typename Context>
 void Visitor::warnOrThrowIfUnboundVariables(
-    auto* ctx, const SparqlExpressionPimpl& expression,
+    Context* ctx, const SparqlExpressionPimpl& expression,
     std::string_view clauseName) {
   for (const auto& var : expression.containedVariables()) {
     if (!ad_utility::contains(visibleVariables_, *var)) {
@@ -1636,6 +1639,7 @@ SubjectOrObjectAndTriples Visitor::visit(Parser::ObjectRContext* ctx) {
 }
 
 // ____________________________________________________________________________________
+template <typename Context>
 void Visitor::setMatchingWordAndScoreVisibleIfPresent(
     // If a triple `?var ql:contains-word "words"` or `?var ql:contains-entity
     // <entity>` is contained in the query, then the variable
@@ -1643,7 +1647,7 @@ void Visitor::setMatchingWordAndScoreVisibleIfPresent(
     // Similarly, if a triple `?var ql:contains-word "words"` is contained in
     // the query, then the variable `ql_matchingword_var` is implicitly created
     // and visible in the query body.
-    auto* ctx, const TripleWithPropertyPath& triple) {
+    Context* ctx, const TripleWithPropertyPath& triple) {
   const auto& [subject, predicate, object] = triple;
 
   auto* var = std::get_if<Variable>(&subject);

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -3,8 +3,6 @@
 // Authors: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 //          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_PARSER_SPARQLPARSER_SPARQLQLEVERVISITOR_H
 #define QLEVER_SRC_PARSER_SPARQLPARSER_SPARQLQLEVERVISITOR_H

--- a/src/parser/sparqlParser/SparqlQleverVisitor.h
+++ b/src/parser/sparqlParser/SparqlQleverVisitor.h
@@ -3,6 +3,8 @@
 // Authors: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
 //          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_PARSER_SPARQLPARSER_SPARQLQLEVERVISITOR_H
 #define QLEVER_SRC_PARSER_SPARQLPARSER_SPARQLQLEVERVISITOR_H
@@ -555,10 +557,11 @@ class SparqlQleverVisitor {
   // Return the `SparqlExpressionPimpl` for a context that returns a
   // `ExpressionPtr` when visited. The descriptor is set automatically on the
   // `SparqlExpressionPimpl`.
-  SparqlExpressionPimpl visitExpressionPimpl(auto* ctx);
+  template <typename Context>
+  SparqlExpressionPimpl visitExpressionPimpl(Context* ctx);
 
-  template <typename Expr>
-  ExpressionPtr createExpression(auto... children) {
+  template <typename Expr, typename... Children>
+  ExpressionPtr createExpression(Children... children) {
     return std::make_unique<Expr>(
         std::array<ExpressionPtr, sizeof...(children)>{std::move(children)...});
   }
@@ -618,13 +621,15 @@ class SparqlQleverVisitor {
   // variables for the matching word and the score that will be created when
   // processing those triples in the query body, s.t. they can be selected as
   // part of the query result.
+  template <typename Context>
   void setMatchingWordAndScoreVisibleIfPresent(
-      auto* ctx, const TripleWithPropertyPath& triple);
+      Context* ctx, const TripleWithPropertyPath& triple);
 
   // If any of the variables used in `expression` did not appear previously in
   // the query, add a warning or throw an exception (depending on the setting of
   // the corresponding `RuntimeParameter`).
-  void warnOrThrowIfUnboundVariables(auto* ctx,
+  template <typename Context>
+  void warnOrThrowIfUnboundVariables(Context* ctx,
                                      const SparqlExpressionPimpl& expression,
                                      std::string_view clauseName);
 

--- a/src/util/BufferedVector.h
+++ b/src/util/BufferedVector.h
@@ -1,8 +1,6 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_BUFFEREDVECTOR_H
 #define QLEVER_SRC_UTIL_BUFFEREDVECTOR_H

--- a/src/util/BufferedVector.h
+++ b/src/util/BufferedVector.h
@@ -1,6 +1,8 @@
 // Copyright 2018, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (joka921) <johannes.kalmbach@gmail.com>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_BUFFEREDVECTOR_H
 #define QLEVER_SRC_UTIL_BUFFEREDVECTOR_H
@@ -106,7 +108,8 @@ class BufferedVector {
   // add element specified by arg el at the end of the array
   // possibly invalidates iterators
  private:
-  void push_backImpl(auto&&... args) {
+  template <typename... Args>
+  void push_backImpl(Args&&... args) {
     auto oldSize = size();
     if (!_isInternal) {
       _extVec.push_back(T{AD_FWD(args)...});
@@ -125,7 +128,10 @@ class BufferedVector {
 
  public:
   void push_back(const T& el) { push_backImpl(el); }
-  void emplace_back(auto&&... args) { push_backImpl(AD_FWD(args)...); }
+  template <typename... Args>
+  void emplace_back(Args&&... args) {
+    push_backImpl(AD_FWD(args)...);
+  }
 
   // Change the size of the `BufferedVector` to `newSize`. This might move
   // the data from the internal to the external vector or vice versa. If
@@ -156,7 +162,8 @@ class BufferedVector {
   // `[it1, it2)` into the vector at `target`. The `it1` and `it2` must not
   // overlap with `this` and `target` must be a valid iterator for `this`. Both
   // of these conditions are checked via an `AD_CONTRACT_CHECK`.
-  void insert(T* target, auto it1, auto it2) {
+  template <typename It>
+  void insert(T* target, It it1, It it2) {
     AD_CONTRACT_CHECK(target >= begin() && target <= end());
     AD_CONTRACT_CHECK(it2 >= it1);
     auto addr1 = &(*it1);

--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -1,6 +1,8 @@
 // Copyright 2021, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (kalmbacj@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_CONCURRENTCACHE_H
 #define QLEVER_CONCURRENTCACHE_H
@@ -63,7 +65,8 @@ constexpr std::string_view toString(CacheStatus status) {
 
 // Given a `cache` and a `key` determine the corresponding `CacheStatus`.
 // Note: `computed` in this case means "not contained in the cache".
-CacheStatus getCacheStatus(const auto& cache, const auto& key) {
+template <typename Cache, typename Key>
+CacheStatus getCacheStatus(const Cache& cache, const Key& key) {
   if (cache.containsPinned(key)) {
     return CacheStatus::cachedPinned;
   } else if (cache.containsNonPinned(key)) {

--- a/src/util/ConcurrentCache.h
+++ b/src/util/ConcurrentCache.h
@@ -1,8 +1,6 @@
 // Copyright 2021, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach (kalmbacj@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_CONCURRENTCACHE_H
 #define QLEVER_CONCURRENTCACHE_H

--- a/src/util/ConfigManager/ConfigOption.cpp
+++ b/src/util/ConfigManager/ConfigOption.cpp
@@ -35,9 +35,9 @@ Manually checks if the json represents one of the possibilities of
 `AvailableTypes`.
 */
 struct IsValueTypeSubType {
-  template <typename T>
+  template <typename T, typename F>
   constexpr bool operator()(const nlohmann::json& j,
-                            const auto& isValueTypeSubType) const {
+                            const F& isValueTypeSubType) const {
     if constexpr (std::is_same_v<T, bool>) {
       return j.is_boolean();
     } else if constexpr (std::is_same_v<T, std::string>) {

--- a/src/util/ConstexprUtils.h
+++ b/src/util/ConstexprUtils.h
@@ -25,7 +25,8 @@ namespace ad_utility {
 // library should be chosen.
 // TODO<joka921> why can't this be consteval when the result is bound to a
 // `constexpr` variable?
-constexpr auto pow(auto base, int exponent) {
+template <typename T>
+constexpr auto pow(T base, int exponent) {
   if (exponent < 0) {
     throw std::runtime_error{"negative exponent"};
   }
@@ -230,8 +231,8 @@ CPP_template(auto Upper,
 @brief Call the given lambda function with each of the given types `Ts` as
 explicit template parameter, keeping the same order.
 */
-template <typename... Ts>
-constexpr void forEachTypeInParameterPack(const auto& lambda) {
+template <typename... Ts, typename F>
+constexpr void forEachTypeInParameterPack(const F& lambda) {
   (lambda.template operator()<Ts>(), ...);
 }
 
@@ -254,7 +255,8 @@ struct forEachTypeInTemplateTypeImpl;
 
 template <template <typename...> typename Template, typename... Ts>
 struct forEachTypeInTemplateTypeImpl<Template<Ts...>> {
-  constexpr void operator()(const auto& lambda) const {
+  template <typename F>
+  constexpr void operator()(const F& lambda) const {
     forEachTypeInParameterPack<Ts...>(lambda);
   }
 };
@@ -274,8 +276,8 @@ struct forEachTypeInTemplateTypeWithTIImpl<Template<Ts...>> {
 @brief Call the given lambda function with each type in the given instantiated
 template type as explicit template parameter, keeping the same order.
 */
-template <typename TemplateType>
-constexpr void forEachTypeInTemplateType(const auto& lambda) {
+template <typename TemplateType, typename F>
+constexpr void forEachTypeInTemplateType(const F& lambda) {
   detail::forEachTypeInTemplateTypeImpl<TemplateType>{}(lambda);
 }
 

--- a/src/util/CopyableUniquePtr.h
+++ b/src/util/CopyableUniquePtr.h
@@ -1,6 +1,8 @@
 // Copyright 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (April of 2023, schlegea@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_COPYABLEUNIQUEPTR_H
 #define QLEVER_SRC_UTIL_COPYABLEUNIQUEPTR_H
@@ -66,14 +68,15 @@ CPP_template(typename T, typename Deleter = std::default_delete<T>)(
 
  private:
   // This function uses a private constructor, so it needs private access.
-  template <typename T2>
-  friend constexpr CopyableUniquePtr<T2> make_copyable_unique(auto&&... args);
+  template <typename T2, typename... Args>
+  friend constexpr CopyableUniquePtr<T2> make_copyable_unique(Args&&... args);
 
   /*
   @brief Returns an unique pointer, that holds a copy of the dereferenced
   (copyable) unique pointer, that was given.
   */
-  Base CopyDereferencedPointer(const auto& ptr) {
+  template <typename P>
+  Base CopyDereferencedPointer(const P& ptr) {
     // Different behaviour based on whenever the ptr actually owns an object.
     return ptr ? std::make_unique<T>(*ptr) : nullptr;
   }
@@ -88,8 +91,8 @@ CPP_template(typename T, typename Deleter = std::default_delete<T>)(
 /*
 @brief Same as `std::make_unique`, but for `CopyableUniquePtr`.
 */
-template <typename T>
-constexpr CopyableUniquePtr<T> make_copyable_unique(auto&&... args) {
+template <typename T, typename... Args>
+constexpr CopyableUniquePtr<T> make_copyable_unique(Args&&... args) {
   return CopyableUniquePtr<T>(std::make_unique<T>(AD_FWD(args)...));
 }
 

--- a/src/util/CopyableUniquePtr.h
+++ b/src/util/CopyableUniquePtr.h
@@ -1,8 +1,6 @@
 // Copyright 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Andre Schlegel (April of 2023, schlegea@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_COPYABLEUNIQUEPTR_H
 #define QLEVER_SRC_UTIL_COPYABLEUNIQUEPTR_H

--- a/src/util/Date.h
+++ b/src/util/Date.h
@@ -24,7 +24,8 @@ class DateOutOfRangeException : public std::exception {
   std::string message_;
 
  public:
-  DateOutOfRangeException(std::string_view name, const auto& value)
+  template <typename T>
+  DateOutOfRangeException(std::string_view name, const T& value)
       : message_(absl::StrCat(name, " ", value,
                               " is out of range for a DateTime")) {}
   [[nodiscard]] const char* what() const noexcept override {
@@ -42,8 +43,9 @@ class DateParseException : public std::runtime_error {
 namespace detail {
 // Check that `min <= element <= max`. Throw `DateOutOfRangeException` if the
 // check fails.
-constexpr void checkBoundsIncludingMax(const auto& element, const auto& min,
-                                       const auto& max, std::string_view name) {
+template <typename T>
+constexpr void checkBoundsIncludingMax(const T& element, const T& min,
+                                       const T& max, std::string_view name) {
   if (element < min || element > max) {
     throw DateOutOfRangeException{name, element};
   }
@@ -51,8 +53,9 @@ constexpr void checkBoundsIncludingMax(const auto& element, const auto& min,
 
 // Check that `min <= element < max`. Throw `DateOutOfRangeException` if the
 // check fails.
-constexpr void checkBoundsExcludingMax(const auto& element, const auto& min,
-                                       const auto& max, std::string_view name) {
+template <typename T>
+constexpr void checkBoundsExcludingMax(const T& element, const T& min,
+                                       const T& max, std::string_view name) {
   if (element < min || element >= max) {
     throw DateOutOfRangeException{name, element};
   }
@@ -311,7 +314,8 @@ class Date {
   std::string formatTimeZone() const;
 
   // Get the correct `TimeZone` from a regex match for the `timeZoneRegex`.
-  static TimeZone parseTimeZone(const auto& match);
+  template <typename T>
+  static TimeZone parseTimeZone(const T& match);
 
   // Convert to a string (without quotes) that represents the stored date, and a
   // pointer to the IRI of the corresponding datatype (currently always

--- a/src/util/DateYearDuration.cpp
+++ b/src/util/DateYearDuration.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "util/DateYearDuration.h"
 

--- a/src/util/DateYearDuration.cpp
+++ b/src/util/DateYearDuration.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "util/DateYearDuration.h"
 
@@ -52,7 +54,8 @@ std::pair<std::string, const char*> DateYearOrDuration::toStringAndType()
 }
 
 // _____________________________________________________________________________
-static Date::TimeZone parseTimeZone(const auto& match) {
+template <typename T>
+static Date::TimeZone parseTimeZone(const T& match) {
   if (match.template get<"tzZ">() == "Z") {
     return Date::TimeZoneZ{};
   } else if (!match.template get<"tzHours">()) {

--- a/src/util/Duration.h
+++ b/src/util/Duration.h
@@ -3,6 +3,8 @@
 //  Author: Hannes Baumann <baumannh@informatik.uni-freiburg.de>
 //
 //  Tests for this class can be found in DurationTest.cpp
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_DURATION_H
 #define QLEVER_DURATION_H
@@ -39,7 +41,8 @@ class DurationOverflowException : public std::exception {
 
 //______________________________________________________________________________
 namespace detail {
-constexpr void checkBoundDuration(const auto& value, const auto& max,
+template <typename T>
+constexpr void checkBoundDuration(const T& value, const T& max,
                                   std::string_view className,
                                   std::string_view xsdDatatype) {
   if (value >= max) {

--- a/src/util/Duration.h
+++ b/src/util/Duration.h
@@ -1,10 +1,8 @@
 //  Copyright 2024, University of Freiburg,
 //                  Chair of Algorithms and Data Structures
 //  Author: Hannes Baumann <baumannh@informatik.uni-freiburg.de>
-//
+
 //  Tests for this class can be found in DurationTest.cpp
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_DURATION_H
 #define QLEVER_DURATION_H

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -2,8 +2,6 @@
 // Structures.
 // Author: 2011-2017 Björn Buchhold <buchholb@cs.uni-freiburg.de>
 //         2020-     Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_EXCEPTION_H
 #define QLEVER_SRC_UTIL_EXCEPTION_H

--- a/src/util/Exception.h
+++ b/src/util/Exception.h
@@ -2,6 +2,8 @@
 // Structures.
 // Author: 2011-2017 Björn Buchhold <buchholb@cs.uni-freiburg.de>
 //         2020-     Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_EXCEPTION_H
 #define QLEVER_SRC_UTIL_EXCEPTION_H
@@ -114,7 +116,8 @@ CPP_template(typename T)(
 // Helper function used to format the arguments passed to `AD_CONTRACT_CHECK`
 // etc. Return "<concatenation of `getMessageImpl(messages)...`>" followed by
 // a full stop and space if there is at least one message.
-std::string concatMessages(auto&&... messages) {
+template <typename... Args>
+std::string concatMessages(Args&&... messages) {
   if constexpr (sizeof...(messages) == 0) {
     return "";
   } else {

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -1,8 +1,6 @@
 // Copyright 2024, University of Freiburg,
 //                 Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_FSSTCOMPRESSOR_H
 #define QLEVER_FSSTCOMPRESSOR_H

--- a/src/util/FsstCompressor.h
+++ b/src/util/FsstCompressor.h
@@ -1,6 +1,8 @@
 // Copyright 2024, University of Freiburg,
 //                 Chair of Algorithms and Data Structures.
 // Author: Johannes Kalmbach <johannes.kalmbach@gmail.com>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_FSSTCOMPRESSOR_H
 #define QLEVER_FSSTCOMPRESSOR_H
@@ -163,15 +165,16 @@ class FsstEncoder {
   // strings again.
   using BulkResult = std::tuple<std::shared_ptr<std::string>,
                                 std::vector<std::string_view>, FsstDecoder>;
-  static BulkResult compressAll(const auto& strings) {
+  template <typename T>
+  static BulkResult compressAll(const T& strings) {
     return makeEncoder<true>(strings);
   }
 
  private:
   // The implementation of the constructor and of `compressAll`.
-  template <bool alsoCompressAll = false>
+  template <bool alsoCompressAll = false, typename Strings>
   static std::conditional_t<alsoCompressAll, BulkResult, Encoder> makeEncoder(
-      const auto& strings) {
+      const Strings& strings) {
     std::vector<size_t> lengths;
     std::vector<const unsigned char*> pointers;
     [[maybe_unused]] size_t totalSize = 0;

--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -1,6 +1,8 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_GENERATORS_H
 #define QLEVER_SRC_UTIL_GENERATORS_H
@@ -53,9 +55,9 @@ CPP_template(typename InputRange, typename AggregatorT,
 // callable that takes a `callback` with signature `void(T)`. The arguments with
 // which this callback is called when running the `functionWithCallback` become
 // the elements that are yielded by the created `generator`.
-template <typename T>
-cppcoro::generator<T> generatorFromActionWithCallback(
-    std::invocable<std::function<void(T)>> auto functionWithCallback) {
+template <typename T, typename F>
+cppcoro::generator<T> generatorFromActionWithCallback(F functionWithCallback)
+    requires std::invocable<F, std::function<void(T)>> {
   std::mutex mutex;
   std::condition_variable cv;
 

--- a/src/util/Generators.h
+++ b/src/util/Generators.h
@@ -1,8 +1,6 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_GENERATORS_H
 #define QLEVER_SRC_UTIL_GENERATORS_H

--- a/src/util/JoinAlgorithms/FindUndefRanges.h
+++ b/src/util/JoinAlgorithms/FindUndefRanges.h
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_JOINALGORITHMS_FINDUNDEFRANGES_H
 #define QLEVER_SRC_UTIL_JOINALGORITHMS_FINDUNDEFRANGES_H

--- a/src/util/JoinAlgorithms/FindUndefRanges.h
+++ b/src/util/JoinAlgorithms/FindUndefRanges.h
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_JOINALGORITHMS_FINDUNDEFRANGES_H
 #define QLEVER_SRC_UTIL_JOINALGORITHMS_FINDUNDEFRANGES_H
@@ -36,9 +38,10 @@ namespace ad_utility {
 // is the number of matching elements.
 // TODO<joka921> This can be optimized when we also know which columns of
 // `[begin, end)` can possibly contain UNDEF values.
-CPP_template(typename It)(requires std::random_access_iterator<It>)  //
+CPP_template(typename R,
+             typename It)(requires std::random_access_iterator<It>)  //
     auto findSmallerUndefRangesForRowsWithoutUndef(
-        const auto& row, It begin, It end,
+        const R& row, It begin, It end,
         [[maybe_unused]] bool& resultMightBeUnsorted)
         -> cppcoro::generator<It> {
   using Row = typename std::iterator_traits<It>::value_type;
@@ -170,8 +173,9 @@ CPP_template(typename It)(requires std::random_access_iterator<It>)  //
 // columns contain no UNDEF at all) and therefore a more specialized routine
 // should be chosen.
 struct FindSmallerUndefRanges {
-  CPP_template(typename It)(requires std::random_access_iterator<It>) auto
-  operator()(const auto& row, It begin, It end,
+  CPP_template(typename Row,
+               typename It)(requires std::random_access_iterator<It>) auto
+  operator()(const Row& row, It begin, It end,
              bool& resultMightBeUnsorted) const -> cppcoro::generator<It> {
     size_t numLastUndefined = 0;
     assert(row.size() > 0);

--- a/src/util/LambdaHelpers.h
+++ b/src/util/LambdaHelpers.h
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_LAMBDAHELPERS_H
 #define QLEVER_LAMBDAHELPERS_H
@@ -29,12 +31,14 @@ struct AssignableLambdaImpl<Lambda, false, false> {
       : _lambda{std::move(lambda)} {}
   AssignableLambdaImpl() = default;
 
-  decltype(auto) operator()(auto&&... args) noexcept(
+  template <typename... Args>
+  decltype(auto) operator()(Args&&... args) noexcept(
       noexcept(_lambda(AD_FWD(args)...))) {
     return _lambda(AD_FWD(args)...);
   }
 
-  decltype(auto) constexpr operator()(auto&&... args) const
+  template <typename... Args>
+  decltype(auto) constexpr operator()(Args&&... args) const
       noexcept(noexcept(_lambda(AD_FWD(args)...))) {
     return _lambda(AD_FWD(args)...);
   }

--- a/src/util/LambdaHelpers.h
+++ b/src/util/LambdaHelpers.h
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_LAMBDAHELPERS_H
 #define QLEVER_LAMBDAHELPERS_H

--- a/src/util/Parameters.h
+++ b/src/util/Parameters.h
@@ -153,16 +153,26 @@ namespace detail::parameterShortNames {
 // TODO<joka921> Replace these by versions that actually parse the whole
 // string.
 struct fl {
-  float operator()(const auto& s) const { return std::stof(s); }
+  template <typename T>
+  float operator()(const T& s) const {
+    return std::stof(s);
+  }
 };
 struct dbl {
-  double operator()(const auto& s) const { return std::stod(s); }
+  template <typename T>
+  double operator()(const T& s) const {
+    return std::stod(s);
+  }
 };
 struct szt {
-  size_t operator()(const auto& s) const { return std::stoull(s); }
+  template <typename T>
+  size_t operator()(const T& s) const {
+    return std::stoull(s);
+  }
 };
 struct bl {
-  bool operator()(const auto& s) const {
+  template <typename T>
+  bool operator()(const T& s) const {
     if (s == "true") return true;
     if (s == "false") return false;
     AD_THROW(
@@ -171,7 +181,10 @@ struct bl {
 };
 
 struct toString {
-  std::string operator()(const auto& s) const { return std::to_string(s); }
+  template <typename T>
+  std::string operator()(const T& s) const {
+    return std::to_string(s);
+  }
 };
 struct boolToString {
   std::string operator()(const bool& v) const { return v ? "true" : "false"; }

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -1,8 +1,6 @@
 //   Copyright 2025, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #pragma once
 

--- a/src/util/Serializer/TripleSerializer.h
+++ b/src/util/Serializer/TripleSerializer.h
@@ -1,6 +1,8 @@
 //   Copyright 2025, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #pragma once
 
@@ -113,11 +115,11 @@ CPP_template(typename Range, typename Serializer)(
 
 // Deserialize a range of Ids from the input stream. If an Id is of type
 // LocalVocabIndex, apply the mapping to the Id after reading it.
-CPP_template(typename BlankNodeFunc)(
+CPP_template(typename Serializer, typename BlankNodeFunc)(
     requires ad_utility::InvocableWithConvertibleReturnType<BlankNodeFunc,
                                                             BlankNodeIndex>)
     std::vector<Id> deserializeIds(
-        auto& serializer, const absl::flat_hash_map<Id::T, Id>& mapping,
+        Serializer& serializer, const absl::flat_hash_map<Id::T, Id>& mapping,
         BlankNodeFunc newBlankNodeIndex) {
   std::vector<Id> ids = readValue<std::vector<Id>>(serializer);
   absl::flat_hash_map<Id, BlankNodeIndex> blankNodeMapping;

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -2,6 +2,8 @@
 // Structures.
 // Author: Andre Schlegel (November of 2023,
 // schlegea@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "util/StringUtils.h"
 
@@ -94,7 +96,8 @@ std::pair<size_t, std::string_view> getUTF8Prefix(std::string_view sv,
 namespace detail {
 // The common implementation of `utf8ToLower` and `utf8ToUpper` (for
 // details see below).
-std::string utf8StringTransform(std::string_view s, auto transformation) {
+template <typename F>
+std::string utf8StringTransform(std::string_view s, F transformation) {
   std::string result;
   icu::StringByteSink<std::string> sink(&result);
   UErrorCode err = U_ZERO_ERROR;

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -2,8 +2,6 @@
 // Structures.
 // Author: Andre Schlegel (November of 2023,
 // schlegea@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "util/StringUtils.h"
 

--- a/src/util/ThreadSafeQueue.h
+++ b/src/util/ThreadSafeQueue.h
@@ -2,8 +2,6 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Robin Textor-Falconi (textorr@informatik.uni-freiburg.de)
 //          Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_THREADSAFEQUEUE_H
 #define QLEVER_SRC_UTIL_THREADSAFEQUEUE_H

--- a/src/util/ThreadSafeQueue.h
+++ b/src/util/ThreadSafeQueue.h
@@ -2,6 +2,8 @@
 // Chair of Algorithms and Data Structures.
 // Authors: Robin Textor-Falconi (textorr@informatik.uni-freiburg.de)
 //          Johannes Kalmbach (kalmbach@cs.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_THREADSAFEQUEUE_H
 #define QLEVER_SRC_UTIL_THREADSAFEQUEUE_H
@@ -267,10 +269,10 @@ CPP_template(typename Queue, typename Producer)(
 // exception. In that case the exception is propagated to the resulting
 // generator. The resulting generator yields all the values that have been
 // pushed to the queue.
-template <typename Queue>
+template <typename Queue, typename Producer>
 cppcoro::generator<typename Queue::value_type> queueManager(size_t queueSize,
                                                             size_t numThreads,
-                                                            auto producer) {
+                                                            Producer producer) {
   Queue queue{queueSize};
   AD_CONTRACT_CHECK(numThreads > 0u);
   std::vector<ad_utility::JThread> threads;

--- a/src/util/TransparentFunctors.h
+++ b/src/util/TransparentFunctors.h
@@ -1,6 +1,8 @@
 // Copyright 2022 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_TRANSPARENTFUNCTORS_H
 #define QLEVER_SRC_UTIL_TRANSPARENTFUNCTORS_H
@@ -43,7 +45,8 @@ struct SecondImpl {
 // Implementation of `holdsAlternative` (see below).
 template <typename T>
 struct HoldsAlternativeImpl {
-  constexpr decltype(auto) operator()(auto&& variant) const {
+  template <typename V>
+  constexpr decltype(auto) operator()(V&& variant) const {
     return std::holds_alternative<T>(AD_FWD(variant));
   }
 };
@@ -51,7 +54,8 @@ struct HoldsAlternativeImpl {
 // Implementation of `get` (see below).
 template <typename T>
 struct GetImpl {
-  constexpr decltype(auto) operator()(auto&& variant) const {
+  template <typename V>
+  constexpr decltype(auto) operator()(V&& variant) const {
     return std::get<T>(AD_FWD(variant));
   }
 };
@@ -73,7 +77,8 @@ struct GetIfImpl {
 
 // Implementation of `toBool` (see below).
 struct ToBoolImpl {
-  constexpr decltype(auto) operator()(const auto& x) const {
+  template <typename T>
+  constexpr decltype(auto) operator()(const T& x) const {
     return static_cast<bool>(x);
   }
 };
@@ -81,14 +86,18 @@ struct ToBoolImpl {
 // Implementation of `staticCast` (see below).
 template <typename T>
 struct StaticCastImpl {
-  constexpr decltype(auto) operator()(auto&& x) const {
+  template <typename X>
+  constexpr decltype(auto) operator()(X&& x) const {
     return static_cast<T>(AD_FWD(x));
   }
 };
 
 // Implementation of `dereference` (see below).
 struct DereferenceImpl {
-  constexpr decltype(auto) operator()(auto&& x) const { return *AD_FWD(x); }
+  template <typename X>
+  constexpr decltype(auto) operator()(X&& x) const {
+    return *AD_FWD(x);
+  }
 };
 
 }  // namespace detail
@@ -133,7 +142,8 @@ static constexpr detail::DereferenceImpl dereference;
 // and does nothing. We also use the type `Noop`, hence it is defined here and
 // not in the `detail` namespace above.
 struct Noop {
-  void operator()(const auto&...) const {
+  template <typename... Args>
+  void operator()(const Args&...) const {
     // This function deliberately does nothing (static analysis expects a
     // comment here).
   }

--- a/src/util/TransparentFunctors.h
+++ b/src/util/TransparentFunctors.h
@@ -1,8 +1,6 @@
 // Copyright 2022 - 2024, University of Freiburg
 // Chair of Algorithms and Data Structures
 // Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_UTIL_TRANSPARENTFUNCTORS_H
 #define QLEVER_SRC_UTIL_TRANSPARENTFUNCTORS_H

--- a/src/util/VisitMixin.h
+++ b/src/util/VisitMixin.h
@@ -1,6 +1,8 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_VISITMIXIN_H
 #define QLEVER_VISITMIXIN_H
@@ -21,12 +23,14 @@ template <typename Derived, typename BaseVariant>
 class VisitMixin {
  public:
   // TODO<C++23> use the `deducing this` feature.
-  decltype(auto) visit(auto&& f) {
+  template <typename F>
+  decltype(auto) visit(F&& f) {
     return std::visit(AD_FWD(f),
                       static_cast<BaseVariant&>(static_cast<Derived&>(*this)));
   }
 
-  decltype(auto) visit(auto&& f) const {
+  template <typename F>
+  decltype(auto) visit(F&& f) const {
     return std::visit(AD_FWD(f), static_cast<const BaseVariant&>(
                                      static_cast<const Derived&>(*this)));
   }

--- a/src/util/VisitMixin.h
+++ b/src/util/VisitMixin.h
@@ -1,8 +1,6 @@
 // Copyright 2022, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Julian Mundhahs (mundhahj@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_VISITMIXIN_H
 #define QLEVER_VISITMIXIN_H

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/AddCombinedRowToTableTest.cpp
+++ b/test/AddCombinedRowToTableTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -10,7 +12,8 @@
 namespace {
 static constexpr auto U = Id::makeUndefined();
 
-void testWithAllBuffersizes(const auto& testFunction) {
+template <typename F>
+void testWithAllBuffersizes(const F& testFunction) {
   for (auto bufferSize : ql::views::iota(0, 10)) {
     testFunction(bufferSize);
   }

--- a/test/ComparisonWithNanTest.cpp
+++ b/test/ComparisonWithNanTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/ComparisonWithNanTest.cpp
+++ b/test/ComparisonWithNanTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -36,7 +38,8 @@ TEST(ComparisonWithNan, Sorting) {
 
 // Test several invariants of the relations `<, <=, ==, !=, >, >=` for two
 // arbitrary inputs `a, b`.
-void testInvariants(auto a, auto b) {
+template <typename T1, typename T2>
+void testInvariants(T1 a, T2 b) {
   // `==` and `!=` are symmetric.
   ASSERT_EQ(eq(a, b), eq(b, a));
   ASSERT_EQ(ne(a, b), ne(b, a));
@@ -50,7 +53,8 @@ void testInvariants(auto a, auto b) {
 }
 
 // Run exhaustive tests for numbers `a, b` where `a < b`.
-void testLess(auto a, auto b) {
+template <typename T1, typename T2>
+void testLess(T1 a, T2 b) {
   ASSERT_TRUE(lt(a, b));
   ASSERT_TRUE(le(a, b));
   ASSERT_FALSE(eq(a, b));
@@ -58,7 +62,8 @@ void testLess(auto a, auto b) {
 }
 
 // Run exhaustive tests for numbers `a, b` where `a == b`.
-void testEqual(auto a, auto b) {
+template <typename T1, typename T2>
+void testEqual(T1 a, T2 b) {
   ASSERT_FALSE(lt(a, b));
   ASSERT_TRUE(le(a, b));
   ASSERT_TRUE(eq(a, b));

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -102,10 +104,11 @@ auto addGraphColumnIfNecessary(std::vector<RelationInput>& inputs) {
 // Note: This function can't be declared in the anonymous namespace, because it
 // has to be a `friend` of the `CompressedRelationWriter` class. We therefore
 // give it a rather long name.
+template <typename T>
 std::pair<std::vector<CompressedBlockMetadata>,
           std::vector<CompressedRelationMetadata>>
 compressedRelationTestWriteCompressedRelations(
-    auto inputs, std::string filename, ad_utility::MemorySize blocksize) {
+    T inputs, std::string filename, ad_utility::MemorySize blocksize) {
   // First check the invariants of the `inputs`. They must be sorted by the
   // `col0_` and for each of the `inputs` the `col1And2_` must also be sorted.
   AD_CONTRACT_CHECK(ql::ranges::is_sorted(

--- a/test/ConfigManagerTest.cpp
+++ b/test/ConfigManagerTest.cpp
@@ -1144,8 +1144,8 @@ struct CallGivenLambdaWithAllCombinationsOfTypes {
     }
   };
 
-  template <size_t NumTemplateParameter, typename... Ts>
-  void operator()(auto&& func) const {
+  template <size_t NumTemplateParameter, typename... Ts, typename F>
+  void operator()(F&& func) const {
     if constexpr (NumTemplateParameter == 0) {
       func.template operator()<Ts...>();
     } else {
@@ -1631,8 +1631,9 @@ ConstConfigOptionProxy...)`. With `variant` being for the invariant of
 well as adding, of a new validator function.
 @param l For better error messages, when the tests fail.
 */
+template <typename F>
 void doValidatorTest(
-    auto addValidatorFunction,
+    F addValidatorFunction,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorTest")};
@@ -1879,8 +1880,9 @@ signature should look like this: `void func(ConfigManager& m,
 ConstConfigOptionProxy... validatorArguments)`.
 @param l For better error messages, when the tests fail.
 */
+template <typename F>
 void doValidatorExceptionTest(
-    auto addAlwaysValidValidatorFunction,
+    F addAlwaysValidValidatorFunction,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorExceptionTest")};
@@ -1918,8 +1920,9 @@ this: `void func(Validator validatorFunction, std::string_view
 validatorExceptionMessage, ConfigManager& m, ConstConfigOptionProxy...)`.
 @param l For better error messages, when the tests fail.
 */
+template <typename F>
 void doAddOptionValidatorTest(
-    auto addNonExceptionValidatorFunction,
+    F addNonExceptionValidatorFunction,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doAddOptionValidatorTest")};
@@ -2091,8 +2094,9 @@ signature should look like this: `void func(ConfigManager& m,
 ConstConfigOptionProxy... validatorArguments)`.
 @param l For better error messages, when the tests fail.
 */
+template <typename F>
 void doAddOptionValidatorExceptionTest(
-    auto addAlwaysValidValidatorFunction,
+    F addAlwaysValidValidatorFunction,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doValidatorExceptionTest")};

--- a/test/ConstexprUtilsTest.cpp
+++ b/test/ConstexprUtilsTest.cpp
@@ -231,8 +231,9 @@ auto typeToStringFactoryWithTI(std::vector<std::string>* typeToStringVector) {
 parameter pack and a lambda function argument, which it passes to a
 `constExprForEachType` function in the correct form.
 */
+template <typename F>
 void testConstExprForEachNormalCall(
-    const auto& callToForEachWrapper, auto callToTypeToStringFactory,
+    const F& callToForEachWrapper, auto callToTypeToStringFactory,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "testConstExprForEachNormalCall")};
@@ -255,8 +256,8 @@ void testConstExprForEachNormalCall(
 }
 
 struct TestForEachTypeInParameterPack {
-  template <typename... Ts>
-  void operator()(const auto& func) const {
+  template <typename... Ts, typename F>
+  void operator()(const F& func) const {
     forEachTypeInParameterPack<Ts...>(func);
   }
 };
@@ -274,8 +275,8 @@ TEST(ConstexprUtils, ForEachTypeInParameterPack) {
 }
 
 struct TestForEachTypeInParameterPackWithTI {
-  template <typename... Ts>
-  void operator()(const auto& func) const {
+  template <typename... Ts, typename F>
+  void operator()(const F& func) const {
     forEachTypeInParameterPackWithTI<Ts...>(func);
   }
 };
@@ -293,15 +294,15 @@ TEST(ConstexprUtils, ForEachTypeInParameterPackWithTI) {
 }
 
 struct TestForEachTypeInTemplateTypeOfVariant {
-  template <typename... Ts>
-  void operator()(const auto& func) const {
+  template <typename... Ts, typename F>
+  void operator()(const F& func) const {
     forEachTypeInTemplateType<std::variant<Ts...>>(func);
   }
 };
 
 struct TestForEachTypeInTemplateTypeOfTuple {
-  template <typename... Ts>
-  void operator()(const auto& func) const {
+  template <typename... Ts, typename F>
+  void operator()(const F& func) const {
     forEachTypeInTemplateType<std::tuple<Ts...>>(func);
   }
 };
@@ -317,16 +318,16 @@ TEST(ConstexprUtils, forEachTypeInTemplateType) {
 }
 
 struct TestForEachTypeInTemplateTypeWithTIOfVariant {
-  template <typename... Ts>
-  void operator()(const auto& func) const {
+  template <typename... Ts, typename F>
+  void operator()(const F& func) const {
     using use_type_identity::ti;
     forEachTypeInTemplateTypeWithTI(ti<std::variant<Ts...>>, func);
   }
 };
 
 struct TestForEachTypeInTemplateTypeWithTIOfTuple {
-  template <typename... Ts>
-  void operator()(const auto& func) const {
+  template <typename... Ts, typename F>
+  void operator()(const F& func) const {
     using use_type_identity::ti;
     forEachTypeInTemplateTypeWithTI(ti<std::tuple<Ts...>>, func);
   }

--- a/test/CtreHelpersTest.cpp
+++ b/test/CtreHelpersTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -8,7 +10,8 @@
 
 // Test that two `ctll::fixed_string`s are equal. This function is necessary
 // because `ctll::fixed_string` is not compatible with `GTest/GMock` directly.
-static void testEqual(auto s1, auto s2) {
+template <typename T>
+static void testEqual(T s1, T s2) {
   ASSERT_EQ(s1.size(), s2.size());
   for (size_t i = 0; i < s1.size(); ++i) {
     ASSERT_EQ(s1[i], s2[i]);

--- a/test/CtreHelpersTest.cpp
+++ b/test/CtreHelpersTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/DateYearDurationTest.cpp
+++ b/test/DateYearDurationTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -277,10 +279,10 @@ namespace {
 // stores a `Date` with the given xsd `type` and the given `year, month, ... ,
 // timeZone`. Also test that the result of this parsing, when converted back to
 // a string, yields `input` again.
-auto testDatetimeImpl(auto parseFunction, std::string_view input,
-                      const char* type, int year, int month, int day, int hour,
-                      int minute = 0, double second = 0.0,
-                      Date::TimeZone timeZone = 0) {
+template <typename F>
+auto testDatetimeImpl(F parseFunction, std::string_view input, const char* type,
+                      int year, int month, int day, int hour, int minute = 0,
+                      double second = 0.0, Date::TimeZone timeZone = 0) {
   ASSERT_NO_THROW(std::invoke(parseFunction, input));
   DateYearOrDuration dateLarge = std::invoke(parseFunction, input);
   EXPECT_TRUE(dateLarge.isDate());
@@ -394,7 +396,8 @@ namespace {
 // stores a large year with the given xsd `type` and the given `year. Also test
 // that the result of this parsing, when converted back to a string, yields
 // `input` again.
-auto testLargeYearImpl(auto parseFunction, std::string_view input,
+template <typename F>
+auto testLargeYearImpl(F parseFunction, std::string_view input,
                        const char* type, DateYearOrDuration::Type typeEnum,
                        int64_t year,
                        std::optional<std::string> actualOutput = std::nullopt) {

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -3,8 +3,6 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Robin Textor-Falconi <robintf@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gmock/gmock.h>
 

--- a/test/ExportQueryExecutionTreesTest.cpp
+++ b/test/ExportQueryExecutionTreesTest.cpp
@@ -3,6 +3,8 @@
 // Authors: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 //          Robin Textor-Falconi <robintf@cs.uni-freiburg.de>
 //          Hannah Bast <bast@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gmock/gmock.h>
 
@@ -312,7 +314,8 @@ std::vector<IdTable> convertToVector(
 }
 
 // match the contents of a `vector<IdTable>` to the given `tables`.
-auto matchesIdTables(const auto&... tables) {
+template <typename... Tables>
+auto matchesIdTables(const Tables&... tables) {
   return ElementsAre(matchesIdTable(tables)...);
 }
 

--- a/test/FindUndefRangesTest.cpp
+++ b/test/FindUndefRangesTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "./util/AllocatorTestHelpers.h"
 #include "./util/GTestHelpers.h"
@@ -25,7 +27,8 @@ using Arr = std::array<Id, I>;
 // converts a list of iterators that are yielded by the `generator` to indices
 // in the `range` by subtracting `range.begin()`. Requires that the `generator`
 // yields iterators that point into the `range`.
-std::vector<int64_t> toPositions(auto generator, const auto& range) {
+template <typename G, typename R>
+std::vector<int64_t> toPositions(G generator, const R& range) {
   std::vector<int64_t> foundPositions;
   for (auto it : generator) {
     foundPositions.push_back(it - range.begin());

--- a/test/FindUndefRangesTest.cpp
+++ b/test/FindUndefRangesTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2023, University of Freiburg,
 //                  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include "./util/AllocatorTestHelpers.h"
 #include "./util/GTestHelpers.h"

--- a/test/IdTableTest.cpp
+++ b/test/IdTableTest.cpp
@@ -229,8 +229,8 @@ TEST(IdTable, rowIterators) {
 // the second one (if present) is a `std::vector` with `NumIdTables` entries
 // that represent the additional arguments that are needed to instantiate an
 // `IdTable` (e.g. an allocator or a `BufferedVector`).
-template <size_t NumIdTables>
-void runTestForDifferentTypes(auto testCase, std::string testCaseName) {
+template <size_t NumIdTables, typename T>
+void runTestForDifferentTypes(T testCase, std::string testCaseName) {
   using Buffer = ad_utility::BufferedVector<Id>;
   using BufferedTable = columnBasedIdTable::IdTable<Id, 0, Buffer>;
   using IntTable = columnBasedIdTable::IdTable<int, 0>;

--- a/test/NBitIntegerTest.cpp
+++ b/test/NBitIntegerTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -185,7 +187,8 @@ auto testNumericNearLimits = []<size_t N>() {
   testBinaryFunctionNearLimits.operator()<N>(testNumeric);
 };
 
-void testAllN(auto function, auto... args) {
+template <typename F, typename... Args>
+void testAllN(F function, Args... args) {
   // Call function<N>(args) for all N in 1..64.
   // Note that the `(std::make_index_sequence...)` is the argument to the
   // unnamed lambda (immediately invoked lambda). Clang format wants the

--- a/test/NBitIntegerTest.cpp
+++ b/test/NBitIntegerTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_TEST_QUERYPLANNERTESTHELPERS_H
 #define QLEVER_TEST_QUERYPLANNERTESTHELPERS_H
@@ -65,8 +67,8 @@ inline QetMatcher RootOperationBase(Matcher<const Operation&> matcher) {
 /// Returns a matcher that checks that a given `QueryExecutionTree`'s
 /// `rootOperation` can by dynamically cast to `OperationType`, and that
 /// `matcher` matches the result of this cast.
-template <typename OperationType>
-QetMatcher RootOperation(auto matcher) {
+template <typename OperationType, typename M>
+QetMatcher RootOperation(M matcher) {
   return RootOperationBase(WhenDynamicCastTo<const OperationType&>(matcher));
 }
 

--- a/test/QueryPlannerTestHelpers.h
+++ b/test/QueryPlannerTestHelpers.h
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_TEST_QUERYPLANNERTESTHELPERS_H
 #define QLEVER_TEST_QUERYPLANNERTESTHELPERS_H

--- a/test/RelationalExpressionTest.cpp
+++ b/test/RelationalExpressionTest.cpp
@@ -446,8 +446,9 @@ void testLessThanGreaterThanEqualMultipleValuesHelper(
 // converted to a ValueID before the call. `rightValue` "" both values ""
 // Requires that both `leftValue` and `rightValue` are either numeric constants
 // or numeric vectors, and that at least one of them is a vector.
+template <typename T1, typename T2>
 void testLessThanGreaterThanEqualMultipleValues(
-    auto leftValue, auto rightValue,
+    T1 leftValue, T2 rightValue,
     source_location l = source_location::current()) {
   auto trace = generateLocationTrace(
       l, "testLessThanGreaterThanEqualMultipleValues was called here");
@@ -637,8 +638,9 @@ TEST(RelationalExpression, StringVectorAndStringVector) {
   // is actually supported.
 }
 
-void testInExpressionVector(auto leftValue, auto rightValue, auto& ctx,
-                            const auto& expected) {
+template <typename T1, typename T2, typename Ctx, typename E>
+void testInExpressionVector(T1 leftValue, T2 rightValue, Ctx& ctx,
+                            const E& expected) {
   auto expression =
       makeInExpression(liftToValueId(leftValue), liftToValueId(rightValue));
   auto check = [&]() {
@@ -662,8 +664,8 @@ void testInExpressionVector(auto leftValue, auto rightValue, auto& ctx,
 // Assert that the expression `leftValue Comparator rightValue`, when evaluated
 // on the `TestContext` (see above), yields the `expected` result.
 
-template <Comparison Comp>
-void testWithExplicitIdResult(auto leftValue, auto rightValue,
+template <Comparison Comp, typename T1, typename T2>
+void testWithExplicitIdResult(T1 leftValue, T2 rightValue,
                               std::vector<Id> expected,
                               source_location l = source_location::current()) {
   static TestContext ctx;
@@ -679,8 +681,8 @@ void testWithExplicitIdResult(auto leftValue, auto rightValue,
   }
 }
 
-template <Comparison Comp>
-void testWithExplicitResult(auto leftValue, auto rightValue,
+template <Comparison Comp, typename T1, typename T2>
+void testWithExplicitResult(T1 leftValue, T2 rightValue,
                             std::vector<bool> expectedAsBool,
                             source_location l = source_location::current()) {
   auto t = generateLocationTrace(l);
@@ -783,9 +785,9 @@ TEST(RelationalExpression, VariableAndVariable) {
 // yields the `expected` result. The type of `expected`, `SetOfIntervals`
 // indicates that the expression was evaluated using binary search on the sorted
 // table.
-template <Comparison Comp>
+template <Comparison Comp, typename T>
 void testSortedVariableAndConstant(
-    Variable leftValue, auto rightValue, ad_utility::SetOfIntervals expected,
+    Variable leftValue, T rightValue, ad_utility::SetOfIntervals expected,
     source_location l = source_location::current()) {
   auto trace = generateLocationTrace(
       l, "test between sorted variable and constant was called here");

--- a/test/ResultTableColumnOperationsTest.cpp
+++ b/test/ResultTableColumnOperationsTest.cpp
@@ -95,8 +95,9 @@ for the function, that you want to test. Must have the signature `ResultTable*
 ColumnNumWithType<ColumnInputTypeOne> inputColumnOne, const
 ColumnNumWithType<ColumnInputTypeTwo> inputColumnTwo`.
 */
+template <typename F>
 static void generalExceptionTestTwoInputColumns(
-    const auto& callTransform,
+    const F& callTransform,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "generalExceptionTestTwoInputColumns")};
@@ -172,8 +173,9 @@ for the function, that you want to test. Must have the signature `ResultTable*
 ,const ColumnNumWithType<ColumnReturnType>& columnToPutResultIn, const
 ColumnNumWithType<ColumnInputTypes>&... inputColumns`.
 */
+template <typename F>
 static void generalExceptionTestUnlimitedInputColumns(
-    const auto& callTransform,
+    const F& callTransform,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{

--- a/test/SparqlAntlrParserTestHelpers.h
+++ b/test/SparqlAntlrParserTestHelpers.h
@@ -136,8 +136,9 @@ inline std::ostream& operator<<(std::ostream& out,
  * @param resultOfParseAndText Parsing result
  * @param matcher Matcher that must be fulfilled
  */
+template <typename Result, typename Matcher>
 void expectCompleteParse(
-    const auto& resultOfParseAndText, auto&& matcher,
+    const Result& resultOfParseAndText, Matcher&& matcher,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   auto trace = generateLocationTrace(l);
   EXPECT_THAT(resultOfParseAndText.resultOfParse_, matcher);
@@ -154,8 +155,9 @@ void expectCompleteParse(
  * @param matcher Matcher that must be fulfilled
  * @param rest Input that is not consumed
  */
+template <typename Result, typename Matcher>
 void expectIncompleteParse(
-    const auto& resultOfParseAndText, const string& rest, auto&& matcher,
+    const Result& resultOfParseAndText, const string& rest, Matcher&& matcher,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   auto trace = generateLocationTrace(l);
   EXPECT_THAT(resultOfParseAndText.resultOfParse_, matcher);
@@ -171,9 +173,9 @@ namespace p = parsedQuery;
 // Recursively unwrap a std::variant object, or return a pointer
 // to the argument directly if it is already unwrapped.
 
-template <typename Current, typename... Others>
+template <typename Current, typename... Others, typename T>
 constexpr const ad_utility::Last<Current, Others...>* unwrapVariant(
-    const auto& arg) {
+    const T& arg) {
   if constexpr (sizeof...(Others) > 0) {
     if constexpr (ad_utility::isSimilar<decltype(arg), Current>) {
       if (const auto ptr = std::get_if<ad_utility::First<Others...>>(&arg)) {
@@ -1068,8 +1070,8 @@ inline auto variableExpressionMatcher = [](const ::Variable& variable) {
 // Return a matcher that matches a `SparqlExpression::Ptr`that stores an
 // `Expression` (template argument), the children of which match the
 // `childrenMatchers`.
-template <typename Expression>
-auto matchPtrWithChildren(auto&&... childrenMatchers)
+template <typename Expression, typename... ChildrenMatchers>
+auto matchPtrWithChildren(ChildrenMatchers&&... childrenMatchers)
     -> Matcher<const SparqlExpression::Ptr&> {
   return matchPtr<Expression>(
       AD_PROPERTY(SparqlExpression, childrenForTesting,
@@ -1126,7 +1128,8 @@ auto matchNary(auto makeFunction,
   return matchNaryWithChildrenMatchers(makeFunction,
                                        variableExpressionMatcher(variables)...);
 }
-auto matchUnary(auto makeFunction) -> Matcher<const SparqlExpression::Ptr&> {
+template <typename F>
+auto matchUnary(F makeFunction) -> Matcher<const SparqlExpression::Ptr&> {
   return matchNary(makeFunction, ::Variable{"?x"});
 }
 

--- a/test/ThreadSafeQueueTest.cpp
+++ b/test/ThreadSafeQueueTest.cpp
@@ -57,7 +57,8 @@ constexpr size_t numValues = 200;
 // Run the `test` function with a `ThreadSafeQueue` and an
 // `OrderedThreadSafeQueue`. Both queues have a size of `queueSize` and `size_t`
 // as their value type.
-void runWithBothQueueTypes(const auto& testFunction) {
+template <typename F>
+void runWithBothQueueTypes(const F& testFunction) {
   testFunction(ThreadSafeQueue<size_t>{queueSize});
   testFunction(OrderedThreadSafeQueue<size_t>{queueSize});
 }

--- a/test/TypeTraitsTest.cpp
+++ b/test/TypeTraitsTest.cpp
@@ -28,8 +28,8 @@ TEST(TypeTraits, IsSimilar) {
 Call the given lambda with explicit types: `std::decay_t<T>`,`const
 std::decay_t<T>`,`std::decay_t<T>&`,`const std::decay_t<T>&`.
 */
-template <typename T>
-constexpr void callLambdaWithAllVariationsOfType(const auto& lambda) {
+template <typename T, typename F>
+constexpr void callLambdaWithAllVariationsOfType(const F& lambda) {
   using decayedT = std::decay_t<T>;
   lambda(ti<decayedT>);
   lambda(ti<const decayedT>);

--- a/test/ValidatorTest.cpp
+++ b/test/ValidatorTest.cpp
@@ -258,8 +258,9 @@ look like this: `void func(std::string errorMessage, std::string descriptor,
 auto translationFunction, std::same_as<ConstConfigOptionProxy<bool>> auto...
 args)`.
 */
+template <typename F>
 void doConstructorTest(
-    auto generateValidatorManager,
+    F generateValidatorManager,
     ad_utility::source_location l = ad_utility::source_location::current()) {
   // For generating better messages, when failing a test.
   auto trace{generateLocationTrace(l, "doConstructorTest")};

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -104,8 +106,10 @@ auto getComparisonFunctor() {
 // (like `std::less` on the values contained in `a` and `b`
 // (`isMatchingDatatype(a) and `isMatchingDatatype(b)` both are true when
 // `applyComparator` is called.
-auto testGetRangesForId(auto begin, auto end, ValueId id,
-                        auto isMatchingDatatype, auto applyComparator,
+template <typename It, typename IsMatchingDatatype, typename ApplyComparator>
+auto testGetRangesForId(It begin, It end, ValueId id,
+                        IsMatchingDatatype isMatchingDatatype,
+                        ApplyComparator applyComparator,
                         source_location l = source_location::current()) {
   auto trage = generateLocationTrace(l);
   // Perform the testing for a single `Comparison`
@@ -214,8 +218,9 @@ TEST_F(ValueIdComparators, Undefined) {
 
 // Similar to `testGetRanges` (see above) but tests the comparison to a range of
 // `ValueId`s that are considered equal.
-auto testGetRangesForEqualIds(auto begin, auto end, ValueId idBegin,
-                              ValueId idEnd, auto isMatchingDatatype) {
+template <typename It, typename IsMatchingDatatype>
+auto testGetRangesForEqualIds(It begin, It end, ValueId idBegin, ValueId idEnd,
+                              IsMatchingDatatype isMatchingDatatype) {
   // Perform the testing for a single `Comparison`
   auto testImpl = [&]<Comparison comparison>() {
     if (comparison == Comparison::NE &&

--- a/test/ValueIdComparatorsTest.cpp
+++ b/test/ValueIdComparatorsTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/test/WebSocketSessionTest.cpp
+++ b/test/WebSocketSessionTest.cpp
@@ -1,6 +1,8 @@
 //   Copyright 2023, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gmock/gmock.h>
 
@@ -92,7 +94,8 @@ struct WebSocketTestContainer {
   tcp::socket client_;
   QueryHub& queryHub() { return *queryHub_; }
 
-  net::awaitable<void> serverLogic(auto&& completionToken) {
+  template <typename T>
+  net::awaitable<void> serverLogic(T&& completionToken) {
     boost::beast::tcp_stream stream{std::move(server_)};
     boost::beast::flat_buffer buffer;
     http::request<http::string_body> request;

--- a/test/WebSocketSessionTest.cpp
+++ b/test/WebSocketSessionTest.cpp
@@ -1,8 +1,6 @@
 //   Copyright 2023, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gmock/gmock.h>
 

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -1,8 +1,6 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/engine/GroupByHashMapOptimizationTest.cpp
+++ b/test/engine/GroupByHashMapOptimizationTest.cpp
@@ -1,6 +1,8 @@
 //   Copyright 2024, University of Freiburg,
 //   Chair of Algorithms and Data Structures.
 //   Author: Robin Textor-Falconi <textorr@informatik.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -30,7 +32,8 @@ class GroupByHashMapOptimizationTest : public ::testing::Test {
 
   Id calculate(const auto& data) { return data.calculateResult(&localVocab_); }
 
-  auto makeCalcAndAddValue(auto& data) {
+  template <typename T>
+  auto makeCalcAndAddValue(T& data) {
     auto calc = [this, &data]() { return calculate(data); };
     auto addValue = [this, &data](auto&& x) {
       data.addValue(AD_FWD(x), &context_);

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 
@@ -25,7 +27,8 @@ struct DummyDecoder {
     return result;
   }
   // This class has no state, but it still needs to be serialized.
-  friend std::true_type allowTrivialSerialization(DummyDecoder, auto);
+  template <typename T>
+  friend std::true_type allowTrivialSerialization(DummyDecoder, T);
 };
 
 // A wrapper for the stateless dummy compression.

--- a/test/index/vocabulary/CompressedVocabularyTest.cpp
+++ b/test/index/vocabulary/CompressedVocabularyTest.cpp
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #include <gtest/gtest.h>
 

--- a/test/index/vocabulary/VocabularyTestHelpers.h
+++ b/test/index/vocabulary/VocabularyTestHelpers.h
@@ -1,8 +1,6 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_VOCABULARYTESTHELPERS_H
 #define QLEVER_VOCABULARYTESTHELPERS_H

--- a/test/index/vocabulary/VocabularyTestHelpers.h
+++ b/test/index/vocabulary/VocabularyTestHelpers.h
@@ -1,6 +1,8 @@
 //  Copyright 2022, University of Freiburg,
 //  Chair of Algorithms and Data Structures.
 //  Author: Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
+//
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_VOCABULARYTESTHELPERS_H
 #define QLEVER_VOCABULARYTESTHELPERS_H
@@ -63,9 +65,12 @@ constexpr auto matchWordAndIndex =
  * @param ids Must have the same size as `words` The tests expect that
  * `vocab[ids[i]] == words[i]` for all i.
  */
-inline void testUpperAndLowerBound(const auto& vocab, auto makeWordLarger,
-                                   auto makeWordSmaller, auto comparator,
-                                   const auto& words,
+template <typename Vocab, typename MakeLarger, typename MakeSmaller,
+          typename Comparator, typename Words>
+inline void testUpperAndLowerBound(const Vocab& vocab,
+                                   MakeLarger makeWordLarger,
+                                   MakeSmaller makeWordSmaller,
+                                   Comparator comparator, const Words& words,
                                    std::vector<uint64_t> ids) {
   ASSERT_FALSE(words.empty());
   ASSERT_EQ(vocab.size(), words.size());
@@ -121,9 +126,13 @@ inline void testUpperAndLowerBound(const auto& vocab, auto makeWordLarger,
  *        `upper_bound` and `lower_bound` functions.
  * @param words The vocabulary is expected to have the same contents as `words`.
  */
-void testUpperAndLowerBoundContiguousIDs(const auto& vocab, auto makeWordLarger,
-                                         auto makeWordSmaller, auto comparator,
-                                         const auto& words) {
+template <typename Vocab, typename MakeLarger, typename MakeSmaller,
+          typename Comparator, typename Words>
+void testUpperAndLowerBoundContiguousIDs(const Vocab& vocab,
+                                         MakeLarger makeWordLarger,
+                                         MakeSmaller makeWordSmaller,
+                                         Comparator comparator,
+                                         const Words& words) {
   std::vector<uint64_t> ids;
   for (size_t i = 0; i < words.size(); ++i) {
     ids.push_back(i);
@@ -135,9 +144,10 @@ void testUpperAndLowerBoundContiguousIDs(const auto& vocab, auto makeWordLarger,
 
 // Same as the previous function, but explicitly state, which IDs are expected
 // in the vocabulary.
-void testUpperAndLowerBoundWithStdLessFromWordsAndIds(auto vocabulary,
-                                                      const auto& words,
-                                                      const auto& ids) {
+template <typename Vocab, typename Words, typename Ids>
+void testUpperAndLowerBoundWithStdLessFromWordsAndIds(Vocab vocabulary,
+                                                      const Words& words,
+                                                      const Ids& ids) {
   auto comparator = std::less<>{};
   auto makeWordSmaller = [](std::string word) {
     word.back()--;
@@ -158,7 +168,8 @@ void testUpperAndLowerBoundWithStdLessFromWordsAndIds(auto vocabulary,
  * @param createVocabulary Function that takes a `std::vector<string>` and
  *           returns a vocabulary.
  */
-void testUpperAndLowerBoundWithStdLess(auto createVocabulary) {
+template <typename F>
+void testUpperAndLowerBoundWithStdLess(F createVocabulary) {
   const std::vector<std::string> words{"alpha", "beta",    "camma",
                                        "delta", "epsilon", "frikadelle"};
 
@@ -177,8 +188,9 @@ void testUpperAndLowerBoundWithStdLess(auto createVocabulary) {
  * @param createVocabulary Function that takes a `std::vector<string>` and
  *           returns a vocabulary.
  */
+template <typename Vocab, typename Words, typename Ids>
 void testUpperAndLowerBoundWithNumericComparatorFromWordsAndIds(
-    auto vocabulary, const auto& words, const auto& ids) {
+    Vocab vocabulary, const Words& words, const Ids& ids) {
   auto comparator = [](const auto& a, const auto& b) {
     return std::stoi(std::string{a}) < std::stoi(std::string{b});
   };
@@ -199,7 +211,8 @@ void testUpperAndLowerBoundWithNumericComparatorFromWordsAndIds(
  * @param createVocabulary Function that takes a `std::vector<string>` and
  *        returns a vocabulary.
  */
-void testUpperAndLowerBoundWithNumericComparator(auto createVocabulary) {
+template <typename F>
+void testUpperAndLowerBoundWithNumericComparator(F createVocabulary) {
   const std::vector<std::string> words{"4", "33", "222", "1111"};
   std::vector<uint64_t> ids;
   for (size_t i = 0; i < words.size(); ++i) {
@@ -212,8 +225,9 @@ void testUpperAndLowerBoundWithNumericComparator(auto createVocabulary) {
 
 // Check that the `operator[]` works as expected for an unordered vocabulary.
 // Checks that vocabulary[ids[i]] == words[i].
-auto testAccessOperatorFromWordsAndIds(auto vocabulary, const auto& words,
-                                       const auto& ids) {
+template <typename Vocab, typename Words, typename Ids>
+auto testAccessOperatorFromWordsAndIds(Vocab vocabulary, const Words& words,
+                                       const Ids& ids) {
   // Not in any particularly order.
   AD_CONTRACT_CHECK(words.size() == ids.size());
   ASSERT_EQ(words.size(), vocabulary.size());
@@ -223,7 +237,8 @@ auto testAccessOperatorFromWordsAndIds(auto vocabulary, const auto& words,
 }
 // Check that the `operator[]` works as expected for an unordered vocabulary,
 // created via `createVocabulary(std::vector<std::string>)`.
-auto testAccessOperatorForUnorderedVocabulary(auto createVocabulary) {
+template <typename F>
+auto testAccessOperatorForUnorderedVocabulary(F createVocabulary) {
   // Not in any particularly order.
   const std::vector<std::string> words{"alpha", "delta", "ALPHA", "beta", "42",
                                        "31",    "0a",    "a0",    "al"};
@@ -237,7 +252,8 @@ auto testAccessOperatorForUnorderedVocabulary(auto createVocabulary) {
 // Check that an empty vocabulary, created via
 // `createVocabulary(std::vector<std::string>{})`, works as expected with the
 // given comparator.
-auto testEmptyVocabularyWithComparator(auto createVocabulary, auto comparator) {
+template <typename F, typename C>
+auto testEmptyVocabularyWithComparator(F createVocabulary, C comparator) {
   auto vocab = createVocabulary(std::vector<std::string>{});
   ASSERT_EQ(0u, vocab.size());
   auto expected = WordAndIndex::end();
@@ -249,7 +265,8 @@ auto testEmptyVocabularyWithComparator(auto createVocabulary, auto comparator) {
 
 // Check that an empty vocabulary, created via
 // `createVocabulary(std::vector<std::string>{})` works as expected.
-auto testEmptyVocabulary(auto createVocabulary) {
+template <typename F>
+auto testEmptyVocabulary(F createVocabulary) {
   testEmptyVocabularyWithComparator(createVocabulary, std::less<>{});
   testEmptyVocabularyWithComparator(createVocabulary, std::greater<>{});
 }

--- a/test/util/TypeTraitsTestHelpers.h
+++ b/test/util/TypeTraitsTestHelpers.h
@@ -17,8 +17,8 @@ parameter type list with itself, as template parameters. For example: If given
 `Func<int, const int>`, `Func<const int, int>` and `Func<const int, const int>`.
 */
 // TODO Why not replace `Func` with `auto`?
-template <typename... Parameters>
-constexpr void passCartesianPorductToLambda(auto&& func) {
+template <typename... Parameters, typename Func>
+constexpr void passCartesianPorductToLambda(Func func) {
   ad_utility::forEachTypeInParameterPackWithTI<Parameters...>([&func](auto t1) {
     ad_utility::forEachTypeInParameterPackWithTI<Parameters...>(
         [&t1, &func](auto t2) { func(t1, t2); });
@@ -31,8 +31,8 @@ list as template parameter.
 For example: If given `<int, const int>`, then the function will be called as
 `func<int>` and `func<const int>`.
 */
-template <typename... Parameters>
-constexpr void passListOfTypesToLambda(auto&& func) {
+template <typename... Parameters, typename F>
+constexpr void passListOfTypesToLambda(F&& func) {
   ad_utility::forEachTypeInParameterPackWithTI<Parameters...>(func);
 }
 


### PR DESCRIPTION
This backport is simple, as we only have to find a new unique explicit name for the implicit type of the rewritten `auto` parameters. For example
```
void f (auto arg) {}
```
can be rewritten to 
```
template <typename Arg>
void f(Arg arg)
```