### PR TITLE
Make the computation of the empty path more memory-efficient

### DIFF
--- a/src/engine/Operation.cpp
+++ b/src/engine/Operation.cpp
@@ -629,6 +629,15 @@ uint64_t Operation::getSizeEstimate() {
 // _____________________________________________________________________________
 std::unique_ptr<Operation> Operation::clone() const {
   auto result = cloneImpl();
+
+  if (variableToColumnMap_ && externallyVisibleVariableToColumnMap_) {
+    // Make sure previously hidden variables remain hidden.
+    std::vector<Variable> visibleVariables;
+    ql::ranges::copy(getExternallyVisibleVariableColumns() | ql::views::keys,
+                     std::back_inserter(visibleVariables));
+    result->setSelectedVariablesForSubquery(visibleVariables);
+  }
+
   auto compareTypes = [this, &result]() {
     const auto& reference = *result;
     return typeid(*this) == typeid(reference);

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -443,7 +443,7 @@ template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
 void TransitivePathBase::copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
                                      IdTableStatic<OUTPUT_WIDTH>& outputTable,
                                      size_t inputRow, size_t outputRow,
-                                     size_t skipCol) const {
+                                     size_t skipCol) {
   size_t inCol = 0;
   size_t outCol = 2;
   AD_CORRECTNESS_CHECK(skipCol < inputTable.numColumns());

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -45,7 +45,8 @@ TransitivePathBase::TransitivePathBase(
   }
   if (minDist_ == 0 && lhs_.isUnboundVariable() && rhs_.isUnboundVariable()) {
     emptyPathBound_ = true;
-    lhs_.treeAndCol_.emplace(makeEmptyPathSide(qec, activeGraphs), 0);
+    lhs_.treeAndCol_.emplace(makeEmptyPathSide(qec, std::move(activeGraphs)),
+                             0);
   }
 
   lhs_.outputCol_ = 0;
@@ -54,7 +55,7 @@ TransitivePathBase::TransitivePathBase(
 
 // _____________________________________________________________________________
 std::shared_ptr<QueryExecutionTree> TransitivePathBase::makeEmptyPathSide(
-    QueryExecutionContext* qec, const Graphs& activeGraphs) {
+    QueryExecutionContext* qec, Graphs activeGraphs) {
   auto makeInternalVariable = [](std::string_view string) {
     return Variable{absl::StrCat("?internal_property_path_variable_", string)};
   };

--- a/src/engine/TransitivePathBase.cpp
+++ b/src/engine/TransitivePathBase.cpp
@@ -63,6 +63,8 @@ std::shared_ptr<QueryExecutionTree> TransitivePathBase::makeEmptyPathSide(
   auto x = makeInternalVariable("x");
   auto y = makeInternalVariable("y");
   auto z = makeInternalVariable("z");
+  // TODO<RobinTF> Ideally we could tell the `IndexScan` to not materialize ?y
+  // and ?z in the first place.
   // We don't need to materialize the extra variables y and z in the union.
   auto selectXVariable =
       [&x](std::shared_ptr<QueryExecutionTree> executionTree) {

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -248,6 +248,11 @@ class TransitivePathBase : public Operation {
                                           size_t targetSideCol, bool yieldOnce,
                                           size_t skipCol = 0) const;
 
+  // Return an execution tree that represents one side of an empty path. This is
+  // used as a starting point for evaluating the empty path.
+  static std::shared_ptr<QueryExecutionTree> makeEmptyPathSide(
+      QueryExecutionContext* qec, const Graphs& activeGraphs);
+
  public:
   size_t getCostEstimate() override;
 

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -219,9 +219,9 @@ class TransitivePathBase : public Operation {
 
   // Copy the columns from the input table to the output table
   template <size_t INPUT_WIDTH, size_t OUTPUT_WIDTH>
-  void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
-                   IdTableStatic<OUTPUT_WIDTH>& outputTable, size_t inputRow,
-                   size_t outputRow, size_t skipCol) const;
+  static void copyColumns(const IdTableView<INPUT_WIDTH>& inputTable,
+                          IdTableStatic<OUTPUT_WIDTH>& outputTable,
+                          size_t inputRow, size_t outputRow, size_t skipCol);
 
   // A small helper function: Insert the `value` to the set at `map[key]`.
   // As the sets all have an allocator with memory limit, this construction is a

--- a/src/engine/TransitivePathBase.h
+++ b/src/engine/TransitivePathBase.h
@@ -251,7 +251,7 @@ class TransitivePathBase : public Operation {
   // Return an execution tree that represents one side of an empty path. This is
   // used as a starting point for evaluating the empty path.
   static std::shared_ptr<QueryExecutionTree> makeEmptyPathSide(
-      QueryExecutionContext* qec, const Graphs& activeGraphs);
+      QueryExecutionContext* qec, Graphs activeGraphs);
 
  public:
   size_t getCostEstimate() override;


### PR DESCRIPTION
For queries that have to compute the empty path, QLever internally computes `SELECT DISTINCT ?x WHERE { { ?x ?p ?y } UNION { ?y ?p ?x } }`; see https://github.com/ad-freiburg/qlever/issues/1809 for a detailed explanation. So far, QLever computed all three variables `?x ?p ?y` of this internal `UNION`, but only `?x` is needed and used. With this change, only `?x` is computed, which reduces the memory footprint of this computation.

On the side, fix an issue in `Operation::clone()`, making sure that previously hidden variables remain hidden.