### PR TITLE
Make `<libspatialjoin>` aware of WKT geometries from `LocalVocab` 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         spatialjoin
         GIT_REPOSITORY https://github.com/ad-freiburg/spatialjoin
-        GIT_TAG e0937d46f0766819fbef1a03ce633af48af7979a
+        GIT_TAG c1e6e3dfa918fa1d6ed0a25210156dc914392e0f
 )
 # disable bzip2 and zlib support in spatialjoin, we don't need it
 add_definitions("-DSPATIALJOIN_NO_BZIP2=True")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         spatialjoin
         GIT_REPOSITORY https://github.com/ad-freiburg/spatialjoin
-        GIT_TAG 21be46ab71ecbc8400daa8c5a19f47853dea0ac8
+        GIT_TAG e0937d46f0766819fbef1a03ce633af48af7979a
 )
 # disable bzip2 and zlib support in spatialjoin, we don't need it
 add_definitions("-DSPATIALJOIN_NO_BZIP2=True")

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -38,8 +38,7 @@ SpatialJoinAlgorithms::SpatialJoinAlgorithms(
 // ____________________________________________________________________________
 util::geo::I32Box SpatialJoinAlgorithms::libspatialjoinParse(
     bool leftOrRightSide, const IdTable* idTable, ColumnIndex column,
-    std::shared_ptr<const Result> result, sj::Sweeper& sweeper,
-    size_t numThreads) const {
+    sj::Sweeper& sweeper, size_t numThreads) const {
   // Initialize the parser.
   sj::WKTParser parser(&sweeper, numThreads);
 
@@ -367,17 +366,15 @@ Result SpatialJoinAlgorithms::LibspatialjoinAlgorithm() {
   // inflated for `WITHIN_DIST` joins) and only add those geometries from the
   // larger table that intersect this bounding box.
   if (idTableLeft->size() < idTableRight->size()) {
-    auto box = libspatialjoinParse(false, idTableLeft, leftJoinCol, resultLeft,
-                                   sweeper, NUM_THREADS);
+    auto box = libspatialjoinParse(false, idTableLeft, leftJoinCol, sweeper,
+                                   NUM_THREADS);
     sweeper.setFilterBox(box);
-    libspatialjoinParse(true, idTableRight, rightJoinCol, resultRight, sweeper,
-                        NUM_THREADS);
+    libspatialjoinParse(true, idTableRight, rightJoinCol, sweeper, NUM_THREADS);
   } else {
-    auto box = libspatialjoinParse(true, idTableRight, rightJoinCol,
-                                   resultRight, sweeper, NUM_THREADS);
+    auto box = libspatialjoinParse(true, idTableRight, rightJoinCol, sweeper,
+                                   NUM_THREADS);
     sweeper.setFilterBox(box);
-    libspatialjoinParse(false, idTableLeft, leftJoinCol, resultLeft, sweeper,
-                        NUM_THREADS);
+    libspatialjoinParse(false, idTableLeft, leftJoinCol, sweeper, NUM_THREADS);
   }
 
   // Flush the geometry caches and the sweepline event list cache to disk and

--- a/src/engine/SpatialJoinAlgorithms.cpp
+++ b/src/engine/SpatialJoinAlgorithms.cpp
@@ -54,13 +54,11 @@ util::geo::I32Box SpatialJoinAlgorithms::libspatialjoinParse(
       parser.parsePoint(util::geo::DPoint(p.getLng(), p.getLat()), row,
                         leftOrRightSide);
     } else if (id.getDatatype() == Datatype::LocalVocabIndex) {
-      const auto& literalOrIri = result->localVocab()
-                                     .getWord(id.getLocalVocabIndex())
-                                     .asLiteralOrIri();
+      const auto& literalOrIri = *id.getLocalVocabIndex();
       if (literalOrIri.isLiteral()) {
-        const auto& wkt = std::string(
-            asStringViewUnsafe(literalOrIri.getLiteral().getContent()));
-        parser.parseWKT(wkt.c_str(), row, leftOrRightSide);
+        const auto& wkt =
+            asStringViewUnsafe(literalOrIri.getLiteral().getContent());
+        parser.parseWKT(wkt, row, leftOrRightSide);
       }
     }
   }

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -209,7 +209,6 @@ class SpatialJoinAlgorithms {
   util::geo::I32Box libspatialjoinParse(bool leftOrRightSide,
                                         const IdTable* idTable,
                                         ColumnIndex column,
-                                        std::shared_ptr<const Result> result,
                                         sj::Sweeper& sweeper,
                                         size_t numThreads) const;
 

--- a/src/engine/SpatialJoinAlgorithms.h
+++ b/src/engine/SpatialJoinAlgorithms.h
@@ -209,6 +209,7 @@ class SpatialJoinAlgorithms {
   util::geo::I32Box libspatialjoinParse(bool leftOrRightSide,
                                         const IdTable* idTable,
                                         ColumnIndex column,
+                                        std::shared_ptr<const Result> result,
                                         sj::Sweeper& sweeper,
                                         size_t numThreads) const;
 

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -27,10 +27,12 @@
 #include "engine/Join.h"
 #include "engine/QueryExecutionContext.h"
 #include "engine/QueryExecutionTree.h"
+#include "engine/QueryPlanner.h"
 #include "engine/SpatialJoin.h"
 #include "engine/VariableToColumnMap.h"
 #include "global/Constants.h"
 #include "gmock/gmock.h"
+#include "parser/SparqlParser.h"
 #include "parser/data/Variable.h"
 
 namespace {  // anonymous namespace to avoid linker problems
@@ -221,6 +223,42 @@ using VarColTestSuiteParam = std::tuple<bool, bool, bool, bool>;
 using V = Variable;
 using VarToColVec = std::vector<std::pair<V, ColumnIndexAndTypeInfo>>;
 
+// Helper function to create a spatial join from VALUEs
+std::shared_ptr<SpatialJoin> makeSpatialJoinFromValues(
+    QueryExecutionContext* qec, PayloadVariables pv = PayloadVariables::all(),
+    SpatialJoinAlgorithm alg = SPATIAL_JOIN_DEFAULT_ALGORITHM) {
+  const auto sharedHandle =
+      std::make_shared<ad_utility::CancellationHandle<>>();
+  // also include some garbage input geometries
+  auto pqLeft = SparqlParser::parseQuery(
+      "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nSELECT ?a {VALUES "
+      "(?a) {(\"POLYGON((8.529 47.375, 8.549 47.375, 8.549 47.395, 8.529 "
+      "47.395, 8.529 47.375))\"^^geo:wktLiteral) (\"garbage\") (5) (<>)}}");
+  auto pqRight = SparqlParser::parseQuery(
+      "PREFIX geo: <http://www.opengis.net/ont/geosparql#>\nSELECT ?b {VALUES "
+      "(?b) {(\"POINT(8.542 47.385)\"^^geo:wktLiteral)}}");
+  QueryPlanner qp{qec, sharedHandle};
+
+  auto leftChild =
+      std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pqLeft));
+  auto rightChild =
+      std::make_shared<QueryExecutionTree>(qp.createExecutionTree(pqRight));
+
+  std::shared_ptr<QueryExecutionTree> spatialJoinOperation =
+      ad_utility::makeExecutionTree<SpatialJoin>(
+          qec,
+          SpatialJoinConfiguration{MaxDistanceConfig{0}, Variable{"?a"},
+                                   Variable{"?b"}, std::nullopt, pv, alg,
+                                   SpatialJoinType::INTERSECTS},
+          std::nullopt, std::nullopt);
+  std::shared_ptr<Operation> op = spatialJoinOperation->getRootOperation();
+  SpatialJoin* spatialJoin = static_cast<SpatialJoin*>(op.get());
+  auto spJoin1 = spatialJoin->addChild(leftChild, Variable{"?a"});
+  spatialJoin = static_cast<SpatialJoin*>(spJoin1.get());
+  auto spJoin2 = spatialJoin->addChild(rightChild, Variable{"?b"});
+  return spJoin2;
+}
+
 class SpatialJoinVarColParamTest
     : public ::testing::TestWithParam<VarColTestSuiteParam> {
  public:
@@ -370,7 +408,7 @@ class SpatialJoinVarColParamTest
     }
   }
 
-  // TODO: comment (avoid redundancy with comment below).
+  // Test spatial join on contains
   void testGetResultWidthOrVariableToColumnMapSpatialJoinContains(
       VarColTestSuiteParam parameters) {
     auto [leftSideBigChild, rightSideBigChild, addLeftChildFirst,
@@ -606,6 +644,18 @@ TEST_P(SpatialJoinVarColParamTest, variableToColumnMapLibspatialjoin) {
 // have different sets of objects,
 TEST_P(SpatialJoinVarColParamTest, variableToColumnMapLibspatialjoinContains) {
   testGetResultWidthOrVariableToColumnMapSpatialJoinContains(GetParam());
+}
+
+// Test a spatial join with VALUES as both childs
+TEST(SpatialJoinVarColParamTest, testLibspatialjoinFromvalues) {
+  auto qec = buildNonSelfJoinDataset();
+
+  auto spJoin2 = makeSpatialJoinFromValues(
+      qec, PayloadVariables::all(), SpatialJoinAlgorithm::LIBSPATIALJOIN);
+  auto spatialJoin = static_cast<SpatialJoin*>(spJoin2.get());
+
+  auto resultTable = spatialJoin->computeResult(false);
+  ASSERT_EQ(resultTable.idTable().numRows(), 1);
 }
 
 TEST_P(SpatialJoinVarColParamTest, payloadVariables) {

--- a/test/engine/SpatialJoinTest.cpp
+++ b/test/engine/SpatialJoinTest.cpp
@@ -646,7 +646,7 @@ TEST_P(SpatialJoinVarColParamTest, variableToColumnMapLibspatialjoinContains) {
   testGetResultWidthOrVariableToColumnMapSpatialJoinContains(GetParam());
 }
 
-// Test a spatial join with VALUES as both childs
+// Test a spatial join with VALUES as both children
 TEST(SpatialJoinVarColParamTest, testLibspatialjoinFromvalues) {
   auto qec = buildNonSelfJoinDataset();
 


### PR DESCRIPTION
When doing spatial joins with `<libspatialjoin>`, the `LocalVocab`s of the two input tables were ignored so far. In particular, geometries that were not part of the original index were therefore ignored. This is now fixed. In particular, fixes #1939

On the side, drop `--ffast-math` from the compilation options of `libspatialjoin` to fix some warnings in the `fmt` library and `Geo.h`, in which `infinity` was still used