### PR TITLE
Add strong type `KeyOrder` for the key order of a permutation

### DIFF
--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -296,9 +296,10 @@ void IndexScan::determineMultiplicities() {
 std::array<const TripleComponent* const, 3> IndexScan::getPermutedTriple()
     const {
   std::array triple{&subject_, &predicate_, &object_};
-  auto permutation = Permutation::toKeyOrder(permutation_);
-  return {triple[permutation[0]], triple[permutation[1]],
-          triple[permutation[2]]};
+  auto [a, b, c, d] = Permutation::toKeyOrder(permutation_).keys();
+  // TODO<joka921> This place has to be changed once we have a graph
+  // permutation.
+  return {triple[a], triple[b], triple[c]};
 }
 
 // _____________________________________________________________________________

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -295,11 +295,11 @@ void IndexScan::determineMultiplicities() {
 // _____________________________________________________________________________
 std::array<const TripleComponent* const, 3> IndexScan::getPermutedTriple()
     const {
-  std::array triple{&subject_, &predicate_, &object_};
-  auto [a, b, c, d] = Permutation::toKeyOrder(permutation_).keys();
+  std::array<const TripleComponent* const, 3> triple{&subject_, &predicate_,
+                                                     &object_};
   // TODO<joka921> This place has to be changed once we have a graph
   // permutation.
-  return {triple[a], triple[b], triple[c]};
+  return Permutation::toKeyOrder(permutation_).permuteSPOOnly(triple);
 }
 
 // _____________________________________________________________________________

--- a/src/engine/IndexScan.cpp
+++ b/src/engine/IndexScan.cpp
@@ -297,9 +297,9 @@ std::array<const TripleComponent* const, 3> IndexScan::getPermutedTriple()
     const {
   std::array<const TripleComponent* const, 3> triple{&subject_, &predicate_,
                                                      &object_};
-  // TODO<joka921> This place has to be changed once we have a graph
-  // permutation.
-  return Permutation::toKeyOrder(permutation_).permuteSPOOnly(triple);
+  // TODO<joka921> This place has to be changed once we have a permutation
+  // that is primarily sorted by G (the graph id).
+  return Permutation::toKeyOrder(permutation_).permuteTriple(triple);
 }
 
 // _____________________________________________________________________________

--- a/src/global/IdTriple.h
+++ b/src/global/IdTriple.h
@@ -12,6 +12,7 @@
 
 #include "global/Id.h"
 #include "index/CompressedRelation.h"
+#include "index/KeyOrder.h"
 
 template <size_t N = 0>
 struct IdTriple {
@@ -52,9 +53,9 @@ struct IdTriple {
 
   // Permutes the ID of this triple according to the given permutation given by
   // its keyOrder.
-  IdTriple<N> permute(const std::array<size_t, 3>& keyOrder) const {
-    std::array<Id, NumCols> newIds{ids_[keyOrder[0]], ids_[keyOrder[1]],
-                                   ids_[keyOrder[2]], ids_[3]};
+  IdTriple<N> permute(const qlever::KeyOrder& keyOrder) const {
+    const auto& [a, b, c, d] = keyOrder.keys();
+    std::array<Id, NumCols> newIds{ids_[a], ids_[b], ids_[b], ids_[c]};
     if constexpr (N == 0) {
       return IdTriple<N>(newIds);
     } else {

--- a/src/global/IdTriple.h
+++ b/src/global/IdTriple.h
@@ -1,8 +1,8 @@
-// Copyright 2024, University of Freiburg
+// Copyright 2024 - 2025, University of Freiburg
 // Chair of Algorithms and Data Structures
-// Authors:
-//    2023 Hannah Bast <bast@cs.uni-freiburg.de>
-//    2024 Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+// Authors: Hannah Bast <bast@cs.uni-freiburg.de>
+//          Julian Mundhahs <mundhahj@tf.uni-freiburg.de>
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #ifndef QLEVER_SRC_GLOBAL_IDTRIPLE_H
 #define QLEVER_SRC_GLOBAL_IDTRIPLE_H
@@ -18,10 +18,14 @@
 template <size_t N = 0>
 struct IdTriple {
   // A triple has four components: subject, predicate, object, and graph.
+  //
+  // NOTE: This used to be `NumCols = 3` and at that time the `triple` was an
+  // appropriate name. Now it should rather be called `quad`.
   static constexpr size_t NumCols = 4;
 
-  // For the case of no payload we use an empty struct which is stored at the
-  // end of a tuple. That way it will consume no additional space in the struct.
+  // For a triple without payload, we use an empty struct as payload, which
+  // does not consume any additional space. That way, we can always iterate
+  // over the payload, even if it is empty.
   static constexpr size_t PayloadSize = N;
   using Payload = std::conditional_t<(N > 0), std::array<Id, N>,
                                      ql::ranges::empty_view<Id>>;
@@ -74,7 +78,7 @@ struct IdTriple {
   // Permutes the ID of this triple according to the given permutation given by
   // its keyOrder.
   IdTriple<N> permute(const qlever::KeyOrder& keyOrder) const {
-    return IdTriple{keyOrder.permute(ids()), payload()};
+    return IdTriple{keyOrder.permuteTuple(ids()), payload()};
   }
 
   CompressedBlockMetadata::PermutedTriple toPermutedTriple() const

--- a/src/global/IdTriple.h
+++ b/src/global/IdTriple.h
@@ -55,7 +55,7 @@ struct IdTriple {
   // its keyOrder.
   IdTriple<N> permute(const qlever::KeyOrder& keyOrder) const {
     const auto& [a, b, c, d] = keyOrder.keys();
-    std::array<Id, NumCols> newIds{ids_[a], ids_[b], ids_[b], ids_[c]};
+    std::array<Id, NumCols> newIds{ids_[a], ids_[b], ids_[c], ids_[d]};
     if constexpr (N == 0) {
       return IdTriple<N>(newIds);
     } else {

--- a/src/index/CompressedRelation.cpp
+++ b/src/index/CompressedRelation.cpp
@@ -1342,10 +1342,13 @@ auto CompressedRelationWriter::createPermutationPair(
     const std::string& basename, WriterAndCallback writerAndCallback1,
     WriterAndCallback writerAndCallback2,
     cppcoro::generator<IdTableStatic<0>> sortedTriples,
-    std::array<size_t, 3> permutation,
+    qlever::KeyOrder permutation,
     const std::vector<std::function<void(const IdTableStatic<0>&)>>&
         perBlockCallbacks) -> PermutationPairResult {
-  auto [c0, c1, c2] = permutation;
+  auto [c0, c1, c2, c3] = permutation.keys();
+  // This logic only works for permutations that have the graph as the fourth
+  // column.
+  AD_CORRECTNESS_CHECK(c3 == 3);
   size_t numDistinctCol0 = 0;
   auto& writer1 = writerAndCallback1.writer_;
   auto& writer2 = writerAndCallback2.writer_;

--- a/src/index/CompressedRelation.h
+++ b/src/index/CompressedRelation.h
@@ -11,6 +11,7 @@
 #include "backports/algorithm.h"
 #include "engine/idTable/IdTable.h"
 #include "global/Id.h"
+#include "index/KeyOrder.h"
 #include "index/ScanSpecification.h"
 #include "parser/data/LimitOffsetClause.h"
 #include "util/CancellationHandle.h"
@@ -290,7 +291,7 @@ class CompressedRelationWriter {
       const std::string& basename, WriterAndCallback writerAndCallback1,
       WriterAndCallback writerAndCallback2,
       cppcoro::generator<IdTableStatic<0>> sortedTriples,
-      std::array<size_t, 3> permutation,
+      qlever::KeyOrder permutation,
       const std::vector<std::function<void(const IdTableStatic<0>&)>>&
           perBlockCallbacks);
 

--- a/src/index/DeltaTriples.cpp
+++ b/src/index/DeltaTriples.cpp
@@ -141,8 +141,8 @@ void DeltaTriples::rewriteLocalVocabEntriesAndBlankNodes(Triples& triples) {
 
   // Convert all local vocab and blank node `Id`s in all `triples`.
   ql::ranges::for_each(triples, [&convertId](IdTriple<0>& triple) {
-    ql::ranges::for_each(triple.ids_, convertId);
-    ql::ranges::for_each(triple.payload_, convertId);
+    ql::ranges::for_each(triple.ids(), convertId);
+    ql::ranges::for_each(triple.payload(), convertId);
   });
 }
 
@@ -291,7 +291,7 @@ void DeltaTriples::writeToDisk() const {
     return map | ql::views::keys |
            ql::views::transform(
                [](const IdTriple<0>& triple) -> const std::array<Id, 4>& {
-                 return triple.ids_;
+                 return triple.ids();
                }) |
            ql::views::join;
   };
@@ -317,9 +317,7 @@ void DeltaTriples::readFromDisk() {
   AD_CORRECTNESS_CHECK(idRanges.size() == 2);
   auto toTriples = [](const std::vector<Id>& ids) {
     Triples triples;
-    static_assert(std::tuple_size_v<
-                      decltype(std::declval<Triples::value_type>().payload_)> ==
-                  0);
+    static_assert(Triples::value_type::PayloadSize == 0);
     constexpr size_t cols = Triples::value_type::NumCols;
     AD_CORRECTNESS_CHECK(ids.size() % cols == 0);
     triples.reserve(ids.size() / cols);

--- a/src/index/IndexImpl.Text.cpp
+++ b/src/index/IndexImpl.Text.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 - 2022, University of Freiburg,
+// Copyright 2015 - 2025, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de>
 //          Johannes Kalmbach <johannes.kalmbach@gmail.com>

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1572,14 +1572,11 @@ vector<float> IndexImpl::getMultiplicities(
     Permutation::Enum permutation) const {
   const auto& p = getPermutation(permutation);
   auto numTriples = static_cast<float>(this->numTriples().normal);
-  std::array<float, 3> m{numTriples / numDistinctSubjects().normal,
-                         numTriples / numDistinctPredicates().normal,
-                         numTriples / numDistinctObjects().normal};
-  auto [a, b, c, d] = p.keyOrder().keys();
-  // TODO<joka921> could we update this once we have the number of distinct
-  // graphs stored and therefore also a multiplicity for the graph column?
-  AD_CORRECTNESS_CHECK(d == ADDITIONAL_COLUMN_GRAPH_ID);
-  return {m[a], m[b], m[c]};
+  std::array m{numTriples / numDistinctSubjects().normal,
+               numTriples / numDistinctPredicates().normal,
+               numTriples / numDistinctObjects().normal};
+  auto permuted = p.keyOrder().permuteSPOOnly(m);
+  return {permuted.begin(), permuted.end()};
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -1,10 +1,7 @@
-// Copyright 2014, University of Freiburg,
-// Chair of Algorithms and Data Structures.
-// Authors:
-//   2014-2017 Björn Buchhold (buchhold@informatik.uni-freiburg.de)
-//   2018-     Johannes Kalmbach (kalmbach@informatik.uni-freiburg.de)
-//
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// Copyright 2014 - 2025, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Authors: Björn Buchhold <buchhold@cs.uni-freiburg.de> [2014-2017]
+//          Johannes Kalmbach <kalmbach@cs.uni-freiburg.de>
 
 #include "./IndexImpl.h"
 
@@ -1571,15 +1568,15 @@ vector<float> IndexImpl::getMultiplicities(
   return {1.0f, 1.0f};
 }
 
-// ___________________________________________________________________
+// _____________________________________________________________________________
 vector<float> IndexImpl::getMultiplicities(
     Permutation::Enum permutation) const {
   const auto& p = getPermutation(permutation);
   auto numTriples = static_cast<float>(this->numTriples().normal);
-  std::array m{numTriples / numDistinctSubjects().normal,
-               numTriples / numDistinctPredicates().normal,
-               numTriples / numDistinctObjects().normal};
-  auto permuted = p.keyOrder().permuteSPOOnly(m);
+  std::array multiplicities{numTriples / numDistinctSubjects().normal,
+                            numTriples / numDistinctPredicates().normal,
+                            numTriples / numDistinctObjects().normal};
+  auto permuted = p.keyOrder().permuteTriple(multiplicities);
   return {permuted.begin(), permuted.end()};
 }
 

--- a/src/index/IndexImpl.cpp
+++ b/src/index/IndexImpl.cpp
@@ -771,7 +771,7 @@ std::tuple<size_t, IndexImpl::IndexMetaDataMmapDispatcher::WriteType,
 IndexImpl::createPermutationPairImpl(size_t numColumns, const string& fileName1,
                                      const string& fileName2,
                                      auto&& sortedTriples,
-                                     std::array<size_t, 3> permutation,
+                                     Permutation::KeyOrder permutation,
                                      auto&&... perTripleCallbacks) {
   using MetaData = IndexMetaDataMmapDispatcher::WriteType;
   MetaData metaData1, metaData2;
@@ -1575,7 +1575,11 @@ vector<float> IndexImpl::getMultiplicities(
   std::array<float, 3> m{numTriples / numDistinctSubjects().normal,
                          numTriples / numDistinctPredicates().normal,
                          numTriples / numDistinctObjects().normal};
-  return {m[p.keyOrder()[0]], m[p.keyOrder()[1]], m[p.keyOrder()[2]]};
+  auto [a, b, c, d] = p.keyOrder().keys();
+  // TODO<joka921> could we update this once we have the number of distinct
+  // graphs stored and therefore also a multiplicity for the graph column?
+  AD_CORRECTNESS_CHECK(d == ADDITIONAL_COLUMN_GRAPH_ID);
+  return {m[a], m[b], m[c]};
 }
 
 // _____________________________________________________________________________

--- a/src/index/IndexImpl.h
+++ b/src/index/IndexImpl.h
@@ -570,7 +570,7 @@ class IndexImpl {
              IndexMetaDataMmapDispatcher::WriteType>
   createPermutationPairImpl(size_t numColumns, const string& fileName1,
                             const string& fileName2, auto&& sortedTriples,
-                            std::array<size_t, 3> permutation,
+                            Permutation::KeyOrder permutation,
                             auto&&... perTripleCallbacks);
 
   // _______________________________________________________________________

--- a/src/index/KeyOrder.h
+++ b/src/index/KeyOrder.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 
 #include "backports/algorithm.h"
 #include "util/Exception.h"
@@ -17,8 +18,9 @@ namespace qlever {
 // `1 0 2 3` represents the `PSOG` permutation.
 class KeyOrder {
  public:
+  using T = uint8_t;
   static constexpr size_t NumKeys = 4;
-  using Array = std::array<size_t, NumKeys>;
+  using Array = std::array<uint8_t, NumKeys>;
 
  private:
   Array keys_;
@@ -26,12 +28,28 @@ class KeyOrder {
  public:
   // Construct from four numbers. If `(a b c d)` is not a permutation of the
   // numbers `[0...4]`, then an `AD_CONTRACT_CHECK` will fail.
-  KeyOrder(size_t a, size_t b, size_t c, size_t d) : keys_{a, b, c, d} {
-    validate();
-  }
+  KeyOrder(T a, T b, T c, T d) : keys_{a, b, c, d} { validate(); }
 
   // Get access to the permutation.
   const Array& keys() const { return keys_; }
+
+  // Apply the permutation specified by this `KeyOrder` to the `input`.
+  // The elements of the input are copied into the result.
+  template <typename T>
+  std::array<T, NumKeys> permute(const std::array<T, NumKeys>& input) const {
+    return permuteImpl(input, std::make_index_sequence<NumKeys>());
+  }
+
+  // Check that `keys()[3] == 3`, i.e that the first three keys specify a
+  // permutation of the numbers `[0..3]`. Then apply this permutation to the
+  // `input` same as in `permute` above. This function is sometimes used in code
+  // for permutations where the graph is the last variable. It will be removed
+  // in the future when we have more proper support for named graphs.
+  template <typename T>
+  std::array<T, 3> permuteSPOOnly(const std::array<T, 3>& input) const {
+    AD_CONTRACT_CHECK(keys()[3] == 3);
+    return permuteImpl(input, std::make_index_sequence<3>());
+  }
 
  private:
   // Check the invariants.
@@ -43,6 +61,15 @@ class KeyOrder {
     ql::ranges::sort(keys);
     AD_CONTRACT_CHECK(std::unique(keys.begin(), keys.end()) == keys.end(),
                       "Keys are not unique.");
+  }
+
+  // The internal implementation of `permute` above.
+  CPP_variadic_template(typename T, size_t N, size_t... Indexes)(requires(
+      sizeof...(Indexes) ==
+      N)) auto permuteImpl(const std::array<T, N>& input,
+                           std::integer_sequence<size_t, Indexes...>) const
+      -> std::array<T, N> {
+    return {input[std::get<Indexes>(keys())]...};
   }
 };
 }  // namespace qlever

--- a/src/index/KeyOrder.h
+++ b/src/index/KeyOrder.h
@@ -13,9 +13,10 @@
 #include "util/Exception.h"
 
 namespace qlever {
-// A strong type for a permutation of the integers `0, 1, 2, 3` that is used to
-// determine a permutation of triples (0 = S, 1 = P, 2 = O, 3 = G), so
-// `1 0 2 3` represents the `PSOG` permutation.
+
+// A strong type for a permutation of the integers `0, 1, 2, 3`. This is used
+// to determine the permutation of a quad (0 = S, 1 = P, 2 = O, 3 = G). For
+// example, `1, 0, 2, 3` represents the permutation `PSOG`.
 class KeyOrder {
  public:
   using T = uint8_t;
@@ -27,7 +28,7 @@ class KeyOrder {
 
  public:
   // Construct from four numbers. If `(a b c d)` is not a permutation of the
-  // numbers `[0...4]`, then an `AD_CONTRACT_CHECK` will fail.
+  // numbers `0, 1, 2, 3`, then an `AD_CONTRACT_CHECK` will fail.
   KeyOrder(T a, T b, T c, T d) : keys_{a, b, c, d} { validate(); }
 
   // Get access to the keys.
@@ -36,7 +37,8 @@ class KeyOrder {
   // Apply the permutation specified by this `KeyOrder` to the `input`.
   // The elements of the input are copied into the result.
   template <typename T>
-  std::array<T, NumKeys> permute(const std::array<T, NumKeys>& input) const {
+  std::array<T, NumKeys> permuteTuple(
+      const std::array<T, NumKeys>& input) const {
     return permuteImpl(input, std::make_index_sequence<NumKeys>());
   }
 
@@ -46,7 +48,7 @@ class KeyOrder {
   // for permutations where the graph is the last variable. It will be removed
   // in the future when we have more proper support for named graphs.
   template <typename T>
-  std::array<T, 3> permuteSPOOnly(const std::array<T, 3>& input) const {
+  std::array<T, 3> permuteTriple(const std::array<T, 3>& input) const {
     AD_CONTRACT_CHECK(keys_[3] == 3);
     return permuteImpl(input, std::make_index_sequence<3>());
   }

--- a/src/index/KeyOrder.h
+++ b/src/index/KeyOrder.h
@@ -1,0 +1,50 @@
+// Copyright 2025, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+
+#ifndef QLEVER_SRC_INDEX_KEYORDER_H
+#define QLEVER_SRC_INDEX_KEYORDER_H
+
+#include <array>
+#include <cstddef>
+
+#include "backports/algorithm.h"
+#include "util/Exception.h"
+
+namespace qlever {
+// A strong type for a permutation of the integers `0, 1, 2, 3` that is used to
+// determine a permutation of triples (0 = S, 1 = P, 2 = O, 3 = G), so
+// `1 0 2 3` represents the `PSOG` permutation.
+class KeyOrder {
+ public:
+  static constexpr size_t NumKeys = 4;
+  using Array = std::array<size_t, NumKeys>;
+
+ private:
+  Array keys_;
+
+ public:
+  // Construct from four numbers. If `(a b c d)` is not a permutation of the
+  // numbers `[0...4]`, then an `AD_CONTRACT_CHECK` will fail.
+  KeyOrder(size_t a, size_t b, size_t c, size_t d) : keys_{a, b, c, d} {
+    validate();
+  }
+
+  // Get access to the permutation.
+  const Array& keys() const { return keys_; }
+
+ private:
+  // Check the invariants.
+  void validate() const {
+    AD_CONTRACT_CHECK(
+        ql::ranges::all_of(keys_, [](size_t x) { return x < NumKeys; }),
+        "Keys are out of range");
+    auto keys = keys_;
+    ql::ranges::sort(keys);
+    AD_CONTRACT_CHECK(std::unique(keys.begin(), keys.end()) == keys.end(),
+                      "Keys are not unique.");
+  }
+};
+}  // namespace qlever
+
+#endif  // QLEVER_SRC_INDEX_KEYORDER_H

--- a/src/index/KeyOrder.h
+++ b/src/index/KeyOrder.h
@@ -20,7 +20,7 @@ class KeyOrder {
  public:
   using T = uint8_t;
   static constexpr size_t NumKeys = 4;
-  using Array = std::array<uint8_t, NumKeys>;
+  using Array = std::array<T, NumKeys>;
 
  private:
   Array keys_;
@@ -30,8 +30,8 @@ class KeyOrder {
   // numbers `[0...4]`, then an `AD_CONTRACT_CHECK` will fail.
   KeyOrder(T a, T b, T c, T d) : keys_{a, b, c, d} { validate(); }
 
-  // Get access to the permutation.
-  const Array& keys() const { return keys_; }
+  // Get access to the keys.
+  const auto& keys() const { return keys_; }
 
   // Apply the permutation specified by this `KeyOrder` to the `input`.
   // The elements of the input are copied into the result.
@@ -47,7 +47,7 @@ class KeyOrder {
   // in the future when we have more proper support for named graphs.
   template <typename T>
   std::array<T, 3> permuteSPOOnly(const std::array<T, 3>& input) const {
-    AD_CONTRACT_CHECK(keys()[3] == 3);
+    AD_CONTRACT_CHECK(keys_[3] == 3);
     return permuteImpl(input, std::make_index_sequence<3>());
   }
 
@@ -69,7 +69,7 @@ class KeyOrder {
       N)) auto permuteImpl(const std::array<T, N>& input,
                            std::integer_sequence<size_t, Indexes...>) const
       -> std::array<T, N> {
-    return {input[std::get<Indexes>(keys())]...};
+    return {input[std::get<Indexes>(keys_)]...};
   }
 };
 }  // namespace qlever

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -91,7 +91,7 @@ CPP_template(size_t numIndexColumns, bool includeGraphColumn)(
     }
     return a;
   }();
-  auto& ids = lt->triple_.ids_;
+  auto& ids = lt->triple_.ids();
   return [&ids]<size_t... I>(ad_utility::ValueSequence<size_t, I...>) {
     return std::tie(ids[I]...);
   }(ad_utility::toIntegerSequence<indices>());
@@ -136,7 +136,7 @@ IdTable LocatedTriplesPerBlock::mergeTriplesImpl(size_t blockIndex,
     static constexpr auto plusOneIfGraph =
         static_cast<size_t>(includeGraphColumn);
     for (size_t i = 0; i < numIndexColumns + plusOneIfGraph; i++) {
-      (*resultIt)[i] = locatedTriple.triple_.ids_[3 - numIndexColumns + i];
+      (*resultIt)[i] = locatedTriple.triple_.ids()[3 - numIndexColumns + i];
     }
     // If the input `block` has payload columns (which located triples don't
     // have), set their values to UNDEF.
@@ -276,7 +276,7 @@ static auto updateGraphMetadata(CompressedBlockMetadata& blockMetadata,
       // Don't update the graph info for triples that are deleted.
       continue;
     }
-    newGraphs.insert(lt.triple_.ids_.at(ADDITIONAL_COLUMN_GRAPH_ID));
+    newGraphs.insert(lt.triple_.ids().at(ADDITIONAL_COLUMN_GRAPH_ID));
     // Handle the case that with the newly added triples we have too many
     // distinct graphs to store them in the graph info.
     if (newGraphs.size() > MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA) {

--- a/src/index/LocatedTriples.cpp
+++ b/src/index/LocatedTriples.cpp
@@ -16,7 +16,7 @@
 std::vector<LocatedTriple> LocatedTriple::locateTriplesInPermutation(
     std::span<const IdTriple<0>> triples,
     std::span<const CompressedBlockMetadata> blockMetadata,
-    const std::array<size_t, 3>& keyOrder, bool shouldExist,
+    const qlever::KeyOrder& keyOrder, bool shouldExist,
     ad_utility::SharedCancellationHandle cancellationHandle) {
   std::vector<LocatedTriple> out;
   out.reserve(triples.size());

--- a/src/index/LocatedTriples.h
+++ b/src/index/LocatedTriples.h
@@ -12,6 +12,7 @@
 #include "engine/idTable/IdTable.h"
 #include "global/IdTriple.h"
 #include "index/CompressedRelation.h"
+#include "index/KeyOrder.h"
 #include "util/HashMap.h"
 
 class Permutation;
@@ -42,7 +43,7 @@ struct LocatedTriple {
   static std::vector<LocatedTriple> locateTriplesInPermutation(
       std::span<const IdTriple<0>> triples,
       std::span<const CompressedBlockMetadata> blockMetadata,
-      const std::array<size_t, 3>& keyOrder, bool shouldExist,
+      const qlever::KeyOrder& keyOrder, bool shouldExist,
       ad_utility::SharedCancellationHandle cancellationHandle);
   bool operator==(const LocatedTriple&) const = default;
 

--- a/src/index/Permutation.cpp
+++ b/src/index/Permutation.cpp
@@ -125,21 +125,21 @@ IdTable Permutation::getDistinctCol0IdsAndCounts(
 }
 
 // _____________________________________________________________________
-std::array<size_t, 3> Permutation::toKeyOrder(Permutation::Enum permutation) {
+auto Permutation::toKeyOrder(Permutation::Enum permutation) -> KeyOrder {
   using enum Permutation::Enum;
   switch (permutation) {
     case POS:
-      return {1, 2, 0};
+      return {1, 2, 0, 3};
     case PSO:
-      return {1, 0, 2};
+      return {1, 0, 2, 3};
     case SOP:
-      return {0, 2, 1};
+      return {0, 2, 1, 3};
     case SPO:
-      return {0, 1, 2};
+      return {0, 1, 2, 3};
     case OPS:
-      return {2, 1, 0};
+      return {2, 1, 0, 3};
     case OSP:
-      return {2, 0, 1};
+      return {2, 0, 1, 3};
   }
   AD_FAIL();
 }

--- a/src/index/Permutation.h
+++ b/src/index/Permutation.h
@@ -11,6 +11,7 @@
 #include "global/Constants.h"
 #include "index/CompressedRelation.h"
 #include "index/IndexMetaData.h"
+#include "index/KeyOrder.h"
 #include "parser/data/LimitOffsetClause.h"
 #include "util/CancellationHandle.h"
 #include "util/File.h"
@@ -28,6 +29,7 @@ struct LocatedTriplesSnapshot;
 // STXXL.
 class Permutation {
  public:
+  using KeyOrder = qlever::KeyOrder;
   /// Identifiers for the six possible permutations.
   enum struct Enum { PSO, POS, SPO, SOP, OPS, OSP };
   // Unfortunately there is a bug in GCC that doesn't allow use to simply use
@@ -53,7 +55,7 @@ class Permutation {
 
   // Convert a permutation to the corresponding permutation of [0, 1, 2], etc.
   // `PSO` is converted to [1, 0, 2].
-  static std::array<size_t, 3> toKeyOrder(Enum permutation);
+  static KeyOrder toKeyOrder(Enum permutation);
 
   explicit Permutation(Enum permutation, Allocator allocator);
 
@@ -151,7 +153,7 @@ class Permutation {
   const std::string& fileSuffix() const { return fileSuffix_; }
 
   // _______________________________________________________
-  const std::array<size_t, 3>& keyOrder() const { return keyOrder_; };
+  const KeyOrder& keyOrder() const { return keyOrder_; };
 
   // _______________________________________________________
   const bool& isLoaded() const { return isLoaded_; }
@@ -184,7 +186,7 @@ class Permutation {
   std::string fileSuffix_;
   // The order of the three components (S=0, P=1, O=2) in this permutation,
   // e.g., `{1, 0, 2}` for `PSO`.
-  std::array<size_t, 3> keyOrder_;
+  KeyOrder keyOrder_;
   // The metadata for this permutation.
   MetaData meta_;
 

--- a/test/CompressedRelationsTest.cpp
+++ b/test/CompressedRelationsTest.cpp
@@ -272,7 +272,7 @@ void testCompressedRelations(const auto& inputsOriginalBeforeCopy,
   // deltaTriples.getLocatedTriplesPerBlock(Permutation::SPO);
   auto locatedTriples = LocatedTriplesPerBlock{};
   auto loc = LocatedTriple::locateTriplesInPermutation(
-      locatedTriplesInput, blocksOriginal, {0, 1, 2}, true, handle);
+      locatedTriplesInput, blocksOriginal, {0, 1, 2, 3}, true, handle);
   locatedTriples.add(loc);
   locatedTriples.setOriginalMetadata(blocksOriginal);
   locatedTriples.updateAugmentedMetadata();

--- a/test/DeltaTriplesTest.cpp
+++ b/test/DeltaTriplesTest.cpp
@@ -266,14 +266,14 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
   auto triples =
       makeIdTriples(vocab, localVocabOutside, {"<A> <notInVocab> <B>"});
   AD_CORRECTNESS_CHECK(triples.size() == 1);
-  triples[0].ids_[2] =
+  triples[0].ids()[2] =
       Id::makeFromBlankNodeIndex(BlankNodeIndex::make(999'888'777));
-  triples[0].ids_[3] = triples[0].ids_[2];
-  auto [s1, p1, o1, g1] = triples[0].ids_;
+  triples[0].ids()[3] = triples[0].ids()[2];
+  auto [s1, p1, o1, g1] = triples[0].ids();
 
   // Rewrite the IDs in the triple.
   deltaTriples.rewriteLocalVocabEntriesAndBlankNodes(triples);
-  auto [s2, p2, o2, g2] = triples[0].ids_;
+  auto [s2, p2, o2, g2] = triples[0].ids();
 
   // The subject <A> is part of the global vocabulary, so it remains unchanged.
   EXPECT_EQ(s2.getBits(), s1.getBits());
@@ -315,7 +315,7 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
   // stores the corresponding values.
   deltaTriples.rewriteLocalVocabEntriesAndBlankNodes(triples);
   ASSERT_EQ(triples.size(), 1);
-  auto [s3, p3, o3, g3] = triples[0].ids_;
+  auto [s3, p3, o3, g3] = triples[0].ids();
   EXPECT_EQ(s3.getBits(), s2.getBits());
   EXPECT_EQ(p3.getBits(), p2.getBits());
   EXPECT_EQ(o3.getBits(), o2.getBits());
@@ -324,9 +324,9 @@ TEST_F(DeltaTriplesTest, rewriteLocalVocabEntriesAndBlankNodes) {
   // If we use a local blank node that is already part of the global vocabulary,
   // nothing gets rewritten either.
   auto blank0 = Id::makeFromBlankNodeIndex(BlankNodeIndex::make(0));
-  triples[0].ids_[0] = blank0;
+  triples[0].ids()[0] = blank0;
   deltaTriples.rewriteLocalVocabEntriesAndBlankNodes(triples);
-  auto s4 = triples[0].ids_[0];
+  auto s4 = triples[0].ids()[0];
   EXPECT_EQ(s4.getBits(), blank0.getBits());
 }
 

--- a/test/IdTripleTest.cpp
+++ b/test/IdTripleTest.cpp
@@ -33,13 +33,14 @@ TEST(IdTripleTest, constructors) {
   }
 }
 
+// TODO<joka921> Also add tests for the permuting of graph permutations.
 TEST(IdTripleTest, permute) {
   auto V = VocabId;
   std::array<Id, 4> ids{V(0), V(1), V(2), V(3)};
   // Without a payload
   {
     IdTriple<0> idTriple{ids};
-    EXPECT_THAT(idTriple.permute({1, 0, 2}),
+    EXPECT_THAT(idTriple.permute({1, 0, 2, 3}),
                 testing::Eq(IdTriple{std::array<Id, 4>{
                     VocabId(1), VocabId(0), VocabId(2), VocabId(3)}}));
   }
@@ -47,7 +48,7 @@ TEST(IdTripleTest, permute) {
   // With a payload
   {
     IdTriple<2> idTriple(ids, {IntId(10), IntId(5)});
-    EXPECT_THAT(idTriple.permute({1, 0, 2}),
+    EXPECT_THAT(idTriple.permute({1, 0, 2, 3}),
                 testing::Eq(IdTriple<2>(
                     {VocabId(1), VocabId(0), VocabId(2), VocabId(3)},
                     {IntId(10), IntId(5)})));

--- a/test/IdTripleTest.cpp
+++ b/test/IdTripleTest.cpp
@@ -21,15 +21,15 @@ TEST(IdTripleTest, constructors) {
   {
     auto idTriple = IdTriple(ids);
     EXPECT_THAT(idTriple,
-                AD_FIELD(IdTriple<>, ids_, testing::ElementsAreArray(ids)));
+                AD_PROPERTY(IdTriple<>, ids, testing::ElementsAreArray(ids)));
   }
 
   {
-    auto idTriple = IdTriple(ids, payload);
+    auto idTriple = IdTriple<2>(ids, payload);
     EXPECT_THAT(idTriple,
-                AD_FIELD(IdTriple<2>, ids_, testing::ElementsAreArray(ids)));
-    EXPECT_THAT(idTriple, AD_FIELD(IdTriple<2>, payload_,
-                                   testing::ElementsAreArray(payload)));
+                AD_PROPERTY(IdTriple<2>, ids, testing::ElementsAreArray(ids)));
+    EXPECT_THAT(idTriple, AD_PROPERTY(IdTriple<2>, payload,
+                                      testing::ElementsAreArray(payload)));
   }
 }
 

--- a/test/IdTripleTest.cpp
+++ b/test/IdTripleTest.cpp
@@ -20,16 +20,13 @@ TEST(IdTripleTest, constructors) {
 
   {
     auto idTriple = IdTriple(ids);
-    EXPECT_THAT(idTriple,
-                AD_PROPERTY(IdTriple<>, ids, testing::ElementsAreArray(ids)));
+    EXPECT_THAT(idTriple.ids(), testing::ElementsAreArray(ids));
   }
 
   {
     auto idTriple = IdTriple<2>(ids, payload);
-    EXPECT_THAT(idTriple,
-                AD_PROPERTY(IdTriple<2>, ids, testing::ElementsAreArray(ids)));
-    EXPECT_THAT(idTriple, AD_PROPERTY(IdTriple<2>, payload,
-                                      testing::ElementsAreArray(payload)));
+    EXPECT_THAT(idTriple.ids(), testing::ElementsAreArray(ids));
+    EXPECT_THAT(idTriple.payload(), ::testing::ElementsAreArray(payload));
   }
 }
 

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -72,6 +72,8 @@ auto numTriplesBlockwise =
       });
   return testing::AllOfArray(blockMatchers);
 };
+
+const qlever::KeyOrder keyOrder{0, 1, 2, 3};
 }  // namespace
 
 // Fixture with helper functions.
@@ -642,7 +644,7 @@ TEST_F(LocatedTriplesTest, locatedTriple) {
         triplesToLocate,
         Span{CBM(PT1, PT1), CBM(PT2, PT2), CBM(PT3, PT3), CBM(PT4, PT4),
              CBM(PT5, PT5), CBM(PT6, PT6), CBM(PT7, PT7), CBM(PT8, PT8)},
-        {0, 1, 2}, false, handle);
+        keyOrder, false, handle);
     EXPECT_THAT(locatedTriples,
                 testing::ElementsAreArray(
                     {LT(0, T1, false), LT(1, T2, false), LT(1, T3, false),
@@ -660,7 +662,7 @@ TEST_F(LocatedTriplesTest, locatedTriple) {
         triplesToLocate,
         Span{CBM(PT1, PT1), CBM(PT2, PT3), CBM(PT4, PT5), CBM(PT6, PT7),
              CBM(PT8, PT8)},
-        {0, 1, 2}, true, handle);
+        keyOrder, true, handle);
     EXPECT_THAT(locatedTriples,
                 testing::ElementsAreArray({LT(0, T1, true), LT(1, T2, true),
                                            LT(1, T3, true), LT(1, T4, true),
@@ -672,7 +674,7 @@ TEST_F(LocatedTriplesTest, locatedTriple) {
     // The relations (identical first column) are in a block each.
     auto locatedTriples = LocatedTriple::locateTriplesInPermutation(
         triplesToLocate, Span{CBM(PT1, PT1), CBM(PT2, PT7), CBM(PT8, PT8)},
-        {0, 1, 2}, false, handle);
+        keyOrder, false, handle);
     EXPECT_THAT(locatedTriples,
                 testing::ElementsAreArray(
                     {LT(0, T1, false), LT(1, T2, false), LT(1, T3, false),
@@ -686,7 +688,7 @@ TEST_F(LocatedTriplesTest, locatedTriple) {
     // is supported.
     auto locatedTriples = LocatedTriple::locateTriplesInPermutation(
         triplesToLocateReverse,
-        Span{CBM(PT1, PT1), CBM(PT2, PT7), CBM(PT8, PT8)}, {0, 1, 2}, false,
+        Span{CBM(PT1, PT1), CBM(PT2, PT7), CBM(PT8, PT8)}, keyOrder, false,
         handle);
     EXPECT_THAT(locatedTriples,
                 testing::ElementsAreArray(
@@ -698,7 +700,7 @@ TEST_F(LocatedTriplesTest, locatedTriple) {
   {
     // All triples are in one block.
     auto locatedTriples = LocatedTriple::locateTriplesInPermutation(
-        triplesToLocate, Span{CBM(PT1, PT8)}, {0, 1, 2}, false, handle);
+        triplesToLocate, Span{CBM(PT1, PT8)}, keyOrder, false, handle);
     EXPECT_THAT(locatedTriples,
                 testing::ElementsAreArray(
                     {LT(0, T1, false), LT(0, T2, false), LT(0, T3, false),
@@ -742,14 +744,14 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
 
     // Adding no triples does no changed the augmented metadata.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        Span{}, metadata, {0, 1, 2}, true, handle));
+        Span{}, metadata, keyOrder, true, handle));
 
     EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
                 testing::ElementsAreArray(expectedAugmentedMetadata));
 
     // T1 is before block 0. The beginning of block 0 changes.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        Span{T1}, metadata, {0, 1, 2}, false, handle));
+        Span{T1}, metadata, keyOrder, false, handle));
 
     expectedAugmentedMetadata[0] = CBM(T1.toPermutedTriple(), PT1);
     expectedAugmentedMetadata[0].containsDuplicatesWithDifferentGraphs_ = true;
@@ -759,7 +761,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
     // T2 is inside block 1. Borders don't change.
     expectedAugmentedMetadata[1].containsDuplicatesWithDifferentGraphs_ = true;
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        Span{T2}, metadata, {0, 1, 2}, true, handle));
+        Span{T2}, metadata, keyOrder, true, handle));
 
     EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
                 testing::ElementsAreArray(expectedAugmentedMetadata));
@@ -768,7 +770,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
     // delete) add to the block borders. Borders don't change.
     expectedAugmentedMetadata[2].containsDuplicatesWithDifferentGraphs_ = true;
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        Span{T3}, metadata, {0, 1, 2}, false, handle));
+        Span{T3}, metadata, keyOrder, false, handle));
 
     EXPECT_THAT(locatedTriplesPerBlock.getAugmentedMetadata(),
                 testing::ElementsAreArray(expectedAugmentedMetadata));
@@ -776,7 +778,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadata) {
     // T4 is before block 4. The beginning of block 4 changes.
     auto handles =
         locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-            Span{T4}, metadata, {0, 1, 2}, true, handle));
+            Span{T4}, metadata, keyOrder, true, handle));
 
     expectedAugmentedMetadata[4] = CBM(T4.toPermutedTriple(), PT8);
     expectedAugmentedMetadata[4].containsDuplicatesWithDifferentGraphs_ = true;
@@ -839,7 +841,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
 
     // Delete the located triples {T1 ... T4}
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        Span{T1, T2, T3, T4}, metadata, {0, 1, 2}, false, handle));
+        Span{T1, T2, T3, T4}, metadata, keyOrder, false, handle));
 
     // All the blocks have updates, so their value of `containsDuplicates..` is
     // set to `true`.
@@ -860,7 +862,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
 
     // Add the located triples {T1 ... T5}
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        Span{T1, T2, T3, T4, T5}, metadata, {0, 1, 2}, true, handle));
+        Span{T1, T2, T3, T4, T5}, metadata, keyOrder, true, handle));
 
     expectedAugmentedMetadata[0] = CBM(T1.toPermutedTriple(), PT1);
     expectedAugmentedMetadata[1].firstTriple_ = T2.toPermutedTriple();
@@ -910,15 +912,15 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
     // Add the exact amount of graphs such that we are at the maximum number of
     // stored graphs.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
-        std::span{triples}.subspan(0, numGraphsToMax), metadata, {0, 1, 2},
-        true, handle));
+        std::span{triples}.subspan(0, numGraphsToMax), metadata, keyOrder, true,
+        handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_TRUE(actualMetadata[1].graphInfo_.has_value());
 
     // Adding one more graph will exceed the maximum.
     locatedTriplesPerBlock.add(LocatedTriple::locateTriplesInPermutation(
         std::span{triples}.subspan(numGraphsToMax, numGraphsToMax + 1),
-        metadata, {0, 1, 2}, true, handle));
+        metadata, keyOrder, true, handle));
     actualMetadata = locatedTriplesPerBlock.getAugmentedMetadata();
     ASSERT_FALSE(actualMetadata[1].graphInfo_.has_value());
   }

--- a/test/LocatedTriplesTest.cpp
+++ b/test/LocatedTriplesTest.cpp
@@ -901,7 +901,7 @@ TEST_F(LocatedTriplesTest, augmentedMetadataGraphInfo) {
     for (size_t i = 30; i < 30 + 2 * MAX_NUM_GRAPHS_STORED_IN_BLOCK_METADATA;
          ++i) {
       auto tr = T3;
-      tr.ids_.at(ADDITIONAL_COLUMN_GRAPH_ID) = V(i);
+      tr.ids().at(ADDITIONAL_COLUMN_GRAPH_ID) = V(i);
       triples.push_back(tr);
     }
 

--- a/test/index/CMakeLists.txt
+++ b/test/index/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(vocabulary)
 addLinkAndDiscoverTest(PatternCreatorTest index)
 addLinkAndDiscoverTestSerial(ScanSpecificationTest index)
+addLinkAndDiscoverTestNoLibs(KeyOrderTest)

--- a/test/index/KeyOrderTest.cpp
+++ b/test/index/KeyOrderTest.cpp
@@ -10,15 +10,15 @@
 using namespace qlever;
 using namespace testing;
 // _____________________________________________________________________________
-TEST(KeyOrder, keyOrder) {
+TEST(KeyOrder, Constructor) {
   AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 4), HasSubstr("out of range"));
   AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 2), HasSubstr("not unique"));
-  KeyOrder keyOrder{3, 0, 1, 2};
+  auto keyOrder = KeyOrder{3, 0, 1, 2};
   EXPECT_THAT(keyOrder.keys(), ElementsAre(3, 0, 1, 2));
 }
 
 // _____________________________________________________________________________
-TEST(KeyOrder, permute) {
+TEST(KeyOrder, Permute) {
   KeyOrder keyOrder{2, 3, 1, 0};
   std::array a{0, 1, 2, 3};
   EXPECT_THAT(keyOrder.permute(a), ElementsAre(2, 3, 1, 0));

--- a/test/index/KeyOrderTest.cpp
+++ b/test/index/KeyOrderTest.cpp
@@ -21,13 +21,13 @@ TEST(KeyOrder, Constructor) {
 TEST(KeyOrder, Permute) {
   KeyOrder keyOrder{2, 3, 1, 0};
   std::array a{0, 1, 2, 3};
-  EXPECT_THAT(keyOrder.permute(a), ElementsAre(2, 3, 1, 0));
+  EXPECT_THAT(keyOrder.permuteTuple(a), ElementsAre(2, 3, 1, 0));
 
   std::array b{0, 1, 2};
   // Not supported, as the permutation doesn't have the graph in the last
   // column.
-  EXPECT_ANY_THROW(keyOrder.permuteSPOOnly(b));
+  EXPECT_ANY_THROW(keyOrder.permuteTriple(b));
 
   keyOrder = KeyOrder{2, 0, 1, 3};
-  EXPECT_THAT(keyOrder.permuteSPOOnly(b), ElementsAre(2, 0, 1));
+  EXPECT_THAT(keyOrder.permuteTriple(b), ElementsAre(2, 0, 1));
 }

--- a/test/index/KeyOrderTest.cpp
+++ b/test/index/KeyOrderTest.cpp
@@ -7,13 +7,27 @@
 #include "../util/GTestHelpers.h"
 #include "index/KeyOrder.h"
 
+using namespace qlever;
+using namespace testing;
 // _____________________________________________________________________________
 TEST(KeyOrder, keyOrder) {
-  using namespace qlever;
-  AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 4),
-                               ::testing::HasSubstr("out of range"));
-  AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 2),
-                               ::testing::HasSubstr("not unique"));
+  AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 4), HasSubstr("out of range"));
+  AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 2), HasSubstr("not unique"));
   KeyOrder keyOrder{3, 0, 1, 2};
-  EXPECT_THAT(keyOrder.keys(), ::testing::ElementsAre(3, 0, 1, 2));
+  EXPECT_THAT(keyOrder.keys(), ElementsAre(3, 0, 1, 2));
+}
+
+// _____________________________________________________________________________
+TEST(KeyOrder, permute) {
+  KeyOrder keyOrder{2, 3, 1, 0};
+  std::array a{0, 1, 2, 3};
+  EXPECT_THAT(keyOrder.permute(a), ElementsAre(2, 3, 1, 0));
+
+  std::array b{0, 1, 2};
+  // Not supported, as the permutation doesn't have the graph in the last
+  // column.
+  EXPECT_ANY_THROW(keyOrder.permuteSPOOnly(b));
+
+  keyOrder = KeyOrder{2, 0, 1, 3};
+  EXPECT_THAT(keyOrder.permuteSPOOnly(b), ElementsAre(2, 0, 1));
 }

--- a/test/index/KeyOrderTest.cpp
+++ b/test/index/KeyOrderTest.cpp
@@ -1,0 +1,19 @@
+// Copyright 2021 - 2024, University of Freiburg
+// Chair of Algorithms and Data Structures
+// Author: Johannes Kalmbach <kalmbacj@cs.uni-freiburg.de>
+
+#include <gmock/gmock.h>
+
+#include "../util/GTestHelpers.h"
+#include "index/KeyOrder.h"
+
+// _____________________________________________________________________________
+TEST(KeyOrder, keyOrder) {
+  using namespace qlever;
+  AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 4),
+                               ::testing::HasSubstr("out of range"));
+  AD_EXPECT_THROW_WITH_MESSAGE(KeyOrder(0, 1, 2, 2),
+                               ::testing::HasSubstr("not unique"));
+  KeyOrder keyOrder{3, 0, 1, 2};
+  EXPECT_THAT(keyOrder.keys(), ::testing::ElementsAre(3, 0, 1, 2));
+}


### PR DESCRIPTION
So far, the type of this order was hard-coded as `std::array<size_t, 3>` in many places. Now, there is an own type `KeyOrder`, which stores an `std::array<uint8_t, 4>`. For example, `{1, 0, 2, 3}` represents the permutation `PSOG`.

On the side, improve the `IdTriple` class (which stores a quad with `N` additional payload `Id`s) such that for `N = 0` (no additional payload) no additional space is used.