### PR TITLE
Rewrite generator coroutines in `Service.cpp`

### DIFF
--- a/src/engine/Service.cpp
+++ b/src/engine/Service.cpp
@@ -250,7 +250,7 @@ CPP_template(typename Range)(
     requires ad_utility::Rvalue<
         Range&&>) auto moveToCachingInputRange(Range&& range) {
   return ad_utility::CachingTransformInputRange(
-      std::move(range), [](auto& input) { return std::move(input); });
+      AD_FWD(range), [](auto& input) { return std::move(input); });
 }
 }  // namespace
 
@@ -265,7 +265,7 @@ Result::LazyResult Service::computeResultLazily(
               idTable = IdTable{getResultWidth(),
                                 getExecutionContext()->getAllocator()},
               rowIdx = size_t{0}, varsChecked = false,
-              resultExists = false]() mutable -> LC {
+              resultExists = false]() mutable {
     auto& details = inputRange.underlyingView().base().details();
     try {
       while (auto partJsonOpt = inputRange.get()) {

--- a/src/engine/Service.h
+++ b/src/engine/Service.h
@@ -1,6 +1,7 @@
 // Copyright 2022 - 2023, University of Freiburg,
 // Chair of Algorithms and Data Structures.
 // Author: Hannah Bast (bast@cs.uni-freiburg.de)
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 
 #ifndef QLEVER_SRC_ENGINE_SERVICE_H
 #define QLEVER_SRC_ENGINE_SERVICE_H
@@ -160,7 +161,7 @@ class Service : public Operation {
 
   // Compute the result lazy as IdTable generator.
   // If the `singleIdTable` flag is set, the result is yielded as one idTable.
-  Result::Generator computeResultLazily(
+  Result::LazyResult computeResultLazily(
       const std::vector<std::string> vars,
       ad_utility::LazyJsonParser::Generator body, bool singleIdTable);
 

--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -1,7 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) Lewis Baker, Johannes Kalmbach (functionality to add details).
 // Licenced under MIT license. See LICENSE.txt for details.
-// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef CPPCORO_GENERATOR_HPP_INCLUDED
 #define CPPCORO_GENERATOR_HPP_INCLUDED

--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -1,6 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) Lewis Baker, Johannes Kalmbach (functionality to add details).
 // Licenced under MIT license. See LICENSE.txt for details.
+// Copyright 2025, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
 ///////////////////////////////////////////////////////////////////////////////
 #ifndef CPPCORO_GENERATOR_HPP_INCLUDED
 #define CPPCORO_GENERATOR_HPP_INCLUDED
@@ -293,6 +294,16 @@ T getSingleElement(generator<T, Details> g) {
   auto it = g.begin();
   AD_CORRECTNESS_CHECK(it != g.end());
   T t = std::move(*it);
+  AD_CORRECTNESS_CHECK(++it == g.end());
+  return t;
+}
+
+// Get the first element of a generator and verify that it's the only one.
+template <typename ReturnType, typename GeneratorType>
+ReturnType getSingleElement(GeneratorType g) {
+  auto it = g.begin();
+  AD_CORRECTNESS_CHECK(it != g.end());
+  ReturnType t = std::move(*it);
   AD_CORRECTNESS_CHECK(++it == g.end());
   return t;
 }

--- a/src/util/Generator.h
+++ b/src/util/Generator.h
@@ -297,16 +297,6 @@ T getSingleElement(generator<T, Details> g) {
   AD_CORRECTNESS_CHECK(++it == g.end());
   return t;
 }
-
-// Get the first element of a generator and verify that it's the only one.
-template <typename ReturnType, typename GeneratorType>
-ReturnType getSingleElement(GeneratorType g) {
-  auto it = g.begin();
-  AD_CORRECTNESS_CHECK(it != g.end());
-  ReturnType t = std::move(*it);
-  AD_CORRECTNESS_CHECK(++it == g.end());
-  return t;
-}
 }  // namespace cppcoro
 
 #endif

--- a/src/util/InputRangeUtils.h
+++ b/src/util/InputRangeUtils.h
@@ -49,6 +49,17 @@ CPP_class_template(typename View, typename F)(requires(
   explicit CachingTransformInputRange(View view, F transformation = {})
       : view_{std::move(view)}, transfomation_(std::move(transformation)) {}
 
+  // Constructor for creating an InputRange from a subrange, which takes an
+  // iterator to the beginning of the subrange. This allows for omitting
+  // elements at the beginning of the original range, but it does not make it
+  // possible to omit elements at the end of the range.
+  explicit CachingTransformInputRange(View view,
+                                      ql::ranges::iterator_t<View> view_begin,
+                                      F transformation = {})
+      : view_{std::move(view)},
+        transfomation_(std::move(transformation)),
+        it_(std::move(view_begin)) {}
+
   // TODO<joka921> Make this private again and give explicit access to low-level
   // tools like the ones below.
  public:
@@ -66,6 +77,9 @@ CPP_class_template(typename View, typename F)(requires(
     }
     return std::invoke(transfomation_, *it_.value());
   }
+
+  const View& view() { return view_; }
+
   // Give the mixin access to the private `get` function.
   friend class InputRangeFromGet<Res>;
 };

--- a/src/util/InputRangeUtils.h
+++ b/src/util/InputRangeUtils.h
@@ -209,9 +209,6 @@ CPP_class_template(typename F)(
     // This loop is executed exactly once unless there is a `continue`
     // statement.
     while (true) {
-      if (receivedBreak_) {
-        return std::nullopt;
-      }
       auto loopControl = getFunction_();
       if (loopControl.isContinue()) {
         continue;
@@ -224,7 +221,9 @@ CPP_class_template(typename F)(
   }
 };
 
-// Actual class definition.
+// A class that takes a view and a function that transforms the elements of the
+// view into a `LoopControl` object, and synthesizes an `input_range` from these
+// arguments.
 CPP_class_template(typename View, typename F)(requires(
     ql::ranges::input_range<View>&& ql::ranges::view<View>&&
         std::is_object_v<F>)) struct CachingContinuableTransformInputRange

--- a/src/util/InputRangeUtils.h
+++ b/src/util/InputRangeUtils.h
@@ -58,7 +58,7 @@ CPP_class_template(typename View, typename F)(requires(
     // with lazy `generator`s.
     if (!it_.has_value()) {
       it_ = view_.begin();
-    } else {
+    } else if (*it_ != view_.end()) {
       ++(it_.value());
     }
     if (*it_ == view_.end()) {

--- a/src/util/Iterators.h
+++ b/src/util/Iterators.h
@@ -273,12 +273,10 @@ class InputRangeFromGet {
   using Storage = std::optional<ValueType>;
   Storage storage_ = std::nullopt;
 
- private:
   // The single virtual function which has to be overloaded. `std::nullopt`
   // means that there will be no more values.
   virtual Storage get() = 0;
 
- public:
   virtual ~InputRangeFromGet() = default;
   InputRangeFromGet() = default;
   InputRangeFromGet(InputRangeFromGet&&) = default;
@@ -428,6 +426,7 @@ class InputRangeTypeErased {
 
   decltype(auto) begin() { return impl_->begin(); }
   decltype(auto) end() { return impl_->end(); }
+  decltype(auto) get() { return impl_->get(); }
   using iterator = typename InputRangeFromGet<ValueType>::Iterator;
 };
 

--- a/test/InputRangeUtilsTest.cpp
+++ b/test/InputRangeUtilsTest.cpp
@@ -80,6 +80,25 @@ TEST(CachingTransformInputRange, BasicTests) {
                                                             firstPlusTwo);
 }
 
+// Test for iterating past the end of a CachingTransformInput range
+TEST(CachingTransformInputRange, IteratePastEnd) {
+  // This test ensures that nullopt is returned repeatedly after all elements
+  // have already been iterated
+  std::vector<int> view{42};
+  auto simpleMove = [](auto& p) { return std::move(p); };
+  ad_utility::CachingTransformInputRange range{view, simpleMove};
+  std::optional<int> element = range.get();
+
+  // The first element shall be returned
+  ASSERT_TRUE(element.has_value());
+  EXPECT_EQ(42, element.value());
+
+  // Subsequent calls shall return nullopt
+  EXPECT_FALSE(range.get().has_value());
+  EXPECT_FALSE(range.get().has_value());
+  EXPECT_FALSE(range.get().has_value());
+}
+
 // Tests for the generator with additional control flow.
 TEST(CachingContinuableTransformInputRange, BreakAndContinue) {
   // This function will move the vector if possible (i.e. if it is not const)

--- a/test/InputRangeUtilsTest.cpp
+++ b/test/InputRangeUtilsTest.cpp
@@ -216,10 +216,6 @@ TEST(CachingContinuableTransformInputRange, StatefulFunctor) {
 }
 
 // Tests for `InputRangeFromLoopControlGet`.
-namespace {
-template <typename F>
-using ILC = ad_utility::InputRangeFromLoopControlGet<F>;
-}
 TEST(InputRangeFromLoopControlGet, BasicTests) {
   using namespace ad_utility;
   using namespace testing;
@@ -235,7 +231,7 @@ TEST(InputRangeFromLoopControlGet, BasicTests) {
     return L::breakWithValue(42);
   };
 
-  EXPECT_THAT(toVec(ILC(f)), ElementsAre(0, 42));
+  EXPECT_THAT(toVec(InputRangeFromLoopControlGet(f)), ElementsAre(0, 42));
 
   // Also add a test with a simple break;
   auto f2 = [i = 0]() mutable -> L {
@@ -257,6 +253,6 @@ TEST(InputRangeFromLoopControlGet, BasicTests) {
     }
     return L::makeBreak();
   };
-  EXPECT_THAT(toVec(ILC(f2)), ElementsAre(0, 42, 123));
+  EXPECT_THAT(toVec(InputRangeFromLoopControlGet(f2)), ElementsAre(0, 42, 123));
 }
 }  // namespace


### PR DESCRIPTION
Those are rewritten using the helpers from `InputRangeUtils.h`, which also have been further extended to be applicable for additional use cases.